### PR TITLE
Silient unused-but-set-parameter in case of Contexts = {}

### DIFF
--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -262,7 +262,10 @@ class ActivityContexts : public ContextHolder<Contexts>... {
     explicit ScopedContext(ActivityContexts* contexts)
         : Context<ContextTypeFromHeld<Contexts>>(
               static_cast<ContextHolder<Contexts>*>(contexts)
-                  ->GetContext())... {}
+                  ->GetContext())... {
+      // Silient `unused-but-set-parameter` in case of Contexts = {}
+      (void)contexts;
+    }
   };
 };
 

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -263,7 +263,7 @@ class ActivityContexts : public ContextHolder<Contexts>... {
         : Context<ContextTypeFromHeld<Contexts>>(
               static_cast<ContextHolder<Contexts>*>(contexts)
                   ->GetContext())... {
-      // Silient `unused-but-set-parameter` in case of Contexts = {}
+      // Silence `unused-but-set-parameter` in case of Contexts = {}
       (void)contexts;
     }
   };


### PR DESCRIPTION
To address this warning

```
external/com_github_grpc_grpc/src/core/lib/promise/activity.h:215:46: warning: parameter 'contexts' set but not used [-Wunused-but-set-parameter]
     explicit ScopedContext(ActivityContexts* contexts)
                            ~~~~~~~~~~~~~~~~~~^~~~~~~~
INFO: From Compiling src/core/ext/filters/channel_idle/channel_idle_filter.cc:
In file included from external/com_github_grpc_grpc/src/core/lib/resource_quota/memory_quota.h:40,
                 from external/com_github_grpc_grpc/src/core/lib/resource_quota/arena.h:41,
                 from external/com_github_grpc_grpc/src/core/lib/promise/arena_promise.h:29,
                 from external/com_github_grpc_grpc/src/core/lib/channel/channel_stack.h:70,
                 from external/com_github_grpc_grpc/src/core/ext/filters/channel_idle/channel_idle_filter.h:30,
                 from external/com_github_grpc_grpc/src/core/ext/filters/channel_idle/channel_idle_filter.cc:20:
external/com_github_grpc_grpc/src/core/lib/promise/activity.h: In instantiation of 'grpc_core::promise_detail::ActivityContexts<Contexts>::ScopedContext::ScopedContext(grpc_core::promise_detail::ActivityContexts<Contexts>*) [with Contexts = {}]':
external/com_github_grpc_grpc/src/core/lib/promise/activity.h:465:19:   required from 'absl::lts_20220623::optional<typename grpc_core::promise_detail::PromiseFactory<void, F>::Promise::Result> grpc_core::promise_detail::PromiseActivity<F, WakeupScheduler, OnDone, Contexts>::Start(grpc_core::promise_detail::PromiseActivity<F, WakeupScheduler, OnDone, Contexts>::Factory) [with F = grpc_core::promise_detail::BasicSeq<grpc_core::promise_detail::TrySeqTraits, grpc_core::Sleep, grpc_core::MaxAgeFilter::PostInit()::<lambda()>, grpc_core::MaxAgeFilter::PostInit()::<lambda()> >; WakeupScheduler = grpc_core::ExecCtxWakeupScheduler; OnDone = grpc_core::MaxAgeFilter::PostInit()::<lambda(absl::lts_20220623::Status)>; Contexts = {}; typename grpc_core::promise_detail::PromiseFactory<void, F>::Promise::Result = absl::lts_20220623::Status; grpc_core::promise_detail::PromiseActivity<F, WakeupScheduler, OnDone, Contexts>::Factory = grpc_core::promise_detail::PromiseFactory<void, grpc_core::promise_detail::BasicSeq<grpc_core::promise_detail::TrySeqTraits, grpc_core::Sleep, grpc_core::MaxAgeFilter::PostInit()::<lambda()>, grpc_core::MaxAgeFilter::PostInit()::<lambda()> > >]'
external/com_github_grpc_grpc/src/core/lib/promise/activity.h:356:19:   required from 'grpc_core::promise_detail::PromiseActivity<F, WakeupScheduler, OnDone, Contexts>::PromiseActivity(F, WakeupScheduler, OnDone, Contexts&& ...) [with F = grpc_core::promise_detail::BasicSeq<grpc_core::promise_detail::TrySeqTraits, grpc_core::Sleep, grpc_core::MaxAgeFilter::PostInit()::<lambda()>, grpc_core::MaxAgeFilter::PostInit()::<lambda()> >; WakeupScheduler = grpc_core::ExecCtxWakeupScheduler; OnDone = grpc_core::MaxAgeFilter::PostInit()::<lambda(absl::lts_20220623::Status)>; Contexts = {}]'
external/com_github_grpc_grpc/src/core/lib/promise/activity.h:526:7:   required from 'grpc_core::ActivityPtr grpc_core::MakeActivity(Factory, WakeupScheduler, OnDone, Contexts&& ...) [with Factory = grpc_core::promise_detail::BasicSeq<grpc_core::promise_detail::TrySeqTraits, grpc_core::Sleep, grpc_core::MaxAgeFilter::PostInit()::<lambda()>, grpc_core::MaxAgeFilter::PostInit()::<lambda()> >; WakeupScheduler = grpc_core::ExecCtxWakeupScheduler; OnDone = grpc_core::MaxAgeFilter::PostInit()::<lambda(absl::lts_20220623::Status)>; Contexts = {}; grpc_core::ActivityPtr = std::unique_ptr<grpc_core::Activity, grpc_core::OrphanableDelete>]'
external/com_github_grpc_grpc/src/core/ext/filters/channel_idle/channel_idle_filter.cc:202:10:   required from here
external/com_github_grpc_grpc/src/core/lib/promise/activity.h:215:4
```