### PR TITLE
[WIP] EventEngine Forkables

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -417,6 +417,7 @@ grpc_cc_library(
         "channel_stack_type",
         "config",
         "default_event_engine_factory_hdrs",
+        "forkable",
         "gpr_base",
         "grpc_authorization_base",
         "grpc_base",
@@ -480,6 +481,7 @@ grpc_cc_library(
         "channel_stack_type",
         "config",
         "default_event_engine_factory_hdrs",
+        "forkable",
         "gpr_base",
         "grpc_authorization_base",
         "grpc_base",
@@ -2237,6 +2239,23 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "forkable",
+    srcs = [
+        "src/core/lib/event_engine/forkable.cc",
+    ],
+    hdrs = [
+        "src/core/lib/event_engine/forkable.h",
+    ],
+    external_deps = [
+        "absl/container:flat_hash_set",
+    ],
+    deps = [
+        "gpr_base",
+        "gpr_platform",
+    ],
+)
+
+grpc_cc_library(
     name = "event_engine_poller",
     hdrs = [
         "src/core/lib/event_engine/poller.h",
@@ -2539,6 +2558,7 @@ grpc_cc_library(
         "event_engine_base_hdrs",
         "event_engine_common",
         "event_engine_trace",
+        "forkable",
         "gpr_base",
         "grpc_trace",
         "iomgr_ee_thread_pool",

--- a/src/core/lib/event_engine/forkable.cc
+++ b/src/core/lib/event_engine/forkable.cc
@@ -1,0 +1,90 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/lib/event_engine/forkable.h"
+
+#ifdef GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
+
+#include <pthread.h>
+
+#include "absl/container/flat_hash_set.h"
+
+#include "src/core/lib/gprpp/sync.h"
+
+namespace grpc_event_engine {
+namespace experimental {
+
+namespace {
+grpc_core::Mutex g_mu;
+bool g_registered{false};
+absl::flat_hash_set<Forkable*> g_forkables;
+}  // namespace
+
+void RegisterForkHandlers() {
+  grpc_core::MutexLock lock(&g_mu);
+  GPR_ASSERT(!g_registered);
+  pthread_atfork(PrepareFork, PostforkParent, PostforkChild);
+};
+
+void PrepareFork() {
+  grpc_core::MutexLock lock(&g_mu);
+  for (auto* forkable : g_forkables) {
+    forkable->PrepareFork();
+  }
+}
+void PostforkParent() {
+  grpc_core::MutexLock lock(&g_mu);
+  for (auto* forkable : g_forkables) {
+    forkable->PostforkParent();
+  }
+}
+
+void PostforkChild() {
+  grpc_core::MutexLock lock(&g_mu);
+  for (auto* forkable : g_forkables) {
+    forkable->PostforkChild();
+  }
+}
+
+void ManageForkable(Forkable* engine) {
+  grpc_core::MutexLock lock(&g_mu);
+  g_forkables.insert(engine);
+}
+void ForgetForkable(Forkable* engine) {
+  grpc_core::MutexLock lock(&g_mu);
+  g_forkables.erase(engine);
+}
+
+}  // namespace experimental
+}  // namespace grpc_event_engine
+
+#else  // GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
+
+namespace grpc_event_engine {
+namespace experimental {
+
+void RegisterForkHandlers() {}
+void PrepareFork() {}
+void PostforkParent() {}
+void PostforkChild() {}
+
+void ManageForkable(Forkable* engine) {}
+void ForgetForkable(Forkable* engine) {}
+
+}  // namespace experimental
+}  // namespace grpc_event_engine
+
+#endif  // GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK

--- a/src/core/lib/event_engine/forkable.h
+++ b/src/core/lib/event_engine/forkable.h
@@ -1,0 +1,57 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GRPC_CORE_LIB_EVENT_ENGINE_FORKABLE_H
+#define GRPC_CORE_LIB_EVENT_ENGINE_FORKABLE_H
+
+#include <grpc/support/port_platform.h>
+
+namespace grpc_event_engine {
+namespace experimental {
+
+// Register fork handlers with the system, enabling fork support.
+//
+// This provides pthread-based support for fork events. Any objects that
+// implement ForkSupported can register themselves with this system using
+// AddForkable, and their respective methods will be called upon fork.
+//
+// This should be called once upon grpc_initialization.
+void RegisterForkHandlers();
+
+// Global callback for pthread_atfork's *prepare argument
+void PrepareFork();
+// Global callback for pthread_atfork's *parent argument
+void PostforkParent();
+// Global callback for pthread_atfork's *child argument
+void PostforkChild();
+
+// An interface to be implemented by EventEngines that wish to have managed fork
+// support.
+class Forkable {
+ public:
+  virtual void PrepareFork() = 0;
+  virtual void PostforkParent() = 0;
+  virtual void PostforkChild() = 0;
+};
+
+// Add Forkables from the set of objects that are supported.
+// Upon fork, each engine will have its respective fork callbacks called on the
+// thread that invoked the fork.
+void ManageForkable(Forkable* engine);
+// Remove a forkable from the managed set.
+void ForgetForkable(Forkable* engine);
+
+}  // namespace experimental
+}  // namespace grpc_event_engine
+
+#endif  // GRPC_CORE_LIB_EVENT_ENGINE_FORKABLE_H

--- a/src/core/lib/event_engine/iomgr_engine/iomgr_engine.h
+++ b/src/core/lib/event_engine/iomgr_engine/iomgr_engine.h
@@ -31,6 +31,7 @@
 #include <grpc/event_engine/memory_allocator.h>
 #include <grpc/event_engine/slice_buffer.h>
 
+#include "src/core/lib/event_engine/forkable.h"
 #include "src/core/lib/event_engine/handle_containers.h"
 #include "src/core/lib/event_engine/iomgr_engine/thread_pool.h"
 #include "src/core/lib/event_engine/iomgr_engine/timer_manager.h"
@@ -42,7 +43,7 @@ namespace experimental {
 
 // An iomgr-based EventEngine implementation.
 // All methods require an ExecCtx to already exist on the thread's stack.
-class IomgrEventEngine final : public EventEngine {
+class IomgrEventEngine final : public EventEngine, public Forkable {
  public:
   class IomgrEndpoint : public EventEngine::Endpoint {
    public:
@@ -102,6 +103,11 @@ class IomgrEventEngine final : public EventEngine {
   TaskHandle RunAfter(Duration when,
                       absl::AnyInvocable<void()> closure) override;
   bool Cancel(TaskHandle handle) override;
+
+  // Forkable
+  void PrepareFork() override;
+  void PostforkParent() override;
+  void PostforkChild() override;
 
  private:
   struct ClosureData;

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -37,6 +37,7 @@
 #include "src/core/lib/channel/channel_stack_builder.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/debug/trace.h"
+#include "src/core/lib/event_engine/forkable.h"
 #include "src/core/lib/gprpp/fork.h"
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/gprpp/thd.h"
@@ -147,6 +148,7 @@ void grpc_init(void) {
       g_shutting_down_cv->SignalAll();
     }
     grpc_core::Fork::GlobalInit();
+    grpc_event_engine::experimental::RegisterForkHandlers();
     grpc_fork_handlers_auto_register();
     grpc_core::ApplicationCallbackExecCtx::GlobalInit();
     grpc_iomgr_init();


### PR DESCRIPTION
A (currently) `pthread_atfork`-based fork support mechanism, allowing EventEngines - or any other object that wants to implement the `Forkable` interface - respond to forks.