### PR TITLE
Istio Echo: Add version string

### DIFF
--- a/test/cpp/interop/istio_echo_server.cc
+++ b/test/cpp/interop/istio_echo_server.cc
@@ -64,6 +64,7 @@ ABSL_FLAG(std::string, crt, "", "gRPC TLS server-side certificate");
 ABSL_FLAG(std::string, key, "", "gRPC TLS server-side key");
 ABSL_FLAG(std::string, forwarding_address, "0.0.0.0:7072",
           "Forwarding address for unhandled protocols");
+ABSL_FLAG(std::string, service_version, "", "Version string for the service");
 
 // The following flags must be defined, but are not used for now. Some may be
 // necessary for certain tests.
@@ -100,11 +101,14 @@ void RunServer(const std::set<int>& grpc_ports, const std::set<int>& xds_ports,
     free(hostname_p);
   }
   EchoTestServiceImpl echo_test_service(
-      std::move(hostname), absl::GetFlag(FLAGS_forwarding_address));
+      std::move(hostname), absl::GetFlag(FLAGS_service_version),
+      absl::GetFlag(FLAGS_forwarding_address));
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   XdsServerBuilder xds_builder;
   bool has_xds_listeners = false;
   builder.RegisterService(&echo_test_service);
+  xds_builder.RegisterService(&echo_test_service);
   for (int port : grpc_ports) {
     auto server_address = grpc_core::JoinHostPort("0.0.0.0", port);
     if (xds_ports.find(port) != xds_ports.end()) {
@@ -161,11 +165,12 @@ int main(int argc, char** argv) {
     size_t equal = arg.find_first_of('=');
     if (equal != std::string::npos) {
       std::string f = arg.substr(0, equal);
-      if (f == "--version") {
-        continue;
-      }
       std::string v = arg.substr(equal + 1, std::string::npos);
-      argv_dict[f].push_back(v);
+      if (f == "--version") {
+        argv_dict["--service_version"].push_back(v);
+      } else {
+        argv_dict[f].push_back(v);
+      }
     }
   }
   std::vector<char*> new_argv_strs;

--- a/test/cpp/interop/istio_echo_server_lib.cc
+++ b/test/cpp/interop/istio_echo_server_lib.cc
@@ -40,7 +40,7 @@ namespace testing {
 namespace {
 
 const absl::string_view kRequestIdField = "x-request-id";
-// const absl::string_view kServiceVersionField = "ServiceVersion";
+const absl::string_view kServiceVersionField = "ServiceVersion";
 // const absl::string_view kServicePortField = "ServicePort";
 const absl::string_view kStatusCodeField = "StatusCode";
 // const absl::string_view kUrlField = "URL";
@@ -66,8 +66,10 @@ struct EchoCall {
 }  // namespace
 
 EchoTestServiceImpl::EchoTestServiceImpl(std::string hostname,
+                                         std::string service_version,
                                          std::string forwarding_address)
     : hostname_(std::move(hostname)),
+      service_version_(std::move(service_version)),
       forwarding_address_(std::move(forwarding_address)) {
   forwarding_stub_ = EchoTestService::NewStub(
       CreateChannel(forwarding_address_, InsecureChannelCredentials()));
@@ -98,10 +100,10 @@ Status EchoTestServiceImpl::Echo(ServerContext* context,
   //  need to add/remove fields later, if required by tests. Only keep the
   //  fields needed for now.
   //
-  //  absl::StrAppend(&s,kServiceVersionField,"=",this->version_,"\n");
   //  absl::StrAppend(&s,kServicePortField,"=",this->port_,"\n");
   //  absl::StrAppend(&s,kClusterField,"=",this->cluster_,"\n");
   //  absl::StrAppend(&s,kIstioVersionField,"=",this->istio_version_,"\n");
+  absl::StrAppend(&s, kServiceVersionField, "=", this->service_version_, "\n");
   absl::StrAppend(&s, kIpField, "=", host, "\n");
   absl::StrAppend(&s, kStatusCodeField, "=", std::to_string(200), "\n");
   absl::StrAppend(&s, kHostnameField, "=", this->hostname_, "\n");
@@ -166,9 +168,12 @@ Status EchoTestServiceImpl::ForwardEcho(ServerContext* context,
         calls[i].context.AddMetadata(header.key(), header.value());
       }
     }
+    constexpr int kDefaultTimeout = 5 * 1000 * 1000 /* 5 seconds */;
     std::chrono::system_clock::time_point deadline =
         std::chrono::system_clock::now() +
-        std::chrono::microseconds(request->timeout_micros());
+        std::chrono::microseconds(request->timeout_micros() > 0
+                                      ? request->timeout_micros()
+                                      : kDefaultTimeout);
     calls[i].context.set_deadline(deadline);
     stub->async()->Echo(&calls[i].context, &echo_request, &calls[i].response,
                         [&, index = i](Status s) {

--- a/test/cpp/interop/istio_echo_server_lib.h
+++ b/test/cpp/interop/istio_echo_server_lib.h
@@ -24,7 +24,8 @@ namespace testing {
 
 class EchoTestServiceImpl : public proto::EchoTestService::Service {
  public:
-  EchoTestServiceImpl(std::string hostname, std::string forwarding_address);
+  EchoTestServiceImpl(std::string hostname, std::string service_version,
+                      std::string forwarding_address);
 
   grpc::Status Echo(grpc::ServerContext* context,
                     const proto::EchoRequest* request,
@@ -36,11 +37,11 @@ class EchoTestServiceImpl : public proto::EchoTestService::Service {
 
  private:
   std::string hostname_;
+  std::string service_version_;
   std::string forwarding_address_;
   std::unique_ptr<proto::EchoTestService::Stub> forwarding_stub_;
   // The following fields are not set yet. But we may need them later.
   //  int port_;
-  //  std::string version_;
   //  std::string cluster_;
   //  std::string istio_version_;
 };

--- a/test/cpp/interop/istio_echo_server_test.cc
+++ b/test/cpp/interop/istio_echo_server_test.cc
@@ -92,8 +92,8 @@ class EchoTest : public ::testing::Test {
     simple_server_ = simple_builder.BuildAndStart();
     // Start the EchoTestServiceImpl server
     ServerBuilder builder;
-    echo_test_service_impl_ =
-        std::make_unique<EchoTestServiceImpl>("hostname", forwarding_address_);
+    echo_test_service_impl_ = std::make_unique<EchoTestServiceImpl>(
+        "hostname", "v1", forwarding_address_);
     builder.RegisterService(echo_test_service_impl_.get());
     int port = grpc_pick_unused_port_or_die();
     server_address_ = grpc_core::JoinHostPort("localhost", port);
@@ -125,7 +125,8 @@ TEST_F(EchoTest, SimpleEchoTest) {
                                ::testing::HasSubstr("Hostname=hostname\n"),
                                ::testing::HasSubstr("Echo=hello\n"),
                                ::testing::HasSubstr("Host="),
-                               ::testing::HasSubstr("IP=")));
+                               ::testing::HasSubstr("IP="),
+                               ::testing::HasSubstr("ServiceVersion=v1")));
 }
 
 TEST_F(EchoTest, ForwardEchoTest) {
@@ -149,7 +150,8 @@ TEST_F(EchoTest, ForwardEchoTest) {
                 absl::StrFormat("[%d body] Hostname=hostname\n", i)),
             ::testing::HasSubstr(absl::StrFormat("[%d body] Echo=hello\n", i)),
             ::testing::HasSubstr(absl::StrFormat("[%d body] Host=", i)),
-            ::testing::HasSubstr(absl::StrFormat("[%d body] IP=", i))));
+            ::testing::HasSubstr(
+                absl::StrFormat("[%d body] ServiceVersion=v1", i))));
   }
 }
 


### PR DESCRIPTION
Add version string in the echo response message. This is to allow using the same image for the example at https://istio.io/v1.12/blog/2021/proxyless-grpc/#in-your-kubernetes-deployment.

I also noticed a major bug where the xDS server was not serving anything earlier.