### PR TITLE
Also allow passing in channel args as part of the check_peer call. 

### DIFF
--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -107,6 +107,7 @@ class grpc_httpcli_ssl_channel_security_connector final
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
+                  const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* /*auth_context*/,
                   grpc_closure* on_peer_checked) override {
     grpc_error_handle error = GRPC_ERROR_NONE;

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -115,6 +115,7 @@ class grpc_alts_channel_security_connector final
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     alts_check_peer(peer, auth_context, on_peer_checked);
@@ -173,6 +174,7 @@ class grpc_alts_server_security_connector final
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     alts_check_peer(peer, auth_context, on_peer_checked);

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -82,6 +82,7 @@ class grpc_fake_channel_security_connector final
   ~grpc_fake_channel_security_connector() override { gpr_free(target_); }
 
   void check_peer(tsi_peer peer, grpc_endpoint* ep,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override;
 
@@ -262,6 +263,7 @@ end:
 
 void grpc_fake_channel_security_connector::check_peer(
     tsi_peer peer, grpc_endpoint* /*ep*/,
+    const grpc_core::ChannelArgs& /*args*/,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   fake_check_peer(this, peer, auth_context, on_peer_checked);
@@ -278,6 +280,7 @@ class grpc_fake_server_security_connector
   ~grpc_fake_server_security_connector() override = default;
 
   void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     fake_check_peer(this, peer, auth_context, on_peer_checked);

--- a/src/core/lib/security/security_connector/insecure/insecure_security_connector.cc
+++ b/src/core/lib/security/security_connector/insecure/insecure_security_connector.cc
@@ -77,7 +77,7 @@ void InsecureChannelSecurityConnector::add_handshakers(
 }
 
 void InsecureChannelSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* /*ep*/,
+    tsi_peer peer, grpc_endpoint* /*ep*/, const ChannelArgs& /*args*/,
     RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   *auth_context = MakeAuthContext();
@@ -104,7 +104,7 @@ void InsecureServerSecurityConnector::add_handshakers(
 }
 
 void InsecureServerSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* /*ep*/,
+    tsi_peer peer, grpc_endpoint* /*ep*/, const ChannelArgs& /*args*/,
     RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   *auth_context = MakeAuthContext();

--- a/src/core/lib/security/security_connector/insecure/insecure_security_connector.h
+++ b/src/core/lib/security/security_connector/insecure/insecure_security_connector.h
@@ -67,7 +67,7 @@ class InsecureChannelSecurityConnector
                        grpc_pollset_set* /* interested_parties */,
                        HandshakeManager* handshake_manager) override;
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* ep, const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override;
 
@@ -90,7 +90,7 @@ class InsecureServerSecurityConnector : public grpc_server_security_connector {
                        grpc_pollset_set* /* interested_parties */,
                        HandshakeManager* handshake_manager) override;
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* ep, const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override;
 

--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -199,6 +199,7 @@ class grpc_local_channel_security_connector final
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* ep,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     grpc_local_credentials* creds =
@@ -246,6 +247,7 @@ class grpc_local_server_security_connector final
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* ep,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     grpc_local_server_credentials* creds =

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -74,9 +74,10 @@ class grpc_security_connector
   }
 
   // Checks the peer. Callee takes ownership of the peer object.
+  // The channel args represent the args after the handshaking is performed.
   // When done, sets *auth_context and invokes on_peer_checked.
   virtual void check_peer(
-      tsi_peer peer, grpc_endpoint* ep,
+      tsi_peer peer, grpc_endpoint* ep, const grpc_core::ChannelArgs& args,
       grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
       grpc_closure* on_peer_checked) = 0;
 

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -153,6 +153,7 @@ class grpc_ssl_channel_security_connector final
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     const char* target_name = overridden_target_name_.empty()
@@ -297,6 +298,7 @@ class grpc_ssl_server_security_connector
   }
 
   void check_peer(tsi_peer peer, grpc_endpoint* /*ep*/,
+                  const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
     grpc_error_handle error = ssl_check_peer(nullptr, &peer, auth_context);

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -353,7 +353,7 @@ void TlsChannelSecurityConnector::add_handshakers(
 }
 
 void TlsChannelSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* /*ep*/,
+    tsi_peer peer, grpc_endpoint* /*ep*/, const ChannelArgs& /*args*/,
     RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   const char* target_name = overridden_target_name_.empty()
@@ -640,7 +640,7 @@ void TlsServerSecurityConnector::add_handshakers(
 }
 
 void TlsServerSecurityConnector::check_peer(
-    tsi_peer peer, grpc_endpoint* /*ep*/,
+    tsi_peer peer, grpc_endpoint* /*ep*/, const ChannelArgs& /*args*/,
     RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   grpc_error_handle error = grpc_ssl_check_alpn(&peer);

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.h
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.h
@@ -78,7 +78,7 @@ class TlsChannelSecurityConnector final
                        grpc_pollset_set* interested_parties,
                        HandshakeManager* handshake_mgr) override;
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* ep, const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override;
 
@@ -191,7 +191,7 @@ class TlsServerSecurityConnector final : public grpc_server_security_connector {
                        grpc_pollset_set* interested_parties,
                        HandshakeManager* handshake_mgr) override;
 
-  void check_peer(tsi_peer peer, grpc_endpoint* ep,
+  void check_peer(tsi_peer peer, grpc_endpoint* ep, const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override;
 

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -361,7 +361,7 @@ grpc_error_handle SecurityHandshaker::CheckPeerLocked() {
     return grpc_set_tsi_error_result(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Peer extraction failed"), result);
   }
-  connector_->check_peer(peer, args_->endpoint, &auth_context_,
+  connector_->check_peer(peer, args_->endpoint, args_->args, &auth_context_,
                          &on_peer_checked_);
   return GRPC_ERROR_NONE;
 }

--- a/test/core/filters/filter_fuzzer.cc
+++ b/test/core/filters/filter_fuzzer.cc
@@ -84,8 +84,8 @@ class FakeChannelSecurityConnector final
   FakeChannelSecurityConnector()
       : grpc_channel_security_connector("fake", nullptr, nullptr) {}
 
-  void check_peer(tsi_peer, grpc_endpoint*, RefCountedPtr<grpc_auth_context>*,
-                  grpc_closure*) override {
+  void check_peer(tsi_peer, grpc_endpoint*, const ChannelArgs&,
+                  RefCountedPtr<grpc_auth_context>*, grpc_closure*) override {
     abort();
   }
 

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -489,8 +489,8 @@ class RequestMetadataState : public RefCounted<RequestMetadataState> {
     explicit BogusSecurityConnector(absl::string_view url_scheme)
         : grpc_channel_security_connector(url_scheme, nullptr, nullptr) {}
 
-    void check_peer(tsi_peer, grpc_endpoint*, RefCountedPtr<grpc_auth_context>*,
-                    grpc_closure*) override {
+    void check_peer(tsi_peer, grpc_endpoint*, const ChannelArgs&,
+                    RefCountedPtr<grpc_auth_context>*, grpc_closure*) override {
       GPR_ASSERT(false);
     }
 

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -402,7 +402,9 @@ TEST_F(TlsSecurityConnectorTest,
   ExecCtx exec_ctx;
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, nullptr, grpc_schedule_on_exec_ctx);
-  tls_connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  ChannelArgs args;
+  tls_connector->check_peer(peer, nullptr, args, &auth_context,
+                            on_peer_checked);
 }
 
 TEST_F(TlsSecurityConnectorTest,
@@ -440,7 +442,8 @@ TEST_F(TlsSecurityConnectorTest,
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, const_cast<char*>(expected_error_msg),
       grpc_schedule_on_exec_ctx);
-  tls_connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  tls_connector->check_peer(peer, nullptr, new_args, &auth_context,
+                            on_peer_checked);
 }
 
 TEST_F(TlsSecurityConnectorTest,
@@ -588,7 +591,8 @@ TEST_F(TlsSecurityConnectorTest,
   ExecCtx exec_ctx;
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, nullptr, grpc_schedule_on_exec_ctx);
-  tls_connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  tls_connector->check_peer(peer, nullptr, new_args, &auth_context,
+                            on_peer_checked);
   core_external_verifier->Unref();
 }
 
@@ -627,7 +631,8 @@ TEST_F(TlsSecurityConnectorTest,
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, const_cast<char*>(expected_error_msg),
       grpc_schedule_on_exec_ctx);
-  tls_connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  tls_connector->check_peer(peer, nullptr, new_args, &auth_context,
+                            on_peer_checked);
   core_external_verifier->Unref();
 }
 
@@ -676,7 +681,8 @@ TEST_F(TlsSecurityConnectorTest,
   ExecCtx exec_ctx;
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, nullptr, grpc_schedule_on_exec_ctx);
-  tls_connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  tls_connector->check_peer(peer, nullptr, new_args, &auth_context,
+                            on_peer_checked);
 }
 
 TEST_F(TlsSecurityConnectorTest,
@@ -728,7 +734,8 @@ TEST_F(TlsSecurityConnectorTest,
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, const_cast<char*>(expected_error_msg),
       grpc_schedule_on_exec_ctx);
-  tls_connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  tls_connector->check_peer(peer, nullptr, new_args, &auth_context,
+                            on_peer_checked);
 }
 
 //
@@ -977,7 +984,8 @@ TEST_F(TlsSecurityConnectorTest,
   ExecCtx exec_ctx;
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, nullptr, grpc_schedule_on_exec_ctx);
-  connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  ChannelArgs args;
+  connector->check_peer(peer, nullptr, args, &auth_context, on_peer_checked);
 }
 
 TEST_F(TlsSecurityConnectorTest,
@@ -1011,7 +1019,8 @@ TEST_F(TlsSecurityConnectorTest,
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, const_cast<char*>(expected_error_msg),
       grpc_schedule_on_exec_ctx);
-  connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  ChannelArgs args;
+  connector->check_peer(peer, nullptr, args, &auth_context, on_peer_checked);
 }
 
 TEST_F(TlsSecurityConnectorTest,
@@ -1041,7 +1050,8 @@ TEST_F(TlsSecurityConnectorTest,
   ExecCtx exec_ctx;
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, nullptr, grpc_schedule_on_exec_ctx);
-  connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  ChannelArgs args;
+  connector->check_peer(peer, nullptr, args, &auth_context, on_peer_checked);
   core_external_verifier->Unref();
 }
 
@@ -1077,7 +1087,8 @@ TEST_F(TlsSecurityConnectorTest,
   grpc_closure* on_peer_checked = GRPC_CLOSURE_CREATE(
       VerifyExpectedErrorCallback, const_cast<char*>(expected_error_msg),
       grpc_schedule_on_exec_ctx);
-  connector->check_peer(peer, nullptr, &auth_context, on_peer_checked);
+  ChannelArgs args;
+  connector->check_peer(peer, nullptr, args, &auth_context, on_peer_checked);
   core_external_verifier->Unref();
 }
 


### PR DESCRIPTION
This allows the security connectors to receive args that might be added by handshakers. Currently none of the connectors use the args, hence they are marked as unused. This is required for changes internally for security connectors related to Directpath

@markdroth 

