### PR TITLE
Fix unused parameter error

### DIFF
--- a/test/core/promise/sleep_test.cc
+++ b/test/core/promise/sleep_test.cc
@@ -105,7 +105,7 @@ TEST(Sleep, StressTest) {
     auto notification = std::make_shared<absl::Notification>();
     auto activity = MakeActivity(
         Sleep(exec_ctx.Now() + Duration::Seconds(1)), ExecCtxWakeupScheduler(),
-        [notification](absl::Status r) { notification->Notify(); });
+        [notification](absl::Status /*r*/) { notification->Notify(); });
     notifications.push_back(std::move(notification));
     activities.push_back(std::move(activity));
   }


### PR DESCRIPTION
It broke macos tests: https://source.cloud.google.com/results/invocations/5fcb7873-72cf-4b7e-8bed-d19db3372acb/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_bazel_c_cpp_opt/log

