### PR TITLE
Revert "Modifying iomgr tcp code to use event engine EndpointConfig instead of channel_args"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2215,7 +2215,6 @@ grpc_cc_library(
         "absl/status",
         "absl/status:statusor",
         "absl/time",
-        "absl/types:optional",
         "absl/functional:any_invocable",
     ],
     tags = ["nofixdeps"],

--- a/include/grpc/event_engine/endpoint_config.h
+++ b/include/grpc/event_engine/endpoint_config.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
+#include "absl/types/variant.h"
 
 namespace grpc_event_engine {
 namespace experimental {
@@ -31,16 +31,10 @@ namespace experimental {
 class EndpointConfig {
  public:
   virtual ~EndpointConfig() = default;
-  // If the key points to an integer config, an integer value gets returned.
-  // Otherwise it returns an absl::nullopt_t
-  virtual absl::optional<int> GetInt(absl::string_view key) const = 0;
-  // If the key points to an string config, an string value gets returned.
-  // Otherwise it returns an absl::nullopt_t
-  virtual absl::optional<absl::string_view> GetString(
-      absl::string_view key) const = 0;
-  // If the key points to an void* config, a void* pointer value gets returned.
-  // Otherwise it returns nullptr
-  virtual void* GetVoidPointer(absl::string_view key) const = 0;
+  using Setting = absl::variant<absl::monostate, int, absl::string_view, void*>;
+  /// Returns the Setting for a specified key, or \a absl::monostate if there is
+  /// no such entry. Caller does not take ownership of the resulting value.
+  virtual Setting Get(absl::string_view key) const = 0;
 };
 
 }  // namespace experimental

--- a/src/core/ext/transport/chttp2/client/chttp2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/chttp2_connector.cc
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -49,7 +50,6 @@
 #include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/unique_type_name.h"
@@ -398,13 +398,12 @@ grpc_channel* grpc_channel_create_from_fd(const char* target, int fd,
           .PreconditionChannelArgs(args)
           .SetIfUnset(GRPC_ARG_DEFAULT_AUTHORITY, "test.authority")
           .SetObject(creds->Ref());
+  auto c_final_args = final_args.ToC();
 
   int flags = fcntl(fd, F_GETFL, 0);
   GPR_ASSERT(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
-  grpc_endpoint* client = grpc_tcp_create_from_fd(
-      grpc_fd_create(fd, "client", true),
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(final_args),
-      "fd-client");
+  grpc_endpoint* client = grpc_tcp_client_create_from_fd(
+      grpc_fd_create(fd, "client", true), c_final_args.get(), "fd-client");
   grpc_transport* transport =
       grpc_create_chttp2_transport(final_args, client, true);
   GPR_ASSERT(transport);

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -54,7 +54,6 @@
 #include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
@@ -89,7 +88,7 @@
 #ifdef GPR_SUPPORT_CHANNELS_FROM_FD
 #include "src/core/lib/iomgr/ev_posix.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
-#include "src/core/lib/iomgr/tcp_client_posix.h"
+#include "src/core/lib/iomgr/tcp_posix.h"
 #endif  // GPR_SUPPORT_CHANNELS_FROM_FD
 
 namespace grpc_core {
@@ -157,8 +156,7 @@ class Chttp2ServerListener : public Server::ListenerInterface {
 
       void Start(grpc_endpoint* endpoint, const ChannelArgs& args);
 
-      // Needed to be able to grab an external ref in
-      // ActiveConnection::Start()
+      // Needed to be able to grab an external ref in ActiveConnection::Start()
       using InternallyRefCounted<HandshakingState>::Ref;
 
      private:
@@ -203,8 +201,8 @@ class Chttp2ServerListener : public Server::ListenerInterface {
     // Set by HandshakingState before the handshaking begins and reset when
     // handshaking is done.
     OrphanablePtr<HandshakingState> handshaking_state_ ABSL_GUARDED_BY(&mu_);
-    // Set by HandshakingState when handshaking is done and a valid transport
-    // is created.
+    // Set by HandshakingState when handshaking is done and a valid transport is
+    // created.
     grpc_chttp2_transport* transport_ ABSL_GUARDED_BY(&mu_) = nullptr;
     grpc_closure on_close_;
     grpc_timer drain_grace_timer_;
@@ -230,11 +228,11 @@ class Chttp2ServerListener : public Server::ListenerInterface {
                               grpc_closure* destroy_done);
 
   // The interface required by RefCountedPtr<> has been manually implemented
-  // here to take a ref on tcp_server_ instead. Note that, the handshaker
-  // needs tcp_server_ to exist for the lifetime of the handshake since it's
-  // needed by acceptor. Sharing refs between the listener and tcp_server_ is
-  // just an optimization to avoid taking additional refs on the listener,
-  // since TcpServerShutdownComplete already holds a ref to the listener.
+  // here to take a ref on tcp_server_ instead. Note that, the handshaker needs
+  // tcp_server_ to exist for the lifetime of the handshake since it's needed by
+  // acceptor. Sharing refs between the listener and tcp_server_ is just an
+  // optimization to avoid taking additional refs on the listener, since
+  // TcpServerShutdownComplete already holds a ref to the listener.
   void IncrementRefCount() { grpc_tcp_server_ref(tcp_server_); }
   void IncrementRefCount(const DebugLocation& /* location */,
                          const char* /* reason */) {
@@ -347,8 +345,8 @@ void Chttp2ServerListener::ConfigFetcherWatcher::StopServing() {
     listener_->is_serving_ = false;
     connections = std::move(listener_->connections_);
   }
-  // Send GOAWAYs on the transports so that they disconnected when existing
-  // RPCs finish.
+  // Send GOAWAYs on the transports so that they disconnected when existing RPCs
+  // finish.
   for (auto& connection : connections) {
     connection.first->SendGoAway();
   }
@@ -489,9 +487,9 @@ void Chttp2ServerListener::ActiveConnection::HandshakingState::OnHandshakeDone(
           self->Ref().release();  // Held by OnReceiveSettings().
           GRPC_CLOSURE_INIT(&self->on_receive_settings_, OnReceiveSettings,
                             self, grpc_schedule_on_exec_ctx);
-          // If the listener has been configured with a config fetcher, we
-          // need to watch on the transport being closed so that we can an
-          // updated list of active connections.
+          // If the listener has been configured with a config fetcher, we need
+          // to watch on the transport being closed so that we can an updated
+          // list of active connections.
           grpc_closure* on_close = nullptr;
           if (self->connection_->listener_->config_fetcher_watcher_ !=
               nullptr) {
@@ -630,8 +628,8 @@ void Chttp2ServerListener::ActiveConnection::OnClose(
   {
     MutexLock listener_lock(&self->listener_->mu_);
     MutexLock connection_lock(&self->mu_);
-    // The node was already deleted from the connections_ list if the
-    // connection is shutdown.
+    // The node was already deleted from the connections_ list if the connection
+    // is shutdown.
     if (!self->shutdown_) {
       auto it = self->listener_->connections_.find(self);
       if (it != self->listener_->connections_.end()) {
@@ -681,10 +679,8 @@ grpc_error_handle Chttp2ServerListener::Create(
     grpc_error_handle error = GRPC_ERROR_NONE;
     // Create Chttp2ServerListener.
     listener = new Chttp2ServerListener(server, args, args_modifier);
-    error = grpc_tcp_server_create(
-        &listener->tcp_server_shutdown_complete_,
-        grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-        &listener->tcp_server_);
+    error = grpc_tcp_server_create(&listener->tcp_server_shutdown_complete_,
+                                   args.ToC().get(), &listener->tcp_server_);
     if (!GRPC_ERROR_IS_NONE(error)) return error;
     if (server->config_fetcher() != nullptr) {
       listener->resolved_address_ = *addr;
@@ -729,10 +725,9 @@ grpc_error_handle Chttp2ServerListener::CreateWithAcceptor(
     Chttp2ServerArgsModifier args_modifier) {
   Chttp2ServerListener* listener =
       new Chttp2ServerListener(server, args, args_modifier);
-  grpc_error_handle error = grpc_tcp_server_create(
-      &listener->tcp_server_shutdown_complete_,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-      &listener->tcp_server_);
+  grpc_error_handle error =
+      grpc_tcp_server_create(&listener->tcp_server_shutdown_complete_,
+                             args.ToC().get(), &listener->tcp_server_);
   if (!GRPC_ERROR_IS_NONE(error)) {
     delete listener;
     return error;
@@ -1078,10 +1073,8 @@ void grpc_server_add_channel_from_fd(grpc_server* server, int fd,
   std::string name = absl::StrCat("fd:", fd);
   auto memory_quota =
       server_args.GetObject<grpc_core::ResourceQuota>()->memory_quota();
-  grpc_endpoint* server_endpoint = grpc_tcp_create_from_fd(
-      grpc_fd_create(fd, name.c_str(), true),
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(server_args),
-      name);
+  grpc_endpoint* server_endpoint = grpc_tcp_create(
+      grpc_fd_create(fd, name.c_str(), true), server_args.ToC().get(), name);
   grpc_transport* transport = grpc_create_chttp2_transport(
       server_args, server_endpoint, false /* is_client */
   );

--- a/src/core/lib/event_engine/channel_args_endpoint_config.h
+++ b/src/core/lib/event_engine/channel_args_endpoint_config.h
@@ -17,30 +17,24 @@
 #include <grpc/support/port_platform.h>
 
 #include "absl/strings/string_view.h"
-#include "absl/types/optional.h"
 
 #include <grpc/event_engine/endpoint_config.h>
-
-#include "src/core/lib/channel/channel_args.h"
+#include <grpc/impl/codegen/grpc_types.h>
 
 namespace grpc_event_engine {
 namespace experimental {
 
+/// A readonly \a EndpointConfig based on grpc_channel_args. This class does not
+/// take ownership of the grpc_endpoint_args*, and instances of this class
+/// should not be used after the underlying args are destroyed.
 class ChannelArgsEndpointConfig : public EndpointConfig {
  public:
-  ChannelArgsEndpointConfig() = default;
-  explicit ChannelArgsEndpointConfig(const grpc_core::ChannelArgs& args)
+  explicit ChannelArgsEndpointConfig(const grpc_channel_args* args)
       : args_(args) {}
-  ChannelArgsEndpointConfig(const ChannelArgsEndpointConfig& config) = default;
-  ChannelArgsEndpointConfig& operator=(const ChannelArgsEndpointConfig& other) =
-      default;
-  absl::optional<int> GetInt(absl::string_view key) const override;
-  absl::optional<absl::string_view> GetString(
-      absl::string_view key) const override;
-  void* GetVoidPointer(absl::string_view key) const override;
+  Setting Get(absl::string_view key) const override;
 
  private:
-  grpc_core::ChannelArgs args_;
+  const grpc_channel_args* args_;
 };
 
 }  // namespace experimental

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -77,9 +77,9 @@ grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(
   create_sockets(sv);
   grpc_core::ExecCtx exec_ctx;
   p.client = grpc_tcp_create(grpc_winsocket_create(sv[1], "endpoint:client"),
-                             "endpoint:server");
+                             channel_args, "endpoint:server");
   p.server = grpc_tcp_create(grpc_winsocket_create(sv[0], "endpoint:server"),
-                             "endpoint:client");
+                             channel_args, "endpoint:client");
   return p;
 }
 

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -43,12 +43,12 @@
 
 #include <string>
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 
@@ -298,9 +298,10 @@ void config_default_tcp_user_timeout(bool enable, int timeout, bool is_client) {
 
 /* Set TCP_USER_TIMEOUT */
 grpc_error_handle grpc_set_socket_tcp_user_timeout(
-    int fd, const grpc_core::PosixTcpOptions& options, bool is_client) {
+    int fd, const grpc_channel_args* channel_args, bool is_client) {
   // Use conditionally-important parameter to avoid warning
   (void)fd;
+  (void)channel_args;
   (void)is_client;
   extern grpc_core::TraceFlag grpc_tcp_trace;
   if (g_socket_supports_tcp_user_timeout.load() >= 0) {
@@ -313,13 +314,29 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
       enable = g_default_server_tcp_user_timeout_enabled;
       timeout = g_default_server_tcp_user_timeout_ms;
     }
-    int value = options.keep_alive_time_ms;
-    if (value > 0) {
-      enable = value != INT_MAX;
-    }
-    value = options.keep_alive_timeout_ms;
-    if (value > 0) {
-      timeout = value;
+    if (channel_args) {
+      for (unsigned int i = 0; i < channel_args->num_args; i++) {
+        if (0 ==
+            strcmp(channel_args->args[i].key, GRPC_ARG_KEEPALIVE_TIME_MS)) {
+          const int value = grpc_channel_arg_get_integer(
+              &channel_args->args[i], grpc_integer_options{0, 1, INT_MAX});
+          /* Continue using default if value is 0 */
+          if (value == 0) {
+            continue;
+          }
+          /* Disable if value is INT_MAX */
+          enable = value != INT_MAX;
+        } else if (0 == strcmp(channel_args->args[i].key,
+                               GRPC_ARG_KEEPALIVE_TIMEOUT_MS)) {
+          const int value = grpc_channel_arg_get_integer(
+              &channel_args->args[i], grpc_integer_options{0, 1, INT_MAX});
+          /* Continue using default if value is 0 */
+          if (value == 0) {
+            continue;
+          }
+          timeout = value;
+        }
+      }
     }
     if (enable) {
       int newval;
@@ -381,11 +398,16 @@ grpc_error_handle grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
 }
 
 grpc_error_handle grpc_apply_socket_mutator_in_args(
-    int fd, grpc_fd_usage usage, const grpc_core::PosixTcpOptions& options) {
-  if (options.socket_mutator == nullptr) {
+    int fd, grpc_fd_usage usage, const grpc_channel_args* args) {
+  const grpc_arg* socket_mutator_arg =
+      grpc_channel_args_find(args, GRPC_ARG_SOCKET_MUTATOR);
+  if (socket_mutator_arg == nullptr) {
     return GRPC_ERROR_NONE;
   }
-  return grpc_set_socket_with_mutator(fd, usage, options.socket_mutator);
+  GPR_DEBUG_ASSERT(socket_mutator_arg->type == GRPC_ARG_POINTER);
+  grpc_socket_mutator* mutator =
+      static_cast<grpc_socket_mutator*>(socket_mutator_arg->value.pointer.p);
+  return grpc_set_socket_with_mutator(fd, usage, mutator);
 }
 
 static gpr_once g_probe_ipv6_once = GPR_ONCE_INIT;

--- a/src/core/lib/iomgr/socket_utils_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_posix.cc
@@ -18,102 +18,18 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "absl/types/optional.h"
-
 #include "src/core/lib/iomgr/port.h"
 
 #ifdef GRPC_POSIX_SOCKETUTILS
+
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/log.h>
 
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/socket_utils_posix.h"
-#endif
-
-#ifdef GRPC_POSIX_SOCKET_TCP
-
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
-#include "src/core/lib/iomgr/socket_utils_posix.h"
-
-using ::grpc_event_engine::experimental::EndpointConfig;
-
-using ::grpc_core::PosixTcpOptions;
-
-namespace {
-
-int AdjustValue(int default_value, int min_value, int max_value,
-                absl::optional<int> actual_value) {
-  if (!actual_value.has_value() || *actual_value < min_value ||
-      *actual_value > max_value) {
-    return default_value;
-  }
-  return *actual_value;
-}
-}  // namespace
-
-PosixTcpOptions TcpOptionsFromEndpointConfig(const EndpointConfig& config) {
-  void* value;
-  PosixTcpOptions options;
-  options.tcp_read_chunk_size = AdjustValue(
-      PosixTcpOptions::kDefaultReadChunkSize, 1, PosixTcpOptions::kMaxChunkSize,
-      config.GetInt(GRPC_ARG_TCP_READ_CHUNK_SIZE));
-  options.tcp_min_read_chunk_size =
-      AdjustValue(PosixTcpOptions::kDefaultMinReadChunksize, 1,
-                  PosixTcpOptions::kMaxChunkSize,
-                  config.GetInt(GRPC_ARG_TCP_MIN_READ_CHUNK_SIZE));
-  options.tcp_max_read_chunk_size =
-      AdjustValue(PosixTcpOptions::kDefaultMaxReadChunksize, 1,
-                  PosixTcpOptions::kMaxChunkSize,
-                  config.GetInt(GRPC_ARG_TCP_MAX_READ_CHUNK_SIZE));
-  options.tcp_tx_zerocopy_send_bytes_threshold =
-      AdjustValue(PosixTcpOptions::kDefaultSendBytesThreshold, 0, INT_MAX,
-                  config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_SEND_BYTES_THRESHOLD));
-  options.tcp_tx_zerocopy_max_simultaneous_sends =
-      AdjustValue(PosixTcpOptions::kDefaultMaxSends, 0, INT_MAX,
-                  config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS));
-  options.tcp_tx_zero_copy_enabled =
-      (AdjustValue(PosixTcpOptions::kZerocpTxEnabledDefault, 0, 1,
-                   config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED)) != 0);
-  options.keep_alive_time_ms =
-      (AdjustValue(0, 1, INT_MAX, config.GetInt(GRPC_ARG_KEEPALIVE_TIME_MS)) !=
-       0);
-  options.keep_alive_timeout_ms =
-      (AdjustValue(0, 1, INT_MAX,
-                   config.GetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS)) != 0);
-  options.expand_wildcard_addrs =
-      (AdjustValue(0, 1, INT_MAX,
-                   config.GetInt(GRPC_ARG_EXPAND_WILDCARD_ADDRS)) != 0);
-  options.allow_reuse_port =
-      (AdjustValue(0, 1, INT_MAX, config.GetInt(GRPC_ARG_ALLOW_REUSEPORT)) !=
-       0);
-
-  if (options.tcp_min_read_chunk_size > options.tcp_max_read_chunk_size) {
-    options.tcp_min_read_chunk_size = options.tcp_max_read_chunk_size;
-  }
-  options.tcp_read_chunk_size = grpc_core::Clamp(
-      options.tcp_read_chunk_size, options.tcp_min_read_chunk_size,
-      options.tcp_max_read_chunk_size);
-
-  value = config.GetVoidPointer(GRPC_ARG_RESOURCE_QUOTA);
-  if (value != nullptr) {
-    options.resource_quota =
-        reinterpret_cast<grpc_core::ResourceQuota*>(value)->Ref();
-  }
-  value = config.GetVoidPointer(GRPC_ARG_SOCKET_MUTATOR);
-  if (value != nullptr) {
-    options.socket_mutator =
-        grpc_socket_mutator_ref(static_cast<grpc_socket_mutator*>(value));
-  }
-  return options;
-}
-
-#endif /* GRPC_POSIX_SOCKET_TCP */
-
-#ifdef GRPC_POSIX_SOCKETUTILS
 
 int grpc_accept4(int sockfd, grpc_resolved_address* resolved_addr, int nonblock,
                  int cloexec) {

--- a/src/core/lib/iomgr/tcp_client.cc
+++ b/src/core/lib/iomgr/tcp_client.cc
@@ -22,13 +22,14 @@
 
 grpc_tcp_client_vtable* grpc_tcp_client_impl;
 
-int64_t grpc_tcp_client_connect(
-    grpc_closure* on_connect, grpc_endpoint** endpoint,
-    grpc_pollset_set* interested_parties,
-    const grpc_event_engine::experimental::EndpointConfig& config,
-    const grpc_resolved_address* addr, grpc_core::Timestamp deadline) {
+int64_t grpc_tcp_client_connect(grpc_closure* on_connect,
+                                grpc_endpoint** endpoint,
+                                grpc_pollset_set* interested_parties,
+                                const grpc_channel_args* channel_args,
+                                const grpc_resolved_address* addr,
+                                grpc_core::Timestamp deadline) {
   return grpc_tcp_client_impl->connect(on_connect, endpoint, interested_parties,
-                                       config, addr, deadline);
+                                       channel_args, addr, deadline);
 }
 
 bool grpc_tcp_client_cancel_connect(int64_t connection_handle) {

--- a/src/core/lib/iomgr/tcp_client.h
+++ b/src/core/lib/iomgr/tcp_client.h
@@ -21,7 +21,6 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/time.h>
 
@@ -31,11 +30,11 @@
 #include "src/core/lib/resource_quota/memory_quota.h"
 
 typedef struct grpc_tcp_client_vtable {
-  int64_t (*connect)(
-      grpc_closure* on_connect, grpc_endpoint** endpoint,
-      grpc_pollset_set* interested_parties,
-      const grpc_event_engine::experimental::EndpointConfig& config,
-      const grpc_resolved_address* addr, grpc_core::Timestamp deadline);
+  int64_t (*connect)(grpc_closure* on_connect, grpc_endpoint** endpoint,
+                     grpc_pollset_set* interested_parties,
+                     const grpc_channel_args* channel_args,
+                     const grpc_resolved_address* addr,
+                     grpc_core::Timestamp deadline);
   bool (*cancel_connect)(int64_t connection_handle);
 } grpc_tcp_client_vtable;
 
@@ -46,11 +45,12 @@ typedef struct grpc_tcp_client_vtable {
    in this connection being established (in order to continue their work). It
    returns a handle to the connect operation which can be used to cancel the
    connection attempt. */
-int64_t grpc_tcp_client_connect(
-    grpc_closure* on_connect, grpc_endpoint** endpoint,
-    grpc_pollset_set* interested_parties,
-    const grpc_event_engine::experimental::EndpointConfig& config,
-    const grpc_resolved_address* addr, grpc_core::Timestamp deadline);
+int64_t grpc_tcp_client_connect(grpc_closure* on_connect,
+                                grpc_endpoint** endpoint,
+                                grpc_pollset_set* interested_parties,
+                                const grpc_channel_args* channel_args,
+                                const grpc_resolved_address* addr,
+                                grpc_core::Timestamp deadline);
 
 // Returns true if a connect attempt corresponding to the provided handle
 // is successfully cancelled. Otherwise it returns false. If the connect

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -27,12 +27,12 @@
 #include <netinet/in.h>
 #include <string.h>
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/iomgr/cfstream_handle.h"
 #include "src/core/lib/iomgr/closure.h"
@@ -149,11 +149,11 @@ static void ParseResolvedAddress(const grpc_resolved_address* addr,
   *port = grpc_sockaddr_get_port(addr);
 }
 
-static int64_t CFStreamClientConnect(
-    grpc_closure* closure, grpc_endpoint** ep,
-    grpc_pollset_set* interested_parties,
-    const grpc_event_engine::experimental::EndpointConfig& /*config*/,
-    const grpc_resolved_address* resolved_addr, grpc_core::Timestamp deadline) {
+static int64_t CFStreamClientConnect(grpc_closure* closure, grpc_endpoint** ep,
+                                     grpc_pollset_set* interested_parties,
+                                     const grpc_channel_args* channel_args,
+                                     const grpc_resolved_address* resolved_addr,
+                                     grpc_core::Timestamp deadline) {
   auto addr_uri = grpc_sockaddr_to_uri(resolved_addr);
   if (!addr_uri.ok()) {
     grpc_error_handle error =

--- a/src/core/lib/iomgr/tcp_client_posix.h
+++ b/src/core/lib/iomgr/tcp_client_posix.h
@@ -23,24 +23,23 @@
 
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/ev_posix.h"
-#include "src/core/lib/iomgr/socket_utils_posix.h"
 #include "src/core/lib/iomgr/tcp_client.h"
 
 /* Create an endpoint from a connected grpc_fd.
 
    fd: a connected FD. Ownership is taken.
-   config: may contain custom settings for the endpoint
+   channel_args: may contain custom settings for the endpoint
    addr_str: destination address in printable format
    slice_allocator: ownership is taken by client.
    Returns: a new endpoint
 */
-grpc_endpoint* grpc_tcp_create_from_fd(
-    grpc_fd* fd, const grpc_event_engine::experimental::EndpointConfig& config,
+grpc_endpoint* grpc_tcp_client_create_from_fd(
+    grpc_fd* fd, const grpc_channel_args* channel_args,
     absl::string_view addr_str);
 
 /* Return a configured, unbound, unconnected TCP client fd.
 
-   options: may contain custom settings for the fd
+   channel_args: may contain custom settings for the fd
    addr: the destination address
    mapped_addr: out parameter. addr mapped to an address appropriate to the
      type of socket FD created. For example, if addr is IPv4 and dual stack
@@ -49,9 +48,8 @@ grpc_endpoint* grpc_tcp_create_from_fd(
    Returns: error, if any. Out parameters are not set on error
 */
 grpc_error_handle grpc_tcp_client_prepare_fd(
-    const grpc_core::PosixTcpOptions& options,
-    const grpc_resolved_address* addr, grpc_resolved_address* mapped_addr,
-    int* fd);
+    const grpc_channel_args* channel_args, const grpc_resolved_address* addr,
+    grpc_resolved_address* mapped_addr, int* fd);
 
 /* Connect a configured TCP client fd.
 
@@ -59,14 +57,13 @@ grpc_error_handle grpc_tcp_client_prepare_fd(
      connection being established (in order to continue their work
    closure: called when complete. On success, *ep will be set.
    fd: an FD returned from grpc_tcp_client_prepare_fd().
-   options: may contain custom settings for the endpoint
+   channel_args: may contain custom settings for the endpoint
    deadline: connection deadline
    ep: out parameter. Set before closure is called if successful
 */
 int64_t grpc_tcp_client_create_from_prepared_fd(
     grpc_pollset_set* interested_parties, grpc_closure* closure, const int fd,
-    const grpc_core::PosixTcpOptions& options,
-    const grpc_resolved_address* addr, grpc_core::Timestamp deadline,
-    grpc_endpoint** ep);
+    const grpc_channel_args* channel_args, const grpc_resolved_address* addr,
+    grpc_core::Timestamp deadline, grpc_endpoint** ep);
 
 #endif /* GRPC_CORE_LIB_IOMGR_TCP_CLIENT_POSIX_H */

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -47,6 +47,7 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/string.h"
@@ -472,12 +473,8 @@ bool ExperimentalTcpFrameSizeTuningEnabled() {
 }
 
 struct grpc_tcp {
-  explicit grpc_tcp(const grpc_core::PosixTcpOptions& tcp_options)
-      : min_read_chunk_size(tcp_options.tcp_min_read_chunk_size),
-        max_read_chunk_size(tcp_options.tcp_max_read_chunk_size),
-        tcp_zerocopy_send_ctx(
-            tcp_options.tcp_tx_zerocopy_max_simultaneous_sends,
-            tcp_options.tcp_tx_zerocopy_send_bytes_threshold) {}
+  grpc_tcp(int max_sends, size_t send_bytes_threshold)
+      : tcp_zerocopy_send_ctx(max_sends, send_bytes_threshold) {}
   grpc_endpoint base;
   grpc_fd* em_fd;
   int fd;
@@ -1872,16 +1869,72 @@ static const grpc_endpoint_vtable vtable = {tcp_read,
                                             tcp_get_fd,
                                             tcp_can_track_err};
 
+#define MAX_CHUNK_SIZE (32 * 1024 * 1024)
+
 grpc_endpoint* grpc_tcp_create(grpc_fd* em_fd,
-                               const grpc_core::PosixTcpOptions& options,
+                               const grpc_channel_args* channel_args,
                                absl::string_view peer_string) {
-  grpc_tcp* tcp = new grpc_tcp(options);
+  static constexpr bool kZerocpTxEnabledDefault = false;
+  int tcp_read_chunk_size = GRPC_TCP_DEFAULT_READ_SLICE_SIZE;
+  int tcp_max_read_chunk_size = 4 * 1024 * 1024;
+  int tcp_min_read_chunk_size = 256;
+  bool tcp_tx_zerocopy_enabled = kZerocpTxEnabledDefault;
+  int tcp_tx_zerocopy_send_bytes_thresh =
+      grpc_core::TcpZerocopySendCtx::kDefaultSendBytesThreshold;
+  int tcp_tx_zerocopy_max_simult_sends =
+      grpc_core::TcpZerocopySendCtx::kDefaultMaxSends;
+  if (channel_args != nullptr) {
+    for (size_t i = 0; i < channel_args->num_args; i++) {
+      if (0 ==
+          strcmp(channel_args->args[i].key, GRPC_ARG_TCP_READ_CHUNK_SIZE)) {
+        grpc_integer_options options = {tcp_read_chunk_size, 1, MAX_CHUNK_SIZE};
+        tcp_read_chunk_size =
+            grpc_channel_arg_get_integer(&channel_args->args[i], options);
+      } else if (0 == strcmp(channel_args->args[i].key,
+                             GRPC_ARG_TCP_MIN_READ_CHUNK_SIZE)) {
+        grpc_integer_options options = {tcp_read_chunk_size, 1, MAX_CHUNK_SIZE};
+        tcp_min_read_chunk_size =
+            grpc_channel_arg_get_integer(&channel_args->args[i], options);
+      } else if (0 == strcmp(channel_args->args[i].key,
+                             GRPC_ARG_TCP_MAX_READ_CHUNK_SIZE)) {
+        grpc_integer_options options = {tcp_read_chunk_size, 1, MAX_CHUNK_SIZE};
+        tcp_max_read_chunk_size =
+            grpc_channel_arg_get_integer(&channel_args->args[i], options);
+      } else if (0 == strcmp(channel_args->args[i].key,
+                             GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED)) {
+        tcp_tx_zerocopy_enabled = grpc_channel_arg_get_bool(
+            &channel_args->args[i], kZerocpTxEnabledDefault);
+      } else if (0 == strcmp(channel_args->args[i].key,
+                             GRPC_ARG_TCP_TX_ZEROCOPY_SEND_BYTES_THRESHOLD)) {
+        grpc_integer_options options = {
+            grpc_core::TcpZerocopySendCtx::kDefaultSendBytesThreshold, 0,
+            INT_MAX};
+        tcp_tx_zerocopy_send_bytes_thresh =
+            grpc_channel_arg_get_integer(&channel_args->args[i], options);
+      } else if (0 == strcmp(channel_args->args[i].key,
+                             GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS)) {
+        grpc_integer_options options = {
+            grpc_core::TcpZerocopySendCtx::kDefaultMaxSends, 0, INT_MAX};
+        tcp_tx_zerocopy_max_simult_sends =
+            grpc_channel_arg_get_integer(&channel_args->args[i], options);
+      }
+    }
+  }
+
+  if (tcp_min_read_chunk_size > tcp_max_read_chunk_size) {
+    tcp_min_read_chunk_size = tcp_max_read_chunk_size;
+  }
+  tcp_read_chunk_size = grpc_core::Clamp(
+      tcp_read_chunk_size, tcp_min_read_chunk_size, tcp_max_read_chunk_size);
+
+  grpc_tcp* tcp = new grpc_tcp(tcp_tx_zerocopy_max_simult_sends,
+                               tcp_tx_zerocopy_send_bytes_thresh);
   tcp->base.vtable = &vtable;
   tcp->peer_string = std::string(peer_string);
   tcp->fd = grpc_fd_wrapped_fd(em_fd);
-  GPR_ASSERT(options.resource_quota != nullptr);
-  tcp->memory_owner =
-      options.resource_quota->memory_quota()->CreateMemoryOwner(peer_string);
+  tcp->memory_owner = grpc_core::ResourceQuotaFromChannelArgs(channel_args)
+                          ->memory_quota()
+                          ->CreateMemoryOwner(peer_string);
   tcp->self_reservation = tcp->memory_owner.MakeReservation(sizeof(grpc_tcp));
   grpc_resolved_address resolved_local_addr;
   memset(&resolved_local_addr, 0, sizeof(resolved_local_addr));
@@ -1900,7 +1953,9 @@ grpc_endpoint* grpc_tcp_create(grpc_fd* em_fd,
   tcp->current_zerocopy_send = nullptr;
   tcp->release_fd_cb = nullptr;
   tcp->release_fd = nullptr;
-  tcp->target_length = static_cast<double>(options.tcp_read_chunk_size);
+  tcp->target_length = static_cast<double>(tcp_read_chunk_size);
+  tcp->min_read_chunk_size = tcp_min_read_chunk_size;
+  tcp->max_read_chunk_size = tcp_max_read_chunk_size;
   tcp->bytes_read_this_round = 0;
   /* Will be set to false by the very first endpoint read function */
   tcp->is_first_read = true;
@@ -1911,8 +1966,7 @@ grpc_endpoint* grpc_tcp_create(grpc_fd* em_fd,
   tcp->outgoing_buffer_arg = nullptr;
   tcp->frame_size_tuning_enabled = ExperimentalTcpFrameSizeTuningEnabled();
   tcp->min_progress_size = 1;
-  if (options.tcp_tx_zero_copy_enabled &&
-      !tcp->tcp_zerocopy_send_ctx.memory_limited()) {
+  if (tcp_tx_zerocopy_enabled && !tcp->tcp_zerocopy_send_ctx.memory_limited()) {
 #ifdef GRPC_LINUX_ERRQUEUE
     const int enable = 1;
     auto err =

--- a/src/core/lib/iomgr/tcp_posix.h
+++ b/src/core/lib/iomgr/tcp_posix.h
@@ -36,14 +36,12 @@
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/ev_posix.h"
 #include "src/core/lib/iomgr/port.h"
-#include "src/core/lib/iomgr/socket_utils_posix.h"
 
 extern grpc_core::TraceFlag grpc_tcp_trace;
 
 /// Create a tcp endpoint given a file desciptor and a read slice size.
 /// Takes ownership of \a fd. Takes ownership of the \a slice_allocator.
-grpc_endpoint* grpc_tcp_create(grpc_fd* fd,
-                               const grpc_core::PosixTcpOptions& options,
+grpc_endpoint* grpc_tcp_create(grpc_fd* fd, const grpc_channel_args* args,
                                absl::string_view peer_string);
 
 /// Return the tcp endpoint's fd, or -1 if this is not available. Does not

--- a/src/core/lib/iomgr/tcp_server.cc
+++ b/src/core/lib/iomgr/tcp_server.cc
@@ -22,11 +22,10 @@
 
 grpc_tcp_server_vtable* grpc_tcp_server_impl;
 
-grpc_error_handle grpc_tcp_server_create(
-    grpc_closure* shutdown_complete,
-    const grpc_event_engine::experimental::EndpointConfig& config,
-    grpc_tcp_server** server) {
-  return grpc_tcp_server_impl->create(shutdown_complete, config, server);
+grpc_error_handle grpc_tcp_server_create(grpc_closure* shutdown_complete,
+                                         const grpc_channel_args* args,
+                                         grpc_tcp_server** server) {
+  return grpc_tcp_server_impl->create(shutdown_complete, args, server);
 }
 
 void grpc_tcp_server_start(grpc_tcp_server* server,

--- a/src/core/lib/iomgr/tcp_server.h
+++ b/src/core/lib/iomgr/tcp_server.h
@@ -23,7 +23,6 @@
 
 #include <vector>
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
 
@@ -64,10 +63,9 @@ class TcpServerFdHandler {
 }  // namespace grpc_core
 
 typedef struct grpc_tcp_server_vtable {
-  grpc_error_handle (*create)(
-      grpc_closure* shutdown_complete,
-      const grpc_event_engine::experimental::EndpointConfig& config,
-      grpc_tcp_server** server);
+  grpc_error_handle (*create)(grpc_closure* shutdown_complete,
+                              const grpc_channel_args* args,
+                              grpc_tcp_server** server);
   void (*start)(grpc_tcp_server* server,
                 const std::vector<grpc_pollset*>* pollsets,
                 grpc_tcp_server_cb on_accept_cb, void* cb_arg);
@@ -88,10 +86,9 @@ typedef struct grpc_tcp_server_vtable {
    If shutdown_complete is not NULL, it will be used by
    grpc_tcp_server_unref() when the ref count reaches zero.
    Takes ownership of the slice_allocator_factory. */
-grpc_error_handle grpc_tcp_server_create(
-    grpc_closure* shutdown_complete,
-    const grpc_event_engine::experimental::EndpointConfig& config,
-    grpc_tcp_server** server);
+grpc_error_handle grpc_tcp_server_create(grpc_closure* shutdown_complete,
+                                         const grpc_channel_args* args,
+                                         grpc_tcp_server** server);
 
 /* Start listening to bound ports */
 void grpc_tcp_server_start(grpc_tcp_server* server,

--- a/src/core/lib/iomgr/tcp_server_utils_posix.h
+++ b/src/core/lib/iomgr/tcp_server_utils_posix.h
@@ -90,8 +90,8 @@ struct grpc_tcp_server {
   /* next pollset to assign a channel to */
   gpr_atm next_pollset_to_assign = 0;
 
-  /* Contains config extracted from channel args for this server */
-  grpc_core::PosixTcpOptions options;
+  /* channel args for this server */
+  grpc_channel_args* channel_args = nullptr;
 
   /* a handler for external connections, owned */
   grpc_core::TcpServerFdHandler* fd_handler = nullptr;

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -178,15 +178,15 @@ grpc_error_handle grpc_tcp_server_prepare_socket(
     if (!GRPC_ERROR_IS_NONE(err)) goto error;
     err = grpc_set_socket_reuse_addr(fd, 1);
     if (!GRPC_ERROR_IS_NONE(err)) goto error;
-    err =
-        grpc_set_socket_tcp_user_timeout(fd, s->options, false /* is_client */);
+    err = grpc_set_socket_tcp_user_timeout(fd, s->channel_args,
+                                           false /* is_client */);
     if (!GRPC_ERROR_IS_NONE(err)) goto error;
   }
   err = grpc_set_socket_no_sigpipe_if_possible(fd);
   if (!GRPC_ERROR_IS_NONE(err)) goto error;
 
   err = grpc_apply_socket_mutator_in_args(fd, GRPC_FD_SERVER_LISTENER_USAGE,
-                                          s->options);
+                                          s->channel_args);
   if (!GRPC_ERROR_IS_NONE(err)) goto error;
 
   if (bind(fd, reinterpret_cast<grpc_sockaddr*>(const_cast<char*>(addr->addr)),

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -29,7 +29,6 @@
 
 #include "absl/strings/str_cat.h"
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/log_windows.h>
@@ -38,6 +37,7 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/iomgr/iocp_windows.h"
 #include "src/core/lib/iomgr/pollset_windows.h"
 #include "src/core/lib/iomgr/resolve_address.h"
@@ -45,12 +45,9 @@
 #include "src/core/lib/iomgr/socket_windows.h"
 #include "src/core/lib/iomgr/tcp_server.h"
 #include "src/core/lib/iomgr/tcp_windows.h"
-#include "src/core/lib/resource_quota/api.h"
 #include "src/core/lib/slice/slice_internal.h"
 
 #define MIN_SAFE_ACCEPT_QUEUE_SIZE 100
-
-using ::grpc_event_engine::experimental::EndpointConfig;
 
 /* one listening port */
 typedef struct grpc_tcp_listener grpc_tcp_listener;
@@ -97,14 +94,17 @@ struct grpc_tcp_server {
 
   /* shutdown callback */
   grpc_closure* shutdown_complete;
+
+  grpc_channel_args* channel_args;
 };
 
 /* Public function. Allocates the proper data structures to hold a
    grpc_tcp_server. */
 static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
-                                           const EndpointConfig& config,
+                                           const grpc_channel_args* args,
                                            grpc_tcp_server** server) {
   grpc_tcp_server* s = (grpc_tcp_server*)gpr_malloc(sizeof(grpc_tcp_server));
+  s->channel_args = grpc_channel_args_copy(args);
   gpr_ref_init(&s->refs, 1);
   gpr_mu_init(&s->mu);
   s->active_ports = 0;
@@ -132,6 +132,7 @@ static void destroy_server(void* arg, grpc_error_handle error) {
     grpc_winsocket_destroy(sp->socket);
     gpr_free(sp);
   }
+  grpc_channel_args_destroy(s->channel_args);
   gpr_mu_destroy(&s->mu);
   gpr_free(s);
 }
@@ -362,7 +363,7 @@ static void on_accept(void* arg, grpc_error_handle error) {
       }
       std::string fd_name = absl::StrCat("tcp_server:", peer_name_string);
       ep = grpc_tcp_create(grpc_winsocket_create(sock, fd_name.c_str()),
-                           peer_name_string);
+                           sp->server->channel_args, peer_name_string);
     } else {
       closesocket(sock);
     }

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -505,6 +505,7 @@ static grpc_endpoint_vtable vtable = {win_read,
                                       win_can_track_err};
 
 grpc_endpoint* grpc_tcp_create(grpc_winsocket* socket,
+                               grpc_channel_args* channel_args,
                                absl::string_view peer_string) {
   // TODO(jtattermusch): C++ize grpc_tcp and its dependencies (i.e. add
   // constructors) to ensure proper initialization

--- a/src/core/lib/iomgr/tcp_windows.h
+++ b/src/core/lib/iomgr/tcp_windows.h
@@ -41,6 +41,7 @@
  * Takes ownership of the handle.
  */
 grpc_endpoint* grpc_tcp_create(grpc_winsocket* socket,
+                               grpc_channel_args* channel_args,
                                absl::string_view peer_string);
 
 grpc_error_handle grpc_tcp_prepare_socket(SOCKET sock);

--- a/src/core/lib/resource_quota/api.cc
+++ b/src/core/lib/resource_quota/api.cc
@@ -44,15 +44,6 @@ ResourceQuotaRefPtr ResourceQuotaFromChannelArgs(
       ->Ref();
 }
 
-ResourceQuotaRefPtr ResourceQuotaFromEndpointConfig(
-    const grpc_event_engine::experimental::EndpointConfig& config) {
-  void* value = config.GetVoidPointer(GRPC_ARG_RESOURCE_QUOTA);
-  if (value != nullptr) {
-    return reinterpret_cast<ResourceQuota*>(value)->Ref();
-  }
-  return nullptr;
-}
-
 ChannelArgs EnsureResourceQuotaInChannelArgs(const ChannelArgs& args) {
   if (args.GetObject<ResourceQuota>() != nullptr) return args;
   // If there's no existing quota, add it to the default one - shared between

--- a/src/core/lib/resource_quota/api.h
+++ b/src/core/lib/resource_quota/api.h
@@ -19,7 +19,6 @@
 
 #include <stddef.h>
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/impl/codegen/grpc_types.h>
 
 #include "src/core/lib/config/core_configuration.h"
@@ -36,11 +35,6 @@ constexpr size_t kResourceQuotaChannelSize = 34 * 1024;
 // Retrieve the resource quota from the channel args.
 // UB if not set.
 ResourceQuotaRefPtr ResourceQuotaFromChannelArgs(const grpc_channel_args* args);
-
-// Retrieve the resource quota from the EndpointConfig.
-// Returns nullptr if not set.
-ResourceQuotaRefPtr ResourceQuotaFromEndpointConfig(
-    const grpc_event_engine::experimental::EndpointConfig& config);
 
 void RegisterResourceQuota(CoreConfiguration::Builder* builder);
 

--- a/src/core/lib/transport/tcp_connect_handshaker.cc
+++ b/src/core/lib/transport/tcp_connect_handshaker.cc
@@ -35,7 +35,6 @@
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/config/core_configuration.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/sync.h"
@@ -155,10 +154,9 @@ void TCPConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
   // we don't want to pass args->endpoint directly.
   // Instead pass endpoint_ and swap this endpoint to
   // args endpoint on success.
-  grpc_tcp_client_connect(
-      &connected_, &endpoint_to_destroy_, interested_parties_,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(args->args),
-      &addr_, args->deadline);
+  grpc_tcp_client_connect(&connected_, &endpoint_to_destroy_,
+                          interested_parties_, args->args.ToC().get(), &addr_,
+                          args->deadline);
 }
 
 void TCPConnectHandshaker::Connected(void* arg, grpc_error_handle error) {
@@ -181,9 +179,8 @@ void TCPConnectHandshaker::Connected(void* arg, grpc_error_handle error) {
         self->shutdown_ = true;
         self->FinishLocked(error);
       } else {
-        // The on_handshake_done_ is already as part of shutdown when
-        // connecting So nothing to be done here other than unrefing the
-        // error.
+        // The on_handshake_done_ is already as part of shutdown when connecting
+        // So nothing to be done here other than unrefing the error.
         GRPC_ERROR_UNREF(error);
       }
       return;

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -36,7 +36,6 @@
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -314,11 +313,11 @@ static void sched_connect(grpc_closure* closure, grpc_endpoint** ep,
       GRPC_CLOSURE_CREATE(do_connect, fc, grpc_schedule_on_exec_ctx));
 }
 
-static int64_t my_tcp_client_connect(
-    grpc_closure* closure, grpc_endpoint** ep,
-    grpc_pollset_set* /*interested_parties*/,
-    const grpc_event_engine::experimental::EndpointConfig& /*config*/,
-    const grpc_resolved_address* /*addr*/, grpc_core::Timestamp deadline) {
+static int64_t my_tcp_client_connect(grpc_closure* closure, grpc_endpoint** ep,
+                                     grpc_pollset_set* /*interested_parties*/,
+                                     const grpc_channel_args* /*channel_args*/,
+                                     const grpc_resolved_address* /*addr*/,
+                                     grpc_core::Timestamp deadline) {
   sched_connect(closure, ep, deadline.as_timespec(GPR_CLOCK_MONOTONIC));
   return 0;
 }

--- a/test/core/event_engine/endpoint_config_test.cc
+++ b/test/core/event_engine/endpoint_config_test.cc
@@ -26,17 +26,16 @@
 using ::grpc_event_engine::experimental::ChannelArgsEndpointConfig;
 
 TEST(EndpointConfigTest, CanSRetrieveValuesFromChannelArgs) {
-  grpc_core::ChannelArgs args;
-  args = args.Set("arst", 3);
-  ChannelArgsEndpointConfig config(args);
-  EXPECT_EQ(*config.GetInt("arst"), 3);
+  grpc_arg arg = grpc_channel_arg_integer_create(const_cast<char*>("arst"), 3);
+  const grpc_channel_args args = {1, &arg};
+  ChannelArgsEndpointConfig config(&args);
+  EXPECT_EQ(absl::get<int>(config.Get("arst")), 3);
 }
 
-TEST(EndpointConfigTest, ReturnsNoValueForMissingKeys) {
-  ChannelArgsEndpointConfig config;
-  EXPECT_TRUE(!config.GetInt("nonexistent").has_value());
-  EXPECT_TRUE(!config.GetString("nonexistent").has_value());
-  EXPECT_EQ(config.GetVoidPointer("nonexistent"), nullptr);
+TEST(EndpointConfigTest, ReturnsMonostateForMissingKeys) {
+  ChannelArgsEndpointConfig config(nullptr);
+  EXPECT_TRUE(
+      absl::holds_alternative<absl::monostate>(config.Get("nonexistent")));
 }
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/test_suite/event_engine_test_utils.cc
+++ b/test/core/event_engine/test_suite/event_engine_test_utils.cc
@@ -137,11 +137,11 @@ absl::Status ConnectionManager::BindAndStartListener(
   EventEngine* event_engine = listener_type_oracle ? oracle_event_engine_.get()
                                                    : test_event_engine_.get();
 
-  ChannelArgsEndpointConfig config;
   auto status = event_engine->CreateListener(
       std::move(accept_cb),
-      [](absl::Status status) { GPR_ASSERT(status.ok()); }, config,
-      absl::make_unique<grpc_core::MemoryQuota>("foo"));
+      [](absl::Status status) { GPR_ASSERT(status.ok()); },
+      ChannelArgsEndpointConfig(nullptr),
+      std::make_unique<grpc_core::MemoryQuota>("foo"));
   if (!status.ok()) {
     return status.status();
   }
@@ -174,7 +174,6 @@ ConnectionManager::CreateConnection(std::string target_addr,
       absl::StrCat("connection-", std::to_string(num_processed_connections_++));
   EventEngine* event_engine = client_type_oracle ? oracle_event_engine_.get()
                                                  : test_event_engine_.get();
-  ChannelArgsEndpointConfig config;
   event_engine->Connect(
       [this](absl::StatusOr<std::unique_ptr<Endpoint>> status) {
         if (!status.ok()) {
@@ -185,7 +184,7 @@ ConnectionManager::CreateConnection(std::string target_addr,
           last_in_progress_connection_.SetClientEndpoint(std::move(*status));
         }
       },
-      URIToResolvedAddress(target_addr), config,
+      URIToResolvedAddress(target_addr), ChannelArgsEndpointConfig(nullptr),
       memory_quota_->CreateMemoryAllocator(conn_name), timeout);
 
   auto client_endpoint = last_in_progress_connection_.GetClientEndpoint();

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
@@ -30,7 +30,6 @@
 
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/tcp_client.h"
@@ -104,12 +103,12 @@ static void must_fail(void* arg, grpc_error_handle error) {
   /* connect to it */
   GPR_ASSERT(getsockname(svr_fd, (struct sockaddr*)addr, (socklen_t*)&resolved_addr->len) == 0);
   GRPC_CLOSURE_INIT(&done, must_succeed, nullptr, grpc_schedule_on_exec_ctx);
-  auto args =
-      grpc_core::CoreConfiguration::Get().channel_args_preconditioning().PreconditionChannelArgs(
-          nullptr);
-  grpc_tcp_client_connect(&done, &g_connecting, nullptr,
-                          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-                          &*resolved_addr, grpc_core::Timestamp::InfFuture());
+  auto args = grpc_core::CoreConfiguration::Get()
+                  .channel_args_preconditioning()
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  grpc_tcp_client_connect(&done, &g_connecting, nullptr, args.get(), &*resolved_addr,
+                          grpc_core::Timestamp::InfFuture());
 
   /* await the connection */
   do {
@@ -161,12 +160,12 @@ static void must_fail(void* arg, grpc_error_handle error) {
 
   /* connect to a broken address */
   GRPC_CLOSURE_INIT(&done, must_fail, nullptr, grpc_schedule_on_exec_ctx);
-  auto args =
-      grpc_core::CoreConfiguration::Get().channel_args_preconditioning().PreconditionChannelArgs(
-          nullptr);
-  grpc_tcp_client_connect(&done, &g_connecting, nullptr,
-                          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-                          &*resolved_addr, grpc_core::Timestamp::InfFuture());
+  auto args = grpc_core::CoreConfiguration::Get()
+                  .channel_args_preconditioning()
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  grpc_tcp_client_connect(&done, &g_connecting, nullptr, args.get(), &*resolved_addr,
+                          grpc_core::Timestamp::InfFuture());
 
   grpc_core::ExecCtx::Get()->Flush();
 

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -32,7 +32,6 @@
 
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/tcp_client.h"
@@ -126,12 +125,12 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   /* connect to it */
   XCTAssertEqual(getsockname(svr_fd, (struct sockaddr *)addr, (socklen_t *)&resolved_addr->len), 0);
   init_event_closure(&done, &connected_promise);
-  auto args =
-      grpc_core::CoreConfiguration::Get().channel_args_preconditioning().PreconditionChannelArgs(
-          nullptr);
-  grpc_tcp_client_connect(&done, &ep_, nullptr,
-                          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-                          &*resolved_addr, grpc_core::Timestamp::InfFuture());
+  auto args = grpc_core::CoreConfiguration::Get()
+                  .channel_args_preconditioning()
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  grpc_tcp_client_connect(&done, &ep_, nullptr, args.get(), &*resolved_addr,
+                          grpc_core::Timestamp::InfFuture());
 
   /* await the connection */
   do {

--- a/test/core/iomgr/tcp_client_posix_test.cc
+++ b/test/core/iomgr/tcp_client_posix_test.cc
@@ -37,7 +37,6 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/core/lib/iomgr/pollset_set.h"
 #include "src/core/lib/iomgr/socket_utils_posix.h"
@@ -117,9 +116,8 @@ void test_succeeds(void) {
                                     .channel_args_preconditioning()
                                     .PreconditionChannelArgs(nullptr);
   int64_t connection_handle = grpc_tcp_client_connect(
-      &done, &g_connecting, g_pollset_set,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-      &resolved_addr, grpc_core::Timestamp::InfFuture());
+      &done, &g_connecting, g_pollset_set, args.ToC().get(), &resolved_addr,
+      grpc_core::Timestamp::InfFuture());
   /* await the connection */
   do {
     resolved_addr.len = static_cast<socklen_t>(sizeof(addr));
@@ -171,9 +169,8 @@ void test_fails(void) {
   /* connect to a broken address */
   GRPC_CLOSURE_INIT(&done, must_fail, nullptr, grpc_schedule_on_exec_ctx);
   int64_t connection_handle = grpc_tcp_client_connect(
-      &done, &g_connecting, g_pollset_set,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(),
-      &resolved_addr, grpc_core::Timestamp::InfFuture());
+      &done, &g_connecting, g_pollset_set, nullptr, &resolved_addr,
+      grpc_core::Timestamp::InfFuture());
   gpr_mu_lock(g_mu);
 
   /* wait for the connection callback to finish */
@@ -235,9 +232,8 @@ void test_connect_cancellation_succeeds(void) {
                                     .channel_args_preconditioning()
                                     .PreconditionChannelArgs(nullptr);
   int64_t connection_handle = grpc_tcp_client_connect(
-      &done, &g_connecting, g_pollset_set,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-      &resolved_addr, grpc_core::Timestamp::InfFuture());
+      &done, &g_connecting, g_pollset_set, args.ToC().get(), &resolved_addr,
+      grpc_core::Timestamp::InfFuture());
   ASSERT_GT(connection_handle, 0);
   ASSERT_EQ(grpc_tcp_client_cancel_connect(connection_handle), true);
   close(svr_fd);
@@ -261,10 +257,8 @@ void test_fails_bad_addr_no_leak(void) {
   gpr_mu_unlock(g_mu);
   // connect to an invalid address.
   GRPC_CLOSURE_INIT(&done, must_fail, nullptr, grpc_schedule_on_exec_ctx);
-  grpc_tcp_client_connect(
-      &done, &g_connecting, g_pollset_set,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(),
-      &resolved_addr, grpc_core::Timestamp::InfFuture());
+  grpc_tcp_client_connect(&done, &g_connecting, g_pollset_set, nullptr,
+                          &resolved_addr, grpc_core::Timestamp::InfFuture());
   gpr_mu_lock(g_mu);
   while (g_connections_complete == connections_complete_before) {
     grpc_pollset_worker* worker = nullptr;

--- a/test/core/iomgr/tcp_posix_test.cc
+++ b/test/core/iomgr/tcp_posix_test.cc
@@ -16,7 +16,6 @@
  *
  */
 
-#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/port.h"
 
@@ -36,12 +35,10 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/buffer_list.h"
 #include "src/core/lib/iomgr/ev_posix.h"
 #include "src/core/lib/iomgr/sockaddr_posix.h"
-#include "src/core/lib/iomgr/socket_utils_posix.h"
 #include "src/core/lib/iomgr/tcp_posix.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "test/core/iomgr/endpoint_tests.h"
@@ -234,12 +231,8 @@ static void read_test(size_t num_bytes, size_t slice_size,
   a[1].value.pointer.p = grpc_resource_quota_create("test");
   a[1].value.pointer.vtable = grpc_resource_quota_arg_vtable();
   grpc_channel_args args = {GPR_ARRAY_SIZE(a), a};
-  ep = grpc_tcp_create(
-      grpc_fd_create(sv[1], "read_test", false),
-      TcpOptionsFromEndpointConfig(
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-              grpc_core::ChannelArgs::FromC(&args))),
-      "test");
+  ep =
+      grpc_tcp_create(grpc_fd_create(sv[1], "read_test", false), &args, "test");
   grpc_endpoint_add_to_pollset(ep, g_pollset);
 
   written_bytes = fill_socket_partial(sv[0], num_bytes);
@@ -298,12 +291,8 @@ static void large_read_test(size_t slice_size, int min_progress_size) {
   a[1].value.pointer.p = grpc_resource_quota_create("test");
   a[1].value.pointer.vtable = grpc_resource_quota_arg_vtable();
   grpc_channel_args args = {GPR_ARRAY_SIZE(a), a};
-  ep = grpc_tcp_create(
-      grpc_fd_create(sv[1], "large_read_test", false),
-      TcpOptionsFromEndpointConfig(
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-              grpc_core::ChannelArgs::FromC(&args))),
-      "test");
+  ep = grpc_tcp_create(grpc_fd_create(sv[1], "large_read_test", false), &args,
+                       "test");
   grpc_endpoint_add_to_pollset(ep, g_pollset);
 
   written_bytes = fill_socket(sv[0]);
@@ -472,12 +461,8 @@ static void write_test(size_t num_bytes, size_t slice_size,
   a[1].value.pointer.p = grpc_resource_quota_create("test");
   a[1].value.pointer.vtable = grpc_resource_quota_arg_vtable();
   grpc_channel_args args = {GPR_ARRAY_SIZE(a), a};
-  ep = grpc_tcp_create(
-      grpc_fd_create(sv[1], "write_test", collect_timestamps),
-      TcpOptionsFromEndpointConfig(
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-              grpc_core::ChannelArgs::FromC(&args))),
-      "test");
+  ep = grpc_tcp_create(grpc_fd_create(sv[1], "write_test", collect_timestamps),
+                       &args, "test");
   grpc_endpoint_add_to_pollset(ep, g_pollset);
 
   state.ep = ep;
@@ -560,12 +545,8 @@ static void release_fd_test(size_t num_bytes, size_t slice_size) {
   a[1].value.pointer.p = grpc_resource_quota_create("test");
   a[1].value.pointer.vtable = grpc_resource_quota_arg_vtable();
   grpc_channel_args args = {GPR_ARRAY_SIZE(a), a};
-  ep = grpc_tcp_create(
-      grpc_fd_create(sv[1], "read_test", false),
-      TcpOptionsFromEndpointConfig(
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-              grpc_core::ChannelArgs::FromC(&args))),
-      "test");
+  ep =
+      grpc_tcp_create(grpc_fd_create(sv[1], "read_test", false), &args, "test");
   GPR_ASSERT(grpc_tcp_fd(ep) == sv[1] && sv[1] >= 0);
   grpc_endpoint_add_to_pollset(ep, g_pollset);
 
@@ -667,18 +648,10 @@ static grpc_endpoint_test_fixture create_fixture_tcp_socketpair(
   a[1].value.pointer.p = grpc_resource_quota_create("test");
   a[1].value.pointer.vtable = grpc_resource_quota_arg_vtable();
   grpc_channel_args args = {GPR_ARRAY_SIZE(a), a};
-  f.client_ep = grpc_tcp_create(
-      grpc_fd_create(sv[0], "fixture:client", false),
-      TcpOptionsFromEndpointConfig(
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-              grpc_core::ChannelArgs::FromC(&args))),
-      "test");
-  f.server_ep = grpc_tcp_create(
-      grpc_fd_create(sv[1], "fixture:server", false),
-      TcpOptionsFromEndpointConfig(
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-              grpc_core::ChannelArgs::FromC(&args))),
-      "test");
+  f.client_ep = grpc_tcp_create(grpc_fd_create(sv[0], "fixture:client", false),
+                                &args, "test");
+  f.server_ep = grpc_tcp_create(grpc_fd_create(sv[1], "fixture:server", false),
+                                &args, "test");
   grpc_endpoint_add_to_pollset(f.client_ep, g_pollset);
   grpc_endpoint_add_to_pollset(f.server_ep, g_pollset);
   grpc_resource_quota_unref(

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -43,7 +43,6 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr.h"
@@ -170,13 +169,9 @@ static void test_no_op(void) {
   grpc_tcp_server* s;
   auto args = grpc_core::CoreConfiguration::Get()
                   .channel_args_preconditioning()
-                  .PreconditionChannelArgs(nullptr);
-  ASSERT_EQ(
-      GRPC_ERROR_NONE,
-      grpc_tcp_server_create(
-          nullptr,
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  ASSERT_EQ(GRPC_ERROR_NONE, grpc_tcp_server_create(nullptr, args.get(), &s));
   grpc_tcp_server_unref(s);
 }
 
@@ -185,13 +180,9 @@ static void test_no_op_with_start(void) {
   grpc_tcp_server* s;
   auto args = grpc_core::CoreConfiguration::Get()
                   .channel_args_preconditioning()
-                  .PreconditionChannelArgs(nullptr);
-  ASSERT_EQ(
-      GRPC_ERROR_NONE,
-      grpc_tcp_server_create(
-          nullptr,
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  ASSERT_EQ(GRPC_ERROR_NONE, grpc_tcp_server_create(nullptr, args.get(), &s));
   LOG_TEST("test_no_op_with_start");
   std::vector<grpc_pollset*> empty_pollset;
   grpc_tcp_server_start(s, &empty_pollset, on_connect, nullptr);
@@ -206,13 +197,9 @@ static void test_no_op_with_port(void) {
   grpc_tcp_server* s;
   auto args = grpc_core::CoreConfiguration::Get()
                   .channel_args_preconditioning()
-                  .PreconditionChannelArgs(nullptr);
-  ASSERT_EQ(
-      GRPC_ERROR_NONE,
-      grpc_tcp_server_create(
-          nullptr,
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  ASSERT_EQ(GRPC_ERROR_NONE, grpc_tcp_server_create(nullptr, args.get(), &s));
   LOG_TEST("test_no_op_with_port");
 
   memset(&resolved_addr, 0, sizeof(resolved_addr));
@@ -234,13 +221,9 @@ static void test_no_op_with_port_and_start(void) {
   grpc_tcp_server* s;
   auto args = grpc_core::CoreConfiguration::Get()
                   .channel_args_preconditioning()
-                  .PreconditionChannelArgs(nullptr);
-  ASSERT_EQ(
-      GRPC_ERROR_NONE,
-      grpc_tcp_server_create(
-          nullptr,
-          grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
+  ASSERT_EQ(GRPC_ERROR_NONE, grpc_tcp_server_create(nullptr, args.get(), &s));
   LOG_TEST("test_no_op_with_port_and_start");
   int port = -1;
 
@@ -338,13 +321,10 @@ static void test_connect(size_t num_connects,
   const unsigned num_ports = 2;
   auto new_channel_args = grpc_core::CoreConfiguration::Get()
                               .channel_args_preconditioning()
-                              .PreconditionChannelArgs(channel_args);
+                              .PreconditionChannelArgs(channel_args)
+                              .ToC();
   ASSERT_EQ(GRPC_ERROR_NONE,
-            grpc_tcp_server_create(
-                nullptr,
-                grpc_event_engine::experimental::ChannelArgsEndpointConfig(
-                    new_channel_args),
-                &s));
+            grpc_tcp_server_create(nullptr, new_channel_args.get(), &s));
   unsigned port_num;
   server_weak_ref weak_ref;
   server_weak_ref_init(&weak_ref);

--- a/test/core/surface/concurrent_connectivity_test.cc
+++ b/test/core/surface/concurrent_connectivity_test.cc
@@ -32,7 +32,6 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -141,11 +140,10 @@ void bad_server_thread(void* vargs) {
   grpc_tcp_server* s;
   auto channel_args = grpc_core::CoreConfiguration::Get()
                           .channel_args_preconditioning()
-                          .PreconditionChannelArgs(nullptr);
-  grpc_error_handle error = grpc_tcp_server_create(
-      nullptr,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(channel_args),
-      &s);
+                          .PreconditionChannelArgs(nullptr)
+                          .ToC();
+  grpc_error_handle error =
+      grpc_tcp_server_create(nullptr, channel_args.get(), &s);
   ASSERT_TRUE(GRPC_ERROR_IS_NONE(error));
   memset(&resolved_addr, 0, sizeof(resolved_addr));
   addr->sa_family = GRPC_AF_INET;

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -31,7 +31,6 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/pollset.h"
@@ -126,11 +125,11 @@ class Client {
     EventState state;
     auto args = CoreConfiguration::Get()
                     .channel_args_preconditioning()
-                    .PreconditionChannelArgs(nullptr);
-    grpc_tcp_client_connect(
-        state.closure(), &endpoint_, pollset_set,
-        grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-        addresses_or->data(), ExecCtx::Get()->Now() + Duration::Seconds(1));
+                    .PreconditionChannelArgs(nullptr)
+                    .ToC();
+    grpc_tcp_client_connect(state.closure(), &endpoint_, pollset_set,
+                            args.get(), addresses_or->data(),
+                            ExecCtx::Get()->Now() + Duration::Seconds(1));
     ASSERT_TRUE(PollUntilDone(&state, Timestamp::InfFuture()));
     ASSERT_EQ(GRPC_ERROR_NONE, state.error());
     grpc_pollset_set_destroy(pollset_set);

--- a/test/core/util/test_tcp_server.cc
+++ b/test/core/util/test_tcp_server.cc
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <memory>
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
@@ -29,9 +30,9 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_args_preconditioning.h"
 #include "src/core/lib/config/core_configuration.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -74,11 +75,10 @@ void test_tcp_server_start(test_tcp_server* server, int port) {
 
   auto args = grpc_core::CoreConfiguration::Get()
                   .channel_args_preconditioning()
-                  .PreconditionChannelArgs(nullptr);
+                  .PreconditionChannelArgs(nullptr)
+                  .ToC();
   grpc_error_handle error = grpc_tcp_server_create(
-      &server->shutdown_complete,
-      grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-      &server->tcp_server);
+      &server->shutdown_complete, args.get(), &server->tcp_server);
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   error =
       grpc_tcp_server_add_port(server->tcp_server, &resolved_addr, &port_added);

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -30,7 +30,6 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 
-#include <grpc/event_engine/endpoint_config.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/atm.h>

--- a/test/cpp/end2end/connection_delay_injector.cc
+++ b/test/cpp/end2end/connection_delay_injector.cc
@@ -21,12 +21,9 @@
 
 #include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/gprpp/sync.h"
-#include "src/core/lib/resource_quota/api.h"
 
 // defined in tcp_client.cc
 extern grpc_tcp_client_vtable* grpc_tcp_client_impl;
-
-using ::grpc_event_engine::experimental::EndpointConfig;
 
 namespace grpc {
 namespace testing {
@@ -44,17 +41,17 @@ ConnectionAttemptInjector* g_injector ABSL_GUARDED_BY(*g_mu) = nullptr;
 
 int64_t TcpConnectWithDelay(grpc_closure* closure, grpc_endpoint** ep,
                             grpc_pollset_set* interested_parties,
-                            const EndpointConfig& config,
+                            const grpc_channel_args* channel_args,
                             const grpc_resolved_address* addr,
                             grpc_core::Timestamp deadline) {
   grpc_core::MutexLock lock(g_mu);
   if (g_injector == nullptr) {
-    g_original_vtable->connect(closure, ep, interested_parties, config, addr,
-                               deadline);
+    g_original_vtable->connect(closure, ep, interested_parties, channel_args,
+                               addr, deadline);
     return 0;
   }
-  g_injector->HandleConnection(closure, ep, interested_parties, config, addr,
-                               deadline);
+  g_injector->HandleConnection(closure, ep, interested_parties, channel_args,
+                               addr, deadline);
   return 0;
 }
 
@@ -92,10 +89,10 @@ void ConnectionAttemptInjector::Start() {
 
 void ConnectionAttemptInjector::AttemptConnection(
     grpc_closure* closure, grpc_endpoint** ep,
-    grpc_pollset_set* interested_parties, const EndpointConfig& config,
+    grpc_pollset_set* interested_parties, const grpc_channel_args* channel_args,
     const grpc_resolved_address* addr, grpc_core::Timestamp deadline) {
-  g_original_vtable->connect(closure, ep, interested_parties, config, addr,
-                             deadline);
+  g_original_vtable->connect(closure, ep, interested_parties, channel_args,
+                             addr, deadline);
 }
 
 //
@@ -104,9 +101,9 @@ void ConnectionAttemptInjector::AttemptConnection(
 
 ConnectionAttemptInjector::InjectedDelay::InjectedDelay(
     grpc_core::Duration duration, grpc_closure* closure, grpc_endpoint** ep,
-    grpc_pollset_set* interested_parties, const EndpointConfig& config,
+    grpc_pollset_set* interested_parties, const grpc_channel_args* channel_args,
     const grpc_resolved_address* addr, grpc_core::Timestamp deadline)
-    : attempt_(closure, ep, interested_parties, config, addr, deadline) {
+    : attempt_(closure, ep, interested_parties, channel_args, addr, deadline) {
   GRPC_CLOSURE_INIT(&timer_callback_, TimerCallback, this, nullptr);
   grpc_core::Timestamp now = grpc_core::ExecCtx::Get()->Now();
   duration = std::min(duration, deadline - now);
@@ -127,10 +124,10 @@ void ConnectionAttemptInjector::InjectedDelay::TimerCallback(
 
 void ConnectionDelayInjector::HandleConnection(
     grpc_closure* closure, grpc_endpoint** ep,
-    grpc_pollset_set* interested_parties, const EndpointConfig& config,
+    grpc_pollset_set* interested_parties, const grpc_channel_args* channel_args,
     const grpc_resolved_address* addr, grpc_core::Timestamp deadline) {
-  new InjectedDelay(duration_, closure, ep, interested_parties, config, addr,
-                    deadline);
+  new InjectedDelay(duration_, closure, ep, interested_parties, channel_args,
+                    addr, deadline);
 }
 
 //
@@ -216,7 +213,7 @@ std::unique_ptr<ConnectionHoldInjector::Hold> ConnectionHoldInjector::AddHold(
 
 void ConnectionHoldInjector::HandleConnection(
     grpc_closure* closure, grpc_endpoint** ep,
-    grpc_pollset_set* interested_parties, const EndpointConfig& config,
+    grpc_pollset_set* interested_parties, const grpc_channel_args* channel_args,
     const grpc_resolved_address* addr, grpc_core::Timestamp deadline) {
   const int port = grpc_sockaddr_get_port(addr);
   gpr_log(GPR_INFO, "==> HandleConnection(): port=%d", port);
@@ -232,7 +229,7 @@ void ConnectionHoldInjector::HandleConnection(
                                       hold, nullptr);
         }
         hold->queued_attempt_ = absl::make_unique<QueuedAttempt>(
-            closure, ep, interested_parties, config, addr, deadline);
+            closure, ep, interested_parties, channel_args, addr, deadline);
         hold->start_cv_.Signal();
         holds_.erase(it);
         return;
@@ -240,7 +237,8 @@ void ConnectionHoldInjector::HandleConnection(
     }
   }
   // Anything we're not holding should proceed normally.
-  AttemptConnection(closure, ep, interested_parties, config, addr, deadline);
+  AttemptConnection(closure, ep, interested_parties, channel_args, addr,
+                    deadline);
 }
 
 }  // namespace testing

--- a/test/cpp/end2end/connection_delay_injector.h
+++ b/test/cpp/end2end/connection_delay_injector.h
@@ -17,9 +17,8 @@
 
 #include <memory>
 
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/socket_utils_posix.h"
 #include "src/core/lib/iomgr/tcp_client.h"
 #include "src/core/lib/iomgr/timer.h"
 
@@ -55,11 +54,11 @@ class ConnectionAttemptInjector {
   // themselves or delegate to the iomgr implementation by calling
   // AttemptConnection().  QueuedAttempt may be used to queue an attempt
   // for asynchronous processing.
-  virtual void HandleConnection(
-      grpc_closure* closure, grpc_endpoint** ep,
-      grpc_pollset_set* interested_parties,
-      const grpc_event_engine::experimental::EndpointConfig& config,
-      const grpc_resolved_address* addr, grpc_core::Timestamp deadline) = 0;
+  virtual void HandleConnection(grpc_closure* closure, grpc_endpoint** ep,
+                                grpc_pollset_set* interested_parties,
+                                const grpc_channel_args* channel_args,
+                                const grpc_resolved_address* addr,
+                                grpc_core::Timestamp deadline) = 0;
 
  protected:
   // Represents a queued attempt.
@@ -68,24 +67,26 @@ class ConnectionAttemptInjector {
    public:
     QueuedAttempt(grpc_closure* closure, grpc_endpoint** ep,
                   grpc_pollset_set* interested_parties,
-                  const grpc_event_engine::experimental::EndpointConfig& config,
+                  const grpc_channel_args* channel_args,
                   const grpc_resolved_address* addr,
                   grpc_core::Timestamp deadline)
         : closure_(closure),
           endpoint_(ep),
           interested_parties_(interested_parties),
-          config_(*reinterpret_cast<const grpc_event_engine::experimental::
-                                        ChannelArgsEndpointConfig*>(&config)),
+          channel_args_(grpc_channel_args_copy(channel_args)),
           deadline_(deadline) {
       memcpy(&address_, addr, sizeof(address_));
     }
 
-    ~QueuedAttempt() { GPR_ASSERT(closure_ == nullptr); }
+    ~QueuedAttempt() {
+      GPR_ASSERT(closure_ == nullptr);
+      grpc_channel_args_destroy(channel_args_);
+    }
 
     // Caller must invoke this from a thread with an ExecCtx.
     void Resume() {
       GPR_ASSERT(closure_ != nullptr);
-      AttemptConnection(closure_, endpoint_, interested_parties_, config_,
+      AttemptConnection(closure_, endpoint_, interested_parties_, channel_args_,
                         &address_, deadline_);
       closure_ = nullptr;
     }
@@ -101,7 +102,7 @@ class ConnectionAttemptInjector {
     grpc_closure* closure_;
     grpc_endpoint** endpoint_;
     grpc_pollset_set* interested_parties_;
-    grpc_event_engine::experimental::ChannelArgsEndpointConfig config_;
+    const grpc_channel_args* channel_args_;
     grpc_resolved_address address_;
     grpc_core::Timestamp deadline_;
   };
@@ -113,7 +114,7 @@ class ConnectionAttemptInjector {
 
     InjectedDelay(grpc_core::Duration duration, grpc_closure* closure,
                   grpc_endpoint** ep, grpc_pollset_set* interested_parties,
-                  const grpc_event_engine::experimental::EndpointConfig& config,
+                  const grpc_channel_args* channel_args,
                   const grpc_resolved_address* addr,
                   grpc_core::Timestamp deadline);
 
@@ -128,11 +129,11 @@ class ConnectionAttemptInjector {
     grpc_closure timer_callback_;
   };
 
-  static void AttemptConnection(
-      grpc_closure* closure, grpc_endpoint** ep,
-      grpc_pollset_set* interested_parties,
-      const grpc_event_engine::experimental::EndpointConfig& config,
-      const grpc_resolved_address* addr, grpc_core::Timestamp deadline);
+  static void AttemptConnection(grpc_closure* closure, grpc_endpoint** ep,
+                                grpc_pollset_set* interested_parties,
+                                const grpc_channel_args* channel_args,
+                                const grpc_resolved_address* addr,
+                                grpc_core::Timestamp deadline);
 };
 
 // A concrete implementation that injects a fixed delay.
@@ -141,12 +142,11 @@ class ConnectionDelayInjector : public ConnectionAttemptInjector {
   explicit ConnectionDelayInjector(grpc_core::Duration duration)
       : duration_(duration) {}
 
-  void HandleConnection(
-      grpc_closure* closure, grpc_endpoint** ep,
-      grpc_pollset_set* interested_parties,
-      const grpc_event_engine::experimental::EndpointConfig& config,
-      const grpc_resolved_address* addr,
-      grpc_core::Timestamp deadline) override;
+  void HandleConnection(grpc_closure* closure, grpc_endpoint** ep,
+                        grpc_pollset_set* interested_parties,
+                        const grpc_channel_args* channel_args,
+                        const grpc_resolved_address* addr,
+                        grpc_core::Timestamp deadline) override;
 
  private:
   grpc_core::Duration duration_;
@@ -205,12 +205,11 @@ class ConnectionHoldInjector : public ConnectionAttemptInjector {
   std::unique_ptr<Hold> AddHold(int port, bool intercept_completion = false);
 
  private:
-  void HandleConnection(
-      grpc_closure* closure, grpc_endpoint** ep,
-      grpc_pollset_set* interested_parties,
-      const grpc_event_engine::experimental::EndpointConfig& config,
-      const grpc_resolved_address* addr,
-      grpc_core::Timestamp deadline) override;
+  void HandleConnection(grpc_closure* closure, grpc_endpoint** ep,
+                        grpc_pollset_set* interested_parties,
+                        const grpc_channel_args* channel_args,
+                        const grpc_resolved_address* addr,
+                        grpc_core::Timestamp deadline) override;
 
   std::vector<Hold*> holds_;
 };

--- a/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
@@ -21,8 +21,6 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 
-#include <grpc/event_engine/endpoint_config.h>
-
 #include "src/core/ext/filters/client_channel/backup_poller.h"
 #include "src/core/ext/filters/client_channel/lb_policy/xds/xds_channel_args.h"
 #include "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"

--- a/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
@@ -22,8 +22,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
-#include <grpc/event_engine/endpoint_config.h>
-
 #include "src/core/ext/filters/client_channel/backup_poller.h"
 #include "src/core/ext/filters/client_channel/lb_policy/xds/xds_channel_args.h"
 #include "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"


### PR DESCRIPTION
Reverts grpc/grpc#30028 - The PR increased flakiness of internal tests