### PR TITLE
Add type stub generation support to grpcio-tools

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_tools/command.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/command.py
@@ -38,6 +38,7 @@ def build_package_protos(package_root, strict_mode=False):
             '--proto_path={}'.format(inclusion_root),
             '--proto_path={}'.format(well_known_protos_include),
             '--python_out={}'.format(inclusion_root),
+            '--pyi_out={}'.format(inclusion_root),
             '--grpc_python_out={}'.format(inclusion_root),
         ] + [proto_file]
         if protoc.main(command) != 0:

--- a/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
@@ -25,6 +25,7 @@
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/compiler/python/python_generator.h>
+#include <google/protobuf/compiler/python/pyi_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 
@@ -48,6 +49,11 @@ int protoc_main(int argc, char* argv[]) {
   google::protobuf::compiler::python::Generator py_generator;
   cli.RegisterGenerator("--python_out", &py_generator,
                         "Generate Python source file.");
+
+  // pyi files for type checking
+  google::protobuf::compiler::python::PyiGenerator pyi_generator;
+  cli.RegisterGenerator("--pyi_out", &pyi_generator,
+                        "Generate Python pyi stub.");
 
   // gRPC Python
   grpc_python_generator::GeneratorConfiguration grpc_py_config;

--- a/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
@@ -24,8 +24,8 @@
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/compiler/importer.h>
-#include <google/protobuf/compiler/python/python_generator.h>
 #include <google/protobuf/compiler/python/pyi_generator.h>
+#include <google/protobuf/compiler/python/python_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 


### PR DESCRIPTION
Example usage:

```
python3 -m grpc_tools.protoc --python_out=helloworld --grpc_python_out=helloworld --pyi_out=helloworld -I ../protos ../protos/helloworld.proto
```