### PR TITLE
Update python version for AWS tests

### DIFF
--- a/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
+++ b/tools/internal_ci/linux/aws/grpc_run_basictests_python_aarch64.sh
@@ -28,8 +28,8 @@ cd grpc
 
 git submodule update --init
 
-# build and test python (currently we only test with python3.6, but that's ok since our aarch64 testing resources are limited)
-tools/run_tests/run_tests.py -l python --compiler python3.6 -c opt -t -x run_tests/python_linux_opt_native/sponge_log.xml --report_suite_name python_linux_opt_native --report_multi_target || FAILED=true
+# build and test python (currently we only test with python3.7, but that's ok since our aarch64 testing resources are limited)
+tools/run_tests/run_tests.py -l python --compiler python3.7 -c opt -t -x run_tests/python_linux_opt_native/sponge_log.xml --report_suite_name python_linux_opt_native --report_multi_target || FAILED=true
 
 if [ "$FAILED" != "" ]
 then


### PR DESCRIPTION
Fix b/241435702
Python 3.6 support was dropped in [https://github.com/grpc/grpc/pull/30377](https://www.google.com/url?q=https://github.com/grpc/grpc/pull/30377&sa=D&source=buganizer&usg=AOvVaw1pHJF6mbUXiVdCY_CmcOpS)
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

