### PR TITLE
Fix missing destructors on JSON Object Loader

### DIFF
--- a/src/core/lib/json/json_object_loader.h
+++ b/src/core/lib/json/json_object_loader.h
@@ -235,6 +235,9 @@ class LoadBool : public LoaderInterface {
  public:
   void LoadInto(const Json& json, const JsonArgs& /*args*/, void* dst,
                 ErrorList* errors) const override;
+
+ protected:
+  ~LoadBool() = default;
 };
 
 // Loads an unprocessed JSON object value.
@@ -242,6 +245,9 @@ class LoadUnprocessedJsonObject : public LoaderInterface {
  public:
   void LoadInto(const Json& json, const JsonArgs& /*args*/, void* dst,
                 ErrorList* errors) const override;
+
+ protected:
+  ~LoadUnprocessedJsonObject() = default;
 };
 
 // Load a vector of some type.


### PR DESCRIPTION
This was causing failures with `-Wnon-virtual-dtor` in the feature
example tests.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

