### PR TITLE
Allow storing security context extension in grpc_auth_context

### DIFF
--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 
 #include <utility>
+#include <memory>
 
 #include "absl/strings/string_view.h"
 

--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -64,7 +64,7 @@ struct grpc_auth_context
     : public grpc_core::RefCounted<grpc_auth_context,
                                    grpc_core::NonPolymorphicRefCount> {
  public:
-  // Base class for all extensions to inherit form.
+  // Base class for all extensions to inherit from.
   class Extension {
    public:
     virtual ~Extension() = default;

--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -23,8 +23,8 @@
 
 #include <stddef.h>
 
-#include <utility>
 #include <memory>
+#include <utility>
 
 #include "absl/strings/string_view.h"
 

--- a/test/core/security/auth_context_test.cc
+++ b/test/core/security/auth_context_test.cc
@@ -131,6 +131,15 @@ TEST(AuthContextTest, ChainedContext) {
   ctx.reset(DEBUG_LOCATION, "test");
 }
 
+TEST(AuthContextTest, ContextWithExtension) {
+  class SampleExtension : public grpc_auth_context::Extension {};
+  grpc_core::RefCountedPtr<grpc_auth_context> ctx =
+      grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
+  // Just set the extension, the goal of this test is to catch any memory
+  // leaks when context goes out of scope.
+  ctx->set_extension(std::make_unique<SampleExtension>());
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This is currently unused, but will be used internally for passing required references that can be tied to auth contexts.

@markdroth 