### PR TITLE
xDS interop: log the subTest start and beginning

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
+import contextlib
 import datetime
 import enum
 import hashlib
@@ -168,6 +169,14 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         cls.k8s_api_manager.close()
         cls.secondary_k8s_api_manager.close()
         cls.gcp_api_manager.close()
+
+    @contextlib.contextmanager
+    def subTest(self, msg, **params):  # noqa pylint: disable=signature-differs
+        logger.info('--- Starting subTest %s.%s ---', self.id(), msg)
+        try:
+            yield super().subTest(msg, **params)
+        finally:
+            logger.info('--- Finished subTest %s.%s ---', self.id(), msg)
 
     def setupTrafficDirectorGrpc(self):
         self.td.setup_for_grpc(self.server_xds_host,


### PR DESCRIPTION
To improve debugging of the tests with steps that look similar, f.e. failover.
Note: URL map test suite does not use subtests, so I didn't add the logging there.


Makes the end of one subtest, and the beginning of the next one much clearer:
![image](https://user-images.githubusercontent.com/672669/183210621-c4a085c4-c86b-47fd-baf3-d6409e17ae39.png)
