### PR TITLE
xDS interop: add support for the reference xds test server

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -2,6 +2,13 @@
 # https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.14.0
 --td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:d6baaf7b0e0c63054ac4d9bedc09021ff261d599
 
+# The reference implementation of the xDS test server.
+# Can be used in tests where language-specific xDS test server does not exist,
+# or missing a feature required for the test.
+# TODO(sergiitk): Update every ~ 6 months; next 2023-02.
+# https://github.com/grpc/grpc-java/commits/v1.48.1
+--server_image_universal=gcr.io/grpc-testing/xds-interop/java-server:d56f8fbe1d2822bc4f91515dd471ad49493fc385
+
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0
 # Google projects: remove if console.cloud.google.com redirects to Logs Explorer

--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -1,11 +1,14 @@
 --resource_prefix=interop-psm-url-map
 --strategy=reuse
 --server_xds_port=8848
+
+# TODO(sergiitk): Use --server_image_universal instead.
 # NOTE(lidiz) we pin the server image to java-server because:
 # 1. Only Java server understands the rpc-behavior metadata.
 # 2. All UrlMap tests today are testing client-side logic.
 # grpc-java master: 438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa TODO: use v1.40.0
 --server_image=gcr.io/grpc-testing/xds-interop/java-server:438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa
+
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None
 --private_api_key_secret_name=None

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -48,7 +48,10 @@ class Lang(enum.Flag):
 
 @dataclass
 class TestConfig:
-    """Describes the config for the test suite."""
+    """Describes the config for the test suite.
+
+    TODO(sergiitk): rename to LangSpec and rename skips.py to lang.py.
+    """
     client_lang: Lang
     server_lang: Lang
     version: Optional[str]
@@ -85,8 +88,11 @@ def _get_lang(image_name: str) -> Lang:
         re.search(r'/(\w+)-(client|server):', image_name).group(1))
 
 
-def evaluate_test_config(check: Callable[[TestConfig], bool]) -> None:
-    """Evaluates the test config check against Abseil flags."""
+def evaluate_test_config(check: Callable[[TestConfig], bool]) -> TestConfig:
+    """Evaluates the test config check against Abseil flags.
+
+    TODO(sergiitk): split into parse_lang_spec and check_is_supported.
+    """
     # NOTE(lidiz) a manual skip mechanism is needed because absl/flags
     # cannot be used in the built-in test-skipping decorators. See the
     # official FAQs:
@@ -100,3 +106,4 @@ def evaluate_test_config(check: Callable[[TestConfig], bool]) -> None:
         raise unittest.SkipTest(f'Unsupported test config: {test_config}')
 
     logger.info('Detected language and version: %s', test_config)
+    return test_config

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_flags.py
@@ -34,6 +34,12 @@ TD_BOOTSTRAP_IMAGE = flags.DEFINE_string(
 SERVER_IMAGE = flags.DEFINE_string("server_image",
                                    default=None,
                                    help="Server Docker image name")
+SERVER_IMAGE_UNIVERSAL = flags.DEFINE_string(
+    "server_image_universal",
+    default=None,
+    help=("Server Docker image name to use in tests that need to override\n"
+          "the language-specific xDS test server with the reference\n"
+          "implementation of a different language, or a different version."))
 CLIENT_IMAGE = flags.DEFINE_string("client_image",
                                    default=None,
                                    help="Client Docker image name")

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -72,6 +72,7 @@ class TdPropagationRetryableError(Exception):
 
 
 class XdsKubernetesBaseTestCase(absltest.TestCase):
+    lang_spec: skips.TestConfig
     client_namespace: str
     client_runner: KubernetesClientRunner
     ensure_firewall: bool
@@ -115,7 +116,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
 
         # Raises unittest.SkipTest if given client/server/version does not
         # support current test case.
-        skips.evaluate_test_config(cls.is_supported)
+        cls.lang_spec = skips.evaluate_test_config(cls.is_supported)
 
         # Must be called before KubernetesApiManager or GcpApiManager init.
         xds_flags.set_socket_default_timeout_from_flag()

--- a/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
@@ -24,7 +24,7 @@ from framework.helpers import skips
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)
-flags.mark_flags_as_required(xds_k8s_flags.SERVER_IMAGE_UNIVERSAL)
+flags.mark_flag_as_required('server_image_universal')
 
 # Type aliases
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall

--- a/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
@@ -62,8 +62,6 @@ class OutlierDetectionTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.server_lang != _Lang.JAVA:
-            return False
         if config.client_lang in _Lang.CPP | _Lang.PYTHON:
             return config.version_gte('v1.48.x')
         if config.client_lang == _Lang.NODE:


### PR DESCRIPTION
- xDS interop: add support for the reference xds test server
- Set default xDS test server reference to Java `v1.48.1`
- Override xDS test server with the reference in Outlier Detection