### PR TITLE
Change shebang of generate_proto_ruby.sh to bash

### DIFF
--- a/src/ruby/pb/generate_proto_ruby.sh
+++ b/src/ruby/pb/generate_proto_ruby.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2015 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
sh does not support the brace expansion from lines 31 and 44
see: https://datacadamia.com/lang/bash/brace_expansion#sh