### PR TITLE
xDS interop: override retriable cleanup instead of tearDown

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -451,11 +451,11 @@ class IsolatedXdsKubernetesTestCase(XdsKubernetesBaseTestCase,
                                             attempts=3,
                                             log_level=logging.INFO)
         try:
-            retryer(self._cleanup)
+            retryer(self.cleanup)
         except retryers.RetryError:
             logger.exception('Got error during teardown')
 
-    def _cleanup(self):
+    def cleanup(self):
         self.td.cleanup(force=self.force_cleanup)
         self.client_runner.cleanup(force=self.force_cleanup)
         self.server_runner.cleanup(force=self.force_cleanup,

--- a/tools/run_tests/xds_k8s_test_driver/tests/change_backend_service_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/change_backend_service_test.py
@@ -48,10 +48,11 @@ class ChangeBackendServiceTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             debug_use_port_forwarding=self.debug_use_port_forwarding,
             reuse_namespace=True)
 
-    def tearDown(self):
+    def cleanup(self):
+        super().cleanup()
         if hasattr(self, 'alternate_server_runner'):
-            self.alternate_server_runner.cleanup()
-        super().tearDown()
+            self.alternate_server_runner.cleanup(
+                force=self.force_cleanup, force_namespace=self.force_cleanup)
 
     def test_change_backend_service(self) -> None:
         with self.subTest('00_create_health_check'):

--- a/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
@@ -49,10 +49,11 @@ class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             debug_use_port_forwarding=self.debug_use_port_forwarding,
             reuse_namespace=True)
 
-    def tearDown(self):
+    def cleanup(self):
+        super().cleanup()
         if hasattr(self, 'secondary_server_runner'):
-            self.secondary_server_runner.cleanup()
-        super().tearDown()
+            self.secondary_server_runner.cleanup(
+                force=self.force_cleanup, force_namespace=self.force_cleanup)
 
     def test_failover(self) -> None:
         with self.subTest('00_create_health_check'):

--- a/tools/run_tests/xds_k8s_test_driver/tests/remove_neg_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/remove_neg_test.py
@@ -47,10 +47,11 @@ class RemoveNegTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             debug_use_port_forwarding=self.debug_use_port_forwarding,
             reuse_namespace=True)
 
-    def tearDown(self):
+    def cleanup(self):
+        super().cleanup()
         if hasattr(self, 'alternate_server_runner'):
-            self.alternate_server_runner.cleanup()
-        super().tearDown()
+            self.alternate_server_runner.cleanup(
+                force=self.force_cleanup, force_namespace=self.force_cleanup)
 
     def test_remove_neg(self) -> None:
         with self.subTest('00_create_health_check'):


### PR DESCRIPTION
Some tests override unittest's `tearDown()`, which is not wrong, but less resilient than overriding custom `cleanup()` that is being retried in framework's `tearDown()`. 

