### PR TITLE
[test] Fix too many pings test

### DIFF
--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -111,6 +111,7 @@ grpc_status_code PerformCall(grpc_channel* channel, grpc_server* server,
   grpc_core::CqVerifier cqv(cq);
   grpc_op ops[6];
   grpc_op* op;
+  grpc_metadata_array initial_metadata_recv;
   grpc_metadata_array trailing_metadata_recv;
   grpc_metadata_array request_metadata_recv;
   grpc_call_details call_details;
@@ -123,6 +124,7 @@ grpc_status_code PerformCall(grpc_channel* channel, grpc_server* server,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);
   GPR_ASSERT(c);
+  grpc_metadata_array_init(&initial_metadata_recv);
   grpc_metadata_array_init(&trailing_metadata_recv);
   grpc_metadata_array_init(&request_metadata_recv);
   grpc_call_details_init(&call_details);
@@ -137,6 +139,11 @@ grpc_status_code PerformCall(grpc_channel* channel, grpc_server* server,
   op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv;
   op->data.recv_status_on_client.status = &status;
   op->data.recv_status_on_client.status_details = &details;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_INITIAL_METADATA;
+  op->data.recv_initial_metadata.recv_initial_metadata = &initial_metadata_recv;
   op->flags = 0;
   op->reserved = nullptr;
   op++;
@@ -155,6 +162,7 @@ grpc_status_code PerformCall(grpc_channel* channel, grpc_server* server,
   cqv.Verify();
   // cleanup
   grpc_slice_unref(details);
+  grpc_metadata_array_destroy(&initial_metadata_recv);
   grpc_metadata_array_destroy(&trailing_metadata_recv);
   grpc_metadata_array_destroy(&request_metadata_recv);
   grpc_call_details_destroy(&call_details);
@@ -232,6 +240,7 @@ grpc_status_code PerformWaitingCall(grpc_channel* channel, grpc_server* server,
   grpc_core::CqVerifier cqv(cq);
   grpc_op ops[6];
   grpc_op* op;
+  grpc_metadata_array initial_metadata_recv;
   grpc_metadata_array trailing_metadata_recv;
   grpc_metadata_array request_metadata_recv;
   grpc_call_details call_details;
@@ -244,6 +253,7 @@ grpc_status_code PerformWaitingCall(grpc_channel* channel, grpc_server* server,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);
   GPR_ASSERT(c);
+  grpc_metadata_array_init(&initial_metadata_recv);
   grpc_metadata_array_init(&trailing_metadata_recv);
   grpc_metadata_array_init(&request_metadata_recv);
   grpc_call_details_init(&call_details);
@@ -258,6 +268,11 @@ grpc_status_code PerformWaitingCall(grpc_channel* channel, grpc_server* server,
   op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv;
   op->data.recv_status_on_client.status = &status;
   op->data.recv_status_on_client.status_details = &details;
+  op->flags = 0;
+  op->reserved = nullptr;
+  op++;
+  op->op = GRPC_OP_RECV_INITIAL_METADATA;
+  op->data.recv_initial_metadata.recv_initial_metadata = &initial_metadata_recv;
   op->flags = 0;
   op->reserved = nullptr;
   op++;
@@ -282,6 +297,7 @@ grpc_status_code PerformWaitingCall(grpc_channel* channel, grpc_server* server,
   cqv.Verify(grpc_core::Duration::Seconds(60));
   // cleanup
   grpc_slice_unref(details);
+  grpc_metadata_array_destroy(&initial_metadata_recv);
   grpc_metadata_array_destroy(&trailing_metadata_recv);
   grpc_metadata_array_destroy(&request_metadata_recv);
   grpc_call_details_destroy(&call_details);


### PR DESCRIPTION
From `grpc_types.h`:
```
  /** Receive initial metadata: one and only one MUST be made on the client,
      must not be made on the server.
      This op completes after all initial metadata has been read from the
      peer. */
  GRPC_OP_RECV_INITIAL_METADATA,
```

This change fulfills the contract that we *MUST* perform a RECV_INITIAL_METADATA on client calls.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

