### PR TITLE
Start to buildfix OpenBSD.

### DIFF
--- a/src/core/lib/iomgr/sockaddr_utils_posix.cc
+++ b/src/core/lib/iomgr/sockaddr_utils_posix.cc
@@ -23,6 +23,8 @@
 #ifdef GRPC_POSIX_SOCKET_UTILS_COMMON
 
 #include "src/core/lib/iomgr/socket_utils.h"
+// sys/types.h must precede netinet/tcp.h for compatibility.
+#include <sys/types.h>
 #ifdef GRPC_LINUX_TCP_H
 #include <linux/tcp.h>
 #else
@@ -31,7 +33,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include <string>

--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -88,6 +88,11 @@ config_setting(
     values = {"cpu": "watchos_arm64_32"}
 )
 
+config_setting(
+    name = "openbsd",
+    values = {"cpu": "openbsd"},
+)
+
 copy_file(
     name = "ares_build_h",
     src = "@com_github_grpc_grpc//third_party/cares:ares_build.h",
@@ -113,6 +118,7 @@ copy_file(
         ":darwin_arm64e": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
         ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
         ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+        ":openbsd": "@com_github_grpc_grpc//third_party/cares:config_openbsd/ares_config.h",
         "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
     }),
     out = "ares_config.h",


### PR DESCRIPTION
Some minor changes for the platform:

* `sys/types.h` needs to be included before `netinet/tcp.h` to provide
  definitions for `u_int8_t`, `u_int16_t`, and `u_int32_t`.

* cares has an OpenBSD-specific config header but is not actually hooked
  up in cares.BUILD. Remedy that.