### PR TITLE
Update OpenCensus to HEAD

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -323,11 +323,11 @@ def grpc_deps():
     if "io_opencensus_cpp" not in native.existing_rules():
         http_archive(
             name = "io_opencensus_cpp",
-            sha256 = "90d6fafa8b1a2ea613bf662731d3086e1c2ed286f458a95c81744df2dbae41b1",
-            strip_prefix = "opencensus-cpp-c9a4da319bc669a772928ffc55af4a61be1a1176",
+            sha256 = "20119a53cc1c140347671ac40650d797567ec63bd3a9f135e17f144fdb36c272",
+            strip_prefix = "opencensus-cpp-3e6aa4c0fb31d2f39a2d38365483599ab50bef6d",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
-                "https://github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-cpp/archive/3e6aa4c0fb31d2f39a2d38365483599ab50bef6d.tar.gz",
+                "https://github.com/census-instrumentation/opencensus-cpp/archive/3e6aa4c0fb31d2f39a2d38365483599ab50bef6d.tar.gz",
             ],
         )
 

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -36,6 +36,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "opencensus/stats/stats.h"
 #include "opencensus/tags/tag_key.h"
 
 #include <grpc/grpc_security.h>

--- a/src/cpp/ext/filters/census/views.cc
+++ b/src/cpp/ext/filters/census/views.cc
@@ -22,7 +22,6 @@
 
 #include "absl/time/time.h"
 #include "opencensus/stats/stats.h"
-#include "opencensus/stats/view_descriptor.h"
 
 #include <grpcpp/opencensus.h>
 

--- a/src/cpp/ext/filters/census/views.cc
+++ b/src/cpp/ext/filters/census/views.cc
@@ -21,9 +21,8 @@
 #include <algorithm>
 
 #include "absl/time/time.h"
-#include "opencensus/stats/internal/aggregation_window.h"
-#include "opencensus/stats/internal/set_aggregation_window.h"
 #include "opencensus/stats/stats.h"
+#include "opencensus/stats/view_descriptor.h"
 
 #include <grpcpp/opencensus.h>
 

--- a/src/cpp/server/load_reporter/load_reporter.cc
+++ b/src/cpp/server/load_reporter/load_reporter.cc
@@ -21,7 +21,6 @@
 #include "src/cpp/server/load_reporter/load_reporter.h"
 
 #include <inttypes.h>
-#include <stdint.h>
 #include <stdio.h>
 
 #include <chrono>

--- a/src/cpp/server/load_reporter/load_reporter.cc
+++ b/src/cpp/server/load_reporter/load_reporter.cc
@@ -32,7 +32,6 @@
 
 #include <google/protobuf/duration.pb.h>
 
-#include "opencensus/stats/internal/set_aggregation_window.h"
 #include "opencensus/tags/tag_key.h"
 
 #include <grpc/support/log.h>
@@ -66,8 +65,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta count of calls started broken down by <token, host, "
               "user_id>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_start_count);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_start_count);
   view_descriptor_map_.emplace(kViewStartCount, vd_start_count);
   // Four views related to ending a call.
   // If this view is set as Count of kMeasureEndBytesSent (in hope of saving one
@@ -86,8 +85,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta count of calls ended broken down by <token, host, "
               "user_id, status>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_end_count);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_end_count);
   view_descriptor_map_.emplace(kViewEndCount, vd_end_count);
   auto vd_end_bytes_sent =
       ::opencensus::stats::ViewDescriptor()
@@ -101,8 +100,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta sum of bytes sent broken down by <token, host, user_id, "
               "status>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_end_bytes_sent);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_end_bytes_sent);
   view_descriptor_map_.emplace(kViewEndBytesSent, vd_end_bytes_sent);
   auto vd_end_bytes_received =
       ::opencensus::stats::ViewDescriptor()
@@ -116,8 +115,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta sum of bytes received broken down by <token, host, "
               "user_id, status>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_end_bytes_received);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_end_bytes_received);
   view_descriptor_map_.emplace(kViewEndBytesReceived, vd_end_bytes_received);
   auto vd_end_latency_ms =
       ::opencensus::stats::ViewDescriptor()
@@ -131,8 +130,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta sum of latency in ms broken down by <token, host, "
               "user_id, status>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_end_latency_ms);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_end_latency_ms);
   view_descriptor_map_.emplace(kViewEndLatencyMs, vd_end_latency_ms);
   // Two views related to other call metrics.
   auto vd_metric_call_count =
@@ -147,8 +146,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta count of calls broken down by <token, host, user_id, "
               "metric_name>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_metric_call_count);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_metric_call_count);
   view_descriptor_map_.emplace(kViewOtherCallMetricCount, vd_metric_call_count);
   auto vd_metric_value =
       ::opencensus::stats::ViewDescriptor()
@@ -162,8 +161,8 @@ CensusViewProvider::CensusViewProvider()
           .set_description(
               "Delta sum of call metric value broken down "
               "by <token, host, user_id, metric_name>.");
-  ::opencensus::stats::SetAggregationWindow(
-      ::opencensus::stats::AggregationWindow::Delta(), &vd_metric_value);
+  SetAggregationWindow(::opencensus::stats::AggregationWindow::Delta(),
+                       &vd_metric_value);
   view_descriptor_map_.emplace(kViewOtherCallMetricValue, vd_metric_value);
 }
 

--- a/src/cpp/server/load_reporter/load_reporter.h
+++ b/src/cpp/server/load_reporter/load_reporter.h
@@ -22,7 +22,6 @@
 #include <grpc/support/port_platform.h>
 
 #include <stddef.h>
-#include <stdint.h>
 
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
Update OpenCensus to https://github.com/census-instrumentation/opencensus-cpp/commit/3e6aa4c0fb31d2f39a2d38365483599ab50bef6d to pull in fix https://github.com/census-instrumentation/opencensus-cpp/commit/a1d84d346aac7ceb1ed3412a20e2df86d88d390b

I noticed this when I was trying to depend on the stackdriver exporter.
In the newer commits, OpenCensus has also hidden the internal files from the build targets.
