### PR TITLE
Fix occasional UnboundLocalError exception on grpc aio call cancellation

### DIFF
--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -342,6 +342,7 @@ class _StreamResponseMixin(Call):
             if not self.cancelled():
                 self.cancel()
             await self._raise_for_status()
+            return cygrpc.EOF
 
         if raw_response is cygrpc.EOF:
             return cygrpc.EOF


### PR DESCRIPTION
Fix occasional UnboundLocalError exception on grpc aio call cancellation  

  File "/venv/lib/python3.10/site-packages/grpc/aio/_call.py", line 323, in _fetch_stream_responses
    message = await self._read()
  File "/venv/lib/python3.10/site-packages/grpc/aio/_call.py", line 346, in _read
    if raw_response is cygrpc.EOF:
UnboundLocalError: local variable 'raw_response' referenced before assignment

release notes: no