### PR TITLE
[fixit] Make activity_test lighter weight

### DIFF
--- a/test/core/promise/activity_test.cc
+++ b/test/core/promise/activity_test.cc
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <ratio>
 #include <thread>
 #include <tuple>
 #include <vector>
@@ -360,25 +361,28 @@ TEST(AtomicWakerTest, ThreadStress) {
   AtomicWaker waker;
 
   threads.reserve(90);
-  for (int i = 0; i < 30; i++) {
+  for (int i = 0; i < 5; i++) {
     threads.emplace_back([&] {
       while (!done.load(std::memory_order_relaxed)) {
         waker.Wakeup();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
     });
   }
-  for (int i = 0; i < 30; i++) {
+  for (int i = 0; i < 5; i++) {
     threads.emplace_back([&] {
       while (!done.load(std::memory_order_relaxed)) {
         waker.Set(Waker(new TestWakeable(&wakeups, &drops)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
     });
   }
-  for (int i = 0; i < 30; i++) {
+  for (int i = 0; i < 5; i++) {
     threads.emplace_back([&] {
       while (!done.load(std::memory_order_relaxed)) {
         (waker.Armed() ? &armed : &not_armed)
             ->fetch_add(1, std::memory_order_relaxed);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
     });
   }


### PR DESCRIPTION
This has been flaking a bit on Windows... introduce some sleeps and lower thread counts - I think the properties the test wants to cover are still here (and TSAN should see the same set of things), and I expect we drastically increase the odds of the test passing on other platforms.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

