### PR TITLE
[fixit] Fix bad_client duplicate_header test

### DIFF
--- a/test/core/bad_client/tests/duplicate_header.cc
+++ b/test/core/bad_client/tests/duplicate_header.cc
@@ -113,6 +113,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(103), true);
+  cqv.Verify();
 
   grpc_metadata_array_destroy(&request_metadata_recv);
   grpc_call_details_destroy(&call_details);


### PR DESCRIPTION
We were missing a `Verify()` call, without which we wouldn't block to finish the call and instead leave the `verifier` function... and we'd end up clobbering the `was_cancelled` stack memory in some different stack.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

