### PR TITLE
[fixit] Fix too many pings test

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1626,6 +1626,10 @@ grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
                 complete_pick->subchannel.get());
             RefCountedPtr<ConnectedSubchannel> connected_subchannel =
                 subchannel->connected_subchannel();
+            if (connected_subchannel == nullptr) {
+              return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+                  "LB pick for ping not connected");
+            }
             connected_subchannel->Ping(op->send_ping.on_initiate,
                                        op->send_ping.on_ack);
             return GRPC_ERROR_NONE;

--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -333,17 +333,14 @@ void VerifyChannelDisconnected(grpc_channel* channel,
                                grpc_completion_queue* cq) {
   // Verify channel gets disconnected. Use a ping to make sure that clients
   // tries sending/receiving bytes if the channel is connected.
-  grpc_event ev;
-  do {
-    grpc_channel_ping(channel, cq, reinterpret_cast<void*>(2000), nullptr);
-    ev = grpc_completion_queue_next(cq, grpc_timeout_seconds_to_deadline(5),
-                                    nullptr);
-    GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
-    GPR_ASSERT(ev.tag == reinterpret_cast<void*>(2000));
-    // Keep retrying until it actually disconnects: this could take an iteration
-    // or two to settle out.
-  } while (ev.success != 0 || grpc_channel_check_connectivity_state(
-                                  channel, 0) == GRPC_CHANNEL_READY);
+  grpc_channel_ping(channel, cq, reinterpret_cast<void*>(2000), nullptr);
+  grpc_event ev = grpc_completion_queue_next(
+      cq, grpc_timeout_seconds_to_deadline(5), nullptr);
+  GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+  GPR_ASSERT(ev.tag == reinterpret_cast<void*>(2000));
+  GPR_ASSERT(ev.success == 0);
+  GPR_ASSERT(grpc_channel_check_connectivity_state(channel, 0) !=
+             GRPC_CHANNEL_READY);
 }
 
 class KeepaliveThrottlingTest : public ::testing::Test {


### PR DESCRIPTION
Got a crash dump that made one of the failures we've been seeing very apparent (https://paste.googleplex.com/4859100247621632 - sorry, internal only link)

After the ping bit was fixed in the channel, it needed a slight extension to the verify disconnected logic to get this all working, but I've verified internally that this passes 12million/12million attempts.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

