### PR TITLE
Add handshaker tracing to the max_connection_idle tests

### DIFF
--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -232,4 +232,7 @@ void max_connection_idle(grpc_end2end_test_config config) {
   test_max_connection_idle(config);
 }
 
-void max_connection_idle_pre_init(void) {}
+void max_connection_idle_pre_init(void) {
+  // TODO(b/238249704): remove tracing once the flakiness is resolved
+  GPR_ASSERT(1 == grpc_tracer_set_enabled("handshaker", 1));
+}


### PR DESCRIPTION
Helping to debug a 0.4% flaky test that occurs on h2_tls_test@max_connection_idle MSAN builds. This is hard to reproduce on demand, so I'm adding this in case our tests catch it naturally before we can do so manually.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

