### PR TITLE
Add a fixed minimum connection timeout for testing

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -587,10 +587,17 @@ BackOff::Options ParseArgsForBackoffValues(const ChannelArgs& args,
                                            Duration* min_connect_timeout) {
   const absl::optional<Duration> fixed_reconnect_backoff =
       args.GetDurationFromIntMillis("grpc.testing.fixed_reconnect_backoff_ms");
+  const absl::optional<Duration> fixed_min_connect_timeout =
+      args.GetDurationFromIntMillis(
+          "grpc.testing.fixed_min_connect_timeout_ms");
   if (fixed_reconnect_backoff.has_value()) {
     const Duration backoff =
         std::max(Duration::Milliseconds(100), *fixed_reconnect_backoff);
-    *min_connect_timeout = backoff;
+    if (fixed_min_connect_timeout.has_value()) {
+      *min_connect_timeout = *fixed_min_connect_timeout;
+    } else {
+      *min_connect_timeout = backoff;
+    }
     return BackOff::Options()
         .set_initial_backoff(backoff)
         .set_multiplier(1.0)

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -172,11 +172,11 @@ static void test_max_connection_idle(grpc_end2end_test_config config) {
   client_a[0].type = GRPC_ARG_INTEGER;
   client_a[0].key =
       const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
-  client_a[0].value.integer = 500;
+  client_a[0].value.integer = 1000;
   client_a[1].type = GRPC_ARG_INTEGER;
   client_a[1].key =
       const_cast<char*>("grpc.testing.fixed_min_connect_timeout_ms");
-  client_a[1].value.integer = 1500;
+  client_a[1].value.integer = 2000;
   grpc_arg server_a[2];
   server_a[0].type = GRPC_ARG_INTEGER;
   server_a[0].key = const_cast<char*>(GRPC_ARG_MAX_CONNECTION_IDLE_MS);
@@ -236,7 +236,4 @@ void max_connection_idle(grpc_end2end_test_config config) {
   test_max_connection_idle(config);
 }
 
-void max_connection_idle_pre_init(void) {
-  // TODO(b/238249704): remove tracing once the flakiness is resolved
-  GPR_ASSERT(1 == grpc_tracer_set_enabled("handshaker", 1));
-}
+void max_connection_idle_pre_init(void) {}

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -232,4 +232,7 @@ void max_connection_idle(grpc_end2end_test_config config) {
   test_max_connection_idle(config);
 }
 
-void max_connection_idle_pre_init(void) {}
+void max_connection_idle_pre_init(void) {
+  // TODO(b/238249704): remove tracing once the flakiness is resolved
+  GPR_ASSERT(1 == grpc_tracer_set_enabled("handshaker", 1));
+}

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -168,11 +168,15 @@ static void test_max_connection_idle(grpc_end2end_test_config config) {
   grpc_connectivity_state state = GRPC_CHANNEL_IDLE;
   grpc_core::CqVerifier cqv(f.cq);
 
-  grpc_arg client_a[1];
+  grpc_arg client_a[2];
   client_a[0].type = GRPC_ARG_INTEGER;
   client_a[0].key =
       const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
-  client_a[0].value.integer = 1000;
+  client_a[0].value.integer = 500;
+  client_a[1].type = GRPC_ARG_INTEGER;
+  client_a[1].key =
+      const_cast<char*>("grpc.testing.fixed_min_connect_timeout_ms");
+  client_a[1].value.integer = 1500;
   grpc_arg server_a[2];
   server_a[0].type = GRPC_ARG_INTEGER;
   server_a[0].key = const_cast<char*>(GRPC_ARG_MAX_CONNECTION_IDLE_MS);


### PR DESCRIPTION
This decouples the backoff reconnect timeout from the connection timeout when fixed-length timeouts are set in the end2end tests. If we can do away with the fixed timeouts altogether, then that solution can probably supersede this one.