### PR TITLE
[fixit] Core End2End Tests: Increase the connect timeout

### DIFF
--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -247,27 +247,23 @@ int main(int argc, char** argv) {
 
   std::string addr;
 
-  grpc_arg arg_array[] = {
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000),
-      /* When this test brings down server1 and then brings up server2,
-       * the targetted server port number changes, and the client channel
-       * needs to re-resolve to pick this up. This test requires that
-       * happen within 10 seconds, but gRPC's DNS resolvers rate limit
-       * resolution attempts to at most once every 30 seconds by default.
-       * So we tweak it for this test. */
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS),
-          1000)};
-  grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
+  auto client_args =
+      grpc_core::ChannelArgs()
+          .Set(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS, 1000)
+          .Set(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS, 1000)
+          .Set(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 5000)
+          /* When this test brings down server1 and then brings up server2,
+           * the targetted server port number changes, and the client channel
+           * needs to re-resolve to pick this up. This test requires that
+           * happen within 10 seconds, but gRPC's DNS resolvers rate limit
+           * resolution attempts to at most once every 30 seconds by default.
+           * So we tweak it for this test. */
+          .Set(GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS, 1000)
+          .ToC();
 
   /* create a channel that picks first amongst the servers */
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();
-  grpc_channel* chan = grpc_channel_create("test", creds, &client_args);
+  grpc_channel* chan = grpc_channel_create("test", creds, client_args.get());
   grpc_channel_credentials_release(creds);
   /* and an initial call to them */
   grpc_slice host = grpc_slice_from_static_string("127.0.0.1");

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -247,24 +247,23 @@ int main(int argc, char** argv) {
 
   std::string addr;
 
-  grpc_channel_args client_args;
-  grpc_arg arg_array[2];
-  arg_array[0].type = GRPC_ARG_INTEGER;
-  arg_array[0].key =
-      const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
-  arg_array[0].value.integer = 1000;
-  /* When this test brings down server1 and then brings up server2,
-   * the targetted server port number changes, and the client channel
-   * needs to re-resolve to pick this up. This test requires that
-   * happen within 10 seconds, but gRPC's DNS resolvers rate limit
-   * resolution attempts to at most once every 30 seconds by default.
-   * So we tweak it for this test. */
-  arg_array[1].type = GRPC_ARG_INTEGER;
-  arg_array[1].key =
-      const_cast<char*>(GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
-  arg_array[1].value.integer = 1000;
-  client_args.args = arg_array;
-  client_args.num_args = 2;
+  grpc_arg arg_array[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000),
+      /* When this test brings down server1 and then brings up server2,
+       * the targetted server port number changes, and the client channel
+       * needs to re-resolve to pick this up. This test requires that
+       * happen within 10 seconds, but gRPC's DNS resolvers rate limit
+       * resolution attempts to at most once every 30 seconds by default.
+       * So we tweak it for this test. */
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS),
+          1000)};
+  grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
 
   /* create a channel that picks first amongst the servers */
   grpc_channel_credentials* creds = grpc_insecure_credentials_create();

--- a/test/core/end2end/tests/connectivity.cc
+++ b/test/core/end2end/tests/connectivity.cc
@@ -18,6 +18,8 @@
 
 #include <stdint.h>
 
+#include <memory>
+
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
@@ -25,6 +27,7 @@
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/thd.h"
+#include "src/core/lib/gprpp/time.h"
 #include "test/core/end2end/cq_verifier.h"
 #include "test/core/end2end/end2end_tests.h"
 #include "test/core/util/test_config.h"

--- a/test/core/end2end/tests/connectivity.cc
+++ b/test/core/end2end/tests/connectivity.cc
@@ -23,6 +23,7 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/thd.h"
 #include "test/core/end2end/cq_verifier.h"
 #include "test/core/end2end/end2end_tests.h"
@@ -65,14 +66,18 @@ static void test_connectivity(grpc_end2end_test_config config) {
   grpc_core::CqVerifier cqv(f.cq);
   child_events ce;
 
-  grpc_channel_args client_args;
-  grpc_arg arg_array[1];
+  grpc_arg arg_array[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000)};
   arg_array[0].type = GRPC_ARG_INTEGER;
   arg_array[0].key =
       const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
   arg_array[0].value.integer = 1000;
-  client_args.args = arg_array;
-  client_args.num_args = 1;
+  grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
 
   config.init_client(&f, &client_args);
 
@@ -104,7 +109,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
              GRPC_CHANNEL_IDLE);
   /* start watching for a change */
   grpc_channel_watch_connectivity_state(f.client, GRPC_CHANNEL_IDLE,
-                                        grpc_timeout_seconds_to_deadline(3),
+                                        grpc_timeout_seconds_to_deadline(10),
                                         f.cq, tag(2));
 
   /* and now the watch should trigger */
@@ -116,7 +121,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
 
   /* quickly followed by a transition to TRANSIENT_FAILURE */
   grpc_channel_watch_connectivity_state(f.client, GRPC_CHANNEL_CONNECTING,
-                                        grpc_timeout_seconds_to_deadline(3),
+                                        grpc_timeout_seconds_to_deadline(10),
                                         f.cq, tag(3));
   cqv.Expect(tag(3), true);
   cqv.Verify();
@@ -135,9 +140,9 @@ static void test_connectivity(grpc_end2end_test_config config) {
      READY is reached */
   while (state != GRPC_CHANNEL_READY) {
     grpc_channel_watch_connectivity_state(
-        f.client, state, grpc_timeout_seconds_to_deadline(3), f.cq, tag(4));
+        f.client, state, grpc_timeout_seconds_to_deadline(10), f.cq, tag(4));
     cqv.Expect(tag(4), true);
-    cqv.Verify();
+    cqv.Verify(grpc_core::Duration::Seconds(20));
     state = grpc_channel_check_connectivity_state(f.client, 0);
     GPR_ASSERT(state == GRPC_CHANNEL_READY ||
                state == GRPC_CHANNEL_CONNECTING ||
@@ -149,7 +154,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
   gpr_log(GPR_DEBUG, "*** SHUTTING DOWN SERVER ***");
 
   grpc_channel_watch_connectivity_state(f.client, GRPC_CHANNEL_READY,
-                                        grpc_timeout_seconds_to_deadline(3),
+                                        grpc_timeout_seconds_to_deadline(10),
                                         f.cq, tag(5));
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));

--- a/test/core/end2end/tests/connectivity.cc
+++ b/test/core/end2end/tests/connectivity.cc
@@ -73,10 +73,6 @@ static void test_connectivity(grpc_end2end_test_config config) {
           const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
       grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000)};
-  arg_array[0].type = GRPC_ARG_INTEGER;
-  arg_array[0].key =
-      const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
-  arg_array[0].value.integer = 1000;
   grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
 
   config.init_client(&f, &client_args);

--- a/test/core/end2end/tests/connectivity.cc
+++ b/test/core/end2end/tests/connectivity.cc
@@ -66,16 +66,13 @@ static void test_connectivity(grpc_end2end_test_config config) {
   grpc_core::CqVerifier cqv(f.cq);
   child_events ce;
 
-  grpc_arg arg_array[] = {
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000)};
-  grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
+  auto client_args = grpc_core::ChannelArgs()
+                         .Set(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 5000)
+                         .ToC();
 
-  config.init_client(&f, &client_args);
+  config.init_client(&f, client_args.get());
 
   ce.channel = f.client;
   ce.cq = f.cq;

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <memory>
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
 #include <grpc/slice.h>

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -169,13 +169,11 @@ static void test_max_connection_idle(grpc_end2end_test_config config) {
   grpc_connectivity_state state = GRPC_CHANNEL_IDLE;
   grpc_core::CqVerifier cqv(f.cq);
 
-  grpc_arg client_a[] = {
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000)};
+  auto client_args = grpc_core::ChannelArgs()
+                         .Set(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 5000)
+                         .ToC();
   grpc_arg server_a[2];
   server_a[0].type = GRPC_ARG_INTEGER;
   server_a[0].key = const_cast<char*>(GRPC_ARG_MAX_CONNECTION_IDLE_MS);
@@ -183,10 +181,9 @@ static void test_max_connection_idle(grpc_end2end_test_config config) {
   server_a[1].type = GRPC_ARG_INTEGER;
   server_a[1].key = const_cast<char*>(GRPC_ARG_MAX_CONNECTION_AGE_MS);
   server_a[1].value.integer = MAX_CONNECTION_AGE_MS;
-  grpc_channel_args client_args = {GPR_ARRAY_SIZE(client_a), client_a};
   grpc_channel_args server_args = {GPR_ARRAY_SIZE(server_a), server_a};
 
-  config.init_client(&f, &client_args);
+  config.init_client(&f, client_args.get());
   config.init_server(&f, &server_args);
 
   /* check that we're still in idle, and start connecting */

--- a/test/core/end2end/tests/simple_delayed_request.cc
+++ b/test/core/end2end/tests/simple_delayed_request.cc
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <memory>
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
 #include <grpc/slice.h>

--- a/test/core/end2end/tests/simple_delayed_request.cc
+++ b/test/core/end2end/tests/simple_delayed_request.cc
@@ -76,8 +76,8 @@ static void end_test(grpc_end2end_test_fixture* f) {
 
 static void simple_delayed_request_body(grpc_end2end_test_config config,
                                         grpc_end2end_test_fixture* f,
-                                        grpc_channel_args* client_args,
-                                        grpc_channel_args* server_args,
+                                        const grpc_channel_args* client_args,
+                                        const grpc_channel_args* server_args,
                                         long /*delay_us*/) {
   grpc_call* c;
   grpc_call* s;
@@ -186,40 +186,33 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
 
 static void test_simple_delayed_request_short(grpc_end2end_test_config config) {
   grpc_end2end_test_fixture f;
-  grpc_arg arg_array[] = {
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
-      grpc_channel_arg_integer_create(
-          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000)};
-  grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
-
+  auto client_args = grpc_core::ChannelArgs()
+                         .Set(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 5000)
+                         .ToC();
   gpr_log(GPR_INFO, "Running test: %s/%s", "test_simple_delayed_request_short",
           config.name);
   f = config.create_fixture(nullptr, nullptr);
 
-  simple_delayed_request_body(config, &f, &client_args, nullptr, 100000);
+  simple_delayed_request_body(config, &f, client_args.get(), nullptr, 100000);
   end_test(&f);
   config.tear_down_data(&f);
 }
 
 static void test_simple_delayed_request_long(grpc_end2end_test_config config) {
   grpc_end2end_test_fixture f;
-  grpc_channel_args client_args;
-  grpc_arg arg_array[1];
-  arg_array[0].type = GRPC_ARG_INTEGER;
-  arg_array[0].key =
-      const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
-  arg_array[0].value.integer = 1000;
-  client_args.args = arg_array;
-  client_args.num_args = 1;
+  auto client_args = grpc_core::ChannelArgs()
+                         .Set(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS, 1000)
+                         .Set(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, 5000)
+                         .ToC();
 
   gpr_log(GPR_INFO, "Running test: %s/%s", "test_simple_delayed_request_long",
           config.name);
   f = config.create_fixture(nullptr, nullptr);
   /* This timeout should be longer than a single retry */
-  simple_delayed_request_body(config, &f, &client_args, nullptr, 1500000);
+  simple_delayed_request_body(config, &f, client_args.get(), nullptr, 1500000);
   end_test(&f);
   config.tear_down_data(&f);
 }

--- a/test/core/end2end/tests/simple_delayed_request.cc
+++ b/test/core/end2end/tests/simple_delayed_request.cc
@@ -25,6 +25,7 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 
+#include "src/core/lib/channel/channel_args.h"
 #include "test/core/end2end/cq_verifier.h"
 #include "test/core/end2end/end2end_tests.h"
 #include "test/core/util/test_config.h"
@@ -185,14 +186,14 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
 
 static void test_simple_delayed_request_short(grpc_end2end_test_config config) {
   grpc_end2end_test_fixture f;
-  grpc_channel_args client_args;
-  grpc_arg arg_array[1];
-  arg_array[0].type = GRPC_ARG_INTEGER;
-  arg_array[0].key =
-      const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
-  arg_array[0].value.integer = 1000;
-  client_args.args = arg_array;
-  client_args.num_args = 1;
+  grpc_arg arg_array[] = {
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS), 1000),
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_MAX_RECONNECT_BACKOFF_MS), 1000),
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS), 5000)};
+  grpc_channel_args client_args = {GPR_ARRAY_SIZE(arg_array), arg_array};
 
   gpr_log(GPR_INFO, "Running test: %s/%s", "test_simple_delayed_request_short",
           config.name);


### PR DESCRIPTION
In the case of tls fixtures, the 1 second connect timeout does not seem to be enough for some configurations.

So, instead of the testing arg "grpc.testing.fixed_reconnect_backoff_ms" which uses the same value for both the backoff and the connection timeout, use the other args to separate out the two.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

