### PR TITLE
Reduce transferred data size in invoke_large_test to reduce flakiness

### DIFF
--- a/test/core/end2end/tests/invoke_large_request.cc
+++ b/test/core/end2end/tests/invoke_large_request.cc
@@ -88,7 +88,7 @@ static void end_test(grpc_end2end_test_fixture* f) {
 }
 
 static grpc_slice large_slice(void) {
-  grpc_slice slice = grpc_slice_malloc(1000000);
+  grpc_slice slice = grpc_slice_malloc(100000);
   memset(GRPC_SLICE_START_PTR(slice), 'x', GRPC_SLICE_LENGTH(slice));
   return slice;
 }
@@ -133,7 +133,7 @@ static void test_invoke_large_request(grpc_end2end_test_config config,
   grpc_slice details;
   int was_cancelled = 2;
 
-  gpr_timespec deadline = n_seconds_from_now(30);
+  gpr_timespec deadline = n_seconds_from_now(300);
   c = grpc_channel_create_call(f.client, nullptr, GRPC_PROPAGATE_DEFAULTS, f.cq,
                                grpc_slice_from_static_string("/foo"), nullptr,
                                deadline, nullptr);
@@ -264,23 +264,23 @@ void invoke_large_request(grpc_end2end_test_config config) {
   test_invoke_large_request(config, 16384, 65536);
   test_invoke_large_request(config, 32768, 65536);
 
-  test_invoke_large_request(config, 1000000 - 1, 65536);
-  test_invoke_large_request(config, 1000000, 65536);
-  test_invoke_large_request(config, 1000000 + 1, 65536);
-  test_invoke_large_request(config, 1000000 + 2, 65536);
-  test_invoke_large_request(config, 1000000 + 3, 65536);
-  test_invoke_large_request(config, 1000000 + 4, 65536);
-  test_invoke_large_request(config, 1000000 + 5, 65536);
-  test_invoke_large_request(config, 1000000 + 6, 65536);
+  test_invoke_large_request(config, 100000 - 1, 65536);
+  test_invoke_large_request(config, 100000, 65536);
+  test_invoke_large_request(config, 100000 + 1, 65536);
+  test_invoke_large_request(config, 100000 + 2, 65536);
+  test_invoke_large_request(config, 100000 + 3, 65536);
+  test_invoke_large_request(config, 100000 + 4, 65536);
+  test_invoke_large_request(config, 100000 + 5, 65536);
+  test_invoke_large_request(config, 100000 + 6, 65536);
 
-  test_invoke_large_request(config, 1000000 - 1, 2000000);
-  test_invoke_large_request(config, 1000000, 2000000);
-  test_invoke_large_request(config, 1000000 + 1, 2000000);
-  test_invoke_large_request(config, 1000000 + 2, 2000000);
-  test_invoke_large_request(config, 1000000 + 3, 2000000);
-  test_invoke_large_request(config, 1000000 + 4, 2000000);
-  test_invoke_large_request(config, 1000000 + 5, 2000000);
-  test_invoke_large_request(config, 1000000 + 6, 2000000);
+  test_invoke_large_request(config, 100000 - 1, 200000);
+  test_invoke_large_request(config, 100000, 200000);
+  test_invoke_large_request(config, 100000 + 1, 200000);
+  test_invoke_large_request(config, 100000 + 2, 200000);
+  test_invoke_large_request(config, 100000 + 3, 200000);
+  test_invoke_large_request(config, 100000 + 4, 200000);
+  test_invoke_large_request(config, 100000 + 5, 200000);
+  test_invoke_large_request(config, 100000 + 6, 200000);
 }
 
 void invoke_large_request_pre_init(void) {}


### PR DESCRIPTION
The large mallocs and data transfers were taking more time previously leading to timeouts. These changes still retain the intent to test GRPC_ARG_HTTP2_MAX_FRAME_SIZE and GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES with values larger than 65K

