### PR TITLE
Add interop matrix 1.47.1 for C++, Python, Ruby and PHP

### DIFF
--- a/tools/interop_matrix/README.md
+++ b/tools/interop_matrix/README.md
@@ -9,7 +9,7 @@ from specific releases/tag, are used to test version compatibility between gRPC 
 We have continuous nightly test setup to test gRPC backward compatibility between old clients and latest server.  When a gRPC developer creates a new gRPC release, s/he is also responsible to add the just-released gRPC client to the nightly test.  The steps are:
 - Add (or update) an entry in `./client_matrix.py` file to reference the github tag for the release.
 - Build new client docker image(s).  For example, for C and wrapper languages release `v1.9.9`, do
-  - `tools/interop_matrix/create_matrix_images.py --git_checkout --release=v1.9.9 --upload_images --language cxx csharp python ruby php`
+  - `tools/interop_matrix/create_matrix_images.py --git_checkout --release=v1.9.9 --upload_images --language cxx python ruby php`
 - Verify that the new docker image was built successfully and uploaded to GCR.  For example,
   - `gcloud container images list --repository gcr.io/grpc-testing` lists available images.
   - `gcloud container images list-tags gcr.io/grpc-testing/grpc_interop_java` should show an image entry with tag `v1.9.9`.

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -119,6 +119,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
             ('v1.46.2', ReleaseInfo()),
+            ('v1.47.1', ReleaseInfo()),
             ('v1.48.0', ReleaseInfo()),
         ]),
     'go':
@@ -420,6 +421,9 @@ LANG_RELEASE_MATRIX = {
                 ('v1.46.2',
                  ReleaseInfo(runtimes=['python'],
                              testcases_file='python__master')),
+                ('v1.47.1',
+                 ReleaseInfo(runtimes=['python'],
+                             testcases_file='python__master')),
                 ('v1.48.0',
                  ReleaseInfo(runtimes=['python'],
                              testcases_file='python__master')),
@@ -496,6 +500,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
             ('v1.46.2', ReleaseInfo()),
+            ('v1.47.1', ReleaseInfo()),
             ('v1.48.0', ReleaseInfo()),
         ]),
     'php':
@@ -543,6 +548,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.43.0', ReleaseInfo()),
             ('v1.44.0', ReleaseInfo()),
             ('v1.46.2', ReleaseInfo()),
+            ('v1.47.1', ReleaseInfo()),
             ('v1.48.0', ReleaseInfo()),
         ]),
     'csharp':


### PR DESCRIPTION
- 1.47.x release is missing in the interop matrix
- adjust the interop matrix docs to stop including C# for new releases (as C# has been removed from the master branch). 