### PR TITLE
Make ruby unit tests work on ruby 3

### DIFF
--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -17,7 +17,7 @@ describe 'Server Interceptors' do
   let(:interceptor) { TestServerInterceptor.new }
   let(:request) { EchoMsg.new }
   let(:trailing_metadata) { {} }
-  let(:service) { EchoService.new(trailing_metadata) }
+  let(:service) { EchoService.new(**trailing_metadata) }
   let(:interceptors) { [] }
 
   before(:each) do

--- a/src/ruby/spec/user_agent_spec.rb
+++ b/src/ruby/spec/user_agent_spec.rb
@@ -49,7 +49,7 @@ describe 'user agent' do
   it 'client sends expected user agent' do
     stub = UserAgentEchoServiceStub.new("localhost:#{@port}",
                                         :this_channel_is_insecure,
-                                        {})
+                                        channel_args: {})
     response = stub.an_rpc(EchoMsg.new)
     expected_user_agent_prefix = "grpc-ruby/#{GRPC::VERSION}"
     expect(response.msg.start_with?(expected_user_agent_prefix)).to be true


### PR DESCRIPTION
Fixes a style that was broken due to https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

