### PR TITLE
xDS interop: Improve retry logic and logging for the k8s retry operations

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -7,7 +7,7 @@ Work in progress. Internal APIs may and will change. Please refrain from making
 changes to this codebase at the moment.
 
 ### Stabilization roadmap 
-- [ ] Replace retrying with tenacity
+- [x] Replace retrying with tenacity
 - [x] Generate namespace for each test to prevent resource name conflicts and
       allow running tests in parallel
 - [x] Security: run server and client in separate namespaces

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
@@ -34,6 +34,9 @@ _SECURE = flags.DEFINE_bool("secure",
 _REUSE_NAMESPACE = flags.DEFINE_bool("reuse_namespace",
                                      default=True,
                                      help="Use existing namespace if exists")
+_REUSE_SERVICE = flags.DEFINE_bool("reuse_service",
+                                   default=False,
+                                   help="Use existing service if exists")
 _CLEANUP_NAMESPACE = flags.DEFINE_bool(
     "cleanup_namespace",
     default=False,
@@ -71,7 +74,8 @@ def main(argv):
         gcp_api_manager=gcp.api.GcpApiManager(),
         gcp_service_account=gcp_service_account,
         network=xds_flags.NETWORK.value,
-        reuse_namespace=_REUSE_NAMESPACE.value)
+        reuse_namespace=_REUSE_NAMESPACE.value,
+        reuse_service=_REUSE_SERVICE.value)
 
     if _SECURE.value:
         runner_kwargs.update(

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
@@ -22,13 +22,13 @@ We use tenacity as a general-purpose retrying library.
 """
 import datetime
 import logging
-from typing import Any, Optional, Sequence, Callable, List
+from typing import Any, Callable, List, Optional, Sequence
 
 import tenacity
-from tenacity.retry import retry_base
-from tenacity import wait
-from tenacity import stop
 from tenacity import _utils as tenacity_utils
+from tenacity import stop
+from tenacity import wait
+from tenacity.retry import retry_base
 
 retryers_logger = logging.getLogger(__name__)
 # Type aliases

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
@@ -171,7 +171,7 @@ class RetryError(tenacity.RetryError):
         callback_name = tenacity_utils.get_callback_name(retry_state.fn)
         self.message = f'Retry error calling {callback_name}:'
         if timeout:
-            self.message += f' timeout {timeout} exceeded'
+            self.message += f' timeout {timeout} (h:mm:ss) exceeded'
             if attempts:
                 self.message += ' or'
         if attempts:

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/retryers.py
@@ -22,30 +22,36 @@ We use tenacity as a general-purpose retrying library.
 """
 import datetime
 import logging
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Callable, List
 
 import tenacity
+from tenacity.retry import retry_base
+from tenacity import wait
+from tenacity import stop
+from tenacity import _utils as tenacity_utils
 
 retryers_logger = logging.getLogger(__name__)
 # Type aliases
 timedelta = datetime.timedelta
 Retrying = tenacity.Retrying
-RetryError = tenacity.RetryError
-_after_log = tenacity.after_log
-_before_sleep_log = tenacity.before_sleep_log
-_retry_if_exception_type = tenacity.retry_if_exception_type
-_stop_after_attempt = tenacity.stop_after_attempt
-_stop_after_delay = tenacity.stop_after_delay
-_stop_any = tenacity.stop_any
-_wait_exponential = tenacity.wait_exponential
-_wait_fixed = tenacity.wait_fixed
+CheckResultFn = Callable[[Any], bool]
 
 
 def _retry_on_exceptions(retry_on_exceptions: Optional[Sequence[Any]] = None):
     # Retry on all exceptions by default
     if retry_on_exceptions is None:
         retry_on_exceptions = (Exception,)
-    return _retry_if_exception_type(retry_on_exceptions)
+    return tenacity.retry_if_exception_type(retry_on_exceptions)
+
+
+def _build_retry_conditions(
+        *,
+        retry_on_exceptions: Optional[Sequence[Any]] = None,
+        check_result: Optional[CheckResultFn] = None) -> List[retry_base]:
+    retry_conditions = [_retry_on_exceptions(retry_on_exceptions)]
+    if check_result is not None:
+        retry_conditions.append(tenacity.retry_if_not_result(check_result))
+    return retry_conditions
 
 
 def exponential_retryer_with_timeout(
@@ -54,17 +60,24 @@ def exponential_retryer_with_timeout(
         wait_max: timedelta,
         timeout: timedelta,
         retry_on_exceptions: Optional[Sequence[Any]] = None,
+        check_result: Optional[CheckResultFn] = None,
         logger: Optional[logging.Logger] = None,
         log_level: Optional[int] = logging.DEBUG) -> Retrying:
     if logger is None:
         logger = retryers_logger
     if log_level is None:
         log_level = logging.DEBUG
-    return Retrying(retry=_retry_on_exceptions(retry_on_exceptions),
-                    wait=_wait_exponential(min=wait_min.total_seconds(),
-                                           max=wait_max.total_seconds()),
-                    stop=_stop_after_delay(timeout.total_seconds()),
-                    before_sleep=_before_sleep_log(logger, log_level))
+
+    retry_conditions = _build_retry_conditions(
+        retry_on_exceptions=retry_on_exceptions, check_result=check_result)
+    retry_error_callback = _on_error_callback(timeout=timeout,
+                                              check_result=check_result)
+    return Retrying(retry=tenacity.retry_any(*retry_conditions),
+                    wait=wait.wait_exponential(min=wait_min.total_seconds(),
+                                               max=wait_max.total_seconds()),
+                    stop=stop.stop_after_delay(timeout.total_seconds()),
+                    before_sleep=tenacity.before_sleep_log(logger, log_level),
+                    retry_error_callback=retry_error_callback)
 
 
 def constant_retryer(*,
@@ -72,6 +85,7 @@ def constant_retryer(*,
                      attempts: int = 0,
                      timeout: Optional[timedelta] = None,
                      retry_on_exceptions: Optional[Sequence[Any]] = None,
+                     check_result: Optional[CheckResultFn] = None,
                      logger: Optional[logging.Logger] = None,
                      log_level: Optional[int] = logging.DEBUG) -> Retrying:
     if logger is None:
@@ -82,11 +96,65 @@ def constant_retryer(*,
         raise ValueError('The number of attempts or the timeout must be set')
     stops = []
     if attempts > 0:
-        stops.append(_stop_after_attempt(attempts))
+        stops.append(stop.stop_after_attempt(attempts))
     if timeout is not None:
-        stops.append(_stop_after_delay(timeout.total_seconds()))
+        stops.append(stop.stop_after_delay(timeout.total_seconds()))
 
-    return Retrying(retry=_retry_on_exceptions(retry_on_exceptions),
-                    wait=_wait_fixed(wait_fixed.total_seconds()),
-                    stop=_stop_any(*stops),
-                    before_sleep=_before_sleep_log(logger, log_level))
+    retry_conditions = _build_retry_conditions(
+        retry_on_exceptions=retry_on_exceptions, check_result=check_result)
+    retry_error_callback = _on_error_callback(timeout=timeout,
+                                              attempts=attempts,
+                                              check_result=check_result)
+    return Retrying(retry=tenacity.retry_any(*retry_conditions),
+                    wait=wait.wait_fixed(wait_fixed.total_seconds()),
+                    stop=stop.stop_any(*stops),
+                    before_sleep=tenacity.before_sleep_log(logger, log_level),
+                    retry_error_callback=retry_error_callback)
+
+
+def _on_error_callback(*,
+                       timeout: Optional[timedelta] = None,
+                       attempts: int = 0,
+                       check_result: Optional[CheckResultFn] = None):
+
+    def error_handler(retry_state: tenacity.RetryCallState):
+        raise RetryError(retry_state,
+                         timeout=timeout,
+                         attempts=attempts,
+                         check_result=check_result)
+
+    return error_handler
+
+
+class RetryError(tenacity.RetryError):
+
+    def __init__(self,
+                 retry_state,
+                 *,
+                 timeout: Optional[timedelta] = None,
+                 attempts: int = 0,
+                 check_result: Optional[CheckResultFn] = None):
+        super().__init__(retry_state.outcome)
+        callback_name = tenacity_utils.get_callback_name(retry_state.fn)
+        self.message = f'Retry error calling {callback_name}:'
+        if timeout:
+            self.message += f' timeout {timeout} exceeded'
+            if attempts:
+                self.message += ' or'
+        if attempts:
+            self.message += f' {attempts} attempts exhausted'
+
+        self.message += '.'
+
+        if retry_state.outcome.failed:
+            ex = retry_state.outcome.exception()
+            self.message += f' Last exception: {type(ex).__name__}: {ex}'
+        elif check_result:
+            self.message += ' Check result callback returned False.'
+
+    def result(self, *, default=None):
+        return default if self.last_attempt.failed else self.last_attempt.result(
+        )
+
+    def __str__(self):
+        return self.message

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -312,7 +312,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
             name: str,
             count: int = 1,
             timeout_sec: int = WAIT_MEDIUM_TIMEOUT_SEC,
-            wait_sec: int = WAIT_MEDIUM_SLEEP_SEC):
+            wait_sec: int = WAIT_SHORT_SLEEP_SEC):
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -235,18 +235,19 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
 
     def wait_for_service_deleted(self,
                                  name: str,
-                                 timeout_sec=WAIT_SHORT_TIMEOUT_SEC,
-                                 wait_sec=WAIT_SHORT_SLEEP_SEC):
+                                 timeout_sec: int = WAIT_SHORT_TIMEOUT_SEC,
+                                 wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
             timeout=datetime.timedelta(seconds=timeout_sec),
             check_result=lambda service: service is None)
         retryer(self.get_service, name)
 
-    def wait_for_service_account_deleted(self,
-                                         name: str,
-                                         timeout_sec=WAIT_SHORT_TIMEOUT_SEC,
-                                         wait_sec=WAIT_SHORT_SLEEP_SEC):
+    def wait_for_service_account_deleted(
+            self,
+            name: str,
+            timeout_sec: int = WAIT_SHORT_TIMEOUT_SEC,
+            wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
             timeout=datetime.timedelta(seconds=timeout_sec),
@@ -254,8 +255,8 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         retryer(self.get_service_account, name)
 
     def wait_for_namespace_deleted(self,
-                                   timeout_sec=WAIT_LONG_TIMEOUT_SEC,
-                                   wait_sec=WAIT_LONG_SLEEP_SEC):
+                                   timeout_sec: int = WAIT_LONG_TIMEOUT_SEC,
+                                   wait_sec: int = WAIT_LONG_SLEEP_SEC) -> None:
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
             timeout=datetime.timedelta(seconds=timeout_sec),
@@ -265,7 +266,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
     def wait_for_service_neg(self,
                              name: str,
                              timeout_sec: int = WAIT_SHORT_TIMEOUT_SEC,
-                             wait_sec: int = WAIT_SHORT_SLEEP_SEC):
+                             wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
@@ -293,9 +294,10 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
     def get_deployment(self, name) -> V1Deployment:
         return self.api.apps.read_namespaced_deployment(name, self.name)
 
-    def delete_deployment(self,
-                          name,
-                          grace_period_seconds=DELETE_GRACE_PERIOD_SEC):
+    def delete_deployment(
+            self,
+            name: str,
+            grace_period_seconds: int = DELETE_GRACE_PERIOD_SEC) -> None:
         self.api.apps.delete_namespaced_deployment(
             name=name,
             namespace=self.name,
@@ -312,7 +314,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
             name: str,
             count: int = 1,
             timeout_sec: int = WAIT_MEDIUM_TIMEOUT_SEC,
-            wait_sec: int = WAIT_SHORT_SLEEP_SEC):
+            wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
@@ -333,7 +335,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
             count: int = 1,
             *,
             timeout_sec: int = WAIT_MEDIUM_TIMEOUT_SEC,
-            wait_sec: int = WAIT_SHORT_SLEEP_SEC):
+            wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
@@ -349,10 +351,11 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
                 self._pretty_format_statuses(result))
             raise
 
-    def wait_for_deployment_deleted(self,
-                                    deployment_name: str,
-                                    timeout_sec=WAIT_MEDIUM_TIMEOUT_SEC,
-                                    wait_sec=WAIT_MEDIUM_SLEEP_SEC):
+    def wait_for_deployment_deleted(
+            self,
+            deployment_name: str,
+            timeout_sec: int = WAIT_MEDIUM_TIMEOUT_SEC,
+            wait_sec: int = WAIT_MEDIUM_SLEEP_SEC) -> None:
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
             timeout=datetime.timedelta(seconds=timeout_sec),
@@ -370,7 +373,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
     def wait_for_pod_started(self,
                              pod_name: str,
                              timeout_sec: int = WAIT_SHORT_TIMEOUT_SEC,
-                             wait_sec: int = WAIT_SHORT_SLEEP_SEC):
+                             wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
@@ -398,12 +401,13 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         pf.connect()
         return pf
 
-    def _pretty_format_statuses(self, k8s_objects: List[Optional[object]]):
+    def _pretty_format_statuses(self,
+                                k8s_objects: List[Optional[object]]) -> str:
         return '\n'.join(
             self._pretty_format_status(k8s_object)
             for k8s_object in k8s_objects)
 
-    def _pretty_format_status(self, k8s_object: Optional[object]):
+    def _pretty_format_status(self, k8s_object: Optional[object]) -> str:
         if k8s_object is None:
             return 'No data'
         if hasattr(k8s_object, 'metadata') and hasattr(k8s_object.metadata,
@@ -426,16 +430,17 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         return self._highlighter.highlight(yaml_out)
 
     @classmethod
-    def _check_service_neg_annotation(cls, service: Optional[V1Service]):
+    def _check_service_neg_annotation(cls,
+                                      service: Optional[V1Service]) -> bool:
         return (service is not None and
                 cls.NEG_STATUS_META in service.metadata.annotations)
 
     @classmethod
-    def _pod_started(cls, pod: V1Pod):
+    def _pod_started(cls, pod: V1Pod) -> bool:
         return pod.status.phase not in ('Pending', 'Unknown')
 
     @classmethod
-    def _replicas_available(cls, deployment: V1Deployment, count: int):
+    def _replicas_available(cls, deployment: V1Deployment, count: int) -> bool:
         return (deployment is not None and
                 deployment.status.available_replicas is not None and
                 deployment.status.available_replicas >= count)

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -276,8 +276,8 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
             retryer(self.get_service, name)
         except retryers.RetryError as e:
             logger.error(
-                'Timeout %s waiting for service %s to report NEG status. '
-                'Last service status:\n%s', timeout, name,
+                'Timeout %s (h:mm:ss) waiting for service %s to report NEG '
+                'status. Last service status:\n%s', timeout, name,
                 self._pretty_format_status(e.result()))
             raise
 
@@ -324,7 +324,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
             retryer(self.get_deployment, name)
         except retryers.RetryError as e:
             logger.error(
-                'Timeout %s waiting for deployment %s to report %i '
+                'Timeout %s (h:mm:ss) waiting for deployment %s to report %i '
                 'replicas available. Last status:\n%s', timeout, name, count,
                 self._pretty_format_status(e.result()))
             raise
@@ -346,7 +346,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         except retryers.RetryError as e:
             result = e.result(default=[])
             logger.error(
-                'Timeout %s waiting for pod count %i, got: %i. '
+                'Timeout %s (h:mm:ss) waiting for pod count %i, got: %i. '
                 'Pod statuses:\n%s', timeout, count, len(result),
                 self._pretty_format_statuses(result))
             raise
@@ -383,7 +383,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
             retryer(self.get_pod, pod_name)
         except retryers.RetryError as e:
             logger.error(
-                'Timeout %s waiting for pod %s to start. '
+                'Timeout %s (h:mm:ss) waiting for pod %s to start. '
                 'Pod status:\n%s', timeout, pod_name,
                 self._pretty_format_status(e.result()))
             raise

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -406,11 +406,12 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
     def _pretty_format_status(self, k8s_object: Optional[object]):
         if k8s_object is None:
             return 'No data'
-        if 'metadata' in k8s_object.metadata and 'name' in k8s_object.metadata:
+        if hasattr(k8s_object, 'metadata') and hasattr(k8s_object.metadata,
+                                                       'name'):
             name = k8s_object.metadata.name
         else:
             name = 'Can\'t parse resource name'
-        if 'status' in k8s_object:
+        if hasattr(k8s_object, 'status'):
             try:
                 status = self._pretty_format(k8s_object.status.to_dict())
             except Exception as e:

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -295,23 +295,25 @@ class KubernetesBaseRunner(base_runner.BaseRunner):
     def _wait_deployment_pod_count(self,
                                    deployment: k8s.V1Deployment,
                                    count: int = 1,
-                                   **kwargs) -> List[k8s.V1Pod]:
+                                   **kwargs) -> List[str]:
         logger.info('Waiting for deployment %s to initialize %s pod(s)',
                     deployment.metadata.name, count)
         self.k8s_namespace.wait_for_deployment_replica_count(
             deployment, count, **kwargs)
         pods = self.k8s_namespace.list_deployment_pods(deployment)
+        pod_names = [pod.metadata.name for pod in pods]
         logger.info('Deployment %s initialized %i pod(s): %s',
-                    deployment.metadata.name, count,
-                    [pod.metadata.name for pod in pods])
-        return pods
+                    deployment.metadata.name, count, pod_names)
+        # Pods may not  be started yet, just return the names.
+        return pod_names
 
-    def _wait_pod_started(self, name, **kwargs):
+    def _wait_pod_started(self, name, **kwargs) -> k8s.V1Pod:
         logger.info('Waiting for pod %s to start', name)
         self.k8s_namespace.wait_for_pod_started(name, **kwargs)
         pod = self.k8s_namespace.get_pod(name)
         logger.info('Pod %s ready, IP: %s', pod.metadata.name,
                     pod.status.pod_ip)
+        return pod
 
     def _wait_service_neg(self, name, service_port, **kwargs):
         logger.info('Waiting for NEG for service %s', name)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -141,9 +141,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             print_response=print_response)
 
         # Load test client pod. We need only one client at the moment
-        pod: k8s.V1Pod = self._wait_deployment_pod_count(self.deployment)[0]
-        pod_name = pod.metadata.name
-        self._wait_pod_started(pod_name)
+        pod_name = self._wait_deployment_pod_count(self.deployment)[0]
+        pod: k8s.V1Pod = self._wait_pod_started(pod_name)
 
         # Verify the deployment reports all pods started as well.
         self._wait_deployment_with_available_replicas(self.deployment_name)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -140,16 +140,18 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             config_mesh=config_mesh,
             print_response=print_response)
 
+        # Load test client pod. We need only one client at the moment
+        pod: k8s.V1Pod = self._wait_deployment_pod_count(self.deployment)[0]
+        pod_name = pod.metadata.name
+        self._wait_pod_started(pod_name)
+
+        # Verify the deployment reports all pods started as well.
         self._wait_deployment_with_available_replicas(self.deployment_name)
 
-        # Load test client pod. We need only one client at the moment
-        pod = self.k8s_namespace.list_deployment_pods(self.deployment)[0]
-        self._wait_pod_started(pod.metadata.name)
+        # Experimental, for local debugging.
         pod_ip = pod.status.pod_ip
         rpc_port = self.stats_port
         rpc_host = None
-
-        # Experimental, for local debugging.
         if self.debug_use_port_forwarding:
             logger.info('LOCAL DEV MODE: Enabling port forwarding to %s:%s',
                         pod_ip, self.stats_port)
@@ -162,7 +164,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
                              rpc_port=rpc_port,
                              server_target=server_target,
                              rpc_host=rpc_host,
-                             hostname=pod.metadata.name)
+                             hostname=pod_name)
 
     def cleanup(self, *, force=False, force_namespace=False):  # pylint: disable=arguments-differ
         if self.port_forwarder:

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -181,17 +181,16 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
             maintenance_port=maintenance_port,
             secure_mode=secure_mode)
 
+        pods = self._wait_deployment_pod_count(self.deployment, replica_count)
+        for pod in pods:
+            self._wait_pod_started(pod.metadata.name)
+
+        # Verify the deployment reports all pods started as well.
         self._wait_deployment_with_available_replicas(self.deployment_name,
                                                       replica_count)
 
-        # Wait for pods running
-        pods = self.k8s_namespace.list_deployment_pods(self.deployment)
-
         servers = []
         for pod in pods:
-            pod_name = pod.metadata.name
-            self._wait_pod_started(pod_name)
-
             pod_ip = pod.status.pod_ip
             rpc_host = None
             # Experimental, for local debugging.
@@ -208,7 +207,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
             servers.append(
                 XdsTestServer(ip=pod_ip,
                               rpc_port=test_port,
-                              hostname=pod_name,
+                              hostname=pod.metadata.name,
                               maintenance_port=local_port,
                               secure_mode=secure_mode,
                               rpc_host=rpc_host))

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -181,14 +181,13 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
             maintenance_port=maintenance_port,
             secure_mode=secure_mode)
 
-        pods = self._wait_deployment_pod_count(self.deployment, replica_count)
-        for pod in pods:
-            self._wait_pod_started(pod.metadata.name)
+        pod_names = self._wait_deployment_pod_count(self.deployment,
+                                                    replica_count)
+        pods = [self._wait_pod_started(pod_name) for pod_name in pod_names]
 
         # Verify the deployment reports all pods started as well.
         self._wait_deployment_with_available_replicas(self.deployment_name,
                                                       replica_count)
-
         servers = []
         for pod in pods:
             pod_ip = pod.status.pod_ip

--- a/tools/run_tests/xds_k8s_test_driver/requirements.txt
+++ b/tools/run_tests/xds_k8s_test_driver/requirements.txt
@@ -9,9 +9,6 @@ grpcio-health-checking~=1.34
 grpcio-tools~=1.34
 grpcio-channelz~=1.34
 kubernetes~=12.0
-# TODO(sergiitk): remove retrying when replaced with tenacity in code.
-# Context: https://github.com/grpc/grpc/pull/24983#discussion_r543017022
-retrying~=1.3
 six~=1.13
 tenacity~=6.2
 packaging~=21.3


### PR DESCRIPTION
- Changes the order of waiting for pods to start: wait for the pods first, then for the deployment to transition to active. This should provide more useful information in the logs, showing exactly why the pod didn't start, instead of generic "Replicas not available" ref b/200293121. This also needed for https://github.com/grpc/grpc/pull/30594
- Add support for `check_result` callback in the retryer helpers
- Completely replaces `retrying` with `tenacity`, ref b/200293121. Retrying is not longer maintained.
- Improves the readability of timeout errors: now they contain the timeout (or the attempt number) exceeded, and information why the timeout failed (exception/check function):
  Before:  
  > `tenacity.RetryError: RetryError[<Future at 0x7f8ce156bc18 state=finished returned dict>]`
  
  After:
  > `framework.helpers.retryers.RetryError: Retry error calling framework.infrastructure.k8s.KubernetesNamespace.get_pod: timeout 0:01:00 exceeded. Check result callback returned False.`
- Improves the readability of the k8s wait operation errors: now the log includes colorized and formatted status of the k8s object being watched, instead of dumping the full k8s object. For example, here's how an error caused by using incorrect TD bootstrap image:
  <img width="1397" alt="Screen Shot 2022-08-22 at 3 12 15 PM" src="https://user-images.githubusercontent.com/672669/186027855-5ff2cc93-2f11-4ad1-9614-4bae0cc2437c.png"> 
  <img width="1392" alt="Screen Shot 2022-08-22 at 3 13 44 PM" src="https://user-images.githubusercontent.com/672669/186027986-01e60a7a-5464-4805-bdfd-553a79274d72.png">

Should also fix b/217861014
