### PR TITLE
[fixit] Loosen bounds on periodic update test

### DIFF
--- a/test/core/resource_quota/periodic_update_test.cc
+++ b/test/core/resource_quota/periodic_update_test.cc
@@ -60,12 +60,12 @@ TEST(PeriodicUpdateTest, SimpleTest) {
       ExecCtx exec_ctx;
       upd->Tick([&](Duration) { done = true; });
     }
-    // Ensure the time taken was between 1 and 1.5 seconds - we make a little
+    // Ensure the time taken was between 1 and 3 seconds - we make a little
     // allowance for the presumed inaccuracy of this type.
     {
       ExecCtx exec_ctx;
       EXPECT_GE(exec_ctx.Now() - start, Duration::Seconds(1));
-      EXPECT_LE(exec_ctx.Now() - start, Duration::Milliseconds(1500));
+      EXPECT_LE(exec_ctx.Now() - start, Duration::Seconds(3));
       start = exec_ctx.Now();
     }
   }
@@ -101,11 +101,11 @@ TEST(PeriodicUpdate, ThreadTest) {
   for (auto& th : threads) {
     th.join();
   }
-  // Ensure our ten cycles took at least 10 seconds, and no more than 15.
+  // Ensure our ten cycles took at least 10 seconds, and no more than 30.
   {
     ExecCtx exec_ctx;
     EXPECT_GE(exec_ctx.Now() - start, Duration::Seconds(10));
-    EXPECT_LE(exec_ctx.Now() - start, Duration::Seconds(15));
+    EXPECT_LE(exec_ctx.Now() - start, Duration::Seconds(30));
   }
 }
 


### PR DESCRIPTION
This test failed on Mac, and it seems like an easy fix.

Failure log:
https://source.cloud.google.com/results/invocations/4d101887-8aca-42a8-b1b1-2d4454ae823d/targets/grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_basictests_c_cpp/log

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

