### PR TITLE
[fixit] PeriodicUpdate test - accounting for missing time

### DIFF
--- a/test/core/resource_quota/periodic_update_test.cc
+++ b/test/core/resource_quota/periodic_update_test.cc
@@ -35,6 +35,7 @@ namespace testing {
 TEST(PeriodicUpdateTest, SimpleTest) {
   std::unique_ptr<PeriodicUpdate> upd;
   Timestamp start;
+  Timestamp reset_start;
   // Create a periodic update that updates every second.
   {
     ExecCtx exec_ctx;
@@ -45,20 +46,28 @@ TEST(PeriodicUpdateTest, SimpleTest) {
   bool done = false;
   while (!done) {
     ExecCtx exec_ctx;
-    upd->Tick([&](Duration) { done = true; });
+    upd->Tick([&](Duration elapsed) {
+      reset_start = ExecCtx::Get()->Now();
+      EXPECT_GE(elapsed, Duration::Seconds(1));
+      done = true;
+    });
   }
   // Ensure that took at least 1 second.
   {
     ExecCtx exec_ctx;
     EXPECT_GE(exec_ctx.Now() - start, Duration::Seconds(1));
-    start = exec_ctx.Now();
+    start = reset_start;
   }
   // Do ten more update cycles
   for (int i = 0; i < 10; i++) {
     done = false;
     while (!done) {
       ExecCtx exec_ctx;
-      upd->Tick([&](Duration) { done = true; });
+      upd->Tick([&](Duration elapsed) {
+        reset_start = ExecCtx::Get()->Now();
+        EXPECT_GE(exec_ctx.Now() - start, Duration::Seconds(1));
+        done = true;
+      });
     }
     // Ensure the time taken was between 1 and 1.5 seconds - we make a little
     // allowance for the presumed inaccuracy of this type.
@@ -66,7 +75,7 @@ TEST(PeriodicUpdateTest, SimpleTest) {
       ExecCtx exec_ctx;
       EXPECT_GE(exec_ctx.Now() - start, Duration::Seconds(1));
       EXPECT_LE(exec_ctx.Now() - start, Duration::Milliseconds(1500));
-      start = exec_ctx.Now();
+      start = reset_start;
     }
   }
 }


### PR DESCRIPTION
Previous failure rate around ~1/4000 runs. Symptoms were: elapsed time appeared to be a few milliseconds less than the expect 1s duration. The cause is apparently some previously-unaccounted-for time spent processing the test before it set a new reference timestamp. The periodic updater counted that time, and the test did not.

0 failures in 50,000 runs.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

