### PR TITLE
[fixit] Fix flakiness for test case ChannelzSamplerTest.SimpleTest by reducing the chance of port conflict

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -332,6 +332,7 @@ grpc_cc_binary(
     srcs = ["channelz_sampler.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/strings",
     ],
     language = "c++",
     tags = [

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <thread>
 
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 #include <grpc/grpc.h>
@@ -164,6 +165,12 @@ TEST(ChannelzSamplerTest, SimpleTest) {
   client_thread_2.join();
 }
 
+int GenerateUniuquePortNumber() {
+  return 10000 + (std::hash<pid_t>()(getpid()) +
+                  std::hash<std::thread::id>{}(std::this_thread::get_id())) %
+                     10000;
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
@@ -174,6 +181,9 @@ int main(int argc, char** argv) {
   } else {
     g_root = ".";
   }
+
+  /// ensures the target address is unique even if this test is run in parallel
+  server_address = absl::StrCat("0.0.0.0:", GenerateUniuquePortNumber());
   int ret = RUN_ALL_TESTS();
   return ret;
 }

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -45,6 +45,7 @@
 #include "src/core/lib/gpr/env.h"
 #include "src/cpp/server/channelz/channelz_service.h"
 #include "src/proto/grpc/testing/test.grpc.pb.h"
+#include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/subprocess.h"
 #include "test/cpp/util/test_credentials_provider.h"
@@ -165,12 +166,6 @@ TEST(ChannelzSamplerTest, SimpleTest) {
   client_thread_2.join();
 }
 
-int GenerateUniuquePortNumber() {
-  return 10000 + (std::hash<pid_t>()(getpid()) +
-                  std::hash<std::thread::id>{}(std::this_thread::get_id())) %
-                     10000;
-}
-
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
@@ -183,7 +178,7 @@ int main(int argc, char** argv) {
   }
 
   /// ensures the target address is unique even if this test is run in parallel
-  server_address = absl::StrCat("0.0.0.0:", GenerateUniuquePortNumber());
+  server_address = absl::StrCat("0.0.0.0:", grpc_pick_unused_port_or_die());
   int ret = RUN_ALL_TESTS();
   return ret;
 }


### PR DESCRIPTION
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This test case seems to only fail when it is run in parallel. After digging into it, I found this test case opens a subprocess as a gRPC server using the hard-coded address and port number which are probably the cause of the flakiness.

This PR fixes the issue by always assigning an unused port number to the `server_address`.