### PR TITLE
[fixit] Remove absl::Now() from sensitive EventEngine timer_test

### DIFF
--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -33,7 +33,8 @@ using namespace std::chrono_literals;
 
 class EventEngineTimerTest : public EventEngineTest {
  public:
-  void ScheduleCheckCB(absl::Time when, std::atomic<int>* call_count,
+  void ScheduleCheckCB(std::chrono::steady_clock::time_point when,
+                       std::atomic<int>* call_count,
                        std::atomic<int>* fail_count, int total_expected);
 
  protected:
@@ -125,11 +126,10 @@ TEST_F(EventEngineTimerTest, CancellingExecutedCallbackIsNoopAndReturnsFalse) {
   ASSERT_FALSE(engine->Cancel(handle));
 }
 
-void EventEngineTimerTest::ScheduleCheckCB(absl::Time when,
-                                           std::atomic<int>* call_count,
-                                           std::atomic<int>* fail_count,
-                                           int total_expected) {
-  auto now = absl::Now();
+void EventEngineTimerTest::ScheduleCheckCB(
+    std::chrono::steady_clock::time_point when, std::atomic<int>* call_count,
+    std::atomic<int>* fail_count, int total_expected) {
+  auto now = std::chrono::steady_clock::now();
   EXPECT_LE(when, now);
   if (when > now) ++(*fail_count);
   if (++(*call_count) == total_expected) {
@@ -157,7 +157,8 @@ TEST_F(EventEngineTimerTest, StressTestTimersNotCalledBeforeScheduled) {
                                            timeout_max_seconds);
       for (int call_n = 0; call_n < call_count_per_thread; ++call_n) {
         const auto dur = static_cast<int64_t>(1e9 * dis(gen));
-        auto deadline = absl::Now() + absl::Nanoseconds(dur);
+        auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::nanoseconds(dur);
         engine->RunAfter(
             std::chrono::nanoseconds(dur),
             absl::bind_front(&EventEngineTimerTest::ScheduleCheckCB, this,


### PR DESCRIPTION
absl::Now() is not guaranteed to be monotonic, and we are seeing some
potential time travel at different frequencies on different machines. I've
replaced the most sensitive pieces with std::chrono::steady_clock to see
if that fixes the flakes we are seeing.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

