### PR TITLE
[fixit] MaxConnectionIdle: Increase idleness period to 2sec

### DIFF
--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -34,7 +34,7 @@
 #include "test/core/end2end/end2end_tests.h"
 #include "test/core/util/test_config.h"
 
-#define MAX_CONNECTION_IDLE_MS 500
+#define MAX_CONNECTION_IDLE_MS 2000
 #define MAX_CONNECTION_AGE_MS 9999
 
 static void* tag(intptr_t t) { return reinterpret_cast<void*>(t); }


### PR DESCRIPTION
In CI, we were seeing flakes like https://source.cloud.google.com/results/invocations/15100403-0ddd-426b-acab-254b14d83fd1/targets/%2F%2Ftest%2Fcore%2Fend2end:h2_oauth2_test@max_connection_idle@poller%3Depoll1/log where the idle filter was kicking in too early.