### PR TITLE
Add comments for copybara to add proguard annotation

### DIFF
--- a/src/core/ext/transport/binder/java/io/grpc/binder/cpp/BUILD
+++ b/src/core/ext/transport/binder/java/io/grpc/binder/cpp/BUILD
@@ -24,5 +24,7 @@ android_library(
         "NativeConnectionHelper.java",
     ],
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+        # copybara: Add proguard dependency here
+    ],
 )

--- a/src/core/ext/transport/binder/java/io/grpc/binder/cpp/NativeConnectionHelper.java
+++ b/src/core/ext/transport/binder/java/io/grpc/binder/cpp/NativeConnectionHelper.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Parcel;
 import android.util.Log;
+// copybara: Import proguard UsedByNative annotation here
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,10 +27,12 @@ import java.util.Map;
  * src/core/ext/transport/binder/client/jni_utils.cc) to perform operations that are only possible
  * in Java
  */
+// copybara: Add @UsedByNative("jni_utils.cc")
 final class NativeConnectionHelper {
   // Maps connection id to GrpcBinderConnection instances
   static Map<String, GrpcBinderConnection> connectionIdToGrpcBinderConnectionMap = new HashMap<>();
 
+  // copybara: Add @UsedByNative("jni_utils.cc")
   static void tryEstablishConnection(
       Context context, String pkg, String cls, String actionName, String connId) {
     // TODO(mingcl): Assert that connId is unique
@@ -37,6 +40,7 @@ final class NativeConnectionHelper {
     connectionIdToGrpcBinderConnectionMap.get(connId).tryConnect(pkg, cls, actionName);
   }
 
+  // copybara: Add @UsedByNative("jni_utils.cc")
   static void tryEstablishConnectionWithUri(Context context, String uri, String connId) {
     // TODO(mingcl): Assert that connId is unique
     connectionIdToGrpcBinderConnectionMap.put(connId, new GrpcBinderConnection(context, connId));
@@ -48,6 +52,7 @@ final class NativeConnectionHelper {
   // Suppress unnecessary internal warnings related to checkSignatures compatibility issue.
   // BinderTransport code is only used on newer Android platform versions so this is fine.
   @SuppressWarnings("CheckSignatures")
+  // copybara: Add @UsedByNative("jni_utils.cc")
   static boolean isSignatureMatch(Context context, int uid1, int uid2) {
     int result = context.getPackageManager().checkSignatures(uid1, uid2);
     if (result == PackageManager.SIGNATURE_MATCH) {
@@ -59,6 +64,7 @@ final class NativeConnectionHelper {
     return false;
   }
 
+  // copybara: Add @UsedByNative("jni_utils.cc")
   static Parcel getEmptyParcel() {
     return Parcel.obtain();
   }


### PR DESCRIPTION
These comments are added so copybara can replace these comments with
actual annotations to prevent the class from being stripped.