### PR TITLE
Backport: "stabilize the C2P resolver URI scheme" to v1.49.x

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -454,8 +454,6 @@ class ExperimentalGoogleCloud2ProdResolverFactory : public ResolverFactory {
   }
 };
 
-};
-
 }  // namespace
 
 void RegisterCloud2ProdResolver(CoreConfiguration::Builder* builder) {

--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -414,11 +414,7 @@ void GoogleCloud2ProdResolver::StartXdsResolver() {
 
 class GoogleCloud2ProdResolverFactory : public ResolverFactory {
  public:
-  // TODO(roth): Remove experimental suffix once this code is proven stable,
-  // and update the scheme in google_c2p_resolver_test.cc when doing so.
-  absl::string_view scheme() const override {
-    return "google-c2p-experimental";
-  }
+  absl::string_view scheme() const override { return "google-c2p"; }
 
   bool IsValidUri(const URI& uri) const override {
     if (GPR_UNLIKELY(!uri.authority().empty())) {
@@ -434,11 +430,39 @@ class GoogleCloud2ProdResolverFactory : public ResolverFactory {
   }
 };
 
+// TODO(apolcyn): remove this class after user code has updated to the
+// stable "google-c2p" URI scheme.
+class ExperimentalGoogleCloud2ProdResolverFactory : public ResolverFactory {
+ public:
+  absl::string_view scheme() const override {
+    return "google-c2p-experimental";
+  }
+
+  bool IsValidUri(const URI& uri) const override {
+    if (GPR_UNLIKELY(!uri.authority().empty())) {
+      gpr_log(
+          GPR_ERROR,
+          "google-c2p-experimental URI scheme does not support authorities");
+      return false;
+    }
+    return true;
+  }
+
+  OrphanablePtr<Resolver> CreateResolver(ResolverArgs args) const override {
+    if (!IsValidUri(args.uri)) return nullptr;
+    return MakeOrphanable<GoogleCloud2ProdResolver>(std::move(args));
+  }
+};
+
+};
+
 }  // namespace
 
 void RegisterCloud2ProdResolver(CoreConfiguration::Builder* builder) {
   builder->resolver_registry()->RegisterResolverFactory(
       absl::make_unique<GoogleCloud2ProdResolverFactory>());
+  builder->resolver_registry()->RegisterResolverFactory(
+      absl::make_unique<ExperimentalGoogleCloud2ProdResolverFactory>());
 }
 
 }  // namespace grpc_core

--- a/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
+++ b/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
@@ -47,7 +47,7 @@ namespace {
 
 void TryConnectAndDestroy(const char* fake_metadata_server_address) {
   grpc::ChannelArguments args;
-  std::string target = "google-c2p-experimental:///servername_not_used";
+  std::string target = "google-c2p:///servername_not_used";
   args.SetInt("grpc.testing.google_c2p_resolver_pretend_running_on_gcp", 1);
   args.SetString("grpc.testing.google_c2p_resolver_metadata_server_override",
                  fake_metadata_server_address);


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/30653