### PR TITLE
Enable outlier detection k8s interop test for Java >= 1.49.x

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
@@ -62,7 +62,7 @@ class OutlierDetectionTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in _Lang.CPP | _Lang.PYTHON:
+        if config.client_lang in _Lang.CPP | _Lang.PYTHON | _Lang.JAVA:
             return config.version_gte('v1.48.x')
         if config.client_lang == _Lang.NODE:
             return config.version_gte('v1.6.x')

--- a/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/outlier_detection_test.py
@@ -62,8 +62,10 @@ class OutlierDetectionTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang in _Lang.CPP | _Lang.PYTHON | _Lang.JAVA:
+        if config.client_lang in _Lang.CPP | _Lang.PYTHON:
             return config.version_gte('v1.48.x')
+        if config.client_lang == _Lang.JAVA:
+            return config.version_gte('v1.49.x')
         if config.client_lang == _Lang.NODE:
             return config.version_gte('v1.6.x')
         return False


### PR DESCRIPTION
Restores https://github.com/grpc/grpc/pull/30641 for testing. 

Java works now.