### PR TITLE
[fixit] Increase timeout, fix atomicity

### DIFF
--- a/test/core/security/grpc_tls_credentials_options_test.cc
+++ b/test/core/security/grpc_tls_credentials_options_test.cc
@@ -415,9 +415,10 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
   tmp_root_cert.RewriteFile(root_cert_2_);
   tmp_identity_key.RewriteFile(private_key_2_);
   tmp_identity_cert.RewriteFile(cert_chain_2_);
-  // Wait 2 seconds for the provider's refresh thread to read the updated files.
+  // Wait 10 seconds for the provider's refresh thread to read the updated
+  // files.
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
-                               gpr_time_from_seconds(2, GPR_TIMESPAN)));
+                               gpr_time_from_seconds(10, GPR_TIMESPAN)));
   // Expect to see new credential data loaded by the security connector.
   EXPECT_NE(tls_connector->ClientHandshakerFactoryForTesting(), nullptr);
   ASSERT_TRUE(tls_connector->RootCertsForTesting().has_value());
@@ -461,9 +462,10 @@ TEST_F(GrpcTlsCredentialsOptionsTest,
   tmp_root_cert.reset();
   tmp_identity_key.reset();
   tmp_identity_cert.reset();
-  // Wait 2 seconds for the provider's refresh thread to read the deleted files.
+  // Wait 10 seconds for the provider's refresh thread to read the deleted
+  // files.
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
-                               gpr_time_from_seconds(2, GPR_TIMESPAN)));
+                               gpr_time_from_seconds(10, GPR_TIMESPAN)));
   // It's a bit hard to test if errors are sent to the security connector,
   // because the security connector simply logs the error. We will see the err
   // messages if we open the log.

--- a/test/core/util/tls_utils.cc
+++ b/test/core/util/tls_utils.cc
@@ -47,6 +47,9 @@ void TmpFile::RewriteFile(absl::string_view data) {
   GPR_ASSERT(!new_name.empty());
 #ifdef GPR_WINDOWS
   // Remove the old file.
+  // On Windows rename requires that the new name not exist, whereas
+  // on posix systems rename does an atomic replacement of the new
+  // name.
   GPR_ASSERT(remove(name_.c_str()) == 0);
 #endif
   // Rename the new file to the original name.

--- a/test/core/util/tls_utils.cc
+++ b/test/core/util/tls_utils.cc
@@ -45,8 +45,6 @@ void TmpFile::RewriteFile(absl::string_view data) {
   // Create a new file containing new data.
   std::string new_name = CreateTmpFileAndWriteData(data);
   GPR_ASSERT(!new_name.empty());
-  // Remove the old file.
-  GPR_ASSERT(remove(name_.c_str()) == 0);
   // Rename the new file to the original name.
   GPR_ASSERT(rename(new_name.c_str(), name_.c_str()) == 0);
 }

--- a/test/core/util/tls_utils.cc
+++ b/test/core/util/tls_utils.cc
@@ -45,6 +45,10 @@ void TmpFile::RewriteFile(absl::string_view data) {
   // Create a new file containing new data.
   std::string new_name = CreateTmpFileAndWriteData(data);
   GPR_ASSERT(!new_name.empty());
+#ifdef GPR_WINDOWS
+  // Remove the old file.
+  GPR_ASSERT(remove(name_.c_str()) == 0);
+#endif
   // Rename the new file to the original name.
   GPR_ASSERT(rename(new_name.c_str(), name_.c_str()) == 0);
 }


### PR DESCRIPTION
This test was allowing two seconds to schedule a thread and read a file on a one second timer - meaning we probably got less than one second in the common case. In the CI environment we have this is likely too little time. Up the timeout, and fix a problem whereby we weren't doing an atomic update to the file.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

