### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
+++ b/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
@@ -71,7 +71,7 @@ TEST(DestroyGoogleC2pChannelWithActiveConnectStressTest,
           kWaitForClientToSendFirstBytes,
       grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
   std::vector<std::unique_ptr<std::thread>> threads;
-  const int kNumThreads = 100;
+  const int kNumThreads = 10;
   threads.reserve(kNumThreads);
   for (int i = 0; i < kNumThreads; i++) {
     threads.emplace_back(
@@ -90,7 +90,7 @@ TEST(DestroyGoogleC2pChannelWithActiveConnectStressTest,
   int port = grpc_pick_unused_port_or_die();
   std::string address = absl::StrFormat("[::1]:%d", port);
   std::vector<std::unique_ptr<std::thread>> threads;
-  const int kNumThreads = 100;
+  const int kNumThreads = 10;
   threads.reserve(kNumThreads);
   for (int i = 0; i < kNumThreads; i++) {
     threads.emplace_back(


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

