### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/event_engine/windows/iocp_test.cc
+++ b/test/core/event_engine/windows/iocp_test.cc
@@ -252,10 +252,10 @@ TEST_F(IOCPTest, CrashOnWatchingAClosedSocket) {
 }
 
 TEST_F(IOCPTest, StressTestThousandsOfSockets) {
-  // Start 100 threads, each with their own IOCP
+  // Start 10 threads, each with their own IOCP
   // On each thread, create 50 socket pairs (100 sockets) and have them exchange
   // a message before shutting down.
-  int thread_count = 100;
+  int thread_count = 10;
   int sockets_per_thread = 50;
   std::atomic<int> read_count{0};
   std::atomic<int> write_count{0};


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

