### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/transport/binder/end2end/binder_server_test.cc
+++ b/test/core/transport/binder/end2end/binder_server_test.cc
@@ -176,7 +176,7 @@ TEST_F(BinderServerTest, CreateChannelWithEndpointBinderMultipleConnections) {
   std::unique_ptr<grpc::Server> server = server_builder.BuildAndStart();
   void* raw_endpoint_binder = grpc::experimental::binder::GetEndpointBinder(
       "example.service.multiple.connections");
-  constexpr size_t kNumThreads = 128;
+  constexpr size_t kNumThreads = 10;
 
   auto thread_fn = [&](size_t id) {
     std::unique_ptr<grpc_binder::Binder> endpoint_binder =
@@ -225,7 +225,7 @@ TEST_F(BinderServerTest, CreateChannelWithEndpointBinderParallelRequests) {
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub =
       grpc::testing::EchoTestService::NewStub(channel);
 
-  constexpr size_t kNumRequests = 128;
+  constexpr size_t kNumRequests = 10;
 
   auto thread_fn = [&](size_t id) {
     grpc::testing::EchoRequest request;


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

