### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/security/grpc_tls_certificate_distributor_test.cc
+++ b/test/core/security/grpc_tls_certificate_distributor_test.cc
@@ -574,12 +574,12 @@ TEST_F(GrpcTlsCertificateDistributorTest, SetKeyMaterialsInCallback) {
                                                  kIdentityCert1Contents))));
     CancelWatch(watcher_state_1);
   };
-  // Start 1000 threads that will register a watcher to a new cert name, verify
+  // Start 10 threads that will register a watcher to a new cert name, verify
   // the key materials being set, and then cancel the watcher, to make sure the
   // lock mechanism in the distributor is safe.
   std::vector<std::thread> threads;
-  threads.reserve(1000);
-  for (int i = 0; i < 1000; ++i) {
+  threads.reserve(10);
+  for (int i = 0; i < 10; ++i) {
     threads.emplace_back(verify_function, std::to_string(i));
   }
   for (auto& th : threads) {


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

