### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/resource_quota/memory_quota_stress_test.cc
+++ b/test/core/resource_quota/memory_quota_stress_test.cc
@@ -230,7 +230,7 @@ TEST(MemoryQuotaStressTest, MainTest) {
         "platform independent, we simply skip this test in 32-bit builds.");
     GTEST_SKIP();
   }
-  grpc_core::StressTest(16, 64).Run(8);
+  grpc_core::StressTest(16, 20).Run(8);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

