### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -348,6 +348,7 @@ grpc_cc_test(
         # TODO(apolcyn): This test is failing on Windows at entry, enable once passing.
         # See e.g. https://source.cloud.google.com/results/invocations/6716596a-c9e1-4780-85ed-890d8758d582/targets
         "no_windows",
+        "cpu:10",
     ],
     deps = [
         "//:gpr",

--- a/test/core/iomgr/stranded_event_test.cc
+++ b/test/core/iomgr/stranded_event_test.cc
@@ -316,7 +316,7 @@ TEST(Pollers, TestReadabilityNotificationsDontGetStrandedOnOneCq) {
   /* 64 is a somewhat arbitary number, the important thing is that it
    * exceeds the value of MAX_EPOLL_EVENTS_HANDLED_EACH_POLL_CALL (16), which
    * is enough to repro a bug at time of writing. */
-  const int kNumCalls = 64;
+  const int kNumCalls = 32;
   size_t ping_pong_round = 0;
   size_t ping_pongs_done = 0;
   grpc_core::Mutex ping_pong_round_mu;


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

