### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/event_engine/test_suite/timer_test.cc
+++ b/test/core/event_engine/test_suite/timer_test.cc
@@ -141,7 +141,7 @@ void EventEngineTimerTest::ScheduleCheckCB(
 
 TEST_F(EventEngineTimerTest, StressTestTimersNotCalledBeforeScheduled) {
   auto engine = this->NewEventEngine();
-  constexpr int thread_count = 100;
+  constexpr int thread_count = 10;
   constexpr int call_count_per_thread = 100;
   constexpr float timeout_min_seconds = 1;
   constexpr float timeout_max_seconds = 10;


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

