### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/config/core_configuration_test.cc
+++ b/test/core/config/core_configuration_test.cc
@@ -53,8 +53,8 @@ TEST(ConfigTest, ThreadedInit) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
   };
   std::vector<std::thread> threads;
-  threads.reserve(64);
-  for (int i = 0; i < 64; i++) {
+  threads.reserve(10);
+  for (int i = 0; i < 10; i++) {
     threads.push_back(std::thread([]() { CoreConfiguration::Get(); }));
   }
   for (auto& t : threads) {


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

