### PR TITLE
[fixit] Scale down large tests

### DIFF
--- a/test/core/client_idle/idle_filter_state_test.cc
+++ b/test/core/client_idle/idle_filter_state_test.cc
@@ -58,7 +58,7 @@ TEST(IdleFilterStateTest, StressTest) {
   int idle_polls = 0;
   int thread_jumps = 0;
   std::vector<std::thread> threads;
-  for (int idx = 0; idx < 100; idx++) {
+  for (int idx = 0; idx < 10; idx++) {
     std::thread t([&] {
       int ctr = 0;
       auto increase = [&] {


### PR DESCRIPTION
We have many tests that create 100 threads or more, and mounting evidence that
this is harmful to our CI environment.

When the original code for many of these tests was written we ran our tests
under run_tests, which had explicit handling for tracking the number of threads
each test needed and making sure that we weren't over subscribing the test
runner. Bazel has no such facility (and the facility in run_tests has since
been removed) and so we need to adjust.

This PR adjusts down a single test and is part of a series so that we can
review and roll back easily if required.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

