### PR TITLE
fixit: Avoid flake in C# Grpc.Tools tests by running tests sequentially

### DIFF
--- a/tools/internal_ci/windows/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows csharp -j 1 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests windows csharp -j 1 --inner_jobs 1 --internal_ci --bq_result_table aggregate_results"
 }


### PR DESCRIPTION
Tentative fix for b/232853126.

I've experimented with the `An attempt was made to load a program with an incorrect format.` flakes triggered by the C# Grpc.Tools tests and it seems that for some reason, if the test are run right after the build too quickly, the tests can occasionally flake with the above error. I wasn't able to rootcause the issue fully, but after many experiments,
it seems that simply running the Grpc.Tools tests serially mitigates the problem (likely because this slightly increases the delay before finishing the build and the affected tests starting).

Running the C# tests serially (`--inner_jobs 1`) seems like a good workaround since we currently have very few C# tests (most C# tests have been removed when C# got moved out of the master branch) and they are fast, so there should be virtually no impact on the overall test job latency.

Example issue that this is hopefully fixing.
```
Errors, Failures and Warnings

1) Invalid : T:/altsrc/github/grpc/workspace_csharp_windows_dbg_native/src/csharp/Grpc.Tools.Tests/bin/Debug/netcoreapp3.1/Grpc.Tools.Tests.dll

Unable to load one or more of the requested types.

Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. An attempt was made to load a program with an incorrect format.

  ----> Could not load file or assembly 'Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. An attempt was made to load a program with an incorrect format.
```