### PR TITLE
Fix PickFirstTest flake in client_lb_end2end_test

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -2281,13 +2281,8 @@ class ClientLbInterceptTrailingMetadataTest : public ClientLbEnd2endTest {
   static ClientLbInterceptTrailingMetadataTest* current_test_instance_;
   int num_trailers_intercepted_ = 0;
   bool trailer_intercepted_ = false;
-<<<<<<< HEAD
   grpc_core::Mutex mu_;
   grpc_core::CondVar cond_;
-=======
-  grpc::internal::Mutex mu_;
-  grpc::internal::CondVar cond_;
->>>>>>> 609ebbf43d65b191dff5f41f5ffbc9ca58656847
   absl::Status last_status_;
   grpc_core::MetadataVector trailing_metadata_;
   absl::optional<xds::data::orca::v3::OrcaLoadReport> load_report_;

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -429,7 +429,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
       cond_.Signal();
     }
 
-    void Shutdown() {
+    void Shutdown(int timeout_ms = 0) {
       grpc_core::MutexLock lock(&mu_);
       if (!started_) return;
       server_->Shutdown(grpc_timeout_milliseconds_to_deadline(0));
@@ -1254,7 +1254,7 @@ TEST_F(PickFirstTest, CheckStateBeforeStartWatch) {
   gpr_log(GPR_INFO, "****** RESOLUTION SET FOR CHANNEL 1 *******");
   WaitForServer(DEBUG_LOCATION, stub_1, 0);
   gpr_log(GPR_INFO, "****** CHANNEL 1 CONNECTED *******");
-  servers_[0]->Shutdown();
+  servers_[0]->Shutdown(/*timeout_ms=*/3000);
   // Channel 1 will receive a re-resolution containing the same server. It will
   // create a new subchannel and hold a ref to it.
   StartServers(1, ports);


### PR DESCRIPTION
Add delay to shutdown for `PickFirstTest.CheckStateBeforeStartWatch` to make sure server is properly shut down before being restarted. Otherwise, the test sometimes has broken pipe failures if the server is in some middle state.

Verified with blase - no failures after change.