### PR TITLE
Revert "[import] 4 cpus is the max"

### DIFF
--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -350,7 +350,7 @@ grpc_cc_test(
         # TODO(apolcyn): This test is failing on Windows at entry, enable once passing.
         # See e.g. https://source.cloud.google.com/results/invocations/6716596a-c9e1-4780-85ed-890d8758d582/targets
         "no_windows",
-        "cpu:4",
+        "cpu:10",
     ],
     deps = [
         "//:gpr",


### PR DESCRIPTION
Reverts grpc/grpc#30696

Not necessary after all