### PR TITLE
client_lb_e2e_test: fix flake in PickFirstTest.CheckStateBeforeStartWatch

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1255,6 +1255,7 @@ TEST_F(PickFirstTest, CheckStateBeforeStartWatch) {
   WaitForServer(DEBUG_LOCATION, stub_1, 0);
   gpr_log(GPR_INFO, "****** CHANNEL 1 CONNECTED *******");
   servers_[0]->Shutdown();
+  EXPECT_TRUE(WaitForChannelNotReady(channel_1.get()));
   // Channel 1 will receive a re-resolution containing the same server. It will
   // create a new subchannel and hold a ref to it.
   StartServers(1, ports);


### PR DESCRIPTION
The second channel was failing its first RPC with "Broken pipe" because the second channel was starting up before the subchannel saw the disconnection from the server.  To fix this, we wait for the first channel to become non-READY before we create the second channel.