### PR TITLE
Add DebugLocation to CqVerifier

### DIFF
--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -217,7 +217,7 @@ unsigned int parse_h2_length(const char *field) {
   });
 
   cqv.Expect((void *)1, true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
 
@@ -390,7 +390,7 @@ unsigned int parse_h2_length(const char *field) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect((void *)1, true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_slice_unref(details);
   grpc_metadata_array_destroy(&initial_metadata_recv);

--- a/test/core/bad_client/bad_client.cc
+++ b/test/core/bad_client/bad_client.cc
@@ -332,7 +332,7 @@ void server_verifier_request_call(grpc_server* server,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.host, "localhost"));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo/bar"));

--- a/test/core/bad_client/tests/duplicate_header.cc
+++ b/test/core/bad_client/tests/duplicate_header.cc
@@ -69,7 +69,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.host, "localhost"));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo/bar"));
@@ -91,7 +91,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), grpc_core::CqVerifier::AnyStatus());
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -113,7 +113,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(103), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_metadata_array_destroy(&request_metadata_recv);
   grpc_call_details_destroy(&call_details);

--- a/test/core/bad_client/tests/head_of_line_blocking.cc
+++ b/test/core/bad_client/tests/head_of_line_blocking.cc
@@ -83,7 +83,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
                                               &payload, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(payload != nullptr);
 

--- a/test/core/bad_client/tests/server_registered_method.cc
+++ b/test/core/bad_client/tests/server_registered_method.cc
@@ -55,7 +55,7 @@ static void verifier_succeeds(grpc_server* server, grpc_completion_queue* cq,
                                               &payload, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(payload != nullptr);
 

--- a/test/core/bad_client/tests/simple_request.cc
+++ b/test/core/bad_client/tests/simple_request.cc
@@ -101,7 +101,7 @@ static void verifier(grpc_server* server, grpc_completion_queue* cq,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.host, "localhost"));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo/bar"));

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -99,7 +99,7 @@ static void run_test(const char* target, size_t nops) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status != GRPC_STATUS_OK);
 

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -253,7 +253,7 @@ static void start_rpc(int target_port, grpc_status_code expected_status,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == expected_status);
   if (expected_detail != nullptr) {

--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -112,7 +112,7 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
                                                    nullptr));
   /* verify that all tags get completed */
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   if (wait_for_ready) {
     GPR_ASSERT(status == GRPC_STATUS_DEADLINE_EXCEEDED);

--- a/test/core/end2end/cq_verifier.h
+++ b/test/core/end2end/cq_verifier.h
@@ -57,10 +57,17 @@ class CqVerifier {
 
   // Ensure all expected events (and only those events) are present on the
   // bound completion queue within \a timeout.
-  void Verify(Duration timeout = Duration::Seconds(10));
+  // Default timeout: 5 seconds
+  void Verify(const DebugLocation& location);
+  // Ensure all expected events (and only those events) are present on the
+  // bound completion queue within \a timeout.
+  void Verify(Duration timeout, const DebugLocation& location);
 
   // Ensure that the completion queue is empty, waiting up to \a timeout.
-  void VerifyEmpty(Duration timeout = Duration::Seconds(1));
+  // Default timeout: 1 second
+  void VerifyEmpty(const DebugLocation& location);
+  // Ensure that the completion queue is empty, waiting up to \a timeout.
+  void VerifyEmpty(Duration timeout, const DebugLocation& location);
 
   // Match an expectation about a status.
   // location must be DEBUG_LOCATION.
@@ -80,8 +87,8 @@ class CqVerifier {
     std::string ToString() const;
   };
 
-  void FailNoEventReceived() const;
-  void FailUnexpectedEvent(grpc_event* ev) const;
+  void FailNoEventReceived(const DebugLocation& location) const;
+  void FailUnexpectedEvent(grpc_event* ev, const DebugLocation& location) const;
   bool AllMaybes() const;
 
   grpc_completion_queue* const cq_;

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -207,7 +207,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
                                      &request_metadata_recv, cq, cq, tag(101));
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(101), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     memset(ops, 0, sizeof(ops));
     op = ops;
@@ -232,7 +232,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
 
     cqv.Expect(tag(102), true);
     cqv.Expect(tag(1), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     peer = grpc_call_get_peer(c);
     gpr_log(GPR_DEBUG, "got peer: '%s'", peer);
@@ -249,7 +249,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
   } else {
     /* Check for a failed connection. */
     cqv.Expect(tag(1), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     gpr_log(GPR_INFO, "status: %d (expected: %d)", status,
             GRPC_STATUS_UNAVAILABLE);

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -317,7 +317,7 @@ int main(int argc, char** argv) {
   /* first call should now start */
   cqv.Expect(tag(0x101), true);
   cqv.Expect(tag(0x301), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(GRPC_CHANNEL_READY ==
              grpc_channel_check_connectivity_state(chan, 0));
@@ -341,8 +341,8 @@ int main(int argc, char** argv) {
   set_resolve_port(-1);
   grpc_server_shutdown_and_notify(server1, cq, tag(0xdead1));
   cqv.Expect(tag(0x9999), true);
-  cqv.Verify();
-  cqv.VerifyEmpty();
+  cqv.Verify(DEBUG_LOCATION);
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 
   /* and a new call: should go through to server2 when we start it */
   grpc_call* call2 =
@@ -394,7 +394,7 @@ int main(int argc, char** argv) {
   /* second call should now start */
   cqv.Expect(tag(0x201), true);
   cqv.Expect(tag(0x401), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* listen for close on the server call to probe for finishing */
   memset(ops, 0, sizeof(ops));
@@ -409,7 +409,7 @@ int main(int argc, char** argv) {
 
   /* shutdown second server: we should see nothing */
   grpc_server_shutdown_and_notify(server2, cq, tag(0xdead2));
-  cqv.VerifyEmpty();
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 
   grpc_call_cancel(call1, nullptr);
   grpc_call_cancel(call2, nullptr);
@@ -421,7 +421,7 @@ int main(int argc, char** argv) {
   cqv.Expect(tag(0x402), true);
   cqv.Expect(tag(0xdead1), true);
   cqv.Expect(tag(0xdead2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(call1);
   grpc_call_unref(call2);

--- a/test/core/end2end/h2_ssl_cert_test.cc
+++ b/test/core/end2end/h2_ssl_cert_test.cc
@@ -325,7 +325,7 @@ static void simple_request_body(grpc_end2end_test_fixture f,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   CQ_EXPECT_COMPLETION(cqv, tag(1), expected_result == SUCCESS);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c);
 }

--- a/test/core/end2end/h2_ssl_session_reuse_test.cc
+++ b/test/core/end2end/h2_ssl_session_reuse_test.cc
@@ -194,7 +194,7 @@ void do_round_trip(grpc_completion_queue* cq, grpc_server* server,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_auth_context* auth = grpc_call_auth_context(s);
   grpc_auth_property_iterator it = grpc_auth_context_find_properties_by_name(
@@ -232,7 +232,7 @@ void do_round_trip(grpc_completion_queue* cq, grpc_server* server,
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_metadata_array_destroy(&initial_metadata_recv);
   grpc_metadata_array_destroy(&trailing_metadata_recv);

--- a/test/core/end2end/invalid_call_argument_test.cc
+++ b/test/core/end2end/invalid_call_argument_test.cc
@@ -123,7 +123,7 @@ static void prepare_test(int is_client) {
                                         g_state.cq, g_state.cq, tag(101)));
     g_state.cqv->Expect(tag(101), true);
     g_state.cqv->Expect(tag(1), true);
-    g_state.cqv->Verify();
+    g_state.cqv->Verify(DEBUG_LOCATION);
   }
 }
 
@@ -198,7 +198,7 @@ static void test_send_initial_metadata_more_than_once() {
                                                    (size_t)(op - g_state.ops),
                                                    tag(1), nullptr));
   g_state.cqv->Expect(tag(1), false);
-  g_state.cqv->Verify();
+  g_state.cqv->Verify(DEBUG_LOCATION);
 
   op = g_state.ops;
   op->op = GRPC_OP_SEND_INITIAL_METADATA;
@@ -327,7 +327,7 @@ static void test_receive_initial_metadata_twice_at_client() {
                                                    (size_t)(op - g_state.ops),
                                                    tag(1), nullptr));
   g_state.cqv->Expect(tag(1), false);
-  g_state.cqv->Verify();
+  g_state.cqv->Verify(DEBUG_LOCATION);
   op = g_state.ops;
   op->op = GRPC_OP_RECV_INITIAL_METADATA;
   op->data.recv_initial_metadata.recv_initial_metadata =
@@ -423,7 +423,7 @@ static void test_recv_status_on_client_twice() {
                                                    (size_t)(op - g_state.ops),
                                                    tag(1), nullptr));
   g_state.cqv->Expect(tag(1), true);
-  g_state.cqv->Verify();
+  g_state.cqv->Verify(DEBUG_LOCATION);
 
   op = g_state.ops;
   op->op = GRPC_OP_RECV_STATUS_ON_CLIENT;

--- a/test/core/end2end/no_server_test.cc
+++ b/test/core/end2end/no_server_test.cc
@@ -89,7 +89,7 @@ void run_test(bool wait_for_ready) {
 
   /* verify that all tags get completed */
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_log(GPR_INFO, "call status: %d", status);
   if (wait_for_ready) {

--- a/test/core/end2end/tests/authority_not_supported.cc
+++ b/test/core/end2end/tests/authority_not_supported.cc
@@ -160,7 +160,7 @@ static void test_with_authority_header(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_CANCELLED);
 

--- a/test/core/end2end/tests/bad_hostname.cc
+++ b/test/core/end2end/tests/bad_hostname.cc
@@ -138,7 +138,7 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_INTERNAL);
 

--- a/test/core/end2end/tests/bad_ping.cc
+++ b/test/core/end2end/tests/bad_ping.cc
@@ -146,7 +146,7 @@ static void test_bad_ping(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Send too many pings to the server to trigger the punishment:
   // The first ping will let server mark its last_recv time. Afterwards, each
@@ -160,7 +160,7 @@ static void test_bad_ping(grpc_end2end_test_config config) {
     if (i == MAX_PING_STRIKES + 2) {
       cqv.Expect(tag(1), true);
     }
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
   }
 
   memset(ops, 0, sizeof(ops));
@@ -188,11 +188,11 @@ static void test_bad_ping(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
   cqv.Expect(tag(0xdead), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
 
@@ -297,7 +297,7 @@ static void test_pings_without_data(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Send too many pings to the server similar to the previous test case.
   // However, since we set the MAX_PINGS_WITHOUT_DATA at the client side, only
@@ -308,7 +308,7 @@ static void test_pings_without_data(grpc_end2end_test_config config) {
     if (i <= MAX_PING_STRIKES) {
       cqv.Expect(tag(200 + i), true);
     }
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
   }
 
   memset(ops, 0, sizeof(ops));
@@ -338,7 +338,7 @@ static void test_pings_without_data(grpc_end2end_test_config config) {
   cqv.Expect(tag(102), true);
   // Client call should return.
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
   cqv.Expect(tag(0xdead), true);
@@ -347,7 +347,7 @@ static void test_pings_without_data(grpc_end2end_test_config config) {
   cqv.Expect(tag(200 + MAX_PING_STRIKES + 1), false);
   cqv.Expect(tag(200 + MAX_PING_STRIKES + 2), false);
 
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
 

--- a/test/core/end2end/tests/binary_metadata.cc
+++ b/test/core/end2end/tests/binary_metadata.cc
@@ -205,7 +205,7 @@ static void test_request_response_with_metadata_and_payload(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -225,7 +225,7 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -268,7 +268,7 @@ static void test_request_response_with_metadata_and_payload(
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(

--- a/test/core/end2end/tests/call_creds.cc
+++ b/test/core/end2end/tests/call_creds.cc
@@ -246,7 +246,7 @@ static void request_response_with_payload_and_call_creds(
     // Expect the call to fail since the channel credentials did not satisfy the
     // minimum security level requirements.
     cqv.Expect(tag(1), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     GPR_ASSERT(status == GRPC_STATUS_UNAUTHENTICATED);
   } else {
     error =
@@ -254,7 +254,7 @@ static void request_response_with_payload_and_call_creds(
                                  &request_metadata_recv, f.cq, f.cq, tag(101));
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(101), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     server_auth_context = grpc_call_auth_context(s);
     GPR_ASSERT(server_auth_context != nullptr);
     print_auth_context(0, server_auth_context);
@@ -285,7 +285,7 @@ static void request_response_with_payload_and_call_creds(
     GPR_ASSERT(GRPC_CALL_OK == error);
 
     cqv.Expect(tag(102), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     memset(ops, 0, sizeof(ops));
     op = ops;
@@ -313,7 +313,7 @@ static void request_response_with_payload_and_call_creds(
 
     cqv.Expect(tag(103), true);
     cqv.Expect(tag(1), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     GPR_ASSERT(status == GRPC_STATUS_OK);
     GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
@@ -498,7 +498,7 @@ static void test_request_with_server_rejecting_client_creds(
   GPR_ASSERT(error == GRPC_CALL_OK);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNAUTHENTICATED);
 

--- a/test/core/end2end/tests/call_host_override.cc
+++ b/test/core/end2end/tests/call_host_override.cc
@@ -162,7 +162,7 @@ static void test_invoke_simple_request(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(error == GRPC_CALL_OK);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -199,7 +199,7 @@ static void test_invoke_simple_request(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/cancel_after_accept.cc
+++ b/test/core/end2end/tests/cancel_after_accept.cc
@@ -193,7 +193,7 @@ static void test_cancel_after_accept(grpc_end2end_test_config config,
                                    &request_metadata_recv, f.cq, f.cq, tag(2));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -225,7 +225,7 @@ static void test_cancel_after_accept(grpc_end2end_test_config config,
 
   cqv.Expect(tag(3), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == mode.expect_status || status == GRPC_STATUS_INTERNAL);
   GPR_ASSERT(was_cancelled == 1);

--- a/test/core/end2end/tests/cancel_after_client_done.cc
+++ b/test/core/end2end/tests/cancel_after_client_done.cc
@@ -172,7 +172,7 @@ static void test_cancel_after_accept_and_writes_closed(
                                    &request_metadata_recv, f.cq, f.cq, tag(2));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -204,7 +204,7 @@ static void test_cancel_after_accept_and_writes_closed(
 
   cqv.Expect(tag(3), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == mode.expect_status || status == GRPC_STATUS_INTERNAL);
   GPR_ASSERT(was_cancelled == 1);

--- a/test/core/end2end/tests/cancel_after_invoke.cc
+++ b/test/core/end2end/tests/cancel_after_invoke.cc
@@ -163,7 +163,7 @@ static void test_cancel_after_invoke(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == mode.initiate_cancel(c, nullptr));
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == mode.expect_status || status == GRPC_STATUS_INTERNAL);
 

--- a/test/core/end2end/tests/cancel_after_round_trip.cc
+++ b/test/core/end2end/tests/cancel_after_round_trip.cc
@@ -189,7 +189,7 @@ static void test_cancel_after_round_trip(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -214,7 +214,7 @@ static void test_cancel_after_round_trip(grpc_end2end_test_config config,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_byte_buffer_destroy(request_payload_recv);
   grpc_byte_buffer_destroy(response_payload_recv);
@@ -259,7 +259,7 @@ static void test_cancel_after_round_trip(grpc_end2end_test_config config,
 
   cqv.Expect(tag(2), true);
   cqv.Expect(tag(103), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == mode.expect_status || status == GRPC_STATUS_INTERNAL);
   GPR_ASSERT(was_cancelled == 1);

--- a/test/core/end2end/tests/cancel_before_invoke.cc
+++ b/test/core/end2end/tests/cancel_before_invoke.cc
@@ -161,7 +161,7 @@ static void test_cancel_before_invoke(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_CANCELLED);
 

--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -147,7 +147,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
   gpr_free(dynamic_string);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/channelz.cc
+++ b/test/core/end2end/tests/channelz.cc
@@ -153,7 +153,7 @@ static void run_one_request(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -182,7 +182,7 @@ static void run_one_request(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo"));

--- a/test/core/end2end/tests/client_streaming.cc
+++ b/test/core/end2end/tests/client_streaming.cc
@@ -144,7 +144,7 @@ static void test_client_streaming(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(100));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(100), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -159,7 +159,7 @@ static void test_client_streaming(grpc_end2end_test_config config,
 
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client writes bunch of messages and server reads them
   for (i = 0; i < messages; i++) {
@@ -188,7 +188,7 @@ static void test_client_streaming(grpc_end2end_test_config config,
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(102), true);
     cqv.Expect(tag(103), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
     grpc_byte_buffer_destroy(request_payload_recv);
   }
@@ -208,9 +208,9 @@ static void test_client_streaming(grpc_end2end_test_config config,
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   // Do an empty verify to make sure that the client receives the status
-  cqv.VerifyEmpty();
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 
   // Client tries sending another message which should fail
   request_payload = grpc_raw_byte_buffer_create(&request_payload_slice, 1);
@@ -226,7 +226,7 @@ static void test_client_streaming(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_byte_buffer_destroy(request_payload);
   cqv.Expect(tag(103), false);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client sends close and requests status
   memset(ops, 0, sizeof(ops));
@@ -246,7 +246,7 @@ static void test_client_streaming(grpc_end2end_test_config config,
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
 

--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -209,7 +209,7 @@ static void request_for_disabled_algorithm(
 
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   op = ops;
   op->op = GRPC_OP_SEND_INITIAL_METADATA;
@@ -239,7 +239,7 @@ static void request_for_disabled_algorithm(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(103), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* call was cancelled (closed) ... */
   GPR_ASSERT(was_cancelled != 0);
@@ -394,7 +394,7 @@ static void request_with_payload_template_inner(
                                &request_metadata_recv, f.cq, f.cq, tag(100));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(100), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(grpc_core::BitCount(
                  grpc_call_test_only_get_encodings_accepted_by_peer(s)) ==
@@ -458,7 +458,7 @@ static void request_with_payload_template_inner(
     GPR_ASSERT(GRPC_CALL_OK == error);
 
     cqv.Expect(tag(102), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     GPR_ASSERT(request_payload_recv->type == GRPC_BB_RAW);
     GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, request_str));
@@ -490,7 +490,7 @@ static void request_with_payload_template_inner(
 
     cqv.Expect(tag(103), true);
     cqv.Expect(tag(3), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     GPR_ASSERT(response_payload_recv->type == GRPC_BB_RAW);
     GPR_ASSERT(byte_buffer_eq_string(response_payload_recv, response_str));
@@ -542,7 +542,7 @@ static void request_with_payload_template_inner(
   cqv.Expect(tag(4), true);
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/connectivity.cc
+++ b/test/core/end2end/tests/connectivity.cc
@@ -110,7 +110,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
 
   /* and now the watch should trigger */
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   state = grpc_channel_check_connectivity_state(f.client, 0);
   GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING);
@@ -120,7 +120,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
                                         grpc_timeout_seconds_to_deadline(10),
                                         f.cq, tag(3));
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   state = grpc_channel_check_connectivity_state(f.client, 0);
   GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING);
@@ -138,7 +138,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
     grpc_channel_watch_connectivity_state(
         f.client, state, grpc_timeout_seconds_to_deadline(10), f.cq, tag(4));
     cqv.Expect(tag(4), true);
-    cqv.Verify(grpc_core::Duration::Seconds(20));
+    cqv.Verify(grpc_core::Duration::Seconds(20), DEBUG_LOCATION);
     state = grpc_channel_check_connectivity_state(f.client, 0);
     GPR_ASSERT(state == GRPC_CHANNEL_READY ||
                state == GRPC_CHANNEL_CONNECTING ||
@@ -157,7 +157,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(5), true);
   cqv.Expect(tag(0xdead), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   state = grpc_channel_check_connectivity_state(f.client, 0);
   GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING || state == GRPC_CHANNEL_IDLE);

--- a/test/core/end2end/tests/default_host.cc
+++ b/test/core/end2end/tests/default_host.cc
@@ -152,7 +152,7 @@ static void test_invoke_simple_request(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(error == GRPC_CALL_OK);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -189,7 +189,7 @@ static void test_invoke_simple_request(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/disappearing_server.cc
+++ b/test/core/end2end/tests/disappearing_server.cc
@@ -126,7 +126,7 @@ static void do_request_and_shutdown_server(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f->cq, f->cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* should be able to shut down the server early
      - and still complete the request */
@@ -159,7 +159,7 @@ static void do_request_and_shutdown_server(grpc_end2end_test_config /*config*/,
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
   cqv.Expect(tag(1000), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   /* Please refer https://github.com/grpc/grpc/issues/21221 for additional
    * details.
    * TODO(yashykt@) - The following line should be removeable after C-Core
@@ -167,7 +167,7 @@ static void do_request_and_shutdown_server(grpc_end2end_test_config /*config*/,
    * test remains flaky even after this, an alternative fix would be to send a
    * request when the server is in the shut down state.
    */
-  cqv.VerifyEmpty();
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/empty_batch.cc
+++ b/test/core/end2end/tests/empty_batch.cc
@@ -99,7 +99,7 @@ static void empty_batch_body(grpc_end2end_test_config /*config*/,
   error = grpc_call_start_batch(c, op, 0, tag(1), nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c);
 }

--- a/test/core/end2end/tests/filter_causes_close.cc
+++ b/test/core/end2end/tests/filter_causes_close.cc
@@ -168,7 +168,7 @@ static void test_request(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_PERMISSION_DENIED);
   GPR_ASSERT(0 ==

--- a/test/core/end2end/tests/filter_context.cc
+++ b/test/core/end2end/tests/filter_context.cc
@@ -177,7 +177,7 @@ static void test_request(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -205,7 +205,7 @@ static void test_request(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/filter_init_fails.cc
+++ b/test/core/end2end/tests/filter_init_fails.cc
@@ -178,7 +178,7 @@ static void test_server_channel_filter(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   if (g_channel_filter_init_failure) {
     // Inproc channel returns invalid_argument and other clients return
@@ -274,7 +274,7 @@ static void test_client_channel_filter(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   if (g_channel_filter_init_failure) {
     GPR_ASSERT(status == GRPC_STATUS_INVALID_ARGUMENT);
@@ -366,7 +366,7 @@ static void test_client_subchannel_filter(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   if (g_channel_filter_init_failure) {
     GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
@@ -393,7 +393,7 @@ static void test_client_subchannel_filter(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   if (g_channel_filter_init_failure) {
     GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);

--- a/test/core/end2end/tests/filter_latency.cc
+++ b/test/core/end2end/tests/filter_latency.cc
@@ -185,7 +185,7 @@ static void test_request(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -213,7 +213,7 @@ static void test_request(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/filter_status_code.cc
+++ b/test/core/end2end/tests/filter_status_code.cc
@@ -195,7 +195,7 @@ static void test_request(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_mu_lock(&g_mu);
   g_server_call_stack = grpc_call_get_call_stack(s);
@@ -227,7 +227,7 @@ static void test_request(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/filtered_metadata.cc
+++ b/test/core/end2end/tests/filtered_metadata.cc
@@ -162,7 +162,7 @@ static void test_request_response_with_metadata_to_be_filtered(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -177,7 +177,7 @@ static void test_request_response_with_metadata_to_be_filtered(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -200,7 +200,7 @@ static void test_request_response_with_metadata_to_be_filtered(
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/graceful_server_shutdown.cc
+++ b/test/core/end2end/tests/graceful_server_shutdown.cc
@@ -142,11 +142,11 @@ static void test_early_server_shutdown_finishes_inflight_calls(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* shutdown and destroy the server */
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
-  cqv.VerifyEmpty();
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -175,7 +175,7 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(0xdead), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
 

--- a/test/core/end2end/tests/grpc_authz.cc
+++ b/test/core/end2end/tests/grpc_authz.cc
@@ -157,7 +157,7 @@ static void test_allow_authorized_request(grpc_end2end_test_fixture f) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -185,7 +185,7 @@ static void test_allow_authorized_request(grpc_end2end_test_fixture f) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   GPR_ASSERT(GRPC_STATUS_OK == status);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
 
@@ -250,7 +250,7 @@ static void test_deny_unauthorized_request(grpc_end2end_test_fixture f) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(GRPC_STATUS_PERMISSION_DENIED == status);
   GPR_ASSERT(0 ==

--- a/test/core/end2end/tests/high_initial_seqno.cc
+++ b/test/core/end2end/tests/high_initial_seqno.cc
@@ -148,7 +148,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -176,7 +176,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
@@ -196,7 +196,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                     retry has been implemented; until then cross-thread chatter
                     may result in some requests needing to be cancelled due to
                     seqno exhaustion. */
-  cqv.VerifyEmpty();
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 }
 
 static void test_invoke_10_simple_requests(grpc_end2end_test_config config,

--- a/test/core/end2end/tests/hpack_size.cc
+++ b/test/core/end2end/tests/hpack_size.cc
@@ -303,7 +303,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -331,7 +331,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/invoke_large_request.cc
+++ b/test/core/end2end/tests/invoke_large_request.cc
@@ -177,7 +177,7 @@ static void test_invoke_large_request(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify(grpc_core::Duration::Seconds(60));
+  cqv.Verify(grpc_core::Duration::Seconds(60), DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -196,7 +196,7 @@ static void test_invoke_large_request(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify(grpc_core::Duration::Seconds(60));
+  cqv.Verify(grpc_core::Duration::Seconds(60), DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -224,7 +224,7 @@ static void test_invoke_large_request(grpc_end2end_test_config config,
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify(grpc_core::Duration::Seconds(60));
+  cqv.Verify(grpc_core::Duration::Seconds(60), DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/keepalive_timeout.cc
+++ b/test/core/end2end/tests/keepalive_timeout.cc
@@ -157,7 +157,7 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "keepalive watchdog timeout"));
@@ -263,7 +263,7 @@ static void test_read_delays_keepalive(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(100));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(100), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -312,7 +312,7 @@ static void test_read_delays_keepalive(grpc_end2end_test_config config) {
                                   tag(102), nullptr);
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(102), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     memset(ops, 0, sizeof(ops));
     op = ops;
@@ -326,7 +326,7 @@ static void test_read_delays_keepalive(grpc_end2end_test_config config) {
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(103), true);
     cqv.Expect(tag(2), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     grpc_byte_buffer_destroy(request_payload);
     grpc_byte_buffer_destroy(response_payload);
@@ -367,7 +367,7 @@ static void test_read_delays_keepalive(grpc_end2end_test_config config) {
   cqv.Expect(tag(3), true);
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c);
   grpc_call_unref(s);

--- a/test/core/end2end/tests/large_metadata.cc
+++ b/test/core/end2end/tests/large_metadata.cc
@@ -172,7 +172,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   // Server: send initial metadata and receive request.
@@ -192,7 +192,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   // Server: receive close and send status.  This should trigger
@@ -217,7 +217,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
@@ -321,7 +321,7 @@ static void test_request_with_bad_large_metadata_response(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   // Server: send large initial metadata
@@ -350,7 +350,7 @@ static void test_request_with_bad_large_metadata_response(
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_RESOURCE_EXHAUSTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(

--- a/test/core/end2end/tests/load_reporting_hook.cc
+++ b/test/core/end2end/tests/load_reporting_hook.cc
@@ -190,7 +190,7 @@ static void request_response_with_payload(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -209,7 +209,7 @@ static void request_response_with_payload(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -239,7 +239,7 @@ static void request_response_with_payload(
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
 

--- a/test/core/end2end/tests/max_concurrent_streams.cc
+++ b/test/core/end2end/tests/max_concurrent_streams.cc
@@ -144,7 +144,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -172,7 +172,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
@@ -377,7 +377,7 @@ static void test_max_concurrent_streams(grpc_end2end_test_config config) {
   /* first request is finished, we should be able to start the second */
   live_call = (live_call == 300) ? 400 : 300;
   cqv.Expect(tag(live_call + 1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_details_destroy(&call_details);
 
@@ -385,7 +385,7 @@ static void test_max_concurrent_streams(grpc_end2end_test_config config) {
                                  f.server, &s2, &call_details,
                                  &request_metadata_recv, f.cq, f.cq, tag(201)));
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -412,7 +412,7 @@ static void test_max_concurrent_streams(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(live_call + 2), true);
   cqv.Expect(tag(202), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c1);
   grpc_call_unref(s1);
@@ -531,7 +531,7 @@ static void test_max_concurrent_streams_with_timeout_on_first(
 
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(301), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -577,7 +577,7 @@ static void test_max_concurrent_streams_with_timeout_on_first(
   /* first request is finished, we should be able to start the second */
   cqv.Expect(tag(401), true);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -605,7 +605,7 @@ static void test_max_concurrent_streams_with_timeout_on_first(
 
   cqv.Expect(tag(402), true);
   cqv.Expect(tag(202), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c1);
   grpc_call_unref(s1);
@@ -724,7 +724,7 @@ static void test_max_concurrent_streams_with_timeout_on_second(
 
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(301), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -763,7 +763,7 @@ static void test_max_concurrent_streams_with_timeout_on_second(
   /* the second request is time out*/
   cqv.Expect(tag(401), false);
   cqv.Expect(tag(402), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* second request is finished because of time out, so destroy the second call
    */
@@ -796,7 +796,7 @@ static void test_max_concurrent_streams_with_timeout_on_second(
 
   cqv.Expect(tag(302), true);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c1);
   grpc_call_unref(s1);

--- a/test/core/end2end/tests/max_connection_age.cc
+++ b/test/core/end2end/tests/max_connection_age.cc
@@ -160,7 +160,7 @@ static void test_max_age_forcibly_close(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv->Expect(tag(101), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   gpr_timespec expect_shutdown_time = grpc_timeout_milliseconds_to_deadline(
       static_cast<int>(MAX_CONNECTION_AGE_MS *
@@ -169,12 +169,13 @@ static void test_max_age_forcibly_close(grpc_end2end_test_config config) {
 
   /* Wait for the channel to reach its max age */
   cqv->VerifyEmpty(
-      grpc_core::Duration::Seconds(CQ_MAX_CONNECTION_AGE_WAIT_TIME_S));
+      grpc_core::Duration::Seconds(CQ_MAX_CONNECTION_AGE_WAIT_TIME_S),
+      DEBUG_LOCATION);
 
   /* After the channel reaches its max age, we still do nothing here. And wait
      for it to use up its max age grace period. */
   cqv->Expect(tag(1), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   gpr_timespec channel_shutdown_time = gpr_now(GPR_CLOCK_MONOTONIC);
   GPR_ASSERT(gpr_time_cmp(channel_shutdown_time, expect_shutdown_time) < 0);
@@ -203,11 +204,11 @@ static void test_max_age_forcibly_close(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv->Expect(tag(102), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
   cqv->Expect(tag(0xdead), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
 
@@ -303,16 +304,18 @@ static void test_max_age_gracefully_close(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv->Expect(tag(101), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   /* Wait for the channel to reach its max age */
   cqv->VerifyEmpty(
-      grpc_core::Duration::Seconds(CQ_MAX_CONNECTION_AGE_WAIT_TIME_S));
+      grpc_core::Duration::Seconds(CQ_MAX_CONNECTION_AGE_WAIT_TIME_S),
+      DEBUG_LOCATION);
 
   /* The connection is shutting down gracefully. In-progress rpc should not be
      closed, hence the completion queue should see nothing here. */
   cqv->VerifyEmpty(
-      grpc_core::Duration::Seconds(CQ_MAX_CONNECTION_AGE_GRACE_WAIT_TIME_S));
+      grpc_core::Duration::Seconds(CQ_MAX_CONNECTION_AGE_GRACE_WAIT_TIME_S),
+      DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -340,11 +343,11 @@ static void test_max_age_gracefully_close(grpc_end2end_test_config config) {
 
   cqv->Expect(tag(102), true);
   cqv->Expect(tag(1), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
   cqv->Expect(tag(0xdead), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
 

--- a/test/core/end2end/tests/max_connection_idle.cc
+++ b/test/core/end2end/tests/max_connection_idle.cc
@@ -114,7 +114,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f->cq, f->cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -151,7 +151,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
@@ -199,7 +199,7 @@ static void test_max_connection_idle(grpc_end2end_test_config config) {
     grpc_channel_watch_connectivity_state(
         f.client, state, grpc_timeout_seconds_to_deadline(10), f.cq, tag(99));
     cqv.Expect(tag(99), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     state = grpc_channel_check_connectivity_state(f.client, 0);
     GPR_ASSERT(state == GRPC_CHANNEL_READY ||
                state == GRPC_CHANNEL_CONNECTING ||
@@ -216,14 +216,14 @@ static void test_max_connection_idle(grpc_end2end_test_config config) {
                    gpr_time_from_millis(MAX_CONNECTION_IDLE_MS, GPR_TIMESPAN)),
       f.cq, tag(99));
   cqv.Expect(tag(99), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   state = grpc_channel_check_connectivity_state(f.client, 0);
   GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING || state == GRPC_CHANNEL_IDLE);
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
   cqv.Expect(tag(0xdead), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_server_destroy(f.server);
   grpc_channel_destroy(f.client);

--- a/test/core/end2end/tests/max_message_length.cc
+++ b/test/core/end2end/tests/max_message_length.cc
@@ -225,7 +225,7 @@ static void test_max_message_length_on_request(grpc_end2end_test_config config,
 
   if (send_limit) {
     cqv.Expect(tag(1), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     goto done;
   }
 
@@ -234,7 +234,7 @@ static void test_max_message_length_on_request(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -254,7 +254,7 @@ static void test_max_message_length_on_request(grpc_end2end_test_config config,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   GPR_ASSERT(was_cancelled == 1);
@@ -413,7 +413,7 @@ static void test_max_message_length_on_response(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -446,7 +446,7 @@ static void test_max_message_length_on_response(grpc_end2end_test_config config,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   GPR_ASSERT(status == GRPC_STATUS_RESOURCE_EXHAUSTED);
@@ -572,7 +572,7 @@ static void test_max_receive_message_length_on_compressed_request(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -608,7 +608,7 @@ static void test_max_receive_message_length_on_compressed_request(
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   if (minimal_stack) {
@@ -727,7 +727,7 @@ static void test_max_receive_message_length_on_compressed_response(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_metadata compression_md = gzip_compression_override();
   memset(ops, 0, sizeof(ops));
@@ -762,7 +762,7 @@ static void test_max_receive_message_length_on_compressed_response(
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   if (minimal_stack) {

--- a/test/core/end2end/tests/negative_deadline.cc
+++ b/test/core/end2end/tests/negative_deadline.cc
@@ -138,7 +138,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_DEADLINE_EXCEEDED);
 

--- a/test/core/end2end/tests/no_error_on_hotpath.cc
+++ b/test/core/end2end/tests/no_error_on_hotpath.cc
@@ -151,7 +151,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -185,7 +185,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(GRPC_SLICE_LENGTH(details) == 0);

--- a/test/core/end2end/tests/no_logging.cc
+++ b/test/core/end2end/tests/no_logging.cc
@@ -181,7 +181,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -216,7 +216,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/payload.cc
+++ b/test/core/end2end/tests/payload.cc
@@ -187,7 +187,7 @@ static void request_response_with_payload(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -206,7 +206,7 @@ static void request_response_with_payload(grpc_end2end_test_config /*config*/,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -234,7 +234,7 @@ static void request_response_with_payload(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/ping.cc
+++ b/test/core/end2end/tests/ping.cc
@@ -74,7 +74,7 @@ static void test_ping(grpc_end2end_test_config config,
                                           GPR_TIMESPAN)),
         f.cq, tag(99));
     cqv.Expect(tag(99), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     state = grpc_channel_check_connectivity_state(f.client, 0);
     GPR_ASSERT(state == GRPC_CHANNEL_READY ||
                state == GRPC_CHANNEL_CONNECTING ||
@@ -84,12 +84,12 @@ static void test_ping(grpc_end2end_test_config config,
   for (i = 1; i <= PING_NUM; i++) {
     grpc_channel_ping(f.client, f.cq, tag(i), nullptr);
     cqv.Expect(tag(i), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
   }
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
   cqv.Expect(tag(0xdead), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* cleanup server */
   grpc_server_destroy(f.server);

--- a/test/core/end2end/tests/ping_pong_streaming.cc
+++ b/test/core/end2end/tests/ping_pong_streaming.cc
@@ -153,7 +153,7 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(100));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(100), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -202,7 +202,7 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
                                   tag(102), nullptr);
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(102), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     memset(ops, 0, sizeof(ops));
     op = ops;
@@ -216,7 +216,7 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv.Expect(tag(103), true);
     cqv.Expect(tag(2), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     grpc_byte_buffer_destroy(request_payload);
     grpc_byte_buffer_destroy(response_payload);
@@ -255,7 +255,7 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
   cqv.Expect(tag(3), true);
   cqv.Expect(tag(101), true);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(c);
   grpc_call_unref(s);

--- a/test/core/end2end/tests/proxy_auth.cc
+++ b/test/core/end2end/tests/proxy_auth.cc
@@ -152,7 +152,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -189,7 +189,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/registered_call.cc
+++ b/test/core/end2end/tests/registered_call.cc
@@ -143,7 +143,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -171,7 +171,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/request_with_flags.cc
+++ b/test/core/end2end/tests/request_with_flags.cc
@@ -155,7 +155,7 @@ static void test_invoke_request_with_flags(
 
   if (expectation == GRPC_CALL_OK) {
     cqv.Expect(tag(1), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
     grpc_slice_unref(details);
   }
 

--- a/test/core/end2end/tests/request_with_payload.cc
+++ b/test/core/end2end/tests/request_with_payload.cc
@@ -156,7 +156,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
                                  f.server, &s, &call_details,
                                  &request_metadata_recv, f.cq, f.cq, tag(101)));
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -175,7 +175,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -198,7 +198,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry.cc
+++ b/test/core/end2end/tests/retry.cc
@@ -188,7 +188,7 @@ static void test_retry(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was not sent in the
   // initial attempt.
@@ -225,7 +225,7 @@ static void test_retry(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -238,7 +238,7 @@ static void test_retry(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was sent in the retry.
   bool found_retry_header = false;
@@ -288,7 +288,7 @@ static void test_retry(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_cancel_after_first_attempt_starts.cc
+++ b/test/core/end2end/tests/retry_cancel_after_first_attempt_starts.cc
@@ -194,7 +194,7 @@ static void test_retry_cancel_after_first_attempt_starts(
   cqv.Expect(tag(1), grpc_core::CqVerifier::AnyStatus());
   cqv.Expect(tag(2), grpc_core::CqVerifier::AnyStatus());
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_slice_unref(details);
   grpc_metadata_array_destroy(&initial_metadata_recv);

--- a/test/core/end2end/tests/retry_cancel_during_delay.cc
+++ b/test/core/end2end/tests/retry_cancel_during_delay.cc
@@ -201,7 +201,7 @@ static void test_retry_cancel_during_delay(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -230,7 +230,7 @@ static void test_retry_cancel_during_delay(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -249,7 +249,7 @@ static void test_retry_cancel_during_delay(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == mode.initiate_cancel(c, nullptr));
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_timespec finish_time = gpr_now(GPR_CLOCK_MONOTONIC);
 

--- a/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
+++ b/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
@@ -225,7 +225,7 @@ static void test_retry_cancel_with_multiple_send_batches(
   cqv.Expect(tag(2), false);
   cqv.Expect(tag(3), false);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_log(GPR_INFO, "status=%d expected=%d", status, mode.expect_status);
   GPR_ASSERT(status == mode.expect_status);

--- a/test/core/end2end/tests/retry_cancellation.cc
+++ b/test/core/end2end/tests/retry_cancellation.cc
@@ -195,7 +195,7 @@ static void test_retry_cancellation(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -224,7 +224,7 @@ static void test_retry_cancellation(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -238,13 +238,13 @@ static void test_retry_cancellation(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Initiate cancellation.
   GPR_ASSERT(GRPC_CALL_OK == mode.initiate_cancel(c, nullptr));
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == mode.expect_status);
   GPR_ASSERT(was_cancelled == 0);

--- a/test/core/end2end/tests/retry_disabled.cc
+++ b/test/core/end2end/tests/retry_disabled.cc
@@ -191,7 +191,7 @@ static void test_retry_disabled(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -221,7 +221,7 @@ static void test_retry_disabled(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_exceeds_buffer_size_in_delay.cc
+++ b/test/core/end2end/tests/retry_exceeds_buffer_size_in_delay.cc
@@ -195,7 +195,7 @@ static void test_retry_exceeds_buffer_size_in_delay(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -224,7 +224,7 @@ static void test_retry_exceeds_buffer_size_in_delay(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -235,7 +235,7 @@ static void test_retry_exceeds_buffer_size_in_delay(
   // Do a bit more polling, to make sure the client sees status from the
   // first attempt.  (Note: This polls for 1s, which is less than the
   // retry initial backoff time of 2s from the service config above.)
-  cqv.VerifyEmpty();
+  cqv.VerifyEmpty(DEBUG_LOCATION);
 
   // Client sends a message that puts it over the buffer size limit.
   memset(ops, 0, sizeof(ops));
@@ -249,7 +249,7 @@ static void test_retry_exceeds_buffer_size_in_delay(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server gets another call.
   error =
@@ -257,7 +257,7 @@ static void test_retry_exceeds_buffer_size_in_delay(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server again sends ABORTED.  But this time, the client won't retry,
   // since the call has been committed by exceeding the buffer size.
@@ -279,7 +279,7 @@ static void test_retry_exceeds_buffer_size_in_delay(
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "message2"));

--- a/test/core/end2end/tests/retry_exceeds_buffer_size_in_initial_batch.cc
+++ b/test/core/end2end/tests/retry_exceeds_buffer_size_in_initial_batch.cc
@@ -194,7 +194,7 @@ static void test_retry_exceeds_buffer_size_in_initial_batch(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -224,7 +224,7 @@ static void test_retry_exceeds_buffer_size_in_initial_batch(
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_exceeds_buffer_size_in_subsequent_batch.cc
+++ b/test/core/end2end/tests/retry_exceeds_buffer_size_in_subsequent_batch.cc
@@ -179,7 +179,7 @@ static void test_retry_exceeds_buffer_size_in_subsequent_batch(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -208,7 +208,7 @@ static void test_retry_exceeds_buffer_size_in_subsequent_batch(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -238,7 +238,7 @@ static void test_retry_exceeds_buffer_size_in_subsequent_batch(
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_lb_drop.cc
+++ b/test/core/end2end/tests/retry_lb_drop.cc
@@ -252,7 +252,7 @@ static void test_retry_lb_drop(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
   GPR_ASSERT(0 ==

--- a/test/core/end2end/tests/retry_lb_fail.cc
+++ b/test/core/end2end/tests/retry_lb_fail.cc
@@ -238,7 +238,7 @@ static void test_retry_lb_fail(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(1), false);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -252,7 +252,7 @@ static void test_retry_lb_fail(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "LB pick failed"));

--- a/test/core/end2end/tests/retry_non_retriable_status.cc
+++ b/test/core/end2end/tests/retry_non_retriable_status.cc
@@ -187,7 +187,7 @@ static void test_retry_non_retriable_status(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -217,7 +217,7 @@ static void test_retry_non_retriable_status(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_INVALID_ARGUMENT);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_non_retriable_status_before_recv_trailing_metadata_started.cc
+++ b/test/core/end2end/tests/retry_non_retriable_status_before_recv_trailing_metadata_started.cc
@@ -184,7 +184,7 @@ test_retry_non_retriable_status_before_recv_trailing_metadata_started(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -214,7 +214,7 @@ test_retry_non_retriable_status_before_recv_trailing_metadata_started(
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -231,7 +231,7 @@ test_retry_non_retriable_status_before_recv_trailing_metadata_started(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_INVALID_ARGUMENT);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_per_attempt_recv_timeout.cc
+++ b/test/core/end2end/tests/retry_per_attempt_recv_timeout.cc
@@ -194,7 +194,7 @@ static void test_retry_per_attempt_recv_timeout(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was not sent in the
   // initial attempt.
@@ -215,7 +215,7 @@ static void test_retry_per_attempt_recv_timeout(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Now we can unref the first call.
   grpc_call_unref(s0);
@@ -261,7 +261,7 @@ static void test_retry_per_attempt_recv_timeout(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(202), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -275,7 +275,7 @@ static void test_retry_per_attempt_recv_timeout(
                                &request_metadata_recv, f.cq, f.cq, tag(301));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(301), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was sent in the retry.
   found_retry_header = false;
@@ -317,7 +317,7 @@ static void test_retry_per_attempt_recv_timeout(
 
   cqv.Expect(tag(302), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_per_attempt_recv_timeout_on_last_attempt.cc
+++ b/test/core/end2end/tests/retry_per_attempt_recv_timeout_on_last_attempt.cc
@@ -189,7 +189,7 @@ static void test_retry_per_attempt_recv_timeout_on_last_attempt(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was not sent in the
   // initial attempt.
@@ -210,7 +210,7 @@ static void test_retry_per_attempt_recv_timeout_on_last_attempt(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Now we can unref the first call.
   grpc_call_unref(s0);
@@ -231,7 +231,7 @@ static void test_retry_per_attempt_recv_timeout_on_last_attempt(
 
   // Client sees call completion.
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_CANCELLED);
   GPR_ASSERT(

--- a/test/core/end2end/tests/retry_recv_initial_metadata.cc
+++ b/test/core/end2end/tests/retry_recv_initial_metadata.cc
@@ -192,7 +192,7 @@ static void test_retry_recv_initial_metadata(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -221,7 +221,7 @@ static void test_retry_recv_initial_metadata(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -239,7 +239,7 @@ static void test_retry_recv_initial_metadata(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_recv_message.cc
+++ b/test/core/end2end/tests/retry_recv_message.cc
@@ -188,7 +188,7 @@ static void test_retry_recv_message(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -221,7 +221,7 @@ static void test_retry_recv_message(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_recv_message_replay.cc
+++ b/test/core/end2end/tests/retry_recv_message_replay.cc
@@ -215,7 +215,7 @@ static void test_retry_recv_message_replay(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server fails with status ABORTED.
   memset(ops, 0, sizeof(ops));
@@ -242,7 +242,7 @@ static void test_retry_recv_message_replay(grpc_end2end_test_config config) {
   cqv.Expect(tag(1), true);
   cqv.Expect(tag(2), true);
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
+++ b/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
@@ -198,7 +198,7 @@ static void test_retry_recv_trailing_metadata_error(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -228,7 +228,7 @@ static void test_retry_recv_trailing_metadata_error(
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -242,7 +242,7 @@ static void test_retry_recv_trailing_metadata_error(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_INVALID_ARGUMENT);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "injected error"));

--- a/test/core/end2end/tests/retry_send_initial_metadata_refs.cc
+++ b/test/core/end2end/tests/retry_send_initial_metadata_refs.cc
@@ -195,7 +195,7 @@ static void test_retry_send_initial_metadata_refs(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   for (size_t i = 0; i < client_send_initial_metadata.count; ++i) {
     grpc_slice_unref(client_send_initial_metadata.metadata[i].key);
@@ -225,7 +225,7 @@ static void test_retry_send_initial_metadata_refs(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was not sent in the
   // initial attempt.
@@ -262,7 +262,7 @@ static void test_retry_send_initial_metadata_refs(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -275,7 +275,7 @@ static void test_retry_send_initial_metadata_refs(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Make sure the "grpc-previous-rpc-attempts" header was sent in the retry.
   GPR_ASSERT(contains_metadata_slices(
@@ -324,7 +324,7 @@ static void test_retry_send_initial_metadata_refs(
 
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_send_op_fails.cc
+++ b/test/core/end2end/tests/retry_send_op_fails.cc
@@ -210,7 +210,7 @@ static void test_retry_send_op_fails(grpc_end2end_test_config config) {
 
   // Client send ops should now complete.
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server should get a call.
   error =
@@ -218,7 +218,7 @@ static void test_retry_send_op_fails(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server fails with status ABORTED.
   memset(ops, 0, sizeof(ops));
@@ -243,7 +243,7 @@ static void test_retry_send_op_fails(grpc_end2end_test_config config) {
   // involved, so the completion order tends to be a little racy.
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_send_recv_batch.cc
+++ b/test/core/end2end/tests/retry_send_recv_batch.cc
@@ -183,7 +183,7 @@ static void test_retry_send_recv_batch(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client starts a batch containing recv_message.
   memset(ops, 0, sizeof(ops));
@@ -217,7 +217,7 @@ static void test_retry_send_recv_batch(grpc_end2end_test_config config) {
   cqv.Expect(tag(1), true);
   cqv.Expect(tag(2), true);
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_PERMISSION_DENIED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_server_pushback_delay.cc
+++ b/test/core/end2end/tests/retry_server_pushback_delay.cc
@@ -201,7 +201,7 @@ static void test_retry_server_pushback_delay(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify(grpc_core::Duration::Seconds(20));
+  cqv.Verify(grpc_core::Duration::Seconds(20), DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -231,7 +231,7 @@ static void test_retry_server_pushback_delay(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_timespec before_retry = gpr_now(GPR_CLOCK_MONOTONIC);
 
@@ -246,7 +246,7 @@ static void test_retry_server_pushback_delay(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_timespec after_retry = gpr_now(GPR_CLOCK_MONOTONIC);
   gpr_timespec retry_delay = gpr_time_sub(after_retry, before_retry);
@@ -287,7 +287,7 @@ static void test_retry_server_pushback_delay(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   gpr_log(GPR_INFO, "status=%d message=\"%s\"", status,
           std::string(grpc_core::StringViewFromSlice(details)).c_str());

--- a/test/core/end2end/tests/retry_server_pushback_disabled.cc
+++ b/test/core/end2end/tests/retry_server_pushback_disabled.cc
@@ -194,7 +194,7 @@ static void test_retry_server_pushback_disabled(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -223,7 +223,7 @@ static void test_retry_server_pushback_disabled(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -236,7 +236,7 @@ static void test_retry_server_pushback_disabled(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -267,7 +267,7 @@ static void test_retry_server_pushback_disabled(
 
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_streaming.cc
+++ b/test/core/end2end/tests/retry_streaming.cc
@@ -214,7 +214,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server gets a call with received initial metadata.
   error =
@@ -222,7 +222,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -243,7 +243,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client sends a second message.
   memset(ops, 0, sizeof(ops));
@@ -255,7 +255,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives the second message.
   memset(ops, 0, sizeof(ops));
@@ -267,7 +267,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(103), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server sends both initial and trailing metadata.
   memset(ops, 0, sizeof(ops));
@@ -287,7 +287,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Clean up from first attempt.
   grpc_call_unref(s);
@@ -309,7 +309,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -330,7 +330,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(202), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives a second message.
   memset(ops, 0, sizeof(ops));
@@ -342,7 +342,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(203), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client sends a third message and a close.
   memset(ops, 0, sizeof(ops));
@@ -356,7 +356,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives a third message.
   memset(ops, 0, sizeof(ops));
@@ -368,7 +368,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(204), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives a close and sends initial metadata, a message, and
   // trailing metadata.
@@ -395,7 +395,7 @@ static void test_retry_streaming(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(205), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_streaming_after_commit.cc
+++ b/test/core/end2end/tests/retry_streaming_after_commit.cc
@@ -191,7 +191,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server gets a call with received initial metadata.
   error =
@@ -199,7 +199,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -220,7 +220,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server sends initial metadata and a message.
   memset(ops, 0, sizeof(ops));
@@ -237,7 +237,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
   cqv.Expect(tag(103), true);
   // Client receives initial metadata and a message.
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client sends a second message and a close.
   memset(ops, 0, sizeof(ops));
@@ -251,7 +251,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives a second message.
   memset(ops, 0, sizeof(ops));
@@ -263,7 +263,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives a close, sends a second message, and sends status.
   memset(ops, 0, sizeof(ops));
@@ -285,7 +285,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(105), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client receives a second message.
   memset(ops, 0, sizeof(ops));
@@ -297,7 +297,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(5), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client receives status.
   memset(ops, 0, sizeof(ops));
@@ -311,7 +311,7 @@ static void test_retry_streaming_after_commit(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_streaming_succeeds_before_replay_finished.cc
+++ b/test/core/end2end/tests/retry_streaming_succeeds_before_replay_finished.cc
@@ -197,7 +197,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server gets a call with received initial metadata.
   error =
@@ -205,7 +205,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -226,7 +226,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client sends a second message.
   memset(ops, 0, sizeof(ops));
@@ -238,7 +238,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(3), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives the second message.
   memset(ops, 0, sizeof(ops));
@@ -250,7 +250,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(103), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client sends a third message.
   memset(ops, 0, sizeof(ops));
@@ -262,7 +262,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives the third message.
   memset(ops, 0, sizeof(ops));
@@ -274,7 +274,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server sends both initial and trailing metadata.
   memset(ops, 0, sizeof(ops));
@@ -294,7 +294,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(105), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Clean up from first attempt.
   grpc_call_unref(s);
@@ -320,7 +320,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -341,7 +341,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(202), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server sends initial metadata, a message, and trailing metadata.
   memset(ops, 0, sizeof(ops));
@@ -364,7 +364,7 @@ static void test_retry_streaming_succeeds_before_replay_finished(
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(205), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_throttled.cc
+++ b/test/core/end2end/tests/retry_throttled.cc
@@ -194,7 +194,7 @@ static void test_retry_throttled(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -224,7 +224,7 @@ static void test_retry_throttled(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_too_many_attempts.cc
+++ b/test/core/end2end/tests/retry_too_many_attempts.cc
@@ -188,7 +188,7 @@ static void test_retry_too_many_attempts(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -217,7 +217,7 @@ static void test_retry_too_many_attempts(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -230,7 +230,7 @@ static void test_retry_too_many_attempts(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -260,7 +260,7 @@ static void test_retry_too_many_attempts(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_ABORTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_transparent_goaway.cc
+++ b/test/core/end2end/tests/retry_transparent_goaway.cc
@@ -182,7 +182,7 @@ static void test_retry_transparent_goaway(grpc_end2end_test_config config) {
 
   // Client send ops should now complete.
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server should get a call.
   error =
@@ -190,7 +190,7 @@ static void test_retry_transparent_goaway(grpc_end2end_test_config config) {
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives the request.
   memset(ops, 0, sizeof(ops));
@@ -202,7 +202,7 @@ static void test_retry_transparent_goaway(grpc_end2end_test_config config) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server sends a response with status OK.
   memset(ops, 0, sizeof(ops));
@@ -230,7 +230,7 @@ static void test_retry_transparent_goaway(grpc_end2end_test_config config) {
   // involved, so the completion order tends to be a little racy.
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_transparent_max_concurrent_streams.cc
+++ b/test/core/end2end/tests/retry_transparent_max_concurrent_streams.cc
@@ -165,7 +165,7 @@ static void test_retry_transparent_max_concurrent_streams(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   grpc_call_details_destroy(&call_details);
   grpc_metadata_array_destroy(&request_metadata_recv);
@@ -250,7 +250,7 @@ static void test_retry_transparent_max_concurrent_streams(
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Clean up from first call.
   GPR_ASSERT(byte_buffer_eq_slice(request_payload_recv, request_payload_slice));
@@ -282,7 +282,7 @@ static void test_retry_transparent_max_concurrent_streams(
                                &request_metadata_recv, f.cq, f.cq, tag(201));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(201), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   grpc_call_details_destroy(&call_details);
   // Make sure the "grpc-previous-rpc-attempts" header was NOT sent, since
@@ -325,7 +325,7 @@ static void test_retry_transparent_max_concurrent_streams(
   // Second call completes.
   cqv.Expect(tag(202), true);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Clean up from second call.
   GPR_ASSERT(byte_buffer_eq_slice(request_payload_recv, request_payload_slice));

--- a/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
+++ b/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
@@ -183,7 +183,7 @@ static void test_retry_transparent_not_sent_on_wire(
 
   // Client send ops should now complete.
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server should get a call.
   error =
@@ -191,7 +191,7 @@ static void test_retry_transparent_not_sent_on_wire(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server receives the request.
   memset(ops, 0, sizeof(ops));
@@ -203,7 +203,7 @@ static void test_retry_transparent_not_sent_on_wire(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server sends a response with status OK.
   memset(ops, 0, sizeof(ops));
@@ -231,7 +231,7 @@ static void test_retry_transparent_not_sent_on_wire(
   // involved, so the completion order tends to be a little racy.
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/retry_unref_before_finish.cc
+++ b/test/core/end2end/tests/retry_unref_before_finish.cc
@@ -179,7 +179,7 @@ static void test_retry_unref_before_finish(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Server immediately sends FAILED_PRECONDITION status (not retriable).
   // This forces the retry filter to start a recv_trailing_metadata op
@@ -204,7 +204,7 @@ static void test_retry_unref_before_finish(grpc_end2end_test_config config) {
   // Server ops complete and client recv ops complete.
   cqv.Expect(tag(2), true);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   GPR_ASSERT(was_cancelled == 0);

--- a/test/core/end2end/tests/retry_unref_before_recv.cc
+++ b/test/core/end2end/tests/retry_unref_before_recv.cc
@@ -180,7 +180,7 @@ static void test_retry_unref_before_recv(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(1), true);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   // Client unrefs the call without starting recv_trailing_metadata.
   // This should trigger a cancellation.
@@ -209,7 +209,7 @@ static void test_retry_unref_before_recv(grpc_end2end_test_config config) {
   // Server ops complete and client recv ops complete.
   cqv.Expect(tag(2), false);  // Failure!
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/service/method"));
   // Note: Not checking the value of was_cancelled here, because it will

--- a/test/core/end2end/tests/server_finishes_request.cc
+++ b/test/core/end2end/tests/server_finishes_request.cc
@@ -140,7 +140,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -168,7 +168,7 @@ static void simple_request_body(grpc_end2end_test_config /*config*/,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/server_streaming.cc
+++ b/test/core/end2end/tests/server_streaming.cc
@@ -162,14 +162,14 @@ static void test_server_streaming(grpc_end2end_test_config config,
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv->Expect(tag(3), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   error =
       grpc_server_request_call(f.server, &s, &call_details,
                                &request_metadata_recv, f.cq, f.cq, tag(100));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv->Expect(tag(100), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -183,7 +183,7 @@ static void test_server_streaming(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv->Expect(tag(101), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   // Server writes bunch of messages
   for (int i = 0; i < num_messages; i++) {
@@ -200,7 +200,7 @@ static void test_server_streaming(grpc_end2end_test_config config,
                                   tag(103), nullptr);
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv->Expect(tag(103), true);
-    cqv->Verify();
+    cqv->Verify(DEBUG_LOCATION);
 
     grpc_byte_buffer_destroy(response_payload);
   }
@@ -227,7 +227,7 @@ static void test_server_streaming(grpc_end2end_test_config config,
   bool seen_status = false;
   cqv->Expect(tag(1), grpc_core::CqVerifier::Maybe{&seen_status});
   cqv->Expect(tag(104), true);
-  cqv->Verify();
+  cqv->Verify(DEBUG_LOCATION);
 
   // Client keeps reading messages till it gets the status
   int num_messages_received = 0;
@@ -244,7 +244,7 @@ static void test_server_streaming(grpc_end2end_test_config config,
     GPR_ASSERT(GRPC_CALL_OK == error);
     cqv->Expect(tag(1), grpc_core::CqVerifier::Maybe{&seen_status});
     cqv->Expect(tag(102), true);
-    cqv->Verify();
+    cqv->Verify(DEBUG_LOCATION);
     if (request_payload_recv == nullptr) {
       // The transport has received the trailing metadata.
       break;
@@ -256,7 +256,7 @@ static void test_server_streaming(grpc_end2end_test_config config,
   GPR_ASSERT(num_messages_received == num_messages);
   if (!seen_status) {
     cqv->Expect(tag(1), true);
-    cqv->Verify();
+    cqv->Verify(DEBUG_LOCATION);
   }
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/shutdown_finishes_calls.cc
+++ b/test/core/end2end/tests/shutdown_finishes_calls.cc
@@ -136,7 +136,7 @@ static void test_early_server_shutdown_finishes_inflight_calls(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -163,7 +163,7 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   cqv.Expect(tag(1000), true);
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   grpc_server_destroy(f.server);
 

--- a/test/core/end2end/tests/shutdown_finishes_tags.cc
+++ b/test/core/end2end/tests/shutdown_finishes_tags.cc
@@ -87,7 +87,7 @@ static void test_early_server_shutdown_finishes_tags(
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(1000));
   cqv.Expect(tag(101), false);
   cqv.Expect(tag(1000), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   GPR_ASSERT(s == nullptr);
 
   grpc_server_destroy(f.server);

--- a/test/core/end2end/tests/simple_delayed_request.cc
+++ b/test/core/end2end/tests/simple_delayed_request.cc
@@ -141,7 +141,7 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
                                &request_metadata_recv, f->cq, f->cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -169,7 +169,7 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/simple_metadata.cc
+++ b/test/core/end2end/tests/simple_metadata.cc
@@ -182,7 +182,7 @@ static void test_request_response_with_metadata_and_payload(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -202,7 +202,7 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -230,7 +230,7 @@ static void test_request_response_with_metadata_and_payload(
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/simple_request.cc
+++ b/test/core/end2end/tests/simple_request.cc
@@ -174,7 +174,7 @@ static void simple_request_body(grpc_end2end_test_config config,
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
@@ -213,7 +213,7 @@ static void simple_request_body(grpc_end2end_test_config config,
 
   cqv.Expect(tag(102), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/streaming_error_response.cc
+++ b/test/core/end2end/tests/streaming_error_response.cc
@@ -164,7 +164,7 @@ static void test(grpc_end2end_test_config config, bool request_status_early,
                                  f.server, &s, &call_details,
                                  &request_metadata_recv, f.cq, f.cq, tag(101)));
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -196,7 +196,7 @@ static void test(grpc_end2end_test_config config, bool request_status_early,
   if (recv_message_separately) {
     cqv.Expect(tag(4), true);
   }
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -224,7 +224,7 @@ static void test(grpc_end2end_test_config config, bool request_status_early,
     GPR_ASSERT(GRPC_CALL_OK == error);
 
     cqv.Expect(tag(2), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
   }
 
   // Cancel the call so that the client sets up an error status.
@@ -242,7 +242,7 @@ static void test(grpc_end2end_test_config config, bool request_status_early,
   if (request_status_early) {
     cqv.Expect(tag(1), true);
   }
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   if (!request_status_early) {
     memset(ops, 0, sizeof(ops));
@@ -257,7 +257,7 @@ static void test(grpc_end2end_test_config config, bool request_status_early,
     GPR_ASSERT(GRPC_CALL_OK == error);
 
     cqv.Expect(tag(3), true);
-    cqv.Verify();
+    cqv.Verify(DEBUG_LOCATION);
 
     GPR_ASSERT(response_payload1_recv != nullptr);
     GPR_ASSERT(response_payload2_recv != nullptr);

--- a/test/core/end2end/tests/trailing_metadata.cc
+++ b/test/core/end2end/tests/trailing_metadata.cc
@@ -188,7 +188,7 @@ static void test_request_response_with_metadata_and_payload(
                                &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -208,7 +208,7 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -237,7 +237,7 @@ static void test_request_response_with_metadata_and_payload(
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/write_buffering.cc
+++ b/test/core/end2end/tests/write_buffering.cc
@@ -149,7 +149,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
                                  &request_metadata_recv, f.cq, f.cq, tag(101)));
   cqv.Expect(tag(1), true); /* send message is buffered */
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -183,7 +183,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   cqv.Expect(tag(2), true);
   cqv.Expect(tag(3), true);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* send another message, this time not buffered */
   memset(ops, 0, sizeof(ops));
@@ -199,7 +199,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   /* now the first send should match up with the first recv */
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* and the next recv should be ready immediately also */
   memset(ops, 0, sizeof(ops));
@@ -212,7 +212,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -251,7 +251,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(105), true);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/end2end/tests/write_buffering_at_end.cc
+++ b/test/core/end2end/tests/write_buffering_at_end.cc
@@ -146,7 +146,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
                                  &request_metadata_recv, f.cq, f.cq, tag(101)));
   cqv.Expect(tag(1), true); /* send message is buffered */
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -180,7 +180,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   cqv.Expect(tag(2), true);
   cqv.Expect(tag(3), true);
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* send end of stream: should release the buffering */
   memset(ops, 0, sizeof(ops));
@@ -194,7 +194,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   /* now the first send should match up with the first recv */
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   /* and the next recv should be ready immediately also (and empty) */
   memset(ops, 0, sizeof(ops));
@@ -207,7 +207,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(104), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -242,7 +242,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
 
   cqv.Expect(tag(105), true);
   cqv.Expect(tag(4), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));

--- a/test/core/iomgr/stranded_event_test.cc
+++ b/test/core/iomgr/stranded_event_test.cc
@@ -102,7 +102,7 @@ void StartCall(TestCall* test_call) {
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_core::CqVerifier cqv(test_call->cq);
   cqv.Expect(tag, true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 }
 
 void SendMessage(grpc_call* call, grpc_completion_queue* cq) {
@@ -123,7 +123,7 @@ void SendMessage(grpc_call* call, grpc_completion_queue* cq) {
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_core::CqVerifier cqv(cq);
   cqv.Expect(tag, true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   grpc_byte_buffer_destroy(request_payload);
 }
 
@@ -143,7 +143,7 @@ void ReceiveMessage(grpc_call* call, grpc_completion_queue* cq) {
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_core::CqVerifier cqv(cq);
   cqv.Expect(tag, true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   grpc_byte_buffer_destroy(request_payload);
 }
 

--- a/test/core/surface/lame_client_test.cc
+++ b/test/core/surface/lame_client_test.cc
@@ -116,7 +116,7 @@ TEST(LameClientTest, MainTest) {
 
   /* the call should immediately fail */
   cqv.Expect(tag(1), false);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -133,7 +133,7 @@ TEST(LameClientTest, MainTest) {
 
   /* the call should immediately fail */
   cqv.Expect(tag(2), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   peer = grpc_call_get_peer(call);
   ASSERT_STREQ(peer, "lampoon:national");

--- a/test/core/transport/chttp2/graceful_shutdown_test.cc
+++ b/test/core/transport/chttp2/graceful_shutdown_test.cc
@@ -136,7 +136,7 @@ class GracefulShutdownTest : public ::testing::Test {
     // Shutdown and destroy server
     grpc_server_shutdown_and_notify(server_, cq_, Tag(1000));
     cqv_->Expect(Tag(1000), true);
-    cqv_->Verify();
+    cqv_->Verify(DEBUG_LOCATION);
     grpc_server_destroy(server_);
     cqv_.reset();
     grpc_completion_queue_destroy(cq_);
@@ -257,7 +257,7 @@ TEST_F(GracefulShutdownTest, GracefulGoaway) {
   WaitForGoaway(0);
   // The shutdown should successfully complete.
   cqv_->Expect(Tag(1), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
 }
 
 TEST_F(GracefulShutdownTest, RequestStartedBeforeFinalGoaway) {
@@ -300,7 +300,7 @@ TEST_F(GracefulShutdownTest, RequestStartedBeforeFinalGoaway) {
   cqv_->Expect(Tag(100), false);
   // The shutdown should successfully complete.
   cqv_->Expect(Tag(1), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   grpc_metadata_array_destroy(&request_metadata_recv);
   grpc_call_details_destroy(&call_details);
 }
@@ -332,7 +332,7 @@ TEST_F(GracefulShutdownTest, RequestStartedAfterFinalGoawayIsIgnored) {
       "\x10\x0auser-agent\x17grpc-c/0.12.0.0 (linux)";
   Write(absl::string_view(kRequestFrame, sizeof(kRequestFrame) - 1));
   cqv_->Expect(Tag(100), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
 
   // Initiate shutdown on the server
   grpc_server_shutdown_and_notify(server_, cq_, Tag(1));
@@ -390,7 +390,7 @@ TEST_F(GracefulShutdownTest, RequestStartedAfterFinalGoawayIsIgnored) {
   cqv_->Expect(Tag(101), true);
   // The shutdown should successfully complete.
   cqv_->Expect(Tag(1), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   grpc_call_unref(s);
   grpc_metadata_array_destroy(&request_metadata_recv);
   grpc_call_details_destroy(&call_details);
@@ -414,7 +414,7 @@ TEST_F(GracefulShutdownTest, UnresponsiveClient) {
                     1) /* clock skew between threads due to time caching */);
   // The shutdown should successfully complete.
   cqv_->Expect(Tag(1), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
 }
 
 // Test that servers send a GOAWAY with the last stream ID even when the
@@ -429,7 +429,7 @@ TEST_F(GracefulShutdownTest, GoawayReceivedOnServerDisconnect) {
                 grpc_slice_from_static_string("Cancelling all calls"));
   // The shutdown should successfully complete.
   cqv_->Expect(Tag(1), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
 }
 
 }  // namespace

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -223,7 +223,7 @@ class StreamsNotSeenTest : public ::testing::Test {
       grpc_channel_watch_connectivity_state(
           channel_, state, grpc_timeout_seconds_to_deadline(1), cq_, Tag(1));
       cqv_->Expect(Tag(1), true);
-      cqv_->Verify(Duration::Seconds(5));
+      cqv_->Verify(Duration::Seconds(5), DEBUG_LOCATION);
       state = grpc_channel_check_connectivity_state(channel_, false);
     }
     ExecCtx::Get()->Flush();
@@ -428,7 +428,7 @@ TEST_F(StreamsNotSeenTest, StartStreamBeforeGoaway) {
   error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
                                 nullptr);
   cqv_->Expect(Tag(101), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Send a goaway from server signalling that the request was unseen by the
   // server.
   SendGoaway(0);
@@ -451,7 +451,7 @@ TEST_F(StreamsNotSeenTest, StartStreamBeforeGoaway) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv_->Expect(Tag(102), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
   ASSERT_TRUE(TrailingMetadataRecordingFilter::trailing_metadata_available());
@@ -502,7 +502,7 @@ TEST_F(StreamsNotSeenTest, TransportDestroyed) {
   error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
                                 nullptr);
   cqv_->Expect(Tag(101), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Shutdown the server endpoint
   grpc_endpoint_shutdown(
       tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown"));
@@ -525,7 +525,7 @@ TEST_F(StreamsNotSeenTest, TransportDestroyed) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv_->Expect(Tag(102), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
   EXPECT_FALSE(
@@ -590,7 +590,7 @@ TEST_F(StreamsNotSeenTest, StartStreamAfterGoaway) {
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv_->Expect(Tag(101), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
   ASSERT_TRUE(TrailingMetadataRecordingFilter::trailing_metadata_available());
@@ -668,7 +668,7 @@ TEST_F(ZeroConcurrencyTest, StartStreamBeforeGoaway) {
   SendGoaway(0);
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv_->Expect(Tag(101), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
   ASSERT_TRUE(TrailingMetadataRecordingFilter::trailing_metadata_available());
@@ -734,7 +734,7 @@ TEST_F(ZeroConcurrencyTest, TransportDestroyed) {
       tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown"));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv_->Expect(Tag(101), true);
-  cqv_->Verify();
+  cqv_->Verify(DEBUG_LOCATION);
   // Verify status and metadata
   EXPECT_EQ(status, GRPC_STATUS_UNAVAILABLE);
   ASSERT_TRUE(TrailingMetadataRecordingFilter::trailing_metadata_available());

--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -155,11 +155,11 @@ grpc_status_code PerformCall(grpc_channel* channel, grpc_server* server,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   grpc_call_cancel_with_status(s, GRPC_STATUS_PERMISSION_DENIED, "test status",
                                nullptr);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   // cleanup
   grpc_slice_unref(details);
   grpc_metadata_array_destroy(&initial_metadata_recv);
@@ -284,7 +284,7 @@ grpc_status_code PerformWaitingCall(grpc_channel* channel, grpc_server* server,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   // Since the server is configured to allow only a single ping strike, it would
   // take 3 pings to trigger the GOAWAY frame with "too_many_pings" from the
   // server. (The second ping from the client would be the first bad ping sent
@@ -659,7 +659,7 @@ void PerformCallWithResponsePayload(grpc_channel* channel, grpc_server* server,
                                    &request_metadata_recv, cq, cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv.Expect(tag(101), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -673,7 +673,7 @@ void PerformCallWithResponsePayload(grpc_channel* channel, grpc_server* server,
   GPR_ASSERT(GRPC_CALL_OK == error);
 
   cqv.Expect(tag(102), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   memset(ops, 0, sizeof(ops));
   op = ops;
@@ -701,7 +701,7 @@ void PerformCallWithResponsePayload(grpc_channel* channel, grpc_server* server,
 
   cqv.Expect(tag(103), true);
   cqv.Expect(tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
 
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == grpc_slice_str_cmp(details, "xyz"));
@@ -764,26 +764,26 @@ TEST(TooManyPings, BdpPingNotSentWithoutReceiveSideActivity) {
   // BDP sent.
   grpc_channel_ping(channel, cq, tag(1), nullptr);
   cqv.Expect(tag(1), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   // Second ping
   grpc_channel_ping(channel, cq, tag(2), nullptr);
   cqv.Expect(tag(2), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   ASSERT_EQ(grpc_channel_check_connectivity_state(channel, 0),
             GRPC_CHANNEL_READY);
   PerformCallWithResponsePayload(channel, server, cq);
   // Wait a bit to make sure that the BDP ping goes out.
-  cqv.VerifyEmpty(grpc_core::Duration::Seconds(1));
+  cqv.VerifyEmpty(grpc_core::Duration::Seconds(1), DEBUG_LOCATION);
   // The call with a response payload should have triggered a BDP ping.
   // Send two more pings to verify. The second ping should cause a disconnect.
   // If BDP was not sent, the second ping would not cause a disconnect.
   grpc_channel_ping(channel, cq, tag(3), nullptr);
   cqv.Expect(tag(3), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   // Second ping
   grpc_channel_ping(channel, cq, tag(4), nullptr);
   cqv.Expect(tag(4), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   // Make sure that the transports have been destroyed
   VerifyChannelDisconnected(channel, cq);
   TransportCounter::WaitForTransportsToBeDestroyed();
@@ -837,15 +837,15 @@ TEST(TooManyPings, TransportsGetCleanedUpOnDisconnect) {
   // First ping
   grpc_channel_ping(channel, cq, tag(1), nullptr);
   cqv.Expect(tag(1), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   // Second ping
   grpc_channel_ping(channel, cq, tag(2), nullptr);
   cqv.Expect(tag(2), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   // Third ping caused disconnect
   grpc_channel_ping(channel, cq, tag(2), nullptr);
   cqv.Expect(tag(2), true);
-  cqv.Verify(grpc_core::Duration::Seconds(5));
+  cqv.Verify(grpc_core::Duration::Seconds(5), DEBUG_LOCATION);
   // Make sure that the transports have been destroyed
   VerifyChannelDisconnected(channel, cq);
   TransportCounter::WaitForTransportsToBeDestroyed();

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -381,7 +381,7 @@ void TestCancelDuringActiveQuery(
       call, ops_base, static_cast<size_t>(op - ops_base), Tag(1), nullptr);
   EXPECT_EQ(GRPC_CALL_OK, error);
   cqv.Expect(Tag(1), true);
-  cqv.Verify();
+  cqv.Verify(DEBUG_LOCATION);
   EXPECT_EQ(status, expected_status_code);
   EXPECT_THAT(std::string(error_string),
               testing::HasSubstr(expected_error_message_substring));


### PR DESCRIPTION
Most tests call Verify multiple times. This will help us identify which
of those calls failed.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

