### PR TITLE
priority LB: remove optimization for CONNECTING after config update

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
@@ -495,13 +495,6 @@ void PriorityLb::ChoosePriorityLocked() {
     }
   }
   // Did not find any child in CONNECTING, delegate to last child.
-  const std::string& child_name = config_->priorities().back();
-  if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_priority_trace)) {
-    gpr_log(GPR_INFO,
-            "[priority_lb %p] no priority in CONNECTING, delegating to "
-            "lowest priority child",
-            this);
-  }
   SetCurrentPriorityLocked(config_->priorities().size() - 1,
                            /*deactivate_lower_priorities=*/false,
                            "no usable children");


### PR DESCRIPTION
This removes the `current_child_from_before_update_` field, which was an attempt to avoid temporarily queueing picks when we get a config update that inserts a new priority before the current READY priority.  The idea was that while we waited for the new priority to get connected, we would keep using the old READY priority instead of reporting CONNECTING and queuing picks.  However, this code was fairly complex, probably not well-tested, and would not actually handle all cases (e.g., it would not work at all with ring_hash, which initially reports IDLE instead of CONNECTING).  If/when this pick-queuing behavior actually causes someone a problem, we can reevalute whether we want to add something like this, and we can look for a more testable way to implement it.

Also simplify the logic in `ChoosePriorityLocked()` a bit.