### PR TITLE
Declare data types (PHP)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "homepage": "https://grpc.io",
   "license": "Apache-2.0",
   "require": {
-    "php": ">=7.0.0"
+    "php": ">=7.0.0",
+    "ext-grpc": "*"
   },
   "require-dev": {
     "google/auth": "^v1.3.0"

--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -5,6 +5,7 @@
   "version": "1.50.0",
   "require": {
     "php": ">=7.0.0",
+    "ext-grpc": "*",
     "google/protobuf": "^v3.3.0"
   },
   "require-dev": {

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -29,6 +29,9 @@ abstract class AbstractCall
      * @var Call
      */
     protected $call;
+    /**
+     * @var callback|array&callable
+     */
     protected $deserialize;
     protected $metadata;
     protected $trailing_metadata;
@@ -39,8 +42,9 @@ abstract class AbstractCall
      * @param Channel  $channel     The channel to communicate on
      * @param string   $method      The method to call on the
      *                              remote server
-     * @param callback $deserialize A callback function to deserialize
-     *                              the response
+     * @param callback|array&callable $deserialize A callback function
+     * to deserialize the response. It MUST be an array&callable
+     * when the method {@see _deserializeResponse() } is not overridden.
      * @param array    $options     Call options (optional)
      */
     public function __construct(Channel $channel,
@@ -122,12 +126,12 @@ abstract class AbstractCall
      *
      * @param string $value The binary value to deserialize
      *
-     * @return mixed The deserialized value
+     * @return mixed|object|null The deserialized value
      */
     protected function _deserializeResponse($value)
     {
         if ($value === null) {
-            return;
+            return null;
         }
         list($className, $deserializeFunc) = $this->deserialize;
         $obj = new $className();

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -19,6 +19,8 @@
 
 namespace Grpc;
 
+use Grpc\Internal\InterceptorChannel;
+
 /**
  * Base class for generated client stubs. Stub methods are expected to call
  * _simpleRequest or _streamRequest and return the result.

--- a/src/php/lib/Grpc/Interceptor.php
+++ b/src/php/lib/Grpc/Interceptor.php
@@ -19,6 +19,8 @@
 
 namespace Grpc;
 
+use Grpc\Internal\InterceptorChannel;
+
 /**
  * Represents an interceptor that intercept RPC invocations before call starts.
  * There is one proposal related to the argument $deserialize under the review.
@@ -80,10 +82,10 @@ class Interceptor
     {
         if (is_array($interceptors)) {
             for ($i = count($interceptors) - 1; $i >= 0; $i--) {
-                $channel = new Internal\InterceptorChannel($channel, $interceptors[$i]);
+                $channel = new InterceptorChannel($channel, $interceptors[$i]);
             }
         } else {
-            $channel =  new Internal\InterceptorChannel($channel, $interceptors);
+            $channel =  new InterceptorChannel($channel, $interceptors);
         }
         return $channel;
     }

--- a/src/php/lib/Grpc/Internal/InterceptorChannel.php
+++ b/src/php/lib/Grpc/Internal/InterceptorChannel.php
@@ -19,18 +19,29 @@
 
 namespace Grpc\Internal;
 
+use Grpc\Channel;
+use Grpc\Interceptor;
+
 /**
- * This is a PRIVATE API and can change without notice.
+ * This is a PRIVATE API and can be changed without notice.
  */
-class InterceptorChannel extends \Grpc\Channel
+class InterceptorChannel extends Channel
 {
+  /**
+   * @var Channel|InterceptorChannel|null
+   */
     private $next = null;
+    /**
+     * @var Interceptor
+     */
     private $interceptor;
 
     /**
      * @param Channel|InterceptorChannel $channel An already created Channel
      * or InterceptorChannel object (optional)
      * @param Interceptor  $interceptor
+     *
+     * @throws \Exception
      */
     public function __construct($channel, $interceptor)
     {
@@ -44,31 +55,49 @@ class InterceptorChannel extends \Grpc\Channel
         $this->next = $channel;
     }
 
+    /**
+     * @return Channel|static
+     */
     public function getNext()
     {
         return $this->next;
     }
 
+    /**
+     * @return Interceptor
+     */
     public function getInterceptor()
     {
         return $this->interceptor;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getTarget()
     {
         return $this->getNext()->getTarget();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function watchConnectivityState($new_state, $deadline)
     {
         return $this->getNext()->watchConnectivityState($new_state, $deadline);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getConnectivityState($try_to_connect = false)
     {
         return $this->getNext()->getConnectivityState($try_to_connect);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function close()
     {
         return $this->getNext()->close();

--- a/src/php/lib/Grpc/RpcServer.php
+++ b/src/php/lib/Grpc/RpcServer.php
@@ -32,7 +32,10 @@ namespace Grpc;
  */
 class RpcServer extends Server
 {
-    // [ <String method_full_path> => MethodDescriptor ]
+    /**
+     * [ <String method_full_path> => MethodDescriptor ]
+     * @var array<string,MethodDescriptor>
+     */
     private $paths_map = [];
 
     private function waitForNextEvent()
@@ -44,6 +47,8 @@ class RpcServer extends Server
      * Add a service to this server
      *
      * @param Object   $service      The service to be added
+     *
+     * @return array<string,MethodDescriptor>
      */
     public function handle($service)
     {
@@ -58,6 +63,9 @@ class RpcServer extends Server
         return $this->paths_map;
     }
 
+    /**
+     * @return void
+     */
     public function run()
     {
         $this->start();

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -48,7 +48,7 @@ class ServerStreamingCall extends AbstractCall
     }
 
     /**
-     * @return mixed An iterator of response values
+     * @return \Generator<int,object> An iterator of response values
      */
     public function responses()
     {


### PR DESCRIPTION
- Declare data types of parameters and returned data.
- Require gRPC extension in composer requirements.