### PR TITLE
ring_hash: fix subchannel list to not shutdown until picker is destroyed

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4623,12 +4623,12 @@ grpc_cc_library(
     language = "c++",
     deps = [
         "debug_location",
+        "dual_ref_counted",
         "gpr",
         "grpc_base",
         "grpc_codegen",
         "iomgr_fwd",
         "lb_policy",
-        "orphanable",
         "ref_counted_ptr",
         "server_address",
         "subchannel_interface",

--- a/src/core/ext/filters/client_channel/lb_policy/outlier_detection/outlier_detection.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/outlier_detection/outlier_detection.cc
@@ -649,6 +649,12 @@ void OutlierDetectionLb::UpdateLocked(UpdateArgs args) {
         }
       } else if (!config_->CountingEnabled()) {
         // If counting is not enabled, reset state.
+        if (GRPC_TRACE_FLAG_ENABLED(grpc_outlier_detection_lb_trace)) {
+          gpr_log(GPR_INFO,
+                  "[outlier_detection_lb %p] counting disabled; disabling "
+                  "ejection for %s (%p)",
+                  this, address_key.c_str(), subchannel_state.get());
+        }
         subchannel_state->DisableEjection();
       }
       current_addresses.emplace(address_key);

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -162,9 +162,9 @@ class PickFirst : public LoadBalancingPolicy {
   // Lateset update args.
   UpdateArgs latest_update_args_;
   // All our subchannels.
-  OrphanablePtr<PickFirstSubchannelList> subchannel_list_;
+  RefCountedPtr<PickFirstSubchannelList> subchannel_list_;
   // Latest pending subchannel list.
-  OrphanablePtr<PickFirstSubchannelList> latest_pending_subchannel_list_;
+  RefCountedPtr<PickFirstSubchannelList> latest_pending_subchannel_list_;
   // Selected subchannel in \a subchannel_list_.
   PickFirstSubchannelData* selected_ = nullptr;
   // Are we in IDLE state?
@@ -227,7 +227,7 @@ void PickFirst::AttemptToConnectUsingLatestUpdateArgsLocked() {
             "[PF %p] Shutting down previous pending subchannel list %p", this,
             latest_pending_subchannel_list_.get());
   }
-  latest_pending_subchannel_list_ = MakeOrphanable<PickFirstSubchannelList>(
+  latest_pending_subchannel_list_ = MakeRefCounted<PickFirstSubchannelList>(
       this, std::move(addresses), latest_update_args_.args);
   latest_pending_subchannel_list_->StartWatchingLocked();
   // Empty update or no valid subchannels.  Put the channel in

--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -317,8 +317,7 @@ class RingHash : public LoadBalancingPolicy {
     // An interface for running a callback in the control plane WorkSerializer.
     class WorkSerializerRunner : public Orphanable {
      public:
-      explicit WorkSerializerRunner(
-          RefCountedPtr<RingHash> ring_hash_lb)
+      explicit WorkSerializerRunner(RefCountedPtr<RingHash> ring_hash_lb)
           : ring_hash_lb_(std::move(ring_hash_lb)) {
         GRPC_CLOSURE_INIT(&closure_, RunInExecCtx, this, nullptr);
       }

--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -308,7 +308,7 @@ class RingHash : public LoadBalancingPolicy {
     ~Picker() override {
       // Hop into WorkSerializer to unref the ring, since that may
       // trigger the unreffing of the underlying subchannels.
-      new RingUnreffer(std::move(parent_), std::move(ring_));
+      MakeOrphanable<RingUnreffer>(std::move(parent_), std::move(ring_));
     }
 
     PickResult Pick(PickArgs args) override;

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -182,12 +182,12 @@ class RoundRobin : public LoadBalancingPolicy {
   void ShutdownLocked() override;
 
   // List of subchannels.
-  OrphanablePtr<RoundRobinSubchannelList> subchannel_list_;
+  RefCountedPtr<RoundRobinSubchannelList> subchannel_list_;
   // Latest pending subchannel list.
   // When we get an updated address list, we create a new subchannel list
   // for it here, and we wait to swap it into subchannel_list_ until the new
   // list becomes READY.
-  OrphanablePtr<RoundRobinSubchannelList> latest_pending_subchannel_list_;
+  RefCountedPtr<RoundRobinSubchannelList> latest_pending_subchannel_list_;
 
   bool shutdown_ = false;
 };
@@ -288,7 +288,7 @@ void RoundRobin::UpdateLocked(UpdateArgs args) {
     gpr_log(GPR_INFO, "[RR %p] replacing previous pending subchannel list %p",
             this, latest_pending_subchannel_list_.get());
   }
-  latest_pending_subchannel_list_ = MakeOrphanable<RoundRobinSubchannelList>(
+  latest_pending_subchannel_list_ = MakeRefCounted<RoundRobinSubchannelList>(
       this, std::move(addresses), args.args);
   latest_pending_subchannel_list_->StartWatchingLocked();
   // If the new list is empty, immediately promote it to

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -131,7 +131,7 @@ class SubchannelData {
    public:
     Watcher(
         SubchannelData<SubchannelListType, SubchannelDataType>* subchannel_data,
-        RefCountedPtr<SubchannelListType> subchannel_list)
+        WeakRefCountedPtr<SubchannelListType> subchannel_list)
         : subchannel_data_(subchannel_data),
           subchannel_list_(std::move(subchannel_list)) {}
 
@@ -148,7 +148,7 @@ class SubchannelData {
 
    private:
     SubchannelData<SubchannelListType, SubchannelDataType>* subchannel_data_;
-    RefCountedPtr<SubchannelListType> subchannel_list_;
+    WeakRefCountedPtr<SubchannelListType> subchannel_list_;
   };
 
   // Starts watching the connectivity state of the subchannel.
@@ -322,7 +322,7 @@ void SubchannelData<SubchannelListType,
   }
   GPR_ASSERT(pending_watcher_ == nullptr);
   pending_watcher_ =
-      new Watcher(this, subchannel_list()->Ref(DEBUG_LOCATION, "Watcher"));
+      new Watcher(this, subchannel_list()->WeakRef(DEBUG_LOCATION, "Watcher"));
   subchannel_->WatchConnectivityState(
       std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>(
           pending_watcher_));

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -35,8 +35,8 @@
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/gprpp/dual_ref_counted.h"
 #include "src/core/lib/gprpp/manual_constructor.h"
-#include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/load_balancing/lb_policy.h"
@@ -176,7 +176,7 @@ class SubchannelData {
 
 // A list of subchannels.
 template <typename SubchannelListType, typename SubchannelDataType>
-class SubchannelList : public InternallyRefCounted<SubchannelListType> {
+class SubchannelList : public DualRefCounted<SubchannelListType> {
  public:
   // Starts watching the connectivity state of all subchannels.
   // Must be called immediately after instantiation.
@@ -200,10 +200,7 @@ class SubchannelList : public InternallyRefCounted<SubchannelListType> {
   // Resets connection backoff of all subchannels.
   void ResetBackoffLocked();
 
-  void Orphan() override {
-    ShutdownLocked();
-    InternallyRefCounted<SubchannelListType>::Unref(DEBUG_LOCATION, "shutdown");
-  }
+  void Orphan() override;
 
  protected:
   SubchannelList(LoadBalancingPolicy* policy, const char* tracer,
@@ -212,8 +209,6 @@ class SubchannelList : public InternallyRefCounted<SubchannelListType> {
                  const ChannelArgs& args);
 
   virtual ~SubchannelList();
-
-  virtual void ShutdownLocked();
 
  private:
   // For accessing Ref() and Unref().
@@ -365,7 +360,7 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
     LoadBalancingPolicy* policy, const char* tracer,
     ServerAddressList addresses,
     LoadBalancingPolicy::ChannelControlHelper* helper, const ChannelArgs& args)
-    : InternallyRefCounted<SubchannelListType>(tracer),
+    : DualRefCounted<SubchannelListType>(tracer),
       policy_(policy),
       tracer_(tracer) {
   if (GPR_UNLIKELY(tracer_ != nullptr)) {
@@ -419,7 +414,7 @@ void SubchannelList<SubchannelListType,
 }
 
 template <typename SubchannelListType, typename SubchannelDataType>
-void SubchannelList<SubchannelListType, SubchannelDataType>::ShutdownLocked() {
+void SubchannelList<SubchannelListType, SubchannelDataType>::Orphan() {
   if (GPR_UNLIKELY(tracer_ != nullptr)) {
     gpr_log(GPR_INFO, "[%s %p] Shutting down subchannel_list %p", tracer_,
             policy_, this);

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1255,6 +1255,7 @@ TEST_F(PickFirstTest, CheckStateBeforeStartWatch) {
   WaitForServer(DEBUG_LOCATION, stub_1, 0);
   gpr_log(GPR_INFO, "****** CHANNEL 1 CONNECTED *******");
   servers_[0]->Shutdown();
+  EXPECT_TRUE(WaitForChannelNotReady(channel_1.get()));
   // Channel 1 will receive a re-resolution containing the same server. It will
   // create a new subchannel and hold a ref to it.
   StartServers(1, ports);


### PR DESCRIPTION
This fixes a use-after-free bug where the ring_hash picker would crash trying to access a subchannel that had already been unreffed, because the subchannel list was being shut down before the picker was done using it.  The picker was actually holding a ref to the subchannel list, but it was holding an internal ref that did not prevent the subchannel list from being shut down by the LB policy.  To fix this, we change the subchannel list to use `DualRefCounted<>` instead of `InternallyRefCounted<>`, so that the ref held by the picker prevents the subchannel list from being shut down.