### PR TITLE
[fixit] Reduce the size of this benchmark under expensive sanitizers

### DIFF
--- a/test/cpp/microbenchmarks/bm_fullstack_streaming_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_streaming_ping_pong.cc
@@ -18,6 +18,7 @@
 
 /* Benchmark gRPC end2end in various configurations */
 
+#include "test/core/util/build.h"
 #include "test/core/util/test_config.h"
 #include "test/cpp/microbenchmarks/fullstack_streaming_ping_pong.h"
 #include "test/cpp/util/test_config.h"
@@ -29,6 +30,14 @@ namespace testing {
  * CONFIGURATIONS
  */
 
+static const int kMaxMessageSize = [] {
+  if (BuiltUnderMsan() || BuiltUnderTsan() || BuiltUnderUbsan()) {
+    // Scale down sizes for intensive benchmarks to avoid timeouts.
+    return 8 * 1024 * 1024;
+  }
+  return 128 * 1024 * 1024;
+}();
+
 // Generate Args for StreamingPingPong benchmarks. Currently generates args for
 // only "small streams" (i.e streams with 0, 1 or 2 messages)
 static void StreamingPingPongArgs(benchmark::internal::Benchmark* b) {
@@ -36,7 +45,7 @@ static void StreamingPingPongArgs(benchmark::internal::Benchmark* b) {
 
   b->Args({0, 0});  // spl case: 0 ping-pong msgs (msg_size doesn't matter here)
 
-  for (msg_size = 0; msg_size <= 128 * 1024 * 1024;
+  for (msg_size = 0; msg_size <= kMaxMessageSize;
        msg_size == 0 ? msg_size++ : msg_size *= 8) {
     b->Args({msg_size, 1});
     b->Args({msg_size, 2});
@@ -53,12 +62,12 @@ BENCHMARK_TEMPLATE(BM_StreamingPingPong, InProcess, NoOpMutator, NoOpMutator)
 
 BENCHMARK_TEMPLATE(BM_StreamingPingPongMsgs, InProcessCHTTP2, NoOpMutator,
                    NoOpMutator)
-    ->Range(0, 128 * 1024 * 1024);
+    ->Range(0, kMaxMessageSize);
 BENCHMARK_TEMPLATE(BM_StreamingPingPongMsgs, TCP, NoOpMutator, NoOpMutator)
-    ->Range(0, 128 * 1024 * 1024);
+    ->Range(0, kMaxMessageSize);
 BENCHMARK_TEMPLATE(BM_StreamingPingPongMsgs, InProcess, NoOpMutator,
                    NoOpMutator)
-    ->Range(0, 128 * 1024 * 1024);
+    ->Range(0, kMaxMessageSize);
 
 BENCHMARK_TEMPLATE(BM_StreamingPingPong, MinInProcessCHTTP2, NoOpMutator,
                    NoOpMutator)
@@ -70,12 +79,12 @@ BENCHMARK_TEMPLATE(BM_StreamingPingPong, MinInProcess, NoOpMutator, NoOpMutator)
 
 BENCHMARK_TEMPLATE(BM_StreamingPingPongMsgs, MinInProcessCHTTP2, NoOpMutator,
                    NoOpMutator)
-    ->Range(0, 128 * 1024 * 1024);
+    ->Range(0, kMaxMessageSize);
 BENCHMARK_TEMPLATE(BM_StreamingPingPongMsgs, MinTCP, NoOpMutator, NoOpMutator)
-    ->Range(0, 128 * 1024 * 1024);
+    ->Range(0, kMaxMessageSize);
 BENCHMARK_TEMPLATE(BM_StreamingPingPongMsgs, MinInProcess, NoOpMutator,
                    NoOpMutator)
-    ->Range(0, 128 * 1024 * 1024);
+    ->Range(0, kMaxMessageSize);
 
 // Generate Args for StreamingPingPongWithCoalescingApi benchmarks. Currently
 // generates args for only "small streams" (i.e streams with 0, 1 or 2 messages)
@@ -88,7 +97,7 @@ static void StreamingPingPongWithCoalescingApiArgs(
   b->Args(
       {0, 0, 1});  // spl case: 0 ping-pong msgs (msg_size doesn't matter here)
 
-  for (msg_size = 0; msg_size <= 128 * 1024 * 1024;
+  for (msg_size = 0; msg_size <= kMaxMessageSize;
        msg_size == 0 ? msg_size++ : msg_size *= 8) {
     b->Args({msg_size, 1, 0});
     b->Args({msg_size, 2, 0});


### PR DESCRIPTION
This benchmark was taking a very long time under some sanitizers, and consequently timing out fairly reproducibly.
Running locally this change moves from a 300/300 timeout on my machine to a 100/100 success rate.

The tests we're losing are of limited value.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

