### PR TITLE
[fixit] Extend timeout for SameBackendListedMultipleTimes/V3 test

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -478,7 +478,9 @@ TEST_P(EdsTest, SameBackendListedMultipleTimes) {
   EdsResourceArgs args({{"locality0", endpoints}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
   // We need to wait for the backend to come online.
-  WaitForAllBackends(DEBUG_LOCATION);
+  WaitForAllBackends(DEBUG_LOCATION, /*start_index=*/0, /*stop_index=*/0,
+                     /*check_status=*/nullptr, WaitForBackendOptions(),
+                     RpcOptions().set_timeout_ms(2000));
   // Send kNumRpcsPerAddress RPCs per server.
   const size_t kNumRpcsPerAddress = 10;
   CheckRpcSendOk(DEBUG_LOCATION, kNumRpcsPerAddress * endpoints.size());

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -717,6 +717,9 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType> {
   struct RpcOptions {
     RpcService service = SERVICE_ECHO;
     RpcMethod method = METHOD_ECHO;
+    // Dev note: If a timeout or Deadline Exceeded error is occurring in an XDS
+    // end2end test, consider changing that test's timeout instead of this
+    // global default.
     int timeout_ms = 1000;
     bool wait_for_ready = false;
     std::vector<std::pair<std::string, std::string>> metadata;


### PR DESCRIPTION
Previously this failed 1/1000 times with a 1s timeout, giving a
`Deadline Exceeded` error. I was able to reproduce the failure in
22/1000 times with a 500ms timeout. Changing it to a 2s timeout in this
PR, the failure did not reproduce in 5000 runs.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

