### PR TITLE
xDS interop: fix an issue with secondary zone namespaces not cleaned

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/failover_test.py
@@ -60,7 +60,9 @@ class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             xds_server_uri=self.xds_server_uri,
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
-            reuse_namespace=True)
+            # This runner's namespace created in the secondary cluster,
+            # so it's not reused and must be cleaned up.
+            reuse_namespace=False)
 
     def cleanup(self):
         super().cleanup()


### PR DESCRIPTION
All alternative server runners except the failover test reuse the primary server runners' namespace. Failover test is using the secondary cluster, and manages its own namespace there. `reuse_namespace` disables namespace cleanup, and in this case it was set to `True` incorrectly.