### PR TITLE
Add v1.49.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -206,6 +206,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.46.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.47.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.48.0', ReleaseInfo(runtimes=['go1.16'])),
+            ('v1.49.0', ReleaseInfo(runtimes=['go1.16'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
Test run: https://fusion2.corp.google.com/invocations/c0b73686-8aee-4b3a-a0b6-f83289037261/targets
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

