### PR TITLE
Update Bazel version from 4.2.1 to 4.2.2 to solve protoc segfault

### DIFF
--- a/bazel/update_mirror.sh
+++ b/bazel/update_mirror.sh
@@ -69,9 +69,9 @@ upload github.com/bazelbuild/bazel/releases/download/3.7.1/bazel-3.7.1-linux-x86
 upload github.com/bazelbuild/bazel/releases/download/3.7.1/bazel-3.7.1-darwin-x86_64
 upload github.com/bazelbuild/bazel/releases/download/3.7.1/bazel-3.7.1-windows-x86_64.exe
 
-upload github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-linux-x86_64
-upload github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-darwin-x86_64
-upload github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-windows-x86_64.exe
+upload github.com/bazelbuild/bazel/releases/download/4.2.2/bazel-4.2.2-linux-x86_64
+upload github.com/bazelbuild/bazel/releases/download/4.2.2/bazel-4.2.2-darwin-x86_64
+upload github.com/bazelbuild/bazel/releases/download/4.2.2/bazel-4.2.2-windows-x86_64.exe
 
 # Collect the github archives to mirror from grpc_deps.bzl
 grep -o '"https://github.com/[^"]*"' bazel/grpc_deps.bzl | sed 's/^"https:\/\///' | sed 's/"$//' | while read -r line ; do

--- a/templates/tools/dockerfile/bazel.include
+++ b/templates/tools/dockerfile/bazel.include
@@ -2,7 +2,7 @@
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 4.2.1
+ENV BAZEL_VERSION 4.2.2
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/bazel
+++ b/tools/bazel
@@ -42,7 +42,7 @@ fi
 
 # IMPORTANT: if you update the version here, other parts of infrastructure might needs updating as well
 # (e.g. sanity checks, bazel toolchains etc.)
-VERSION=${OVERRIDE_BAZEL_VERSION:-4.2.1}
+VERSION=${OVERRIDE_BAZEL_VERSION:-4.2.2}
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation." >&2
 
 # update tools/update_mirror.sh to populate the mirror with new bazel archives

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get -y install \
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 4.2.1
+ENV BAZEL_VERSION 4.2.2
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/bazel_arm64/Dockerfile
+++ b/tools/dockerfile/test/bazel_arm64/Dockerfile
@@ -88,7 +88,7 @@ RUN apt-get update && apt-get -y install libc++-dev clang && apt-get clean
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 4.2.1
+ENV BAZEL_VERSION 4.2.2
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/binder_transport_apk/Dockerfile
+++ b/tools/dockerfile/test/binder_transport_apk/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get -y install \
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 4.2.1
+ENV BAZEL_VERSION 4.2.2
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update && apt-get install -y jq git
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 4.2.1
+ENV BAZEL_VERSION 4.2.2
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1


### PR DESCRIPTION
Hi. When I tried to build the example target on my Macbook, I got the segment fault which was also mentioned in [protobuf/issues/8884](https://github.com/protocolbuffers/protobuf/issues/8884). According to the following comments in that issue, this segfault could be solved by updating Bazel to version 4.2.2.

I have change all the 4.2.1 about Bazel version in the repository. Can you assess whether this change can be merged?