### PR TITLE
Match the greeter async example to the tutorial

### DIFF
--- a/examples/cpp/helloworld/greeter_async_client.cc
+++ b/examples/cpp/helloworld/greeter_async_client.cc
@@ -64,15 +64,8 @@ class GreeterClient {
     // Storage for the status of the RPC upon completion.
     Status status;
 
-    // stub_->PrepareAsyncSayHello() creates an RPC object, returning
-    // an instance to store in "call" but does not actually start the RPC
-    // Because we are using the asynchronous API, we need to hold on to
-    // the "call" instance in order to get updates on the ongoing RPC.
     std::unique_ptr<ClientAsyncResponseReader<HelloReply> > rpc(
-        stub_->PrepareAsyncSayHello(&context, request, &cq));
-
-    // StartCall initiates the RPC call
-    rpc->StartCall();
+        stub_->AsyncSayHello(&context, request, &cq));
 
     // Request that, upon completion of the RPC, "reply" be updated with the
     // server's response; "status" with the indication of whether the operation


### PR DESCRIPTION
The "Prepare" bit is unnecessary for the basic async example since `StartCall` is issued on the very next line. It seems more appropriate to change the example rather than change the tutorial.

The tutorial that references this example: https://grpc.io/docs/languages/cpp/async/#async-client

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->


Fixes https://github.com/grpc/grpc.io/issues/1022