### PR TITLE
Adjust rpc timeouts in xds tests to reduce Deadline exceeded errors in xds msan tests

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -115,7 +115,9 @@ TEST_P(CdsTest, AcceptsEdsConfigSourceOfTypeAds) {
   balancer_->ads_service()->SetCdsResource(cluster);
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
-  WaitForAllBackends(DEBUG_LOCATION);
+  WaitForAllBackends(DEBUG_LOCATION, /*start_index=*/0, /*stop_index=*/0,
+                     /*check_status=*/nullptr, WaitForBackendOptions(),
+                     RpcOptions().set_timeout_ms(5000));
   auto response_state = balancer_->ads_service()->cds_response_state();
   ASSERT_TRUE(response_state.has_value());
   EXPECT_EQ(response_state->state, AdsServiceImpl::ResponseState::ACKED);
@@ -199,7 +201,8 @@ TEST_P(CdsTest, EdsServiceNameDefaultsToClusterName) {
   Cluster cluster = default_cluster_;
   cluster.mutable_eds_cluster_config()->clear_service_name();
   balancer_->ads_service()->SetCdsResource(cluster);
-  CheckRpcSendOk(DEBUG_LOCATION);
+  CheckRpcSendOk(DEBUG_LOCATION, /*times=*/1,
+                 RpcOptions().set_timeout_ms(5000));
 }
 
 // Tests switching over from one cluster to another.

--- a/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
@@ -139,7 +139,7 @@ TEST_P(RingHashTest, AggregateClusterFallBackFromRingHashAtStartup) {
                                    new_route_config);
   // Verifying that we are using ring hash as only 1 endpoint is receiving all
   // the traffic.
-  CheckRpcSendOk(DEBUG_LOCATION, 100);
+  CheckRpcSendOk(DEBUG_LOCATION, 100, RpcOptions().set_timeout_ms(5000));
   bool found = false;
   for (size_t i = 0; i < backends_.size(); ++i) {
     if (backends_[i]->backend_service()->request_count() > 0) {
@@ -290,7 +290,7 @@ TEST_P(RingHashTest,
   SetUpChannel(&channel_args);
   // Start an RPC in the background.
   LongRunningRpc rpc;
-  rpc.StartRpc(stub_.get(), RpcOptions());
+  rpc.StartRpc(stub_.get(), RpcOptions().set_timeout_ms(5000));
   // Wait for connection attempt to the backend.
   hold->Wait();
   // Channel should report CONNECTING here, and any RPC should be queued.
@@ -304,7 +304,7 @@ TEST_P(RingHashTest,
   // because if the priority policy fails to update the picker, then the
   // pick for the first RPC will not be retried.
   LongRunningRpc rpc2;
-  rpc2.StartRpc(stub_.get(), RpcOptions());
+  rpc2.StartRpc(stub_.get(), RpcOptions().set_timeout_ms(5000));
   // Allow the connection attempt to complete.
   hold->Resume();
   // Now the RPCs should complete successfully.
@@ -335,7 +335,7 @@ TEST_P(RingHashTest, ChannelIdHashing) {
                                    new_route_config);
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
-  CheckRpcSendOk(DEBUG_LOCATION, 100);
+  CheckRpcSendOk(DEBUG_LOCATION, 100, RpcOptions().set_timeout_ms(5000));
   bool found = false;
   for (size_t i = 0; i < backends_.size(); ++i) {
     if (backends_[i]->backend_service()->request_count() > 0) {

--- a/test/cpp/end2end/xds/xds_routing_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_routing_end2end_test.cc
@@ -1017,7 +1017,9 @@ TEST_P(LdsRdsTest, XdsRoutingPathMatching) {
   default_route->mutable_match()->set_prefix("");
   default_route->mutable_route()->set_cluster(kDefaultClusterName);
   SetRouteConfiguration(balancer_.get(), new_route_config);
-  WaitForAllBackends(DEBUG_LOCATION, 0, 2);
+  WaitForAllBackends(DEBUG_LOCATION, 0, 2, /*check_status=*/nullptr,
+                     WaitForBackendOptions(),
+                     RpcOptions().set_timeout_ms(5000));
   CheckRpcSendOk(DEBUG_LOCATION, kNumEchoRpcs,
                  RpcOptions().set_wait_for_ready(true));
   CheckRpcSendOk(DEBUG_LOCATION, kNumEcho1Rpcs,
@@ -1557,13 +1559,17 @@ TEST_P(LdsRdsTest, XdsRoutingWeightedClusterUpdateWeights) {
   default_route->mutable_match()->set_prefix("");
   default_route->mutable_route()->set_cluster(kDefaultClusterName);
   SetRouteConfiguration(balancer_.get(), new_route_config);
-  WaitForAllBackends(DEBUG_LOCATION, 0, 1);
-  WaitForAllBackends(DEBUG_LOCATION, 1, 3, /*check_status=*/nullptr,
+  WaitForAllBackends(DEBUG_LOCATION, 0, 1, /*check_status=*/nullptr,
                      WaitForBackendOptions(),
-                     RpcOptions().set_rpc_service(SERVICE_ECHO1));
-  CheckRpcSendOk(DEBUG_LOCATION, kNumEchoRpcs);
-  CheckRpcSendOk(DEBUG_LOCATION, kNumEcho1Rpcs7525,
-                 RpcOptions().set_rpc_service(SERVICE_ECHO1));
+                     RpcOptions().set_timeout_ms(5000));
+  WaitForAllBackends(
+      DEBUG_LOCATION, 1, 3, /*check_status=*/nullptr, WaitForBackendOptions(),
+      RpcOptions().set_rpc_service(SERVICE_ECHO1).set_timeout_ms(5000));
+  CheckRpcSendOk(DEBUG_LOCATION, kNumEchoRpcs,
+                 RpcOptions().set_timeout_ms(5000));
+  CheckRpcSendOk(
+      DEBUG_LOCATION, kNumEcho1Rpcs7525,
+      RpcOptions().set_rpc_service(SERVICE_ECHO1).set_timeout_ms(5000));
   // Make sure RPCs all go to the correct backend.
   EXPECT_EQ(kNumEchoRpcs, backends_[0]->backend_service()->request_count());
   EXPECT_EQ(0, backends_[0]->backend_service1()->request_count());
@@ -1590,10 +1596,14 @@ TEST_P(LdsRdsTest, XdsRoutingWeightedClusterUpdateWeights) {
   default_route->mutable_route()->set_cluster(kNewCluster3Name);
   SetRouteConfiguration(balancer_.get(), new_route_config);
   ResetBackendCounters();
-  WaitForAllBackends(DEBUG_LOCATION, 3, 4);
-  CheckRpcSendOk(DEBUG_LOCATION, kNumEchoRpcs);
-  CheckRpcSendOk(DEBUG_LOCATION, kNumEcho1Rpcs5050,
-                 RpcOptions().set_rpc_service(SERVICE_ECHO1));
+  WaitForAllBackends(DEBUG_LOCATION, 3, 4, /*check_status=*/nullptr,
+                     WaitForBackendOptions(),
+                     RpcOptions().set_timeout_ms(5000));
+  CheckRpcSendOk(DEBUG_LOCATION, kNumEchoRpcs,
+                 RpcOptions().set_timeout_ms(5000));
+  CheckRpcSendOk(
+      DEBUG_LOCATION, kNumEcho1Rpcs5050,
+      RpcOptions().set_rpc_service(SERVICE_ECHO1).set_timeout_ms(5000));
   // Make sure RPCs all go to the correct backend.
   EXPECT_EQ(0, backends_[0]->backend_service()->request_count());
   EXPECT_EQ(0, backends_[0]->backend_service1()->request_count());


### PR DESCRIPTION
Attempt to fix following flakes by increasing rpc timeout:

- https://source.cloud.google.com/results/invocations/d3af675e-6074-4517-9c94-c95a1eb51ed0/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_routing_end2end_test@poller%3Dpoll/tests
- https://source.cloud.google.com/results/invocations/02483217-05b5-4182-852f-1f3aeedaf392/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_routing_end2end_test@poller%3Dpoll/tests
- https://source.cloud.google.com/results/invocations/71d7aafc-4db2-44a9-8ec4-618641952fcd/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_end2end_test@poller%3Dpoll/tests
- https://source.cloud.google.com/results/invocations/8a5ca189-c538-4854-8e1e-5d67ed5d70cb/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_ring_hash_end2end_test@poller%3Depoll1/tests
- https://source.cloud.google.com/results/invocations/7a626d1e-bcd1-46b1-b229-55dbec1480f0/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_ring_hash_end2end_test@poller%3Dpoll/tests
- https://source.cloud.google.com/results/invocations/749dc2b6-3505-4917-b8f4-32df925d1547/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_ring_hash_end2end_test@poller%3Dpoll/tests
- https://source.cloud.google.com/results/invocations/ab209970-6322-404c-b904-c03d15d6943a/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_routing_end2end_test@poller%3Depoll1/tests

