### PR TITLE
[fixit] bump RPC timeout for flaky XdsRoutingWeightedClusterUpdateWeights test

### DIFF
--- a/test/cpp/end2end/xds/xds_routing_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_routing_end2end_test.cc
@@ -1557,7 +1557,9 @@ TEST_P(LdsRdsTest, XdsRoutingWeightedClusterUpdateWeights) {
   default_route->mutable_match()->set_prefix("");
   default_route->mutable_route()->set_cluster(kDefaultClusterName);
   SetRouteConfiguration(balancer_.get(), new_route_config);
-  WaitForAllBackends(DEBUG_LOCATION, 0, 1);
+  WaitForAllBackends(DEBUG_LOCATION, /*start_index=*/0, /*stop_index=*/1,
+                     /*check_status=*/nullptr, WaitForBackendOptions(),
+                     RpcOptions().set_timeout_ms(2000));
   WaitForAllBackends(DEBUG_LOCATION, 1, 3, /*check_status=*/nullptr,
                      WaitForBackendOptions(),
                      RpcOptions().set_rpc_service(SERVICE_ECHO1));


### PR DESCRIPTION
This has failed once in the past year under MSAN.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

