### PR TITLE
[fixit] Change the default XDS test timeout for MSAN builds

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -40,6 +40,7 @@
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "src/proto/grpc/testing/xds/v3/http_connection_manager.grpc.pb.h"
 #include "src/proto/grpc/testing/xds/v3/http_filter_rbac.grpc.pb.h"
+#include "test/core/util/build.h"
 #include "test/core/util/port.h"
 #include "test/cpp/end2end/counted_service.h"
 #include "test/cpp/end2end/test_service_impl.h"
@@ -720,7 +721,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType> {
     // Dev note: If a timeout or Deadline Exceeded error is occurring in an XDS
     // end2end test, consider changing that test's timeout instead of this
     // global default.
-    int timeout_ms = 1000;
+    int timeout_ms = BuiltUnderMsan() ? 2000 : 1000;
     bool wait_for_ready = false;
     std::vector<std::pair<std::string, std::string>> metadata;
     // These options are used by the backend service impl.


### PR DESCRIPTION
Flakes in MSAN builds of XDS end2end tests have dominated the flaky 
dashboard. This change bumps the default RPC timeout to 2 seconds 
for MSAN builds, which should help. This has been done on a test-by-test 
basis otherwise, and we continue to see multiple Deadline Exceeded 
errors in XDS end2end tests every day.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

