### PR TITLE
priority LB: don't set child picker to null when failover timer fires

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
@@ -845,7 +845,14 @@ void PriorityLb::ChildPriority::OnConnectivityStateUpdateLocked(
   // Store the state and picker.
   connectivity_state_ = state;
   connectivity_status_ = status;
-  picker_wrapper_ = MakeRefCounted<RefCountedPicker>(std::move(picker));
+  // When the failover timer fires, this method will be called with picker
+  // set to null, because we want to consider the child to be in
+  // TRANSIENT_FAILURE, but we have no new picker to report.  In that case,
+  // just keep using the old picker, in case we wind up delegating to this
+  // child when all priorities are failing.
+  if (picker != nullptr) {
+    picker_wrapper_ = MakeRefCounted<RefCountedPicker>(std::move(picker));
+  }
   // If we transition to state CONNECTING and we've not seen
   // TRANSIENT_FAILURE more recently than READY or IDLE, start failover
   // timer if not already pending.


### PR DESCRIPTION
We've seen a number of test crashes over the last few months with the following (not very helpful) stack trace:

```
*** SIGSEGV received at time=1660702562 on cpu 1 ***
PC: @          0x48a4df2  (unknown)  grpc_core::(anonymous namespace)::PriorityLb::ChildPriority::RefCountedPicker::Pick()
    @          0x446cdc9        352  absl::lts_20220623::WriteFailureInfo()
    @          0x446b310        576  absl::lts_20220623::AbslFailureSignalHandler()
    @           0xf9fe2b  (unknown)  SignalAction()
```

Example: https://source.cloud.google.com/results/invocations/300436ee-cbe8-4c53-9e7e-bdeeadbc7e13/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_end2end_test@poller%3Dpoll/log

I can't get this crash to reproduce, but from looking at the code, I believe this PR will fix the problem.  The only thing that could possibly be failing in [`RefCountedPicker::Pick()`](https://github.com/grpc/grpc/blob/03b6b01043f778e76b1f1380f5619067a7c5a42a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc#L155) is if `picker_` is null, and the only place where `RefCountedPicker` is constructed is in [`OnConnectivityStateUpdateLocked()`](https://github.com/grpc/grpc/blob/03b6b01043f778e76b1f1380f5619067a7c5a42a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc#L848), and the only code-path I see where that could be called with the picker being null is when [the failover timer fires](https://github.com/grpc/grpc/blob/03b6b01043f778e76b1f1380f5619067a7c5a42a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc#L720).  And in that case, the right thing to do is to keep using the child's previously reported picker, which will probably queue the pick, so that's what this PR does.

My suspicion is that this bug was triggered by #28339, which introduced a case where we may delegate to a child even if the child is reporting TRANSIENT_FAILURE.  I do not see any occurrances of this crash from before that PR was merged.