### PR TITLE
[fixit] Decrease fallback timeout trying to fix `SingleBalancerTest.Fallback`

### DIFF
--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -1028,7 +1028,7 @@ TEST_F(SingleBalancerTest, AllServersUnreachableFailFast) {
 TEST_F(SingleBalancerTest, Fallback) {
   SetNextResolutionAllBalancers();
   const int kFallbackTimeoutMs = 200 * grpc_test_slowdown_factor();
-  const int kServerlistDelayMs = 500 * grpc_test_slowdown_factor();
+  const int kServerlistDelayMs = 2500 * grpc_test_slowdown_factor();
   const size_t kNumBackendsInResolution = backends_.size() / 2;
 
   ResetStub(kFallbackTimeoutMs);

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -1027,8 +1027,8 @@ TEST_F(SingleBalancerTest, AllServersUnreachableFailFast) {
 
 TEST_F(SingleBalancerTest, Fallback) {
   SetNextResolutionAllBalancers();
-  const int kFallbackTimeoutMs = 200 * grpc_test_slowdown_factor();
-  const int kServerlistDelayMs = 2500 * grpc_test_slowdown_factor();
+  const int kFallbackTimeoutMs = 40 * grpc_test_slowdown_factor();
+  const int kServerlistDelayMs = 500 * grpc_test_slowdown_factor();
   const size_t kNumBackendsInResolution = backends_.size() / 2;
 
   ResetStub(kFallbackTimeoutMs);


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR tries to fix the test case `SingleBalancerTest.Fallback` in `grpclb_end2end_test`. Not sure if this would really fix it.