### PR TITLE
xDS interop: fix the order of rpc-behavior operations

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/retry_test.py
@@ -104,7 +104,7 @@ class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
                                 metadata=[
                                     (RpcTypeUnaryCall,
                                      _RPC_BEHAVIOR_HEADER_NAME,
-                                     'error-code-14,succeed-on-retry-attempt-4')
+                                     'succeed-on-retry-attempt-4,error-code-14')
                                 ],
                                 num_rpcs=_NUM_RPCS)
         self.assertRpcStatusCode(test_client,
@@ -145,7 +145,7 @@ class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
                                 metadata=[
                                     (RpcTypeUnaryCall,
                                      _RPC_BEHAVIOR_HEADER_NAME,
-                                     'error-code-14,succeed-on-retry-attempt-4')
+                                     'succeed-on-retry-attempt-4,error-code-14')
                                 ],
                                 num_rpcs=_NUM_RPCS)
         self.assertRpcStatusCode(test_client,


### PR DESCRIPTION
To account for the API change made in https://github.com/grpc/grpc-java/pull/9171.

ref b/241627571
cc @murgatroid99 
