### PR TITLE
Fix PickFirstTest.PendingUpdateAndSelectedSubchannelFails flake in client_lb_end2end_test

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1339,7 +1339,7 @@ TEST_F(PickFirstTest, PendingUpdateAndSelectedSubchannelFails) {
   gpr_log(GPR_INFO, "Phase 3: Stopping first server.");
   servers_[0]->Shutdown();
   WaitForChannelNotReady(channel.get());
-  EXPECT_THAT(channel->GetState(false), GRPC_CHANNEL_CONNECTING);
+  EXPECT_EQ(channel->GetState(false), GRPC_CHANNEL_CONNECTING);
   // Resume connection attempt to second server now that first server is down.
   // The channel should go to READY state and RPCs should go to the second
   // server.

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1310,8 +1310,6 @@ TEST_F(PickFirstTest, PendingUpdateAndSelectedSubchannelFails) {
   auto channel =
       BuildChannel("", response_generator);  // pick_first is the default.
   auto stub = BuildStub(channel);
-  // Create a number of servers, but only start 1 of them.
-  CreateServers(2);
   StartServers(2);
   // Initially resolve to first server and make sure it connects.
   gpr_log(GPR_INFO, "Phase 1: Connect to first server.");

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1339,13 +1339,12 @@ TEST_F(PickFirstTest, PendingUpdateAndSelectedSubchannelFails) {
   gpr_log(GPR_INFO, "Phase 3: Stopping first server.");
   servers_[0]->Shutdown();
   WaitForChannelNotReady(channel.get());
-  EXPECT_THAT(channel->GetState(false),
-              ::testing::AnyOf(GRPC_CHANNEL_CONNECTING));
+  EXPECT_THAT(channel->GetState(false), GRPC_CHANNEL_CONNECTING);
   // Resume connection attempt to second server now that first server is down.
   // The channel should go to READY state and RPCs should go to the second
   // server.
+  gpr_log(GPR_INFO, "Phase 4: Resuming connection attempt to second server.");
   hold->Resume();
-  gpr_log(GPR_INFO, "Phase 4: Connect to second server.");
   WaitForChannelReady(channel.get());
   WaitForServer(DEBUG_LOCATION, stub, 1, [](const Status& status) {
     EXPECT_EQ(StatusCode::UNAVAILABLE, status.error_code());


### PR DESCRIPTION
Add hold to test case to delay connection failure until test condition succeeds.

No failures in 100k runs.
