### PR TITLE
[fixit] XDS DropPerTenThousand/V3WithLoadReporting Deadline Exceeded

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -969,7 +969,7 @@ TEST_P(EdsTest, DropPerTenThousand) {
   // Send kNumRpcs RPCs and count the drops.
   size_t num_drops = SendRpcsAndCountFailuresWithMessage(
       DEBUG_LOCATION, kNumRpcs, StatusCode::UNAVAILABLE,
-      kStatusMessageDropPrefix);
+      kStatusMessageDropPrefix, RpcOptions().set_timeout_ms(2000));
   // The drop rate should be roughly equal to the expectation.
   const double seen_drop_rate = static_cast<double>(num_drops) / kNumRpcs;
   EXPECT_THAT(seen_drop_rate,


### PR DESCRIPTION
Fixes the deadline exceeded error shown here:
https://source.cloud.google.com/results/invocations/f20f4b2f-f5c1-47bd-b3a3-62d7ed31c287/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_end2end_test@poller%3Depoll1/log




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

