### PR TITLE
TimerManager: Periodically check for thread exits

### DIFF
--- a/src/core/lib/event_engine/posix_engine/timer_manager.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.cc
@@ -237,7 +237,7 @@ TimerManager::~TimerManager() {
     grpc_core::MutexLock lock(&mu_);
     collector.Collect(std::move(completed_threads_));
     if (thread_count_ == 0) break;
-    cv_.Wait(&mu_);
+    cv_.WaitWithTimeout(&mu_, absl::Milliseconds(50));
   }
 }
 


### PR DESCRIPTION
I identified a subtle bug in some other work, but have not figured out how to poke it reliably outside that work (The `std::shared_ptr<EventEngine> GetDefaultEventEngine` change, which should not affect TimerManager behavior).

Some thread ordering is resulting in a hang on TimerManager shutdown, since timer threads are exiting and the cv.Wait on TimerManager destruction is not being woken up.

I believe this invalidates a claimed guarantee about timer checks under contention, so we might want to reword that comment. There may also be a different fix that ensures proper ordering and cv signaling under all circumstances, but this PR works around it without much extra overhead.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

