### PR TITLE
xDS interop: Fix default resource prefix

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,4 +1,4 @@
---resource_prefix=xds-k8s-security
+--resource_prefix=xds-interop
 # https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.14.0
 --td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:d6baaf7b0e0c63054ac4d9bedc09021ff261d599
 

--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,4 +1,4 @@
---resource_prefix=xds-interop
+--resource_prefix=psm-interop
 # https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.14.0
 --td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:d6baaf7b0e0c63054ac4d9bedc09021ff261d599
 


### PR DESCRIPTION
No longer just security tests.
This is done to avoid confusion when debugging resources managed by the LB tests.

For example, pod log names for the LB tests now look like this:
```
xds-k8s-security-client-20220825-2028-j81xh_psm-grpc-client-85c64965d6-h9kp7.log
xds-k8s-security-server-20220825-2028-j81xh_psm-grpc-server-7b9f76bbbd-dkglx.log
xds-k8s-security-server-20220825-2028-j81xh_psm-grpc-server-7b9f76bbbd-m2kww.log
xds-k8s-security-server-20220825-2028-j81xh_psm-grpc-server-7b9f76bbbd-xcf8f.log
xds-k8s-security-server-20220825-2028-j81xh_psm-grpc-server-alt-86f8cdfd5d-p4d52.log
```

This is clearly misleading.

cc @sanjaypujare 