### PR TITLE
If `-infile` is not readable, bail out and show an error!

### DIFF
--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -578,6 +578,12 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
     } else {
       input_file.open(absl::GetFlag(FLAGS_infile),
                       std::ios::in | std::ios::binary);
+      if (!input_file) {
+        fprintf(stderr, "Failed to open infile %s.\n",
+                absl::GetFlag(FLAGS_infile).c_str());
+        return false;
+      }
+
       input_stream = &input_file;
     }
 


### PR DESCRIPTION
Without this, `grpc_cli` will connect, send the metadata and then completely stall until it is killed leading to believe it is the server that is stalled instead of `grpc_cli` that won't send the message.

(release notes: yes)