### PR TITLE
xDS interop: increase pod wait timeout from 1 minute to 3 minutes

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -94,6 +94,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
     WAIT_MEDIUM_SLEEP_SEC: int = 10
     WAIT_LONG_TIMEOUT_SEC: int = 10 * 60
     WAIT_LONG_SLEEP_SEC: int = 30
+    WAIT_POD_START_TIMEOUT_SEC: int = 3 * 60
 
     def __init__(self, api: KubernetesApiManager, name: str):
         self._highlighter = _HighlighterYaml()
@@ -283,7 +284,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
 
     def wait_for_pod_started(self,
                              pod_name: str,
-                             timeout_sec: int = WAIT_SHORT_TIMEOUT_SEC,
+                             timeout_sec: int = WAIT_POD_START_TIMEOUT_SEC,
                              wait_sec: int = WAIT_SHORT_SLEEP_SEC) -> None:
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(


### PR DESCRIPTION
Sometimes it takes about a minute to pull the docker image:

> `message: "Successfully pulled image "gcr.io/grpc-testing/xds-interop/python-server:76aba96359477b6b42c5cc9c109ead54ab999b0a" in 1m4.195323244s"`

Prior to https://github.com/grpc/grpc/pull/30607 1 minute was enough because we were waiting on the deployment first, so there was a bit of a head start.

This increases pod wait time from 1 minute to 3 minutes.

ref b/243671225