### PR TITLE
xDSFaultInjection test: Change number of RPCs

### DIFF
--- a/test/cpp/end2end/xds/xds_fault_injection_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_fault_injection_end2end_test.cc
@@ -149,7 +149,9 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionPercentageAbort) {
   const uint32_t kAbortPercentagePerHundred = 50;
   const double kAbortRate = kAbortPercentagePerHundred / 100.0;
   const double kErrorTolerance = 0.1;
-  const size_t kNumRpcs = ComputeIdealNumRpcs(kAbortRate, kErrorTolerance);
+  // Choose a number of RPCs that's a multiple of 100 for a higher chance of
+  // reaching the mean.
+  const size_t kNumRpcs = 500;
   // Create an EDS resource
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
@@ -177,7 +179,9 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionPercentageAbortViaHeaders) {
   const uint32_t kAbortPercentage = 50;
   const double kAbortRate = kAbortPercentage / 100.0;
   const double kErrorTolerance = 0.1;
-  const size_t kNumRpcs = ComputeIdealNumRpcs(kAbortRate, kErrorTolerance);
+  // Choose a number of RPCs that's a multiple of 100 for a higher chance of
+  // reaching the mean.
+  const size_t kNumRpcs = 500;
   // Create an EDS resource
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
@@ -209,7 +213,9 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionPercentageDelay) {
   const uint32_t kDelayPercentagePerHundred = 50;
   const double kDelayRate = kDelayPercentagePerHundred / 100.0;
   const double kErrorTolerance = 0.1;
-  const size_t kNumRpcs = ComputeIdealNumRpcs(kDelayRate, kErrorTolerance);
+  // Choose a number of RPCs that's a multiple of 100 for a higher chance of
+  // reaching the mean.
+  const size_t kNumRpcs = 500;
   const size_t kMaxConcurrentRequests = kNumRpcs;
   // Create an EDS resource
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});
@@ -255,7 +261,9 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionPercentageDelayViaHeaders) {
   const uint32_t kDelayPercentage = 50;
   const double kDelayRate = kDelayPercentage / 100.0;
   const double kErrorTolerance = 0.1;
-  const size_t kNumRpcs = ComputeIdealNumRpcs(kDelayRate, kErrorTolerance);
+  // Choose a number of RPCs that's a multiple of 100 for a higher chance of
+  // reaching the mean.
+  const size_t kNumRpcs = 500;
   const size_t kMaxConcurrentRequests = kNumRpcs;
   // Create an EDS resource
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});
@@ -339,7 +347,9 @@ TEST_P(FaultInjectionTest, XdsFaultInjectionAlwaysDelayPercentageAbort) {
   const uint32_t kConnectionTimeoutMilliseconds =
       10 * 1000;  // 10s should not reach
   const double kErrorTolerance = 0.1;
-  const size_t kNumRpcs = ComputeIdealNumRpcs(kAbortRate, kErrorTolerance);
+  // Choose a number of RPCs that's a multiple of 100 for a higher chance of
+  // reaching the mean.
+  const size_t kNumRpcs = 500;
   const size_t kMaxConcurrentRequests = kNumRpcs;
   // Create an EDS resource
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});


### PR DESCRIPTION
The current `ComputeIdealNumRpcs` will result in 625 RPCs being sent which is a weird number for a range of 0 to 100. Choosing a multiple of 100 makes more sense for a uniform distribution in my opinion. 

`XdsFaultInjectionAlwaysDelayPercentageAbortSwitchDenominator` on the other hand has a range of 0 to 1,000,000 and a good number would probably be a million to get close to the mean but that might be too much, so leaving it alone since that has not been flaking.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

