### PR TITLE
[windows] Fix cbf

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
@@ -56,7 +56,7 @@ class HPackTable {
     // reading the core static metadata table here; at that point we'd need our
     // own singleton static metadata in the correct order.
     if (index <= hpack_constants::kLastStaticEntry) {
-      return &NoDestructSingleton<StaticMementos>::Get()->memento[index - 1];
+      return &static_mementos_->memento[index - 1];
     } else {
       return LookupDynamic(index);
     }
@@ -114,6 +114,11 @@ class HPackTable {
 
   void EvictOne();
 
+  static const StaticMementos* GetStaticMementos() {
+    static const NoDestruct<StaticMementos> static_mementos;
+    return static_mementos.get();
+  }
+
   // The amount of memory used by the table, according to the hpack algorithm
   uint32_t mem_used_ = 0;
   // The max memory allowed to be used by the table, according to the hpack
@@ -123,6 +128,8 @@ class HPackTable {
   uint32_t current_table_bytes_ = hpack_constants::kInitialTableSize;
   // HPack table entries
   MementoRingBuffer entries_;
+  // Static mementos
+  const StaticMementos* const static_mementos_ = GetStaticMementos();
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
Theory: there's a static table of ints that's getting zero initialized on Windows.
That static table then gets looked at when the static initializer for the hpack static memento table gets loaded (and ultimately needs to parse an int).

Instead, lazily initialize said table when we first create a parser.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

