### PR TITLE
Update protobuf on ancillary packages

### DIFF
--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -63,7 +63,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'protobuf>=3.12.0',
+    'protobuf>=4.21.3',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_csds/setup.py
+++ b/src/python/grpcio_csds/setup.py
@@ -39,7 +39,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'protobuf>=3.12.0',
+    'protobuf>=4.21.3',
     'xds-protos>=0.0.7',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
 )

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -62,7 +62,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'protobuf>=3.12.0',
+    'protobuf>=4.21.3',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -63,7 +63,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'protobuf>=3.12.0',
+    'protobuf>=4.21.3',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -62,7 +62,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'protobuf>=3.12.0',
+    'protobuf>=4.21.3',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
     'googleapis-common-protos>=1.5.5',
 )

--- a/src/python/grpcio_testing/setup.py
+++ b/src/python/grpcio_testing/setup.py
@@ -49,7 +49,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'protobuf>=3.12.0',
+    'protobuf>=4.21.3',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
 )
 


### PR DESCRIPTION
Will backport to 1.49 once this has been confirmed to work.

Fixes #30783