### PR TITLE
[retry] Fix use after free

### DIFF
--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -1358,7 +1358,6 @@ RetryFilter::CallData::CallAttempt::BatchData::~BatchData() {
             call_attempt_.get(), this);
   }
   GRPC_CALL_STACK_UNREF(call_attempt_->calld_->owning_call_, "Retry BatchData");
-  call_attempt_.reset(DEBUG_LOCATION, "~BatchData");
 }
 
 void RetryFilter::CallData::CallAttempt::BatchData::


### PR DESCRIPTION
Resetting this pointer may result in destroying the owning call, which will destroy the arena that hosts this object.
If that occurs then when it comes time to *destroy* the RefCountedPtr itself (later in this destructor) we will be accessing already released memory and thereby inviting UB.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

