### PR TITLE
[cleanup] Remove tracer shutdown

### DIFF
--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -148,8 +148,6 @@ void grpc_tracer_init() {
   parse(value.get());
 }
 
-void grpc_tracer_shutdown(void) {}
-
 int grpc_tracer_set_enabled(const char* name, int enabled) {
   return grpc_core::TraceFlagList::Set(name, enabled != 0);
 }

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -122,6 +122,7 @@ static void do_basic_init(void) {
   grpc_register_built_in_plugins();
   gpr_time_init();
   grpc_core::PrintExperimentsList();
+  grpc_tracer_init();
 }
 
 typedef struct grpc_plugin {
@@ -160,7 +161,6 @@ void grpc_init(void) {
         g_all_of_the_plugins[i].init();
       }
     }
-    grpc_tracer_init();
     grpc_iomgr_start();
   }
 
@@ -183,7 +183,6 @@ void grpc_shutdown_internal_locked(void)
     }
     grpc_event_engine::experimental::ResetDefaultEventEngine();
     grpc_iomgr_shutdown();
-    grpc_tracer_shutdown();
     grpc_core::Fork::GlobalShutdown();
   }
   grpc_core::ApplicationCallbackExecCtx::GlobalShutdown();


### PR DESCRIPTION
Remove no-op shutdown function, move initialization into the one-time group

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

