### PR TITLE
[exec-ctx] Remove ApplicationCallbackExecCtx::Global{Init,Destroy}

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -338,12 +338,6 @@ class ApplicationCallbackExecCtx {
     ctx->tail_ = functor;
   }
 
-  /** Global initialization for ApplicationCallbackExecCtx. Called by init. */
-  static void GlobalInit(void) {}
-
-  /** Global shutdown for ApplicationCallbackExecCtx. Called by init. */
-  static void GlobalShutdown(void) {}
-
   static bool Available() { return Get() != nullptr; }
 
  private:

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -153,7 +153,6 @@ void grpc_init(void) {
     grpc_core::Fork::GlobalInit();
     grpc_event_engine::experimental::RegisterForkHandlers();
     grpc_fork_handlers_auto_register();
-    grpc_core::ApplicationCallbackExecCtx::GlobalInit();
     grpc_iomgr_init();
     for (int i = 0; i < g_number_of_plugins; i++) {
       if (g_all_of_the_plugins[i].init != nullptr) {
@@ -186,7 +185,6 @@ void grpc_shutdown_internal_locked(void)
     grpc_tracer_shutdown();
     grpc_core::Fork::GlobalShutdown();
   }
-  grpc_core::ApplicationCallbackExecCtx::GlobalShutdown();
   g_shutting_down = false;
   g_shutting_down_cv->SignalAll();
 }


### PR DESCRIPTION
Remove these: there's no point keeping empty functions around

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

