### PR TITLE
Avoid frequent PHP mac distribtest timeouts

### DIFF
--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -277,7 +277,7 @@ class PHP7DistribTest(object):
             return create_jobspec(
                 self.name, ['test/distrib/php/run_distrib_test_macos.sh'],
                 environ={'EXTERNAL_GIT_ROOT': '../../../..'},
-                timeout_seconds=15 * 60,
+                timeout_seconds=20 * 60,
                 use_workspace=True)
         else:
             raise Exception("Not supported yet.")


### PR DESCRIPTION
Increase the timeout from 15 to 20 minutes (which still seems acceptable as the kokoro job doesn't do much else than run the distribtests and building PHP artifacts is fast - basically just archiving the sources).

Example:
https://source.cloud.google.com/results/invocations/93465054-49ee-4aca-aaa6-378987d56616/targets/github%2Fgrpc%2Fdistribtests/tests

The current flakiness rate is about 8%


