### PR TITLE
Switch cfstream tests to buildonly

### DIFF
--- a/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_isolated_tests.sh
@@ -23,9 +23,12 @@ cd $(dirname $0)/../../..
 
 ./tools/run_tests/start_port_server.py
 
+# BUILD ONLY TEST!
+# TODO(jtattermusch): the test has been disabled since it was highly flaky for a very long time (b/242971695).
+# Re-enable the test (change "bazel build" to "bazel test") once it's passing reliably.
 # run cfstream_test separately because it messes with the network
 # The "local" execution strategy is required because the test runs sudo and that doesn't work in a sandboxed environment (the default on mac)
-tools/bazel test $RUN_TESTS_FLAGS --genrule_strategy=local --test_output=all --copt="-DGRPC_CFSTREAM=1" //test/cpp/end2end:cfstream_test
+tools/bazel build $RUN_TESTS_FLAGS --genrule_strategy=local --test_output=all --copt="-DGRPC_CFSTREAM=1" //test/cpp/end2end:cfstream_test
 
 # Missing the /var/db/ntp-kod file may breaks the ntp synchronization.
 # Create the file and change the ownership to root before NTP sync.
@@ -37,9 +40,12 @@ sudo chown root:wheel /var/db/ntp-kod
 # NTP sync before exiting. Bazel gets confused if test end time < start time.
 sudo sntp -sS pool.ntp.org
 
+# BUILD ONLY TEST!
+# TODO(jtattermusch): the test has been disabled since it was highly flaky for a very long time (b/242971695).
+# Re-enable the test (change "bazel build" to "bazel test") once it's passing reliably.
 # run time_jump_test separately because it changes system time
 # The "local" execution strategy is required because the test runs sudo and that doesn't work in a sandboxed environment (the default on mac)
-tools/bazel test $RUN_TESTS_FLAGS --genrule_strategy=local --test_output=all //test/cpp/common:time_jump_test
+tools/bazel build $RUN_TESTS_FLAGS --genrule_strategy=local --test_output=all //test/cpp/common:time_jump_test
 
 # kill port_server.py to prevent the build from freezing
 ps aux | grep port_server\\.py | awk '{print $2}' | xargs kill -9


### PR DESCRIPTION
See b/242971695.

The macos/grpc_cfstream, macos/grpc_cfstream_asan and macos/grpc_cfstream_tsan have been highly flaky for very long time. Until they are fixed to pass reliably, there is no point of running them since they only pollute our test job dashboard.

