### PR TITLE
[experiments] Add API to enable/disable experiments

### DIFF
--- a/src/core/lib/experiments/config.h
+++ b/src/core/lib/experiments/config.h
@@ -19,6 +19,8 @@
 
 #include <stddef.h>
 
+#include "absl/strings/string_view.h"
+
 namespace grpc_core {
 
 // Return true if experiment \a experiment_id is enabled.
@@ -28,6 +30,13 @@ bool IsExperimentEnabled(size_t experiment_id);
 
 // Print out a list of all experiments that are built into this binary.
 void PrintExperimentsList();
+
+// Force an experiment to be on or off.
+// Must be called before experiments are configured (the first
+// IsExperimentEnabled call).
+// If the experiment does not exist, emits a warning but continues execution.
+// If this is called twice for the same experiment, both calls must agree.
+void ForceEnableExperiment(absl::string_view experiment_name, bool enable);
 
 }  // namespace grpc_core
 


### PR DESCRIPTION
This gives us the capability to enable/disable an experiment fleet wide with a guaranteed atomic CL that won't ever be clobbered by import.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

