### PR TITLE
Disable ObjC testKeepaliveWithV2API on InteropTestsRemote

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1601,6 +1601,12 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
 - (void)testKeepaliveWithV2API {
   GRPCTestRunWithFlakeRepeats(self, ^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
+    // The test is highly flaky when ran as part of InteropTestsRemote
+    // TODO(jtattermusch): fix and re-enable the test.
+    if ([[self class] isRemoteTest]) {
+      return;
+    }
+
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     if ([[self class] transport] == gGRPCCoreCronetID) {
       // Cronet does not support keepalive


### PR DESCRIPTION
During my experiments I found that this test case is highly flaky (and it's likely a problem with the test itself rather than a general issue such as the one in https://github.com/grpc/grpc/pull/30869).

Let's disable the test case for now and re-enable once the flakiness is fixed.

I can reproduce locally by simply running `tools/bazel test //src/objective-c/tests:InteropTestsRemote --test_output=errors --runs_per_test 5` (after disabling the retries interop tests).

