### PR TITLE
Increase arm64 C/C++ bazel test timeout

### DIFF
--- a/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/arm64/grpc_bazel.sh"
-timeout_mins: 120
+timeout_mins: 150
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
To avoid recent timeouts of the job. In the long run, we should make C/C++ tests faster.
