### PR TITLE
xDS interop: buildscripts: fix run_test return status (v1.48.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_url_map.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map.sh
@@ -102,7 +102,6 @@ run_test() {
     --log_dir="${out_dir}" \
     --xml_output_file="${out_dir}/sponge_log.xml" \
     |& tee "${out_dir}/sponge_log.log"
-  set +x
 }
 
 #######################################

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.sh
@@ -112,7 +112,6 @@ run_test() {
     --log_dir="${out_dir}" \
     --xml_output_file="${out_dir}/sponge_log.xml" \
     |& tee "${out_dir}/sponge_log.log"
-  set +x
 }
 
 #######################################

--- a/tools/internal_ci/linux/psm-security.sh
+++ b/tools/internal_ci/linux/psm-security.sh
@@ -116,7 +116,6 @@ run_test() {
     --log_dir="${out_dir}" \
     --xml_output_file="${out_dir}/sponge_log.xml" \
     |& tee "${out_dir}/sponge_log.log"
-  set +x
 }
 
 #######################################


### PR DESCRIPTION
Backport of #30768 to v1.48.x.

To capture the return status of the test in run_test the last command must be the call to the test itself.
This removes `set +x`, which makes the run_test always return success, and not propagate the test status.

I can't find it, but this exact error bit us before. Looks like it leaked to other scripts.
The good thing is if the test was executed, it's failure would still be picked up from the result xml.

However, if the test framework didn't start in the first place, the result will be false positive.
Example: https://source.cloud.google.com/results/invocations/98d3e679-ec8a-40bd-9f36-88179747b0d6/targets

```
/home/kbuilder/.pyenv/versions/k8s_xds_test_runner/bin/python3: Error while finding module specification for 'tests.authz_test' (ModuleNotFoundError: No module named 'tests')
+ set +x
Failed test suites: 0

[ID: 3548168] Command finished after 625 secs, exit value: 0
```

To be backported after https://github.com/grpc/grpc/pull/30735.
