### PR TITLE
[init] Move client backup poller init to be directly called by init.cc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -441,6 +441,7 @@ grpc_cc_library(
     deps = [
         "channel_init",
         "channel_stack_type",
+        "grpc_client_channel",
         "config",
         "default_event_engine",
         "experiments",

--- a/src/core/ext/filters/client_channel/backup_poller.cc
+++ b/src/core/ext/filters/client_channel/backup_poller.cc
@@ -54,7 +54,6 @@ struct backup_poller {
 };
 }  // namespace
 
-static gpr_once g_once = GPR_ONCE_INIT;
 static gpr_mu g_poller_mu;
 static backup_poller* g_poller = nullptr;  // guarded by g_poller_mu
 // g_poll_interval_ms is set only once at the first time
@@ -73,7 +72,7 @@ GPR_GLOBAL_CONFIG_DEFINE_INT32(
     "turn off the backup polls.");
 
 void grpc_client_channel_global_init_backup_polling() {
-  gpr_once_init(&g_once, [] { gpr_mu_init(&g_poller_mu); });
+  gpr_mu_init(&g_poller_mu);
   int32_t poll_interval_ms =
       GPR_GLOBAL_CONFIG_GET(grpc_client_channel_backup_poll_interval_ms);
   if (poll_interval_ms < 0) {

--- a/src/core/ext/filters/client_channel/client_channel_plugin.cc
+++ b/src/core/ext/filters/client_channel/client_channel_plugin.cc
@@ -32,7 +32,6 @@
 void grpc_client_channel_init(void) {
   grpc_core::ProxyMapperRegistry::Init();
   grpc_core::RegisterHttpProxyMapper();
-  grpc_client_channel_global_init_backup_polling();
 }
 
 void grpc_client_channel_shutdown(void) {

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -33,6 +33,7 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
+#include "src/core/ext/filters/client_channel/backup_poller.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_stack_builder.h"
 #include "src/core/lib/config/core_configuration.h"
@@ -126,6 +127,7 @@ static void do_basic_init(void) {
   grpc_event_engine::experimental::RegisterForkHandlers();
   grpc_fork_handlers_auto_register();
   grpc_tracer_init();
+  grpc_client_channel_global_init_backup_polling();
 }
 
 typedef struct grpc_plugin {


### PR DESCRIPTION
This is likely tech debt, but one that we'll pay back fairly shortly - and it'll allow removal of the plugin system a little earlier.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

