### PR TITLE
Revert "Revert "GcpObservabilityConfig: Add some basic field parsing structure""

### DIFF
--- a/src/cpp/ext/gcp/BUILD
+++ b/src/cpp/ext/gcp/BUILD
@@ -50,3 +50,16 @@ grpc_cc_library(
         "//:grpc_opencensus_plugin",
     ],
 )
+
+grpc_cc_library(
+    name = "observability_config",
+    hdrs = [
+        "observability_config.h",
+    ],
+    language = "c++",
+    visibility = ["//test:__subpackages__"],
+    deps = [
+        "//:gpr",
+        "//:json_object_loader",
+    ],
+)

--- a/src/cpp/ext/gcp/BUILD
+++ b/src/cpp/ext/gcp/BUILD
@@ -60,6 +60,7 @@ grpc_cc_library(
     visibility = ["//test:__subpackages__"],
     deps = [
         "//:gpr",
+        "//:json_args",
         "//:json_object_loader",
     ],
 )

--- a/src/cpp/ext/gcp/observability_config.h
+++ b/src/cpp/ext/gcp/observability_config.h
@@ -1,0 +1,91 @@
+//
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef GRPC_INTERNAL_CPP_EXT_GCP_OBSERVABILITY_GCP_OBSERVABILITY_CONFIG_H
+#define GRPC_INTERNAL_CPP_EXT_GCP_OBSERVABILITY_GCP_OBSERVABILITY_CONFIG_H
+
+#include <string>
+
+#include "src/core/lib/json/json_args.h"
+#include "src/core/lib/json/json_object_loader.h"
+
+namespace grpc {
+namespace internal {
+
+struct GcpObservabilityConfig {
+  struct CloudLogging {
+    bool enabled = false;
+
+    static const grpc_core::JsonLoaderInterface* JsonLoader(
+        const grpc_core::JsonArgs&) {
+      static const auto* loader =
+          grpc_core::JsonObjectLoader<CloudLogging>()
+              .OptionalField("enabled", &CloudLogging::enabled)
+              .Finish();
+      return loader;
+    }
+  };
+
+  struct CloudMonitoring {
+    bool enabled = false;
+
+    static const grpc_core::JsonLoaderInterface* JsonLoader(
+        const grpc_core::JsonArgs&) {
+      static const auto* loader =
+          grpc_core::JsonObjectLoader<CloudMonitoring>()
+              .OptionalField("enabled", &CloudMonitoring::enabled)
+              .Finish();
+      return loader;
+    }
+  };
+
+  struct CloudTrace {
+    bool enabled = false;
+
+    static const grpc_core::JsonLoaderInterface* JsonLoader(
+        const grpc_core::JsonArgs&) {
+      static const auto* loader =
+          grpc_core::JsonObjectLoader<CloudTrace>()
+              .OptionalField("enabled", &CloudTrace::enabled)
+              .Finish();
+      return loader;
+    }
+  };
+
+  CloudLogging cloud_logging;
+  CloudMonitoring cloud_monitoring;
+  CloudTrace cloud_trace;
+  std::string project_id;
+
+  static const grpc_core::JsonLoaderInterface* JsonLoader(
+      const grpc_core::JsonArgs&) {
+    static const auto* loader =
+        grpc_core::JsonObjectLoader<GcpObservabilityConfig>()
+            .OptionalField("cloud_logging",
+                           &GcpObservabilityConfig::cloud_logging)
+            .OptionalField("cloud_monitoring",
+                           &GcpObservabilityConfig::cloud_monitoring)
+            .OptionalField("cloud_trace", &GcpObservabilityConfig::cloud_trace)
+            .OptionalField("project_id", &GcpObservabilityConfig::project_id)
+            .Finish();
+    return loader;
+  }
+};
+
+}  // namespace internal
+}  // namespace grpc
+
+#endif  // GRPC_INTERNAL_CPP_EXT_GCP_OBSERVABILITY_GCP_OBSERVABILITY_CONFIG_H

--- a/test/cpp/ext/gcp/BUILD
+++ b/test/cpp/ext/gcp/BUILD
@@ -32,3 +32,18 @@ grpc_cc_test(
         "//test/cpp/util:test_util",
     ],
 )
+
+grpc_cc_test(
+    name = "observability_config_test",
+    srcs = [
+        "observability_config_test.cc",
+    ],
+    external_deps = [
+        "gtest",
+    ],
+    language = "C++",
+    deps = [
+        "//src/cpp/ext/gcp:observability_config",
+        "//test/cpp/util:test_util",
+    ],
+)

--- a/test/cpp/ext/gcp/observability_config_test.cc
+++ b/test/cpp/ext/gcp/observability_config_test.cc
@@ -1,0 +1,76 @@
+//
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/cpp/ext/gcp/observability_config.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "test/core/util/test_config.h"
+
+namespace grpc {
+namespace internal {
+namespace {
+
+TEST(GcpObservabilityConfigJsonParsingTest, Basic) {
+  const char* json_str = R"json({
+      "cloud_logging": {
+        "enabled": true
+      },
+      "cloud_monitoring": {
+        "enabled": true
+      },
+      "cloud_trace": {
+        "enabled": true
+      },
+      "project_id": "project"
+    })json";
+  auto json = grpc_core::Json::Parse(json_str);
+  ASSERT_TRUE(json.ok()) << json.status();
+  grpc_core::ErrorList errors;
+  auto config = grpc_core::LoadFromJson<GcpObservabilityConfig>(
+      *json, grpc_core::JsonArgs(), &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status();
+  EXPECT_TRUE(config.cloud_logging.enabled);
+  EXPECT_TRUE(config.cloud_monitoring.enabled);
+  EXPECT_TRUE(config.cloud_trace.enabled);
+  EXPECT_EQ(config.project_id, "project");
+}
+
+TEST(GcpObservabilityConfigJsonParsingTest, Defaults) {
+  const char* json_str = R"json({
+    })json";
+  auto json = grpc_core::Json::Parse(json_str);
+  ASSERT_TRUE(json.ok()) << json.status();
+  grpc_core::ErrorList errors;
+  auto config = grpc_core::LoadFromJson<GcpObservabilityConfig>(
+      *json, grpc_core::JsonArgs(), &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status();
+  EXPECT_FALSE(config.cloud_logging.enabled);
+  EXPECT_FALSE(config.cloud_monitoring.enabled);
+  EXPECT_FALSE(config.cloud_trace.enabled);
+  EXPECT_TRUE(config.project_id.empty());
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace grpc
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Reverts grpc/grpc#30892
It was reverted earlier since it broke the import. Reverting the revert with the fix.