### PR TITLE
Restore sane repeat count and timeout for objC tests

### DIFF
--- a/src/objective-c/tests/Common/TestUtils.m
+++ b/src/objective-c/tests/Common/TestUtils.m
@@ -26,10 +26,10 @@
 #define NSStringize(x) @NSStringize_helper(x)
 
 // Default test flake repeat counts
-static const NSUInteger kGRPCDefaultTestFlakeRepeats = 2;
+static const NSUInteger kGRPCDefaultTestFlakeRepeats = 1;
 
 // Default interop local test timeout.
-const NSTimeInterval GRPCInteropTestTimeoutDefault = 3.0;
+const NSTimeInterval GRPCInteropTestTimeoutDefault = 15.0;
 
 NSString *GRPCGetLocalInteropTestServerAddressPlainText() {
   static NSString *address;
@@ -125,6 +125,10 @@ BOOL GRPCTestRunWithFlakeRepeats(XCTestCase *testCase, GRPCTestRunBlock testBloc
 
     if (result == XCTWaiterResultCompleted && assertionSuccess) {
       return YES;
+    }
+
+    if (!isLastRun) {
+      NSLog(@"test attempt %@ failed, will retry.", NSStringize(runs));
     }
     runs += 1;
   }

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -91,6 +91,12 @@ INTEROP_SERVER_BINARY=bazel-bin/test/cpp/interop/interop_server
 trap 'echo "KILLING interop_server binaries running on the background"; kill -9 $(jobs -p)' EXIT
 # === END SECTION: run interop_server on the background ====
 
+# Environment variables that will be visible to objc tests.
+OBJC_TEST_ENV_ARGS=(
+  --test_env=HOST_PORT_LOCAL=localhost:$PLAIN_PORT
+  --test_env=HOST_PORT_LOCALSSL=localhost:$TLS_PORT
+)
+
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path objc_bazel_tests
 
 # NOTE: When using bazel to run the tests, test env variables like GRPC_VERBOSITY or GRPC_TRACE
@@ -103,9 +109,7 @@ objc_bazel_tests/bazel_wrapper \
   --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
   "${BAZEL_REMOTE_CACHE_ARGS[@]}" \
   $BAZEL_FLAGS \
-  --test_env HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
-  --test_env HOST_PORT_LOCALSSL=localhost:$TLS_PORT \
-  --test_env FLAKE_TEST_REPEATS=3 \
+  "${OBJC_TEST_ENV_ARGS[@]}" \
   -- \
   "${EXAMPLE_TARGETS[@]}" \
   "${TEST_TARGETS[@]}"


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc/pull/30869, but doesn't enable the `GRPC_CFSTREAM_RUN_LOOP=1` flag for tests.

Based on my experiments, it seems that the underlying problem that requires using `GRPC_CFSTREAM_RUN_LOOP=1` to avoid flakiness (see b/133182964) was likely fixed in MacOS Monterey (we don't know when exactly, but it does cause high flakiness rate on MacOS Mojave and that flakiness seems gone on MacOS Monterey).

I basically have everything that's needed for switching ObjC bazel test over to MacOS monterey (we can do the switch very soon), so this PR only restores sane repeat count defaults for objC tests. 