### PR TITLE
v1.49.x -- Ruby: Output a single binary file per platform-specific gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
       |file| file.start_with?(
         "src/ruby/bin/", "src/ruby/ext/", "src/ruby/lib/", "src/ruby/pb/")
     }
-    spec.files += %w( etc/roots.pem grpc_c.32-msvcrt.ruby grpc_c.64-msvcrt.ruby grpc_c.64-ucrt.ruby )
+    spec.files += ['etc/roots.pem', GRPC_RUBY_BINARY]
   end
 end
 
@@ -78,18 +78,19 @@ namespace :suite do
   end
 end
 
+GRPC_RUBY_BINARY = 'grpc_c.ruby'
+
 desc 'Build the Windows gRPC DLLs for Ruby. The argument contains the list of platforms for which to build dll. Empty placeholder files will be created for platforms that were not selected.'
 task 'dlls', [:plat] do |t, args|
-  grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   verbose = ENV['V'] || '0'
   # use env variable to set artifact build paralellism
   nproc_override = ENV['GRPC_RUBY_BUILD_PROCS'] || `nproc`.strip
   plat_list = args[:plat]
 
   build_configs = [
-    { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64-ucrt.ruby', platform: 'x64-mingw-ucrt' },
-    { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64-msvcrt.ruby', platform: 'x64-mingw32' },
-    { cross: 'i686-w64-mingw32', out: 'grpc_c.32-msvcrt.ruby', platform: 'x86-mingw32' }
+    { cross: 'x86_64-w64-mingw32', platform: 'x64-mingw-ucrt' },
+    { cross: 'x86_64-w64-mingw32', platform: 'x64-mingw32' },
+    { cross: 'i686-w64-mingw32', platform: 'x86-mingw32' }
   ]
   selected_build_configs = []
   build_configs.each do |config|
@@ -98,7 +99,7 @@ task 'dlls', [:plat] do |t, args|
       selected_build_configs.append(config)
     else
       # create an empty grpc_c.*.ruby file as a placeholder
-      FileUtils.touch config[:out]
+      FileUtils.touch GRPC_RUBY_BINARY
     end
   end
 
@@ -134,7 +135,7 @@ task 'dlls', [:plat] do |t, args|
       gem update --system --no-document && \
       #{env} #{env_comp} make -j#{nproc_override} #{out} && \
       #{opt[:cross]}-strip -x -S #{out} && \
-      cp #{out} #{opt[:out]}
+      cp #{out} #{GRPC_RUBY_BINARY}
     EOT
   end
 end
@@ -152,9 +153,7 @@ task 'gem:native', [:plat] do |t, args|
       fail "Cannot pass platform as an argument when on Darwin."
     end
 
-    FileUtils.touch 'grpc_c.32-msvcrt.ruby'
-    FileUtils.touch 'grpc_c.64-msvcrt.ruby'
-    FileUtils.touch 'grpc_c.64-ucrt.ruby'
+    FileUtils.touch GRPC_RUBY_BINARY
     unless '2.5' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
       fail "rake gem:native (the rake task to build the binary packages) is being " \
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
@@ -212,9 +211,7 @@ task 'gem:native', [:plat] do |t, args|
 
     # Truncate grpc_c.*.ruby files because they're for Windows only and we don't want
     # them to take up space in the gems that don't target windows.
-    File.truncate('grpc_c.32-msvcrt.ruby', 0)
-    File.truncate('grpc_c.64-msvcrt.ruby', 0)
-    File.truncate('grpc_c.64-ucrt.ruby', 0)
+    File.truncate(GRPC_RUBY_BINARY, 0)
 
     unix_platforms.each do |plat|
       run_rake_compiler(plat, <<~EOT)

--- a/Rakefile
+++ b/Rakefile
@@ -209,8 +209,8 @@ task 'gem:native', [:plat] do |t, args|
       EOT
     end
 
-    # Truncate grpc_c.*.ruby files because they're for Windows only and we don't want
-    # them to take up space in the gems that don't target windows.
+    # Truncate grpc_c.ruby file because it is used for Windows only and we don't want
+    # it to take up space in the gems that don't target windows.
     File.truncate(GRPC_RUBY_BINARY, 0)
 
     unix_platforms.each do |plat|

--- a/Rakefile
+++ b/Rakefile
@@ -210,7 +210,7 @@ task 'gem:native', [:plat] do |t, args|
     end
 
     # Truncate grpc_c.ruby file because it is used for Windows only and we don't want
-    # it to take up space in the gems that don't target windows.
+    # it to take up space in the gems that don't target Windows.
     File.truncate(GRPC_RUBY_BINARY, 0)
 
     unix_platforms.each do |plat|

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ spec = Gem::Specification.load('grpc.gemspec')
 Gem::PackageTask.new(spec) do |pkg|
 end
 
-GRPC_RUBY_BINARY = 'grpc_c.ruby'
+GRPC_WINDOWS_BINARY = 'grpc_c.ruby'
 
 # Add the extension compiler task
 Rake::ExtensionTask.new('grpc_c', spec) do |ext|
@@ -40,7 +40,7 @@ Rake::ExtensionTask.new('grpc_c', spec) do |ext|
       |file| file.start_with?(
         "src/ruby/bin/", "src/ruby/ext/", "src/ruby/lib/", "src/ruby/pb/")
     }
-    spec.files += ['etc/roots.pem', GRPC_RUBY_BINARY]
+    spec.files += ['etc/roots.pem', GRPC_WINDOWS_BINARY]
   end
 end
 
@@ -99,7 +99,7 @@ task 'dlls', [:plat] do |t, args|
       selected_build_configs.append(config)
     else
       # create an empty grpc_c.ruby file as a placeholder
-      FileUtils.touch GRPC_RUBY_BINARY
+      FileUtils.touch GRPC_WINDOWS_BINARY
     end
   end
 
@@ -135,7 +135,7 @@ task 'dlls', [:plat] do |t, args|
       gem update --system --no-document && \
       #{env} #{env_comp} make -j#{nproc_override} #{out} && \
       #{opt[:cross]}-strip -x -S #{out} && \
-      cp #{out} #{GRPC_RUBY_BINARY}
+      cp #{out} #{GRPC_WINDOWS_BINARY}
     EOT
   end
 end
@@ -153,7 +153,7 @@ task 'gem:native', [:plat] do |t, args|
       fail "Cannot pass platform as an argument when on Darwin."
     end
 
-    FileUtils.touch GRPC_RUBY_BINARY
+    FileUtils.touch GRPC_WINDOWS_BINARY
     unless '2.5' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
       fail "rake gem:native (the rake task to build the binary packages) is being " \
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
@@ -209,9 +209,8 @@ task 'gem:native', [:plat] do |t, args|
       EOT
     end
 
-    # Truncate grpc_c.ruby file because it is used for Windows only and we don't want
-    # it to take up space in the gems that don't target Windows.
-    File.truncate(GRPC_RUBY_BINARY, 0)
+    # Truncate grpc_c.ruby file to save space in gems that don't target Windows.
+    File.truncate(GRPC_WINDOWS_BINARY, 0)
 
     unix_platforms.each do |plat|
       run_rake_compiler(plat, <<~EOT)

--- a/Rakefile
+++ b/Rakefile
@@ -95,10 +95,10 @@ task 'dlls', [:plat] do |t, args|
   selected_build_configs = []
   build_configs.each do |config|
     if plat_list.include?(config[:platform])
-      # build the DLL (as grpc_c.*.ruby)
+      # build the DLL as grpc_c.ruby
       selected_build_configs.append(config)
     else
-      # create an empty grpc_c.*.ruby file as a placeholder
+      # create an empty grpc_c.ruby file as a placeholder
       FileUtils.touch GRPC_RUBY_BINARY
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,8 @@ spec = Gem::Specification.load('grpc.gemspec')
 Gem::PackageTask.new(spec) do |pkg|
 end
 
+GRPC_RUBY_BINARY = 'grpc_c.ruby'
+
 # Add the extension compiler task
 Rake::ExtensionTask.new('grpc_c', spec) do |ext|
   ext.source_pattern = '**/*.{c,h}'
@@ -77,8 +79,6 @@ namespace :suite do
     end
   end
 end
-
-GRPC_RUBY_BINARY = 'grpc_c.ruby'
 
 desc 'Build the Windows gRPC DLLs for Ruby. The argument contains the list of platforms for which to build dll. Empty placeholder files will be created for platforms that were not selected.'
 task 'dlls', [:plat] do |t, args|

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -16,7 +16,6 @@ require 'etc'
 require 'mkmf'
 
 windows = RUBY_PLATFORM =~ /mingw|mswin/
-windows_ucrt = RUBY_PLATFORM =~ /(mingw|mswin).*ucrt/
 bsd = RUBY_PLATFORM =~ /bsd/
 darwin = RUBY_PLATFORM =~ /darwin/
 linux = RUBY_PLATFORM =~ /linux/
@@ -86,7 +85,6 @@ end
 
 env_append 'CPPFLAGS', '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_NAME_SUFFIX="\"RUBY\""'
-env_append 'CPPFLAGS', '-DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 
 require_relative '../../lib/grpc/version'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="\"' + GRPC::VERSION + '\""'

--- a/src/ruby/ext/grpc/rb_loader.c
+++ b/src/ruby/ext/grpc/rb_loader.c
@@ -22,15 +22,7 @@
 #include <tchar.h>
 
 int grpc_rb_load_core() {
-#if GPR_ARCH_64
-#if GRPC_RUBY_WINDOWS_UCRT
-  TCHAR fname[] = _T("grpc_c.64-ucrt.ruby");
-#else
-  TCHAR fname[] = _T("grpc_c.64-msvcrt.ruby");
-#endif
-#else
-  TCHAR fname[] = _T("grpc_c.32-msvcrt.ruby");
-#endif
+  TCHAR fname[] = _T("grpc_c.ruby");
   HMODULE module = GetModuleHandle(_T("grpc_c.so"));
   TCHAR path[2048 + 32] = _T("");
   LPTSTR seek_back = NULL;


### PR DESCRIPTION
In #30933, I discovered the Ruby UCRT gem attempting to load the MSVCRT binary, and failing because that binary file is a zero-byte placeholder. Specifically, the gem root dir looks like this:

```
grpc_c.32-msvcrt.ruby - 0 KB
grpc_c.64-msvcrt.ruby - 0 KB
grpc_c.64-ucrt.ruby - 9,650 KB
```

It would be possible to fix the reference so the UCRT binary is loaded (probably a C build flag issue), *however*...

Rather than having 3 binaries files (1 real + 2 placeholders), the most elegant solution is to only create 1 binary file for each platform-specific, named `grpc_c.ruby`, which is:
- On Windows: the correct binary file for the given Windows architecture
- On Linux/Mac: a 0-byte placeholder

For reference, the UCRT gem root dir will now look like this:

```
grpc_c.ruby - 9,650 KB
```

This solution unambiguously avoids loading the wrong binary, and also gets rid of a lot of cruft in the build code at the same time. Obviously we'll never need more than one `grpc_c` binary for any given platform gem.

