### PR TITLE
Update Bazel latest version heuristic

### DIFF
--- a/test/distrib/bazel/test_latest_bazel_version.sh
+++ b/test/distrib/bazel/test_latest_bazel_version.sh
@@ -20,8 +20,8 @@ cd "$(dirname "$0")"
 GITHUB_URL="https://github.com"
 REPO="bazelbuild/bazel"
 
-VERSION=$(curl -Ls "${GITHUB_URL}/${REPO}/releases/latest" | \
-          grep "href=.*\.tar.gz" | \
-          grep -o "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*")
+VERSION=$(curl -v "${GITHUB_URL}/${REPO}/releases/latest" 2>/dev/stdout | \
+  grep "location:" | \
+  grep -o "[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*")
 
 ./test_single_bazel_version.sh "$VERSION"


### PR DESCRIPTION
    GitHub has changed their releases pages to not use full server-side
    rendering. Instead, individual artifacts are now fetched as a separate
    HTML chunk via javascript. This defeats the previous method.
    
    Instead, we now rely on the URI of the 301 redirect to indicate the
    identity of the latest release.