### PR TITLE
PR improvement: Use strict warnings on Linux Bazel RBE opt tests

### DIFF
--- a/test/core/event_engine/test_suite/oracle_event_engine_posix.cc
+++ b/test/core/event_engine/test_suite/oracle_event_engine_posix.cc
@@ -321,7 +321,7 @@ PosixOracleListener::~PosixOracleListener() {
     shutdown(listener_fds_[i], SHUT_RDWR);
   }
   // Send a STOP message over the pipe.
-  write(pipefd_[1], kStopMessage, strlen(kStopMessage));
+  GPR_ASSERT(write(pipefd_[1], kStopMessage, strlen(kStopMessage)) != -1);
   serve_.Join();
   on_shutdown_(absl::OkStatus());
 }

--- a/test/core/iomgr/tcp_posix_test.cc
+++ b/test/core/iomgr/tcp_posix_test.cc
@@ -155,7 +155,7 @@ static size_t fill_socket_partial(int fd, size_t bytes) {
 
 struct read_socket_state {
   grpc_endpoint* ep;
-  int min_progress_size;
+  size_t min_progress_size;
   size_t read_bytes;
   size_t target_read_bytes;
   grpc_slice_buffer incoming;

--- a/test/core/memory_usage/callback_server.cc
+++ b/test/core/memory_usage/callback_server.cc
@@ -45,15 +45,15 @@ class ServerCallbackImpl final
 
   grpc::ServerUnaryReactor* UnaryCall(
       grpc::CallbackServerContext* context,
-      const grpc::testing::SimpleRequest* request,
-      grpc::testing::SimpleResponse* response) override {
+      const grpc::testing::SimpleRequest* /* request */,
+      grpc::testing::SimpleResponse* /* response */) override {
     auto* reactor = context->DefaultReactor();
     reactor->Finish(grpc::Status::OK);
     return reactor;
   }
   grpc::ServerUnaryReactor* GetBeforeSnapshot(
       grpc::CallbackServerContext* context,
-      const grpc::testing::SimpleRequest* request,
+      const grpc::testing::SimpleRequest* /* request */,
       grpc::testing::MemorySize* response) override {
     gpr_log(GPR_INFO, "BeforeSnapshot RPC CALL RECEIVED");
     response->set_rss(before_server_create);

--- a/test/core/transport/chttp2/decode_huff_fuzzer.cc
+++ b/test/core/transport/chttp2/decode_huff_fuzzer.cc
@@ -33,7 +33,7 @@ bool leak_check = true;
 absl::optional<std::vector<uint8_t>> DecodeHuffSlow(const uint8_t* begin,
                                                     const uint8_t* end) {
   uint64_t bits = 0;
-  int bits_left = 0;
+  unsigned bits_left = 0;
   std::vector<uint8_t> out;
   while (true) {
     while (begin != end && bits_left < 30) {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
@@ -37,5 +37,5 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation
   key: "BAZEL_FLAGS"
-  value: "--config=opt"
+  value: "--config=opt --define=use_strict_warning=true"
 }


### PR DESCRIPTION
There are apparently no required presubmit tests that use `-Werror`, which has been the source of a few reverts. This fixes that.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

