### PR TITLE
Fix comparison between signed and unsigned in `test/core/transport/chttp2/decode_huff_fuzzer.cc`

### DIFF
--- a/test/core/transport/chttp2/decode_huff_fuzzer.cc
+++ b/test/core/transport/chttp2/decode_huff_fuzzer.cc
@@ -33,7 +33,7 @@ bool leak_check = true;
 absl::optional<std::vector<uint8_t>> DecodeHuffSlow(const uint8_t* begin,
                                                     const uint8_t* end) {
   uint64_t bits = 0;
-  int bits_left = 0;
+  size_t bits_left = 0u;
   std::vector<uint8_t> out;
   while (true) {
     while (begin != end && bits_left < 30) {


### PR DESCRIPTION

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR fixes the issue of comparison between signed and unsigned integers in `test/core/transport/chttp2/decode_huff_fuzzer.cc` which causes CI "Bazel C/C++ Opt MacOS" to fail.

