### PR TITLE
fixing php 8.2 deprecations

### DIFF
--- a/src/php/bin/build_all_docker_images.sh
+++ b/src/php/bin/build_all_docker_images.sh
@@ -17,7 +17,7 @@ set -e
 cd $(dirname $0)/../../..
 
 ALL_IMAGES=( grpc-ext grpc-src alpine centos7 php-src php-future php-zts
-             fork-support i386 php8 )
+             fork-support i386 php8 php8.2 )
 
 if [[ "$1" == "--cmds" ]]; then
   for arg in "${ALL_IMAGES[@]}"

--- a/src/php/bin/run_all_docker_images.sh
+++ b/src/php/bin/run_all_docker_images.sh
@@ -17,7 +17,7 @@ set -e
 cd $(dirname $0)/../../..
 
 ALL_IMAGES=( grpc-ext grpc-src alpine centos7 php-src php-future php-zts
-             fork-support i386 php8 )
+             fork-support i386 php8 php8.2 )
 
 if [[ "$1" == "--cmds" ]]; then
   for arg in "${ALL_IMAGES[@]}"

--- a/src/php/docker/php8.2/Dockerfile
+++ b/src/php/docker/php8.2/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM php:8.2.0RC1-zts-buster
+FROM php:8.2.0RC4-zts-buster
 
 RUN apt-get -qq update && apt-get -qq -y upgrade && apt-get -qq install -y \
   autoconf automake git libtool pkg-config \

--- a/src/php/docker/php8.2/Dockerfile
+++ b/src/php/docker/php8.2/Dockerfile
@@ -1,0 +1,45 @@
+# Copyright 2020 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:8.2.0RC1-zts-buster
+
+RUN apt-get -qq update && apt-get -qq -y upgrade && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  valgrind wget zlib1g-dev
+
+ARG MAKEFLAGS=-j8
+
+
+WORKDIR /tmp
+
+# install pear
+RUN apt-get install expect -y && \
+  curl -LO http://pear.php.net/go-pear.phar && \
+  expect -c 'spawn php ./go-pear.phar; expect "or Enter to continue:"; send "\n"; expect "Currently used php.ini"; send "\n"; expect eof' && \
+  rm go-pear.phar
+
+RUN wget https://phar.phpunit.de/phpunit-9.5.9.phar && \
+  mv phpunit-9.5.9.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+COPY . .
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests", "--ignore-valgrind-undef-errors"]

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -624,5 +624,10 @@ void grpc_init_call(TSRMLS_D) {
   INIT_CLASS_ENTRY(ce, "Grpc\\Call", call_methods);
   ce.create_object = create_wrapped_grpc_call;
   grpc_ce_call = zend_register_internal_class(&ce TSRMLS_CC);
+  zval property_channel_default_value;
+  ZVAL_NULL(&property_channel_default_value);
+  zend_string *property_channel_name = zend_string_init("channel", sizeof("channel") - 1, 1);
+  zend_declare_property_ex(grpc_ce_call, property_channel_name, &property_channel_default_value, ZEND_ACC_PROTECTED, NULL);
+  zend_string_release(property_channel_name);
   PHP_GRPC_INIT_HANDLER(wrapped_grpc_call, call_ce_handlers);
 }

--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -19,6 +19,11 @@
 
 class CallCredentials2Test extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+    private $port;
+    private $host_override;
+    private $channel;
+
     public function setUp(): void
     {
         $credentials = Grpc\ChannelCredentials::createSsl(

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -19,6 +19,13 @@
 
 class CallCredentialsTest extends \PHPUnit\Framework\TestCase
 {
+    private $credentials;
+    private $call_credentials;
+    private $server;
+    private $port;
+    private $host_override;
+    private $channel;
+
     public function setUp(): void
     {
         $this->credentials = Grpc\ChannelCredentials::createSsl(

--- a/src/php/tests/unit_tests/CallInvokerTest.php
+++ b/src/php/tests/unit_tests/CallInvokerTest.php
@@ -161,6 +161,9 @@ class CallInvokerChangeRequestCall
 
 class CallInvokerTest extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+    private $port;
+
     public function setUp(): void
     {
         $this->server = new Grpc\Server([]);

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -20,6 +20,8 @@ class CallTest extends \PHPUnit\Framework\TestCase
 {
     public static $server;
     public static $port;
+    private $channel;
+    private $call;
 
     public static function setUpBeforeClass(): void
     {

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -17,7 +17,7 @@
  *
  */
 
-class ChanellCredentialsTest extends \PHPUnit\Framework\TestCase
+class ChannelCredentialsTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp(): void
     {

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -19,14 +19,20 @@
 
 class ChannelTest extends \PHPUnit\Framework\TestCase
 {
+    private $channel;
+    private $channel1;
+    private $channel2;
+    private $channel3;
+
     public function setUp(): void
     {
     }
 
     public function tearDown(): void
     {
-        if (!empty($this->channel)) {
-            $this->channel->close();
+        foreach ([$this->channel, $this->channel1, $this->channel2, $this->channel3] as $channel)
+        if (!empty($channel)) {
+            $channel->close();
         }
     }
 

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -18,6 +18,10 @@
  */
 class EndToEndTest extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+    private $port;
+    private $channel;
+
     public function setUp(): void
     {
         $this->server = new Grpc\Server([]);

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -217,6 +217,10 @@ class StopCallInterceptor extends Grpc\Interceptor
 
 class InterceptorTest extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+    private $port;
+    private $channel;
+
     public function setUp(): void
     {
         $this->server = new Grpc\Server([]);

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -20,7 +20,7 @@
 /**
  * @group persistent_list_bound_tests
  */
-class PersistentListTest extends \PHPUnit\Framework\TestCase
+class PersistentChannelTest extends \PHPUnit\Framework\TestCase
 {
   public function setUp(): void
   {

--- a/src/php/tests/unit_tests/RpcServerTest.php
+++ b/src/php/tests/unit_tests/RpcServerTest.php
@@ -25,6 +25,9 @@ require_once(dirname(__FILE__) . '/../../lib/Grpc/RpcServer.php');
 
 class RpcServerTest extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+    private $mockService;
+
     public function setUp(): void
     {
         $this->server = new \Grpc\RpcServer();

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -18,6 +18,11 @@
  */
 class SecureEndToEndTest extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+    private $port;
+    private $host_override;
+    private $channel;
+
     public function setUp(): void
     {
         $credentials = Grpc\ChannelCredentials::createSsl(

--- a/src/php/tests/unit_tests/ServerCallTest.php
+++ b/src/php/tests/unit_tests/ServerCallTest.php
@@ -58,6 +58,9 @@ class StringValue
 
 class ServerCallTest extends \PHPUnit\Framework\TestCase
 {
+    private $mockCall;
+    private $serverContext;
+
     public function setUp(): void
     {
         $this->mockCall = $this->getMockBuilder(stdClass::class)

--- a/src/php/tests/unit_tests/ServerCallTest.php
+++ b/src/php/tests/unit_tests/ServerCallTest.php
@@ -282,6 +282,9 @@ class ServerCallTest extends \PHPUnit\Framework\TestCase
         $serverCallWriter->finish($message, ['flags' => 0x02]);
     }
 
+    /**
+     * @todo `at` is deprecated and will be removed in phpunit 10
+     */
     public function testStartWriteFinish()
     {
         $metadata = ['a' => 1];
@@ -289,30 +292,26 @@ class ServerCallTest extends \PHPUnit\Framework\TestCase
         $message1 = $this->newStringMessage();
         $message2 = $this->newStringMessage('another string');
 
-        $this->mockCall->expects($this->at(0))
+        $this->mockCall->expects($this->exactly(4))
             ->method('startBatch')
-            ->with($this->identicalTo([
-                \Grpc\OP_SEND_INITIAL_METADATA => $metadata,
-            ]));
-        $this->mockCall->expects($this->at(1))
-            ->method('startBatch')
-            ->with($this->identicalTo([
-                \Grpc\OP_SEND_MESSAGE => ['message' => $message1->serializeToString()],
-            ]));
-        $this->mockCall->expects($this->at(2))
-            ->method('startBatch')
-            ->with($this->identicalTo([
-                \Grpc\OP_SEND_MESSAGE => [
-                    'message' => $message2->serializeToString(),
-                    'flags' => 0x02,
-                ]
-            ]));
-        $this->mockCall->expects($this->at(3))
-            ->method('startBatch')
-            ->with($this->identicalTo([
-                \Grpc\OP_SEND_STATUS_FROM_SERVER => \Grpc\Status::ok(),
-                \Grpc\OP_RECV_CLOSE_ON_SERVER => true,
-            ]));
+            ->withConsecutive(
+                [$this->identicalTo([
+                    \Grpc\OP_SEND_INITIAL_METADATA => $metadata,
+                ])],
+                [$this->identicalTo([
+                    \Grpc\OP_SEND_MESSAGE => ['message' => $message1->serializeToString()],
+                ])],
+                [$this->identicalTo([
+                    \Grpc\OP_SEND_MESSAGE => [
+                        'message' => $message2->serializeToString(),
+                        'flags' => 0x02,
+                    ]
+                ])],
+                [$this->identicalTo([
+                    \Grpc\OP_SEND_STATUS_FROM_SERVER => \Grpc\Status::ok(),
+                    \Grpc\OP_RECV_CLOSE_ON_SERVER => true,
+                ])]
+            );
 
         $serverCallWriter = new \Grpc\ServerCallWriter(
             $this->mockCall,

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -19,6 +19,8 @@
 
 class ServerTest extends \PHPUnit\Framework\TestCase
 {
+    private $server;
+
     public function setUp(): void
     {
         $this->server = null;

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -18,6 +18,8 @@
  */
 class TimevalTest extends \PHPUnit\Framework\TestCase
 {
+    private $time;
+
     public function setUp(): void
     {
     }
@@ -62,9 +64,12 @@ class TimevalTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Grpc\Timeval', get_class($this->time));
     }
 
+    /**
+     * @todo in PHP 8.1+ implicit conversion from float to int is deprecated
+     */
     public function testConstructorWithFloat()
     {
-        $this->time = new Grpc\Timeval(123.456);
+        $this->time = new Grpc\Timeval((int)123.456);
         $this->assertNotNull($this->time);
         $this->assertSame('Grpc\Timeval', get_class($this->time));
         $timeFromInt = new Grpc\Timeval(123);

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -64,12 +64,12 @@ class TimevalTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Grpc\Timeval', get_class($this->time));
     }
 
-    /**
-     * @todo in PHP 8.1+ implicit conversion from float to int is deprecated
-     */
     public function testConstructorWithFloat()
     {
-        $this->time = new Grpc\Timeval((int)123.456);
+        if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
+            $this->markTestSkipped('implicit float to int cast deprecated in 8.1+');
+        }
+        $this->time = new Grpc\Timeval(123.456);
         $this->assertNotNull($this->time);
         $this->assertSame('Grpc\Timeval', get_class($this->time));
         $timeFromInt = new Grpc\Timeval(123);


### PR DESCRIPTION
PHP 8.2 RC's are out, and grpc complains that `Creation of dynamic property Grpc\Call::$channel is deprecated`.
Adding a property for `channel` resolves this, and I also fixed a bunch of deprecations and minor issues in the tests themselves.

