### PR TITLE
Remove `include/grpcpp/impl/codegen/call.h`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7638,7 +7638,6 @@ grpc_cc_library(
     visibility = ["@grpc:grpc++_test"],
     deps = [
         "grpc++",
-        "grpc++_codegen_base",
         "grpc_base",
     ],
 )

--- a/include/grpcpp/impl/call.h
+++ b/include/grpcpp/impl/call.h
@@ -19,6 +19,76 @@
 #ifndef GRPCPP_IMPL_CALL_H
 #define GRPCPP_IMPL_CALL_H
 
-#include <grpcpp/impl/codegen/call.h>  // IWYU pragma: export
+#include <grpc/impl/codegen/grpc_types.h>
+#include <grpcpp/impl/call_hook.h>
+
+namespace grpc {
+class CompletionQueue;
+namespace experimental {
+class ClientRpcInfo;
+class ServerRpcInfo;
+}  // namespace experimental
+namespace internal {
+class CallHook;
+class CallOpSetInterface;
+
+/// Straightforward wrapping of the C call object
+class Call final {
+ public:
+  Call()
+      : call_hook_(nullptr),
+        cq_(nullptr),
+        call_(nullptr),
+        max_receive_message_size_(-1) {}
+  /** call is owned by the caller */
+  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq)
+      : call_hook_(call_hook),
+        cq_(cq),
+        call_(call),
+        max_receive_message_size_(-1) {}
+
+  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq,
+       experimental::ClientRpcInfo* rpc_info)
+      : call_hook_(call_hook),
+        cq_(cq),
+        call_(call),
+        max_receive_message_size_(-1),
+        client_rpc_info_(rpc_info) {}
+
+  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq,
+       int max_receive_message_size, experimental::ServerRpcInfo* rpc_info)
+      : call_hook_(call_hook),
+        cq_(cq),
+        call_(call),
+        max_receive_message_size_(max_receive_message_size),
+        server_rpc_info_(rpc_info) {}
+
+  void PerformOps(CallOpSetInterface* ops) {
+    call_hook_->PerformOpsOnCall(ops, this);
+  }
+
+  grpc_call* call() const { return call_; }
+  grpc::CompletionQueue* cq() const { return cq_; }
+
+  int max_receive_message_size() const { return max_receive_message_size_; }
+
+  experimental::ClientRpcInfo* client_rpc_info() const {
+    return client_rpc_info_;
+  }
+
+  experimental::ServerRpcInfo* server_rpc_info() const {
+    return server_rpc_info_;
+  }
+
+ private:
+  CallHook* call_hook_;
+  grpc::CompletionQueue* cq_;
+  grpc_call* call_;
+  int max_receive_message_size_;
+  experimental::ClientRpcInfo* client_rpc_info_ = nullptr;
+  experimental::ServerRpcInfo* server_rpc_info_ = nullptr;
+};
+}  // namespace internal
+}  // namespace grpc
 
 #endif  // GRPCPP_IMPL_CALL_H

--- a/include/grpcpp/impl/codegen/call.h
+++ b/include/grpcpp/impl/codegen/call.h
@@ -18,78 +18,8 @@
 #ifndef GRPCPP_IMPL_CODEGEN_CALL_H
 #define GRPCPP_IMPL_CODEGEN_CALL_H
 
-// IWYU pragma: private, include <grpcpp/impl/call.h>
+// IWYU pragma: private
 
-#include <grpc/impl/codegen/grpc_types.h>
-#include <grpcpp/impl/codegen/call_hook.h>
-
-namespace grpc {
-class CompletionQueue;
-namespace experimental {
-class ClientRpcInfo;
-class ServerRpcInfo;
-}  // namespace experimental
-namespace internal {
-class CallHook;
-class CallOpSetInterface;
-
-/// Straightforward wrapping of the C call object
-class Call final {
- public:
-  Call()
-      : call_hook_(nullptr),
-        cq_(nullptr),
-        call_(nullptr),
-        max_receive_message_size_(-1) {}
-  /** call is owned by the caller */
-  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq)
-      : call_hook_(call_hook),
-        cq_(cq),
-        call_(call),
-        max_receive_message_size_(-1) {}
-
-  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq,
-       experimental::ClientRpcInfo* rpc_info)
-      : call_hook_(call_hook),
-        cq_(cq),
-        call_(call),
-        max_receive_message_size_(-1),
-        client_rpc_info_(rpc_info) {}
-
-  Call(grpc_call* call, CallHook* call_hook, grpc::CompletionQueue* cq,
-       int max_receive_message_size, experimental::ServerRpcInfo* rpc_info)
-      : call_hook_(call_hook),
-        cq_(cq),
-        call_(call),
-        max_receive_message_size_(max_receive_message_size),
-        server_rpc_info_(rpc_info) {}
-
-  void PerformOps(CallOpSetInterface* ops) {
-    call_hook_->PerformOpsOnCall(ops, this);
-  }
-
-  grpc_call* call() const { return call_; }
-  grpc::CompletionQueue* cq() const { return cq_; }
-
-  int max_receive_message_size() const { return max_receive_message_size_; }
-
-  experimental::ClientRpcInfo* client_rpc_info() const {
-    return client_rpc_info_;
-  }
-
-  experimental::ServerRpcInfo* server_rpc_info() const {
-    return server_rpc_info_;
-  }
-
- private:
-  CallHook* call_hook_;
-  grpc::CompletionQueue* cq_;
-  grpc_call* call_;
-  int max_receive_message_size_;
-  experimental::ClientRpcInfo* client_rpc_info_ = nullptr;
-  experimental::ServerRpcInfo* server_rpc_info_ = nullptr;
-};
-}  // namespace internal
-}  // namespace grpc
+#include <grpcpp/impl/call.h>
 
 #endif  // GRPCPP_IMPL_CODEGEN_CALL_H

--- a/include/grpcpp/impl/codegen/call.h
+++ b/include/grpcpp/impl/codegen/call.h
@@ -20,6 +20,7 @@
 
 // IWYU pragma: private
 
+/// TODO(chengyuc): Remove this file after solving compatibility.
 #include <grpcpp/impl/call.h>
 
 #endif  // GRPCPP_IMPL_CODEGEN_CALL_H

--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -24,7 +24,7 @@
 #include <functional>
 
 #include <grpc/impl/codegen/grpc_types.h>
-#include <grpcpp/impl/codegen/call.h>
+#include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
 #include <grpcpp/impl/codegen/completion_queue_tag.h>
 #include <grpcpp/impl/codegen/config.h>

--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -22,7 +22,7 @@
 // IWYU pragma: private
 
 #include <grpc/impl/codegen/connectivity_state.h>
-#include <grpcpp/impl/codegen/call.h>
+#include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/status.h>
 #include <grpcpp/impl/codegen/time.h>
 

--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -20,7 +20,7 @@
 
 // IWYU pragma: private, include <grpcpp/support/sync_stream.h>
 
-#include <grpcpp/impl/codegen/call.h>
+#include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
 #include <grpcpp/impl/codegen/client_context.h>
 #include <grpcpp/impl/codegen/completion_queue.h>

--- a/include/grpcpp/test/mock_stream.h
+++ b/include/grpcpp/test/mock_stream.h
@@ -23,7 +23,7 @@
 
 #include <gmock/gmock.h>
 
-#include <grpcpp/impl/codegen/call.h>
+#include <grpcpp/impl/call.h>
 #include <grpcpp/support/async_stream.h>
 #include <grpcpp/support/async_unary_call.h>
 #include <grpcpp/support/sync_stream.h>


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR is a part of [b/196639718](http://b/196639718). It tries to move the content of `include/grpcpp/impl/codegen/call.h` to `include/grpcpp/impl/call.h`. We do not remove anything to achieve backward compatibility. The files `include/grpcpp/impl/codegen/call.h` and `include/grpc++/impl/codegen/call.h` should be removed in the future.
