### PR TITLE
Update release verification script for now PyPi API

### DIFF
--- a/tools/release/verify_python_release.py
+++ b/tools/release/verify_python_release.py
@@ -71,9 +71,11 @@ def _get_remote_artifacts_for_package(package, version):
     experience, it has taken a minute on average to be fresh.
     """
     artifacts = set()
-    payload = requests.get("https://pypi.org/pypi/{}/{}/json".format(
-        package, version)).json()
-    for download_info in payload['releases'][version]:
+    payload_resp = requests.get("https://pypi.org/pypi/{}/{}/json".format(
+        package, version))
+    payload_resp.raise_for_status()
+    payload = payload_resp.json()
+    for download_info in payload['urls']:
         artifacts.add(
             Artifact(download_info['filename'], download_info['md5_digest']))
     return artifacts


### PR DESCRIPTION
It seems PyPi has changed its API for release info:

```
{
  "info": {
    "author": "The gRPC Authors",
  ...
  "urls": [
    {
      "comment_text": "",
      "digests": {
        "md5": "410987793a4e6e77e98866e3cfef7a46",
        "sha256": "79298b2b153d00f34ecbf5db8ec1be9bf37172ff9d2b63a2e0c6ef67f85daf1e"
      },
      "downloads": -1,
...
```


This PR brings us back up to date.

Tested against the (fresh) 1.49.0 release:

```
rbellevi@rbellevi:/tmp/tmp.q7nFb58lSw$ python3 ~/dev/grpc/tools/release/verify_python_release.py 1.49.0
Release verified successfully.
```