### PR TITLE
GcpObservabilityConfig: New changes

### DIFF
--- a/src/cpp/ext/gcp/BUILD
+++ b/src/cpp/ext/gcp/BUILD
@@ -40,6 +40,7 @@ grpc_cc_library(
     external_deps = [
         "absl/status",
         "absl/status:statusor",
+        "absl/types:optional",
         "opencensus-trace",
         "opencensus-trace-stackdriver_exporter",
         "opencensus-stats-stackdriver_exporter",

--- a/src/cpp/ext/gcp/observability.cc
+++ b/src/cpp/ext/gcp/observability.cc
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "absl/status/statusor.h"
+#include "absl/types/optional.h"
 #include "opencensus/exporters/stats/stackdriver/stackdriver_exporter.h"
 #include "opencensus/exporters/trace/stackdriver/stackdriver_exporter.h"
 #include "opencensus/trace/sampler.h"

--- a/src/cpp/ext/gcp/observability.cc
+++ b/src/cpp/ext/gcp/observability.cc
@@ -54,17 +54,17 @@ absl::Status GcpObservabilityInit() {
   }
   grpc::RegisterOpenCensusPlugin();
   grpc::RegisterOpenCensusViewsForExport();
-  if (!config->cloud_trace.disabled) {
+  if (config->cloud_trace.has_value()) {
     opencensus::trace::TraceConfig::SetCurrentTraceParams(
         {kMaxAttributes, kMaxAnnotations, kMaxMessageEvents, kMaxLinks,
          opencensus::trace::ProbabilitySampler(
-             config->cloud_trace.sampling_rate)});
+             config->cloud_trace->sampling_rate)});
     opencensus::exporters::trace::StackdriverOptions trace_opts;
     trace_opts.project_id = config->project_id;
     opencensus::exporters::trace::StackdriverExporter::Register(
         std::move(trace_opts));
   }
-  if (!config->cloud_monitoring.disabled) {
+  if (config->cloud_monitoring.has_value()) {
     opencensus::exporters::stats::StackdriverOptions stats_opts;
     stats_opts.project_id = config->project_id;
     opencensus::exporters::stats::StackdriverExporter::Register(

--- a/src/cpp/ext/gcp/observability_config.h
+++ b/src/cpp/ext/gcp/observability_config.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "absl/status/statusor.h"
+#include "absl/types/optional.h"
 
 #include "src/core/lib/json/json_args.h"
 #include "src/core/lib/json/json_object_loader.h"

--- a/src/cpp/ext/gcp/observability_config.h
+++ b/src/cpp/ext/gcp/observability_config.h
@@ -29,49 +29,39 @@ namespace internal {
 
 struct GcpObservabilityConfig {
   struct CloudLogging {
-    bool disabled = false;
-
     static const grpc_core::JsonLoaderInterface* JsonLoader(
         const grpc_core::JsonArgs&) {
       static const auto* loader =
-          grpc_core::JsonObjectLoader<CloudLogging>()
-              .OptionalField("disabled", &CloudLogging::disabled)
-              .Finish();
+          grpc_core::JsonObjectLoader<CloudLogging>().Finish();
       return loader;
     }
   };
 
   struct CloudMonitoring {
-    bool disabled = false;
-
     static const grpc_core::JsonLoaderInterface* JsonLoader(
         const grpc_core::JsonArgs&) {
       static const auto* loader =
-          grpc_core::JsonObjectLoader<CloudMonitoring>()
-              .OptionalField("disabled", &CloudMonitoring::disabled)
-              .Finish();
+          grpc_core::JsonObjectLoader<CloudMonitoring>().Finish();
       return loader;
     }
   };
 
   struct CloudTrace {
-    bool disabled = false;
     float sampling_rate = 0;
 
     static const grpc_core::JsonLoaderInterface* JsonLoader(
         const grpc_core::JsonArgs&) {
       static const auto* loader =
           grpc_core::JsonObjectLoader<CloudTrace>()
-              .OptionalField("disabled", &CloudTrace::disabled)
               .OptionalField("sampling_rate", &CloudTrace::sampling_rate)
               .Finish();
       return loader;
     }
   };
 
-  CloudLogging cloud_logging;
-  CloudMonitoring cloud_monitoring;
-  CloudTrace cloud_trace;
+  absl::optional<CloudLogging> cloud_logging;
+  absl::optional<CloudMonitoring> cloud_monitoring;
+  absl::optional<CloudTrace> cloud_trace;
   std::string project_id;
 
   static const grpc_core::JsonLoaderInterface* JsonLoader(

--- a/test/cpp/ext/gcp/observability_config_test.cc
+++ b/test/cpp/ext/gcp/observability_config_test.cc
@@ -31,14 +31,9 @@ namespace {
 
 TEST(GcpObservabilityConfigJsonParsingTest, Basic) {
   const char* json_str = R"json({
-      "cloud_logging": {
-        "disabled": true
-      },
-      "cloud_monitoring": {
-        "disabled": true
-      },
+      "cloud_logging": {},
+      "cloud_monitoring": {},
       "cloud_trace": {
-        "disabled": true,
         "sampling_rate": 0.05
       },
       "project_id": "project"
@@ -49,10 +44,10 @@ TEST(GcpObservabilityConfigJsonParsingTest, Basic) {
   auto config = grpc_core::LoadFromJson<GcpObservabilityConfig>(
       *json, grpc_core::JsonArgs(), &errors);
   ASSERT_TRUE(errors.ok()) << errors.status();
-  EXPECT_TRUE(config.cloud_logging.disabled);
-  EXPECT_TRUE(config.cloud_monitoring.disabled);
-  EXPECT_TRUE(config.cloud_trace.disabled);
-  EXPECT_FLOAT_EQ(config.cloud_trace.sampling_rate, 0.05);
+  EXPECT_TRUE(config.cloud_logging.has_value());
+  EXPECT_TRUE(config.cloud_monitoring.has_value());
+  EXPECT_TRUE(config.cloud_trace.has_value());
+  EXPECT_FLOAT_EQ(config.cloud_trace->sampling_rate, 0.05);
   EXPECT_EQ(config.project_id, "project");
 }
 
@@ -65,11 +60,26 @@ TEST(GcpObservabilityConfigJsonParsingTest, Defaults) {
   auto config = grpc_core::LoadFromJson<GcpObservabilityConfig>(
       *json, grpc_core::JsonArgs(), &errors);
   ASSERT_TRUE(errors.ok()) << errors.status();
-  EXPECT_FALSE(config.cloud_logging.disabled);
-  EXPECT_FALSE(config.cloud_monitoring.disabled);
-  EXPECT_FALSE(config.cloud_trace.disabled);
-  EXPECT_FLOAT_EQ(config.cloud_trace.sampling_rate, 0);
+  EXPECT_FALSE(config.cloud_logging.has_value());
+  EXPECT_FALSE(config.cloud_monitoring.has_value());
+  EXPECT_FALSE(config.cloud_trace.has_value());
   EXPECT_TRUE(config.project_id.empty());
+}
+
+TEST(GcpObservabilityConfigJsonParsingTest, SamplingRateDefaults) {
+  const char* json_str = R"json({
+      "cloud_trace": {
+        "sampling_rate": 0.05
+      }
+    })json";
+  auto json = grpc_core::Json::Parse(json_str);
+  ASSERT_TRUE(json.ok()) << json.status();
+  grpc_core::ErrorList errors;
+  auto config = grpc_core::LoadFromJson<GcpObservabilityConfig>(
+      *json, grpc_core::JsonArgs(), &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status();
+  ASSERT_TRUE(config.cloud_trace.has_value());
+  EXPECT_FLOAT_EQ(config.cloud_trace->sampling_rate, 0.05);
 }
 
 TEST(GcpEnvParsingTest, NoEnvironmentVariableSet) {


### PR DESCRIPTION
The new Gcp Observability Config changes (internal link - [go/grpc-observability-config](http://goto.google.com/grpc-observability-config) ) removes the `disabled` field and just bases whether logging/trace/monitoring is disabled/enabled based on the presence of the parent field.

So if "cloud_monitoring" object is present in the config, it is enabled, otherwise disabled.