### PR TITLE
Move objc TvTests to bazel (and make it "build-only")

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -248,7 +248,8 @@ macos_unit_test(
     ],
 )
 
-# bazel run tvos_unit_test is not yet supported by xctestrunner
+# Note that bazel currently doesn't support running tvos_unit_test
+# See https://github.com/bazelbuild/rules_apple/blob/8d841342c238457896cd7596cc29b2d06c9a75f0/apple/testing/default_runner/tvos_test_runner.template.sh
 tvos_unit_test(
     name = "TvTests",
     minimum_os_version = "10.0",
@@ -261,6 +262,20 @@ tvos_unit_test(
         ":NSErrorUnitTests-lib",
         ":RxLibraryUnitTests-lib",
     ],
+)
+
+# TvTests is not runnable with bazel, so the best we can do is to test
+# that the testsuite builds correctly. This is achieved by having
+# a dummy sh_test depend on :TvTests.
+grpc_sh_test(
+    name = "tvtests_build_test",
+    srcs = [
+        "tvtests_build_test.sh"
+    ],
+    data = [
+        ":TvTests",
+    ],
+    uses_polling = False,
 )
 
 grpc_sh_test(

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -270,7 +270,7 @@ tvos_unit_test(
 grpc_sh_test(
     name = "tvtests_build_test",
     srcs = [
-        "tvtests_build_test.sh"
+        "tvtests_build_test.sh",
     ],
     data = [
         ":TvTests",

--- a/src/objective-c/tests/tvtests_build_test.sh
+++ b/src/objective-c/tests/tvtests_build_test.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # //src/objective-c/tests:TvTests is set as "data"
 # for this test. Check that it's there.

--- a/src/objective-c/tests/tvtests_build_test.sh
+++ b/src/objective-c/tests/tvtests_build_test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# //src/objective-c/tests:TvTests is set as "data"
+# for this test. Check that it's there.
+test -f src/objective-c/tests/TvTests

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -57,7 +57,7 @@ TEST_TARGETS=(
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
   //src/objective-c/tests:CronetTests
-  //src/objective-c/tests:TvTests
+  //src/objective-c/tests:tvtests_build_test
   # codegen plugin tests
   //src/objective-c/tests:objc_codegen_plugin_test
   //src/objective-c/tests:objc_codegen_plugin_option_test

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -51,13 +51,13 @@ EXAMPLE_TARGETS=(
 
 TEST_TARGETS=(
   # TODO(jtattermusch): ideally we'd say "//src/objective-c/tests/..." but not all the targets currently build
-  # TODO(jtattermusch): make //src/objective-c/tests:TvTests test pass with bazel
   //src/objective-c/tests:InteropTestsLocalCleartext
   //src/objective-c/tests:InteropTestsLocalSSL
   //src/objective-c/tests:InteropTestsRemote
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
   //src/objective-c/tests:CronetTests
+  //src/objective-c/tests:TvTests
   # codegen plugin tests
   //src/objective-c/tests:objc_codegen_plugin_test
   //src/objective-c/tests:objc_codegen_plugin_option_test

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1037,17 +1037,6 @@ class ObjCLanguage(object):
                                  shortname='ios-cpp-test-cronet',
                                  cpu_cost=1e6,
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS))
-        # TODO(jtattermusch): Make sure the //src/objective-c/tests:TvTests bazel test passes and remove the test from here.
-        out.append(
-            self.config.job_spec(['src/objective-c/tests/run_one_test.sh'],
-                                 timeout_seconds=30 * 60,
-                                 shortname='tvos-test-basictests',
-                                 cpu_cost=1e6,
-                                 environ={
-                                     'SCHEME': 'TvTests',
-                                     'PLATFORM': 'tvos'
-                                 }))
-
         return sorted(out)
 
     def pre_build_steps(self):


### PR DESCRIPTION
Move objC TvTests to bazel. It needs to be done as "build-only" test, since bazel currently doesn't support running `tvos_unit_test` targets (so instead we introduce a test that "tests" that TvTests target was built successfully).