### PR TITLE
EventEngine: fix callers of Run() and RunAfter() to create ExecCtx

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -219,7 +219,6 @@ class GrpcLb : public LoadBalancingPolicy {
     void SendClientLoadReportLocked();
 
     // EventEngine callbacks
-    void MaybeSendClientLoadReport();
     void MaybeSendClientLoadReportLocked();
 
     static void ClientLoadReportDone(void* arg, grpc_error_handle error);
@@ -996,13 +995,9 @@ void GrpcLb::BalancerCallState::ScheduleNextClientLoadReportLocked() {
       GetDefaultEventEngine()->RunAfter(client_stats_report_interval_, [this] {
         ApplicationCallbackExecCtx callback_exec_ctx;
         ExecCtx exec_ctx;
-        MaybeSendClientLoadReport();
+        grpclb_policy()->work_serializer()->Run(
+            [this] { MaybeSendClientLoadReportLocked(); }, DEBUG_LOCATION);
       });
-}
-
-void GrpcLb::BalancerCallState::MaybeSendClientLoadReport() {
-  grpclb_policy()->work_serializer()->Run(
-      [this] { MaybeSendClientLoadReportLocked(); }, DEBUG_LOCATION);
 }
 
 void GrpcLb::BalancerCallState::MaybeSendClientLoadReportLocked() {

--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -51,6 +51,7 @@
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/gprpp/work_serializer.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/pollset_set.h"
 #include "src/core/lib/json/json.h"
 #include "src/core/lib/load_balancing/lb_policy.h"
@@ -468,6 +469,8 @@ WeightedTargetLb::WeightedChild::DelayedRemovalTimer::DelayedRemovalTimer(
     : weighted_child_(std::move(weighted_child)) {
   timer_handle_ = GetDefaultEventEngine()->RunAfter(
       kChildRetentionInterval, [self = Ref()]() mutable {
+        ApplicationCallbackExecCtx app_exec_ctx;
+        ExecCtx exec_ctx;
         self->weighted_child_->weighted_target_policy_->work_serializer()->Run(
             [self = std::move(self)] { self->OnTimerLocked(); },
             DEBUG_LOCATION);

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -185,6 +185,8 @@ DNSResolver::TaskHandle NativeDNSResolver::LookupSRV(
     grpc_pollset_set* /* interested_parties */,
     absl::string_view /* name_server */) {
   GetDefaultEventEngine()->Run([on_resolved] {
+    ApplicationCallbackExecCtx app_exec_ctx;
+    ExecCtx exec_ctx;
     on_resolved(absl::UnimplementedError(
         "The Native resolver does not support looking up SRV records"));
   });
@@ -198,6 +200,8 @@ DNSResolver::TaskHandle NativeDNSResolver::LookupTXT(
     absl::string_view /* name_server */) {
   // Not supported
   GetDefaultEventEngine()->Run([on_resolved] {
+    ApplicationCallbackExecCtx app_exec_ctx;
+    ExecCtx exec_ctx;
     on_resolved(absl::UnimplementedError(
         "The Native resolver does not support looking up TXT records"));
   });

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -169,6 +169,8 @@ DNSResolver::TaskHandle NativeDNSResolver::LookupSRV(
     grpc_pollset_set* /* interested_parties */,
     absl::string_view /* name_server */) {
   GetDefaultEventEngine()->Run([on_resolved] {
+    ApplicationCallbackExecCtx app_exec_ctx;
+    ExecCtx exec_ctx;
     on_resolved(absl::UnimplementedError(
         "The Native resolver does not support looking up SRV records"));
   });
@@ -182,6 +184,8 @@ DNSResolver::TaskHandle NativeDNSResolver::LookupTXT(
     absl::string_view /* name_server */) {
   // Not supported
   GetDefaultEventEngine()->Run([on_resolved] {
+    ApplicationCallbackExecCtx app_exec_ctx;
+    ExecCtx exec_ctx;
     on_resolved(absl::UnimplementedError(
         "The Native resolver does not support looking up TXT records"));
   });

--- a/src/cpp/server/orca/orca_service.cc
+++ b/src/cpp/server/orca/orca_service.cc
@@ -123,8 +123,6 @@ class OrcaService::Reactor : public ServerWriteReactor<ByteBuffer>,
   }
 
   bool MaybeScheduleTimer() {
-    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
-    grpc_core::ExecCtx exec_ctx;
     grpc::internal::MutexLock lock(&timer_mu_);
     if (cancelled_) return false;
     timer_handle_ = GetDefaultEventEngine()->RunAfter(

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -115,6 +115,8 @@ class TestDNSResolver : public grpc_core::DNSResolver {
       grpc_pollset_set* /* interested_parties */,
       absl::string_view /* name_server */) override {
     GetDefaultEventEngine()->Run([on_resolved] {
+      grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+      grpc_core::ExecCtx exec_ctx;
       on_resolved(absl::UnimplementedError(
           "The Testing DNS resolver does not support looking up SRV records"));
     });
@@ -128,6 +130,8 @@ class TestDNSResolver : public grpc_core::DNSResolver {
       absl::string_view /* name_server */) override {
     // Not supported
     GetDefaultEventEngine()->Run([on_resolved] {
+      grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+      grpc_core::ExecCtx exec_ctx;
       on_resolved(absl::UnimplementedError(
           "The Testing DNS resolver does not support looking up TXT records"));
     });

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -207,6 +207,8 @@ class FuzzerDNSResolver : public grpc_core::DNSResolver {
       grpc_pollset_set* /* interested_parties */,
       absl::string_view /* name_server */) override {
     GetDefaultEventEngine()->Run([on_resolved] {
+      grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+      grpc_core::ExecCtx exec_ctx;
       on_resolved(absl::UnimplementedError(
           "The Fuzzing DNS resolver does not support looking up SRV records"));
     });
@@ -220,6 +222,8 @@ class FuzzerDNSResolver : public grpc_core::DNSResolver {
       absl::string_view /* name_server */) override {
     // Not supported
     GetDefaultEventEngine()->Run([on_resolved] {
+      grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+      grpc_core::ExecCtx exec_ctx;
       on_resolved(absl::UnimplementedError(
           "The Fuzing DNS resolver does not support looking up TXT records"));
     });

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -115,6 +115,8 @@ class TestDNSResolver : public grpc_core::DNSResolver {
       grpc_pollset_set* /* interested_parties */,
       absl::string_view /* name_server */) override {
     GetDefaultEventEngine()->Run([on_resolved] {
+      grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+      grpc_core::ExecCtx exec_ctx;
       on_resolved(absl::UnimplementedError(
           "The Testing DNS resolver does not support looking up SRV records"));
     });
@@ -128,6 +130,8 @@ class TestDNSResolver : public grpc_core::DNSResolver {
       absl::string_view /* name_server */) override {
     // Not supported
     GetDefaultEventEngine()->Run([on_resolved] {
+      grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+      grpc_core::ExecCtx exec_ctx;
       on_resolved(absl::UnimplementedError(
           "The Testing DNS resolver does not support looking up TXT records"));
     });

--- a/test/core/surface/init_test.cc
+++ b/test/core/surface/init_test.cc
@@ -144,6 +144,8 @@ TEST(Init, TimerManagerHoldsLastInit) {
   grpc_core::Notification n;
   grpc_event_engine::experimental::GetDefaultEventEngine()->RunAfter(
       std::chrono::seconds(1), [&n] {
+        grpc_core::ApplicationCallbackExecCtx app_exec_ctx;
+        grpc_core::ExecCtx exec_ctx;
         grpc_shutdown();
         n.Notify();
       });


### PR DESCRIPTION
See discussion in #31041.

Given the number of places we missed this, I think we may want to consider adding some sort of test to ensure that all callers of `Run()` or `RunAt()` will create their own `ExecCtx`.

CC @ctiller @veblush 