### PR TITLE
Fix ruby windows ucrt build

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -86,7 +86,6 @@ end
 
 env_append 'CPPFLAGS', '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_NAME_SUFFIX="\"RUBY\""'
-env_append 'CPPFLAGS', '-DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 
 require_relative '../../lib/grpc/version'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="\"' + GRPC::VERSION + '\""'
@@ -111,6 +110,7 @@ unless windows
   exit 1 unless $? == 0
 end
 
+$CFLAGS << ' -DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 $CFLAGS << ' -I' + File.join(grpc_root, 'include')
 
 ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', 'ext-export')


### PR DESCRIPTION
We were previously trying to define this macro through an env var, which actually only affects the `make` invocation that [extconf.rb](https://github.com/grpc/grpc/blob/27e5b4e1877840b58c92d5d853c20ab713d19187/src/ruby/ext/grpc/extconf.rb#L108) uses to build the grpc core library on non-windows platforms.

Note that all of the other `CPPFLAGS` set through env vars are targeting the grpc core library, rather than the ruby C-extension code, so it worked. But this new macro for windows ucrt *is* targeting the ruby C-extension code, so it looks like it needs to be set via $CFLAGS.

Should fix https://github.com/grpc/grpc/issues/30933

cc @johnnyshields 

