### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -1,7 +1,13 @@
 name: PR AutoFix
 on: [push]
+permissions: {}
 jobs:
   PRAutoFix:
+    permissions:
+      actions: write # to cancel/stop running workflows (styfle/cancel-workflow-action)
+      contents: write # to create branch (peter-evans/create-pull-request)
+      pull-requests: write # to create a PR (peter-evans/create-pull-request)
+
     runs-on: ubuntu-latest
     steps:
       # Cache bazel build

--- a/.github/workflows/pr-auto-tag.yaml
+++ b/.github/workflows/pr-auto-tag.yaml
@@ -2,8 +2,15 @@ name: PR AutoTag
 on:
   pull_request_target:
     types: [opened, reopened, synchronized, edited]
+permissions:
+  contents: read # to determine modified files (actions/labeler)
+
 jobs:
   triage:
+    permissions:
+      contents: read # to determine modified files (actions/labeler)
+      pull-requests: write # to add labels to PRs (actions/labeler)
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.