### PR TITLE
Make objc kokoro jobs compatible with macos monterey image

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -85,7 +85,7 @@ then
   echo "Setting default ruby version."
   rvm use 2.7.0 --default
   echo "Installing cocoapods."
-  time gem install cocoapods --version 1.3.1 --no-document
+  time gem install cocoapods --version 1.3.1 --no-document --user-install
   echo "Updating osx-ssl-certs."
   rvm osx-ssl-certs status all
   rvm osx-ssl-certs update all
@@ -98,7 +98,7 @@ if [ "${PREPARE_BUILD_INSTALL_DEPS_OBJC}" == "true" ]
 then
   # cocoapods
   export LANG=en_US.UTF-8
-  time gem install cocoapods --version 1.7.2 --no-document
+  time gem install cocoapods --version 1.7.2 --no-document --user-install
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master


### PR DESCRIPTION
enable switching them to monterey image, which should in turn solve the cfstream test flakiness issue.