### PR TITLE
[event-engine] Throttle thread starting in thread pool

### DIFF
--- a/src/core/lib/event_engine/thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool.h
@@ -21,6 +21,7 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <atomic>
 #include <memory>
 #include <queue>
 

--- a/src/core/lib/event_engine/thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool.h
@@ -90,7 +90,7 @@ class ThreadPool final : public grpc_event_engine::experimental::Forkable {
     ThreadCount thread_count;
     // After pool creation we use this to rate limit creation of threads to one
     // at a time.
-    std::atomic<bool> starting_thread{false};
+    std::atomic<bool> currently_starting_one_thread{false};
   };
 
   using StatePtr = std::shared_ptr<State>;

--- a/src/core/lib/event_engine/thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool.h
@@ -88,12 +88,19 @@ class ThreadPool final : public grpc_event_engine::experimental::Forkable {
     explicit State(int reserve_threads) : queue(reserve_threads) {}
     Queue queue;
     ThreadCount thread_count;
+    // After pool creation we use this to rate limit creation of threads to one
+    // at a time.
+    std::atomic<bool> starting_thread{false};
   };
 
   using StatePtr = std::shared_ptr<State>;
 
   static void ThreadFunc(StatePtr state);
-  static void StartThread(StatePtr state);
+  // Start a new thread; throttled indicates whether the State::starting_thread
+  // variable is being used to throttle this threads creation against others or
+  // not: at thread pool startup we start several threads concurrently, but
+  // after that we only start one at a time.
+  static void StartThread(StatePtr state, bool throttled);
   void Postfork();
 
   const int reserve_threads_;

--- a/test/core/event_engine/thread_pool_test.cc
+++ b/test/core/event_engine/thread_pool_test.cc
@@ -99,6 +99,19 @@ TEST(ThreadPoolDeathTest, CanDetectStucknessAtFork) {
       "Waiting for thread pool to idle before forking");
 }
 
+void ScheduleTwiceUntilZero(ThreadPool* p, int n) {
+  if (n == 0) return;
+  p->Add([p, n] {
+    ScheduleTwiceUntilZero(p, n - 1);
+    ScheduleTwiceUntilZero(p, n - 1);
+  });
+}
+
+TEST(ThreadPoolTest, CanStartLotsOfClosures) {
+  ThreadPool p(1);
+  ScheduleTwiceUntilZero(&p, 20);
+}
+
 }  // namespace experimental
 }  // namespace grpc_event_engine
 

--- a/test/core/event_engine/thread_pool_test.cc
+++ b/test/core/event_engine/thread_pool_test.cc
@@ -109,6 +109,8 @@ void ScheduleTwiceUntilZero(ThreadPool* p, int n) {
 
 TEST(ThreadPoolTest, CanStartLotsOfClosures) {
   ThreadPool p(1);
+  // Our first thread pool implementation tried to create ~1M threads for this
+  // test.
   ScheduleTwiceUntilZero(&p, 20);
 }
 


### PR DESCRIPTION
Cap thread creation rate by ensuring there's at most one thread being added to the pool at a time.

I'm a bit wary about the test I'm adding here and if it goes poorly the fix is probably to remove the test... but it was the best I could come up with that fails with the prior behavior but seems to pass with the new.