### PR TITLE
Fix clang compiler errors for i386-windows-msvc

### DIFF
--- a/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
+++ b/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
@@ -30,12 +30,13 @@ class ExecCtxWakeupScheduler {
  public:
   template <typename ActivityType>
   void ScheduleWakeup(ActivityType* activity) {
-    GRPC_CLOSURE_INIT(
-        &closure_,
-        [](void* arg, grpc_error_handle) {
-          static_cast<ActivityType*>(arg)->RunScheduledWakeup();
-        },
-        activity, grpc_schedule_on_exec_ctx);
+    struct Closure {
+      static void Cb(void* arg, grpc_error_handle) {
+        static_cast<ActivityType*>(arg)->RunScheduledWakeup();
+      }
+    };
+    GRPC_CLOSURE_INIT(&closure_, Closure::Cb, activity,
+                      grpc_schedule_on_exec_ctx);
     ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
   }
 

--- a/src/cpp/client/client_callback.cc
+++ b/src/cpp/client/client_callback.cc
@@ -38,16 +38,14 @@ void ClientReactor::InternalScheduleOnDone(grpc::Status s) {
     grpc_closure closure;
     ClientReactor* const reactor;
     const grpc::Status status;
+    static void Cb(void* void_arg, grpc_error_handle) {
+      ClosureWithArg* arg = static_cast<ClosureWithArg*>(void_arg);
+      arg->reactor->OnDone(arg->status);
+      delete arg;
+    }
     ClosureWithArg(ClientReactor* reactor_arg, grpc::Status s)
         : reactor(reactor_arg), status(std::move(s)) {
-      GRPC_CLOSURE_INIT(
-          &closure,
-          [](void* void_arg, grpc_error_handle) {
-            ClosureWithArg* arg = static_cast<ClosureWithArg*>(void_arg);
-            arg->reactor->OnDone(arg->status);
-            delete arg;
-          },
-          this, grpc_schedule_on_exec_ctx);
+      GRPC_CLOSURE_INIT(&closure, Cb, this, grpc_schedule_on_exec_ctx);
     }
   };
   ClosureWithArg* arg = new ClosureWithArg(this, std::move(s));


### PR DESCRIPTION
This seems to be a known issue with lambdas and clang when targeting i386-windows-msvc, see
https://github.com/llvm/llvm-project/issues/28673.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

