### PR TITLE
[slice] Ensure result is used in test

### DIFF
--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -368,7 +368,7 @@ TEST(SliceTest, ExternalAsOwned) {
   // In ASAN (where we can be sure that it'll crash), go ahead and read the
   // bytes we just deleted.
   if (BuiltUnderAsan()) {
-    ASSERT_DEATH({ SumSlice(slice); }, "");
+    ASSERT_DEATH({ gpr_log(GPR_DEBUG, "%" PRIdPTR, SumSlice(slice)); }, "");
   }
   EXPECT_EQ(initial_sum, SumSlice(owned));
 }


### PR DESCRIPTION
Otherwise sufficiently good compilers may inline SumSlice, see that the result is not used, and discard the code that triggers the crash entirely.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

