### PR TITLE
Replacing grpc_error_handle with absl::Status

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1688,6 +1688,7 @@ grpc_cc_library(
     hdrs = [
         "src/core/lib/promise/exec_ctx_wakeup_scheduler.h",
     ],
+    external_deps = ["absl/status"],
     language = "c++",
     deps = [
         "closure",
@@ -1834,6 +1835,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/container:inlined_vector",
+        "absl/status",
         "absl/strings:str_format",
     ],
     language = "c++",
@@ -1898,6 +1900,7 @@ grpc_cc_library(
     external_deps = [
         "absl/base:core_headers",
         "absl/memory",
+        "absl/status",
         "absl/strings",
         "absl/types:optional",
     ],
@@ -1934,6 +1937,7 @@ grpc_cc_library(
     external_deps = [
         "absl/base:core_headers",
         "absl/memory",
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
         "absl/types:optional",
@@ -3931,6 +3935,7 @@ grpc_cc_library(
         "src/core/ext/filters/server_config_selector/server_config_selector.h",
     ],
     external_deps = [
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
     ],
@@ -4540,8 +4545,8 @@ grpc_cc_library(
     hdrs = [
         "src/core/lib/security/certificate_provider/certificate_provider_factory.h",
     ],
+    external_deps = ["absl/status"],
     deps = [
-        "error",
         "gpr",
         "grpc_public_hdrs",
         "json",
@@ -4827,6 +4832,7 @@ grpc_cc_library(
     hdrs = [
         "src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h",
     ],
+    external_deps = ["absl/status"],
     language = "c++",
     deps = [
         "certificate_provider_factory",
@@ -5676,6 +5682,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/memory",
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
     ],
@@ -6143,6 +6150,7 @@ grpc_cc_library(
         "src/core/lib/security/credentials/google_default/google_default_credentials.h",
     ],
     external_deps = [
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
         "absl/types:optional",
@@ -6530,7 +6538,10 @@ grpc_cc_library(
         "src/core/lib/security/security_connector/load_system_roots_supported.h",
         "src/core/lib/security/util/json_util.h",
     ],
-    external_deps = ["absl/strings"],
+    external_deps = [
+        "absl/status",
+        "absl/strings",
+    ],
     language = "c++",
     visibility = ["@grpc:public"],
     deps = [
@@ -7791,7 +7802,10 @@ grpc_cc_library(
     name = "json_util",
     srcs = ["src/core/lib/json/json_util.cc"],
     hdrs = ["src/core/lib/json/json_util.h"],
-    external_deps = ["absl/strings"],
+    external_deps = [
+        "absl/status",
+        "absl/strings",
+    ],
     deps = [
         "error",
         "gpr",

--- a/src/core/ext/filters/channel_idle/channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/channel_idle_filter.cc
@@ -142,7 +142,7 @@ void MaxAgeFilter::PostInit() {
     MaxAgeFilter* filter;
     grpc_closure closure;
   };
-  auto run_startup = [](void* p, grpc_error_handle) {
+  auto run_startup = [](void* p, absl::Status) {
     auto* startup = static_cast<StartupClosure*>(p);
     // Trigger idle timer
     startup->filter->IncreaseCallCount();
@@ -173,7 +173,7 @@ void MaxAgeFilter::PostInit() {
               GRPC_CHANNEL_STACK_REF(this->channel_stack(),
                                      "max_age send_goaway");
               // Jump out of the activity to send the goaway.
-              auto fn = [](void* arg, grpc_error_handle) {
+              auto fn = [](void* arg, absl::Status) {
                 auto* channel_stack = static_cast<grpc_channel_stack*>(arg);
                 grpc_transport_op* op = grpc_make_transport_op(nullptr);
                 op->goaway_error = grpc_error_set_int(

--- a/src/core/ext/filters/client_channel/backup_poller.cc
+++ b/src/core/ext/filters/client_channel/backup_poller.cc
@@ -92,7 +92,7 @@ static void backup_poller_shutdown_unref(backup_poller* p) {
   }
 }
 
-static void done_poller(void* arg, grpc_error_handle /*error*/) {
+static void done_poller(void* arg, absl::Status /*error*/) {
   backup_poller_shutdown_unref(static_cast<backup_poller*>(arg));
 }
 
@@ -115,7 +115,7 @@ static void g_poller_unref() {
   }
 }
 
-static void run_poller(void* arg, grpc_error_handle error) {
+static void run_poller(void* arg, absl::Status error) {
   backup_poller* p = static_cast<backup_poller*>(arg);
   if (!GRPC_ERROR_IS_NONE(error)) {
     if (error != GRPC_ERROR_CANCELLED) {
@@ -130,7 +130,7 @@ static void run_poller(void* arg, grpc_error_handle error) {
     backup_poller_shutdown_unref(p);
     return;
   }
-  grpc_error_handle err =
+  absl::Status err =
       grpc_pollset_work(p->pollset, nullptr, grpc_core::Timestamp::Now());
   gpr_mu_unlock(p->pollset_mu);
   GRPC_LOG_IF_ERROR("Run client channel backup poller", err);

--- a/src/core/ext/filters/client_channel/channel_connectivity.cc
+++ b/src/core/ext/filters/client_channel/channel_connectivity.cc
@@ -18,6 +18,8 @@
 
 #include <inttypes.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/connectivity_state.h>
 #include <grpc/impl/codegen/gpr_types.h>
@@ -153,7 +155,7 @@ class StateWatcher : public DualRefCounted<StateWatcher> {
     grpc_closure* closure() { return &closure_; }
 
    private:
-    static void WatcherTimerInit(void* arg, grpc_error_handle /*error*/) {
+    static void WatcherTimerInit(void* arg, absl::Status /*error*/) {
       auto* self = static_cast<WatcherTimerInitState*>(arg);
       self->state_watcher_->StartTimer(self->deadline_);
       delete self;
@@ -168,7 +170,7 @@ class StateWatcher : public DualRefCounted<StateWatcher> {
     grpc_timer_init(&timer_, deadline, &on_timeout_);
   }
 
-  static void WatchComplete(void* arg, grpc_error_handle error) {
+  static void WatchComplete(void* arg, absl::Status error) {
     auto* self = static_cast<StateWatcher*>(arg);
     if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_operation_failures)) {
       GRPC_LOG_IF_ERROR("watch_completion_error", GRPC_ERROR_REF(error));
@@ -177,7 +179,7 @@ class StateWatcher : public DualRefCounted<StateWatcher> {
     self->Unref();
   }
 
-  static void TimeoutComplete(void* arg, grpc_error_handle error) {
+  static void TimeoutComplete(void* arg, absl::Status error) {
     auto* self = static_cast<StateWatcher*>(arg);
     self->timer_fired_ = GRPC_ERROR_IS_NONE(error);
     // If this is a client channel (not a lame channel), cancel the watch.
@@ -192,7 +194,7 @@ class StateWatcher : public DualRefCounted<StateWatcher> {
   // Invoked when both strong refs are released.
   void Orphan() override {
     WeakRef().release();  // Take a weak ref until completion is finished.
-    grpc_error_handle error =
+    absl::Status error =
         timer_fired_ ? GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                            "Timed out waiting for connection state change")
                      : GRPC_ERROR_NONE;

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -106,8 +106,8 @@ TraceFlag grpc_client_channel_lb_call_trace(false, "client_channel_lb_call");
 
 class ClientChannel::CallData {
  public:
-  static grpc_error_handle Init(grpc_call_element* elem,
-                                const grpc_call_element_args* args);
+  static absl::Status Init(grpc_call_element* elem,
+                           const grpc_call_element_args* args);
   static void Destroy(grpc_call_element* elem,
                       const grpc_call_final_info* final_info,
                       grpc_closure* then_schedule_closure);
@@ -116,18 +116,18 @@ class ClientChannel::CallData {
   static void SetPollent(grpc_call_element* elem, grpc_polling_entity* pollent);
 
   // Invoked by channel for queued calls when name resolution is completed.
-  static void CheckResolution(void* arg, grpc_error_handle error);
+  static void CheckResolution(void* arg, absl::Status error);
   // Helper function for applying the service config to a call while
   // holding ClientChannel::resolution_mu_.
   // Returns true if the service config has been applied to the call, in which
   // case the caller must invoke ResolutionDone() or AsyncResolutionDone()
   // with the returned error.
-  bool CheckResolutionLocked(grpc_call_element* elem, grpc_error_handle* error)
+  bool CheckResolutionLocked(grpc_call_element* elem, absl::Status* error)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::resolution_mu_);
   // Schedules a callback to continue processing the call once
   // resolution is complete.  The callback will not run until after this
   // method returns.
-  void AsyncResolutionDone(grpc_call_element* elem, grpc_error_handle error);
+  void AsyncResolutionDone(grpc_call_element* elem, absl::Status error);
 
  private:
   class ResolverQueuedCallCanceller;
@@ -140,8 +140,7 @@ class ClientChannel::CallData {
   static size_t GetBatchIndex(grpc_transport_stream_op_batch* batch);
   void PendingBatchesAdd(grpc_call_element* elem,
                          grpc_transport_stream_op_batch* batch);
-  static void FailPendingBatchInCallCombiner(void* arg,
-                                             grpc_error_handle error);
+  static void FailPendingBatchInCallCombiner(void* arg, absl::Status error);
   // A predicate type and some useful implementations for PendingBatchesFail().
   typedef bool (*YieldCallCombinerPredicate)(
       const CallCombinerClosureList& closures);
@@ -159,10 +158,9 @@ class ClientChannel::CallData {
   // If yield_call_combiner_predicate returns true, assumes responsibility for
   // yielding the call combiner.
   void PendingBatchesFail(
-      grpc_call_element* elem, grpc_error_handle error,
+      grpc_call_element* elem, absl::Status error,
       YieldCallCombinerPredicate yield_call_combiner_predicate);
-  static void ResumePendingBatchInCallCombiner(void* arg,
-                                               grpc_error_handle ignored);
+  static void ResumePendingBatchInCallCombiner(void* arg, absl::Status ignored);
   // Resumes all pending batches on lb_call_.
   void PendingBatchesResume(grpc_call_element* elem);
 
@@ -170,12 +168,12 @@ class ClientChannel::CallData {
   // that the resolver has returned results to the channel.
   // If an error is returned, the error indicates the status with which
   // the call should be failed.
-  grpc_error_handle ApplyServiceConfigToCallLocked(
+  absl::Status ApplyServiceConfigToCallLocked(
       grpc_call_element* elem, grpc_metadata_batch* initial_metadata)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::resolution_mu_);
   // Invoked when the resolver result is applied to the caller, on both
   // success or failure.
-  static void ResolutionDone(void* arg, grpc_error_handle error);
+  static void ResolutionDone(void* arg, absl::Status error);
   // Removes the call (if present) from the channel's list of calls queued
   // for name resolution.
   void MaybeRemoveCallFromResolverQueuedCallsLocked(grpc_call_element* elem)
@@ -186,7 +184,7 @@ class ClientChannel::CallData {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::resolution_mu_);
 
   static void RecvTrailingMetadataReadyForConfigSelectorCommitCallback(
-      void* arg, grpc_error_handle error);
+      void* arg, absl::Status error);
 
   void CreateDynamicCall(grpc_call_element* elem);
 
@@ -234,7 +232,7 @@ class ClientChannel::CallData {
   grpc_transport_stream_op_batch* pending_batches_[MAX_PENDING_BATCHES] = {};
 
   // Set when we get a cancel_stream op.
-  grpc_error_handle cancel_error_ = GRPC_ERROR_NONE;
+  absl::Status cancel_error_ = GRPC_ERROR_NONE;
 };
 
 //
@@ -269,8 +267,8 @@ class DynamicTerminationFilter {
 
   static const grpc_channel_filter kFilterVtable;
 
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* args) {
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* args) {
     GPR_ASSERT(args->is_last);
     GPR_ASSERT(elem->filter == &kFilterVtable);
     new (elem->channel_data) DynamicTerminationFilter(args->channel_args);
@@ -298,8 +296,8 @@ class DynamicTerminationFilter {
 
 class DynamicTerminationFilter::CallData {
  public:
-  static grpc_error_handle Init(grpc_call_element* elem,
-                                const grpc_call_element_args* args) {
+  static absl::Status Init(grpc_call_element* elem,
+                           const grpc_call_element_args* args) {
     new (elem->call_data) CallData(*args);
     return GRPC_ERROR_NONE;
   }
@@ -950,11 +948,11 @@ ClientChannel* ClientChannel::GetFromChannel(Channel* channel) {
   return static_cast<ClientChannel*>(elem->channel_data);
 }
 
-grpc_error_handle ClientChannel::Init(grpc_channel_element* elem,
-                                      grpc_channel_element_args* args) {
+absl::Status ClientChannel::Init(grpc_channel_element* elem,
+                                 grpc_channel_element_args* args) {
   GPR_ASSERT(args->is_last);
   GPR_ASSERT(elem->filter == &kFilterVtable);
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   new (elem->channel_data) ClientChannel(args, &error);
   return error;
 }
@@ -977,7 +975,7 @@ RefCountedPtr<SubchannelPoolInterface> GetSubchannelPool(
 }  // namespace
 
 ClientChannel::ClientChannel(grpc_channel_element_args* args,
-                             grpc_error_handle* error)
+                             absl::Status* error)
     : channel_args_(ChannelArgs::FromC(args->channel_args)),
       deadline_checking_enabled_(grpc_deadline_checking_enabled(channel_args_)),
       owning_stack_(args->channel_stack),
@@ -1310,7 +1308,7 @@ void ClientChannel::OnResolverErrorLocked(absl::Status status) {
   // result, then we continue to let it set the connectivity state.
   // Otherwise, we go into TRANSIENT_FAILURE.
   if (lb_policy_ == nullptr) {
-    grpc_error_handle error = absl_status_to_grpc_error(status);
+    absl::Status error = absl_status_to_grpc_error(status);
     {
       MutexLock lock(&resolution_mu_);
       // Update resolver transient failure.
@@ -1321,7 +1319,7 @@ void ClientChannel::OnResolverErrorLocked(absl::Status status) {
            call = call->next) {
         grpc_call_element* elem = call->elem;
         CallData* calld = static_cast<CallData*>(elem->call_data);
-        grpc_error_handle error = GRPC_ERROR_NONE;
+        absl::Status error = GRPC_ERROR_NONE;
         if (calld->CheckResolutionLocked(elem, &error)) {
           calld->AsyncResolutionDone(elem, error);
         }
@@ -1489,7 +1487,7 @@ void ClientChannel::UpdateServiceConfigInDataPlaneLocked() {
       ExecCtx::Get()->InvalidateNow();
       grpc_call_element* elem = call->elem;
       CallData* calld = static_cast<CallData*>(elem->call_data);
-      grpc_error_handle error = GRPC_ERROR_NONE;
+      absl::Status error = GRPC_ERROR_NONE;
       if (calld->CheckResolutionLocked(elem, &error)) {
         calld->AsyncResolutionDone(elem, error);
       }
@@ -1587,7 +1585,7 @@ void ClientChannel::UpdateStateAndPickerLocked(
       // on the stale value, which results in the timer firing too early. To
       // avoid this, we invalidate the cached value for each call we process.
       ExecCtx::Get()->InvalidateNow();
-      grpc_error_handle error = GRPC_ERROR_NONE;
+      absl::Status error = GRPC_ERROR_NONE;
       if (call->lb_call->PickSubchannelLocked(&error)) {
         call->lb_call->AsyncPickDone(error);
       }
@@ -1629,7 +1627,7 @@ T HandlePickResult(
 
 }  // namespace
 
-grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
+absl::Status ClientChannel::DoPingLocked(grpc_transport_op* op) {
   if (state_tracker_.state() != GRPC_CHANNEL_READY) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("channel not connected");
   }
@@ -1638,7 +1636,7 @@ grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
     MutexLock lock(&data_plane_mu_);
     result = picker_->Pick(LoadBalancingPolicy::PickArgs());
   }
-  return HandlePickResult<grpc_error_handle>(
+  return HandlePickResult<absl::Status>(
       &result,
       // Complete pick.
       [op](LoadBalancingPolicy::PickResult::Complete* complete_pick)
@@ -1680,7 +1678,7 @@ void ClientChannel::StartTransportOpLocked(grpc_transport_op* op) {
   }
   // Ping.
   if (op->send_ping.on_initiate != nullptr || op->send_ping.on_ack != nullptr) {
-    grpc_error_handle error = DoPingLocked(op);
+    absl::Status error = DoPingLocked(op);
     if (!GRPC_ERROR_IS_NONE(error)) {
       ExecCtx::Run(DEBUG_LOCATION, op->send_ping.on_initiate,
                    GRPC_ERROR_REF(error));
@@ -1849,8 +1847,8 @@ ClientChannel::CallData::~CallData() {
   }
 }
 
-grpc_error_handle ClientChannel::CallData::Init(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+absl::Status ClientChannel::CallData::Init(grpc_call_element* elem,
+                                           const grpc_call_element_args* args) {
   ClientChannel* chand = static_cast<ClientChannel*>(elem->channel_data);
   new (elem->call_data) CallData(elem, *chand, *args);
   return GRPC_ERROR_NONE;
@@ -2008,7 +2006,7 @@ void ClientChannel::CallData::PendingBatchesAdd(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void ClientChannel::CallData::FailPendingBatchInCallCombiner(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   CallData* calld = static_cast<CallData*>(batch->handler_private.extra_arg);
@@ -2019,7 +2017,7 @@ void ClientChannel::CallData::FailPendingBatchInCallCombiner(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void ClientChannel::CallData::PendingBatchesFail(
-    grpc_call_element* elem, grpc_error_handle error,
+    grpc_call_element* elem, absl::Status error,
     YieldCallCombinerPredicate yield_call_combiner_predicate) {
   GPR_ASSERT(!GRPC_ERROR_IS_NONE(error));
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_call_trace)) {
@@ -2055,7 +2053,7 @@ void ClientChannel::CallData::PendingBatchesFail(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void ClientChannel::CallData::ResumePendingBatchInCallCombiner(
-    void* arg, grpc_error_handle /*ignored*/) {
+    void* arg, absl::Status /*ignored*/) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   auto* elem =
@@ -2112,7 +2110,7 @@ class ClientChannel::CallData::ResolverQueuedCallCanceller {
   }
 
  private:
-  static void CancelLocked(void* arg, grpc_error_handle error) {
+  static void CancelLocked(void* arg, absl::Status error) {
     auto* self = static_cast<ResolverQueuedCallCanceller*>(arg);
     auto* chand = static_cast<ClientChannel*>(self->elem_->channel_data);
     auto* calld = static_cast<CallData*>(self->elem_->call_data);
@@ -2172,7 +2170,7 @@ void ClientChannel::CallData::MaybeAddCallToResolverQueuedCallsLocked(
   resolver_call_canceller_ = new ResolverQueuedCallCanceller(elem);
 }
 
-grpc_error_handle ClientChannel::CallData::ApplyServiceConfigToCallLocked(
+absl::Status ClientChannel::CallData::ApplyServiceConfigToCallLocked(
     grpc_call_element* elem, grpc_metadata_batch* initial_metadata) {
   ClientChannel* chand = static_cast<ClientChannel*>(elem->channel_data);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_call_trace)) {
@@ -2234,7 +2232,7 @@ grpc_error_handle ClientChannel::CallData::ApplyServiceConfigToCallLocked(
 
 void ClientChannel::CallData::
     RecvTrailingMetadataReadyForConfigSelectorCommitCallback(
-        void* arg, grpc_error_handle error) {
+        void* arg, absl::Status error) {
   auto* elem = static_cast<grpc_call_element*>(arg);
   auto* chand = static_cast<ClientChannel*>(elem->channel_data);
   auto* calld = static_cast<CallData*>(elem->call_data);
@@ -2257,14 +2255,13 @@ void ClientChannel::CallData::
 }
 
 void ClientChannel::CallData::AsyncResolutionDone(grpc_call_element* elem,
-                                                  grpc_error_handle error) {
+                                                  absl::Status error) {
   // TODO(roth): Does this callback need to hold a ref to the call stack?
   GRPC_CLOSURE_INIT(&resolution_done_closure_, ResolutionDone, elem, nullptr);
   ExecCtx::Run(DEBUG_LOCATION, &resolution_done_closure_, error);
 }
 
-void ClientChannel::CallData::ResolutionDone(void* arg,
-                                             grpc_error_handle error) {
+void ClientChannel::CallData::ResolutionDone(void* arg, absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(arg);
   ClientChannel* chand = static_cast<ClientChannel*>(elem->channel_data);
   CallData* calld = static_cast<CallData*>(elem->call_data);
@@ -2280,8 +2277,7 @@ void ClientChannel::CallData::ResolutionDone(void* arg,
   calld->CreateDynamicCall(elem);
 }
 
-void ClientChannel::CallData::CheckResolution(void* arg,
-                                              grpc_error_handle error) {
+void ClientChannel::CallData::CheckResolution(void* arg, absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(arg);
   CallData* calld = static_cast<CallData*>(elem->call_data);
   ClientChannel* chand = static_cast<ClientChannel*>(elem->channel_data);
@@ -2297,7 +2293,7 @@ void ClientChannel::CallData::CheckResolution(void* arg,
 }
 
 bool ClientChannel::CallData::CheckResolutionLocked(grpc_call_element* elem,
-                                                    grpc_error_handle* error) {
+                                                    absl::Status* error) {
   ClientChannel* chand = static_cast<ClientChannel*>(elem->channel_data);
   // If we're still in IDLE, we need to start resolving.
   if (GPR_UNLIKELY(chand->CheckConnectivityState(false) == GRPC_CHANNEL_IDLE)) {
@@ -2312,7 +2308,7 @@ bool ClientChannel::CallData::CheckResolutionLocked(grpc_call_element* elem,
     ExecCtx::Run(
         DEBUG_LOCATION,
         GRPC_CLOSURE_CREATE(
-            [](void* arg, grpc_error_handle /*error*/) {
+            [](void* arg, absl::Status /*error*/) {
               auto* chand = static_cast<ClientChannel*>(arg);
               chand->work_serializer_->Run(
                   [chand]()
@@ -2376,7 +2372,7 @@ void ClientChannel::CallData::CreateDynamicCall(grpc_call_element* elem) {
                                      arena_,
                                      call_context_,
                                      call_combiner_};
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   DynamicFilters* channel_stack = args.channel_stack.get();
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_call_trace)) {
     gpr_log(
@@ -2632,7 +2628,7 @@ void ClientChannel::LoadBalancedCall::PendingBatchesAdd(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void ClientChannel::LoadBalancedCall::FailPendingBatchInCallCombiner(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   auto* self = static_cast<LoadBalancedCall*>(batch->handler_private.extra_arg);
@@ -2643,7 +2639,7 @@ void ClientChannel::LoadBalancedCall::FailPendingBatchInCallCombiner(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void ClientChannel::LoadBalancedCall::PendingBatchesFail(
-    grpc_error_handle error,
+    absl::Status error,
     YieldCallCombinerPredicate yield_call_combiner_predicate) {
   GPR_ASSERT(!GRPC_ERROR_IS_NONE(error));
   GRPC_ERROR_UNREF(failure_error_);
@@ -2679,7 +2675,7 @@ void ClientChannel::LoadBalancedCall::PendingBatchesFail(
 
 // This is called via the call combiner, so access to calld is synchronized.
 void ClientChannel::LoadBalancedCall::ResumePendingBatchInCallCombiner(
-    void* arg, grpc_error_handle /*ignored*/) {
+    void* arg, absl::Status /*ignored*/) {
   grpc_transport_stream_op_batch* batch =
       static_cast<grpc_transport_stream_op_batch*>(arg);
   SubchannelCall* subchannel_call =
@@ -2854,7 +2850,7 @@ void ClientChannel::LoadBalancedCall::StartTransportStreamOpBatch(
 }
 
 void ClientChannel::LoadBalancedCall::SendInitialMetadataOnComplete(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   auto* self = static_cast<LoadBalancedCall*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_lb_call_trace)) {
     gpr_log(GPR_INFO,
@@ -2870,7 +2866,7 @@ void ClientChannel::LoadBalancedCall::SendInitialMetadataOnComplete(
 }
 
 void ClientChannel::LoadBalancedCall::RecvInitialMetadataReady(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   auto* self = static_cast<LoadBalancedCall*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_lb_call_trace)) {
     gpr_log(GPR_INFO,
@@ -2886,8 +2882,8 @@ void ClientChannel::LoadBalancedCall::RecvInitialMetadataReady(
                GRPC_ERROR_REF(error));
 }
 
-void ClientChannel::LoadBalancedCall::RecvMessageReady(
-    void* arg, grpc_error_handle error) {
+void ClientChannel::LoadBalancedCall::RecvMessageReady(void* arg,
+                                                       absl::Status error) {
   auto* self = static_cast<LoadBalancedCall*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_lb_call_trace)) {
     gpr_log(GPR_INFO, "chand=%p lb_call=%p: got recv_message_ready: error=%s",
@@ -2901,7 +2897,7 @@ void ClientChannel::LoadBalancedCall::RecvMessageReady(
 }
 
 void ClientChannel::LoadBalancedCall::RecvTrailingMetadataReady(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   auto* self = static_cast<LoadBalancedCall*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_lb_call_trace)) {
     gpr_log(GPR_INFO,
@@ -2976,7 +2972,7 @@ void ClientChannel::LoadBalancedCall::CreateSubchannelCall() {
       // TODO(roth): When we implement hedging support, we will probably
       // need to use a separate call context for each subchannel call.
       call_context_, call_combiner_};
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   subchannel_call_ = SubchannelCall::Create(std::move(call_args), &error);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_lb_call_trace)) {
     gpr_log(GPR_INFO,
@@ -3011,7 +3007,7 @@ class ClientChannel::LoadBalancedCall::LbQueuedCallCanceller {
   }
 
  private:
-  static void CancelLocked(void* arg, grpc_error_handle error) {
+  static void CancelLocked(void* arg, absl::Status error) {
     auto* self = static_cast<LbQueuedCallCanceller*>(arg);
     auto* lb_call = self->lb_call_.get();
     auto* chand = lb_call->chand_;
@@ -3066,14 +3062,13 @@ void ClientChannel::LoadBalancedCall::MaybeAddCallToLbQueuedCallsLocked() {
   lb_call_canceller_ = new LbQueuedCallCanceller(Ref());
 }
 
-void ClientChannel::LoadBalancedCall::AsyncPickDone(grpc_error_handle error) {
+void ClientChannel::LoadBalancedCall::AsyncPickDone(absl::Status error) {
   // TODO(roth): Does this callback need to hold a ref to LoadBalancedCall?
   GRPC_CLOSURE_INIT(&pick_closure_, PickDone, this, grpc_schedule_on_exec_ctx);
   ExecCtx::Run(DEBUG_LOCATION, &pick_closure_, error);
 }
 
-void ClientChannel::LoadBalancedCall::PickDone(void* arg,
-                                               grpc_error_handle error) {
+void ClientChannel::LoadBalancedCall::PickDone(void* arg, absl::Status error) {
   auto* self = static_cast<LoadBalancedCall*>(arg);
   if (!GRPC_ERROR_IS_NONE(error)) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_lb_call_trace)) {
@@ -3089,7 +3084,7 @@ void ClientChannel::LoadBalancedCall::PickDone(void* arg,
 }
 
 void ClientChannel::LoadBalancedCall::PickSubchannel(void* arg,
-                                                     grpc_error_handle error) {
+                                                     absl::Status error) {
   auto* self = static_cast<LoadBalancedCall*>(arg);
   bool pick_complete;
   {
@@ -3103,7 +3098,7 @@ void ClientChannel::LoadBalancedCall::PickSubchannel(void* arg,
 }
 
 bool ClientChannel::LoadBalancedCall::PickSubchannelLocked(
-    grpc_error_handle* error) {
+    absl::Status* error) {
   GPR_ASSERT(connected_subchannel_ == nullptr);
   GPR_ASSERT(subchannel_call_ == nullptr);
   // Grab initial metadata.

--- a/src/core/ext/filters/client_channel/connector.h
+++ b/src/core/ext/filters/client_channel/connector.h
@@ -19,6 +19,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/gprpp/orphanable.h"
@@ -71,7 +73,7 @@ class SubchannelConnector : public InternallyRefCounted<SubchannelConnector> {
 
   // Cancels any in-flight connection attempt and shuts down the
   // connector.
-  virtual void Shutdown(grpc_error_handle error) = 0;
+  virtual void Shutdown(absl::Status error) = 0;
 
   void Orphan() override {
     Shutdown(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Subchannel disconnected"));

--- a/src/core/ext/filters/client_channel/dynamic_filters.cc
+++ b/src/core/ext/filters/client_channel/dynamic_filters.cc
@@ -33,6 +33,7 @@
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/alloc.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/surface/lame_client.h"
 
 // Conversion between call and call stack.
@@ -50,7 +51,7 @@ namespace grpc_core {
 // DynamicFilters::Call
 //
 
-DynamicFilters::Call::Call(Args args, grpc_error_handle* error)
+DynamicFilters::Call::Call(Args args, absl::Status* error)
     : channel_stack_(std::move(args.channel_stack)) {
   grpc_call_stack* call_stack = CALL_TO_CALL_STACK(this);
   const grpc_call_element_args call_args = {
@@ -106,7 +107,7 @@ void DynamicFilters::Call::Unref(const DebugLocation& /*location*/,
   GRPC_CALL_STACK_UNREF(CALL_TO_CALL_STACK(this), reason);
 }
 
-void DynamicFilters::Call::Destroy(void* arg, grpc_error_handle /*error*/) {
+void DynamicFilters::Call::Destroy(void* arg, absl::Status /*error*/) {
   DynamicFilters::Call* self = static_cast<DynamicFilters::Call*>(arg);
   // Keep some members before destroying the subchannel call.
   grpc_closure* after_call_stack_destroy = self->after_call_stack_destroy_;
@@ -136,13 +137,13 @@ void DynamicFilters::Call::IncrementRefCount(const DebugLocation& /*location*/,
 
 namespace {
 
-void DestroyChannelStack(void* arg, grpc_error_handle /*error*/) {
+void DestroyChannelStack(void* arg, absl::Status /*error*/) {
   grpc_channel_stack* channel_stack = static_cast<grpc_channel_stack*>(arg);
   grpc_channel_stack_destroy(channel_stack);
   gpr_free(channel_stack);
 }
 
-std::pair<grpc_channel_stack*, grpc_error_handle> CreateChannelStack(
+std::pair<grpc_channel_stack*, absl::Status> CreateChannelStack(
     const grpc_channel_args* args,
     std::vector<const grpc_channel_filter*> filters) {
   // Allocate memory for channel stack.
@@ -151,7 +152,7 @@ std::pair<grpc_channel_stack*, grpc_error_handle> CreateChannelStack(
   grpc_channel_stack* channel_stack =
       reinterpret_cast<grpc_channel_stack*>(gpr_zalloc(channel_stack_size));
   // Initialize stack.
-  grpc_error_handle error = grpc_channel_stack_init(
+  absl::Status error = grpc_channel_stack_init(
       /*initial_refs=*/1, DestroyChannelStack, channel_stack, filters.data(),
       filters.size(), args, "DynamicFilters", channel_stack);
   if (!GRPC_ERROR_IS_NONE(error)) {
@@ -174,7 +175,7 @@ RefCountedPtr<DynamicFilters> DynamicFilters::Create(
   if (!GRPC_ERROR_IS_NONE(p.second)) {
     // Channel stack creation failed with requested filters.
     // Create with lame filter instead.
-    grpc_error_handle error = p.second;
+    absl::Status error = p.second;
     grpc_arg error_arg = MakeLameClientErrorArg(&error);
     grpc_channel_args* new_args =
         grpc_channel_args_copy_and_add(args, &error_arg, 1);
@@ -191,7 +192,7 @@ DynamicFilters::~DynamicFilters() {
 }
 
 RefCountedPtr<DynamicFilters::Call> DynamicFilters::CreateCall(
-    DynamicFilters::Call::Args args, grpc_error_handle* error) {
+    DynamicFilters::Call::Args args, absl::Status* error) {
   size_t allocation_size = GPR_ROUND_UP_TO_ALIGNMENT_SIZE(sizeof(Call)) +
                            channel_stack_->call_stack_size;
   Call* call = static_cast<Call*>(args.arena->Alloc(allocation_size));

--- a/src/core/ext/filters/client_channel/dynamic_filters.h
+++ b/src/core/ext/filters/client_channel/dynamic_filters.h
@@ -21,6 +21,8 @@
 
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>
 
@@ -33,7 +35,6 @@
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/call_combiner.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/transport/transport.h"
@@ -56,7 +57,7 @@ class DynamicFilters : public RefCounted<DynamicFilters> {
       CallCombiner* call_combiner;
     };
 
-    Call(Args args, grpc_error_handle* error);
+    Call(Args args, absl::Status* error);
 
     // Continues processing a transport stream op batch.
     void StartTransportStreamOpBatch(grpc_transport_stream_op_batch* batch);
@@ -83,7 +84,7 @@ class DynamicFilters : public RefCounted<DynamicFilters> {
     void IncrementRefCount();
     void IncrementRefCount(const DebugLocation& location, const char* reason);
 
-    static void Destroy(void* arg, grpc_error_handle error);
+    static void Destroy(void* arg, absl::Status error);
 
     RefCountedPtr<DynamicFilters> channel_stack_;
     grpc_closure* after_call_stack_destroy_ = nullptr;
@@ -98,7 +99,7 @@ class DynamicFilters : public RefCounted<DynamicFilters> {
 
   ~DynamicFilters() override;
 
-  RefCountedPtr<Call> CreateCall(Call::Args args, grpc_error_handle* error);
+  RefCountedPtr<Call> CreateCall(Call::Args args, absl::Status* error);
 
  private:
   grpc_channel_stack* channel_stack_;

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
@@ -22,6 +22,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/log.h>
@@ -34,8 +35,8 @@
 #include "src/core/lib/transport/metadata_batch.h"
 #include "src/core/lib/transport/transport.h"
 
-static grpc_error_handle clr_init_channel_elem(
-    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
+static absl::Status clr_init_channel_elem(grpc_channel_element* /*elem*/,
+                                          grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
@@ -58,7 +59,7 @@ struct call_data {
 
 }  // namespace
 
-static void on_complete_for_send(void* arg, grpc_error_handle error) {
+static void on_complete_for_send(void* arg, absl::Status error) {
   call_data* calld = static_cast<call_data*>(arg);
   if (GRPC_ERROR_IS_NONE(error)) {
     calld->send_initial_metadata_succeeded = true;
@@ -67,7 +68,7 @@ static void on_complete_for_send(void* arg, grpc_error_handle error) {
                           GRPC_ERROR_REF(error));
 }
 
-static void recv_initial_metadata_ready(void* arg, grpc_error_handle error) {
+static void recv_initial_metadata_ready(void* arg, absl::Status error) {
   call_data* calld = static_cast<call_data*>(arg);
   if (GRPC_ERROR_IS_NONE(error)) {
     calld->recv_initial_metadata_succeeded = true;
@@ -77,8 +78,8 @@ static void recv_initial_metadata_ready(void* arg, grpc_error_handle error) {
                           GRPC_ERROR_REF(error));
 }
 
-static grpc_error_handle clr_init_call_elem(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+static absl::Status clr_init_call_elem(grpc_call_element* elem,
+                                       const grpc_call_element_args* args) {
   GPR_ASSERT(args->context != nullptr);
   new (elem->call_data) call_data();
   return GRPC_ERROR_NONE;

--- a/src/core/ext/filters/client_channel/lb_policy/oob_backend_metric.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/oob_backend_metric.cc
@@ -267,8 +267,7 @@ class OrcaProducer::OrcaStreamEventHandler
     }
 
    private:
-    static void NotifyWatchersInExecCtx(void* arg,
-                                        grpc_error_handle /*error*/) {
+    static void NotifyWatchersInExecCtx(void* arg, absl::Status /*error*/) {
       auto* self = static_cast<BackendMetricAllocator*>(arg);
       self->producer_->NotifyWatchers(self->backend_metric_data_);
       delete self;

--- a/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/priority/priority.cc
@@ -212,8 +212,8 @@ class PriorityLb : public LoadBalancingPolicy {
       void Orphan() override;
 
      private:
-      static void OnTimer(void* arg, grpc_error_handle error);
-      void OnTimerLocked(grpc_error_handle);
+      static void OnTimer(void* arg, absl::Status error);
+      void OnTimerLocked(absl::Status);
 
       RefCountedPtr<ChildPriority> child_priority_;
       grpc_timer timer_;
@@ -228,8 +228,8 @@ class PriorityLb : public LoadBalancingPolicy {
       void Orphan() override;
 
      private:
-      static void OnTimer(void* arg, grpc_error_handle error);
-      void OnTimerLocked(grpc_error_handle);
+      static void OnTimer(void* arg, absl::Status error);
+      void OnTimerLocked(absl::Status);
 
       RefCountedPtr<ChildPriority> child_priority_;
       grpc_timer timer_;
@@ -563,8 +563,8 @@ void PriorityLb::ChildPriority::DeactivationTimer::Orphan() {
   Unref();
 }
 
-void PriorityLb::ChildPriority::DeactivationTimer::OnTimer(
-    void* arg, grpc_error_handle error) {
+void PriorityLb::ChildPriority::DeactivationTimer::OnTimer(void* arg,
+                                                           absl::Status error) {
   auto* self = static_cast<DeactivationTimer*>(arg);
   (void)GRPC_ERROR_REF(error);  // ref owned by lambda
   self->child_priority_->priority_policy_->work_serializer()->Run(
@@ -572,7 +572,7 @@ void PriorityLb::ChildPriority::DeactivationTimer::OnTimer(
 }
 
 void PriorityLb::ChildPriority::DeactivationTimer::OnTimerLocked(
-    grpc_error_handle error) {
+    absl::Status error) {
   if (GRPC_ERROR_IS_NONE(error) && timer_pending_) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_priority_trace)) {
       gpr_log(GPR_INFO,
@@ -627,8 +627,8 @@ void PriorityLb::ChildPriority::FailoverTimer::Orphan() {
   Unref();
 }
 
-void PriorityLb::ChildPriority::FailoverTimer::OnTimer(
-    void* arg, grpc_error_handle error) {
+void PriorityLb::ChildPriority::FailoverTimer::OnTimer(void* arg,
+                                                       absl::Status error) {
   auto* self = static_cast<FailoverTimer*>(arg);
   (void)GRPC_ERROR_REF(error);  // ref owned by lambda
   self->child_priority_->priority_policy_->work_serializer()->Run(
@@ -636,7 +636,7 @@ void PriorityLb::ChildPriority::FailoverTimer::OnTimer(
 }
 
 void PriorityLb::ChildPriority::FailoverTimer::OnTimerLocked(
-    grpc_error_handle error) {
+    absl::Status error) {
   if (GRPC_ERROR_IS_NONE(error) && timer_pending_) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_priority_trace)) {
       gpr_log(GPR_INFO,

--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -292,7 +292,7 @@ class RingHash : public LoadBalancingPolicy {
       }
 
      private:
-      static void RunInExecCtx(void* arg, grpc_error_handle /*error*/) {
+      static void RunInExecCtx(void* arg, absl::Status /*error*/) {
         auto* self = static_cast<SubchannelConnectionAttempter*>(arg);
         self->ring_hash_lb()->work_serializer()->Run(
             [self]() {

--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -533,7 +533,7 @@ void CdsLb::OnClusterChanged(const std::string& name,
       gpr_log(GPR_INFO, "[cdslb %p] generated config for child policy: %s",
               this, json_str.c_str());
     }
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    absl::Status error = GRPC_ERROR_NONE;
     auto config =
         CoreConfiguration::Get().lb_policy_registry().ParseLoadBalancingConfig(
             json);

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -206,8 +206,8 @@ class XdsClusterManagerLb : public LoadBalancingPolicy {
     OrphanablePtr<LoadBalancingPolicy> CreateChildPolicyLocked(
         const ChannelArgs& args);
 
-    static void OnDelayedRemovalTimer(void* arg, grpc_error_handle error);
-    void OnDelayedRemovalTimerLocked(grpc_error_handle error);
+    static void OnDelayedRemovalTimer(void* arg, absl::Status error);
+    void OnDelayedRemovalTimerLocked(absl::Status error);
 
     // The owning LB policy.
     RefCountedPtr<XdsClusterManagerLb> xds_cluster_manager_policy_;
@@ -557,7 +557,7 @@ void XdsClusterManagerLb::ClusterChild::DeactivateLocked() {
 }
 
 void XdsClusterManagerLb::ClusterChild::OnDelayedRemovalTimer(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   ClusterChild* self = static_cast<ClusterChild*>(arg);
   (void)GRPC_ERROR_REF(error);  // Ref owned by the lambda
   self->xds_cluster_manager_policy_->work_serializer()->Run(
@@ -566,7 +566,7 @@ void XdsClusterManagerLb::ClusterChild::OnDelayedRemovalTimer(
 }
 
 void XdsClusterManagerLb::ClusterChild::OnDelayedRemovalTimerLocked(
-    grpc_error_handle error) {
+    absl::Status error) {
   delayed_removal_timer_callback_pending_ = false;
   if (GRPC_ERROR_IS_NONE(error) && !shutdown_) {
     xds_cluster_manager_policy_->children_.erase(name_);

--- a/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/iomgr/port.h"  // IWYU pragma: keep
 
 #ifdef GRPC_HAVE_UNIX_SOCKET
@@ -90,8 +92,8 @@ class BinderResolverFactory : public ResolverFactory {
   }
 
  private:
-  static grpc_error_handle BinderAddrPopulate(
-      absl::string_view path, grpc_resolved_address* resolved_addr) {
+  static absl::Status BinderAddrPopulate(absl::string_view path,
+                                         grpc_resolved_address* resolved_addr) {
     path = absl::StripPrefix(path, "/");
     if (path.empty()) {
       return GRPC_ERROR_CREATE_FROM_CPP_STRING("path is empty");
@@ -123,7 +125,7 @@ class BinderResolverFactory : public ResolverFactory {
         gpr_log(GPR_ERROR, "authority is not supported in binder scheme");
         return false;
       }
-      grpc_error_handle error = BinderAddrPopulate(uri.path(), &addr);
+      absl::Status error = BinderAddrPopulate(uri.path(), &addr);
       if (!GRPC_ERROR_IS_NONE(error)) {
         gpr_log(GPR_ERROR, "%s", grpc_error_std_string(error).c_str());
         GRPC_ERROR_UNREF(error);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
@@ -18,7 +18,6 @@
 
 #ifndef GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_RESOLVER_DNS_C_ARES_GRPC_ARES_EV_DRIVER_H
 #define GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_RESOLVER_DNS_C_ARES_GRPC_ARES_EV_DRIVER_H
-
 #include <grpc/support/port_platform.h>
 
 #include <memory>
@@ -26,11 +25,11 @@
 #include <ares.h>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 
 namespace grpc_core {
@@ -53,7 +52,7 @@ class GrpcPolledFd {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&grpc_ares_request::mu) = 0;
   /* Called once and only once. Must cause cancellation of any pending
    * read/write callbacks. */
-  virtual void ShutdownLocked(grpc_error_handle error)
+  virtual void ShutdownLocked(absl::Status error)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&grpc_ares_request::mu) = 0;
   /* Get the underlying ares_socket_t that this was created from */
   virtual ares_socket_t GetWrappedAresSocketLocked()

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -22,10 +22,10 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/iomgr/port.h"
 #if GRPC_ARES == 1 && defined(GRPC_POSIX_SOCKET_ARES_EV_DRIVER)
@@ -78,7 +78,7 @@ class GrpcPolledFdPosix : public GrpcPolledFd {
            bytes_available > 0;
   }
 
-  void ShutdownLocked(grpc_error_handle error)
+  void ShutdownLocked(absl::Status error)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&grpc_ares_request::mu) override {
     grpc_fd_shutdown(fd_, error);
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -130,12 +130,12 @@ class GrpcPolledFdWindows {
     grpc_winsocket_destroy(winsocket_);
   }
 
-  void ScheduleAndNullReadClosure(grpc_error_handle error) {
+  void ScheduleAndNullReadClosure(absl::Status error) {
     ExecCtx::Run(DEBUG_LOCATION, read_closure_, error);
     read_closure_ = nullptr;
   }
 
-  void ScheduleAndNullWriteClosure(grpc_error_handle error) {
+  void ScheduleAndNullWriteClosure(absl::Status error) {
     ExecCtx::Run(DEBUG_LOCATION, write_closure_, error);
     write_closure_ = nullptr;
   }
@@ -250,7 +250,7 @@ class GrpcPolledFdWindows {
 
   bool IsFdStillReadableLocked() { return read_buf_has_data_; }
 
-  void ShutdownLocked(grpc_error_handle error) {
+  void ShutdownLocked(absl::Status error) {
     grpc_winsocket_shutdown(winsocket_);
   }
 
@@ -417,14 +417,14 @@ class GrpcPolledFdWindows {
     abort();
   }
 
-  static void OnTcpConnect(void* arg, grpc_error_handle error) {
+  static void OnTcpConnect(void* arg, absl::Status error) {
     GrpcPolledFdWindows* grpc_polled_fd =
         static_cast<GrpcPolledFdWindows*>(arg);
     MutexLock lock(grpc_polled_fd->mu_);
     grpc_polled_fd->OnTcpConnectLocked(error);
   }
 
-  void OnTcpConnectLocked(grpc_error_handle error) {
+  void OnTcpConnectLocked(absl::Status error) {
     GRPC_CARES_TRACE_LOG(
         "fd:%s InnerOnTcpConnectLocked error:|%s| "
         "pending_register_for_readable:%d"
@@ -566,7 +566,7 @@ class GrpcPolledFdWindows {
     return out;
   }
 
-  static void OnIocpReadable(void* arg, grpc_error_handle error) {
+  static void OnIocpReadable(void* arg, absl::Status error) {
     GrpcPolledFdWindows* polled_fd = static_cast<GrpcPolledFdWindows*>(arg);
     (void)GRPC_ERROR_REF(error);
     MutexLock lock(polled_fd->mu_);
@@ -578,7 +578,7 @@ class GrpcPolledFdWindows {
   // c-ares reads from this socket later, but it shouldn't necessarily cancel
   // the entire resolution attempt. Doing so will allow the "inject broken
   // nameserver list" test to pass on Windows.
-  void OnIocpReadableLocked(grpc_error_handle error) {
+  void OnIocpReadableLocked(absl::Status error) {
     if (GRPC_ERROR_IS_NONE(error)) {
       if (winsocket_->read_info.wsa_error != 0) {
         /* WSAEMSGSIZE would be due to receiving more data
@@ -610,14 +610,14 @@ class GrpcPolledFdWindows {
     ScheduleAndNullReadClosure(error);
   }
 
-  static void OnIocpWriteable(void* arg, grpc_error_handle error) {
+  static void OnIocpWriteable(void* arg, absl::Status error) {
     GrpcPolledFdWindows* polled_fd = static_cast<GrpcPolledFdWindows*>(arg);
     (void)GRPC_ERROR_REF(error);
     MutexLock lock(polled_fd->mu_);
     polled_fd->OnIocpWriteableLocked(error);
   }
 
-  void OnIocpWriteableLocked(grpc_error_handle error) {
+  void OnIocpWriteableLocked(absl::Status error) {
     GRPC_CARES_TRACE_LOG("OnIocpWriteableInner. fd:|%s|", GetName());
     GPR_ASSERT(socket_type_ == SOCK_STREAM);
     if (GRPC_ERROR_IS_NONE(error)) {
@@ -838,7 +838,7 @@ class GrpcPolledFdWindowsWrapper : public GrpcPolledFd {
     return wrapped_->IsFdStillReadableLocked();
   }
 
-  void ShutdownLocked(grpc_error_handle error) override {
+  void ShutdownLocked(absl::Status error) override {
     wrapped_->ShutdownLocked(error);
   }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -28,6 +28,7 @@
 #include <ares.h>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 
 #include <grpc/support/log.h>
 
@@ -75,7 +76,7 @@ struct grpc_ares_request {
   /** number of ongoing queries */
   size_t pending_queries ABSL_GUARDED_BY(mu) = 0;
   /** the errors explaining query failures, appended to in query callbacks */
-  grpc_error_handle error ABSL_GUARDED_BY(mu) = GRPC_ERROR_NONE;
+  absl::Status error ABSL_GUARDED_BY(mu) = GRPC_ERROR_NONE;
 };
 
 /* Asynchronously resolve \a name (A/AAAA records only).
@@ -115,7 +116,7 @@ extern void (*grpc_cancel_ares_request)(grpc_ares_request* request);
 
 /* Initialize gRPC ares wrapper. Must be called at least once before
    grpc_resolve_address_ares(). */
-grpc_error_handle grpc_ares_init(void);
+absl::Status grpc_ares_init(void);
 
 /* Uninitialized gRPC ares wrapper. If there was more than one previous call to
    grpc_ares_init(), this function uninitializes the gRPC ares wrapper only if

--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -86,12 +86,12 @@ class GoogleCloud2ProdResolver : public Resolver {
     void Orphan() override;
 
    private:
-    static void OnHttpRequestDone(void* arg, grpc_error_handle error);
+    static void OnHttpRequestDone(void* arg, absl::Status error);
 
     // If error is not GRPC_ERROR_NONE, then it's not safe to look at response.
     virtual void OnDone(GoogleCloud2ProdResolver* resolver,
                         const grpc_http_response* response,
-                        grpc_error_handle error) = 0;
+                        absl::Status error) = 0;
 
     RefCountedPtr<GoogleCloud2ProdResolver> resolver_;
     OrphanablePtr<HttpRequest> http_request_;
@@ -108,7 +108,7 @@ class GoogleCloud2ProdResolver : public Resolver {
    private:
     void OnDone(GoogleCloud2ProdResolver* resolver,
                 const grpc_http_response* response,
-                grpc_error_handle error) override;
+                absl::Status error) override;
   };
 
   // A metadata server query to get the IPv6 address.
@@ -120,7 +120,7 @@ class GoogleCloud2ProdResolver : public Resolver {
    private:
     void OnDone(GoogleCloud2ProdResolver* resolver,
                 const grpc_http_response* response,
-                grpc_error_handle error) override;
+                absl::Status error) override;
   };
 
   void ZoneQueryDone(std::string zone);
@@ -185,7 +185,7 @@ void GoogleCloud2ProdResolver::MetadataQuery::Orphan() {
 }
 
 void GoogleCloud2ProdResolver::MetadataQuery::OnHttpRequestDone(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   auto* self = static_cast<MetadataQuery*>(arg);
   // Hop back into WorkSerializer to call OnDone().
   // Note: We implicitly pass our ref to the callback here.
@@ -210,7 +210,7 @@ GoogleCloud2ProdResolver::ZoneQuery::ZoneQuery(
 
 void GoogleCloud2ProdResolver::ZoneQuery::OnDone(
     GoogleCloud2ProdResolver* resolver, const grpc_http_response* response,
-    grpc_error_handle error) {
+    absl::Status error) {
   absl::StatusOr<std::string> zone;
   if (!GRPC_ERROR_IS_NONE(error)) {
     zone = absl::UnknownError(
@@ -252,7 +252,7 @@ GoogleCloud2ProdResolver::IPv6Query::IPv6Query(
 
 void GoogleCloud2ProdResolver::IPv6Query::OnDone(
     GoogleCloud2ProdResolver* resolver, const grpc_http_response* response,
-    grpc_error_handle error) {
+    absl::Status error) {
   if (!GRPC_ERROR_IS_NONE(error)) {
     gpr_log(GPR_ERROR, "error fetching IPv6 address from metadata server: %s",
             grpc_error_std_string(error).c_str());

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.cc
@@ -37,6 +37,7 @@
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/work_serializer.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/service_config/service_config.h"
@@ -104,14 +105,14 @@ void PollingResolver::ShutdownLocked() {
   request_.reset();
 }
 
-void PollingResolver::OnNextResolution(void* arg, grpc_error_handle error) {
+void PollingResolver::OnNextResolution(void* arg, absl::Status error) {
   auto* self = static_cast<PollingResolver*>(arg);
   (void)GRPC_ERROR_REF(error);  // ref owned by lambda
   self->work_serializer_->Run(
       [self, error]() { self->OnNextResolutionLocked(error); }, DEBUG_LOCATION);
 }
 
-void PollingResolver::OnNextResolutionLocked(grpc_error_handle error) {
+void PollingResolver::OnNextResolutionLocked(absl::Status error) {
   if (GPR_UNLIKELY(tracer_ != nullptr && tracer_->enabled())) {
     gpr_log(GPR_INFO,
             "[polling resolver %p] re-resolution timer fired: error=\"%s\", "

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -32,7 +32,6 @@
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/gprpp/work_serializer.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/resolver/resolver.h"
@@ -80,8 +79,8 @@ class PollingResolver : public Resolver {
 
   void GetResultStatus(absl::Status status);
 
-  static void OnNextResolution(void* arg, grpc_error_handle error);
-  void OnNextResolutionLocked(grpc_error_handle error);
+  static void OnNextResolution(void* arg, absl::Status error);
+  void OnNextResolutionLocked(absl::Status error);
 
   /// authority
   std::string authority_;

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -793,7 +793,7 @@ ConfigSelector::CallConfig XdsResolver::XdsConfigSelector::GetCallConfig(
 //
 
 void XdsResolver::StartLocked() {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto xds_client = GrpcXdsClient::GetOrCreate(args_, "xds resolver");
   if (!xds_client.ok()) {
     gpr_log(GPR_ERROR,

--- a/src/core/ext/filters/client_channel/retry_service_config.cc
+++ b/src/core/ext/filters/client_channel/retry_service_config.cc
@@ -61,14 +61,13 @@ void RetryServiceConfigParser::Register(CoreConfiguration::Builder* builder) {
 
 namespace {
 
-grpc_error_handle ParseRetryThrottling(const Json& json,
-                                       intptr_t* max_milli_tokens,
-                                       intptr_t* milli_token_ratio) {
+absl::Status ParseRetryThrottling(const Json& json, intptr_t* max_milli_tokens,
+                                  intptr_t* milli_token_ratio) {
   if (json.type() != Json::Type::OBJECT) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "field:retryThrottling error:Type should be object");
   }
-  std::vector<grpc_error_handle> error_list;
+  std::vector<absl::Status> error_list;
   // Parse maxTokens.
   auto it = json.object_value().find("maxTokens");
   if (it == json.object_value().end()) {
@@ -148,7 +147,7 @@ RetryServiceConfigParser::ParseGlobalParams(const ChannelArgs& /*args*/,
   if (it == json.object_value().end()) return nullptr;
   intptr_t max_milli_tokens = 0;
   intptr_t milli_token_ratio = 0;
-  grpc_error_handle error =
+  absl::Status error =
       ParseRetryThrottling(it->second, &max_milli_tokens, &milli_token_ratio);
   if (!GRPC_ERROR_IS_NONE(error)) {
     absl::Status status = absl::InvalidArgumentError(
@@ -163,7 +162,7 @@ RetryServiceConfigParser::ParseGlobalParams(const ChannelArgs& /*args*/,
 
 namespace {
 
-grpc_error_handle ParseRetryPolicy(
+absl::Status ParseRetryPolicy(
     const ChannelArgs& args, const Json& json, int* max_attempts,
     Duration* initial_backoff, Duration* max_backoff, float* backoff_multiplier,
     StatusCodeSet* retryable_status_codes,
@@ -172,7 +171,7 @@ grpc_error_handle ParseRetryPolicy(
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "field:retryPolicy error:should be of type object");
   }
-  std::vector<grpc_error_handle> error_list;
+  std::vector<absl::Status> error_list;
   // Parse maxAttempts.
   auto it = json.object_value().find("maxAttempts");
   if (it == json.object_value().end()) {
@@ -305,7 +304,7 @@ RetryServiceConfigParser::ParsePerMethodParams(const ChannelArgs& args,
   float backoff_multiplier = 0;
   StatusCodeSet retryable_status_codes;
   absl::optional<Duration> per_attempt_recv_timeout;
-  grpc_error_handle error = ParseRetryPolicy(
+  absl::Status error = ParseRetryPolicy(
       args, it->second, &max_attempts, &initial_backoff, &max_backoff,
       &backoff_multiplier, &retryable_status_codes, &per_attempt_recv_timeout);
   if (!GRPC_ERROR_IS_NONE(error)) {

--- a/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
+++ b/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
@@ -102,7 +102,7 @@ class ServiceConfigChannelArgCallData {
   ServiceConfigCallData service_config_call_data_;
 };
 
-grpc_error_handle ServiceConfigChannelArgInitCallElem(
+absl::Status ServiceConfigChannelArgInitCallElem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   auto* chand =
       static_cast<ServiceConfigChannelArgChannelData*>(elem->channel_data);
@@ -125,7 +125,7 @@ void ServiceConfigChannelArgDestroyCallElem(
   calld->~ServiceConfigChannelArgCallData();
 }
 
-grpc_error_handle ServiceConfigChannelArgInitChannelElem(
+absl::Status ServiceConfigChannelArgInitChannelElem(
     grpc_channel_element* elem, grpc_channel_element_args* args) {
   ServiceConfigChannelArgChannelData* chand =
       static_cast<ServiceConfigChannelArgChannelData*>(elem->channel_data);

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -51,7 +51,6 @@
 #include "src/core/lib/gprpp/unique_type_name.h"
 #include "src/core/lib/iomgr/call_combiner.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/iomgr/resolved_address.h"
@@ -106,8 +105,7 @@ class SubchannelCall {
     grpc_call_context_element* context;
     CallCombiner* call_combiner;
   };
-  static RefCountedPtr<SubchannelCall> Create(Args args,
-                                              grpc_error_handle* error);
+  static RefCountedPtr<SubchannelCall> Create(Args args, absl::Status* error);
 
   // Continues processing a transport stream op batch.
   void StartTransportStreamOpBatch(grpc_transport_stream_op_batch* batch);
@@ -133,20 +131,20 @@ class SubchannelCall {
   template <typename T>
   friend class RefCountedPtr;
 
-  SubchannelCall(Args args, grpc_error_handle* error);
+  SubchannelCall(Args args, absl::Status* error);
 
   // If channelz is enabled, intercepts recv_trailing so that we may check the
   // status and associate it to a subchannel.
   void MaybeInterceptRecvTrailingMetadata(
       grpc_transport_stream_op_batch* batch);
 
-  static void RecvTrailingMetadataReady(void* arg, grpc_error_handle error);
+  static void RecvTrailingMetadataReady(void* arg, absl::Status error);
 
   // Interface of RefCounted<>.
   void IncrementRefCount();
   void IncrementRefCount(const DebugLocation& location, const char* reason);
 
-  static void Destroy(void* arg, grpc_error_handle error);
+  static void Destroy(void* arg, absl::Status error);
 
   RefCountedPtr<ConnectedSubchannel> connected_subchannel_;
   grpc_closure* after_call_stack_destroy_ = nullptr;
@@ -367,9 +365,9 @@ class Subchannel : public DualRefCounted<Subchannel> {
   void OnRetryTimer() ABSL_LOCKS_EXCLUDED(mu_);
   void OnRetryTimerLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
   void StartConnectingLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  static void OnConnectingFinished(void* arg, grpc_error_handle error)
+  static void OnConnectingFinished(void* arg, absl::Status error)
       ABSL_LOCKS_EXCLUDED(mu_);
-  void OnConnectingFinishedLocked(grpc_error_handle error)
+  void OnConnectingFinishedLocked(absl::Status error)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
   bool PublishTransportLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 

--- a/src/core/ext/filters/client_channel/subchannel_stream_client.h
+++ b/src/core/ext/filters/client_channel/subchannel_stream_client.h
@@ -39,7 +39,6 @@
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/call_combiner.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/iomgr/timer.h"
@@ -127,21 +126,21 @@ class SubchannelStreamClient
     void Cancel();
 
     void StartBatch(grpc_transport_stream_op_batch* batch);
-    static void StartBatchInCallCombiner(void* arg, grpc_error_handle error);
+    static void StartBatchInCallCombiner(void* arg, absl::Status error);
 
     void CallEndedLocked(bool retry)
         ABSL_EXCLUSIVE_LOCKS_REQUIRED(&subchannel_stream_client_->mu_);
 
     void RecvMessageReady();
 
-    static void OnComplete(void* arg, grpc_error_handle error);
-    static void RecvInitialMetadataReady(void* arg, grpc_error_handle error);
-    static void RecvMessageReady(void* arg, grpc_error_handle error);
-    static void RecvTrailingMetadataReady(void* arg, grpc_error_handle error);
-    static void StartCancel(void* arg, grpc_error_handle error);
-    static void OnCancelComplete(void* arg, grpc_error_handle error);
+    static void OnComplete(void* arg, absl::Status error);
+    static void RecvInitialMetadataReady(void* arg, absl::Status error);
+    static void RecvMessageReady(void* arg, absl::Status error);
+    static void RecvTrailingMetadataReady(void* arg, absl::Status error);
+    static void StartCancel(void* arg, absl::Status error);
+    static void OnCancelComplete(void* arg, absl::Status error);
 
-    static void AfterCallStackDestruction(void* arg, grpc_error_handle error);
+    static void AfterCallStackDestruction(void* arg, absl::Status error);
 
     RefCountedPtr<SubchannelStreamClient> subchannel_stream_client_;
     grpc_polling_entity pollent_;
@@ -196,7 +195,7 @@ class SubchannelStreamClient
   void StartCallLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu_);
 
   void StartRetryTimerLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu_);
-  static void OnRetryTimer(void* arg, grpc_error_handle error);
+  static void OnRetryTimer(void* arg, absl::Status error);
 
   RefCountedPtr<ConnectedSubchannel> connected_subchannel_;
   grpc_pollset_set* interested_parties_;  // Do not own.

--- a/src/core/ext/filters/deadline/deadline_filter.cc
+++ b/src/core/ext/filters/deadline/deadline_filter.cc
@@ -57,7 +57,7 @@ class TimerState {
  private:
   // The on_complete callback used when sending a cancel_error batch down the
   // filter stack.  Yields the call combiner when the batch returns.
-  static void YieldCallCombiner(void* arg, grpc_error_handle /*ignored*/) {
+  static void YieldCallCombiner(void* arg, absl::Status /*ignored*/) {
     TimerState* self = static_cast<TimerState*>(arg);
     grpc_deadline_state* deadline_state =
         static_cast<grpc_deadline_state*>(self->elem_->call_data);
@@ -68,7 +68,7 @@ class TimerState {
 
   // This is called via the call combiner, so access to deadline_state is
   // synchronized.
-  static void SendCancelOpInCallCombiner(void* arg, grpc_error_handle error) {
+  static void SendCancelOpInCallCombiner(void* arg, absl::Status error) {
     TimerState* self = static_cast<TimerState*>(arg);
     grpc_transport_stream_op_batch* batch = grpc_make_transport_stream_op(
         GRPC_CLOSURE_INIT(&self->closure_, YieldCallCombiner, self, nullptr));
@@ -78,7 +78,7 @@ class TimerState {
   }
 
   // Timer callback.
-  static void TimerCallback(void* arg, grpc_error_handle error) {
+  static void TimerCallback(void* arg, absl::Status error) {
     TimerState* self = static_cast<TimerState*>(arg);
     grpc_deadline_state* deadline_state =
         static_cast<grpc_deadline_state*>(self->elem_->call_data);
@@ -139,7 +139,7 @@ static void cancel_timer_if_needed(grpc_deadline_state* deadline_state) {
 }
 
 // Callback run when we receive trailing metadata.
-static void recv_trailing_metadata_ready(void* arg, grpc_error_handle error) {
+static void recv_trailing_metadata_ready(void* arg, absl::Status error) {
   grpc_deadline_state* deadline_state = static_cast<grpc_deadline_state*>(arg);
   cancel_timer_if_needed(deadline_state);
   // Invoke the original callback.
@@ -173,7 +173,7 @@ struct start_timer_after_init_state {
   grpc_core::Timestamp deadline;
   grpc_closure closure;
 };
-static void start_timer_after_init(void* arg, grpc_error_handle error) {
+static void start_timer_after_init(void* arg, absl::Status error) {
   struct start_timer_after_init_state* state =
       static_cast<struct start_timer_after_init_state*>(arg);
   grpc_deadline_state* deadline_state =
@@ -246,7 +246,7 @@ void grpc_deadline_state_client_start_transport_stream_op_batch(
 //
 
 // Constructor for channel_data.  Used for both client and server filters.
-static grpc_error_handle deadline_init_channel_elem(
+static absl::Status deadline_init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* args) {
   GPR_ASSERT(!args->is_last);
   return GRPC_ERROR_NONE;
@@ -273,7 +273,7 @@ typedef struct server_call_data {
 } server_call_data;
 
 // Constructor for call_data.  Used for both client and server filters.
-static grpc_error_handle deadline_init_call_elem(
+static absl::Status deadline_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   new (elem->call_data) grpc_deadline_state(elem, *args, args->deadline);
   return GRPC_ERROR_NONE;
@@ -297,7 +297,7 @@ static void deadline_client_start_transport_stream_op_batch(
 }
 
 // Callback for receiving initial metadata on the server.
-static void recv_initial_metadata_ready(void* arg, grpc_error_handle error) {
+static void recv_initial_metadata_ready(void* arg, absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(arg);
   server_call_data* calld = static_cast<server_call_data*>(elem->call_data);
   start_timer_if_needed(

--- a/src/core/ext/filters/fault_injection/service_config_parser.cc
+++ b/src/core/ext/filters/fault_injection/service_config_parser.cc
@@ -38,12 +38,12 @@ namespace {
 
 std::vector<FaultInjectionMethodParsedConfig::FaultInjectionPolicy>
 ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
-                          std::vector<grpc_error_handle>* error_list) {
+                          std::vector<absl::Status>* error_list) {
   std::vector<FaultInjectionMethodParsedConfig::FaultInjectionPolicy> policies;
   for (size_t i = 0; i < policies_json_array.size(); i++) {
     FaultInjectionMethodParsedConfig::FaultInjectionPolicy
         fault_injection_policy;
-    std::vector<grpc_error_handle> sub_error_list;
+    std::vector<absl::Status> sub_error_list;
     if (policies_json_array[i].type() != Json::Type::OBJECT) {
       error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
           "faultInjectionPolicy index ", i, " is not a JSON object")));
@@ -152,7 +152,7 @@ FaultInjectionServiceConfigParser::ParsePerMethodParams(const ChannelArgs& args,
   // Parse fault injection policy from given Json
   std::vector<FaultInjectionMethodParsedConfig::FaultInjectionPolicy>
       fault_injection_policies;
-  std::vector<grpc_error_handle> error_list;
+  std::vector<absl::Status> error_list;
   const Json::Array* policies_json_array;
   if (ParseJsonObjectField(json.object_value(), "faultInjectionPolicy",
                            &policies_json_array, &error_list)) {
@@ -160,7 +160,7 @@ FaultInjectionServiceConfigParser::ParsePerMethodParams(const ChannelArgs& args,
         ParseFaultInjectionPolicy(*policies_json_array, &error_list);
   }
   if (!error_list.empty()) {
-    grpc_error_handle error =
+    absl::Status error =
         GRPC_ERROR_CREATE_FROM_VECTOR("Fault injection parser", &error_list);
     absl::Status status = absl::InvalidArgumentError(
         absl::StrCat("error parsing fault injection method parameters: ",

--- a/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
@@ -25,6 +25,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/optional.h"
@@ -95,20 +96,20 @@ class CallData {
       grpc_call_element* elem, grpc_transport_stream_op_batch* batch);
 
  private:
-  static void OnRecvInitialMetadataReady(void* arg, grpc_error_handle error);
+  static void OnRecvInitialMetadataReady(void* arg, absl::Status error);
 
   // Methods for processing a receive message event
   void MaybeResumeOnRecvMessageReady();
-  static void OnRecvMessageReady(void* arg, grpc_error_handle error);
-  void ContinueRecvMessageReadyCallback(grpc_error_handle error);
+  static void OnRecvMessageReady(void* arg, absl::Status error);
+  void ContinueRecvMessageReadyCallback(absl::Status error);
 
   // Methods for processing a recv_trailing_metadata event
   void MaybeResumeOnRecvTrailingMetadataReady();
-  static void OnRecvTrailingMetadataReady(void* arg, grpc_error_handle error);
+  static void OnRecvTrailingMetadataReady(void* arg, absl::Status error);
 
   CallCombiner* call_combiner_;
   // Overall error for the call
-  grpc_error_handle error_ = GRPC_ERROR_NONE;
+  absl::Status error_ = GRPC_ERROR_NONE;
   // Fields for handling recv_initial_metadata_ready callback
   grpc_closure on_recv_initial_metadata_ready_;
   grpc_closure* original_recv_initial_metadata_ready_ = nullptr;
@@ -125,10 +126,10 @@ class CallData {
   bool seen_recv_trailing_metadata_ready_ = false;
   grpc_closure on_recv_trailing_metadata_ready_;
   grpc_closure* original_recv_trailing_metadata_ready_ = nullptr;
-  grpc_error_handle on_recv_trailing_metadata_ready_error_ = GRPC_ERROR_NONE;
+  absl::Status on_recv_trailing_metadata_ready_error_ = GRPC_ERROR_NONE;
 };
 
-void CallData::OnRecvInitialMetadataReady(void* arg, grpc_error_handle error) {
+void CallData::OnRecvInitialMetadataReady(void* arg, absl::Status error) {
   CallData* calld = static_cast<CallData*>(arg);
   if (GRPC_ERROR_IS_NONE(error)) {
     calld->algorithm_ =
@@ -151,7 +152,7 @@ void CallData::MaybeResumeOnRecvMessageReady() {
   }
 }
 
-void CallData::OnRecvMessageReady(void* arg, grpc_error_handle error) {
+void CallData::OnRecvMessageReady(void* arg, absl::Status error) {
   CallData* calld = static_cast<CallData*>(arg);
   if (GRPC_ERROR_IS_NONE(error)) {
     if (calld->original_recv_initial_metadata_ready_ != nullptr) {
@@ -204,7 +205,7 @@ void CallData::OnRecvMessageReady(void* arg, grpc_error_handle error) {
   calld->ContinueRecvMessageReadyCallback(GRPC_ERROR_REF(error));
 }
 
-void CallData::ContinueRecvMessageReadyCallback(grpc_error_handle error) {
+void CallData::ContinueRecvMessageReadyCallback(absl::Status error) {
   MaybeResumeOnRecvTrailingMetadataReady();
   // The surface will clean up the receiving stream if there is an error.
   grpc_closure* closure = original_recv_message_ready_;
@@ -215,14 +216,14 @@ void CallData::ContinueRecvMessageReadyCallback(grpc_error_handle error) {
 void CallData::MaybeResumeOnRecvTrailingMetadataReady() {
   if (seen_recv_trailing_metadata_ready_) {
     seen_recv_trailing_metadata_ready_ = false;
-    grpc_error_handle error = on_recv_trailing_metadata_ready_error_;
+    absl::Status error = on_recv_trailing_metadata_ready_error_;
     on_recv_trailing_metadata_ready_error_ = GRPC_ERROR_NONE;
     GRPC_CALL_COMBINER_START(call_combiner_, &on_recv_trailing_metadata_ready_,
                              error, "Continuing OnRecvTrailingMetadataReady");
   }
 }
 
-void CallData::OnRecvTrailingMetadataReady(void* arg, grpc_error_handle error) {
+void CallData::OnRecvTrailingMetadataReady(void* arg, absl::Status error) {
   CallData* calld = static_cast<CallData*>(arg);
   if (calld->original_recv_initial_metadata_ready_ != nullptr ||
       calld->original_recv_message_ready_ != nullptr) {
@@ -277,8 +278,8 @@ void DecompressStartTransportStreamOpBatch(
   calld->DecompressStartTransportStreamOpBatch(elem, batch);
 }
 
-grpc_error_handle DecompressInitCallElem(grpc_call_element* elem,
-                                         const grpc_call_element_args* args) {
+absl::Status DecompressInitCallElem(grpc_call_element* elem,
+                                    const grpc_call_element_args* args) {
   ChannelData* chand = static_cast<ChannelData*>(elem->channel_data);
   new (elem->call_data) CallData(*args, chand);
   return GRPC_ERROR_NONE;
@@ -291,8 +292,8 @@ void DecompressDestroyCallElem(grpc_call_element* elem,
   calld->~CallData();
 }
 
-grpc_error_handle DecompressInitChannelElem(grpc_channel_element* elem,
-                                            grpc_channel_element_args* args) {
+absl::Status DecompressInitChannelElem(grpc_channel_element* elem,
+                                       grpc_channel_element_args* args) {
   ChannelData* chand = static_cast<ChannelData*>(elem->channel_data);
   new (chand) ChannelData(args);
   return GRPC_ERROR_NONE;

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -50,9 +50,8 @@
 #include "src/core/lib/surface/channel_stack_type.h"
 #include "src/core/lib/transport/transport.h"
 
-static void recv_message_ready(void* user_data, grpc_error_handle error);
-static void recv_trailing_metadata_ready(void* user_data,
-                                         grpc_error_handle error);
+static void recv_message_ready(void* user_data, absl::Status error);
+static void recv_trailing_metadata_ready(void* user_data, absl::Status error);
 
 namespace grpc_core {
 
@@ -78,7 +77,7 @@ const MessageSizeParsedConfig* MessageSizeParsedConfig::GetFromCallContext(
 absl::StatusOr<std::unique_ptr<ServiceConfigParser::ParsedConfig>>
 MessageSizeParser::ParsePerMethodParams(const ChannelArgs& /*args*/,
                                         const Json& json) {
-  std::vector<grpc_error_handle> error_list;
+  std::vector<absl::Status> error_list;
   // Max request size.
   int max_request_message_bytes = -1;
   auto it = json.object_value().find("maxRequestMessageBytes");
@@ -114,7 +113,7 @@ MessageSizeParser::ParsePerMethodParams(const ChannelArgs& /*args*/,
     }
   }
   if (!error_list.empty()) {
-    grpc_error_handle error =
+    absl::Status error =
         GRPC_ERROR_CREATE_FROM_VECTOR("Message size parser", &error_list);
     absl::Status status = absl::InvalidArgumentError(
         absl::StrCat("error parsing message size method parameters: ",
@@ -197,7 +196,7 @@ struct call_data {
   grpc_closure recv_message_ready;
   grpc_closure recv_trailing_metadata_ready;
   // The error caused by a message that is too large, or GRPC_ERROR_NONE
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   // Used by recv_message_ready.
   absl::optional<grpc_core::SliceBuffer>* recv_message = nullptr;
   // Original recv_message_ready callback, invoked after our own.
@@ -205,20 +204,20 @@ struct call_data {
   // Original recv_trailing_metadata callback, invoked after our own.
   grpc_closure* original_recv_trailing_metadata_ready;
   bool seen_recv_trailing_metadata = false;
-  grpc_error_handle recv_trailing_metadata_error;
+  absl::Status recv_trailing_metadata_error;
 };
 
 }  // namespace
 
 // Callback invoked when we receive a message.  Here we check the max
 // receive message size.
-static void recv_message_ready(void* user_data, grpc_error_handle error) {
+static void recv_message_ready(void* user_data, absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(user_data);
   call_data* calld = static_cast<call_data*>(elem->call_data);
   if (calld->recv_message->has_value() && calld->limits.max_recv_size >= 0 &&
       (*calld->recv_message)->Length() >
           static_cast<size_t>(calld->limits.max_recv_size)) {
-    grpc_error_handle new_error = grpc_error_set_int(
+    absl::Status new_error = grpc_error_set_int(
         GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
             "Received message larger than max (%u vs. %d)",
             (*calld->recv_message)->Length(), calld->limits.max_recv_size)),
@@ -249,8 +248,7 @@ static void recv_message_ready(void* user_data, grpc_error_handle error) {
 
 // Callback invoked on completion of recv_trailing_metadata
 // Notifies the recv_trailing_metadata batch of any message size failures
-static void recv_trailing_metadata_ready(void* user_data,
-                                         grpc_error_handle error) {
+static void recv_trailing_metadata_ready(void* user_data, absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(user_data);
   call_data* calld = static_cast<call_data*>(elem->call_data);
   if (calld->next_recv_message_ready != nullptr) {
@@ -306,7 +304,7 @@ static void message_size_start_transport_stream_op_batch(
 }
 
 // Constructor for call_data.
-static grpc_error_handle message_size_init_call_elem(
+static absl::Status message_size_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   new (elem->call_data) call_data(elem, *chand, *args);
@@ -330,7 +328,7 @@ grpc_core::MessageSizeParsedConfig::message_size_limits get_message_size_limits(
 }
 
 // Constructor for channel_data.
-static grpc_error_handle message_size_init_channel_elem(
+static absl::Status message_size_init_channel_elem(
     grpc_channel_element* elem, grpc_channel_element_args* args) {
   GPR_ASSERT(!args->is_last);
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -28,6 +28,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/authorization/authorization_engine.h"
 #include "src/core/lib/security/authorization/grpc_authorization_engine.h"
 #include "src/core/lib/security/context/security_context.h"
@@ -42,8 +43,8 @@ namespace grpc_core {
 
 // CallData
 
-grpc_error_handle RbacFilter::CallData::Init(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+absl::Status RbacFilter::CallData::Init(grpc_call_element* elem,
+                                        const grpc_call_element_args* args) {
   new (elem->call_data) CallData(elem, *args);
   return GRPC_ERROR_NONE;
 }
@@ -78,7 +79,7 @@ RbacFilter::CallData::CallData(grpc_call_element* elem,
 }
 
 void RbacFilter::CallData::RecvInitialMetadataReady(void* user_data,
-                                                    grpc_error_handle error) {
+                                                    absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(user_data);
   CallData* calld = static_cast<CallData*>(elem->call_data);
   RbacFilter* filter = static_cast<RbacFilter*>(elem->channel_data);
@@ -141,8 +142,8 @@ RbacFilter::RbacFilter(size_t index,
       service_config_parser_index_(RbacServiceConfigParser::ParserIndex()),
       per_channel_evaluate_args_(std::move(per_channel_evaluate_args)) {}
 
-grpc_error_handle RbacFilter::Init(grpc_channel_element* elem,
-                                   grpc_channel_element_args* args) {
+absl::Status RbacFilter::Init(grpc_channel_element* elem,
+                              grpc_channel_element_args* args) {
   GPR_ASSERT(elem->filter == &kFilterVtable);
   auto* auth_context = grpc_find_auth_context_in_args(args->channel_args);
   if (auth_context == nullptr) {

--- a/src/core/ext/filters/rbac/rbac_filter.h
+++ b/src/core/ext/filters/rbac/rbac_filter.h
@@ -21,11 +21,12 @@
 
 #include <stddef.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/context.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/authorization/evaluate_args.h"
 #include "src/core/lib/transport/metadata_batch.h"
 #include "src/core/lib/transport/transport.h"
@@ -45,8 +46,8 @@ class RbacFilter {
  private:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* args);
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* args);
     static void Destroy(grpc_call_element* elem,
                         const grpc_call_final_info* /* final_info */,
                         grpc_closure* /* then_schedule_closure */);
@@ -55,8 +56,7 @@ class RbacFilter {
 
    private:
     CallData(grpc_call_element* elem, const grpc_call_element_args& args);
-    static void RecvInitialMetadataReady(void* user_data,
-                                         grpc_error_handle error);
+    static void RecvInitialMetadataReady(void* user_data, absl::Status error);
 
     grpc_call_context_element* call_context_;
     // State for keeping track of recv_initial_metadata
@@ -67,8 +67,8 @@ class RbacFilter {
 
   RbacFilter(size_t index,
              EvaluateArgs::PerChannelArgs per_channel_evaluate_args);
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* args);
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* args);
   static void Destroy(grpc_channel_element* elem);
 
   // The index of this filter instance among instances of the same filter.

--- a/src/core/ext/filters/rbac/rbac_service_config_parser.cc
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.cc
@@ -41,7 +41,7 @@ namespace grpc_core {
 namespace {
 
 std::string ParseRegexMatcher(const Json::Object& regex_matcher_json,
-                              std::vector<grpc_error_handle>* error_list) {
+                              std::vector<absl::Status>* error_list) {
   std::string regex;
   ParseJsonObjectField(regex_matcher_json, "regex", &regex, error_list);
   return regex;
@@ -49,7 +49,7 @@ std::string ParseRegexMatcher(const Json::Object& regex_matcher_json,
 
 absl::StatusOr<HeaderMatcher> ParseHeaderMatcher(
     const Json::Object& header_matcher_json,
-    std::vector<grpc_error_handle>* error_list) {
+    std::vector<absl::Status>* error_list) {
   std::string name;
   ParseJsonObjectField(header_matcher_json, "name", &name, error_list);
   std::string match;
@@ -68,7 +68,7 @@ absl::StatusOr<HeaderMatcher> ParseHeaderMatcher(
                                   &inner_json, error_list,
                                   /*required=*/false)) {
     type = HeaderMatcher::Type::kSafeRegex;
-    std::vector<grpc_error_handle> safe_regex_matcher_error_list;
+    std::vector<absl::Status> safe_regex_matcher_error_list;
     match = ParseRegexMatcher(*inner_json, &safe_regex_matcher_error_list);
     if (!safe_regex_matcher_error_list.empty()) {
       error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
@@ -78,7 +78,7 @@ absl::StatusOr<HeaderMatcher> ParseHeaderMatcher(
                                   &inner_json, error_list,
                                   /*required=*/false)) {
     type = HeaderMatcher::Type::kRange;
-    std::vector<grpc_error_handle> range_error_list;
+    std::vector<absl::Status> range_error_list;
     ParseJsonObjectField(*inner_json, "start", &start, &range_error_list);
     ParseJsonObjectField(*inner_json, "end", &end, &range_error_list);
     if (!range_error_list.empty()) {
@@ -107,7 +107,7 @@ absl::StatusOr<HeaderMatcher> ParseHeaderMatcher(
 
 absl::StatusOr<StringMatcher> ParseStringMatcher(
     const Json::Object& string_matcher_json,
-    std::vector<grpc_error_handle>* error_list) {
+    std::vector<absl::Status>* error_list) {
   std::string match;
   StringMatcher::Type type = StringMatcher::Type();
   const Json::Object* inner_json;
@@ -126,7 +126,7 @@ absl::StatusOr<StringMatcher> ParseStringMatcher(
   } else if (ParseJsonObjectField(string_matcher_json, "safeRegex", &inner_json,
                                   error_list, /*required=*/false)) {
     type = StringMatcher::Type::kSafeRegex;
-    std::vector<grpc_error_handle> safe_regex_matcher_error_list;
+    std::vector<absl::Status> safe_regex_matcher_error_list;
     match = ParseRegexMatcher(*inner_json, &safe_regex_matcher_error_list);
     if (!safe_regex_matcher_error_list.empty()) {
       error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
@@ -143,11 +143,11 @@ absl::StatusOr<StringMatcher> ParseStringMatcher(
 
 absl::StatusOr<StringMatcher> ParsePathMatcher(
     const Json::Object& path_matcher_json,
-    std::vector<grpc_error_handle>* error_list) {
+    std::vector<absl::Status>* error_list) {
   const Json::Object* string_matcher_json;
   if (ParseJsonObjectField(path_matcher_json, "path", &string_matcher_json,
                            error_list)) {
-    std::vector<grpc_error_handle> sub_error_list;
+    std::vector<absl::Status> sub_error_list;
     auto matcher = ParseStringMatcher(*string_matcher_json, &sub_error_list);
     if (!sub_error_list.empty()) {
       error_list->push_back(
@@ -159,7 +159,7 @@ absl::StatusOr<StringMatcher> ParsePathMatcher(
 }
 
 Rbac::CidrRange ParseCidrRange(const Json::Object& cidr_range_json,
-                               std::vector<grpc_error_handle>* error_list) {
+                               std::vector<absl::Status>* error_list) {
   std::string address_prefix;
   ParseJsonObjectField(cidr_range_json, "addressPrefix", &address_prefix,
                        error_list);
@@ -167,7 +167,7 @@ Rbac::CidrRange ParseCidrRange(const Json::Object& cidr_range_json,
   uint32_t prefix_len = 0;  // default value
   if (ParseJsonObjectField(cidr_range_json, "prefixLen", &uint32_json,
                            error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> sub_error_list;
+    std::vector<absl::Status> sub_error_list;
     ParseJsonObjectField(*uint32_json, "value", &prefix_len, &sub_error_list);
     if (!sub_error_list.empty()) {
       error_list->push_back(
@@ -178,9 +178,9 @@ Rbac::CidrRange ParseCidrRange(const Json::Object& cidr_range_json,
 }
 
 Rbac::Permission ParsePermission(const Json::Object& permission_json,
-                                 std::vector<grpc_error_handle>* error_list) {
+                                 std::vector<absl::Status>* error_list) {
   auto parse_permission_set = [](const Json::Object& permission_set_json,
-                                 std::vector<grpc_error_handle>* error_list) {
+                                 std::vector<absl::Status>* error_list) {
     const Json::Array* rules_json;
     std::vector<std::unique_ptr<Rbac::Permission>> permissions;
     if (ParseJsonObjectField(permission_set_json, "rules", &rules_json,
@@ -192,7 +192,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
                              &permission_json, error_list)) {
           continue;
         }
-        std::vector<grpc_error_handle> permission_error_list;
+        std::vector<absl::Status> permission_error_list;
         permissions.emplace_back(absl::make_unique<Rbac::Permission>(
             ParsePermission(*permission_json, &permission_error_list)));
         if (!permission_error_list.empty()) {
@@ -209,7 +209,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
   int port;
   if (ParseJsonObjectField(permission_json, "andRules", &inner_json, error_list,
                            /*required=*/false)) {
-    std::vector<grpc_error_handle> and_rules_error_list;
+    std::vector<absl::Status> and_rules_error_list;
     permission = Rbac::Permission::MakeAndPermission(
         parse_permission_set(*inner_json, &and_rules_error_list));
     if (!and_rules_error_list.empty()) {
@@ -218,7 +218,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
     }
   } else if (ParseJsonObjectField(permission_json, "orRules", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> or_rules_error_list;
+    std::vector<absl::Status> or_rules_error_list;
     permission = Rbac::Permission::MakeOrPermission(
         parse_permission_set(*inner_json, &or_rules_error_list));
     if (!or_rules_error_list.empty()) {
@@ -232,7 +232,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
   } else if (ParseJsonObjectField(permission_json, "header", &inner_json,
                                   error_list,
                                   /*required=*/false)) {
-    std::vector<grpc_error_handle> header_error_list;
+    std::vector<absl::Status> header_error_list;
     auto matcher = ParseHeaderMatcher(*inner_json, &header_error_list);
     if (matcher.ok()) {
       permission = Rbac::Permission::MakeHeaderPermission(*matcher);
@@ -246,7 +246,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
   } else if (ParseJsonObjectField(permission_json, "urlPath", &inner_json,
                                   error_list,
                                   /*required=*/false)) {
-    std::vector<grpc_error_handle> url_path_error_list;
+    std::vector<absl::Status> url_path_error_list;
     auto matcher = ParsePathMatcher(*inner_json, &url_path_error_list);
     if (matcher.ok()) {
       permission = Rbac::Permission::MakePathPermission(*matcher);
@@ -260,7 +260,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
     }
   } else if (ParseJsonObjectField(permission_json, "destinationIp", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> destination_ip_error_list;
+    std::vector<absl::Status> destination_ip_error_list;
     permission = Rbac::Permission::MakeDestIpPermission(
         ParseCidrRange(*inner_json, &destination_ip_error_list));
     if (!destination_ip_error_list.empty()) {
@@ -272,7 +272,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
     permission = Rbac::Permission::MakeDestPortPermission(port);
   } else if (ParseJsonObjectField(permission_json, "metadata", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> metadata_error_list;
+    std::vector<absl::Status> metadata_error_list;
     bool invert = false;
     ParseJsonObjectField(*inner_json, "invert", &invert, &metadata_error_list,
                          /*required=*/false);
@@ -284,7 +284,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
     }
   } else if (ParseJsonObjectField(permission_json, "notRule", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> not_rule_error_list;
+    std::vector<absl::Status> not_rule_error_list;
     permission = Rbac::Permission::MakeNotPermission(
         ParsePermission(*inner_json, &not_rule_error_list));
     if (!not_rule_error_list.empty()) {
@@ -294,7 +294,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
   } else if (ParseJsonObjectField(permission_json, "requestedServerName",
                                   &inner_json, error_list,
                                   /*required=*/false)) {
-    std::vector<grpc_error_handle> req_server_name_error_list;
+    std::vector<absl::Status> req_server_name_error_list;
     auto matcher = ParseStringMatcher(*inner_json, &req_server_name_error_list);
     if (matcher.ok()) {
       permission = Rbac::Permission::MakeReqServerNamePermission(*matcher);
@@ -314,9 +314,9 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
 }
 
 Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
-                               std::vector<grpc_error_handle>* error_list) {
+                               std::vector<absl::Status>* error_list) {
   auto parse_principal_set = [](const Json::Object& principal_set_json,
-                                std::vector<grpc_error_handle>* error_list) {
+                                std::vector<absl::Status>* error_list) {
     const Json::Array* rules_json;
     std::vector<std::unique_ptr<Rbac::Principal>> principals;
     if (ParseJsonObjectField(principal_set_json, "ids", &rules_json,
@@ -328,7 +328,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
                              &principal_json, error_list)) {
           continue;
         }
-        std::vector<grpc_error_handle> principal_error_list;
+        std::vector<absl::Status> principal_error_list;
         principals.emplace_back(absl::make_unique<Rbac::Principal>(
             ParsePrincipal(*principal_json, &principal_error_list)));
         if (!principal_error_list.empty()) {
@@ -344,7 +344,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
   bool any;
   if (ParseJsonObjectField(principal_json, "andIds", &inner_json, error_list,
                            /*required=*/false)) {
-    std::vector<grpc_error_handle> and_rules_error_list;
+    std::vector<absl::Status> and_rules_error_list;
     principal = Rbac::Principal::MakeAndPrincipal(
         parse_principal_set(*inner_json, &and_rules_error_list));
     if (!and_rules_error_list.empty()) {
@@ -353,7 +353,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     }
   } else if (ParseJsonObjectField(principal_json, "orIds", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> or_rules_error_list;
+    std::vector<absl::Status> or_rules_error_list;
     principal = Rbac::Principal::MakeOrPrincipal(
         parse_principal_set(*inner_json, &or_rules_error_list));
     if (!or_rules_error_list.empty()) {
@@ -366,11 +366,11 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     principal = Rbac::Principal::MakeAnyPrincipal();
   } else if (ParseJsonObjectField(principal_json, "authenticated", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> authenticated_error_list;
+    std::vector<absl::Status> authenticated_error_list;
     const Json::Object* principal_name_json;
     if (ParseJsonObjectField(*inner_json, "principalName", &principal_name_json,
                              &authenticated_error_list, /*required=*/false)) {
-      std::vector<grpc_error_handle> principal_name_error_list;
+      std::vector<absl::Status> principal_name_error_list;
       auto matcher =
           ParseStringMatcher(*principal_name_json, &principal_name_error_list);
       if (matcher.ok()) {
@@ -392,7 +392,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     }
   } else if (ParseJsonObjectField(principal_json, "sourceIp", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> source_ip_error_list;
+    std::vector<absl::Status> source_ip_error_list;
     principal = Rbac::Principal::MakeSourceIpPrincipal(
         ParseCidrRange(*inner_json, &source_ip_error_list));
     if (!source_ip_error_list.empty()) {
@@ -401,7 +401,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     }
   } else if (ParseJsonObjectField(principal_json, "directRemoteIp", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> direct_remote_ip_error_list;
+    std::vector<absl::Status> direct_remote_ip_error_list;
     principal = Rbac::Principal::MakeDirectRemoteIpPrincipal(
         ParseCidrRange(*inner_json, &direct_remote_ip_error_list));
     if (!direct_remote_ip_error_list.empty()) {
@@ -410,7 +410,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     }
   } else if (ParseJsonObjectField(principal_json, "remoteIp", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> remote_ip_error_list;
+    std::vector<absl::Status> remote_ip_error_list;
     principal = Rbac::Principal::MakeRemoteIpPrincipal(
         ParseCidrRange(*inner_json, &remote_ip_error_list));
     if (!remote_ip_error_list.empty()) {
@@ -420,7 +420,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
   } else if (ParseJsonObjectField(principal_json, "header", &inner_json,
                                   error_list,
                                   /*required=*/false)) {
-    std::vector<grpc_error_handle> header_error_list;
+    std::vector<absl::Status> header_error_list;
     auto matcher = ParseHeaderMatcher(*inner_json, &header_error_list);
     if (matcher.ok()) {
       principal = Rbac::Principal::MakeHeaderPrincipal(*matcher);
@@ -434,7 +434,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
   } else if (ParseJsonObjectField(principal_json, "urlPath", &inner_json,
                                   error_list,
                                   /*required=*/false)) {
-    std::vector<grpc_error_handle> url_path_error_list;
+    std::vector<absl::Status> url_path_error_list;
     auto matcher = ParsePathMatcher(*inner_json, &url_path_error_list);
     if (matcher.ok()) {
       principal = Rbac::Principal::MakePathPrincipal(*matcher);
@@ -448,7 +448,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     }
   } else if (ParseJsonObjectField(principal_json, "metadata", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> metadata_error_list;
+    std::vector<absl::Status> metadata_error_list;
     bool invert = false;
     ParseJsonObjectField(*inner_json, "invert", &invert, &metadata_error_list,
                          /*required=*/false);
@@ -460,7 +460,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
     }
   } else if (ParseJsonObjectField(principal_json, "notId", &inner_json,
                                   error_list, /*required=*/false)) {
-    std::vector<grpc_error_handle> not_rule_error_list;
+    std::vector<absl::Status> not_rule_error_list;
     principal = Rbac::Principal::MakeNotPrincipal(
         ParsePrincipal(*inner_json, &not_rule_error_list));
     if (!not_rule_error_list.empty()) {
@@ -475,7 +475,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
 }
 
 Rbac::Policy ParsePolicy(const Json::Object& policy_json,
-                         std::vector<grpc_error_handle>* error_list) {
+                         std::vector<absl::Status>* error_list) {
   Rbac::Policy policy;
   const Json::Array* permissions_json_array;
   std::vector<std::unique_ptr<Rbac::Permission>> permissions;
@@ -488,7 +488,7 @@ Rbac::Policy ParsePolicy(const Json::Object& policy_json,
                            &permission_json, error_list)) {
         continue;
       }
-      std::vector<grpc_error_handle> permission_error_list;
+      std::vector<absl::Status> permission_error_list;
       permissions.emplace_back(absl::make_unique<Rbac::Permission>(
           ParsePermission(*permission_json, &permission_error_list)));
       if (!permission_error_list.empty()) {
@@ -508,7 +508,7 @@ Rbac::Policy ParsePolicy(const Json::Object& policy_json,
                            &principal_json, error_list)) {
         continue;
       }
-      std::vector<grpc_error_handle> principal_error_list;
+      std::vector<absl::Status> principal_error_list;
       principals.emplace_back(absl::make_unique<Rbac::Principal>(
           ParsePrincipal(*principal_json, &principal_error_list)));
       if (!principal_error_list.empty()) {
@@ -524,7 +524,7 @@ Rbac::Policy ParsePolicy(const Json::Object& policy_json,
 }
 
 Rbac ParseRbac(const Json::Object& rbac_json,
-               std::vector<grpc_error_handle>* error_list) {
+               std::vector<absl::Status>* error_list) {
   Rbac rbac;
   const Json::Object* rules_json;
   if (!ParseJsonObjectField(rbac_json, "rules", &rules_json, error_list,
@@ -545,7 +545,7 @@ Rbac ParseRbac(const Json::Object& rbac_json,
   if (ParseJsonObjectField(*rules_json, "policies", &policies_json, error_list,
                            /*required=*/false)) {
     for (const auto& entry : *policies_json) {
-      std::vector<grpc_error_handle> policy_error_list;
+      std::vector<absl::Status> policy_error_list;
       rbac.policies.emplace(
           entry.first,
           ParsePolicy(entry.second.object_value(), &policy_error_list));
@@ -560,7 +560,7 @@ Rbac ParseRbac(const Json::Object& rbac_json,
 }
 
 std::vector<Rbac> ParseRbacArray(const Json::Array& policies_json_array,
-                                 std::vector<grpc_error_handle>* error_list) {
+                                 std::vector<absl::Status>* error_list) {
   std::vector<Rbac> policies;
   for (size_t i = 0; i < policies_json_array.size(); ++i) {
     const Json::Object* rbac_json;
@@ -569,7 +569,7 @@ std::vector<Rbac> ParseRbacArray(const Json::Array& policies_json_array,
                          error_list)) {
       continue;
     }
-    std::vector<grpc_error_handle> rbac_policy_error_list;
+    std::vector<absl::Status> rbac_policy_error_list;
     policies.emplace_back(ParseRbac(*rbac_json, &rbac_policy_error_list));
     if (!rbac_policy_error_list.empty()) {
       error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
@@ -589,13 +589,13 @@ RbacServiceConfigParser::ParsePerMethodParams(const ChannelArgs& args,
     return nullptr;
   }
   std::vector<Rbac> rbac_policies;
-  std::vector<grpc_error_handle> error_list;
+  std::vector<absl::Status> error_list;
   const Json::Array* policies_json_array;
   if (ParseJsonObjectField(json.object_value(), "rbacPolicy",
                            &policies_json_array, &error_list)) {
     rbac_policies = ParseRbacArray(*policies_json_array, &error_list);
   }
-  grpc_error_handle error =
+  absl::Status error =
       GRPC_ERROR_CREATE_FROM_VECTOR("Rbac parser", &error_list);
   if (!GRPC_ERROR_IS_NONE(error)) {
     absl::Status status = absl::InvalidArgumentError(

--- a/src/core/ext/filters/server_config_selector/server_config_selector.h
+++ b/src/core/ext/filters/server_config_selector/server_config_selector.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
@@ -43,7 +44,7 @@ class ServerConfigSelector : public RefCounted<ServerConfigSelector> {
  public:
   // Configuration to apply to an incoming call
   struct CallConfig {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    absl::Status error = GRPC_ERROR_NONE;
     const ServiceConfigParser::ParsedConfigVector* method_configs = nullptr;
     RefCountedPtr<ServiceConfig> service_config;
   };

--- a/src/core/ext/transport/binder/client/binder_connector.cc
+++ b/src/core/ext/transport/binder/client/binder_connector.cc
@@ -99,7 +99,7 @@ class BinderConnector : public grpc_core::SubchannelConnector {
 
     Unref();  // Was referenced in BinderConnector::Connect
   }
-  void Shutdown(grpc_error_handle error) override { (void)error; }
+  void Shutdown(absl::Status error) override { (void)error; }
 
  private:
   Args args_;

--- a/src/core/ext/transport/binder/server/binder_server.cc
+++ b/src/core/ext/transport/binder/server/binder_server.cc
@@ -213,7 +213,7 @@ class BinderServerListener : public Server::ListenerInterface {
     grpc_transport* server_transport = grpc_create_binder_transport_server(
         std::move(client_binder), security_policy_);
     GPR_ASSERT(server_transport);
-    grpc_error_handle error = server_->SetupTransport(
+    absl::Status error = server_->SetupTransport(
         server_transport, nullptr, server_->channel_args(), nullptr);
     return grpc_error_to_absl_status(error);
   }

--- a/src/core/ext/transport/binder/transport/binder_stream.h
+++ b/src/core/ext/transport/binder/transport/binder_stream.h
@@ -88,7 +88,7 @@ struct grpc_binder_stream {
   grpc_closure destroy_stream;
 
   // The reason why this stream is cancelled and closed.
-  grpc_error_handle cancel_self_error = GRPC_ERROR_NONE;
+  absl::Status cancel_self_error = GRPC_ERROR_NONE;
 
   grpc_closure recv_initial_metadata_closure;
   RecvInitialMetadataArgs recv_initial_metadata_args;

--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -95,7 +95,7 @@ static void grpc_binder_unref_transport(grpc_binder_transport* t) {
 #define GRPC_BINDER_UNREF_TRANSPORT(t, r) grpc_binder_unref_transport(t)
 #endif
 
-static void register_stream_locked(void* arg, grpc_error_handle /*error*/) {
+static void register_stream_locked(void* arg, absl::Status /*error*/) {
   RegisterStreamArgs* args = static_cast<RegisterStreamArgs*>(arg);
   args->gbt->registered_stream[args->gbs->GetTxCode()] = args->gbs;
 }
@@ -146,8 +146,7 @@ static void AssignMetadata(grpc_metadata_batch* mb,
 }
 
 static void cancel_stream_locked(grpc_binder_transport* gbt,
-                                 grpc_binder_stream* gbs,
-                                 grpc_error_handle error) {
+                                 grpc_binder_stream* gbs, absl::Status error) {
   gpr_log(GPR_INFO, "cancel_stream_locked");
   if (!gbs->is_closed) {
     GPR_ASSERT(GRPC_ERROR_IS_NONE(gbs->cancel_self_error));
@@ -195,8 +194,7 @@ static bool ContainsAuthorityAndPath(const grpc_binder::Metadata& metadata) {
   return has_authority && has_path;
 }
 
-static void recv_initial_metadata_locked(void* arg,
-                                         grpc_error_handle /*error*/) {
+static void recv_initial_metadata_locked(void* arg, absl::Status /*error*/) {
   RecvInitialMetadataArgs* args = static_cast<RecvInitialMetadataArgs*>(arg);
   grpc_binder_stream* gbs = args->gbs;
 
@@ -205,7 +203,7 @@ static void recv_initial_metadata_locked(void* arg,
           gbs->is_client, gbs->is_closed);
 
   if (!gbs->is_closed) {
-    grpc_error_handle error = [&] {
+    absl::Status error = [&] {
       GPR_ASSERT(gbs->recv_initial_metadata);
       GPR_ASSERT(gbs->recv_initial_metadata_ready);
       if (!args->initial_metadata.ok()) {
@@ -231,7 +229,7 @@ static void recv_initial_metadata_locked(void* arg,
   GRPC_BINDER_STREAM_UNREF(gbs, "recv_initial_metadata");
 }
 
-static void recv_message_locked(void* arg, grpc_error_handle /*error*/) {
+static void recv_message_locked(void* arg, absl::Status /*error*/) {
   RecvMessageArgs* args = static_cast<RecvMessageArgs*>(arg);
   grpc_binder_stream* gbs = args->gbs;
 
@@ -239,7 +237,7 @@ static void recv_message_locked(void* arg, grpc_error_handle /*error*/) {
           gbs->is_client, gbs->is_closed);
 
   if (!gbs->is_closed) {
-    grpc_error_handle error = [&] {
+    absl::Status error = [&] {
       GPR_ASSERT(gbs->recv_message);
       GPR_ASSERT(gbs->recv_message_ready);
       if (!args->message.ok()) {
@@ -274,8 +272,7 @@ static void recv_message_locked(void* arg, grpc_error_handle /*error*/) {
   GRPC_BINDER_STREAM_UNREF(gbs, "recv_message");
 }
 
-static void recv_trailing_metadata_locked(void* arg,
-                                          grpc_error_handle /*error*/) {
+static void recv_trailing_metadata_locked(void* arg, absl::Status /*error*/) {
   RecvTrailingMetadataArgs* args = static_cast<RecvTrailingMetadataArgs*>(arg);
   grpc_binder_stream* gbs = args->gbs;
 
@@ -284,7 +281,7 @@ static void recv_trailing_metadata_locked(void* arg,
           gbs->is_client, gbs->is_closed);
 
   if (!gbs->is_closed) {
-    grpc_error_handle error = [&] {
+    absl::Status error = [&] {
       GPR_ASSERT(gbs->recv_trailing_metadata);
       GPR_ASSERT(gbs->recv_trailing_metadata_finished);
       if (!args->trailing_metadata.ok()) {
@@ -374,8 +371,7 @@ class MetadataEncoder {
 }  // namespace
 }  // namespace grpc_binder
 
-static void perform_stream_op_locked(void* stream_op,
-                                     grpc_error_handle /*error*/) {
+static void perform_stream_op_locked(void* stream_op, absl::Status /*error*/) {
   grpc_transport_stream_op_batch* op =
       static_cast<grpc_transport_stream_op_batch*>(stream_op);
   grpc_binder_stream* gbs =
@@ -586,7 +582,7 @@ static void close_transport_locked(grpc_binder_transport* gbt) {
 }
 
 static void perform_transport_op_locked(void* transport_op,
-                                        grpc_error_handle /*error*/) {
+                                        absl::Status /*error*/) {
   grpc_transport_op* op = static_cast<grpc_transport_op*>(transport_op);
   grpc_binder_transport* gbt =
       static_cast<grpc_binder_transport*>(op->handler_private.extra_arg);
@@ -631,7 +627,7 @@ static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
       GRPC_ERROR_NONE);
 }
 
-static void destroy_stream_locked(void* sp, grpc_error_handle /*error*/) {
+static void destroy_stream_locked(void* sp, absl::Status /*error*/) {
   grpc_binder_stream* gbs = static_cast<grpc_binder_stream*>(sp);
   grpc_binder_transport* gbt = gbs->t;
   cancel_stream_locked(
@@ -651,7 +647,7 @@ static void destroy_stream(grpc_transport* /*gt*/, grpc_stream* gs,
                         GRPC_ERROR_NONE);
 }
 
-static void destroy_transport_locked(void* gt, grpc_error_handle /*error*/) {
+static void destroy_transport_locked(void* gt, absl::Status /*error*/) {
   grpc_binder_transport* gbt = static_cast<grpc_binder_transport*>(gt);
   close_transport_locked(gbt);
   // Release the references held by the transport.
@@ -689,7 +685,7 @@ static const grpc_transport_vtable vtable = {sizeof(grpc_binder_stream),
 
 static const grpc_transport_vtable* get_vtable() { return &vtable; }
 
-static void accept_stream_locked(void* gt, grpc_error_handle /*error*/) {
+static void accept_stream_locked(void* gt, absl::Status /*error*/) {
   grpc_binder_transport* gbt = static_cast<grpc_binder_transport*>(gt);
   if (gbt->accept_stream_fn) {
     // must pass in a non-null value.

--- a/src/core/ext/transport/binder/wire_format/wire_writer.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_writer.cc
@@ -40,7 +40,7 @@ bool CanBeSentInOneTransaction(const Transaction& tx) {
 }
 
 // Simply forward the call to `WireWriterImpl::RunScheduledTx`.
-void RunScheduledTx(void* arg, grpc_error_handle /*error*/) {
+void RunScheduledTx(void* arg, absl::Status /*error*/) {
   auto* run_scheduled_tx_args =
       static_cast<WireWriterImpl::RunScheduledTxArgs*>(arg);
   run_scheduled_tx_args->writer->RunScheduledTxInternal(run_scheduled_tx_args);

--- a/src/core/ext/transport/chttp2/server/chttp2_server.h
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.h
@@ -23,8 +23,9 @@
 
 #include <functional>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/channel/channel_args.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/surface/server.h"
 
 namespace grpc_core {
@@ -34,11 +35,11 @@ namespace grpc_core {
 // configured with a config fetcher. Not invoked if there is no config fetcher
 // added to the server. On failure, the error parameter will be set.
 using Chttp2ServerArgsModifier =
-    std::function<ChannelArgs(const ChannelArgs&, grpc_error_handle*)>;
+    std::function<ChannelArgs(const ChannelArgs&, absl::Status*)>;
 
 /// Adds a port to \a server.  Sets \a port_num to the port number.
 /// Takes ownership of \a args.
-grpc_error_handle Chttp2ServerAddPort(
+absl::Status Chttp2ServerAddPort(
     Server* server, const char* addr, const ChannelArgs& args,
     Chttp2ServerArgsModifier connection_args_modifier, int* port_num);
 

--- a/src/core/ext/transport/chttp2/transport/context_list.cc
+++ b/src/core/ext/transport/chttp2/transport/context_list.cc
@@ -26,7 +26,7 @@
 
 namespace {
 void (*write_timestamps_callback_g)(void*, grpc_core::Timestamps*,
-                                    grpc_error_handle error) = nullptr;
+                                    absl::Status error) = nullptr;
 void* (*get_copied_context_fn_g)(void*) = nullptr;
 }  // namespace
 
@@ -44,7 +44,7 @@ void ContextList::Append(ContextList** head, grpc_chttp2_stream* s) {
   *head = elem;
 }
 
-void ContextList::Execute(void* arg, Timestamps* ts, grpc_error_handle error) {
+void ContextList::Execute(void* arg, Timestamps* ts, absl::Status error) {
   ContextList* head = static_cast<ContextList*>(arg);
   ContextList* to_be_freed;
   while (head != nullptr) {
@@ -60,8 +60,8 @@ void ContextList::Execute(void* arg, Timestamps* ts, grpc_error_handle error) {
   }
 }
 
-void grpc_http2_set_write_timestamps_callback(
-    void (*fn)(void*, Timestamps*, grpc_error_handle error)) {
+void grpc_http2_set_write_timestamps_callback(void (*fn)(void*, Timestamps*,
+                                                         absl::Status error)) {
   write_timestamps_callback_g = fn;
 }
 

--- a/src/core/ext/transport/chttp2/transport/context_list.h
+++ b/src/core/ext/transport/chttp2/transport/context_list.h
@@ -23,9 +23,10 @@
 
 #include <stddef.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/ext/transport/chttp2/transport/frame.h"
 #include "src/core/lib/iomgr/buffer_list.h"
-#include "src/core/lib/iomgr/error.h"
 
 namespace grpc_core {
 /** A list of RPC Contexts */
@@ -38,7 +39,7 @@ class ContextList {
   /* Executes a function \a fn with each context in the list and \a ts. It also
    * frees up the entire list after this operation. It is intended as a callback
    * and hence does not take a ref on \a error */
-  static void Execute(void* arg, Timestamps* ts, grpc_error_handle error);
+  static void Execute(void* arg, Timestamps* ts, absl::Status error);
 
  private:
   void* trace_context_ = nullptr;
@@ -46,8 +47,8 @@ class ContextList {
   size_t byte_offset_ = 0;
 };
 
-void grpc_http2_set_write_timestamps_callback(
-    void (*fn)(void*, Timestamps*, grpc_error_handle error));
+void grpc_http2_set_write_timestamps_callback(void (*fn)(void*, Timestamps*,
+                                                         absl::Status error));
 void grpc_http2_set_fn_get_copied_context(void* (*fn)(void*));
 } /* namespace grpc_core */
 

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -29,6 +29,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/ext/transport/chttp2/transport/internal.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/slice/slice_buffer.h"
 #include "src/core/lib/slice/slice_refcount.h"
 #include "src/core/lib/transport/transport.h"
@@ -79,11 +80,11 @@ void grpc_chttp2_encode_data(uint32_t id, grpc_slice_buffer* inbuf,
   stats->data_bytes += write_bytes;
 }
 
-grpc_core::Poll<grpc_error_handle> grpc_deframe_unprocessed_incoming_frames(
+grpc_core::Poll<absl::Status> grpc_deframe_unprocessed_incoming_frames(
     grpc_chttp2_stream* s, uint32_t* min_progress_size,
     grpc_core::SliceBuffer* stream_out, uint32_t* message_flags) {
   grpc_slice_buffer* slices = &s->frame_storage;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
 
   if (slices->length < 5) {
     if (min_progress_size != nullptr) *min_progress_size = 5 - slices->length;
@@ -134,11 +135,11 @@ grpc_core::Poll<grpc_error_handle> grpc_deframe_unprocessed_incoming_frames(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_chttp2_data_parser_parse(void* /*parser*/,
-                                                grpc_chttp2_transport* t,
-                                                grpc_chttp2_stream* s,
-                                                const grpc_slice& slice,
-                                                int is_last) {
+absl::Status grpc_chttp2_data_parser_parse(void* /*parser*/,
+                                           grpc_chttp2_transport* t,
+                                           grpc_chttp2_stream* s,
+                                           const grpc_slice& slice,
+                                           int is_last) {
   grpc_slice_ref_internal(slice);
   grpc_slice_buffer_add(&s->frame_storage, slice);
   grpc_chttp2_maybe_complete_recv_message(t, s);

--- a/src/core/ext/transport/chttp2/transport/frame_data.h
+++ b/src/core/ext/transport/chttp2/transport/frame_data.h
@@ -30,7 +30,6 @@
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/promise/poll.h"
 #include "src/core/lib/slice/slice_buffer.h"
 #include "src/core/lib/transport/transport.h"
@@ -42,18 +41,18 @@ absl::Status grpc_chttp2_data_parser_begin_frame(uint8_t flags,
 
 /* handle a slice of a data frame - is_last indicates the last slice of a
    frame */
-grpc_error_handle grpc_chttp2_data_parser_parse(void* parser,
-                                                grpc_chttp2_transport* t,
-                                                grpc_chttp2_stream* s,
-                                                const grpc_slice& slice,
-                                                int is_last);
+absl::Status grpc_chttp2_data_parser_parse(void* parser,
+                                           grpc_chttp2_transport* t,
+                                           grpc_chttp2_stream* s,
+                                           const grpc_slice& slice,
+                                           int is_last);
 
 void grpc_chttp2_encode_data(uint32_t id, grpc_slice_buffer* inbuf,
                              uint32_t write_bytes, int is_eof,
                              grpc_transport_one_way_stats* stats,
                              grpc_slice_buffer* outbuf);
 
-grpc_core::Poll<grpc_error_handle> grpc_deframe_unprocessed_incoming_frames(
+grpc_core::Poll<absl::Status> grpc_deframe_unprocessed_incoming_frames(
     grpc_chttp2_stream* s, uint32_t* min_progress_size,
     grpc_core::SliceBuffer* stream_out, uint32_t* message_flags);
 

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -31,6 +31,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/ext/transport/chttp2/transport/internal.h"
+#include "src/core/lib/iomgr/error.h"
 
 void grpc_chttp2_goaway_parser_init(grpc_chttp2_goaway_parser* p) {
   p->debug_data = nullptr;
@@ -40,8 +41,9 @@ void grpc_chttp2_goaway_parser_destroy(grpc_chttp2_goaway_parser* p) {
   gpr_free(p->debug_data);
 }
 
-grpc_error_handle grpc_chttp2_goaway_parser_begin_frame(
-    grpc_chttp2_goaway_parser* p, uint32_t length, uint8_t /*flags*/) {
+absl::Status grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
+                                                   uint32_t length,
+                                                   uint8_t /*flags*/) {
   if (length < 8) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrFormat("goaway frame too short (%d bytes)", length));
@@ -55,11 +57,11 @@ grpc_error_handle grpc_chttp2_goaway_parser_begin_frame(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
-                                                  grpc_chttp2_transport* t,
-                                                  grpc_chttp2_stream* /*s*/,
-                                                  const grpc_slice& slice,
-                                                  int is_last) {
+absl::Status grpc_chttp2_goaway_parser_parse(void* parser,
+                                             grpc_chttp2_transport* t,
+                                             grpc_chttp2_stream* /*s*/,
+                                             const grpc_slice& slice,
+                                             int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
   const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
   const uint8_t* cur = beg;

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.h
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.h
@@ -23,10 +23,11 @@
 
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
-#include "src/core/lib/iomgr/error.h"
 
 typedef enum {
   GRPC_CHTTP2_GOAWAY_LSI0,
@@ -50,13 +51,13 @@ struct grpc_chttp2_goaway_parser {
 };
 void grpc_chttp2_goaway_parser_init(grpc_chttp2_goaway_parser* p);
 void grpc_chttp2_goaway_parser_destroy(grpc_chttp2_goaway_parser* p);
-grpc_error_handle grpc_chttp2_goaway_parser_begin_frame(
+absl::Status grpc_chttp2_goaway_parser_begin_frame(
     grpc_chttp2_goaway_parser* parser, uint32_t length, uint8_t flags);
-grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
-                                                  grpc_chttp2_transport* t,
-                                                  grpc_chttp2_stream* s,
-                                                  const grpc_slice& slice,
-                                                  int is_last);
+absl::Status grpc_chttp2_goaway_parser_parse(void* parser,
+                                             grpc_chttp2_transport* t,
+                                             grpc_chttp2_stream* s,
+                                             const grpc_slice& slice,
+                                             int is_last);
 
 void grpc_chttp2_goaway_append(uint32_t last_stream_id, uint32_t error_code,
                                const grpc_slice& debug_data,

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -32,6 +32,7 @@
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/ext/transport/chttp2/transport/stream_map.h"
 #include "src/core/lib/gprpp/time.h"
+#include "src/core/lib/iomgr/error.h"
 
 static bool g_disable_ping_ack = false;
 
@@ -60,7 +61,7 @@ grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
   return slice;
 }
 
-grpc_error_handle grpc_chttp2_ping_parser_begin_frame(
+absl::Status grpc_chttp2_ping_parser_begin_frame(
     grpc_chttp2_ping_parser* parser, uint32_t length, uint8_t flags) {
   if (flags & 0xfe || length != 8) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(
@@ -72,11 +73,11 @@ grpc_error_handle grpc_chttp2_ping_parser_begin_frame(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
-                                                grpc_chttp2_transport* t,
-                                                grpc_chttp2_stream* /*s*/,
-                                                const grpc_slice& slice,
-                                                int is_last) {
+absl::Status grpc_chttp2_ping_parser_parse(void* parser,
+                                           grpc_chttp2_transport* t,
+                                           grpc_chttp2_stream* /*s*/,
+                                           const grpc_slice& slice,
+                                           int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
   const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
   const uint8_t* cur = beg;

--- a/src/core/ext/transport/chttp2/transport/frame_ping.h
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.h
@@ -23,10 +23,11 @@
 
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
-#include "src/core/lib/iomgr/error.h"
 
 struct grpc_chttp2_ping_parser {
   uint8_t byte;
@@ -35,13 +36,13 @@ struct grpc_chttp2_ping_parser {
 };
 grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes);
 
-grpc_error_handle grpc_chttp2_ping_parser_begin_frame(
+absl::Status grpc_chttp2_ping_parser_begin_frame(
     grpc_chttp2_ping_parser* parser, uint32_t length, uint8_t flags);
-grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
-                                                grpc_chttp2_transport* t,
-                                                grpc_chttp2_stream* s,
-                                                const grpc_slice& slice,
-                                                int is_last);
+absl::Status grpc_chttp2_ping_parser_parse(void* parser,
+                                           grpc_chttp2_transport* t,
+                                           grpc_chttp2_stream* s,
+                                           const grpc_slice& slice,
+                                           int is_last);
 
 /* Test-only function for disabling ping ack */
 void grpc_set_disable_ping_ack(bool disable_ping_ack);

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -32,6 +32,7 @@
 #include "src/core/ext/transport/chttp2/transport/hpack_encoder.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/lib/debug/trace.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/http2_errors.h"
 #include "src/core/lib/transport/metadata_batch.h"
 
@@ -72,7 +73,7 @@ void grpc_chttp2_add_rst_stream_to_next_write(
                         grpc_chttp2_rst_stream_create(id, code, stats));
 }
 
-grpc_error_handle grpc_chttp2_rst_stream_parser_begin_frame(
+absl::Status grpc_chttp2_rst_stream_parser_begin_frame(
     grpc_chttp2_rst_stream_parser* parser, uint32_t length, uint8_t flags) {
   if (length != 4) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
@@ -82,11 +83,11 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_begin_frame(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
-                                                      grpc_chttp2_transport* t,
-                                                      grpc_chttp2_stream* s,
-                                                      const grpc_slice& slice,
-                                                      int is_last) {
+absl::Status grpc_chttp2_rst_stream_parser_parse(void* parser,
+                                                 grpc_chttp2_transport* t,
+                                                 grpc_chttp2_stream* s,
+                                                 const grpc_slice& slice,
+                                                 int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
   const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
   const uint8_t* cur = beg;
@@ -111,7 +112,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
               "[chttp2 transport=%p stream=%p] received RST_STREAM(reason=%d)",
               t, s, reason);
     }
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    absl::Status error = GRPC_ERROR_NONE;
     if (reason != GRPC_HTTP2_NO_ERROR || s->trailing_metadata_buffer.empty()) {
       error = grpc_error_set_int(
           grpc_error_set_str(

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.h
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.h
@@ -23,10 +23,11 @@
 
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/transport.h"
 
 struct grpc_chttp2_rst_stream_parser {
@@ -43,12 +44,12 @@ void grpc_chttp2_add_rst_stream_to_next_write(
     grpc_chttp2_transport* t, uint32_t id, uint32_t code,
     grpc_transport_one_way_stats* stats);
 
-grpc_error_handle grpc_chttp2_rst_stream_parser_begin_frame(
+absl::Status grpc_chttp2_rst_stream_parser_begin_frame(
     grpc_chttp2_rst_stream_parser* parser, uint32_t length, uint8_t flags);
-grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
-                                                      grpc_chttp2_transport* t,
-                                                      grpc_chttp2_stream* s,
-                                                      const grpc_slice& slice,
-                                                      int is_last);
+absl::Status grpc_chttp2_rst_stream_parser_parse(void* parser,
+                                                 grpc_chttp2_transport* t,
+                                                 grpc_chttp2_stream* s,
+                                                 const grpc_slice& slice,
+                                                 int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_RST_STREAM_H */

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -38,6 +38,7 @@
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 
 static uint8_t* fill_header(uint8_t* out, uint32_t length, uint8_t flags) {
@@ -91,7 +92,7 @@ grpc_slice grpc_chttp2_settings_ack_create(void) {
   return output;
 }
 
-grpc_error_handle grpc_chttp2_settings_parser_begin_frame(
+absl::Status grpc_chttp2_settings_parser_begin_frame(
     grpc_chttp2_settings_parser* parser, uint32_t length, uint8_t flags,
     uint32_t* settings) {
   parser->target_settings = settings;
@@ -117,11 +118,11 @@ grpc_error_handle grpc_chttp2_settings_parser_begin_frame(
   }
 }
 
-grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
-                                                    grpc_chttp2_transport* t,
-                                                    grpc_chttp2_stream* /*s*/,
-                                                    const grpc_slice& slice,
-                                                    int is_last) {
+absl::Status grpc_chttp2_settings_parser_parse(void* p,
+                                               grpc_chttp2_transport* t,
+                                               grpc_chttp2_stream* /*s*/,
+                                               const grpc_slice& slice,
+                                               int is_last) {
   grpc_chttp2_settings_parser* parser =
       static_cast<grpc_chttp2_settings_parser*>(p);
   const uint8_t* cur = GRPC_SLICE_START_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.h
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.h
@@ -24,11 +24,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
 #include "src/core/ext/transport/chttp2/transport/http2_settings.h"
-#include "src/core/lib/iomgr/error.h"
 
 typedef enum {
   GRPC_CHTTP2_SPS_ID0,
@@ -54,13 +55,13 @@ grpc_slice grpc_chttp2_settings_create(uint32_t* old_settings,
 /* Create an ack settings frame */
 grpc_slice grpc_chttp2_settings_ack_create(void);
 
-grpc_error_handle grpc_chttp2_settings_parser_begin_frame(
+absl::Status grpc_chttp2_settings_parser_begin_frame(
     grpc_chttp2_settings_parser* parser, uint32_t length, uint8_t flags,
     uint32_t* settings);
-grpc_error_handle grpc_chttp2_settings_parser_parse(void* parser,
-                                                    grpc_chttp2_transport* t,
-                                                    grpc_chttp2_stream* s,
-                                                    const grpc_slice& slice,
-                                                    int is_last);
+absl::Status grpc_chttp2_settings_parser_parse(void* parser,
+                                               grpc_chttp2_transport* t,
+                                               grpc_chttp2_stream* s,
+                                               const grpc_slice& slice,
+                                               int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_SETTINGS_H */

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -29,6 +29,7 @@
 
 #include "src/core/ext/transport/chttp2/transport/flow_control.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
+#include "src/core/lib/iomgr/error.h"
 
 grpc_slice grpc_chttp2_window_update_create(
     uint32_t id, uint32_t window_delta, grpc_transport_one_way_stats* stats) {
@@ -56,7 +57,7 @@ grpc_slice grpc_chttp2_window_update_create(
   return slice;
 }
 
-grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
+absl::Status grpc_chttp2_window_update_parser_begin_frame(
     grpc_chttp2_window_update_parser* parser, uint32_t length, uint8_t flags) {
   if (flags || length != 4) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
@@ -67,9 +68,11 @@ grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_chttp2_window_update_parser_parse(
-    void* parser, grpc_chttp2_transport* t, grpc_chttp2_stream* s,
-    const grpc_slice& slice, int is_last) {
+absl::Status grpc_chttp2_window_update_parser_parse(void* parser,
+                                                    grpc_chttp2_transport* t,
+                                                    grpc_chttp2_stream* s,
+                                                    const grpc_slice& slice,
+                                                    int is_last) {
   const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
   const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
   const uint8_t* cur = beg;

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.h
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.h
@@ -23,10 +23,11 @@
 
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/transport.h"
 
 struct grpc_chttp2_window_update_parser {
@@ -37,10 +38,12 @@ struct grpc_chttp2_window_update_parser {
 grpc_slice grpc_chttp2_window_update_create(
     uint32_t id, uint32_t window_delta, grpc_transport_one_way_stats* stats);
 
-grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
+absl::Status grpc_chttp2_window_update_parser_begin_frame(
     grpc_chttp2_window_update_parser* parser, uint32_t length, uint8_t flags);
-grpc_error_handle grpc_chttp2_window_update_parser_parse(
-    void* parser, grpc_chttp2_transport* t, grpc_chttp2_stream* s,
-    const grpc_slice& slice, int is_last);
+absl::Status grpc_chttp2_window_update_parser_parse(void* parser,
+                                                    grpc_chttp2_transport* t,
+                                                    grpc_chttp2_stream* s,
+                                                    const grpc_slice& slice,
+                                                    int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_WINDOW_UPDATE_H */

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.h
@@ -25,11 +25,12 @@
 
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
 #include "src/core/ext/transport/chttp2/transport/hpack_parser_table.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/metadata_batch.h"
 
 // IWYU pragma: no_include <type_traits>
@@ -85,7 +86,7 @@ class HPackParser {
   // Start throwing away any received headers after parsing them.
   void StopBufferingFrame() { metadata_buffer_ = nullptr; }
   // Parse one slice worth of data
-  grpc_error_handle Parse(const grpc_slice& slice, bool is_last);
+  absl::Status Parse(const grpc_slice& slice, bool is_last);
   // Reset state ready for the next BeginFrame
   void FinishFrame();
 
@@ -102,7 +103,7 @@ class HPackParser {
   class Input;
   class String;
 
-  grpc_error_handle ParseInput(Input input, bool is_last);
+  absl::Status ParseInput(Input input, bool is_last);
   bool ParseInputInner(Input* input);
 
   // Target metadata buffer
@@ -133,10 +134,10 @@ class HPackParser {
 
 /* wraps grpc_chttp2_hpack_parser_parse to provide a frame level parser for
    the transport */
-grpc_error_handle grpc_chttp2_header_parser_parse(void* hpack_parser,
-                                                  grpc_chttp2_transport* t,
-                                                  grpc_chttp2_stream* s,
-                                                  const grpc_slice& slice,
-                                                  int is_last);
+absl::Status grpc_chttp2_header_parser_parse(void* hpack_parser,
+                                             grpc_chttp2_transport* t,
+                                             grpc_chttp2_stream* s,
+                                             const grpc_slice& slice,
+                                             int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_HPACK_PARSER_H */

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -34,6 +34,7 @@
 
 #include "src/core/ext/transport/chttp2/transport/hpack_constants.h"
 #include "src/core/lib/debug/trace.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/slice/slice.h"
 
 extern grpc_core::TraceFlag grpc_http_trace;
@@ -98,7 +99,7 @@ void HPackTable::SetMaxBytes(uint32_t max_bytes) {
   max_bytes_ = max_bytes;
 }
 
-grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
+absl::Status HPackTable::SetCurrentTableSize(uint32_t bytes) {
   if (current_table_bytes_ == bytes) {
     return GRPC_ERROR_NONE;
   }
@@ -120,7 +121,7 @@ grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle HPackTable::Add(Memento md) {
+absl::Status HPackTable::Add(Memento md) {
   if (current_table_bytes_ > max_bytes_) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
         "HPACK max table size reduced to %d but not reflected by hpack "

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.h
@@ -25,9 +25,10 @@
 
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include "src/core/ext/transport/chttp2/transport/hpack_constants.h"
 #include "src/core/lib/gprpp/no_destruct.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/metadata_batch.h"
 #include "src/core/lib/transport/parsed_metadata.h"
 
@@ -43,7 +44,7 @@ class HPackTable {
   HPackTable& operator=(const HPackTable&) = delete;
 
   void SetMaxBytes(uint32_t max_bytes);
-  grpc_error_handle SetCurrentTableSize(uint32_t bytes);
+  absl::Status SetCurrentTableSize(uint32_t bytes);
 
   using Memento = ParsedMetadata<grpc_metadata_batch>;
 
@@ -63,7 +64,7 @@ class HPackTable {
   }
 
   // add a table entry to the index
-  grpc_error_handle Add(Memento md) GRPC_MUST_USE_RESULT;
+  absl::Status Add(Memento md) GRPC_MUST_USE_RESULT;
 
   // Current entry count in the table.
   uint32_t num_entries() const { return entries_.num_entries(); }

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -26,6 +26,7 @@
 
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
@@ -261,7 +262,7 @@ struct grpc_chttp2_transport {
   /** is the transport destroying itself? */
   uint8_t destroying = false;
   /** has the upper layer closed the transport? */
-  grpc_error_handle closed_with_error = GRPC_ERROR_NONE;
+  absl::Status closed_with_error = GRPC_ERROR_NONE;
 
   /** is there a read request to the endpoint outstanding? */
   uint8_t endpoint_reading = 1;
@@ -310,7 +311,7 @@ struct grpc_chttp2_transport {
 
   /** Set to a grpc_error object if a goaway frame is received. By default, set
    * to GRPC_ERROR_NONE */
-  grpc_error_handle goaway_error = GRPC_ERROR_NONE;
+  absl::Status goaway_error = GRPC_ERROR_NONE;
 
   grpc_chttp2_sent_goaway_state sent_goaway_state = GRPC_CHTTP2_NO_GOAWAY_SEND;
 
@@ -376,9 +377,9 @@ struct grpc_chttp2_transport {
   /* active parser */
   void* parser_data = nullptr;
   grpc_chttp2_stream* incoming_stream = nullptr;
-  grpc_error_handle (*parser)(void* parser_user_data, grpc_chttp2_transport* t,
-                              grpc_chttp2_stream* s, const grpc_slice& slice,
-                              int is_last);
+  absl::Status (*parser)(void* parser_user_data, grpc_chttp2_transport* t,
+                         grpc_chttp2_stream* s, const grpc_slice& slice,
+                         int is_last);
 
   grpc_chttp2_write_cb* write_cb_pool = nullptr;
 
@@ -391,7 +392,7 @@ struct grpc_chttp2_transport {
 
   /* if non-NULL, close the transport with this error when writes are finished
    */
-  grpc_error_handle close_transport_on_writes_finished = GRPC_ERROR_NONE;
+  absl::Status close_transport_on_writes_finished = GRPC_ERROR_NONE;
 
   /* a list of closures to run after writes are finished */
   grpc_closure_list run_after_write = GRPC_CLOSURE_LIST_INIT;
@@ -527,9 +528,9 @@ struct grpc_chttp2_stream {
   bool eos_sent = false;
 
   /** the error that resulted in this stream being read-closed */
-  grpc_error_handle read_closed_error = GRPC_ERROR_NONE;
+  absl::Status read_closed_error = GRPC_ERROR_NONE;
   /** the error that resulted in this stream being write-closed */
-  grpc_error_handle write_closed_error = GRPC_ERROR_NONE;
+  absl::Status write_closed_error = GRPC_ERROR_NONE;
 
   grpc_published_metadata_method published_metadata[2] = {};
   bool final_metadata_requested = false;
@@ -543,7 +544,7 @@ struct grpc_chttp2_stream {
   grpc_core::Timestamp deadline = grpc_core::Timestamp::InfFuture();
 
   /** saw some stream level error */
-  grpc_error_handle forced_close_error = GRPC_ERROR_NONE;
+  absl::Status forced_close_error = GRPC_ERROR_NONE;
   /** how many header frames have we received? */
   uint8_t header_frames_received = 0;
   /** number of bytes received - reset at end of parse thread execution */
@@ -592,12 +593,12 @@ struct grpc_chttp2_begin_write_result {
 };
 grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
     grpc_chttp2_transport* t);
-void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error_handle error);
+void grpc_chttp2_end_write(grpc_chttp2_transport* t, absl::Status error);
 
 /** Process one slice of incoming data; return 1 if the connection is still
     viable after reading, or 0 if the connection should be torn down */
-grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
-                                           const grpc_slice& slice);
+absl::Status grpc_chttp2_perform_read(grpc_chttp2_transport* t,
+                                      const grpc_slice& slice);
 
 bool grpc_chttp2_list_add_writable_stream(grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s);
@@ -667,8 +668,7 @@ void grpc_chttp2_parsing_become_skip_parser(grpc_chttp2_transport* t);
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
                                        grpc_chttp2_stream* s,
                                        grpc_closure** pclosure,
-                                       grpc_error_handle error,
-                                       const char* desc);
+                                       absl::Status error, const char* desc);
 
 #define GRPC_HEADER_SIZE_IN_BYTES 5
 #define MAX_SIZE_T (~(size_t)0)
@@ -688,11 +688,10 @@ void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
   } while (0)
 
 void grpc_chttp2_fake_status(grpc_chttp2_transport* t,
-                             grpc_chttp2_stream* stream,
-                             grpc_error_handle error);
+                             grpc_chttp2_stream* stream, absl::Status error);
 void grpc_chttp2_mark_stream_closed(grpc_chttp2_transport* t,
                                     grpc_chttp2_stream* s, int close_reads,
-                                    int close_writes, grpc_error_handle error);
+                                    int close_writes, absl::Status error);
 void grpc_chttp2_start_writing(grpc_chttp2_transport* t);
 
 #ifndef NDEBUG
@@ -760,7 +759,7 @@ void grpc_chttp2_mark_stream_writable(grpc_chttp2_transport* t,
                                       grpc_chttp2_stream* s);
 
 void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
-                               grpc_error_handle due_to_error);
+                               absl::Status due_to_error);
 
 void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
                                                       grpc_chttp2_stream* s);
@@ -770,15 +769,14 @@ void grpc_chttp2_maybe_complete_recv_trailing_metadata(grpc_chttp2_transport* t,
                                                        grpc_chttp2_stream* s);
 
 void grpc_chttp2_fail_pending_writes(grpc_chttp2_transport* t,
-                                     grpc_chttp2_stream* s,
-                                     grpc_error_handle error);
+                                     grpc_chttp2_stream* s, absl::Status error);
 
 /** Set the default keepalive configurations, must only be called at
     initialization */
 void grpc_chttp2_config_default_keepalive_args(grpc_channel_args* args,
                                                bool is_client);
 
-void grpc_chttp2_retry_initiate_ping(void* tp, grpc_error_handle error);
+void grpc_chttp2_retry_initiate_ping(void* tp, absl::Status error);
 
 void schedule_bdp_ping_locked(grpc_chttp2_transport* t);
 

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/slice.h>
@@ -71,7 +72,7 @@ static void add_to_write_list(grpc_chttp2_write_cb** list,
 }
 
 static void finish_write_cb(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
-                            grpc_chttp2_write_cb* cb, grpc_error_handle error) {
+                            grpc_chttp2_write_cb* cb, absl::Status error) {
   grpc_chttp2_complete_closure_step(t, s, &cb->closure, error,
                                     "finish_write_cb");
   cb->next = t->write_cb_pool;
@@ -184,7 +185,7 @@ static void maybe_initiate_ping(grpc_chttp2_transport* t) {
 
 static bool update_list(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                         int64_t send_bytes, grpc_chttp2_write_cb** list,
-                        int64_t* ctr, grpc_error_handle error) {
+                        int64_t* ctr, absl::Status error) {
   bool sched_any = false;
   grpc_chttp2_write_cb* cb = *list;
   *list = nullptr;
@@ -661,7 +662,7 @@ grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
   return ctx.Result();
 }
 
-void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error_handle error) {
+void grpc_chttp2_end_write(grpc_chttp2_transport* t, absl::Status error) {
   grpc_chttp2_stream* s;
 
   if (t->channelz_socket != nullptr) {

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -28,6 +28,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -174,7 +175,7 @@ struct op_state {
   /* User requested RECV_TRAILING_METADATA */
   bool pending_recv_trailing_metadata = false;
   cronet_net_error_code net_error = OK;
-  grpc_error_handle cancel_error = GRPC_ERROR_NONE;
+  absl::Status cancel_error = GRPC_ERROR_NONE;
   /* data structure for storing data coming from server */
   struct read_state rs;
   /* data structure for storing data going to the server */
@@ -315,9 +316,9 @@ static void read_grpc_header(stream_obj* s) {
                             s->state.rs.remaining_bytes);
 }
 
-static grpc_error_handle make_error_with_desc(int error_code,
-                                              int cronet_internal_error_code,
-                                              const char* desc) {
+static absl::Status make_error_with_desc(int error_code,
+                                         int cronet_internal_error_code,
+                                         const char* desc) {
   return grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
                                 "Cronet error code:%d, Cronet error detail:%s",
                                 cronet_internal_error_code, desc)),
@@ -1294,7 +1295,7 @@ static enum e_op_result execute_stream_op(struct op_and_state* oas) {
              op_can_be_run(stream_op, s, &oas->state,
                            OP_RECV_TRAILING_METADATA)) {
     CRONET_LOG(GPR_DEBUG, "running: %p  OP_RECV_TRAILING_METADATA", oas);
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    absl::Status error = GRPC_ERROR_NONE;
     if (stream_state->state_op_done[OP_CANCEL_ERROR]) {
       error = GRPC_ERROR_REF(stream_state->cancel_error);
     } else if (stream_state->state_callback_received[OP_FAILED]) {

--- a/src/core/ext/xds/certificate_provider_store.cc
+++ b/src/core/ext/xds/certificate_provider_store.cc
@@ -20,6 +20,7 @@
 
 #include "src/core/ext/xds/certificate_provider_store.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/support/log.h>
@@ -74,7 +75,7 @@ void CertificateProviderStore::PluginDefinition::JsonPostLoad(
     }
     if (factory == nullptr) return;
     // Use plugin to validate and parse config.
-    grpc_error_handle parse_error = GRPC_ERROR_NONE;
+    absl::Status parse_error = GRPC_ERROR_NONE;
     config =
         factory->CreateCertificateProviderConfig(config_json, &parse_error);
     if (!GRPC_ERROR_IS_NONE(parse_error)) {

--- a/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
+++ b/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
@@ -32,6 +32,7 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/config/core_configuration.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/json/json_util.h"
 #include "src/core/lib/security/certificate_provider/certificate_provider_registry.h"
 #include "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h"
@@ -74,14 +75,14 @@ std::string FileWatcherCertificateProviderFactory::Config::ToString() const {
 
 RefCountedPtr<FileWatcherCertificateProviderFactory::Config>
 FileWatcherCertificateProviderFactory::Config::Parse(const Json& config_json,
-                                                     grpc_error_handle* error) {
+                                                     absl::Status* error) {
   auto config = MakeRefCounted<FileWatcherCertificateProviderFactory::Config>();
   if (config_json.type() != Json::Type::OBJECT) {
     *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "error:config type should be OBJECT.");
     return nullptr;
   }
-  std::vector<grpc_error_handle> error_list;
+  std::vector<absl::Status> error_list;
   ParseJsonObjectField(config_json.object_value(), "certificate_file",
                        &config->identity_cert_file_, &error_list, false);
   ParseJsonObjectField(config_json.object_value(), "private_key_file",
@@ -122,7 +123,7 @@ const char* FileWatcherCertificateProviderFactory::name() const {
 
 RefCountedPtr<CertificateProviderFactory::Config>
 FileWatcherCertificateProviderFactory::CreateCertificateProviderConfig(
-    const Json& config_json, grpc_error_handle* error) {
+    const Json& config_json, absl::Status* error) {
   return FileWatcherCertificateProviderFactory::Config::Parse(config_json,
                                                               error);
 }

--- a/src/core/ext/xds/file_watcher_certificate_provider_factory.h
+++ b/src/core/ext/xds/file_watcher_certificate_provider_factory.h
@@ -23,11 +23,12 @@
 
 #include <string>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc_security.h>
 
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/json/json.h"
 #include "src/core/lib/security/certificate_provider/certificate_provider_factory.h"
 
@@ -39,7 +40,7 @@ class FileWatcherCertificateProviderFactory
   class Config : public CertificateProviderFactory::Config {
    public:
     static RefCountedPtr<Config> Parse(const Json& config_json,
-                                       grpc_error_handle* error);
+                                       absl::Status* error);
 
     const char* name() const override;
 
@@ -66,7 +67,7 @@ class FileWatcherCertificateProviderFactory
 
   RefCountedPtr<CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const Json& config_json,
-                                  grpc_error_handle* error) override;
+                                  absl::Status* error) override;
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
       RefCountedPtr<CertificateProviderFactory::Config> config) override;

--- a/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h
+++ b/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.h
@@ -26,11 +26,12 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc_security.h>
 
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/json/json.h"
 #include "src/core/lib/security/certificate_provider/certificate_provider_factory.h"
 #include "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h"
@@ -73,20 +74,19 @@ class GoogleMeshCaCertificateProviderFactory
     const std::string& location() const { return location_; }
 
     static RefCountedPtr<Config> Parse(const Json& config_json,
-                                       grpc_error_handle* error);
+                                       absl::Status* error);
 
    private:
     // Helpers for parsing the config
-    std::vector<grpc_error_handle> ParseJsonObjectStsService(
+    std::vector<absl::Status> ParseJsonObjectStsService(
         const Json::Object& sts_service);
-    std::vector<grpc_error_handle> ParseJsonObjectCallCredentials(
+    std::vector<absl::Status> ParseJsonObjectCallCredentials(
         const Json::Object& call_credentials);
-    std::vector<grpc_error_handle> ParseJsonObjectGoogleGrpc(
+    std::vector<absl::Status> ParseJsonObjectGoogleGrpc(
         const Json::Object& google_grpc);
-    std::vector<grpc_error_handle> ParseJsonObjectGrpcServices(
+    std::vector<absl::Status> ParseJsonObjectGrpcServices(
         const Json::Object& grpc_service);
-    std::vector<grpc_error_handle> ParseJsonObjectServer(
-        const Json::Object& server);
+    std::vector<absl::Status> ParseJsonObjectServer(const Json::Object& server);
 
     std::string endpoint_;
     StsConfig sts_config_;
@@ -101,7 +101,7 @@ class GoogleMeshCaCertificateProviderFactory
 
   RefCountedPtr<CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const Json& config_json,
-                                  grpc_error_handle* error) override;
+                                  absl::Status* error) override;
 
   RefCountedPtr<grpc_tls_certificate_provider> CreateCertificateProvider(
       RefCountedPtr<CertificateProviderFactory::Config> /*config*/) override {

--- a/src/core/ext/xds/xds_certificate_provider.cc
+++ b/src/core/ext/xds/xds_certificate_provider.cc
@@ -24,6 +24,7 @@
 
 #include "absl/functional/bind_front.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/log.h>
@@ -58,8 +59,8 @@ class RootCertificatesWatcher
     }
   }
 
-  void OnError(grpc_error_handle root_cert_error,
-               grpc_error_handle identity_cert_error) override {
+  void OnError(absl::Status root_cert_error,
+               absl::Status identity_cert_error) override {
     if (!GRPC_ERROR_IS_NONE(root_cert_error)) {
       parent_->SetErrorForCert(cert_name_, root_cert_error /* pass the ref */,
                                absl::nullopt);
@@ -93,8 +94,8 @@ class IdentityCertificatesWatcher
     }
   }
 
-  void OnError(grpc_error_handle root_cert_error,
-               grpc_error_handle identity_cert_error) override {
+  void OnError(absl::Status root_cert_error,
+               absl::Status identity_cert_error) override {
     if (!GRPC_ERROR_IS_NONE(identity_cert_error)) {
       parent_->SetErrorForCert(cert_name_, absl::nullopt,
                                identity_cert_error /* pass the ref */);

--- a/src/core/ext/xds/xds_client_grpc.cc
+++ b/src/core/ext/xds/xds_client_grpc.cc
@@ -101,7 +101,7 @@ absl::StatusOr<std::string> GetBootstrapContents(const char* fallback_config) {
               path->c_str());
     }
     grpc_slice contents;
-    grpc_error_handle error =
+    absl::Status error =
         grpc_load_file(path->c_str(), /*add_null_terminator=*/true, &contents);
     if (!GRPC_ERROR_IS_NONE(error)) return grpc_error_to_absl_status(error);
     std::string contents_str(StringViewFromSlice(contents));
@@ -218,7 +218,7 @@ void SetXdsFallbackBootstrapConfig(const char* config) {
 grpc_slice grpc_dump_xds_configs(void) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto xds_client = grpc_core::GrpcXdsClient::GetOrCreate(
       grpc_core::ChannelArgs(), "grpc_dump_xds_configs()");
   if (!xds_client.ok()) {

--- a/src/core/ext/xds/xds_transport_grpc.cc
+++ b/src/core/ext/xds/xds_transport_grpc.cc
@@ -46,6 +46,7 @@
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/closure.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/pollset_set.h"
 #include "src/core/lib/security/credentials/channel_creds_registry.h"
 #include "src/core/lib/security/credentials/credentials.h"
@@ -172,7 +173,7 @@ void GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::SendMessage(
 }
 
 void GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::
-    OnRequestSent(void* arg, grpc_error_handle error) {
+    OnRequestSent(void* arg, absl::Status error) {
   auto* self = static_cast<GrpcStreamingCall*>(arg);
   // Clean up the sent message.
   grpc_byte_buffer_destroy(self->send_message_payload_);
@@ -184,7 +185,7 @@ void GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::
 }
 
 void GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::
-    OnResponseReceived(void* arg, grpc_error_handle /*error*/) {
+    OnResponseReceived(void* arg, absl::Status /*error*/) {
   auto* self = static_cast<GrpcStreamingCall*>(arg);
   // If there was no payload, then we received status before we received
   // another message, so we stop reading.
@@ -214,7 +215,7 @@ void GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::
 }
 
 void GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::
-    OnStatusReceived(void* arg, grpc_error_handle /*error*/) {
+    OnStatusReceived(void* arg, absl::Status /*error*/) {
   auto* self = static_cast<GrpcStreamingCall*>(arg);
   self->event_handler_->OnStatusReceived(
       absl::Status(static_cast<absl::StatusCode>(self->status_code_),

--- a/src/core/ext/xds/xds_transport_grpc.h
+++ b/src/core/ext/xds/xds_transport_grpc.h
@@ -35,7 +35,6 @@
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 
 namespace grpc_core {
@@ -101,9 +100,9 @@ class GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall
   void SendMessage(std::string payload) override;
 
  private:
-  static void OnRequestSent(void* arg, grpc_error_handle error);
-  static void OnResponseReceived(void* arg, grpc_error_handle /*error*/);
-  static void OnStatusReceived(void* arg, grpc_error_handle /*error*/);
+  static void OnRequestSent(void* arg, absl::Status error);
+  static void OnResponseReceived(void* arg, absl::Status /*error*/);
+  static void OnStatusReceived(void* arg, absl::Status /*error*/);
 
   RefCountedPtr<GrpcXdsTransportFactory> factory_;
 

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -36,6 +36,7 @@
 
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/grpc_if_nametoindex.h"
 #include "src/core/lib/iomgr/port.h"
 #include "src/core/lib/iomgr/sockaddr.h"
@@ -50,7 +51,7 @@ bool grpc_parse_unix(const grpc_core::URI& uri,
             uri.scheme().c_str());
     return false;
   }
-  grpc_error_handle error =
+  absl::Status error =
       grpc_core::UnixSockaddrPopulate(uri.path(), resolved_addr);
   if (!GRPC_ERROR_IS_NONE(error)) {
     gpr_log(GPR_ERROR, "%s", grpc_error_std_string(error).c_str());
@@ -67,7 +68,7 @@ bool grpc_parse_unix_abstract(const grpc_core::URI& uri,
             uri.scheme().c_str());
     return false;
   }
-  grpc_error_handle error =
+  absl::Status error =
       grpc_core::UnixAbstractSockaddrPopulate(uri.path(), resolved_addr);
   if (!GRPC_ERROR_IS_NONE(error)) {
     gpr_log(GPR_ERROR, "%s", grpc_error_std_string(error).c_str());
@@ -79,8 +80,8 @@ bool grpc_parse_unix_abstract(const grpc_core::URI& uri,
 
 namespace grpc_core {
 
-grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
-                                       grpc_resolved_address* resolved_addr) {
+absl::Status UnixSockaddrPopulate(absl::string_view path,
+                                  grpc_resolved_address* resolved_addr) {
   memset(resolved_addr, 0, sizeof(*resolved_addr));
   struct sockaddr_un* un =
       reinterpret_cast<struct sockaddr_un*>(resolved_addr->addr);
@@ -96,7 +97,7 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle UnixAbstractSockaddrPopulate(
+absl::Status UnixAbstractSockaddrPopulate(
     absl::string_view path, grpc_resolved_address* resolved_addr) {
   memset(resolved_addr, 0, sizeof(*resolved_addr));
   struct sockaddr_un* un =
@@ -130,12 +131,12 @@ bool grpc_parse_unix_abstract(const grpc_core::URI& /* uri */,
 
 namespace grpc_core {
 
-grpc_error_handle UnixSockaddrPopulate(
-    absl::string_view /* path */, grpc_resolved_address* /* resolved_addr */) {
+absl::Status UnixSockaddrPopulate(absl::string_view /* path */,
+                                  grpc_resolved_address* /* resolved_addr */) {
   abort();
 }
 
-grpc_error_handle UnixAbstractSockaddrPopulate(
+absl::Status UnixAbstractSockaddrPopulate(
     absl::string_view /* path */, grpc_resolved_address* /* resolved_addr */) {
   abort();
 }

--- a/src/core/lib/address_utils/parse_address.h
+++ b/src/core/lib/address_utils/parse_address.h
@@ -23,10 +23,10 @@
 
 #include <stdint.h>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/resolved_address.h"
 #include "src/core/lib/uri/uri_parser.h"
 
@@ -73,13 +73,13 @@ absl::StatusOr<grpc_resolved_address> StringToSockaddr(
     absl::string_view address, int port);
 
 /** Populate \a resolved_addr to be a unix socket at |path| */
-grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
-                                       grpc_resolved_address* resolved_addr);
+absl::Status UnixSockaddrPopulate(absl::string_view path,
+                                  grpc_resolved_address* resolved_addr);
 
 /** Populate \a resolved_addr to be a unix socket in the abstract namespace
  * at |path| */
-grpc_error_handle UnixAbstractSockaddrPopulate(
-    absl::string_view path, grpc_resolved_address* resolved_addr);
+absl::Status UnixAbstractSockaddrPopulate(absl::string_view path,
+                                          grpc_resolved_address* resolved_addr);
 
 }  // namespace grpc_core
 

--- a/src/core/lib/channel/call_tracer.h
+++ b/src/core/lib/channel/call_tracer.h
@@ -28,7 +28,6 @@
 #include <grpc/impl/codegen/gpr_types.h>
 #include <grpc/support/atm.h>
 
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/slice/slice_buffer.h"
 #include "src/core/lib/transport/metadata_batch.h"
 #include "src/core/lib/transport/transport.h"
@@ -71,7 +70,7 @@ class CallTracer {
     virtual void RecordReceivedTrailingMetadata(
         absl::Status status, grpc_metadata_batch* recv_trailing_metadata,
         const grpc_transport_stream_stats* transport_stream_stats) = 0;
-    virtual void RecordCancel(grpc_error_handle cancel_error) = 0;
+    virtual void RecordCancel(absl::Status cancel_error) = 0;
     // Should be the last API call to the object. Once invoked, the tracer
     // library is free to destroy the object.
     virtual void RecordEnd(const gpr_timespec& latency) = 0;

--- a/src/core/lib/channel/channel_stack_builder_impl.cc
+++ b/src/core/lib/channel/channel_stack_builder_impl.cc
@@ -65,9 +65,9 @@ ChannelStackBuilderImpl::Build() {
   }
 
   // and initialize it
-  grpc_error_handle error = grpc_channel_stack_init(
+  absl::Status error = grpc_channel_stack_init(
       1,
-      [](void* p, grpc_error_handle) {
+      [](void* p, absl::Status) {
         auto* stk = static_cast<grpc_channel_stack*>(p);
         grpc_channel_stack_destroy(stk);
         gpr_free(stk);

--- a/src/core/lib/channel/connected_channel.cc
+++ b/src/core/lib/channel/connected_channel.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/channel/connected_channel.h"
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -55,13 +57,13 @@ typedef struct connected_channel_call_data {
   callback_state recv_trailing_metadata_ready;
 } call_data;
 
-static void run_in_call_combiner(void* arg, grpc_error_handle error) {
+static void run_in_call_combiner(void* arg, absl::Status error) {
   callback_state* state = static_cast<callback_state*>(arg);
   GRPC_CALL_COMBINER_START(state->call_combiner, state->original_closure,
                            GRPC_ERROR_REF(error), state->reason);
 }
 
-static void run_cancel_in_call_combiner(void* arg, grpc_error_handle error) {
+static void run_cancel_in_call_combiner(void* arg, absl::Status error) {
   run_in_call_combiner(arg, error);
   gpr_free(arg);
 }
@@ -148,7 +150,7 @@ static void connected_channel_start_transport_op(grpc_channel_element* elem,
 }
 
 /* Constructor for call_data */
-static grpc_error_handle connected_channel_init_call_elem(
+static absl::Status connected_channel_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
@@ -181,7 +183,7 @@ static void connected_channel_destroy_call_elem(
 }
 
 /* Constructor for channel_data */
-static grpc_error_handle connected_channel_init_channel_elem(
+static absl::Status connected_channel_init_channel_elem(
     grpc_channel_element* elem, grpc_channel_element_args* args) {
   channel_data* cd = static_cast<channel_data*>(elem->channel_data);
   GPR_ASSERT(args->is_last);

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -30,6 +30,7 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/meta/type_traits.h"
+#include "absl/status/status.h"
 
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/log.h>
@@ -174,8 +175,7 @@ class BaseCallData : public Activity, private Wakeable {
       release_.push_back(batch);
     }
 
-    void Cancel(grpc_transport_stream_op_batch* batch,
-                grpc_error_handle error) {
+    void Cancel(grpc_transport_stream_op_batch* batch, absl::Status error) {
       grpc_transport_stream_op_batch_queue_finish_with_failure(batch, error,
                                                                &call_closures_);
     }
@@ -185,7 +185,7 @@ class BaseCallData : public Activity, private Wakeable {
                          "Flusher::Complete");
     }
 
-    void AddClosure(grpc_closure* closure, grpc_error_handle error,
+    void AddClosure(grpc_closure* closure, absl::Status error,
                     const char* reason) {
       call_closures_.Add(closure, error, reason);
     }
@@ -217,7 +217,7 @@ class BaseCallData : public Activity, private Wakeable {
     // stack)
     void ResumeWith(Flusher* releaser);
     // Cancel this batch immediately (releases all refs)
-    void CancelWith(grpc_error_handle error, Flusher* releaser);
+    void CancelWith(absl::Status error, Flusher* releaser);
     // Complete this batch (pass it up) assuming refs drop to zero
     void CompleteWith(Flusher* releaser);
 
@@ -318,7 +318,7 @@ class ClientCallData : public BaseCallData {
   class PollContext;
 
   // Handle cancellation.
-  void Cancel(grpc_error_handle error);
+  void Cancel(absl::Status error);
   // Begin running the promise - which will ultimately take some initial
   // metadata and return some trailing metadata.
   void StartPromise(Flusher* flusher);
@@ -336,13 +336,11 @@ class ClientCallData : public BaseCallData {
   // All polls: await receiving the trailing metadata, then return it to the
   // application.
   Poll<ServerMetadataHandle> PollTrailingMetadata();
-  static void RecvTrailingMetadataReadyCallback(void* arg,
-                                                grpc_error_handle error);
-  void RecvTrailingMetadataReady(grpc_error_handle error);
-  void RecvInitialMetadataReady(grpc_error_handle error);
+  static void RecvTrailingMetadataReadyCallback(void* arg, absl::Status error);
+  void RecvTrailingMetadataReady(absl::Status error);
+  void RecvInitialMetadataReady(absl::Status error);
   // Given an error, fill in ServerMetadataHandle to represent that error.
-  void SetStatusFromError(grpc_metadata_batch* metadata,
-                          grpc_error_handle error);
+  void SetStatusFromError(grpc_metadata_batch* metadata, absl::Status error);
   // Wakeup and poll the promise if appropriate.
   void WakeInsideCombiner(Flusher* flusher);
   void OnWakeup() override;
@@ -360,7 +358,7 @@ class ClientCallData : public BaseCallData {
   // Our closure pointing to RecvTrailingMetadataReadyCallback.
   grpc_closure recv_trailing_metadata_ready_;
   // Error received during cancellation.
-  grpc_error_handle cancelled_error_ = GRPC_ERROR_NONE;
+  absl::Status cancelled_error_ = GRPC_ERROR_NONE;
   // State of the send_initial_metadata op.
   SendInitialState send_initial_state_ = SendInitialState::kInitial;
   // State of the recv_trailing_metadata op.
@@ -411,7 +409,7 @@ class ServerCallData : public BaseCallData {
   struct SendInitialMetadata;
 
   // Handle cancellation.
-  void Cancel(grpc_error_handle error, Flusher* flusher);
+  void Cancel(absl::Status error, Flusher* flusher);
   // Construct a promise that will "call" the next filter.
   // Effectively:
   //   - put the modified initial metadata into the batch being sent up.
@@ -421,9 +419,8 @@ class ServerCallData : public BaseCallData {
   // All polls: await sending the trailing metadata, then foward it down the
   // stack.
   Poll<ServerMetadataHandle> PollTrailingMetadata();
-  static void RecvInitialMetadataReadyCallback(void* arg,
-                                               grpc_error_handle error);
-  void RecvInitialMetadataReady(grpc_error_handle error);
+  static void RecvInitialMetadataReadyCallback(void* arg, absl::Status error);
+  void RecvInitialMetadataReady(absl::Status error);
   // Wakeup and poll the promise if appropriate.
   void WakeInsideCombiner(Flusher* flusher);
   void OnWakeup() override;
@@ -439,7 +436,7 @@ class ServerCallData : public BaseCallData {
   // Our closure pointing to RecvInitialMetadataReadyCallback.
   grpc_closure recv_initial_metadata_ready_;
   // Error received during cancellation.
-  grpc_error_handle cancelled_error_ = GRPC_ERROR_NONE;
+  absl::Status cancelled_error_ = GRPC_ERROR_NONE;
   // Trailing metadata batch
   CapturedBatch send_trailing_metadata_batch_;
   // State of the send_initial_metadata op.

--- a/src/core/lib/event_engine/windows/win_socket.cc
+++ b/src/core/lib/event_engine/windows/win_socket.cc
@@ -144,7 +144,7 @@ WinSocket::OpState* WinSocket::GetOpInfoForOverlapped(OVERLAPPED* overlapped) {
 
 namespace {
 
-grpc_error_handle grpc_tcp_set_non_block(SOCKET sock) {
+absl::Status grpc_tcp_set_non_block(SOCKET sock) {
   int status;
   uint32_t param = 1;
   DWORD ret;
@@ -155,7 +155,7 @@ grpc_error_handle grpc_tcp_set_non_block(SOCKET sock) {
              : GRPC_WSA_ERROR(WSAGetLastError(), "WSAIoctl(GRPC_FIONBIO)");
 }
 
-static grpc_error_handle set_dualstack(SOCKET sock) {
+static absl::Status set_dualstack(SOCKET sock) {
   int status;
   DWORD param = 0;
   status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&param,
@@ -165,7 +165,7 @@ static grpc_error_handle set_dualstack(SOCKET sock) {
              : GRPC_WSA_ERROR(WSAGetLastError(), "setsockopt(IPV6_V6ONLY)");
 }
 
-static grpc_error_handle enable_socket_low_latency(SOCKET sock) {
+static absl::Status enable_socket_low_latency(SOCKET sock) {
   int status;
   BOOL param = TRUE;
   status = ::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -240,7 +240,7 @@ void HttpRequest::Orphan() {
   Unref();
 }
 
-void HttpRequest::AppendError(grpc_error_handle error) {
+void HttpRequest::AppendError(absl::Status error) {
   if (GRPC_ERROR_IS_NONE(overall_error_)) {
     overall_error_ =
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed HTTP/1 client request");
@@ -254,11 +254,11 @@ void HttpRequest::AppendError(grpc_error_handle error) {
           addr_text.ok() ? addr_text.value() : addr_text.status().ToString()));
 }
 
-void HttpRequest::OnReadInternal(grpc_error_handle error) {
+void HttpRequest::OnReadInternal(absl::Status error) {
   for (size_t i = 0; i < incoming_.count; i++) {
     if (GRPC_SLICE_LENGTH(incoming_.slices[i])) {
       have_read_byte_ = 1;
-      grpc_error_handle err =
+      absl::Status err =
           grpc_http_parser_parse(&parser_, incoming_.slices[i], nullptr);
       if (!GRPC_ERROR_IS_NONE(err)) {
         Finish(err);
@@ -278,8 +278,8 @@ void HttpRequest::OnReadInternal(grpc_error_handle error) {
   }
 }
 
-void HttpRequest::ContinueDoneWriteAfterScheduleOnExecCtx(
-    void* arg, grpc_error_handle error) {
+void HttpRequest::ContinueDoneWriteAfterScheduleOnExecCtx(void* arg,
+                                                          absl::Status error) {
   RefCountedPtr<HttpRequest> req(static_cast<HttpRequest*>(arg));
   MutexLock lock(&req->mu_);
   if (GRPC_ERROR_IS_NONE(error) && !req->cancelled_) {
@@ -297,7 +297,7 @@ void HttpRequest::StartWrite() {
                       /*max_frame_size=*/INT_MAX);
 }
 
-void HttpRequest::OnHandshakeDone(void* arg, grpc_error_handle error) {
+void HttpRequest::OnHandshakeDone(void* arg, absl::Status error) {
   auto* args = static_cast<HandshakerArgs*>(arg);
   RefCountedPtr<HttpRequest> req(static_cast<HttpRequest*>(args->user_data));
   if (g_test_only_on_handshake_done_intercept != nullptr) {
@@ -357,7 +357,7 @@ void HttpRequest::DoHandshake(const grpc_resolved_address* addr) {
                               /*user_data=*/this);
 }
 
-void HttpRequest::NextAddress(grpc_error_handle error) {
+void HttpRequest::NextAddress(absl::Status error) {
   if (!GRPC_ERROR_IS_NONE(error)) {
     AppendError(error);
   }

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -109,7 +109,7 @@ class grpc_httpcli_ssl_channel_security_connector final
                   const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* /*auth_context*/,
                   grpc_closure* on_peer_checked) override {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    absl::Status error = GRPC_ERROR_NONE;
 
     /* Check the peer name. */
     if (secure_peer_name_ != nullptr &&
@@ -122,7 +122,7 @@ class grpc_httpcli_ssl_channel_security_connector final
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 

--- a/src/core/lib/http/parser.h
+++ b/src/core/lib/http/parser.h
@@ -24,10 +24,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/iomgr/error.h"
 
 /* Maximum length of a header string of the form 'Key: Value\r\n' */
 #define GRPC_HTTP_PARSER_MAX_HEADER_LENGTH 4096
@@ -117,10 +118,10 @@ void grpc_http_parser_init(grpc_http_parser* parser, grpc_http_type type,
 void grpc_http_parser_destroy(grpc_http_parser* parser);
 
 /* Sets \a start_of_body to the offset in \a slice of the start of the body. */
-grpc_error_handle grpc_http_parser_parse(grpc_http_parser* parser,
-                                         const grpc_slice& slice,
-                                         size_t* start_of_body);
-grpc_error_handle grpc_http_parser_eof(grpc_http_parser* parser);
+absl::Status grpc_http_parser_parse(grpc_http_parser* parser,
+                                    const grpc_slice& slice,
+                                    size_t* start_of_body);
+absl::Status grpc_http_parser_eof(grpc_http_parser* parser);
 
 void grpc_http_request_destroy(grpc_http_request* request);
 void grpc_http_response_destroy(grpc_http_response* response);

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -41,14 +41,13 @@ void fill_gpr_from_timestamp(gpr_timespec* gts, const struct timespec* ts) {
 }
 
 void default_timestamps_callback(void* /*arg*/, Timestamps* /*ts*/,
-                                 grpc_error_handle /*shudown_err*/) {
+                                 absl::Status /*shudown_err*/) {
   gpr_log(GPR_DEBUG, "Timestamps callback has not been registered");
 }
 
 /** The saved callback function that will be invoked when we get all the
  * timestamps that we are going to get for a TracedBuffer. */
-void (*timestamps_callback)(void*, Timestamps*,
-                            grpc_error_handle shutdown_err) =
+void (*timestamps_callback)(void*, Timestamps*, absl::Status shutdown_err) =
     default_timestamps_callback;
 
 /* Used to extract individual opt stats from cmsg, so as to avoid troubles with
@@ -269,7 +268,7 @@ void TracedBuffer::ProcessTimestamp(TracedBuffer** head,
 }
 
 void TracedBuffer::Shutdown(TracedBuffer** head, void* remaining,
-                            grpc_error_handle shutdown_err) {
+                            absl::Status shutdown_err) {
   GPR_DEBUG_ASSERT(head != nullptr);
   TracedBuffer* elem = *head;
   while (elem != nullptr) {
@@ -285,8 +284,8 @@ void TracedBuffer::Shutdown(TracedBuffer** head, void* remaining,
   GRPC_ERROR_UNREF(shutdown_err);
 }
 
-void grpc_tcp_set_write_timestamps_callback(
-    void (*fn)(void*, Timestamps*, grpc_error_handle error)) {
+void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*, Timestamps*,
+                                                       absl::Status error)) {
   timestamps_callback = fn;
 }
 } /* namespace grpc_core */
@@ -294,8 +293,8 @@ void grpc_tcp_set_write_timestamps_callback(
 #else /* GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_core {
-void grpc_tcp_set_write_timestamps_callback(
-    void (*fn)(void*, Timestamps*, grpc_error_handle error)) {
+void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*, Timestamps*,
+                                                       absl::Status error)) {
   // Cast value of fn to void to avoid unused parameter warning.
   // Can't comment out the name because some compilers and formatters don't
   // like the sequence */* , which would arise from */*fn*/.

--- a/src/core/lib/iomgr/buffer_list.h
+++ b/src/core/lib/iomgr/buffer_list.h
@@ -134,7 +134,7 @@ class TracedBuffer {
   /** Cleans the list by calling the callback for each traced buffer in the list
    * with timestamps that it has. */
   static void Shutdown(TracedBuffer** head, void* remaining,
-                       grpc_error_handle shutdown_err);
+                       absl::Status shutdown_err);
 
  private:
   uint32_t seq_no_;    /* The sequence number for the last byte in the buffer */
@@ -147,7 +147,7 @@ class TracedBuffer {
  public:
   /* Phony shutdown function */
   static void Shutdown(TracedBuffer** /*head*/, void* /*remaining*/,
-                       grpc_error_handle shutdown_err) {
+                       absl::Status shutdown_err) {
     GRPC_ERROR_UNREF(shutdown_err);
   }
 };
@@ -155,8 +155,8 @@ class TracedBuffer {
 
 /** Sets the callback function to call when timestamps for a write are
  *  collected. The callback does not own a reference to error. */
-void grpc_tcp_set_write_timestamps_callback(
-    void (*fn)(void*, Timestamps*, grpc_error_handle error));
+void grpc_tcp_set_write_timestamps_callback(void (*fn)(void*, Timestamps*,
+                                                       absl::Status error));
 
 } /* namespace grpc_core */
 

--- a/src/core/lib/iomgr/call_combiner.h
+++ b/src/core/lib/iomgr/call_combiner.h
@@ -58,7 +58,7 @@ class CallCombiner {
 #define GRPC_CALL_COMBINER_STOP(call_combiner, reason) \
   (call_combiner)->Stop(__FILE__, __LINE__, (reason))
   /// Starts processing \a closure.
-  void Start(grpc_closure* closure, grpc_error_handle error, const char* file,
+  void Start(grpc_closure* closure, absl::Status error, const char* file,
              int line, const char* reason);
   /// Yields the call combiner to the next closure in the queue, if any.
   void Stop(const char* file, int line, const char* reason);
@@ -68,8 +68,7 @@ class CallCombiner {
 #define GRPC_CALL_COMBINER_STOP(call_combiner, reason) \
   (call_combiner)->Stop((reason))
   /// Starts processing \a closure.
-  void Start(grpc_closure* closure, grpc_error_handle error,
-             const char* reason);
+  void Start(grpc_closure* closure, absl::Status error, const char* reason);
   /// Yields the call combiner to the next closure in the queue, if any.
   void Stop(const char* reason);
 #endif
@@ -98,19 +97,19 @@ class CallCombiner {
   void SetNotifyOnCancel(grpc_closure* closure);
 
   /// Indicates that the call has been cancelled.
-  void Cancel(grpc_error_handle error);
+  void Cancel(absl::Status error);
 
  private:
-  void ScheduleClosure(grpc_closure* closure, grpc_error_handle error);
+  void ScheduleClosure(grpc_closure* closure, absl::Status error);
 #ifdef GRPC_TSAN_ENABLED
-  static void TsanClosure(void* arg, grpc_error_handle error);
+  static void TsanClosure(void* arg, absl::Status error);
 #endif
 
   gpr_atm size_ = 0;  // size_t, num closures in queue or currently executing
   MultiProducerSingleConsumerQueue queue_;
   // Either 0 (if not cancelled and no cancellation closure set),
   // a grpc_closure* (if the lowest bit is 0),
-  // or a grpc_error_handle (if the lowest bit is 1).
+  // or a absl::Status (if the lowest bit is 1).
   gpr_atm cancel_state_ = 0;
 #ifdef GRPC_TSAN_ENABLED
   // A fake ref-counted lock that is kept alive after the destruction of
@@ -147,7 +146,7 @@ class CallCombinerClosureList {
 
   // Adds a closure to the list.  The closure must eventually result in
   // the call combiner being yielded.
-  void Add(grpc_closure* closure, grpc_error_handle error, const char* reason) {
+  void Add(grpc_closure* closure, absl::Status error, const char* reason) {
     closures_.emplace_back(closure, error, reason);
   }
 
@@ -197,10 +196,10 @@ class CallCombinerClosureList {
  private:
   struct CallCombinerClosure {
     grpc_closure* closure;
-    grpc_error_handle error;
+    absl::Status error;
     const char* reason;
 
-    CallCombinerClosure(grpc_closure* closure, grpc_error_handle error,
+    CallCombinerClosure(grpc_closure* closure, absl::Status error,
                         const char* reason)
         : closure(closure), error(error), reason(reason) {}
   };

--- a/src/core/lib/iomgr/cfstream_handle.cc
+++ b/src/core/lib/iomgr/cfstream_handle.cc
@@ -62,7 +62,7 @@ void CFStreamHandle::ReadCallback(CFReadStreamRef stream,
                                   void* client_callback_info) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
-  grpc_error_handle error;
+  absl::Status error;
   CFErrorRef stream_error;
   CFStreamHandle* handle = static_cast<CFStreamHandle*>(client_callback_info);
   if (grpc_tcp_trace.enabled()) {
@@ -97,7 +97,7 @@ void CFStreamHandle::WriteCallback(CFWriteStreamRef stream,
                                    void* clientCallBackInfo) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
-  grpc_error_handle error;
+  absl::Status error;
   CFErrorRef stream_error;
   CFStreamHandle* handle = static_cast<CFStreamHandle*>(clientCallBackInfo);
   if (grpc_tcp_trace.enabled()) {
@@ -171,7 +171,7 @@ void CFStreamHandle::NotifyOnWrite(grpc_closure* closure) {
   write_event_.NotifyOn(closure);
 }
 
-void CFStreamHandle::Shutdown(grpc_error_handle error) {
+void CFStreamHandle::Shutdown(absl::Status error) {
   open_event_.SetShutdown(GRPC_ERROR_REF(error));
   read_event_.SetShutdown(GRPC_ERROR_REF(error));
   write_event_.SetShutdown(GRPC_ERROR_REF(error));

--- a/src/core/lib/iomgr/cfstream_handle.h
+++ b/src/core/lib/iomgr/cfstream_handle.h
@@ -53,7 +53,7 @@ class CFStreamHandle : public GrpcLibraryInitHolder {
   void NotifyOnOpen(grpc_closure* closure);
   void NotifyOnRead(grpc_closure* closure);
   void NotifyOnWrite(grpc_closure* closure);
-  void Shutdown(grpc_error_handle error);
+  void Shutdown(absl::Status error);
 
   void Ref(const char* file = "", int line = 0, const char* reason = nullptr);
   void Unref(const char* file = "", int line = 0, const char* reason = nullptr);

--- a/src/core/lib/iomgr/closure.h
+++ b/src/core/lib/iomgr/closure.h
@@ -49,7 +49,7 @@ typedef struct grpc_closure_list {
  *              describing what went wrong.
  *              Error contract: it is not the cb's job to unref this error;
  *              the closure scheduler will do that after the cb returns */
-typedef void (*grpc_iomgr_cb_func)(void* arg, grpc_error_handle error);
+typedef void (*grpc_iomgr_cb_func)(void* arg, absl::Status error);
 
 /** A closure over a grpc_iomgr_cb_func. */
 struct grpc_closure {
@@ -125,7 +125,7 @@ struct wrapped_closure {
   void* cb_arg;
   grpc_closure wrapper;
 };
-inline void closure_wrapper(void* arg, grpc_error_handle error) {
+inline void closure_wrapper(void* arg, absl::Status error) {
   wrapped_closure* wc = static_cast<wrapped_closure*>(arg);
   grpc_iomgr_cb_func cb = wc->cb;
   void* cb_arg = wc->cb_arg;
@@ -193,7 +193,7 @@ inline bool grpc_closure_list_append(grpc_closure_list* closure_list,
     Returns true if \a list becomes non-empty */
 inline bool grpc_closure_list_append(grpc_closure_list* closure_list,
                                      grpc_closure* closure,
-                                     grpc_error_handle error) {
+                                     absl::Status error) {
   if (closure == nullptr) {
     GRPC_ERROR_UNREF(error);
     return false;
@@ -204,7 +204,7 @@ inline bool grpc_closure_list_append(grpc_closure_list* closure_list,
 
 /** force all success bits in \a list to false */
 inline void grpc_closure_list_fail_all(grpc_closure_list* list,
-                                       grpc_error_handle forced_failure) {
+                                       absl::Status forced_failure) {
   for (grpc_closure* c = list->head; c != nullptr; c = c->next_data.next) {
     if (c->error_data.error == 0) {
       c->error_data.error =
@@ -238,7 +238,7 @@ namespace grpc_core {
 class Closure {
  public:
   static void Run(const DebugLocation& location, grpc_closure* closure,
-                  grpc_error_handle error) {
+                  absl::Status error) {
     (void)location;
     if (closure == nullptr) {
       GRPC_ERROR_UNREF(error);

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -44,12 +44,11 @@ grpc_core::DebugOnlyTraceFlag grpc_combiner_trace(false, "combiner");
 #define STATE_ELEM_COUNT_LOW_BIT 2
 
 static void combiner_exec(grpc_core::Combiner* lock, grpc_closure* closure,
-                          grpc_error_handle error);
+                          absl::Status error);
 static void combiner_finally_exec(grpc_core::Combiner* lock,
-                                  grpc_closure* closure,
-                                  grpc_error_handle error);
+                                  grpc_closure* closure, absl::Status error);
 
-static void offload(void* arg, grpc_error_handle error);
+static void offload(void* arg, absl::Status error);
 
 grpc_core::Combiner* grpc_combiner_create(void) {
   grpc_core::Combiner* lock = new grpc_core::Combiner();
@@ -125,7 +124,7 @@ static void push_first_on_exec_ctx(grpc_core::Combiner* lock) {
 }
 
 static void combiner_exec(grpc_core::Combiner* lock, grpc_closure* cl,
-                          grpc_error_handle error) {
+                          absl::Status error) {
   gpr_atm last = gpr_atm_full_fetch_add(&lock->state, STATE_ELEM_COUNT_LOW_BIT);
   GRPC_COMBINER_TRACE(gpr_log(GPR_INFO,
                               "C:%p grpc_combiner_execute c=%p last=%" PRIdPTR,
@@ -163,7 +162,7 @@ static void move_next() {
   }
 }
 
-static void offload(void* arg, grpc_error_handle /*error*/) {
+static void offload(void* arg, absl::Status /*error*/) {
   grpc_core::Combiner* lock = static_cast<grpc_core::Combiner*>(arg);
   push_last_on_exec_ctx(lock);
 }
@@ -224,7 +223,7 @@ bool grpc_combiner_continue_exec_ctx() {
 #ifndef NDEBUG
     cl->scheduled = false;
 #endif
-    grpc_error_handle cl_err =
+    absl::Status cl_err =
         grpc_core::internal::StatusMoveFromHeapPtr(cl->error_data.error);
     cl->error_data.error = 0;
     cl->cb(cl->cb_arg, std::move(cl_err));
@@ -240,7 +239,7 @@ bool grpc_combiner_continue_exec_ctx() {
 #ifndef NDEBUG
       c->scheduled = false;
 #endif
-      grpc_error_handle error =
+      absl::Status error =
           grpc_core::internal::StatusMoveFromHeapPtr(c->error_data.error);
       c->error_data.error = 0;
       c->cb(c->cb_arg, std::move(error));
@@ -288,11 +287,10 @@ bool grpc_combiner_continue_exec_ctx() {
   return true;
 }
 
-static void enqueue_finally(void* closure, grpc_error_handle error);
+static void enqueue_finally(void* closure, absl::Status error);
 
 static void combiner_finally_exec(grpc_core::Combiner* lock,
-                                  grpc_closure* closure,
-                                  grpc_error_handle error) {
+                                  grpc_closure* closure, absl::Status error) {
   GPR_ASSERT(lock != nullptr);
   GRPC_COMBINER_TRACE(gpr_log(
       GPR_INFO, "C:%p grpc_combiner_execute_finally c=%p; ac=%p", lock, closure,
@@ -311,7 +309,7 @@ static void combiner_finally_exec(grpc_core::Combiner* lock,
   grpc_closure_list_append(&lock->final_list, closure, error);
 }
 
-static void enqueue_finally(void* closure, grpc_error_handle error) {
+static void enqueue_finally(void* closure, absl::Status error) {
   grpc_closure* cl = static_cast<grpc_closure*>(closure);
   grpc_core::Combiner* lock =
       reinterpret_cast<grpc_core::Combiner*>(cl->error_data.scratch);
@@ -320,11 +318,11 @@ static void enqueue_finally(void* closure, grpc_error_handle error) {
 }
 
 namespace grpc_core {
-void Combiner::Run(grpc_closure* closure, grpc_error_handle error) {
+void Combiner::Run(grpc_closure* closure, absl::Status error) {
   combiner_exec(this, closure, error);
 }
 
-void Combiner::FinallyRun(grpc_closure* closure, grpc_error_handle error) {
+void Combiner::FinallyRun(grpc_closure* closure, absl::Status error) {
   combiner_finally_exec(this, closure, error);
 }
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/combiner.h
+++ b/src/core/lib/iomgr/combiner.h
@@ -33,9 +33,9 @@ namespace grpc_core {
 // use ExecCtx
 class Combiner {
  public:
-  void Run(grpc_closure* closure, grpc_error_handle error);
+  void Run(grpc_closure* closure, absl::Status error);
   // TODO(yashkt) : Remove this method
-  void FinallyRun(grpc_closure* closure, grpc_error_handle error);
+  void FinallyRun(grpc_closure* closure, absl::Status error);
   Combiner* next_combiner_on_this_exec_ctx = nullptr;
   MultiProducerSingleConsumerQueue queue;
   // either:

--- a/src/core/lib/iomgr/endpoint.cc
+++ b/src/core/lib/iomgr/endpoint.cc
@@ -46,7 +46,7 @@ void grpc_endpoint_delete_from_pollset_set(grpc_endpoint* ep,
   ep->vtable->delete_from_pollset_set(ep, pollset_set);
 }
 
-void grpc_endpoint_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
+void grpc_endpoint_shutdown(grpc_endpoint* ep, absl::Status why) {
   ep->vtable->shutdown(ep, why);
 }
 

--- a/src/core/lib/iomgr/endpoint.h
+++ b/src/core/lib/iomgr/endpoint.h
@@ -44,7 +44,7 @@ struct grpc_endpoint_vtable {
   void (*add_to_pollset)(grpc_endpoint* ep, grpc_pollset* pollset);
   void (*add_to_pollset_set)(grpc_endpoint* ep, grpc_pollset_set* pollset);
   void (*delete_from_pollset_set)(grpc_endpoint* ep, grpc_pollset_set* pollset);
-  void (*shutdown)(grpc_endpoint* ep, grpc_error_handle why);
+  void (*shutdown)(grpc_endpoint* ep, absl::Status why);
   void (*destroy)(grpc_endpoint* ep);
   absl::string_view (*get_peer)(grpc_endpoint* ep);
   absl::string_view (*get_local_address)(grpc_endpoint* ep);
@@ -87,7 +87,7 @@ void grpc_endpoint_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
 
 /* Causes any pending and future read/write callbacks to run immediately with
    success==0 */
-void grpc_endpoint_shutdown(grpc_endpoint* ep, grpc_error_handle why);
+void grpc_endpoint_shutdown(grpc_endpoint* ep, absl::Status why);
 void grpc_endpoint_destroy(grpc_endpoint* ep);
 
 /* Add an endpoint to a pollset or pollset_set, so that when the pollset is

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -92,8 +92,8 @@ absl::Status grpc_wsa_error(const grpc_core::DebugLocation& location, int err,
 }
 #endif
 
-grpc_error_handle grpc_error_set_int(grpc_error_handle src,
-                                     grpc_error_ints which, intptr_t value) {
+absl::Status grpc_error_set_int(absl::Status src, grpc_error_ints which,
+                                intptr_t value) {
   if (GRPC_ERROR_IS_NONE(src)) {
     src = absl::UnknownError("");
     StatusSetInt(&src, grpc_core::StatusIntProperty::kRpcStatus,
@@ -104,7 +104,7 @@ grpc_error_handle grpc_error_set_int(grpc_error_handle src,
   return src;
 }
 
-bool grpc_error_get_int(grpc_error_handle error, grpc_error_ints which,
+bool grpc_error_get_int(absl::Status error, grpc_error_ints which,
                         intptr_t* p) {
   absl::optional<intptr_t> value = grpc_core::StatusGetInt(
       error, static_cast<grpc_core::StatusIntProperty>(which));
@@ -132,9 +132,8 @@ bool grpc_error_get_int(grpc_error_handle error, grpc_error_ints which,
   }
 }
 
-grpc_error_handle grpc_error_set_str(grpc_error_handle src,
-                                     grpc_error_strs which,
-                                     absl::string_view str) {
+absl::Status grpc_error_set_str(absl::Status src, grpc_error_strs which,
+                                absl::string_view str) {
   if (GRPC_ERROR_IS_NONE(src)) {
     src = absl::UnknownError("");
     StatusSetInt(&src, grpc_core::StatusIntProperty::kRpcStatus,
@@ -156,7 +155,7 @@ grpc_error_handle grpc_error_set_str(grpc_error_handle src,
   return src;
 }
 
-bool grpc_error_get_str(grpc_error_handle error, grpc_error_strs which,
+bool grpc_error_get_str(absl::Status error, grpc_error_strs which,
                         std::string* s) {
   if (which == GRPC_ERROR_STR_DESCRIPTION) {
     // absl::Status uses the message field for GRPC_ERROR_STR_DESCRIPTION
@@ -196,8 +195,7 @@ bool grpc_error_get_str(grpc_error_handle error, grpc_error_strs which,
   }
 }
 
-grpc_error_handle grpc_error_add_child(grpc_error_handle src,
-                                       grpc_error_handle child) {
+absl::Status grpc_error_add_child(absl::Status src, absl::Status child) {
   if (src.ok()) {
     return child;
   } else {
@@ -208,7 +206,7 @@ grpc_error_handle grpc_error_add_child(grpc_error_handle src,
   }
 }
 
-bool grpc_log_error(const char* what, grpc_error_handle error, const char* file,
+bool grpc_log_error(const char* what, absl::Status error, const char* file,
                     int line) {
   GPR_DEBUG_ASSERT(!GRPC_ERROR_IS_NONE(error));
   gpr_log(file, line, GPR_LOG_SEVERITY_ERROR, "%s: %s", what,

--- a/src/core/lib/iomgr/error_cfstream.cc
+++ b/src/core/lib/iomgr/error_cfstream.cc
@@ -31,9 +31,9 @@
 
 #define MAX_ERROR_DESCRIPTION 256
 
-grpc_error_handle grpc_error_create_from_cferror(const char* file, int line,
-                                                 void* arg,
-                                                 const char* custom_desc) {
+absl::Status grpc_error_create_from_cferror(const char* file, int line,
+                                            void* arg,
+                                            const char* custom_desc) {
   CFErrorRef error = static_cast<CFErrorRef>(arg);
   char buf_domain[MAX_ERROR_DESCRIPTION];
   char buf_desc[MAX_ERROR_DESCRIPTION];

--- a/src/core/lib/iomgr/error_cfstream.h
+++ b/src/core/lib/iomgr/error_cfstream.h
@@ -24,8 +24,8 @@
 #define GRPC_ERROR_CREATE_FROM_CFERROR(error, desc)  \
   grpc_error_create_from_cferror(__FILE__, __LINE__, \
                                  static_cast<void*>((error)), (desc))
-grpc_error_handle grpc_error_create_from_cferror(const char* file, int line,
-                                                 void* arg, const char* desc);
+absl::Status grpc_error_create_from_cferror(const char* file, int line,
+                                            void* arg, const char* desc);
 #endif /* GRPC_CFSTREAM */
 
 #endif /* GRPC_CORE_LIB_IOMGR_ERROR_CFSTREAM_H */

--- a/src/core/lib/iomgr/ev_apple.cc
+++ b/src/core/lib/iomgr/ev_apple.cc
@@ -219,9 +219,9 @@ static void pollset_global_shutdown(void) {
 /// The Apple pollset simply waits on a condition variable until it is kicked.
 /// The network events are handled in the global run loop thread. Processing of
 /// these events will eventually trigger the kick.
-static grpc_error_handle pollset_work(grpc_pollset* pollset,
-                                      grpc_pollset_worker** worker,
-                                      grpc_core::Timestamp deadline) {
+static absl::Status pollset_work(grpc_pollset* pollset,
+                                 grpc_pollset_worker** worker,
+                                 grpc_core::Timestamp deadline) {
   GRPC_POLLING_TRACE("pollset work: %p, worker: %p, deadline: %" PRIu64,
                      pollset, worker,
                      deadline.milliseconds_after_process_epoch());
@@ -273,8 +273,8 @@ static void kick_worker(GrpcAppleWorker* worker) {
 /// The caller must acquire the lock GrpcApplePollset.mu before calling this
 /// function. The kick action simply signals the condition variable of the
 /// worker.
-static grpc_error_handle pollset_kick(grpc_pollset* pollset,
-                                      grpc_pollset_worker* specific_worker) {
+static absl::Status pollset_kick(grpc_pollset* pollset,
+                                 grpc_pollset_worker* specific_worker) {
   GrpcApplePollset* apple_pollset =
       reinterpret_cast<GrpcApplePollset*>(pollset);
 

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -239,7 +239,7 @@ struct grpc_pollset_set {
  * Common helpers
  */
 
-static bool append_error(grpc_error_handle* composite, grpc_error_handle error,
+static bool append_error(absl::Status* composite, absl::Status error,
                          const char* desc) {
   if (GRPC_ERROR_IS_NONE(error)) return true;
   if (GRPC_ERROR_IS_NONE(*composite)) {
@@ -380,7 +380,7 @@ static int fd_wrapped_fd(grpc_fd* fd) { return fd->fd; }
 /* if 'releasing_fd' is true, it means that we are going to detach the internal
  * fd from grpc_fd structure (i.e which means we should not be calling
  * shutdown() syscall on that fd) */
-static void fd_shutdown_internal(grpc_fd* fd, grpc_error_handle why,
+static void fd_shutdown_internal(grpc_fd* fd, absl::Status why,
                                  bool releasing_fd) {
   if (fd->read_closure->SetShutdown(GRPC_ERROR_REF(why))) {
     if (!releasing_fd) {
@@ -400,13 +400,13 @@ static void fd_shutdown_internal(grpc_fd* fd, grpc_error_handle why,
 }
 
 /* Might be called multiple times */
-static void fd_shutdown(grpc_fd* fd, grpc_error_handle why) {
+static void fd_shutdown(grpc_fd* fd, absl::Status why) {
   fd_shutdown_internal(fd, why, false);
 }
 
 static void fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
                       const char* reason) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   bool is_release_fd = (release_fd != nullptr);
 
   if (!fd->read_closure->IsShutdown()) {
@@ -512,10 +512,10 @@ static size_t choose_neighborhood(void) {
   return static_cast<size_t>(gpr_cpu_current_cpu()) % g_num_neighborhoods;
 }
 
-static grpc_error_handle pollset_global_init(void) {
+static absl::Status pollset_global_init(void) {
   gpr_atm_no_barrier_store(&g_active_poller, 0);
   global_wakeup_fd.read_fd = -1;
-  grpc_error_handle err = grpc_wakeup_fd_init(&global_wakeup_fd);
+  absl::Status err = grpc_wakeup_fd_init(&global_wakeup_fd);
   if (!GRPC_ERROR_IS_NONE(err)) return err;
   struct epoll_event ev;
   ev.events = static_cast<uint32_t>(EPOLLIN | EPOLLET);
@@ -584,8 +584,8 @@ static void pollset_destroy(grpc_pollset* pollset) {
   gpr_mu_destroy(&pollset->mu);
 }
 
-static grpc_error_handle pollset_kick_all(grpc_pollset* pollset) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+static absl::Status pollset_kick_all(grpc_pollset* pollset) {
+  absl::Status error = GRPC_ERROR_NONE;
   if (pollset->root_worker != nullptr) {
     grpc_pollset_worker* worker = pollset->root_worker;
     do {
@@ -651,9 +651,9 @@ static int poll_deadline_to_millis_timeout(grpc_core::Timestamp millis) {
    NOTE ON SYNCRHONIZATION: Similar to do_epoll_wait(), this function is only
    called by g_active_poller thread. So there is no need for synchronization
    when accessing fields in g_epoll_set */
-static grpc_error_handle process_epoll_events(grpc_pollset* /*pollset*/) {
+static absl::Status process_epoll_events(grpc_pollset* /*pollset*/) {
   static const char* err_desc = "process_events";
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   long num_events = gpr_atm_acq_load(&g_epoll_set.num_events);
   long cursor = gpr_atm_acq_load(&g_epoll_set.cursor);
   for (int idx = 0;
@@ -701,8 +701,8 @@ static grpc_error_handle process_epoll_events(grpc_pollset* /*pollset*/) {
    NOTE ON SYNCHRONIZATION: At any point of time, only the g_active_poller
    (i.e the designated poller thread) will be calling this function. So there is
    no need for any synchronization when accesing fields in g_epoll_set */
-static grpc_error_handle do_epoll_wait(grpc_pollset* ps,
-                                       grpc_core::Timestamp deadline) {
+static absl::Status do_epoll_wait(grpc_pollset* ps,
+                                  grpc_core::Timestamp deadline) {
   int r;
   int timeout = poll_deadline_to_millis_timeout(deadline);
   if (timeout != 0) {
@@ -990,11 +990,11 @@ static void end_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
    The function pollset_work() may temporarily release the lock (pollset->po.mu)
    during the course of its execution but it will always re-acquire the lock and
    ensure that it is held by the time the function returns */
-static grpc_error_handle pollset_work(grpc_pollset* ps,
-                                      grpc_pollset_worker** worker_hdl,
-                                      grpc_core::Timestamp deadline) {
+static absl::Status pollset_work(grpc_pollset* ps,
+                                 grpc_pollset_worker** worker_hdl,
+                                 grpc_core::Timestamp deadline) {
   grpc_pollset_worker worker;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   static const char* err_desc = "pollset_work";
   if (ps->kicked_without_poller) {
     ps->kicked_without_poller = false;
@@ -1040,9 +1040,9 @@ static grpc_error_handle pollset_work(grpc_pollset* ps,
   return error;
 }
 
-static grpc_error_handle pollset_kick(grpc_pollset* pollset,
-                                      grpc_pollset_worker* specific_worker) {
-  grpc_error_handle ret_err = GRPC_ERROR_NONE;
+static absl::Status pollset_kick(grpc_pollset* pollset,
+                                 grpc_pollset_worker* specific_worker) {
+  absl::Status ret_err = GRPC_ERROR_NONE;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     std::vector<std::string> log;
     log.push_back(absl::StrFormat(
@@ -1217,7 +1217,7 @@ static bool is_any_background_poller_thread(void) { return false; }
 static void shutdown_background_closure(void) {}
 
 static bool add_closure_to_background_poller(grpc_closure* /*closure*/,
-                                             grpc_error_handle /*error*/) {
+                                             absl::Status /*error*/) {
   return false;
 }
 

--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -227,7 +227,7 @@ void grpc_fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
   g_event_engine->fd_orphan(fd, on_done, release_fd, reason);
 }
 
-void grpc_fd_shutdown(grpc_fd* fd, grpc_error_handle why) {
+void grpc_fd_shutdown(grpc_fd* fd, absl::Status why) {
   GRPC_POLLING_API_TRACE("fd_shutdown(%d)", grpc_fd_wrapped_fd(fd));
   GRPC_FD_TRACE("fd_shutdown(%d)", grpc_fd_wrapped_fd(fd));
   g_event_engine->fd_shutdown(fd, why);
@@ -272,20 +272,19 @@ static void pollset_destroy(grpc_pollset* pollset) {
   g_event_engine->pollset_destroy(pollset);
 }
 
-static grpc_error_handle pollset_work(grpc_pollset* pollset,
-                                      grpc_pollset_worker** worker,
-                                      grpc_core::Timestamp deadline) {
+static absl::Status pollset_work(grpc_pollset* pollset,
+                                 grpc_pollset_worker** worker,
+                                 grpc_core::Timestamp deadline) {
   GRPC_POLLING_API_TRACE("pollset_work(%p, %" PRId64 ") begin", pollset,
                          deadline.milliseconds_after_process_epoch());
-  grpc_error_handle err =
-      g_event_engine->pollset_work(pollset, worker, deadline);
+  absl::Status err = g_event_engine->pollset_work(pollset, worker, deadline);
   GRPC_POLLING_API_TRACE("pollset_work(%p, %" PRId64 ") end", pollset,
                          deadline.milliseconds_after_process_epoch());
   return err;
 }
 
-static grpc_error_handle pollset_kick(grpc_pollset* pollset,
-                                      grpc_pollset_worker* specific_worker) {
+static absl::Status pollset_kick(grpc_pollset* pollset,
+                                 grpc_pollset_worker* specific_worker) {
   GRPC_POLLING_API_TRACE("pollset_kick(%p, %p)", pollset, specific_worker);
   return g_event_engine->pollset_kick(pollset, specific_worker);
 }
@@ -364,7 +363,7 @@ bool grpc_is_any_background_poller_thread(void) {
 }
 
 bool grpc_add_closure_to_background_poller(grpc_closure* closure,
-                                           grpc_error_handle error) {
+                                           absl::Status error) {
   return g_event_engine->add_closure_to_background_poller(closure, error);
 }
 

--- a/src/core/lib/iomgr/ev_posix.h
+++ b/src/core/lib/iomgr/ev_posix.h
@@ -52,7 +52,7 @@ typedef struct grpc_event_engine_vtable {
   int (*fd_wrapped_fd)(grpc_fd* fd);
   void (*fd_orphan)(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
                     const char* reason);
-  void (*fd_shutdown)(grpc_fd* fd, grpc_error_handle why);
+  void (*fd_shutdown)(grpc_fd* fd, absl::Status why);
   void (*fd_notify_on_read)(grpc_fd* fd, grpc_closure* closure);
   void (*fd_notify_on_write)(grpc_fd* fd, grpc_closure* closure);
   void (*fd_notify_on_error)(grpc_fd* fd, grpc_closure* closure);
@@ -64,11 +64,11 @@ typedef struct grpc_event_engine_vtable {
   void (*pollset_init)(grpc_pollset* pollset, gpr_mu** mu);
   void (*pollset_shutdown)(grpc_pollset* pollset, grpc_closure* closure);
   void (*pollset_destroy)(grpc_pollset* pollset);
-  grpc_error_handle (*pollset_work)(grpc_pollset* pollset,
-                                    grpc_pollset_worker** worker,
-                                    grpc_core::Timestamp deadline);
-  grpc_error_handle (*pollset_kick)(grpc_pollset* pollset,
-                                    grpc_pollset_worker* specific_worker);
+  absl::Status (*pollset_work)(grpc_pollset* pollset,
+                               grpc_pollset_worker** worker,
+                               grpc_core::Timestamp deadline);
+  absl::Status (*pollset_kick)(grpc_pollset* pollset,
+                               grpc_pollset_worker* specific_worker);
   void (*pollset_add_fd)(grpc_pollset* pollset, struct grpc_fd* fd);
 
   grpc_pollset_set* (*pollset_set_create)(void);
@@ -91,7 +91,7 @@ typedef struct grpc_event_engine_vtable {
   void (*shutdown_background_closure)(void);
   void (*shutdown_engine)(void);
   bool (*add_closure_to_background_poller)(grpc_closure* closure,
-                                           grpc_error_handle error);
+                                           absl::Status error);
 } grpc_event_engine_vtable;
 
 /* register a new event engine factory */
@@ -141,7 +141,7 @@ void grpc_fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
 bool grpc_fd_is_shutdown(grpc_fd* fd);
 
 /* Cause any current and future callbacks to fail. */
-void grpc_fd_shutdown(grpc_fd* fd, grpc_error_handle why);
+void grpc_fd_shutdown(grpc_fd* fd, absl::Status why);
 
 /* Register read interest, causing read_cb to be called once when fd becomes
    readable, on deadline specified by deadline, or on shutdown triggered by
@@ -197,7 +197,7 @@ bool grpc_is_any_background_poller_thread();
  * that the closure may or may not run yet when this function returns, and the
  * closure should not be blocking or long-running. */
 bool grpc_add_closure_to_background_poller(grpc_closure* closure,
-                                           grpc_error_handle error);
+                                           absl::Status error);
 
 /* Shut down all the closures registered in the background poller. */
 void grpc_shutdown_background_closure();

--- a/src/core/lib/iomgr/exec_ctx.cc
+++ b/src/core/lib/iomgr/exec_ctx.cc
@@ -36,7 +36,7 @@ static void exec_ctx_run(grpc_closure* closure) {
             closure->line_initiated);
   }
 #endif
-  grpc_error_handle error =
+  absl::Status error =
       grpc_core::internal::StatusMoveFromHeapPtr(closure->error_data.error);
   closure->error_data.error = 0;
   closure->cb(closure->cb_arg, std::move(error));
@@ -78,7 +78,7 @@ bool ExecCtx::Flush() {
 }
 
 void ExecCtx::Run(const DebugLocation& location, grpc_closure* closure,
-                  grpc_error_handle error) {
+                  absl::Status error) {
   (void)location;
   if (closure == nullptr) {
     GRPC_ERROR_UNREF(error);

--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -189,7 +189,7 @@ class ExecCtx {
   static ExecCtx* Get() { return exec_ctx_; }
 
   static void Run(const DebugLocation& location, grpc_closure* closure,
-                  grpc_error_handle error);
+                  absl::Status error);
 
   static void RunList(const DebugLocation& location, grpc_closure_list* list);
 

--- a/src/core/lib/iomgr/executor.h
+++ b/src/core/lib/iomgr/executor.h
@@ -70,7 +70,7 @@ class Executor {
 
   /** Enqueue the closure onto the executor. is_short is true if the closure is
    * a short job (i.e expected to not block and complete quickly) */
-  void Enqueue(grpc_closure* closure, grpc_error_handle error, bool is_short);
+  void Enqueue(grpc_closure* closure, absl::Status error, bool is_short);
 
   // TODO(sreek): Currently we have two executors (available globally): The
   // default executor and the resolver executor.
@@ -83,7 +83,7 @@ class Executor {
   // Initialize ALL the executors
   static void InitAll();
 
-  static void Run(grpc_closure* closure, grpc_error_handle error,
+  static void Run(grpc_closure* closure, absl::Status error,
                   ExecutorType executor_type = ExecutorType::DEFAULT,
                   ExecutorJobType job_type = ExecutorJobType::SHORT);
 

--- a/src/core/lib/iomgr/iomgr.cc
+++ b/src/core/lib/iomgr/iomgr.cc
@@ -175,7 +175,7 @@ bool grpc_iomgr_is_any_background_poller_thread() {
 }
 
 bool grpc_iomgr_add_closure_to_background_poller(grpc_closure* closure,
-                                                 grpc_error_handle error) {
+                                                 absl::Status error) {
   return grpc_iomgr_platform_add_closure_to_background_poller(closure, error);
 }
 

--- a/src/core/lib/iomgr/iomgr.h
+++ b/src/core/lib/iomgr/iomgr.h
@@ -52,7 +52,7 @@ bool grpc_iomgr_is_any_background_poller_thread();
  * that the closure may or may not run yet when this function returns, and the
  * closure should not be blocking or long-running. */
 bool grpc_iomgr_add_closure_to_background_poller(grpc_closure* closure,
-                                                 grpc_error_handle error);
+                                                 absl::Status error);
 
 /* Exposed only for testing */
 size_t grpc_iomgr_count_objects_for_testing();

--- a/src/core/lib/iomgr/iomgr_internal.cc
+++ b/src/core/lib/iomgr/iomgr_internal.cc
@@ -46,8 +46,8 @@ bool grpc_iomgr_platform_is_any_background_poller_thread() {
   return iomgr_platform_vtable->is_any_background_poller_thread();
 }
 
-bool grpc_iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error_handle error) {
+bool grpc_iomgr_platform_add_closure_to_background_poller(grpc_closure* closure,
+                                                          absl::Status error) {
   return iomgr_platform_vtable->add_closure_to_background_poller(closure,
                                                                  error);
 }

--- a/src/core/lib/iomgr/iomgr_internal.h
+++ b/src/core/lib/iomgr/iomgr_internal.h
@@ -39,7 +39,7 @@ typedef struct grpc_iomgr_platform_vtable {
   void (*shutdown_background_closure)(void);
   bool (*is_any_background_poller_thread)(void);
   bool (*add_closure_to_background_poller)(grpc_closure* closure,
-                                           grpc_error_handle error);
+                                           absl::Status error);
 } grpc_iomgr_platform_vtable;
 
 void grpc_iomgr_register_object(grpc_iomgr_object* obj, const char* name);
@@ -66,8 +66,8 @@ bool grpc_iomgr_platform_is_any_background_poller_thread(void);
 /** Return true if the closure is registered into the background poller. Note
  * that the closure may or may not run yet when this function returns, and the
  * closure should not be blocking or long-running. */
-bool grpc_iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error_handle error);
+bool grpc_iomgr_platform_add_closure_to_background_poller(grpc_closure* closure,
+                                                          absl::Status error);
 
 bool grpc_iomgr_abort_on_leaks(void);
 

--- a/src/core/lib/iomgr/iomgr_posix.cc
+++ b/src/core/lib/iomgr/iomgr_posix.cc
@@ -61,7 +61,7 @@ static bool iomgr_platform_is_any_background_poller_thread(void) {
 }
 
 static bool iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error_handle error) {
+    grpc_closure* closure, absl::Status error) {
   return grpc_add_closure_to_background_poller(closure, error);
 }
 

--- a/src/core/lib/iomgr/iomgr_posix_cfstream.cc
+++ b/src/core/lib/iomgr/iomgr_posix_cfstream.cc
@@ -72,7 +72,7 @@ static bool apple_iomgr_platform_is_any_background_poller_thread(void) {
 }
 
 static bool apple_iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error_handle error) {
+    grpc_closure* closure, absl::Status error) {
   return false;
 }
 
@@ -142,7 +142,7 @@ static bool iomgr_platform_is_any_background_poller_thread(void) {
 }
 
 static bool iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error_handle error) {
+    grpc_closure* closure, absl::Status error) {
   return grpc_add_closure_to_background_poller(closure, error);
 }
 

--- a/src/core/lib/iomgr/iomgr_windows.cc
+++ b/src/core/lib/iomgr/iomgr_windows.cc
@@ -78,7 +78,7 @@ static bool iomgr_platform_is_any_background_poller_thread(void) {
 }
 
 static bool iomgr_platform_add_closure_to_background_poller(
-    grpc_closure* closure, grpc_error_handle error) {
+    grpc_closure* closure, absl::Status error) {
   return false;
 }
 

--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -30,14 +30,14 @@
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/block_annotate.h"
 
-grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
-                                 grpc_slice* output) {
+absl::Status grpc_load_file(const char* filename, int add_null_terminator,
+                            grpc_slice* output) {
   unsigned char* contents = nullptr;
   size_t contents_size = 0;
   grpc_slice result = grpc_empty_slice();
   FILE* file;
   size_t bytes_read = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
 
   GRPC_SCHEDULING_START_BLOCKING_REGION;
   file = fopen(filename, "rb");
@@ -67,7 +67,7 @@ end:
   *output = result;
   if (file != nullptr) fclose(file);
   if (!GRPC_ERROR_IS_NONE(error)) {
-    grpc_error_handle error_out =
+    absl::Status error_out =
         grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                "Failed to load file", &error, 1),
                            GRPC_ERROR_STR_FILENAME,

--- a/src/core/lib/iomgr/load_file.h
+++ b/src/core/lib/iomgr/load_file.h
@@ -29,7 +29,7 @@
 
 /* Loads the content of a file into a slice. add_null_terminator will add
    a NULL terminator if non-zero. */
-grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
-                                 grpc_slice* output);
+absl::Status grpc_load_file(const char* filename, int add_null_terminator,
+                            grpc_slice* output);
 
 #endif /* GRPC_CORE_LIB_IOMGR_LOAD_FILE_H */

--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -139,7 +139,7 @@ void LockfreeEvent::NotifyOn(grpc_closure* closure) {
            contains a pointer to the shutdown-error). If the fd is shutdown,
            schedule the closure with the shutdown error */
         if ((curr & kShutdownBit) > 0) {
-          grpc_error_handle shutdown_err =
+          absl::Status shutdown_err =
               internal::StatusGetFromHeapPtr(curr & ~kShutdownBit);
           ExecCtx::Run(DEBUG_LOCATION, closure,
                        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
@@ -159,7 +159,7 @@ void LockfreeEvent::NotifyOn(grpc_closure* closure) {
   GPR_UNREACHABLE_CODE(return );
 }
 
-bool LockfreeEvent::SetShutdown(grpc_error_handle shutdown_error) {
+bool LockfreeEvent::SetShutdown(absl::Status shutdown_error) {
   intptr_t status_ptr = internal::StatusAllocHeapPtr(shutdown_error);
   gpr_atm new_state = status_ptr | kShutdownBit;
 

--- a/src/core/lib/iomgr/lockfree_event.h
+++ b/src/core/lib/iomgr/lockfree_event.h
@@ -56,7 +56,7 @@ class LockfreeEvent {
 
   // Sets the shutdown state. If a closure had been provided by NotifyOn and has
   // not yet been scheduled, it will be scheduled with \a shutdown_error.
-  bool SetShutdown(grpc_error_handle shutdown_error);
+  bool SetShutdown(absl::Status shutdown_error);
 
   // Signals that the event has been received.
   void SetReady();

--- a/src/core/lib/iomgr/pollset.cc
+++ b/src/core/lib/iomgr/pollset.cc
@@ -42,14 +42,14 @@ void grpc_pollset_destroy(grpc_pollset* pollset) {
   grpc_pollset_impl->destroy(pollset);
 }
 
-grpc_error_handle grpc_pollset_work(grpc_pollset* pollset,
-                                    grpc_pollset_worker** worker,
-                                    grpc_core::Timestamp deadline) {
+absl::Status grpc_pollset_work(grpc_pollset* pollset,
+                               grpc_pollset_worker** worker,
+                               grpc_core::Timestamp deadline) {
   return grpc_pollset_impl->work(pollset, worker, deadline);
 }
 
-grpc_error_handle grpc_pollset_kick(grpc_pollset* pollset,
-                                    grpc_pollset_worker* specific_worker) {
+absl::Status grpc_pollset_kick(grpc_pollset* pollset,
+                               grpc_pollset_worker* specific_worker) {
   return grpc_pollset_impl->kick(pollset, specific_worker);
 }
 

--- a/src/core/lib/iomgr/pollset.h
+++ b/src/core/lib/iomgr/pollset.h
@@ -44,10 +44,10 @@ typedef struct grpc_pollset_vtable {
   void (*init)(grpc_pollset* pollset, gpr_mu** mu);
   void (*shutdown)(grpc_pollset* pollset, grpc_closure* closure);
   void (*destroy)(grpc_pollset* pollset);
-  grpc_error_handle (*work)(grpc_pollset* pollset, grpc_pollset_worker** worker,
-                            grpc_core::Timestamp deadline);
-  grpc_error_handle (*kick)(grpc_pollset* pollset,
-                            grpc_pollset_worker* specific_worker);
+  absl::Status (*work)(grpc_pollset* pollset, grpc_pollset_worker** worker,
+                       grpc_core::Timestamp deadline);
+  absl::Status (*kick)(grpc_pollset* pollset,
+                       grpc_pollset_worker* specific_worker);
   size_t (*pollset_size)(void);
 } grpc_pollset_vtable;
 
@@ -86,14 +86,14 @@ void grpc_pollset_destroy(grpc_pollset* pollset);
    May call grpc_closure_list_run on grpc_closure_list, without holding the
    pollset
    lock */
-grpc_error_handle grpc_pollset_work(
+absl::Status grpc_pollset_work(
     grpc_pollset* pollset, grpc_pollset_worker** worker,
     grpc_core::Timestamp deadline) GRPC_MUST_USE_RESULT;
 
 /* Break one polling thread out of polling work for this pollset.
    If specific_worker is non-NULL, then kick that worker. */
-grpc_error_handle grpc_pollset_kick(grpc_pollset* pollset,
-                                    grpc_pollset_worker* specific_worker)
+absl::Status grpc_pollset_kick(grpc_pollset* pollset,
+                               grpc_pollset_worker* specific_worker)
     GRPC_MUST_USE_RESULT;
 
 #endif /* GRPC_CORE_LIB_IOMGR_POLLSET_H */

--- a/src/core/lib/iomgr/pollset_windows.cc
+++ b/src/core/lib/iomgr/pollset_windows.cc
@@ -106,9 +106,9 @@ static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
 
 static void pollset_destroy(grpc_pollset* pollset) {}
 
-static grpc_error_handle pollset_work(grpc_pollset* pollset,
-                                      grpc_pollset_worker** worker_hdl,
-                                      grpc_core::Timestamp deadline) {
+static absl::Status pollset_work(grpc_pollset* pollset,
+                                 grpc_pollset_worker** worker_hdl,
+                                 grpc_core::Timestamp deadline) {
   grpc_pollset_worker worker;
   if (worker_hdl) *worker_hdl = &worker;
 
@@ -183,8 +183,8 @@ done:
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error_handle pollset_kick(grpc_pollset* p,
-                                      grpc_pollset_worker* specific_worker) {
+static absl::Status pollset_kick(grpc_pollset* p,
+                                 grpc_pollset_worker* specific_worker) {
   bool should_kick_global = false;
   if (specific_worker != NULL) {
     if (specific_worker == GRPC_POLLSET_KICK_BROADCAST) {

--- a/src/core/lib/iomgr/python_util.h
+++ b/src/core/lib/iomgr/python_util.h
@@ -30,7 +30,7 @@
 // They are easier to define here (rather than in Cython)
 // because Cython doesn't handle #defines well.
 
-inline grpc_error_handle grpc_socket_error(char* error) {
+inline absl::Status grpc_socket_error(char* error) {
   return grpc_error_set_int(GRPC_ERROR_CREATE_FROM_COPIED_STRING(error),
                             GRPC_ERROR_INT_GRPC_STATUS,
                             GRPC_STATUS_UNAVAILABLE);

--- a/src/core/lib/iomgr/resolve_address_impl.h
+++ b/src/core/lib/iomgr/resolve_address_impl.h
@@ -41,7 +41,7 @@ class DNSCallbackExecCtxScheduler {
   }
 
  private:
-  static void RunCallback(void* arg, grpc_error_handle /* error */) {
+  static void RunCallback(void* arg, absl::Status /* error */) {
     DNSCallbackExecCtxScheduler* self =
         static_cast<DNSCallbackExecCtxScheduler*>(arg);
     self->on_done_(std::move(self->param_));

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -63,7 +63,7 @@ class NativeDNSRequest {
  private:
   // Callback to be passed to grpc Executor to asynch-ify
   // LookupHostnameBlocking
-  static void DoRequestThread(void* rp, grpc_error_handle /*error*/) {
+  static void DoRequestThread(void* rp, absl::Status /*error*/) {
     NativeDNSRequest* r = static_cast<NativeDNSRequest*>(rp);
     auto result =
         GetDNSResolver()->LookupHostnameBlocking(r->name_, r->default_port_);
@@ -105,7 +105,7 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
   struct addrinfo *result = nullptr, *resp;
   int s;
   size_t i;
-  grpc_error_handle err;
+  absl::Status err;
   std::vector<grpc_resolved_address> addresses;
   std::string host;
   std::string port;

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -66,7 +66,7 @@ class NativeDNSRequest {
  private:
   // Callback to be passed to grpc Executor to asynch-ify
   // LookupHostnameBlocking
-  static void DoRequestThread(void* rp, grpc_error_handle /*error*/) {
+  static void DoRequestThread(void* rp, absl::Status /*error*/) {
     NativeDNSRequest* r = static_cast<NativeDNSRequest*>(rp);
     auto result =
         GetDNSResolver()->LookupHostnameBlocking(r->name_, r->default_port_);
@@ -107,7 +107,7 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
   struct addrinfo *result = NULL, *resp;
   int s;
   size_t i;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   std::vector<grpc_resolved_address> addresses;
 
   // parse name, splitting it into host and port parts

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -53,7 +53,7 @@
 #include "src/core/lib/iomgr/sockaddr.h"
 
 /* set a socket to use zerocopy */
-grpc_error_handle grpc_set_socket_zerocopy(int fd) {
+absl::Status grpc_set_socket_zerocopy(int fd) {
 #ifdef GRPC_LINUX_ERRQUEUE
   const int enable = 1;
   auto err = setsockopt(fd, SOL_SOCKET, SO_ZEROCOPY, &enable, sizeof(enable));
@@ -68,7 +68,7 @@ grpc_error_handle grpc_set_socket_zerocopy(int fd) {
 }
 
 /* set a socket to non blocking mode */
-grpc_error_handle grpc_set_socket_nonblocking(int fd, int non_blocking) {
+absl::Status grpc_set_socket_nonblocking(int fd, int non_blocking) {
   int oldflags = fcntl(fd, F_GETFL, 0);
   if (oldflags < 0) {
     return GRPC_OS_ERROR(errno, "fcntl");
@@ -87,7 +87,7 @@ grpc_error_handle grpc_set_socket_nonblocking(int fd, int non_blocking) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_set_socket_no_sigpipe_if_possible(int fd) {
+absl::Status grpc_set_socket_no_sigpipe_if_possible(int fd) {
 #ifdef GRPC_HAVE_SO_NOSIGPIPE
   int val = 1;
   int newval;
@@ -108,7 +108,7 @@ grpc_error_handle grpc_set_socket_no_sigpipe_if_possible(int fd) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_set_socket_ip_pktinfo_if_possible(int fd) {
+absl::Status grpc_set_socket_ip_pktinfo_if_possible(int fd) {
   // Use conditionally-important parameter to avoid warning
   (void)fd;
 #ifdef GRPC_HAVE_IP_PKTINFO
@@ -121,7 +121,7 @@ grpc_error_handle grpc_set_socket_ip_pktinfo_if_possible(int fd) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
+absl::Status grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
   // Use conditionally-important parameter to avoid warning
   (void)fd;
 #ifdef GRPC_HAVE_IPV6_RECVPKTINFO
@@ -134,14 +134,14 @@ grpc_error_handle grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_set_socket_sndbuf(int fd, int buffer_size_bytes) {
+absl::Status grpc_set_socket_sndbuf(int fd, int buffer_size_bytes) {
   return 0 == setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buffer_size_bytes,
                          sizeof(buffer_size_bytes))
              ? GRPC_ERROR_NONE
              : GRPC_OS_ERROR(errno, "setsockopt(SO_SNDBUF)");
 }
 
-grpc_error_handle grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes) {
+absl::Status grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes) {
   return 0 == setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buffer_size_bytes,
                          sizeof(buffer_size_bytes))
              ? GRPC_ERROR_NONE
@@ -149,7 +149,7 @@ grpc_error_handle grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes) {
 }
 
 /* set a socket to close on exec */
-grpc_error_handle grpc_set_socket_cloexec(int fd, int close_on_exec) {
+absl::Status grpc_set_socket_cloexec(int fd, int close_on_exec) {
   int oldflags = fcntl(fd, F_GETFD, 0);
   if (oldflags < 0) {
     return GRPC_OS_ERROR(errno, "fcntl");
@@ -169,7 +169,7 @@ grpc_error_handle grpc_set_socket_cloexec(int fd, int close_on_exec) {
 }
 
 /* set a socket to reuse old addresses */
-grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse) {
+absl::Status grpc_set_socket_reuse_addr(int fd, int reuse) {
   int val = (reuse != 0);
   int newval;
   socklen_t intlen = sizeof(newval);
@@ -187,7 +187,7 @@ grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse) {
 }
 
 /* set a socket to reuse old addresses */
-grpc_error_handle grpc_set_socket_reuse_port(int fd, int reuse) {
+absl::Status grpc_set_socket_reuse_port(int fd, int reuse) {
 #ifndef SO_REUSEPORT
   return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
       "SO_REUSEPORT unavailable on compiling system");
@@ -232,7 +232,7 @@ bool grpc_is_socket_reuse_port_supported() {
 }
 
 /* disable nagle */
-grpc_error_handle grpc_set_socket_low_latency(int fd, int low_latency) {
+absl::Status grpc_set_socket_low_latency(int fd, int low_latency) {
   int val = (low_latency != 0);
   int newval;
   socklen_t intlen = sizeof(newval);
@@ -297,7 +297,7 @@ void config_default_tcp_user_timeout(bool enable, int timeout, bool is_client) {
 }
 
 /* Set TCP_USER_TIMEOUT */
-grpc_error_handle grpc_set_socket_tcp_user_timeout(
+absl::Status grpc_set_socket_tcp_user_timeout(
     int fd, const grpc_core::PosixTcpOptions& options, bool is_client) {
   // Use conditionally-important parameter to avoid warning
   (void)fd;
@@ -371,8 +371,8 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
 }
 
 /* set a socket using a grpc_socket_mutator */
-grpc_error_handle grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
-                                               grpc_socket_mutator* mutator) {
+absl::Status grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
+                                          grpc_socket_mutator* mutator) {
   GPR_ASSERT(mutator);
   if (!grpc_socket_mutator_mutate_fd(mutator, fd, usage)) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("grpc_socket_mutator failed.");
@@ -380,7 +380,7 @@ grpc_error_handle grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_apply_socket_mutator_in_args(
+absl::Status grpc_apply_socket_mutator_in_args(
     int fd, grpc_fd_usage usage, const grpc_core::PosixTcpOptions& options) {
   if (options.socket_mutator == nullptr) {
     return GRPC_ERROR_NONE;
@@ -416,17 +416,16 @@ int grpc_ipv6_loopback_available(void) {
   return g_ipv6_loopback_available;
 }
 
-static grpc_error_handle error_for_fd(int fd,
-                                      const grpc_resolved_address* addr) {
+static absl::Status error_for_fd(int fd, const grpc_resolved_address* addr) {
   if (fd >= 0) return GRPC_ERROR_NONE;
   auto addr_str = grpc_sockaddr_to_string(addr, false);
-  grpc_error_handle err = grpc_error_set_str(
+  absl::Status err = grpc_error_set_str(
       GRPC_OS_ERROR(errno, "socket"), GRPC_ERROR_STR_TARGET_ADDRESS,
       addr_str.ok() ? addr_str.value() : addr_str.status().ToString());
   return err;
 }
 
-grpc_error_handle grpc_create_dualstack_socket(
+absl::Status grpc_create_dualstack_socket(
     const grpc_resolved_address* resolved_addr, int type, int protocol,
     grpc_dualstack_mode* dsmode, int* newfd) {
   return grpc_create_dualstack_socket_using_factory(
@@ -440,7 +439,7 @@ static int create_socket(grpc_socket_factory* factory, int domain, int type,
              : socket(domain, type, protocol);
 }
 
-grpc_error_handle grpc_create_dualstack_socket_using_factory(
+absl::Status grpc_create_dualstack_socket_using_factory(
     grpc_socket_factory* factory, const grpc_resolved_address* resolved_addr,
     int type, int protocol, grpc_dualstack_mode* dsmode, int* newfd) {
   const grpc_sockaddr* addr =

--- a/src/core/lib/iomgr/socket_utils_posix.h
+++ b/src/core/lib/iomgr/socket_utils_posix.h
@@ -136,31 +136,31 @@ int grpc_accept4(int sockfd, grpc_resolved_address* resolved_addr, int nonblock,
                  int cloexec);
 
 /* set a socket to use zerocopy */
-grpc_error_handle grpc_set_socket_zerocopy(int fd);
+absl::Status grpc_set_socket_zerocopy(int fd);
 
 /* set a socket to non blocking mode */
-grpc_error_handle grpc_set_socket_nonblocking(int fd, int non_blocking);
+absl::Status grpc_set_socket_nonblocking(int fd, int non_blocking);
 
 /* set a socket to close on exec */
-grpc_error_handle grpc_set_socket_cloexec(int fd, int close_on_exec);
+absl::Status grpc_set_socket_cloexec(int fd, int close_on_exec);
 
 /* set a socket to reuse old addresses */
-grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse);
+absl::Status grpc_set_socket_reuse_addr(int fd, int reuse);
 
 /* return true if SO_REUSEPORT is supported */
 bool grpc_is_socket_reuse_port_supported();
 
 /* disable nagle */
-grpc_error_handle grpc_set_socket_low_latency(int fd, int low_latency);
+absl::Status grpc_set_socket_low_latency(int fd, int low_latency);
 
 /* set SO_REUSEPORT */
-grpc_error_handle grpc_set_socket_reuse_port(int fd, int reuse);
+absl::Status grpc_set_socket_reuse_port(int fd, int reuse);
 
 /* Configure the default values for TCP_USER_TIMEOUT */
 void config_default_tcp_user_timeout(bool enable, int timeout, bool is_client);
 
 /* Set TCP_USER_TIMEOUT */
-grpc_error_handle grpc_set_socket_tcp_user_timeout(
+absl::Status grpc_set_socket_tcp_user_timeout(
     int fd, const grpc_core::PosixTcpOptions& options, bool is_client);
 
 /* Returns true if this system can create AF_INET6 sockets bound to ::1.
@@ -175,29 +175,29 @@ int grpc_ipv6_loopback_available(void);
 
 /* Tries to set SO_NOSIGPIPE if available on this platform.
    If SO_NO_SIGPIPE is not available, returns 1. */
-grpc_error_handle grpc_set_socket_no_sigpipe_if_possible(int fd);
+absl::Status grpc_set_socket_no_sigpipe_if_possible(int fd);
 
 /* Tries to set IP_PKTINFO if available on this platform.
    If IP_PKTINFO is not available, returns 1. */
-grpc_error_handle grpc_set_socket_ip_pktinfo_if_possible(int fd);
+absl::Status grpc_set_socket_ip_pktinfo_if_possible(int fd);
 
 /* Tries to set IPV6_RECVPKTINFO if available on this platform.
    If IPV6_RECVPKTINFO is not available, returns 1. */
-grpc_error_handle grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd);
+absl::Status grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd);
 
 /* Tries to set the socket's send buffer to given size. */
-grpc_error_handle grpc_set_socket_sndbuf(int fd, int buffer_size_bytes);
+absl::Status grpc_set_socket_sndbuf(int fd, int buffer_size_bytes);
 
 /* Tries to set the socket's receive buffer to given size. */
-grpc_error_handle grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes);
+absl::Status grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes);
 
 /* Tries to set the socket using a grpc_socket_mutator */
-grpc_error_handle grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
-                                               grpc_socket_mutator* mutator);
+absl::Status grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
+                                          grpc_socket_mutator* mutator);
 
 /* Extracts the first socket mutator from config if any and applies on the fd.
  */
-grpc_error_handle grpc_apply_socket_mutator_in_args(
+absl::Status grpc_apply_socket_mutator_in_args(
     int fd, grpc_fd_usage usage, const grpc_core::PosixTcpOptions& options);
 
 /* An enum to keep track of IPv4/IPv6 socket modes.
@@ -242,13 +242,14 @@ int grpc_set_socket_dualstack(int fd);
      IPv4, so that bind() or connect() see the correct family.
    Also, it's important to distinguish between DUALSTACK and IPV6 when
    listening on the [::] wildcard address. */
-grpc_error_handle grpc_create_dualstack_socket(
-    const grpc_resolved_address* addr, int type, int protocol,
-    grpc_dualstack_mode* dsmode, int* newfd);
+absl::Status grpc_create_dualstack_socket(const grpc_resolved_address* addr,
+                                          int type, int protocol,
+                                          grpc_dualstack_mode* dsmode,
+                                          int* newfd);
 
 /* Same as grpc_create_dualstack_socket(), but use the given socket factory (if
    non-null) to create the socket, rather than calling socket() directly. */
-grpc_error_handle grpc_create_dualstack_socket_using_factory(
+absl::Status grpc_create_dualstack_socket_using_factory(
     grpc_socket_factory* factory, const grpc_resolved_address* addr, int type,
     int protocol, grpc_dualstack_mode* dsmode, int* newfd);
 

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -74,7 +74,7 @@ static void CFStreamConnectCleanup(CFStreamConnect* connect) {
   delete connect;
 }
 
-static void OnAlarm(void* arg, grpc_error_handle error) {
+static void OnAlarm(void* arg, absl::Status error) {
   CFStreamConnect* connect = static_cast<CFStreamConnect*>(arg);
   if (grpc_tcp_trace.enabled()) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT :%p OnAlarm, error:%s", connect,
@@ -90,13 +90,13 @@ static void OnAlarm(void* arg, grpc_error_handle error) {
   if (done) {
     CFStreamConnectCleanup(connect);
   } else {
-    grpc_error_handle error =
+    absl::Status error =
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("connect() timed out");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
   }
 }
 
-static void OnOpen(void* arg, grpc_error_handle error) {
+static void OnOpen(void* arg, absl::Status error) {
   CFStreamConnect* connect = static_cast<CFStreamConnect*>(arg);
   if (grpc_tcp_trace.enabled()) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT :%p OnOpen, error:%s", connect,
@@ -156,7 +156,7 @@ static int64_t CFStreamClientConnect(
     const grpc_resolved_address* resolved_addr, grpc_core::Timestamp deadline) {
   auto addr_uri = grpc_sockaddr_to_uri(resolved_addr);
   if (!addr_uri.ok()) {
-    grpc_error_handle error =
+    absl::Status error =
         GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_uri.status().ToString());
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
     return 0;

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -91,10 +91,9 @@ void grpc_tcp_client_global_init() {
   gpr_once_init(&g_tcp_client_posix_init, do_tcp_client_global_init);
 }
 
-static grpc_error_handle prepare_socket(
-    const grpc_resolved_address* addr, int fd,
-    const grpc_core::PosixTcpOptions& options) {
-  grpc_error_handle err = GRPC_ERROR_NONE;
+static absl::Status prepare_socket(const grpc_resolved_address* addr, int fd,
+                                   const grpc_core::PosixTcpOptions& options) {
+  absl::Status err = GRPC_ERROR_NONE;
 
   GPR_ASSERT(fd >= 0);
 
@@ -127,7 +126,7 @@ done:
   return err;
 }
 
-static void tc_on_alarm(void* acp, grpc_error_handle error) {
+static void tc_on_alarm(void* acp, absl::Status error) {
   int done;
   async_connect* ac = static_cast<async_connect*>(acp);
   if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
@@ -159,7 +158,7 @@ grpc_endpoint* grpc_tcp_create_from_fd(
   return grpc_tcp_create(fd, TcpOptionsFromEndpointConfig(config), addr_str);
 }
 
-static void on_writable(void* acp, grpc_error_handle error) {
+static void on_writable(void* acp, absl::Status error) {
   async_connect* ac = static_cast<async_connect*>(acp);
   int so_error = 0;
   socklen_t so_error_size;
@@ -287,12 +286,12 @@ finish:
   }
 }
 
-grpc_error_handle grpc_tcp_client_prepare_fd(
+absl::Status grpc_tcp_client_prepare_fd(
     const grpc_core::PosixTcpOptions& options,
     const grpc_resolved_address* addr, grpc_resolved_address* mapped_addr,
     int* fd) {
   grpc_dualstack_mode dsmode;
-  grpc_error_handle error;
+  absl::Status error;
   *fd = -1;
   /* Use dualstack sockets where available. Set mapped to v6 or v4 mapped to
      v6. */
@@ -330,7 +329,7 @@ int64_t grpc_tcp_client_create_from_prepared_fd(
 
   auto addr_uri = grpc_sockaddr_to_uri(addr);
   if (!addr_uri.ok()) {
-    grpc_error_handle error =
+    absl::Status error =
         GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_uri.status().ToString());
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
     return 0;
@@ -354,7 +353,7 @@ int64_t grpc_tcp_client_create_from_prepared_fd(
   if (errno != EWOULDBLOCK && errno != EINPROGRESS) {
     // Connection already failed. Return 0 to discourage any cancellation
     // attempts.
-    grpc_error_handle error = GRPC_OS_ERROR(errno, "connect");
+    absl::Status error = GRPC_OS_ERROR(errno, "connect");
     error = grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
                                addr_uri.value());
     grpc_fd_orphan(fdobj, nullptr, nullptr, "tcp_client_connect_error");
@@ -406,7 +405,7 @@ static int64_t tcp_connect(grpc_closure* closure, grpc_endpoint** ep,
   grpc_resolved_address mapped_addr;
   grpc_core::PosixTcpOptions options(TcpOptionsFromEndpointConfig(config));
   int fd = -1;
-  grpc_error_handle error;
+  absl::Status error;
   *ep = nullptr;
   if ((error = grpc_tcp_client_prepare_fd(options, addr, &mapped_addr, &fd)) !=
       GRPC_ERROR_NONE) {

--- a/src/core/lib/iomgr/tcp_client_posix.h
+++ b/src/core/lib/iomgr/tcp_client_posix.h
@@ -48,7 +48,7 @@ grpc_endpoint* grpc_tcp_create_from_fd(
    fd: out parameter. The new FD
    Returns: error, if any. Out parameters are not set on error
 */
-grpc_error_handle grpc_tcp_client_prepare_fd(
+absl::Status grpc_tcp_client_prepare_fd(
     const grpc_core::PosixTcpOptions& options,
     const grpc_resolved_address* addr, grpc_resolved_address* mapped_addr,
     int* fd);

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -66,7 +66,7 @@ static void async_connect_unlock_and_cleanup(async_connect* ac,
   if (socket != NULL) grpc_winsocket_destroy(socket);
 }
 
-static void on_alarm(void* acp, grpc_error_handle error) {
+static void on_alarm(void* acp, absl::Status error) {
   async_connect* ac = (async_connect*)acp;
   gpr_mu_lock(&ac->mu);
   grpc_winsocket* socket = ac->socket;
@@ -77,7 +77,7 @@ static void on_alarm(void* acp, grpc_error_handle error) {
   async_connect_unlock_and_cleanup(ac, socket);
 }
 
-static void on_connect(void* acp, grpc_error_handle error) {
+static void on_connect(void* acp, absl::Status error) {
   async_connect* ac = (async_connect*)acp;
   grpc_endpoint** ep = ac->endpoint;
   GPR_ASSERT(*ep == NULL);
@@ -137,7 +137,7 @@ static int64_t tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   GUID guid = WSAID_CONNECTEX;
   DWORD ioctl_num_bytes;
   grpc_winsocket_callback_info* info;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   async_connect* ac = NULL;
   absl::StatusOr<std::string> addr_uri;
 
@@ -220,7 +220,7 @@ static int64_t tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
 
 failure:
   GPR_ASSERT(!GRPC_ERROR_IS_NONE(error));
-  grpc_error_handle final_error = grpc_error_set_str(
+  absl::Status final_error = grpc_error_set_str(
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Failed to connect",
                                                        &error, 1),
       GRPC_ERROR_STR_TARGET_ADDRESS,

--- a/src/core/lib/iomgr/tcp_server.cc
+++ b/src/core/lib/iomgr/tcp_server.cc
@@ -22,7 +22,7 @@
 
 grpc_tcp_server_vtable* grpc_tcp_server_impl;
 
-grpc_error_handle grpc_tcp_server_create(
+absl::Status grpc_tcp_server_create(
     grpc_closure* shutdown_complete,
     const grpc_event_engine::experimental::EndpointConfig& config,
     grpc_tcp_server** server) {
@@ -35,9 +35,9 @@ void grpc_tcp_server_start(grpc_tcp_server* server,
   grpc_tcp_server_impl->start(server, pollsets, on_accept_cb, cb_arg);
 }
 
-grpc_error_handle grpc_tcp_server_add_port(grpc_tcp_server* s,
-                                           const grpc_resolved_address* addr,
-                                           int* out_port) {
+absl::Status grpc_tcp_server_add_port(grpc_tcp_server* s,
+                                      const grpc_resolved_address* addr,
+                                      int* out_port) {
   return grpc_tcp_server_impl->add_port(s, addr, out_port);
 }
 

--- a/src/core/lib/iomgr/tcp_server.h
+++ b/src/core/lib/iomgr/tcp_server.h
@@ -64,16 +64,15 @@ class TcpServerFdHandler {
 }  // namespace grpc_core
 
 typedef struct grpc_tcp_server_vtable {
-  grpc_error_handle (*create)(
+  absl::Status (*create)(
       grpc_closure* shutdown_complete,
       const grpc_event_engine::experimental::EndpointConfig& config,
       grpc_tcp_server** server);
   void (*start)(grpc_tcp_server* server,
                 const std::vector<grpc_pollset*>* pollsets,
                 grpc_tcp_server_cb on_accept_cb, void* cb_arg);
-  grpc_error_handle (*add_port)(grpc_tcp_server* s,
-                                const grpc_resolved_address* addr,
-                                int* out_port);
+  absl::Status (*add_port)(grpc_tcp_server* s,
+                           const grpc_resolved_address* addr, int* out_port);
   grpc_core::TcpServerFdHandler* (*create_fd_handler)(grpc_tcp_server* s);
   unsigned (*port_fd_count)(grpc_tcp_server* s, unsigned port_index);
   int (*port_fd)(grpc_tcp_server* s, unsigned port_index, unsigned fd_index);
@@ -88,7 +87,7 @@ typedef struct grpc_tcp_server_vtable {
    If shutdown_complete is not NULL, it will be used by
    grpc_tcp_server_unref() when the ref count reaches zero.
    Takes ownership of the slice_allocator_factory. */
-grpc_error_handle grpc_tcp_server_create(
+absl::Status grpc_tcp_server_create(
     grpc_closure* shutdown_complete,
     const grpc_event_engine::experimental::EndpointConfig& config,
     grpc_tcp_server** server);
@@ -107,9 +106,9 @@ void grpc_tcp_server_start(grpc_tcp_server* server,
    but not dualstack sockets. */
 /* TODO(ctiller): deprecate this, and make grpc_tcp_server_add_ports to handle
                   all of the multiple socket port matching logic in one place */
-grpc_error_handle grpc_tcp_server_add_port(grpc_tcp_server* s,
-                                           const grpc_resolved_address* addr,
-                                           int* out_port);
+absl::Status grpc_tcp_server_add_port(grpc_tcp_server* s,
+                                      const grpc_resolved_address* addr,
+                                      int* out_port);
 
 /* Create and return a TcpServerFdHandler so that it can be used by upper layer
    to hand over an externally connected fd to the grpc server. */

--- a/src/core/lib/iomgr/tcp_server_utils_posix.h
+++ b/src/core/lib/iomgr/tcp_server_utils_posix.h
@@ -102,27 +102,26 @@ struct grpc_tcp_server {
 
 /* If successful, add a listener to \a s for \a addr, set \a dsmode for the
    socket, and return the \a listener. */
-grpc_error_handle grpc_tcp_server_add_addr(grpc_tcp_server* s,
-                                           const grpc_resolved_address* addr,
-                                           unsigned port_index,
-                                           unsigned fd_index,
-                                           grpc_dualstack_mode* dsmode,
-                                           grpc_tcp_listener** listener);
+absl::Status grpc_tcp_server_add_addr(grpc_tcp_server* s,
+                                      const grpc_resolved_address* addr,
+                                      unsigned port_index, unsigned fd_index,
+                                      grpc_dualstack_mode* dsmode,
+                                      grpc_tcp_listener** listener);
 
 /* Get all addresses assigned to network interfaces on the machine and create a
    listener for each. requested_port is the port to use for every listener, or 0
    to select one random port that will be used for every listener. Set *out_port
    to the port selected. Return GRPC_ERROR_NONE only if all listeners were
    added. */
-grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
-                                                      unsigned port_index,
-                                                      int requested_port,
-                                                      int* out_port);
+absl::Status grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
+                                                 unsigned port_index,
+                                                 int requested_port,
+                                                 int* out_port);
 
 /* Prepare a recently-created socket for listening. */
-grpc_error_handle grpc_tcp_server_prepare_socket(
-    grpc_tcp_server*, int fd, const grpc_resolved_address* addr,
-    bool so_reuseport, int* port);
+absl::Status grpc_tcp_server_prepare_socket(grpc_tcp_server*, int fd,
+                                            const grpc_resolved_address* addr,
+                                            bool so_reuseport, int* port);
 /* Ruturn true if the platform supports ifaddrs */
 bool grpc_tcp_server_have_ifaddrs(void);
 

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -80,15 +80,14 @@ static int get_max_accept_queue_size(void) {
   return s_max_accept_queue_size;
 }
 
-static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, int fd,
-                                              const grpc_resolved_address* addr,
-                                              unsigned port_index,
-                                              unsigned fd_index,
-                                              grpc_tcp_listener** listener) {
+static absl::Status add_socket_to_server(grpc_tcp_server* s, int fd,
+                                         const grpc_resolved_address* addr,
+                                         unsigned port_index, unsigned fd_index,
+                                         grpc_tcp_listener** listener) {
   *listener = nullptr;
   int port = -1;
 
-  grpc_error_handle err =
+  absl::Status err =
       grpc_tcp_server_prepare_socket(s, fd, addr, s->so_reuseport, &port);
   if (!GRPC_ERROR_IS_NONE(err)) return err;
   GPR_ASSERT(port > 0);
@@ -127,15 +126,14 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, int fd,
 
 /* If successful, add a listener to s for addr, set *dsmode for the socket, and
    return the *listener. */
-grpc_error_handle grpc_tcp_server_add_addr(grpc_tcp_server* s,
-                                           const grpc_resolved_address* addr,
-                                           unsigned port_index,
-                                           unsigned fd_index,
-                                           grpc_dualstack_mode* dsmode,
-                                           grpc_tcp_listener** listener) {
+absl::Status grpc_tcp_server_add_addr(grpc_tcp_server* s,
+                                      const grpc_resolved_address* addr,
+                                      unsigned port_index, unsigned fd_index,
+                                      grpc_dualstack_mode* dsmode,
+                                      grpc_tcp_listener** listener) {
   grpc_resolved_address addr4_copy;
   int fd;
-  grpc_error_handle err =
+  absl::Status err =
       grpc_create_dualstack_socket(addr, SOCK_STREAM, 0, dsmode, &fd);
   if (!GRPC_ERROR_IS_NONE(err)) {
     return err;
@@ -148,11 +146,11 @@ grpc_error_handle grpc_tcp_server_add_addr(grpc_tcp_server* s,
 }
 
 /* Prepare a recently-created socket for listening. */
-grpc_error_handle grpc_tcp_server_prepare_socket(
-    grpc_tcp_server* s, int fd, const grpc_resolved_address* addr,
-    bool so_reuseport, int* port) {
+absl::Status grpc_tcp_server_prepare_socket(grpc_tcp_server* s, int fd,
+                                            const grpc_resolved_address* addr,
+                                            bool so_reuseport, int* port) {
   grpc_resolved_address sockname_temp;
-  grpc_error_handle err = GRPC_ERROR_NONE;
+  absl::Status err = GRPC_ERROR_NONE;
 
   GPR_ASSERT(fd >= 0);
 
@@ -216,7 +214,7 @@ error:
   if (fd >= 0) {
     close(fd);
   }
-  grpc_error_handle ret =
+  absl::Status ret =
       grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                              "Unable to configure socket", &err, 1),
                          GRPC_ERROR_INT_FD, fd);

--- a/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
@@ -58,12 +58,12 @@ static grpc_tcp_listener* find_listener_with_addr(grpc_tcp_server* s,
 }
 
 /* Bind to "::" to get a port number not used by any address. */
-static grpc_error_handle get_unused_port(int* port) {
+static absl::Status get_unused_port(int* port) {
   grpc_resolved_address wild;
   grpc_sockaddr_make_wildcard6(0, &wild);
   grpc_dualstack_mode dsmode;
   int fd;
-  grpc_error_handle err =
+  absl::Status err =
       grpc_create_dualstack_socket(&wild, SOCK_STREAM, 0, &dsmode, &fd);
   if (!GRPC_ERROR_IS_NONE(err)) {
     return err;
@@ -89,15 +89,15 @@ static grpc_error_handle get_unused_port(int* port) {
                     : GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
-                                                      unsigned port_index,
-                                                      int requested_port,
-                                                      int* out_port) {
+absl::Status grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
+                                                 unsigned port_index,
+                                                 int requested_port,
+                                                 int* out_port) {
   struct ifaddrs* ifa = nullptr;
   struct ifaddrs* ifa_it;
   unsigned fd_index = 0;
   grpc_tcp_listener* sp = nullptr;
-  grpc_error_handle err = GRPC_ERROR_NONE;
+  absl::Status err = GRPC_ERROR_NONE;
   if (requested_port == 0) {
     /* Note: There could be a race where some local addrs can listen on the
        selected port and some can't. The sane way to handle this would be to
@@ -149,7 +149,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     }
     if ((err = grpc_tcp_server_add_addr(s, &addr, port_index, fd_index, &dsmode,
                                         &new_sp)) != GRPC_ERROR_NONE) {
-      grpc_error_handle root_err = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      absl::Status root_err = GRPC_ERROR_CREATE_FROM_CPP_STRING(
           absl::StrCat("Failed to add listener: ", addr_str.value()));
       err = grpc_error_add_child(root_err, err);
       break;

--- a/src/core/lib/iomgr/tcp_server_utils_posix_noifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_noifaddrs.cc
@@ -24,10 +24,10 @@
 
 #include "src/core/lib/iomgr/tcp_server_utils_posix.h"
 
-grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* /*s*/,
-                                                      unsigned /*port_index*/,
-                                                      int /*requested_port*/,
-                                                      int* /*out_port*/) {
+absl::Status grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* /*s*/,
+                                                 unsigned /*port_index*/,
+                                                 int /*requested_port*/,
+                                                 int* /*out_port*/) {
   return GRPC_ERROR_CREATE_FROM_STATIC_STRING("no ifaddrs available");
 }
 

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -101,9 +101,9 @@ struct grpc_tcp_server {
 
 /* Public function. Allocates the proper data structures to hold a
    grpc_tcp_server. */
-static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
-                                           const EndpointConfig& config,
-                                           grpc_tcp_server** server) {
+static absl::Status tcp_server_create(grpc_closure* shutdown_complete,
+                                      const EndpointConfig& config,
+                                      grpc_tcp_server** server) {
   grpc_tcp_server* s = (grpc_tcp_server*)gpr_malloc(sizeof(grpc_tcp_server));
   gpr_ref_init(&s->refs, 1);
   gpr_mu_init(&s->mu);
@@ -119,7 +119,7 @@ static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
   return GRPC_ERROR_NONE;
 }
 
-static void destroy_server(void* arg, grpc_error_handle error) {
+static void destroy_server(void* arg, absl::Status error) {
   grpc_tcp_server* s = (grpc_tcp_server*)arg;
 
   /* Now that the accepts have been aborted, we can destroy the sockets.
@@ -188,11 +188,11 @@ static void tcp_server_unref(grpc_tcp_server* s) {
 }
 
 /* Prepare (bind) a recently-created socket for listening. */
-static grpc_error_handle prepare_socket(SOCKET sock,
-                                        const grpc_resolved_address* addr,
-                                        int* port) {
+static absl::Status prepare_socket(SOCKET sock,
+                                   const grpc_resolved_address* addr,
+                                   int* port) {
   grpc_resolved_address sockname_temp;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   int sockname_temp_len;
 
   error = grpc_tcp_prepare_socket(sock);
@@ -247,12 +247,12 @@ static void decrement_active_ports_and_notify_locked(grpc_tcp_listener* sp) {
 
 /* In order to do an async accept, we need to create a socket first which
    will be the one assigned to the new incoming connection. */
-static grpc_error_handle start_accept_locked(grpc_tcp_listener* port) {
+static absl::Status start_accept_locked(grpc_tcp_listener* port) {
   SOCKET sock = INVALID_SOCKET;
   BOOL success;
   DWORD addrlen = sizeof(grpc_sockaddr_in6) + 16;
   DWORD bytes_received = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
 
   if (port->shutting_down) {
     return GRPC_ERROR_NONE;
@@ -297,7 +297,7 @@ failure:
 }
 
 /* Event manager callback when reads are ready. */
-static void on_accept(void* arg, grpc_error_handle error) {
+static void on_accept(void* arg, absl::Status error) {
   grpc_tcp_listener* sp = (grpc_tcp_listener*)arg;
   SOCKET sock = sp->new_socket;
   grpc_winsocket_callback_info* info = &sp->socket->read_info;
@@ -391,17 +391,17 @@ static void on_accept(void* arg, grpc_error_handle error) {
   gpr_mu_unlock(&sp->server->mu);
 }
 
-static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
-                                              const grpc_resolved_address* addr,
-                                              unsigned port_index,
-                                              grpc_tcp_listener** listener) {
+static absl::Status add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
+                                         const grpc_resolved_address* addr,
+                                         unsigned port_index,
+                                         grpc_tcp_listener** listener) {
   grpc_tcp_listener* sp = NULL;
   int port = -1;
   int status;
   GUID guid = WSAID_ACCEPTEX;
   DWORD ioctl_num_bytes;
   LPFN_ACCEPTEX AcceptEx;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
 
   /* We need to grab the AcceptEx pointer for that port, as it may be
      interface-dependent. We'll cache it to avoid doing that again. */
@@ -449,9 +449,9 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
-                                             const grpc_resolved_address* addr,
-                                             int* port) {
+static absl::Status tcp_server_add_port(grpc_tcp_server* s,
+                                        const grpc_resolved_address* addr,
+                                        int* port) {
   grpc_tcp_listener* sp = NULL;
   SOCKET sock;
   grpc_resolved_address addr6_v4mapped;
@@ -459,7 +459,7 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
   grpc_resolved_address* allocated_addr = NULL;
   grpc_resolved_address sockname_temp;
   unsigned port_index = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
 
   if (s->tail != NULL) {
     port_index = s->tail->port_index + 1;
@@ -511,9 +511,8 @@ done:
   gpr_free(allocated_addr);
 
   if (!GRPC_ERROR_IS_NONE(error)) {
-    grpc_error_handle error_out =
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-            "Failed to add port to server", &error, 1);
+    absl::Status error_out = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+        "Failed to add port to server", &error, 1);
     GRPC_ERROR_UNREF(error);
     error = error_out;
     *port = -1;

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -53,7 +53,7 @@
 
 extern grpc_core::TraceFlag grpc_tcp_trace;
 
-grpc_error_handle grpc_tcp_set_non_block(SOCKET sock) {
+absl::Status grpc_tcp_set_non_block(SOCKET sock) {
   int status;
   uint32_t param = 1;
   DWORD ret;
@@ -64,7 +64,7 @@ grpc_error_handle grpc_tcp_set_non_block(SOCKET sock) {
              : GRPC_WSA_ERROR(WSAGetLastError(), "WSAIoctl(GRPC_FIONBIO)");
 }
 
-static grpc_error_handle set_dualstack(SOCKET sock) {
+static absl::Status set_dualstack(SOCKET sock) {
   int status;
   unsigned long param = 0;
   status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&param,
@@ -74,7 +74,7 @@ static grpc_error_handle set_dualstack(SOCKET sock) {
              : GRPC_WSA_ERROR(WSAGetLastError(), "setsockopt(IPV6_V6ONLY)");
 }
 
-static grpc_error_handle enable_socket_low_latency(SOCKET sock) {
+static absl::Status enable_socket_low_latency(SOCKET sock) {
   int status;
   BOOL param = TRUE;
   status = ::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
@@ -86,8 +86,8 @@ static grpc_error_handle enable_socket_low_latency(SOCKET sock) {
                      : GRPC_WSA_ERROR(status, "setsockopt(TCP_NODELAY)");
 }
 
-grpc_error_handle grpc_tcp_prepare_socket(SOCKET sock) {
-  grpc_error_handle err;
+absl::Status grpc_tcp_prepare_socket(SOCKET sock) {
+  absl::Status err;
   err = grpc_tcp_set_non_block(sock);
   if (!GRPC_ERROR_IS_NONE(err)) return err;
   err = set_dualstack(sock);
@@ -121,7 +121,7 @@ typedef struct grpc_tcp {
      to protect ourselves when requesting a shutdown. */
   gpr_mu mu;
   int shutting_down;
-  grpc_error_handle shutdown_error;
+  absl::Status shutdown_error;
 
   std::string peer_string;
   std::string local_address;
@@ -174,7 +174,7 @@ static void tcp_ref(grpc_tcp* tcp) { gpr_ref(&tcp->refcount); }
 #endif
 
 /* Asynchronous callback from the IOCP, or the background thread. */
-static void on_read(void* tcpp, grpc_error_handle error) {
+static void on_read(void* tcpp, absl::Status error) {
   grpc_tcp* tcp = (grpc_tcp*)tcpp;
   grpc_closure* cb = tcp->read_cb;
   grpc_winsocket* socket = tcp->socket;
@@ -314,7 +314,7 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
 }
 
 /* Asynchronous callback from the IOCP, or the background thread. */
-static void on_write(void* tcpp, grpc_error_handle error) {
+static void on_write(void* tcpp, absl::Status error) {
   grpc_tcp* tcp = (grpc_tcp*)tcpp;
   grpc_winsocket* handle = tcp->socket;
   grpc_winsocket_callback_info* info = &handle->write_info;
@@ -402,9 +402,9 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
      connection that has its send queue filled up. But if we don't, then we can
      avoid doing an async write operation at all. */
   if (info->wsa_error != WSAEWOULDBLOCK) {
-    grpc_error_handle error = status == 0
-                                  ? GRPC_ERROR_NONE
-                                  : GRPC_WSA_ERROR(info->wsa_error, "WSASend");
+    absl::Status error = status == 0
+                             ? GRPC_ERROR_NONE
+                             : GRPC_WSA_ERROR(info->wsa_error, "WSASend");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, error);
     if (allocated) gpr_free(allocated);
     return;
@@ -457,7 +457,7 @@ static void win_delete_from_pollset_set(grpc_endpoint* ep,
    we're not going to protect against these. However the IO Completion Port
    callback will happen from another thread, so we need to protect against
    concurrent access of the data structure in that regard. */
-static void win_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
+static void win_shutdown(grpc_endpoint* ep, absl::Status why) {
   grpc_tcp* tcp = (grpc_tcp*)ep;
   gpr_mu_lock(&tcp->mu);
   /* At that point, what may happen is that we're already inside the IOCP

--- a/src/core/lib/iomgr/tcp_windows.h
+++ b/src/core/lib/iomgr/tcp_windows.h
@@ -43,9 +43,9 @@
 grpc_endpoint* grpc_tcp_create(grpc_winsocket* socket,
                                absl::string_view peer_string);
 
-grpc_error_handle grpc_tcp_prepare_socket(SOCKET sock);
+absl::Status grpc_tcp_prepare_socket(SOCKET sock);
 
-grpc_error_handle grpc_tcp_set_non_block(SOCKET sock);
+absl::Status grpc_tcp_set_non_block(SOCKET sock);
 
 #endif
 

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -231,8 +231,7 @@ struct shared_mutables {
 static struct shared_mutables g_shared_mutables;
 
 static grpc_timer_check_result run_some_expired_timers(
-    grpc_core::Timestamp now, grpc_core::Timestamp* next,
-    grpc_error_handle error);
+    grpc_core::Timestamp now, grpc_core::Timestamp* next, absl::Status error);
 
 static grpc_core::Timestamp compute_min_deadline(timer_shard* shard) {
   return grpc_timer_heap_is_empty(&shard->heap)
@@ -545,7 +544,7 @@ static grpc_timer* pop_one(timer_shard* shard, grpc_core::Timestamp now) {
 /* REQUIRES: shard->mu unlocked */
 static size_t pop_timers(timer_shard* shard, grpc_core::Timestamp now,
                          grpc_core::Timestamp* new_min_deadline,
-                         grpc_error_handle error) {
+                         absl::Status error) {
   size_t n = 0;
   grpc_timer* timer;
   gpr_mu_lock(&shard->mu);
@@ -565,8 +564,7 @@ static size_t pop_timers(timer_shard* shard, grpc_core::Timestamp now,
 }
 
 static grpc_timer_check_result run_some_expired_timers(
-    grpc_core::Timestamp now, grpc_core::Timestamp* next,
-    grpc_error_handle error) {
+    grpc_core::Timestamp now, grpc_core::Timestamp* next, absl::Status error) {
   grpc_timer_check_result result = GRPC_TIMERS_NOT_CHECKED;
 
 #if GPR_ARCH_64
@@ -685,7 +683,7 @@ static grpc_timer_check_result timer_check(grpc_core::Timestamp* next) {
     return GRPC_TIMERS_CHECKED_AND_EMPTY;
   }
 
-  grpc_error_handle shutdown_error =
+  absl::Status shutdown_error =
       now != grpc_core::Timestamp::InfFuture()
           ? GRPC_ERROR_NONE
           : GRPC_ERROR_CREATE_FROM_STATIC_STRING("Shutting down timer system");

--- a/src/core/lib/iomgr/unix_sockets_posix.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix.cc
@@ -33,6 +33,7 @@
 
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/unix_sockets_posix.h"
 #include "src/core/lib/transport/error_utils.h"
@@ -44,7 +45,7 @@ void grpc_create_socketpair_if_unix(int sv[2]) {
 absl::StatusOr<std::vector<grpc_resolved_address>>
 grpc_resolve_unix_domain_address(absl::string_view name) {
   grpc_resolved_address addr;
-  grpc_error_handle error = grpc_core::UnixSockaddrPopulate(name, &addr);
+  absl::Status error = grpc_core::UnixSockaddrPopulate(name, &addr);
   if (GRPC_ERROR_IS_NONE(error)) {
     return std::vector<grpc_resolved_address>({addr});
   }
@@ -56,8 +57,7 @@ grpc_resolve_unix_domain_address(absl::string_view name) {
 absl::StatusOr<std::vector<grpc_resolved_address>>
 grpc_resolve_unix_abstract_domain_address(const absl::string_view name) {
   grpc_resolved_address addr;
-  grpc_error_handle error =
-      grpc_core::UnixAbstractSockaddrPopulate(name, &addr);
+  absl::Status error = grpc_core::UnixAbstractSockaddrPopulate(name, &addr);
   if (GRPC_ERROR_IS_NONE(error)) {
     return std::vector<grpc_resolved_address>({addr});
   }

--- a/src/core/lib/iomgr/wakeup_fd_eventfd.cc
+++ b/src/core/lib/iomgr/wakeup_fd_eventfd.cc
@@ -30,7 +30,7 @@
 
 #include "src/core/lib/iomgr/wakeup_fd_posix.h"
 
-static grpc_error_handle eventfd_create(grpc_wakeup_fd* fd_info) {
+static absl::Status eventfd_create(grpc_wakeup_fd* fd_info) {
   fd_info->read_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
   fd_info->write_fd = -1;
   if (fd_info->read_fd < 0) {
@@ -39,7 +39,7 @@ static grpc_error_handle eventfd_create(grpc_wakeup_fd* fd_info) {
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error_handle eventfd_consume(grpc_wakeup_fd* fd_info) {
+static absl::Status eventfd_consume(grpc_wakeup_fd* fd_info) {
   eventfd_t value;
   int err;
   do {
@@ -51,7 +51,7 @@ static grpc_error_handle eventfd_consume(grpc_wakeup_fd* fd_info) {
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error_handle eventfd_wakeup(grpc_wakeup_fd* fd_info) {
+static absl::Status eventfd_wakeup(grpc_wakeup_fd* fd_info) {
   int err;
   do {
     err = eventfd_write(fd_info->read_fd, 1);

--- a/src/core/lib/iomgr/wakeup_fd_pipe.cc
+++ b/src/core/lib/iomgr/wakeup_fd_pipe.cc
@@ -32,14 +32,14 @@
 #include "src/core/lib/iomgr/wakeup_fd_pipe.h"
 #include "src/core/lib/iomgr/wakeup_fd_posix.h"
 
-static grpc_error_handle pipe_init(grpc_wakeup_fd* fd_info) {
+static absl::Status pipe_init(grpc_wakeup_fd* fd_info) {
   int pipefd[2];
   int r = pipe(pipefd);
   if (0 != r) {
     gpr_log(GPR_ERROR, "pipe creation failed (%d): %s", errno, strerror(errno));
     return GRPC_OS_ERROR(errno, "pipe");
   }
-  grpc_error_handle err;
+  absl::Status err;
   err = grpc_set_socket_nonblocking(pipefd[0], 1);
   if (!GRPC_ERROR_IS_NONE(err)) return err;
   err = grpc_set_socket_nonblocking(pipefd[1], 1);
@@ -49,7 +49,7 @@ static grpc_error_handle pipe_init(grpc_wakeup_fd* fd_info) {
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error_handle pipe_consume(grpc_wakeup_fd* fd_info) {
+static absl::Status pipe_consume(grpc_wakeup_fd* fd_info) {
   char buf[128];
   ssize_t r;
 
@@ -68,7 +68,7 @@ static grpc_error_handle pipe_consume(grpc_wakeup_fd* fd_info) {
   }
 }
 
-static grpc_error_handle pipe_wakeup(grpc_wakeup_fd* fd_info) {
+static absl::Status pipe_wakeup(grpc_wakeup_fd* fd_info) {
   char c = 0;
   while (write(fd_info->write_fd, &c, 1) != 1 && errno == EINTR) {
   }

--- a/src/core/lib/iomgr/wakeup_fd_posix.cc
+++ b/src/core/lib/iomgr/wakeup_fd_posix.cc
@@ -54,15 +54,15 @@ void grpc_wakeup_fd_global_destroy(void) {}
 
 int grpc_has_wakeup_fd(void) { return has_real_wakeup_fd; }
 
-grpc_error_handle grpc_wakeup_fd_init(grpc_wakeup_fd* fd_info) {
+absl::Status grpc_wakeup_fd_init(grpc_wakeup_fd* fd_info) {
   return wakeup_fd_vtable->init(fd_info);
 }
 
-grpc_error_handle grpc_wakeup_fd_consume_wakeup(grpc_wakeup_fd* fd_info) {
+absl::Status grpc_wakeup_fd_consume_wakeup(grpc_wakeup_fd* fd_info) {
   return wakeup_fd_vtable->consume(fd_info);
 }
 
-grpc_error_handle grpc_wakeup_fd_wakeup(grpc_wakeup_fd* fd_info) {
+absl::Status grpc_wakeup_fd_wakeup(grpc_wakeup_fd* fd_info) {
   return wakeup_fd_vtable->wakeup(fd_info);
 }
 

--- a/src/core/lib/iomgr/wakeup_fd_posix.h
+++ b/src/core/lib/iomgr/wakeup_fd_posix.h
@@ -63,9 +63,9 @@ int grpc_has_wakeup_fd(void);
 typedef struct grpc_wakeup_fd grpc_wakeup_fd;
 
 typedef struct grpc_wakeup_fd_vtable {
-  grpc_error_handle (*init)(grpc_wakeup_fd* fd_info);
-  grpc_error_handle (*consume)(grpc_wakeup_fd* fd_info);
-  grpc_error_handle (*wakeup)(grpc_wakeup_fd* fd_info);
+  absl::Status (*init)(grpc_wakeup_fd* fd_info);
+  absl::Status (*consume)(grpc_wakeup_fd* fd_info);
+  absl::Status (*wakeup)(grpc_wakeup_fd* fd_info);
   void (*destroy)(grpc_wakeup_fd* fd_info);
   /* Must be called before calling any other functions */
   int (*check_availability)(void);
@@ -81,11 +81,10 @@ extern int grpc_allow_pipe_wakeup_fd;
 
 #define GRPC_WAKEUP_FD_GET_READ_FD(fd_info) ((fd_info)->read_fd)
 
-grpc_error_handle grpc_wakeup_fd_init(grpc_wakeup_fd* fd_info)
+absl::Status grpc_wakeup_fd_init(grpc_wakeup_fd* fd_info) GRPC_MUST_USE_RESULT;
+absl::Status grpc_wakeup_fd_consume_wakeup(grpc_wakeup_fd* fd_info)
     GRPC_MUST_USE_RESULT;
-grpc_error_handle grpc_wakeup_fd_consume_wakeup(grpc_wakeup_fd* fd_info)
-    GRPC_MUST_USE_RESULT;
-grpc_error_handle grpc_wakeup_fd_wakeup(grpc_wakeup_fd* fd_info)
+absl::Status grpc_wakeup_fd_wakeup(grpc_wakeup_fd* fd_info)
     GRPC_MUST_USE_RESULT;
 void grpc_wakeup_fd_destroy(grpc_wakeup_fd* fd_info);
 

--- a/src/core/lib/json/json_util.cc
+++ b/src/core/lib/json/json_util.cc
@@ -36,7 +36,7 @@ bool ParseDurationFromJson(const Json& field, Duration* duration) {
 }
 
 bool ExtractJsonBool(const Json& json, absl::string_view field_name,
-                     bool* output, std::vector<grpc_error_handle>* error_list) {
+                     bool* output, std::vector<absl::Status>* error_list) {
   switch (json.type()) {
     case Json::Type::JSON_TRUE:
       *output = true;
@@ -53,7 +53,7 @@ bool ExtractJsonBool(const Json& json, absl::string_view field_name,
 
 bool ExtractJsonArray(const Json& json, absl::string_view field_name,
                       const Json::Array** output,
-                      std::vector<grpc_error_handle>* error_list) {
+                      std::vector<absl::Status>* error_list) {
   if (json.type() != Json::Type::ARRAY) {
     *output = nullptr;
     error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
@@ -66,7 +66,7 @@ bool ExtractJsonArray(const Json& json, absl::string_view field_name,
 
 bool ExtractJsonObject(const Json& json, absl::string_view field_name,
                        const Json::Object** output,
-                       std::vector<grpc_error_handle>* error_list) {
+                       std::vector<absl::Status>* error_list) {
   if (json.type() != Json::Type::OBJECT) {
     *output = nullptr;
     error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
@@ -80,7 +80,7 @@ bool ExtractJsonObject(const Json& json, absl::string_view field_name,
 bool ParseJsonObjectFieldAsDuration(const Json::Object& object,
                                     absl::string_view field_name,
                                     Duration* output,
-                                    std::vector<grpc_error_handle>* error_list,
+                                    std::vector<absl::Status>* error_list,
                                     bool required) {
   // TODO(roth): Once we can use C++14 heterogenous lookups, stop
   // creating a std::string here.

--- a/src/core/lib/json/json_util.h
+++ b/src/core/lib/json/json_util.h
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -52,7 +53,7 @@ bool ParseDurationFromJson(const Json& field, Duration* duration);
 template <typename NumericType>
 bool ExtractJsonNumber(const Json& json, absl::string_view field_name,
                        NumericType* output,
-                       std::vector<grpc_error_handle>* error_list) {
+                       std::vector<absl::Status>* error_list) {
   static_assert(std::is_integral<NumericType>::value, "Integral required");
   if (json.type() != Json::Type::NUMBER && json.type() != Json::Type::STRING) {
     error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
@@ -68,13 +69,13 @@ bool ExtractJsonNumber(const Json& json, absl::string_view field_name,
 }
 
 bool ExtractJsonBool(const Json& json, absl::string_view field_name,
-                     bool* output, std::vector<grpc_error_handle>* error_list);
+                     bool* output, std::vector<absl::Status>* error_list);
 
 // OutputType can be std::string or absl::string_view.
 template <typename OutputType>
 bool ExtractJsonString(const Json& json, absl::string_view field_name,
                        OutputType* output,
-                       std::vector<grpc_error_handle>* error_list) {
+                       std::vector<absl::Status>* error_list) {
   if (json.type() != Json::Type::STRING) {
     *output = "";
     error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
@@ -87,43 +88,43 @@ bool ExtractJsonString(const Json& json, absl::string_view field_name,
 
 bool ExtractJsonArray(const Json& json, absl::string_view field_name,
                       const Json::Array** output,
-                      std::vector<grpc_error_handle>* error_list);
+                      std::vector<absl::Status>* error_list);
 
 bool ExtractJsonObject(const Json& json, absl::string_view field_name,
                        const Json::Object** output,
-                       std::vector<grpc_error_handle>* error_list);
+                       std::vector<absl::Status>* error_list);
 
 // Wrappers for automatically choosing one of the above functions based
 // on output parameter type.
 template <typename NumericType>
 inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
                             NumericType* output,
-                            std::vector<grpc_error_handle>* error_list) {
+                            std::vector<absl::Status>* error_list) {
   return ExtractJsonNumber(json, field_name, output, error_list);
 }
 inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
                             bool* output,
-                            std::vector<grpc_error_handle>* error_list) {
+                            std::vector<absl::Status>* error_list) {
   return ExtractJsonBool(json, field_name, output, error_list);
 }
 inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
                             std::string* output,
-                            std::vector<grpc_error_handle>* error_list) {
+                            std::vector<absl::Status>* error_list) {
   return ExtractJsonString(json, field_name, output, error_list);
 }
 inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
                             absl::string_view* output,
-                            std::vector<grpc_error_handle>* error_list) {
+                            std::vector<absl::Status>* error_list) {
   return ExtractJsonString(json, field_name, output, error_list);
 }
 inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
                             const Json::Array** output,
-                            std::vector<grpc_error_handle>* error_list) {
+                            std::vector<absl::Status>* error_list) {
   return ExtractJsonArray(json, field_name, output, error_list);
 }
 inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
                             const Json::Object** output,
-                            std::vector<grpc_error_handle>* error_list) {
+                            std::vector<absl::Status>* error_list) {
   return ExtractJsonObject(json, field_name, output, error_list);
 }
 
@@ -135,7 +136,7 @@ inline bool ExtractJsonType(const Json& json, absl::string_view field_name,
 template <typename T>
 bool ParseJsonObjectField(const Json::Object& object,
                           absl::string_view field_name, T* output,
-                          std::vector<grpc_error_handle>* error_list,
+                          std::vector<absl::Status>* error_list,
                           bool required = true) {
   // TODO(roth): Once we can use C++14 heterogenous lookups, stop
   // creating a std::string here.
@@ -155,7 +156,7 @@ bool ParseJsonObjectField(const Json::Object& object,
 bool ParseJsonObjectFieldAsDuration(const Json::Object& object,
                                     absl::string_view field_name,
                                     Duration* output,
-                                    std::vector<grpc_error_handle>* error_list,
+                                    std::vector<absl::Status>* error_list,
                                     bool required = true);
 
 }  // namespace grpc_core

--- a/src/core/lib/load_balancing/lb_policy.cc
+++ b/src/core/lib/load_balancing/lb_policy.cc
@@ -75,7 +75,7 @@ LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
     auto* parent = parent_->Ref().release();  // ref held by lambda.
     ExecCtx::Run(DEBUG_LOCATION,
                  GRPC_CLOSURE_CREATE(
-                     [](void* arg, grpc_error_handle /*error*/) {
+                     [](void* arg, absl::Status /*error*/) {
                        auto* parent = static_cast<LoadBalancingPolicy*>(arg);
                        parent->work_serializer()->Run(
                            [parent]() {

--- a/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
+++ b/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
@@ -17,6 +17,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/error.h"
@@ -32,7 +34,7 @@ class ExecCtxWakeupScheduler {
   void ScheduleWakeup(ActivityType* activity) {
     GRPC_CLOSURE_INIT(
         &closure_,
-        [](void* arg, grpc_error_handle) {
+        [](void* arg, absl::Status) {
           static_cast<ActivityType*>(arg)->RunScheduledWakeup();
         },
         activity, grpc_schedule_on_exec_ctx);

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -62,7 +62,7 @@ namespace {
 
 absl::StatusOr<std::string> ReadPolicyFromFile(absl::string_view policy_path) {
   grpc_slice policy_slice = grpc_empty_slice();
-  grpc_error_handle error =
+  absl::Status error =
       grpc_load_file(std::string(policy_path).c_str(), 0, &policy_slice);
   if (!GRPC_ERROR_IS_NONE(error)) {
     absl::Status status =

--- a/src/core/lib/security/certificate_provider/certificate_provider_factory.h
+++ b/src/core/lib/security/certificate_provider/certificate_provider_factory.h
@@ -23,11 +23,12 @@
 
 #include <string>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc_security.h>
 
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/json/json.h"
 
 namespace grpc_core {
@@ -54,7 +55,7 @@ class CertificateProviderFactory {
   virtual const char* name() const = 0;
 
   virtual RefCountedPtr<Config> CreateCertificateProviderConfig(
-      const Json& config_json, grpc_error_handle* error) = 0;
+      const Json& config_json, absl::Status* error) = 0;
 
   // Create a CertificateProvider instance from config.
   virtual RefCountedPtr<grpc_tls_certificate_provider>

--- a/src/core/lib/security/credentials/external/aws_external_account_credentials.h
+++ b/src/core/lib/security/credentials/external/aws_external_account_credentials.h
@@ -24,11 +24,12 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/http/httpcli.h"
 #include "src/core/lib/http/parser.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/credentials/external/aws_request_signer.h"
 #include "src/core/lib/security/credentials/external/external_account_credentials.h"
 
@@ -37,37 +38,36 @@ namespace grpc_core {
 class AwsExternalAccountCredentials final : public ExternalAccountCredentials {
  public:
   static RefCountedPtr<AwsExternalAccountCredentials> Create(
-      Options options, std::vector<std::string> scopes,
-      grpc_error_handle* error);
+      Options options, std::vector<std::string> scopes, absl::Status* error);
 
   AwsExternalAccountCredentials(Options options,
                                 std::vector<std::string> scopes,
-                                grpc_error_handle* error);
+                                absl::Status* error);
 
  private:
   void RetrieveSubjectToken(
       HTTPRequestContext* ctx, const Options& options,
-      std::function<void(std::string, grpc_error_handle)> cb) override;
+      std::function<void(std::string, absl::Status)> cb) override;
 
   void RetrieveRegion();
-  static void OnRetrieveRegion(void* arg, grpc_error_handle error);
-  void OnRetrieveRegionInternal(grpc_error_handle error);
+  static void OnRetrieveRegion(void* arg, absl::Status error);
+  void OnRetrieveRegionInternal(absl::Status error);
 
   void RetrieveImdsV2SessionToken();
-  static void OnRetrieveImdsV2SessionToken(void* arg, grpc_error_handle error);
-  void OnRetrieveImdsV2SessionTokenInternal(grpc_error_handle error);
+  static void OnRetrieveImdsV2SessionToken(void* arg, absl::Status error);
+  void OnRetrieveImdsV2SessionTokenInternal(absl::Status error);
 
   void RetrieveRoleName();
-  static void OnRetrieveRoleName(void* arg, grpc_error_handle error);
-  void OnRetrieveRoleNameInternal(grpc_error_handle error);
+  static void OnRetrieveRoleName(void* arg, absl::Status error);
+  void OnRetrieveRoleNameInternal(absl::Status error);
 
   void RetrieveSigningKeys();
-  static void OnRetrieveSigningKeys(void* arg, grpc_error_handle error);
-  void OnRetrieveSigningKeysInternal(grpc_error_handle error);
+  static void OnRetrieveSigningKeys(void* arg, absl::Status error);
+  void OnRetrieveSigningKeysInternal(absl::Status error);
 
   void BuildSubjectToken();
   void FinishRetrieveSubjectToken(std::string subject_token,
-                                  grpc_error_handle error);
+                                  absl::Status error);
 
   void AddMetadataRequestHeaders(grpc_http_request* request);
 
@@ -92,7 +92,7 @@ class AwsExternalAccountCredentials final : public ExternalAccountCredentials {
   std::string cred_verification_url_;
 
   HTTPRequestContext* ctx_ = nullptr;
-  std::function<void(std::string, grpc_error_handle)> cb_ = nullptr;
+  std::function<void(std::string, absl::Status)> cb_ = nullptr;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/external/aws_request_signer.cc
+++ b/src/core/lib/security/credentials/external/aws_request_signer.cc
@@ -37,6 +37,8 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 
+#include "src/core/lib/iomgr/error.h"
+
 namespace grpc_core {
 
 namespace {
@@ -75,8 +77,7 @@ AwsRequestSigner::AwsRequestSigner(
     std::string access_key_id, std::string secret_access_key, std::string token,
     std::string method, std::string url, std::string region,
     std::string request_payload,
-    std::map<std::string, std::string> additional_headers,
-    grpc_error_handle* error)
+    std::map<std::string, std::string> additional_headers, absl::Status* error)
     : access_key_id_(std::move(access_key_id)),
       secret_access_key_(std::move(secret_access_key)),
       token_(std::move(token)),

--- a/src/core/lib/security/credentials/external/aws_request_signer.h
+++ b/src/core/lib/security/credentials/external/aws_request_signer.h
@@ -22,7 +22,8 @@
 #include <map>
 #include <string>
 
-#include "src/core/lib/iomgr/error.h"
+#include "absl/status/status.h"
+
 #include "src/core/lib/uri/uri_parser.h"
 
 namespace grpc_core {
@@ -45,7 +46,7 @@ class AwsRequestSigner {
                    std::string token, std::string method, std::string url,
                    std::string region, std::string request_payload,
                    std::map<std::string, std::string> additional_headers,
-                   grpc_error_handle* error);
+                   absl::Status* error);
 
   // This method triggers the signing process then returns the headers of the
   // signed request as a map. In case there is an error, the input `error`

--- a/src/core/lib/security/credentials/external/external_account_credentials.h
+++ b/src/core/lib/security/credentials/external/external_account_credentials.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 #include "src/core/lib/gprpp/orphanable.h"
@@ -31,7 +32,6 @@
 #include "src/core/lib/http/httpcli.h"
 #include "src/core/lib/http/parser.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/json/json.h"
 #include "src/core/lib/security/credentials/oauth2/oauth2_credentials.h"
@@ -61,8 +61,7 @@ class ExternalAccountCredentials
   };
 
   static RefCountedPtr<ExternalAccountCredentials> Create(
-      const Json& json, std::vector<std::string> scopes,
-      grpc_error_handle* error);
+      const Json& json, std::vector<std::string> scopes, absl::Status* error);
 
   ExternalAccountCredentials(Options options, std::vector<std::string> scopes);
   ~ExternalAccountCredentials() override;
@@ -93,7 +92,7 @@ class ExternalAccountCredentials
   // back.
   virtual void RetrieveSubjectToken(
       HTTPRequestContext* ctx, const Options& options,
-      std::function<void(std::string, grpc_error_handle)> cb) = 0;
+      std::function<void(std::string, absl::Status)> cb) = 0;
 
  private:
   // This method implements the common token fetch logic and it will be called
@@ -103,17 +102,17 @@ class ExternalAccountCredentials
                     Timestamp deadline) override;
 
   void OnRetrieveSubjectTokenInternal(absl::string_view subject_token,
-                                      grpc_error_handle error);
+                                      absl::Status error);
 
   void ExchangeToken(absl::string_view subject_token);
-  static void OnExchangeToken(void* arg, grpc_error_handle error);
-  void OnExchangeTokenInternal(grpc_error_handle error);
+  static void OnExchangeToken(void* arg, absl::Status error);
+  void OnExchangeTokenInternal(absl::Status error);
 
   void ImpersenateServiceAccount();
-  static void OnImpersenateServiceAccount(void* arg, grpc_error_handle error);
-  void OnImpersenateServiceAccountInternal(grpc_error_handle error);
+  static void OnImpersenateServiceAccount(void* arg, absl::Status error);
+  void OnImpersenateServiceAccountInternal(absl::Status error);
 
-  void FinishTokenFetch(grpc_error_handle error);
+  void FinishTokenFetch(absl::Status error);
 
   Options options_;
   std::vector<std::string> scopes_;

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.h
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.h
@@ -23,8 +23,9 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/credentials/external/external_account_credentials.h"
 
 namespace grpc_core {
@@ -32,17 +33,16 @@ namespace grpc_core {
 class FileExternalAccountCredentials final : public ExternalAccountCredentials {
  public:
   static RefCountedPtr<FileExternalAccountCredentials> Create(
-      Options options, std::vector<std::string> scopes,
-      grpc_error_handle* error);
+      Options options, std::vector<std::string> scopes, absl::Status* error);
 
   FileExternalAccountCredentials(Options options,
                                  std::vector<std::string> scopes,
-                                 grpc_error_handle* error);
+                                 absl::Status* error);
 
  private:
   void RetrieveSubjectToken(
       HTTPRequestContext* ctx, const Options& options,
-      std::function<void(std::string, grpc_error_handle)> cb) override;
+      std::function<void(std::string, absl::Status)> cb) override;
 
   // Fields of credential source
   std::string file_;

--- a/src/core/lib/security/credentials/external/url_external_account_credentials.h
+++ b/src/core/lib/security/credentials/external/url_external_account_credentials.h
@@ -24,10 +24,11 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/http/httpcli.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/credentials/external/external_account_credentials.h"
 #include "src/core/lib/uri/uri_parser.h"
 
@@ -36,23 +37,22 @@ namespace grpc_core {
 class UrlExternalAccountCredentials final : public ExternalAccountCredentials {
  public:
   static RefCountedPtr<UrlExternalAccountCredentials> Create(
-      Options options, std::vector<std::string> scopes,
-      grpc_error_handle* error);
+      Options options, std::vector<std::string> scopes, absl::Status* error);
 
   UrlExternalAccountCredentials(Options options,
                                 std::vector<std::string> scopes,
-                                grpc_error_handle* error);
+                                absl::Status* error);
 
  private:
   void RetrieveSubjectToken(
       HTTPRequestContext* ctx, const Options& options,
-      std::function<void(std::string, grpc_error_handle)> cb) override;
+      std::function<void(std::string, absl::Status)> cb) override;
 
-  static void OnRetrieveSubjectToken(void* arg, grpc_error_handle error);
-  void OnRetrieveSubjectTokenInternal(grpc_error_handle error);
+  static void OnRetrieveSubjectToken(void* arg, absl::Status error);
+  void OnRetrieveSubjectTokenInternal(absl::Status error);
 
   void FinishRetrieveSubjectToken(std::string subject_token,
-                                  grpc_error_handle error);
+                                  absl::Status error);
 
   // Fields of credential source
   URI url_;
@@ -63,7 +63,7 @@ class UrlExternalAccountCredentials final : public ExternalAccountCredentials {
 
   OrphanablePtr<HttpRequest> http_request_;
   HTTPRequestContext* ctx_ = nullptr;
-  std::function<void(std::string, grpc_error_handle)> cb_ = nullptr;
+  std::function<void(std::string, absl::Status)> cb_ = nullptr;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
@@ -167,8 +168,8 @@ grpc_core::UniqueTypeName grpc_google_default_channel_credentials::type()
   return kFactory.Create();
 }
 
-static void on_metadata_server_detection_http_response(
-    void* user_data, grpc_error_handle error) {
+static void on_metadata_server_detection_http_response(void* user_data,
+                                                       absl::Status error) {
   metadata_server_detector* detector =
       static_cast<metadata_server_detector*>(user_data);
   if (GRPC_ERROR_IS_NONE(error) && detector->response.status == 200 &&
@@ -194,7 +195,7 @@ static void on_metadata_server_detection_http_response(
   gpr_mu_unlock(g_polling_mu);
 }
 
-static void destroy_pollset(void* p, grpc_error_handle /*e*/) {
+static void destroy_pollset(void* p, absl::Status /*e*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 
@@ -300,14 +301,14 @@ bool ValidateExteralAccountCredentials(const Json& json) {
 }  // namespace
 
 /* Takes ownership of creds_path if not NULL. */
-static grpc_error_handle create_default_creds_from_path(
+static absl::Status create_default_creds_from_path(
     const std::string& creds_path,
     grpc_core::RefCountedPtr<grpc_call_credentials>* creds) {
   grpc_auth_json_key key;
   grpc_auth_refresh_token token;
   grpc_core::RefCountedPtr<grpc_call_credentials> result;
   grpc_slice creds_data = grpc_empty_slice();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   Json json;
   if (creds_path.empty()) {
     error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("creds_path unset");
@@ -394,9 +395,9 @@ static bool metadata_server_available() {
 }
 
 static grpc_core::RefCountedPtr<grpc_call_credentials> make_default_call_creds(
-    grpc_error_handle* error) {
+    absl::Status* error) {
   grpc_core::RefCountedPtr<grpc_call_credentials> call_creds;
-  grpc_error_handle err;
+  absl::Status err;
 
   /* First, try the environment variable. */
   auto path_from_env = grpc_core::GetEnv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR);
@@ -433,7 +434,7 @@ grpc_channel_credentials* grpc_google_default_credentials_create(
     grpc_call_credentials* call_credentials) {
   grpc_channel_credentials* result = nullptr;
   grpc_core::RefCountedPtr<grpc_call_credentials> call_creds(call_credentials);
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::ExecCtx exec_ctx;
 
   GRPC_API_TRACE("grpc_google_default_credentials_create(%p)", 1,

--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -77,7 +77,7 @@ grpc_auth_json_key grpc_auth_json_key_create_from_json(const Json& json) {
   BIO* bio = nullptr;
   const char* prop_value;
   int success = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
 
   memset(&result, 0, sizeof(grpc_auth_json_key));
   result.type = GRPC_AUTH_JSON_TYPE_INVALID;

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -57,7 +57,6 @@
 #include "src/core/lib/http/httpcli_ssl_credentials.h"
 #include "src/core/lib/http/parser.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/iomgr/polling_entity.h"
@@ -649,7 +648,7 @@ end:
   return result;
 }
 
-static void on_keys_retrieved(void* user_data, grpc_error_handle /*error*/) {
+static void on_keys_retrieved(void* user_data, absl::Status /*error*/) {
   verifier_cb_ctx* ctx = static_cast<verifier_cb_ctx*>(user_data);
   Json json = json_from_http(&ctx->responses[HTTP_RESPONSE_KEYS]);
   EVP_PKEY* verification_key = nullptr;
@@ -689,7 +688,7 @@ end:
 }
 
 static void on_openid_config_retrieved(void* user_data,
-                                       grpc_error_handle /*error*/) {
+                                       absl::Status /*error*/) {
   verifier_cb_ctx* ctx = static_cast<verifier_cb_ctx*>(user_data);
   const grpc_http_response* response = &ctx->responses[HTTP_RESPONSE_OPENID];
   Json json = json_from_http(response);

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.h
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 
@@ -41,7 +42,6 @@
 #include "src/core/lib/http/httpcli.h"
 #include "src/core/lib/http/parser.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/polling_entity.h"
 #include "src/core/lib/json/json.h"
 #include "src/core/lib/promise/activity.h"
@@ -119,7 +119,7 @@ class grpc_oauth2_token_fetcher_credentials : public grpc_call_credentials {
                      const GetRequestMetadataArgs* args) override;
 
   void on_http_response(grpc_credentials_metadata_request* r,
-                        grpc_error_handle error);
+                        absl::Status error);
   std::string debug_string() override;
 
   grpc_core::UniqueTypeName type() const override;

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
@@ -75,8 +76,8 @@ struct grpc_tls_certificate_distributor
     // certificates.
     // @param identity_cert_error the error occurred while reloading identity
     // certificates.
-    virtual void OnError(grpc_error_handle root_cert_error,
-                         grpc_error_handle identity_cert_error) = 0;
+    virtual void OnError(absl::Status root_cert_error,
+                         absl::Status identity_cert_error) = 0;
   };
 
   // Sets the key materials based on their certificate name.
@@ -102,14 +103,14 @@ struct grpc_tls_certificate_distributor
   // @param identity_cert_error The error that the caller encounters when
   // reloading identity certs.
   void SetErrorForCert(const std::string& cert_name,
-                       absl::optional<grpc_error_handle> root_cert_error,
-                       absl::optional<grpc_error_handle> identity_cert_error);
+                       absl::optional<absl::Status> root_cert_error,
+                       absl::optional<absl::Status> identity_cert_error);
 
   // Propagates the error that the caller (e.g. Producer) encounters to all
   // watchers.
   //
   // @param error The error that the caller encounters.
-  void SetError(grpc_error_handle error);
+  void SetError(absl::Status error);
 
   // Sets the TLS certificate watch status callback function. The
   // grpc_tls_certificate_distributor will invoke this callback when a new
@@ -176,9 +177,9 @@ struct grpc_tls_certificate_distributor
     // The contents of the identity key-certificate pairs.
     grpc_core::PemKeyCertPairList pem_key_cert_pairs;
     // The root cert reloading error propagated by the caller.
-    grpc_error_handle root_cert_error = GRPC_ERROR_NONE;
+    absl::Status root_cert_error = GRPC_ERROR_NONE;
     // The identity cert reloading error propagated by the caller.
-    grpc_error_handle identity_cert_error = GRPC_ERROR_NONE;
+    absl::Status identity_cert_error = GRPC_ERROR_NONE;
     // The set of watchers watching root certificates.
     // This is mainly used for quickly looking up the affected watchers while
     // performing a credential reloading.
@@ -192,11 +193,11 @@ struct grpc_tls_certificate_distributor
       GRPC_ERROR_UNREF(root_cert_error);
       GRPC_ERROR_UNREF(identity_cert_error);
     }
-    void SetRootError(grpc_error_handle error) {
+    void SetRootError(absl::Status error) {
       GRPC_ERROR_UNREF(root_cert_error);
       root_cert_error = error;
     }
-    void SetIdentityError(grpc_error_handle error) {
+    void SetIdentityError(absl::Status error) {
       GRPC_ERROR_UNREF(identity_cert_error);
       identity_cert_error = error;
     }

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -75,7 +75,7 @@ void alts_check_peer(tsi_peer peer,
   *auth_context =
       grpc_core::internal::grpc_alts_auth_context_from_tsi_peer(&peer);
   tsi_peer_destruct(&peer);
-  grpc_error_handle error =
+  absl::Status error =
       *auth_context != nullptr
           ? GRPC_ERROR_NONE
           : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -121,7 +121,7 @@ class grpc_alts_channel_security_connector final
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 
@@ -180,7 +180,7 @@ class grpc_alts_server_security_connector final
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -86,7 +86,7 @@ class grpc_fake_channel_security_connector final
                   grpc_closure* on_peer_checked) override;
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 
@@ -212,7 +212,7 @@ void fake_check_peer(grpc_security_connector* /*sc*/, tsi_peer peer,
                      grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                      grpc_closure* on_peer_checked) {
   const char* prop_name;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   *auth_context = nullptr;
   if (peer.property_count != 2) {
     error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -286,7 +286,7 @@ class grpc_fake_server_security_connector
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 

--- a/src/core/lib/security/security_connector/insecure/insecure_security_connector.h
+++ b/src/core/lib/security/security_connector/insecure/insecure_security_connector.h
@@ -72,7 +72,7 @@ class InsecureChannelSecurityConnector
                   grpc_closure* on_peer_checked) override;
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 
@@ -95,7 +95,7 @@ class InsecureServerSecurityConnector : public grpc_server_security_connector {
                   grpc_closure* on_peer_checked) override;
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 

--- a/src/core/lib/security/security_connector/load_system_roots_supported.cc
+++ b/src/core/lib/security/security_connector/load_system_roots_supported.cc
@@ -22,6 +22,8 @@
 #include <memory>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #if defined(GPR_LINUX) || defined(GPR_ANDROID) || defined(GPR_FREEBSD) || \
     defined(GPR_APPLE)
 
@@ -71,8 +73,7 @@ grpc_slice GetSystemRootCerts() {
   grpc_slice valid_bundle_slice = grpc_empty_slice();
   size_t num_cert_files_ = GPR_ARRAY_SIZE(kCertFiles);
   for (size_t i = 0; i < num_cert_files_; i++) {
-    grpc_error_handle error =
-        grpc_load_file(kCertFiles[i], 1, &valid_bundle_slice);
+    absl::Status error = grpc_load_file(kCertFiles[i], 1, &valid_bundle_slice);
     if (GRPC_ERROR_IS_NONE(error)) {
       return valid_bundle_slice;
     } else {

--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -128,7 +128,7 @@ void local_check_peer(tsi_peer peer, grpc_endpoint* ep,
       }
     }
   }
-  grpc_error_handle error;
+  absl::Status error;
   if (!is_endpoint_local) {
     error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Endpoint is neither UDS or TCP loopback address.");
@@ -208,7 +208,7 @@ class grpc_local_channel_security_connector final
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 
@@ -256,7 +256,7 @@ class grpc_local_server_security_connector final
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -37,7 +37,6 @@
 #include "src/core/lib/gprpp/unique_type_name.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/endpoint.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/promise/arena_promise.h"
 #include "src/core/lib/transport/handshaker.h"
@@ -84,7 +83,7 @@ class grpc_security_connector
   // Cancels the pending check_peer() request associated with on_peer_checked.
   // If there is no such request pending, this is a no-op.
   virtual void cancel_check_peer(grpc_closure* on_peer_checked,
-                                 grpc_error_handle error) = 0;
+                                 absl::Status error) = 0;
 
   /* Compares two security connectors. */
   virtual int cmp(const grpc_security_connector* other) const = 0;

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -57,10 +57,10 @@
 #include "src/core/tsi/transport_security_interface.h"
 
 namespace {
-grpc_error_handle ssl_check_peer(
+absl::Status ssl_check_peer(
     const char* peer_name, const tsi_peer* peer,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context) {
-  grpc_error_handle error = grpc_ssl_check_alpn(peer);
+  absl::Status error = grpc_ssl_check_alpn(peer);
   if (!GRPC_ERROR_IS_NONE(error)) {
     return error;
   }
@@ -158,7 +158,7 @@ class grpc_ssl_channel_security_connector final
     const char* target_name = overridden_target_name_.empty()
                                   ? target_name_.c_str()
                                   : overridden_target_name_.c_str();
-    grpc_error_handle error = ssl_check_peer(target_name, &peer, auth_context);
+    absl::Status error = ssl_check_peer(target_name, &peer, auth_context);
     if (GRPC_ERROR_IS_NONE(error) &&
         verify_options_->verify_peer_callback != nullptr) {
       const tsi_peer_property* p =
@@ -185,7 +185,7 @@ class grpc_ssl_channel_security_connector final
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 
@@ -300,13 +300,13 @@ class grpc_ssl_server_security_connector
                   const grpc_core::ChannelArgs& /*args*/,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
-    grpc_error_handle error = ssl_check_peer(nullptr, &peer, auth_context);
+    absl::Status error = ssl_check_peer(nullptr, &peer, auth_context);
     tsi_peer_destruct(&peer);
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
   }
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override {
+                         absl::Status error) override {
     GRPC_ERROR_UNREF(error);
   }
 

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -42,6 +42,7 @@
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/load_file.h"
 #include "src/core/lib/security/context/security_context.h"
 #include "src/core/lib/security/security_connector/load_system_roots.h"
@@ -138,7 +139,7 @@ tsi_tls_version grpc_get_tsi_tls_version(grpc_tls_version tls_version) {
   }
 }
 
-grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer) {
+absl::Status grpc_ssl_check_alpn(const tsi_peer* peer) {
 #if TSI_OPENSSL_ALPN_SUPPORT
   /* Check the ALPN if ALPN is supported. */
   const tsi_peer_property* p =
@@ -155,8 +156,8 @@ grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle grpc_ssl_check_peer_name(absl::string_view peer_name,
-                                           const tsi_peer* peer) {
+absl::Status grpc_ssl_check_peer_name(absl::string_view peer_name,
+                                      const tsi_peer* peer) {
   /* Check the peer name if specified. */
   if (!peer_name.empty() && !grpc_ssl_host_matches_name(peer, peer_name)) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -35,7 +35,6 @@
 #include <grpc/slice.h>
 
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/security_connector/security_connector.h"
 #include "src/core/tsi/ssl/key_logging/ssl_key_logging.h"
 #include "src/core/tsi/ssl_transport_security.h"
@@ -44,11 +43,11 @@
 /* --- Util --- */
 
 /* Check ALPN information returned from SSL handshakes. */
-grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer);
+absl::Status grpc_ssl_check_alpn(const tsi_peer* peer);
 
 /* Check peer name information returned from SSL handshakes. */
-grpc_error_handle grpc_ssl_check_peer_name(absl::string_view peer_name,
-                                           const tsi_peer* peer);
+absl::Status grpc_ssl_check_peer_name(absl::string_view peer_name,
+                                      const tsi_peer* peer);
 /* Compare targer_name information extracted from SSL security connectors. */
 int grpc_ssl_cmp_target_name(absl::string_view target_name,
                              absl::string_view other_target_name,

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -41,6 +41,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/promise/promise.h"
 #include "src/core/lib/security/context/security_context.h"
@@ -358,7 +359,7 @@ void TlsChannelSecurityConnector::check_peer(
   const char* target_name = overridden_target_name_.empty()
                                 ? target_name_.c_str()
                                 : overridden_target_name_.c_str();
-  grpc_error_handle error = grpc_ssl_check_alpn(&peer);
+  absl::Status error = grpc_ssl_check_alpn(&peer);
   if (!GRPC_ERROR_IS_NONE(error)) {
     ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
     tsi_peer_destruct(&peer);
@@ -377,7 +378,7 @@ void TlsChannelSecurityConnector::check_peer(
 }
 
 void TlsChannelSecurityConnector::cancel_check_peer(
-    grpc_closure* on_peer_checked, grpc_error_handle error) {
+    grpc_closure* on_peer_checked, absl::Status error) {
   if (!GRPC_ERROR_IS_NONE(error)) {
     gpr_log(GPR_ERROR,
             "TlsChannelSecurityConnector::cancel_check_peer error: %s",
@@ -455,7 +456,7 @@ void TlsChannelSecurityConnector::TlsChannelCertificateWatcher::
 // TODO(ZhenLian): implement the logic to signal waiting handshakers once
 // BlockOnInitialCredentialHandshaker is implemented.
 void TlsChannelSecurityConnector::TlsChannelCertificateWatcher::OnError(
-    grpc_error_handle root_cert_error, grpc_error_handle identity_cert_error) {
+    absl::Status root_cert_error, absl::Status identity_cert_error) {
   if (!GRPC_ERROR_IS_NONE(root_cert_error)) {
     gpr_log(GPR_ERROR,
             "TlsChannelCertificateWatcher getting root_cert_error: %s",
@@ -505,7 +506,7 @@ void TlsChannelSecurityConnector::ChannelPendingVerifierRequest::OnVerifyDone(
     MutexLock lock(&security_connector_->verifier_request_map_mu_);
     security_connector_->pending_verifier_requests_.erase(on_peer_checked_);
   }
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   if (!status.ok()) {
     error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
         absl::StrCat("Custom verification check failed with error: ",
@@ -642,7 +643,7 @@ void TlsServerSecurityConnector::check_peer(
     tsi_peer peer, grpc_endpoint* /*ep*/, const ChannelArgs& /*args*/,
     RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
-  grpc_error_handle error = grpc_ssl_check_alpn(&peer);
+  absl::Status error = grpc_ssl_check_alpn(&peer);
   if (!GRPC_ERROR_IS_NONE(error)) {
     ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
     tsi_peer_destruct(&peer);
@@ -665,7 +666,7 @@ void TlsServerSecurityConnector::check_peer(
 }
 
 void TlsServerSecurityConnector::cancel_check_peer(
-    grpc_closure* on_peer_checked, grpc_error_handle error) {
+    grpc_closure* on_peer_checked, absl::Status error) {
   if (!GRPC_ERROR_IS_NONE(error)) {
     gpr_log(GPR_ERROR,
             "TlsServerSecurityConnector::cancel_check_peer error: %s",
@@ -733,7 +734,7 @@ void TlsServerSecurityConnector::TlsServerCertificateWatcher::
 // TODO(ZhenLian): implement the logic to signal waiting handshakers once
 // BlockOnInitialCredentialHandshaker is implemented.
 void TlsServerSecurityConnector::TlsServerCertificateWatcher::OnError(
-    grpc_error_handle root_cert_error, grpc_error_handle identity_cert_error) {
+    absl::Status root_cert_error, absl::Status identity_cert_error) {
   if (!GRPC_ERROR_IS_NONE(root_cert_error)) {
     gpr_log(GPR_ERROR,
             "TlsServerCertificateWatcher getting root_cert_error: %s",
@@ -782,7 +783,7 @@ void TlsServerSecurityConnector::ServerPendingVerifierRequest::OnVerifyDone(
     MutexLock lock(&security_connector_->verifier_request_map_mu_);
     security_connector_->pending_verifier_requests_.erase(on_peer_checked_);
   }
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   if (!status.ok()) {
     error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
         absl::StrCat("Custom verification check failed with error: ",

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.h
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.h
@@ -37,7 +37,6 @@
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/endpoint.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/promise/arena_promise.h"
 #include "src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h"
@@ -83,7 +82,7 @@ class TlsChannelSecurityConnector final
                   grpc_closure* on_peer_checked) override;
 
   void cancel_check_peer(grpc_closure* on_peer_checked,
-                         grpc_error_handle error) override;
+                         absl::Status error) override;
 
   int cmp(const grpc_security_connector* other_sc) const override;
 
@@ -118,8 +117,8 @@ class TlsChannelSecurityConnector final
     void OnCertificatesChanged(
         absl::optional<absl::string_view> root_certs,
         absl::optional<PemKeyCertPairList> key_cert_pairs) override;
-    void OnError(grpc_error_handle root_cert_error,
-                 grpc_error_handle identity_cert_error) override;
+    void OnError(absl::Status root_cert_error,
+                 absl::Status identity_cert_error) override;
 
    private:
     TlsChannelSecurityConnector* security_connector_ = nullptr;
@@ -196,7 +195,7 @@ class TlsServerSecurityConnector final : public grpc_server_security_connector {
                   grpc_closure* on_peer_checked) override;
 
   void cancel_check_peer(grpc_closure* /*on_peer_checked*/,
-                         grpc_error_handle error) override;
+                         absl::Status error) override;
 
   int cmp(const grpc_security_connector* other) const override;
 
@@ -229,8 +228,8 @@ class TlsServerSecurityConnector final : public grpc_server_security_connector {
         absl::optional<absl::string_view> root_certs,
         absl::optional<PemKeyCertPairList> key_cert_pairs) override;
 
-    void OnError(grpc_error_handle root_cert_error,
-                 grpc_error_handle identity_cert_error) override;
+    void OnError(absl::Status root_cert_error,
+                 absl::Status identity_cert_error) override;
 
    private:
     TlsServerSecurityConnector* security_connector_ = nullptr;

--- a/src/core/lib/security/transport/secure_endpoint.cc
+++ b/src/core/lib/security/transport/secure_endpoint.cc
@@ -27,6 +27,7 @@
 #include <memory>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -62,7 +63,7 @@
 
 #define STAGING_BUFFER_SIZE 8192
 
-static void on_read(void* user_data, grpc_error_handle error);
+static void on_read(void* user_data, absl::Status error);
 
 namespace {
 struct secure_endpoint {
@@ -235,7 +236,7 @@ static void flush_read_staging_buffer(secure_endpoint* ep, uint8_t** cur,
   *end = GRPC_SLICE_END_PTR(ep->read_staging_buffer);
 }
 
-static void call_read_cb(secure_endpoint* ep, grpc_error_handle error) {
+static void call_read_cb(secure_endpoint* ep, absl::Status error) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_trace_secure_endpoint)) {
     size_t i;
     for (i = 0; i < ep->read_buffer->count; i++) {
@@ -250,7 +251,7 @@ static void call_read_cb(secure_endpoint* ep, grpc_error_handle error) {
   SECURE_ENDPOINT_UNREF(ep, "read");
 }
 
-static void on_read(void* user_data, grpc_error_handle error) {
+static void on_read(void* user_data, absl::Status error) {
   unsigned i;
   uint8_t keep_looping = 0;
   tsi_result result = TSI_OK;
@@ -495,7 +496,7 @@ static void endpoint_write(grpc_endpoint* secure_ep, grpc_slice_buffer* slices,
                       max_frame_size);
 }
 
-static void endpoint_shutdown(grpc_endpoint* secure_ep, grpc_error_handle why) {
+static void endpoint_shutdown(grpc_endpoint* secure_ep, absl::Status why) {
   secure_endpoint* ep = reinterpret_cast<secure_endpoint*>(secure_ep);
   grpc_endpoint_shutdown(ep->wrapped_ep, why);
 }

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -30,6 +30,7 @@
 
 #include "absl/base/attributes.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -76,36 +77,35 @@ class SecurityHandshaker : public Handshaker {
                      grpc_security_connector* connector,
                      const ChannelArgs& args);
   ~SecurityHandshaker() override;
-  void Shutdown(grpc_error_handle why) override;
+  void Shutdown(absl::Status why) override;
   void DoHandshake(grpc_tcp_server_acceptor* acceptor,
                    grpc_closure* on_handshake_done,
                    HandshakerArgs* args) override;
   const char* name() const override { return "security"; }
 
  private:
-  grpc_error_handle DoHandshakerNextLocked(const unsigned char* bytes_received,
-                                           size_t bytes_received_size);
+  absl::Status DoHandshakerNextLocked(const unsigned char* bytes_received,
+                                      size_t bytes_received_size);
 
-  grpc_error_handle OnHandshakeNextDoneLocked(
+  absl::Status OnHandshakeNextDoneLocked(
       tsi_result result, const unsigned char* bytes_to_send,
       size_t bytes_to_send_size, tsi_handshaker_result* handshaker_result);
-  void HandshakeFailedLocked(grpc_error_handle error);
+  void HandshakeFailedLocked(absl::Status error);
   void CleanupArgsForFailureLocked();
 
-  static void OnHandshakeDataReceivedFromPeerFn(void* arg,
-                                                grpc_error_handle error);
-  static void OnHandshakeDataSentToPeerFn(void* arg, grpc_error_handle error);
-  static void OnHandshakeDataReceivedFromPeerFnScheduler(
-      void* arg, grpc_error_handle error);
+  static void OnHandshakeDataReceivedFromPeerFn(void* arg, absl::Status error);
+  static void OnHandshakeDataSentToPeerFn(void* arg, absl::Status error);
+  static void OnHandshakeDataReceivedFromPeerFnScheduler(void* arg,
+                                                         absl::Status error);
   static void OnHandshakeDataSentToPeerFnScheduler(void* arg,
-                                                   grpc_error_handle error);
+                                                   absl::Status error);
   static void OnHandshakeNextDoneGrpcWrapper(
       tsi_result result, void* user_data, const unsigned char* bytes_to_send,
       size_t bytes_to_send_size, tsi_handshaker_result* handshaker_result);
-  static void OnPeerCheckedFn(void* arg, grpc_error_handle error);
-  void OnPeerCheckedInner(grpc_error_handle error);
+  static void OnPeerCheckedFn(void* arg, absl::Status error);
+  void OnPeerCheckedInner(absl::Status error);
   size_t MoveReadBufferIntoHandshakeBuffer();
-  grpc_error_handle CheckPeerLocked();
+  absl::Status CheckPeerLocked();
 
   // State set at creation time.
   tsi_handshaker* handshaker_;
@@ -195,7 +195,7 @@ void SecurityHandshaker::CleanupArgsForFailureLocked() {
 
 // If the handshake failed or we're shutting down, clean up and invoke the
 // callback with the error.
-void SecurityHandshaker::HandshakeFailedLocked(grpc_error_handle error) {
+void SecurityHandshaker::HandshakeFailedLocked(absl::Status error) {
   if (GRPC_ERROR_IS_NONE(error)) {
     // If we were shut down after the handshake succeeded but before an
     // endpoint callback was invoked, we need to generate our own error.
@@ -246,7 +246,7 @@ MakeChannelzSecurityFromAuthContext(grpc_auth_context* auth_context) {
 
 }  // namespace
 
-void SecurityHandshaker::OnPeerCheckedInner(grpc_error_handle error) {
+void SecurityHandshaker::OnPeerCheckedInner(absl::Status error) {
   MutexLock lock(&mu_);
   if (!GRPC_ERROR_IS_NONE(error) || is_shutdown_) {
     HandshakeFailedLocked(error);
@@ -348,12 +348,12 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error_handle error) {
   is_shutdown_ = true;
 }
 
-void SecurityHandshaker::OnPeerCheckedFn(void* arg, grpc_error_handle error) {
+void SecurityHandshaker::OnPeerCheckedFn(void* arg, absl::Status error) {
   RefCountedPtr<SecurityHandshaker>(static_cast<SecurityHandshaker*>(arg))
       ->OnPeerCheckedInner(GRPC_ERROR_REF(error));
 }
 
-grpc_error_handle SecurityHandshaker::CheckPeerLocked() {
+absl::Status SecurityHandshaker::CheckPeerLocked() {
   tsi_peer peer;
   tsi_result result =
       tsi_handshaker_result_extract_peer(handshaker_result_, &peer);
@@ -366,10 +366,10 @@ grpc_error_handle SecurityHandshaker::CheckPeerLocked() {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle SecurityHandshaker::OnHandshakeNextDoneLocked(
+absl::Status SecurityHandshaker::OnHandshakeNextDoneLocked(
     tsi_result result, const unsigned char* bytes_to_send,
     size_t bytes_to_send_size, tsi_handshaker_result* handshaker_result) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   // Handshaker was shutdown.
   if (is_shutdown_) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshaker shutdown");
@@ -438,7 +438,7 @@ void SecurityHandshaker::OnHandshakeNextDoneGrpcWrapper(
   RefCountedPtr<SecurityHandshaker> h(
       static_cast<SecurityHandshaker*>(user_data));
   MutexLock lock(&h->mu_);
-  grpc_error_handle error = h->OnHandshakeNextDoneLocked(
+  absl::Status error = h->OnHandshakeNextDoneLocked(
       result, bytes_to_send, bytes_to_send_size, handshaker_result);
   if (!GRPC_ERROR_IS_NONE(error)) {
     h->HandshakeFailedLocked(error);
@@ -447,7 +447,7 @@ void SecurityHandshaker::OnHandshakeNextDoneGrpcWrapper(
   }
 }
 
-grpc_error_handle SecurityHandshaker::DoHandshakerNextLocked(
+absl::Status SecurityHandshaker::DoHandshakerNextLocked(
     const unsigned char* bytes_received, size_t bytes_received_size) {
   // Invoke TSI handshaker.
   const unsigned char* bytes_to_send = nullptr;
@@ -471,7 +471,7 @@ grpc_error_handle SecurityHandshaker::DoHandshakerNextLocked(
 // This callback might be run inline while we are still holding on to the mutex,
 // so schedule OnHandshakeDataReceivedFromPeerFn on ExecCtx to avoid a deadlock.
 void SecurityHandshaker::OnHandshakeDataReceivedFromPeerFnScheduler(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   SecurityHandshaker* h = static_cast<SecurityHandshaker*>(arg);
   ExecCtx::Run(
       DEBUG_LOCATION,
@@ -481,8 +481,8 @@ void SecurityHandshaker::OnHandshakeDataReceivedFromPeerFnScheduler(
       GRPC_ERROR_REF(error));
 }
 
-void SecurityHandshaker::OnHandshakeDataReceivedFromPeerFn(
-    void* arg, grpc_error_handle error) {
+void SecurityHandshaker::OnHandshakeDataReceivedFromPeerFn(void* arg,
+                                                           absl::Status error) {
   RefCountedPtr<SecurityHandshaker> h(static_cast<SecurityHandshaker*>(arg));
   MutexLock lock(&h->mu_);
   if (!GRPC_ERROR_IS_NONE(error) || h->is_shutdown_) {
@@ -504,7 +504,7 @@ void SecurityHandshaker::OnHandshakeDataReceivedFromPeerFn(
 // This callback might be run inline while we are still holding on to the mutex,
 // so schedule OnHandshakeDataSentToPeerFn on ExecCtx to avoid a deadlock.
 void SecurityHandshaker::OnHandshakeDataSentToPeerFnScheduler(
-    void* arg, grpc_error_handle error) {
+    void* arg, absl::Status error) {
   SecurityHandshaker* h = static_cast<SecurityHandshaker*>(arg);
   ExecCtx::Run(
       DEBUG_LOCATION,
@@ -515,7 +515,7 @@ void SecurityHandshaker::OnHandshakeDataSentToPeerFnScheduler(
 }
 
 void SecurityHandshaker::OnHandshakeDataSentToPeerFn(void* arg,
-                                                     grpc_error_handle error) {
+                                                     absl::Status error) {
   RefCountedPtr<SecurityHandshaker> h(static_cast<SecurityHandshaker*>(arg));
   MutexLock lock(&h->mu_);
   if (!GRPC_ERROR_IS_NONE(error) || h->is_shutdown_) {
@@ -546,7 +546,7 @@ void SecurityHandshaker::OnHandshakeDataSentToPeerFn(void* arg,
 // public handshaker API
 //
 
-void SecurityHandshaker::Shutdown(grpc_error_handle why) {
+void SecurityHandshaker::Shutdown(absl::Status why) {
   MutexLock lock(&mu_);
   if (!is_shutdown_) {
     is_shutdown_ = true;
@@ -566,7 +566,7 @@ void SecurityHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
   args_ = args;
   on_handshake_done_ = on_handshake_done;
   size_t bytes_received_size = MoveReadBufferIntoHandshakeBuffer();
-  grpc_error_handle error =
+  absl::Status error =
       DoHandshakerNextLocked(handshake_buffer_, bytes_received_size);
   if (!GRPC_ERROR_IS_NONE(error)) {
     HandshakeFailedLocked(error);
@@ -582,11 +582,11 @@ void SecurityHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
 class FailHandshaker : public Handshaker {
  public:
   const char* name() const override { return "security_fail"; }
-  void Shutdown(grpc_error_handle why) override { GRPC_ERROR_UNREF(why); }
+  void Shutdown(absl::Status why) override { GRPC_ERROR_UNREF(why); }
   void DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                    grpc_closure* on_handshake_done,
                    HandshakerArgs* args) override {
-    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    absl::Status error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Failed to create security handshaker");
     grpc_endpoint_shutdown(args->endpoint, GRPC_ERROR_REF(error));
     grpc_endpoint_destroy(args->endpoint);

--- a/src/core/lib/security/transport/tsi_error.cc
+++ b/src/core/lib/security/transport/tsi_error.cc
@@ -20,8 +20,9 @@
 
 #include "src/core/lib/security/transport/tsi_error.h"
 
-grpc_error_handle grpc_set_tsi_error_result(grpc_error_handle error,
-                                            tsi_result result) {
+#include "src/core/lib/iomgr/error.h"
+
+absl::Status grpc_set_tsi_error_result(absl::Status error, tsi_result result) {
   return grpc_error_set_int(grpc_error_set_str(error, GRPC_ERROR_STR_TSI_ERROR,
                                                tsi_result_to_string(result)),
                             GRPC_ERROR_INT_TSI_CODE, result);

--- a/src/core/lib/security/transport/tsi_error.h
+++ b/src/core/lib/security/transport/tsi_error.h
@@ -21,10 +21,10 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "src/core/lib/iomgr/error.h"
+#include "absl/status/status.h"
+
 #include "src/core/tsi/transport_security_interface.h"
 
-grpc_error_handle grpc_set_tsi_error_result(grpc_error_handle error,
-                                            tsi_result result);
+absl::Status grpc_set_tsi_error_result(absl::Status error, tsi_result result);
 
 #endif /* GRPC_CORE_LIB_SECURITY_TRANSPORT_TSI_ERROR_H */

--- a/src/core/lib/security/util/json_util.cc
+++ b/src/core/lib/security/util/json_util.cc
@@ -32,7 +32,7 @@
 
 const char* grpc_json_get_string_property(const grpc_core::Json& json,
                                           const char* prop_name,
-                                          grpc_error_handle* error) {
+                                          absl::Status* error) {
   if (json.type() != grpc_core::Json::Type::OBJECT) {
     if (error != nullptr) {
       *error =
@@ -61,7 +61,7 @@ const char* grpc_json_get_string_property(const grpc_core::Json& json,
 bool grpc_copy_json_string_property(const grpc_core::Json& json,
                                     const char* prop_name,
                                     char** copied_value) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   const char* prop_value =
       grpc_json_get_string_property(json, prop_name, &error);
   GRPC_LOG_IF_ERROR("Could not copy JSON property", error);

--- a/src/core/lib/security/util/json_util.h
+++ b/src/core/lib/security/util/json_util.h
@@ -21,7 +21,8 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "src/core/lib/iomgr/error.h"
+#include "absl/status/status.h"
+
 #include "src/core/lib/json/json.h"
 
 // Constants.
@@ -33,7 +34,7 @@
 // Gets a child property from a json node.
 const char* grpc_json_get_string_property(const grpc_core::Json& json,
                                           const char* prop_name,
-                                          grpc_error_handle* error);
+                                          absl::Status* error);
 
 // Copies the value of the json child property specified by prop_name.
 // Returns false if the property was not found.

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
@@ -37,7 +38,6 @@
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/slice/slice.h"
@@ -70,8 +70,7 @@ typedef struct grpc_call_create_args {
 /* Create a new call based on \a args.
    Regardless of success or failure, always returns a valid new call into *call
    */
-grpc_error_handle grpc_call_create(grpc_call_create_args* args,
-                                   grpc_call** call);
+absl::Status grpc_call_create(grpc_call_create_args* args, grpc_call** call);
 
 void grpc_call_set_completion_queue(grpc_call* call, grpc_completion_queue* cq);
 

--- a/src/core/lib/surface/channel_ping.cc
+++ b/src/core/lib/surface/channel_ping.cc
@@ -18,6 +18,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -43,7 +45,7 @@ static void ping_destroy(void* arg, grpc_cq_completion* /*storage*/) {
   gpr_free(arg);
 }
 
-static void ping_done(void* arg, grpc_error_handle error) {
+static void ping_done(void* arg, absl::Status error) {
   ping_result* pr = static_cast<ping_result*>(arg);
   grpc_cq_end_op(pr->cq, pr->tag, GRPC_ERROR_REF(error), ping_destroy, pr,
                  &pr->completion_storage);

--- a/src/core/lib/surface/completion_queue.h
+++ b/src/core/lib/surface/completion_queue.h
@@ -25,12 +25,13 @@
 
 #include <stdint.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/manual_constructor.h"
 #include "src/core/lib/gprpp/mpscq.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 
 /* These trace flags default to 1. The corresponding lines are only traced
@@ -79,8 +80,7 @@ bool grpc_cq_begin_op(grpc_completion_queue* cq, void* tag);
 
 /* Queue a GRPC_OP_COMPLETED operation; tag must correspond to the tag passed to
    grpc_cq_begin_op */
-void grpc_cq_end_op(grpc_completion_queue* cq, void* tag,
-                    grpc_error_handle error,
+void grpc_cq_end_op(grpc_completion_queue* cq, void* tag, absl::Status error,
                     void (*done)(void* done_arg, grpc_cq_completion* storage),
                     void* done_arg, grpc_cq_completion* storage,
                     bool internal = false);

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -41,6 +41,7 @@
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/sync.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/promise/promise.h"
 #include "src/core/lib/surface/api_trace.h"
@@ -107,7 +108,7 @@ bool LameClientFilter::StartTransportOp(grpc_transport_op* op) {
 
 namespace {
 
-// Channel arg vtable for a grpc_error_handle.
+// Channel arg vtable for a absl::Status.
 void* ErrorCopy(void* p) {
   return new absl::Status(*static_cast<absl::Status*>(p));
 }
@@ -119,7 +120,7 @@ const grpc_arg_pointer_vtable kLameFilterErrorArgVtable = {
 
 }  // namespace
 
-grpc_arg MakeLameClientErrorArg(grpc_error_handle* error) {
+grpc_arg MakeLameClientErrorArg(absl::Status* error) {
   return grpc_channel_arg_pointer_create(
       const_cast<char*>(GRPC_ARG_LAME_FILTER_ERROR), error,
       &kLameFilterErrorArgVtable);

--- a/src/core/lib/surface/lame_client.h
+++ b/src/core/lib/surface/lame_client.h
@@ -33,14 +33,13 @@
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/promise_based_filter.h"
 #include "src/core/lib/gprpp/sync.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/promise/arena_promise.h"
 #include "src/core/lib/transport/connectivity_state.h"
 #include "src/core/lib/transport/transport.h"
 
 namespace grpc_core {
 // Does NOT take ownership of error.
-grpc_arg MakeLameClientErrorArg(grpc_error_handle* error);
+grpc_arg MakeLameClientErrorArg(absl::Status* error);
 
 // This filter becomes the entire channel stack for a channel that fails to be
 // created. Every call returns failure.

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -32,6 +32,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 
@@ -158,7 +159,7 @@ class Server : public InternallyRefCounted<Server>,
   // Sets up a transport.  Creates a channel stack and binds the transport to
   // the server.  Called from the listener when a new connection is accepted.
   // Takes ownership of a ref on resource_user from the caller.
-  grpc_error_handle SetupTransport(
+  absl::Status SetupTransport(
       grpc_transport* transport, grpc_pollset* accepting_pollset,
       const ChannelArgs& args,
       const RefCountedPtr<channelz::SocketNode>& socket_node);
@@ -235,8 +236,8 @@ class Server : public InternallyRefCounted<Server>,
                                                  const grpc_slice& path);
 
     // Filter vtable functions.
-    static grpc_error_handle InitChannelElement(
-        grpc_channel_element* elem, grpc_channel_element_args* args);
+    static absl::Status InitChannelElement(grpc_channel_element* elem,
+                                           grpc_channel_element_args* args);
     static void DestroyChannelElement(grpc_channel_element* elem);
 
    private:
@@ -247,7 +248,7 @@ class Server : public InternallyRefCounted<Server>,
 
     void Destroy() ABSL_EXCLUSIVE_LOCKS_REQUIRED(server_->mu_global_);
 
-    static void FinishDestroy(void* arg, grpc_error_handle error);
+    static void FinishDestroy(void* arg, absl::Status error);
 
     RefCountedPtr<Server> server_;
     RefCountedPtr<Channel> channel_;
@@ -297,8 +298,8 @@ class Server : public InternallyRefCounted<Server>,
     void FailCallCreation();
 
     // Filter vtable functions.
-    static grpc_error_handle InitCallElement(
-        grpc_call_element* elem, const grpc_call_element_args* args);
+    static absl::Status InitCallElement(grpc_call_element* elem,
+                                        const grpc_call_element_args* args);
     static void DestroyCallElement(grpc_call_element* elem,
                                    const grpc_call_final_info* /*final_info*/,
                                    grpc_closure* /*ignored*/);
@@ -307,16 +308,15 @@ class Server : public InternallyRefCounted<Server>,
 
    private:
     // Helper functions for handling calls at the top of the call stack.
-    static void RecvInitialMetadataBatchComplete(void* arg,
-                                                 grpc_error_handle error);
+    static void RecvInitialMetadataBatchComplete(void* arg, absl::Status error);
     void StartNewRpc(grpc_call_element* elem);
-    static void PublishNewRpc(void* arg, grpc_error_handle error);
+    static void PublishNewRpc(void* arg, absl::Status error);
 
     // Functions used inside the call stack.
     void StartTransportStreamOpBatchImpl(grpc_call_element* elem,
                                          grpc_transport_stream_op_batch* batch);
-    static void RecvInitialMetadataReady(void* arg, grpc_error_handle error);
-    static void RecvTrailingMetadataReady(void* arg, grpc_error_handle error);
+    static void RecvInitialMetadataReady(void* arg, absl::Status error);
+    static void RecvTrailingMetadataReady(void* arg, absl::Status error);
 
     RefCountedPtr<Server> server_;
 
@@ -342,12 +342,12 @@ class Server : public InternallyRefCounted<Server>,
     grpc_metadata_batch* recv_initial_metadata_ = nullptr;
     grpc_closure recv_initial_metadata_ready_;
     grpc_closure* original_recv_initial_metadata_ready_;
-    grpc_error_handle recv_initial_metadata_error_ = GRPC_ERROR_NONE;
+    absl::Status recv_initial_metadata_error_ = GRPC_ERROR_NONE;
 
     bool seen_recv_trailing_metadata_ready_ = false;
     grpc_closure recv_trailing_metadata_ready_;
     grpc_closure* original_recv_trailing_metadata_ready_;
-    grpc_error_handle recv_trailing_metadata_error_ = GRPC_ERROR_NONE;
+    absl::Status recv_trailing_metadata_error_ = GRPC_ERROR_NONE;
 
     grpc_closure publish_;
 
@@ -369,7 +369,7 @@ class Server : public InternallyRefCounted<Server>,
     grpc_cq_completion completion;
   };
 
-  static void ListenerDestroyDone(void* arg, grpc_error_handle error);
+  static void ListenerDestroyDone(void* arg, absl::Status error);
 
   static void DoneShutdownEvent(void* server,
                                 grpc_cq_completion* /*completion*/) {
@@ -378,13 +378,13 @@ class Server : public InternallyRefCounted<Server>,
 
   static void DoneRequestEvent(void* req, grpc_cq_completion* completion);
 
-  void FailCall(size_t cq_idx, RequestedCall* rc, grpc_error_handle error);
+  void FailCall(size_t cq_idx, RequestedCall* rc, absl::Status error);
   grpc_call_error QueueRequestedCall(size_t cq_idx, RequestedCall* rc);
 
   void MaybeFinishShutdown() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_global_)
       ABSL_LOCKS_EXCLUDED(mu_call_);
 
-  void KillPendingWorkLocked(grpc_error_handle error)
+  void KillPendingWorkLocked(absl::Status error)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_call_);
 
   static grpc_call_error ValidateServerRequest(

--- a/src/core/lib/surface/validate_metadata.h
+++ b/src/core/lib/surface/validate_metadata.h
@@ -25,13 +25,13 @@
 
 #include <cstring>
 
+#include "absl/status/status.h"
+
 #include <grpc/slice.h>
 #include <grpc/support/log.h>
 
-#include "src/core/lib/iomgr/error.h"
-
-grpc_error_handle grpc_validate_header_key_is_legal(const grpc_slice& slice);
-grpc_error_handle grpc_validate_header_nonbin_value_is_legal(
+absl::Status grpc_validate_header_key_is_legal(const grpc_slice& slice);
+absl::Status grpc_validate_header_nonbin_value_is_legal(
     const grpc_slice& slice);
 
 int grpc_is_binary_header_internal(const grpc_slice& slice);

--- a/src/core/lib/transport/connectivity_state.cc
+++ b/src/core/lib/transport/connectivity_state.cc
@@ -74,7 +74,7 @@ class AsyncConnectivityStateWatcherInterface::Notifier {
   }
 
  private:
-  static void SendNotification(void* arg, grpc_error_handle /*ignored*/) {
+  static void SendNotification(void* arg, absl::Status /*ignored*/) {
     Notifier* self = static_cast<Notifier*>(arg);
     if (GRPC_TRACE_FLAG_ENABLED(grpc_connectivity_state_trace)) {
       gpr_log(GPR_INFO, "watcher %p: delivering async notification for %s (%s)",

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -29,10 +29,11 @@
 #include <grpc/support/string_util.h>
 
 #include "src/core/lib/gprpp/status_helper.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/status_conversion.h"
 
-static grpc_error_handle recursively_find_error_with_field(
-    grpc_error_handle error, grpc_error_ints which) {
+static absl::Status recursively_find_error_with_field(absl::Status error,
+                                                      grpc_error_ints which) {
   intptr_t unused;
   // If the error itself has a status code, return it.
   if (grpc_error_get_int(error, which, &unused)) {
@@ -40,14 +41,13 @@ static grpc_error_handle recursively_find_error_with_field(
   }
   std::vector<absl::Status> children = grpc_core::StatusGetChildren(error);
   for (const absl::Status& child : children) {
-    grpc_error_handle result = recursively_find_error_with_field(child, which);
+    absl::Status result = recursively_find_error_with_field(child, which);
     if (!GRPC_ERROR_IS_NONE(result)) return result;
   }
   return GRPC_ERROR_NONE;
 }
 
-void grpc_error_get_status(grpc_error_handle error,
-                           grpc_core::Timestamp deadline,
+void grpc_error_get_status(absl::Status error, grpc_core::Timestamp deadline,
                            grpc_status_code* code, std::string* message,
                            grpc_http2_error_code* http_error,
                            const char** error_string) {
@@ -73,7 +73,7 @@ void grpc_error_get_status(grpc_error_handle error,
 
   // Start with the parent error and recurse through the tree of children
   // until we find the first one that has a status code.
-  grpc_error_handle found_error =
+  absl::Status found_error =
       recursively_find_error_with_field(error, GRPC_ERROR_INT_GRPC_STATUS);
   if (GRPC_ERROR_IS_NONE(found_error)) {
     /// If no grpc-status exists, retry through the tree to find a http2 error
@@ -129,7 +129,7 @@ void grpc_error_get_status(grpc_error_handle error,
   }
 }
 
-absl::Status grpc_error_to_absl_status(grpc_error_handle error) {
+absl::Status grpc_error_to_absl_status(absl::Status error) {
   grpc_status_code status;
   // TODO(yashykt): This should be updated once we decide on how to use the
   // absl::Status payload to capture all the contents of grpc_error.
@@ -140,7 +140,7 @@ absl::Status grpc_error_to_absl_status(grpc_error_handle error) {
   return absl::Status(static_cast<absl::StatusCode>(status), message);
 }
 
-grpc_error_handle absl_status_to_grpc_error(absl::Status status) {
+absl::Status absl_status_to_grpc_error(absl::Status status) {
   // Special error checks
   if (status.ok()) {
     return GRPC_ERROR_NONE;
@@ -150,7 +150,7 @@ grpc_error_handle absl_status_to_grpc_error(absl::Status status) {
       GRPC_ERROR_INT_GRPC_STATUS, static_cast<grpc_status_code>(status.code()));
 }
 
-bool grpc_error_has_clear_grpc_status(grpc_error_handle error) {
+bool grpc_error_has_clear_grpc_status(absl::Status error) {
   intptr_t unused;
   if (grpc_error_get_int(error, GRPC_ERROR_INT_GRPC_STATUS, &unused)) {
     return true;

--- a/src/core/lib/transport/error_utils.h
+++ b/src/core/lib/transport/error_utils.h
@@ -28,7 +28,6 @@
 #include <grpc/status.h>
 
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/transport/http2_errors.h"
 
 /// A utility function to get the status code and message to be returned
@@ -38,26 +37,25 @@
 /// be populated with the entire error string. If any of the attributes (code,
 /// msg, http_status, error_string) are unneeded, they can be passed as
 /// NULL.
-void grpc_error_get_status(grpc_error_handle error,
-                           grpc_core::Timestamp deadline,
+void grpc_error_get_status(absl::Status error, grpc_core::Timestamp deadline,
                            grpc_status_code* code, std::string* message,
                            grpc_http2_error_code* http_error,
                            const char** error_string);
 
-/// Utility Function to convert a grpc_error_handle  \a error to an
+/// Utility Function to convert a absl::Status  \a error to an
 /// absl::Status. Does NOT consume a ref to grpc_error.
-absl::Status grpc_error_to_absl_status(grpc_error_handle error);
+absl::Status grpc_error_to_absl_status(absl::Status error);
 
 /// Utility function to convert an absl::Status \a status to grpc_error. Note
 /// that this method does not return "special case" errors such as
 /// GRPC_ERROR_CANCELLED, with the exception of GRPC_ERROR_NONE returned for
 /// \a absl::OkStatus().
-grpc_error_handle absl_status_to_grpc_error(absl::Status status);
+absl::Status absl_status_to_grpc_error(absl::Status status);
 
 /// A utility function to check whether there is a clear status code that
 /// doesn't need to be guessed in \a error. This means that \a error or some
 /// child has GRPC_ERROR_INT_GRPC_STATUS set, or that it is GRPC_ERROR_NONE or
 /// GRPC_ERROR_CANCELLED
-bool grpc_error_has_clear_grpc_status(grpc_error_handle error);
+bool grpc_error_has_clear_grpc_status(absl::Status error);
 
 #endif /* GRPC_CORE_LIB_TRANSPORT_ERROR_UTILS_H */

--- a/src/core/lib/transport/handshaker.cc
+++ b/src/core/lib/transport/handshaker.cc
@@ -35,6 +35,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/slice/slice_internal.h"
@@ -72,7 +73,7 @@ void HandshakeManager::Add(RefCountedPtr<Handshaker> handshaker) {
 
 HandshakeManager::~HandshakeManager() { handshakers_.clear(); }
 
-void HandshakeManager::Shutdown(grpc_error_handle why) {
+void HandshakeManager::Shutdown(absl::Status why) {
   {
     MutexLock lock(&mu_);
     // Shutdown the handshaker that's currently in progress, if any.
@@ -87,7 +88,7 @@ void HandshakeManager::Shutdown(grpc_error_handle why) {
 // Helper function to call either the next handshaker or the
 // on_handshake_done callback.
 // Returns true if we've scheduled the on_handshake_done callback.
-bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
+bool HandshakeManager::CallNextHandshakerLocked(absl::Status error) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_handshaker_trace)) {
     gpr_log(GPR_INFO,
             "handshake_manager %p: error=%s shutdown=%d index=%" PRIuPTR
@@ -145,8 +146,7 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
   return is_shutdown_;
 }
 
-void HandshakeManager::CallNextHandshakerFn(void* arg,
-                                            grpc_error_handle error) {
+void HandshakeManager::CallNextHandshakerFn(void* arg, absl::Status error) {
   auto* mgr = static_cast<HandshakeManager*>(arg);
   bool done;
   {
@@ -161,7 +161,7 @@ void HandshakeManager::CallNextHandshakerFn(void* arg,
   }
 }
 
-void HandshakeManager::OnTimeoutFn(void* arg, grpc_error_handle error) {
+void HandshakeManager::OnTimeoutFn(void* arg, absl::Status error) {
   auto* mgr = static_cast<HandshakeManager*>(arg);
   if (GRPC_ERROR_IS_NONE(error)) {  // Timer fired, rather than being cancelled
     mgr->Shutdown(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshake timed out"));

--- a/src/core/lib/transport/handshaker.h
+++ b/src/core/lib/transport/handshaker.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/status/status.h"
 
 #include <grpc/slice.h>
 
@@ -34,7 +35,6 @@
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/endpoint.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/tcp_server.h"
 #include "src/core/lib/iomgr/timer.h"
 
@@ -84,7 +84,7 @@ struct HandshakerArgs {
 class Handshaker : public RefCounted<Handshaker> {
  public:
   ~Handshaker() override = default;
-  virtual void Shutdown(grpc_error_handle why) = 0;
+  virtual void Shutdown(absl::Status why) = 0;
   virtual void DoHandshake(grpc_tcp_server_acceptor* acceptor,
                            grpc_closure* on_handshake_done,
                            HandshakerArgs* args) = 0;
@@ -106,7 +106,7 @@ class HandshakeManager : public RefCounted<HandshakeManager> {
 
   /// Shuts down the handshake manager (e.g., to clean up when the operation is
   /// aborted in the middle).
-  void Shutdown(grpc_error_handle why);
+  void Shutdown(absl::Status why);
 
   /// Invokes handshakers in the order they were added.
   /// Takes ownership of \a endpoint, and then passes that ownership to
@@ -125,14 +125,14 @@ class HandshakeManager : public RefCounted<HandshakeManager> {
                    grpc_iomgr_cb_func on_handshake_done, void* user_data);
 
  private:
-  bool CallNextHandshakerLocked(grpc_error_handle error);
+  bool CallNextHandshakerLocked(absl::Status error);
 
   // A function used as the handshaker-done callback when chaining
   // handshakers together.
-  static void CallNextHandshakerFn(void* arg, grpc_error_handle error);
+  static void CallNextHandshakerFn(void* arg, absl::Status error);
 
   // Callback invoked when deadline is exceeded.
-  static void OnTimeoutFn(void* arg, grpc_error_handle error);
+  static void OnTimeoutFn(void* arg, absl::Status error);
 
   static const size_t HANDSHAKERS_INIT_SIZE = 2;
 

--- a/src/core/lib/transport/tcp_connect_handshaker.cc
+++ b/src/core/lib/transport/tcp_connect_handshaker.cc
@@ -24,6 +24,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -62,7 +63,7 @@ namespace {
 class TCPConnectHandshaker : public Handshaker {
  public:
   explicit TCPConnectHandshaker(grpc_pollset_set* pollset_set);
-  void Shutdown(grpc_error_handle why) override;
+  void Shutdown(absl::Status why) override;
   void DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                    grpc_closure* on_handshake_done,
                    HandshakerArgs* args) override;
@@ -71,8 +72,8 @@ class TCPConnectHandshaker : public Handshaker {
  private:
   ~TCPConnectHandshaker() override;
   void CleanupArgsForFailureLocked() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  void FinishLocked(grpc_error_handle error) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-  static void Connected(void* arg, grpc_error_handle error);
+  void FinishLocked(absl::Status error) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+  static void Connected(void* arg, absl::Status error);
 
   Mutex mu_;
   bool shutdown_ ABSL_GUARDED_BY(mu_) = false;
@@ -100,7 +101,7 @@ TCPConnectHandshaker::TCPConnectHandshaker(grpc_pollset_set* pollset_set)
   GRPC_CLOSURE_INIT(&connected_, Connected, this, grpc_schedule_on_exec_ctx);
 }
 
-void TCPConnectHandshaker::Shutdown(grpc_error_handle why) {
+void TCPConnectHandshaker::Shutdown(absl::Status why) {
   // TODO(anramach): After migration to EventEngine, cancel the in-progress
   // TCP connection attempt.
   {
@@ -162,7 +163,7 @@ void TCPConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
       &addr_, args->deadline);
 }
 
-void TCPConnectHandshaker::Connected(void* arg, grpc_error_handle error) {
+void TCPConnectHandshaker::Connected(void* arg, absl::Status error) {
   RefCountedPtr<TCPConnectHandshaker> self(
       static_cast<TCPConnectHandshaker*>(arg));
   {
@@ -217,7 +218,7 @@ void TCPConnectHandshaker::CleanupArgsForFailureLocked() {
   args_->args = ChannelArgs();
 }
 
-void TCPConnectHandshaker::FinishLocked(grpc_error_handle error) {
+void TCPConnectHandshaker::FinishLocked(absl::Status error) {
   if (interested_parties_ != nullptr) {
     grpc_polling_entity_del_from_pollset_set(&pollent_, interested_parties_);
   }

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -149,7 +149,7 @@ grpc_endpoint* grpc_transport_get_endpoint(grpc_transport* transport) {
 // though it lives in lib, it handles transport stream ops sure
 // it's grpc_transport_stream_op_batch_finish_with_failure
 void grpc_transport_stream_op_batch_finish_with_failure(
-    grpc_transport_stream_op_batch* batch, grpc_error_handle error,
+    grpc_transport_stream_op_batch* batch, absl::Status error,
     grpc_core::CallCombiner* call_combiner) {
   grpc_core::CallCombinerClosureList closures;
   grpc_transport_stream_op_batch_queue_finish_with_failure(batch, error,
@@ -159,7 +159,7 @@ void grpc_transport_stream_op_batch_finish_with_failure(
 }
 
 void grpc_transport_stream_op_batch_queue_finish_with_failure(
-    grpc_transport_stream_op_batch* batch, grpc_error_handle error,
+    grpc_transport_stream_op_batch* batch, absl::Status error,
     grpc_core::CallCombinerClosureList* closures) {
   if (batch->cancel_stream) {
     GRPC_ERROR_UNREF(batch->payload->cancel_stream.cancel_error);
@@ -195,7 +195,7 @@ struct made_transport_op {
   }
 };
 
-static void destroy_made_transport_op(void* arg, grpc_error_handle error) {
+static void destroy_made_transport_op(void* arg, absl::Status error) {
   made_transport_op* op = static_cast<made_transport_op*>(arg);
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->inner_on_complete,
                           GRPC_ERROR_REF(error));
@@ -217,8 +217,7 @@ struct made_transport_stream_op {
   grpc_transport_stream_op_batch op;
   grpc_transport_stream_op_batch_payload payload{nullptr};
 };
-static void destroy_made_transport_stream_op(void* arg,
-                                             grpc_error_handle error) {
+static void destroy_made_transport_stream_op(void* arg, absl::Status error) {
   made_transport_stream_op* op = static_cast<made_transport_stream_op*>(arg);
   grpc_closure* c = op->inner_on_complete;
   delete op;

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -433,7 +433,7 @@ struct grpc_transport_stream_op_batch_payload {
   struct {
     // Error contract: the transport that gets this op must cause cancel_error
     //                 to be unref'ed after processing it
-    grpc_error_handle cancel_error = GRPC_ERROR_NONE;
+    absl::Status cancel_error = GRPC_ERROR_NONE;
   } cancel_stream;
 
   /* Indexes correspond to grpc_context_index enum values */
@@ -453,11 +453,11 @@ typedef struct grpc_transport_op {
   /** should the transport be disconnected
    * Error contract: the transport that gets this op must cause
    *                 disconnect_with_error to be unref'ed after processing it */
-  grpc_error_handle disconnect_with_error = GRPC_ERROR_NONE;
+  absl::Status disconnect_with_error = GRPC_ERROR_NONE;
   /** what should the goaway contain?
    * Error contract: the transport that gets this op must cause
    *                 goaway_error to be unref'ed after processing it */
-  grpc_error_handle goaway_error = GRPC_ERROR_NONE;
+  absl::Status goaway_error = GRPC_ERROR_NONE;
   /** set the callback for accepting new streams;
       this is a permanent callback, unlike the other one-shot closures.
       If true, the callback is set to set_accept_stream_fn, with its
@@ -533,10 +533,10 @@ void grpc_transport_destroy_stream(grpc_transport* transport,
                                    grpc_closure* then_schedule_closure);
 
 void grpc_transport_stream_op_batch_finish_with_failure(
-    grpc_transport_stream_op_batch* batch, grpc_error_handle error,
+    grpc_transport_stream_op_batch* batch, absl::Status error,
     grpc_core::CallCombiner* call_combiner);
 void grpc_transport_stream_op_batch_queue_finish_with_failure(
-    grpc_transport_stream_op_batch* batch, grpc_error_handle error,
+    grpc_transport_stream_op_batch* batch, absl::Status error,
     grpc_core::CallCombinerClosureList* closures);
 
 std::string grpc_transport_stream_op_batch_string(

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -456,7 +456,7 @@ static tsi_result make_grpc_call(alts_handshaker_client* c, bool is_start) {
   }
 }
 
-static void on_status_received(void* arg, grpc_error_handle error) {
+static void on_status_received(void* arg, absl::Status error) {
   alts_grpc_handshaker_client* client =
       static_cast<alts_grpc_handshaker_client*>(arg);
   if (client->handshake_status_code != GRPC_STATUS_OK) {
@@ -664,7 +664,7 @@ static void handshaker_client_shutdown(alts_handshaker_client* c) {
   }
 }
 
-static void handshaker_call_unref(void* arg, grpc_error_handle /* error */) {
+static void handshaker_call_unref(void* arg, absl::Status /* error */) {
   grpc_call* call = static_cast<grpc_call*>(arg);
   grpc_call_unref(call);
 }
@@ -861,8 +861,7 @@ void alts_handshaker_client_ref_for_testing(alts_handshaker_client* c) {
 }
 
 void alts_handshaker_client_on_status_received_for_testing(
-    alts_handshaker_client* c, grpc_status_code status,
-    grpc_error_handle error) {
+    alts_handshaker_client* c, grpc_status_code status, absl::Status error) {
   // We first make sure that the handshake queue has been initialized
   // here because there are tests that use this API that mock out
   // other parts of the alts_handshaker_client in such a way that the

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -383,8 +383,7 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
 }
 
 /* gRPC provided callback used when gRPC thread model is applied. */
-static void on_handshaker_service_resp_recv(void* arg,
-                                            grpc_error_handle error) {
+static void on_handshaker_service_resp_recv(void* arg, absl::Status error) {
   alts_handshaker_client* client = static_cast<alts_handshaker_client*>(arg);
   if (client == nullptr) {
     gpr_log(GPR_ERROR, "ALTS handshaker client is nullptr");
@@ -402,8 +401,8 @@ static void on_handshaker_service_resp_recv(void* arg,
 
 /* gRPC provided callback used when dedicatd CQ and thread are used.
  * It serves to safely bring the control back to application. */
-static void on_handshaker_service_resp_recv_dedicated(
-    void* arg, grpc_error_handle /*error*/) {
+static void on_handshaker_service_resp_recv_dedicated(void* arg,
+                                                      absl::Status /*error*/) {
   alts_shared_resource_dedicated* resource =
       grpc_alts_get_shared_resource_dedicated();
   grpc_cq_end_op(
@@ -496,7 +495,7 @@ struct alts_tsi_handshaker_continue_handshaker_next_args {
 };
 
 static void alts_tsi_handshaker_create_channel(
-    void* arg, grpc_error_handle /* unused_error */) {
+    void* arg, absl::Status /* unused_error */) {
   alts_tsi_handshaker_continue_handshaker_next_args* next_args =
       static_cast<alts_tsi_handshaker_continue_handshaker_next_args*>(arg);
   alts_tsi_handshaker* handshaker = next_args->handshaker;

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker_private.h
@@ -79,7 +79,7 @@ grpc_closure* alts_handshaker_client_get_closure_for_testing(
 
 void alts_handshaker_client_on_status_received_for_testing(
     alts_handshaker_client* client, grpc_status_code status,
-    grpc_error_handle error);
+    absl::Status error);
 
 void alts_handshaker_client_ref_for_testing(alts_handshaker_client* c);
 

--- a/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
+++ b/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
@@ -51,7 +51,7 @@ TlsSessionKeyLoggerCache::TlsSessionKeyLogger::TlsSessionKeyLogger(
   GPR_ASSERT(cache_ != nullptr);
   fd_ = fopen(tls_session_key_log_file_path_.c_str(), "w+");
   if (fd_ == nullptr) {
-    grpc_error_handle error = GRPC_OS_ERROR(errno, "fopen");
+    absl::Status error = GRPC_OS_ERROR(errno, "fopen");
     gpr_log(GPR_ERROR,
             "Ignoring TLS Key logging. ERROR Opening TLS Keylog "
             "file: %s",
@@ -86,7 +86,7 @@ void TlsSessionKeyLoggerCache::TlsSessionKeyLogger::LogSessionKeys(
              session_keys_info.length() + 1, fd_) < session_keys_info.length();
 
   if (err) {
-    grpc_error_handle error = GRPC_OS_ERROR(errno, "fwrite");
+    absl::Status error = GRPC_OS_ERROR(errno, "fwrite");
     gpr_log(GPR_ERROR, "Error Appending to TLS session key log file: %s",
             grpc_error_std_string(error).c_str());
     fclose(fd_);

--- a/src/cpp/client/client_callback.cc
+++ b/src/cpp/client/client_callback.cc
@@ -17,6 +17,8 @@
 
 #include <utility>
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpcpp/support/client_callback.h>
 #include <grpcpp/support/status.h>
@@ -42,7 +44,7 @@ void ClientReactor::InternalScheduleOnDone(grpc::Status s) {
         : reactor(reactor_arg), status(std::move(s)) {
       GRPC_CLOSURE_INIT(
           &closure,
-          [](void* void_arg, grpc_error_handle) {
+          [](void* void_arg, absl::Status) {
             ClosureWithArg* arg = static_cast<ClosureWithArg*>(void_arg);
             arg->reactor->OnDone(arg->status);
             delete arg;

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -225,7 +225,7 @@ grpc::Status StsCredentialsOptionsFromEnv(StsCredentialsOptions* options) {
   ClearStsCredentialsOptions(options);
   grpc_slice json_string = grpc_empty_slice();
   auto sts_creds_path = grpc_core::GetEnv("STS_CREDENTIALS");
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc::Status status;
   // NOLINTNEXTLINE(clang-diagnostic-unused-lambda-capture)
   auto cleanup = [&json_string, &error, &status]() {
@@ -416,7 +416,7 @@ std::shared_ptr<CallCredentials> MetadataCredentialsFromPlugin(
 }
 
 namespace {
-void DeleteWrapper(void* wrapper, grpc_error_handle /*ignored*/) {
+void DeleteWrapper(void* wrapper, absl::Status /*ignored*/) {
   MetadataCredentialsPluginWrapper* w =
       static_cast<MetadataCredentialsPluginWrapper*>(wrapper);
   delete w;

--- a/src/cpp/common/alarm.cc
+++ b/src/cpp/common/alarm.cc
@@ -20,6 +20,8 @@
 #include <functional>
 #include <utility>
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/gpr_types.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/log.h>
@@ -61,7 +63,7 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
     GPR_ASSERT(grpc_cq_begin_op(cq_, this));
     GRPC_CLOSURE_INIT(
         &on_alarm_,
-        [](void* arg, grpc_error_handle error) {
+        [](void* arg, absl::Status error) {
           // queue the op on the completion queue
           AlarmImpl* alarm = static_cast<AlarmImpl*>(arg);
           alarm->Ref();
@@ -88,10 +90,10 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
     Ref();
     GRPC_CLOSURE_INIT(
         &on_alarm_,
-        [](void* arg, grpc_error_handle error) {
+        [](void* arg, absl::Status error) {
           grpc_core::Executor::Run(
               GRPC_CLOSURE_CREATE(
-                  [](void* arg, grpc_error_handle error) {
+                  [](void* arg, absl::Status error) {
                     AlarmImpl* alarm = static_cast<AlarmImpl*>(arg);
                     alarm->callback_(GRPC_ERROR_IS_NONE(error));
                     alarm->Unref();

--- a/src/cpp/common/channel_filter.h
+++ b/src/cpp/common/channel_filter.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/grpc.h>
@@ -83,7 +84,7 @@ class TransportOp {
   grpc_transport_op* op() const { return op_; }
 
   // TODO(roth): Add a C++ wrapper for grpc_error?
-  grpc_error_handle disconnect_with_error() const {
+  absl::Status disconnect_with_error() const {
     return op_->disconnect_with_error;
   }
   bool send_goaway() const { return !GRPC_ERROR_IS_NONE(op_->goaway_error); }
@@ -199,8 +200,8 @@ class ChannelData {
   // TODO(roth): Come up with a more C++-like API for the channel element.
 
   /// Initializes the channel data.
-  virtual grpc_error_handle Init(grpc_channel_element* /*elem*/,
-                                 grpc_channel_element_args* /*args*/) {
+  virtual absl::Status Init(grpc_channel_element* /*elem*/,
+                            grpc_channel_element_args* /*args*/) {
     return GRPC_ERROR_NONE;
   }
 
@@ -222,8 +223,8 @@ class CallData {
   // TODO(roth): Come up with a more C++-like API for the call element.
 
   /// Initializes the call data.
-  virtual grpc_error_handle Init(grpc_call_element* /*elem*/,
-                                 const grpc_call_element_args* /*args*/) {
+  virtual absl::Status Init(grpc_call_element* /*elem*/,
+                            const grpc_call_element_args* /*args*/) {
     return GRPC_ERROR_NONE;
   }
 
@@ -251,8 +252,8 @@ class ChannelFilter final {
  public:
   static const size_t channel_data_size = sizeof(ChannelDataType);
 
-  static grpc_error_handle InitChannelElement(grpc_channel_element* elem,
-                                              grpc_channel_element_args* args) {
+  static absl::Status InitChannelElement(grpc_channel_element* elem,
+                                         grpc_channel_element_args* args) {
     // Construct the object in the already-allocated memory.
     ChannelDataType* channel_data = new (elem->channel_data) ChannelDataType();
     return channel_data->Init(elem, args);
@@ -282,8 +283,8 @@ class ChannelFilter final {
 
   static const size_t call_data_size = sizeof(CallDataType);
 
-  static grpc_error_handle InitCallElement(grpc_call_element* elem,
-                                           const grpc_call_element_args* args) {
+  static absl::Status InitCallElement(grpc_call_element* elem,
+                                      const grpc_call_element_args* args) {
     // Construct the object in the already-allocated memory.
     CallDataType* call_data = new (elem->call_data) CallDataType();
     return call_data->Init(elem, args);

--- a/src/cpp/ext/filters/census/channel_filter.cc
+++ b/src/cpp/ext/filters/census/channel_filter.cc
@@ -20,10 +20,12 @@
 
 #include "src/cpp/ext/filters/census/channel_filter.h"
 
+#include "src/core/lib/iomgr/error.h"
+
 namespace grpc {
 
-grpc_error_handle CensusChannelData::Init(grpc_channel_element* /*elem*/,
-                                          grpc_channel_element_args* /*args*/) {
+absl::Status CensusChannelData::Init(grpc_channel_element* /*elem*/,
+                                     grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/src/cpp/ext/filters/census/channel_filter.h
+++ b/src/cpp/ext/filters/census/channel_filter.h
@@ -21,17 +21,18 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/channel_stack.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/cpp/common/channel_filter.h"
 
 namespace grpc {
 
 class CensusChannelData : public ChannelData {
  public:
-  grpc_error_handle Init(grpc_channel_element* elem,
-                         grpc_channel_element_args* args) override;
+  absl::Status Init(grpc_channel_element* elem,
+                    grpc_channel_element_args* args) override;
 };
 
 }  // namespace grpc

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -48,6 +48,7 @@
 
 #include "src/core/lib/channel/context.h"
 #include "src/core/lib/gprpp/sync.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/slice/slice.h"
 #include "src/core/lib/slice/slice_buffer.h"
@@ -65,8 +66,8 @@ constexpr uint32_t
 constexpr uint32_t
     OpenCensusCallTracer::OpenCensusCallAttemptTracer::kMaxTagsLen;
 
-grpc_error_handle CensusClientCallData::Init(
-    grpc_call_element* /* elem */, const grpc_call_element_args* args) {
+absl::Status CensusClientCallData::Init(grpc_call_element* /* elem */,
+                                        const grpc_call_element_args* args) {
   tracer_ = args->arena->New<OpenCensusCallTracer>(args);
   GPR_DEBUG_ASSERT(args->context[GRPC_CONTEXT_CALL_TRACER].value == nullptr);
   args->context[GRPC_CONTEXT_CALL_TRACER].value = tracer_;
@@ -189,7 +190,7 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
 }
 
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordCancel(
-    grpc_error_handle cancel_error) {
+    absl::Status cancel_error) {
   status_code_ = absl::StatusCode::kCancelled;
   GRPC_ERROR_UNREF(cancel_error);
 }

--- a/src/cpp/ext/filters/census/client_filter.h
+++ b/src/cpp/ext/filters/census/client_filter.h
@@ -21,9 +21,10 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/channel_stack.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/cpp/common/channel_filter.h"
 #include "src/cpp/ext/filters/census/open_census_call_tracer.h"
 
@@ -35,8 +36,8 @@ namespace grpc {
 // a call at a time.
 class CensusClientCallData : public CallData {
  public:
-  grpc_error_handle Init(grpc_call_element* /* elem */,
-                         const grpc_call_element_args* args) override;
+  absl::Status Init(grpc_call_element* /* elem */,
+                    const grpc_call_element_args* args) override;
   void StartTransportStreamOpBatch(grpc_call_element* elem,
                                    TransportStreamOpBatch* op) override;
 

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -35,7 +35,6 @@
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/context.h"
 #include "src/core/lib/gprpp/sync.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/slice/slice.h"
 #include "src/core/lib/slice/slice_buffer.h"
@@ -67,7 +66,7 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
     void RecordReceivedTrailingMetadata(
         absl::Status status, grpc_metadata_batch* recv_trailing_metadata,
         const grpc_transport_stream_stats* transport_stream_stats) override;
-    void RecordCancel(grpc_error_handle cancel_error) override;
+    void RecordCancel(absl::Status cancel_error) override;
     void RecordEnd(const gpr_timespec& /*latency*/) override;
 
     CensusContext* context() { return &context_; }

--- a/src/cpp/ext/filters/census/server_filter.cc
+++ b/src/cpp/ext/filters/census/server_filter.cc
@@ -34,6 +34,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/surface/call.h"
 #include "src/core/lib/transport/transport.h"
 #include "src/cpp/ext/filters/census/channel_filter.h"
@@ -72,7 +73,7 @@ void FilterInitialMetadata(grpc_metadata_batch* b,
 }  // namespace
 
 void CensusServerCallData::OnDoneRecvMessageCb(void* user_data,
-                                               grpc_error_handle error) {
+                                               absl::Status error) {
   grpc_call_element* elem = reinterpret_cast<grpc_call_element*>(user_data);
   CensusServerCallData* calld =
       reinterpret_cast<CensusServerCallData*>(elem->call_data);
@@ -88,8 +89,8 @@ void CensusServerCallData::OnDoneRecvMessageCb(void* user_data,
                           GRPC_ERROR_REF(error));
 }
 
-void CensusServerCallData::OnDoneRecvInitialMetadataCb(
-    void* user_data, grpc_error_handle error) {
+void CensusServerCallData::OnDoneRecvInitialMetadataCb(void* user_data,
+                                                       absl::Status error) {
   grpc_call_element* elem = reinterpret_cast<grpc_call_element*>(user_data);
   CensusServerCallData* calld =
       reinterpret_cast<CensusServerCallData*>(elem->call_data);
@@ -147,8 +148,8 @@ void CensusServerCallData::StartTransportStreamOpBatch(
   grpc_call_next_op(elem, op->op());
 }
 
-grpc_error_handle CensusServerCallData::Init(
-    grpc_call_element* elem, const grpc_call_element_args* args) {
+absl::Status CensusServerCallData::Init(grpc_call_element* elem,
+                                        const grpc_call_element_args* args) {
   start_time_ = absl::Now();
   gc_ =
       grpc_call_from_top_element(grpc_call_stack_element(args->call_stack, 0));

--- a/src/cpp/ext/filters/census/server_filter.h
+++ b/src/cpp/ext/filters/census/server_filter.h
@@ -26,6 +26,7 @@
 
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
@@ -37,7 +38,6 @@
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/iomgr/closure.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/slice/slice.h"
 #include "src/core/lib/slice/slice_buffer.h"
 #include "src/core/lib/transport/metadata_batch.h"
@@ -68,8 +68,8 @@ class CensusServerCallData : public CallData {
     memset(&on_done_recv_message_, 0, sizeof(grpc_closure));
   }
 
-  grpc_error_handle Init(grpc_call_element* elem,
-                         const grpc_call_element_args* args) override;
+  absl::Status Init(grpc_call_element* elem,
+                    const grpc_call_element_args* args) override;
 
   void Destroy(grpc_call_element* elem, const grpc_call_final_info* final_info,
                grpc_closure* then_call_closure) override;
@@ -77,10 +77,9 @@ class CensusServerCallData : public CallData {
   void StartTransportStreamOpBatch(grpc_call_element* elem,
                                    TransportStreamOpBatch* op) override;
 
-  static void OnDoneRecvInitialMetadataCb(void* user_data,
-                                          grpc_error_handle error);
+  static void OnDoneRecvInitialMetadataCb(void* user_data, absl::Status error);
 
-  static void OnDoneRecvMessageCb(void* user_data, grpc_error_handle error);
+  static void OnDoneRecvMessageCb(void* user_data, absl::Status error);
 
  private:
   CensusContext context_;

--- a/src/cpp/ext/gcp/observability_config.cc
+++ b/src/cpp/ext/gcp/observability_config.cc
@@ -49,7 +49,7 @@ absl::StatusOr<std::string> GetGcpObservabilityConfigContents() {
   auto path = grpc_core::GetEnv("GRPC_OBSERVABILITY_CONFIG_FILE");
   if (path.has_value()) {
     grpc_slice contents;
-    grpc_error_handle error =
+    absl::Status error =
         grpc_load_file(path->c_str(), /*add_null_terminator=*/true, &contents);
     if (!GRPC_ERROR_IS_NONE(error)) {
       return grpc_error_to_absl_status(grpc_error_set_int(

--- a/src/cpp/server/server_callback.cc
+++ b/src/cpp/server/server_callback.cc
@@ -15,7 +15,8 @@
  *
  */
 
-#include <grpcpp/impl/codegen/server_callback.h>
+#include "absl/status/status.h"
+
 #include <grpcpp/support/server_callback.h>
 
 #include "src/core/lib/iomgr/closure.h"
@@ -39,7 +40,7 @@ void ServerCallbackCall::ScheduleOnDone(bool inline_ondone) {
       explicit ClosureWithArg(ServerCallbackCall* call_arg) : call(call_arg) {
         GRPC_CLOSURE_INIT(
             &closure,
-            [](void* void_arg, grpc_error_handle) {
+            [](void* void_arg, absl::Status) {
               ClosureWithArg* arg = static_cast<ClosureWithArg*>(void_arg);
               arg->call->CallOnDone();
               delete arg;
@@ -68,7 +69,7 @@ void ServerCallbackCall::CallOnCancel(ServerReactor* reactor) {
           : call(call_arg), reactor(reactor_arg) {
         GRPC_CLOSURE_INIT(
             &closure,
-            [](void* void_arg, grpc_error_handle) {
+            [](void* void_arg, absl::Status) {
               ClosureWithArg* arg = static_cast<ClosureWithArg*>(void_arg);
               arg->reactor->OnCancel();
               arg->call->MaybeDone();

--- a/test/core/address_utils/sockaddr_utils_test.cc
+++ b/test/core/address_utils/sockaddr_utils_test.cc
@@ -31,6 +31,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/address_utils/parse_address.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/socket_utils.h"
 #include "test/core/util/test_config.h"

--- a/test/core/bad_client/bad_client.cc
+++ b/test/core/bad_client/bad_client.cc
@@ -59,7 +59,7 @@ static void thd_func(void* arg) {
 }
 
 /* Sets the done_write event */
-static void set_done_write(void* arg, grpc_error_handle /*error*/) {
+static void set_done_write(void* arg, absl::Status /*error*/) {
   gpr_event* done_write = static_cast<gpr_event*>(arg);
   gpr_event_set(done_write, reinterpret_cast<void*>(1));
 }
@@ -76,7 +76,7 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
 }
 
 /* Sets the read_done event */
-static void set_read_done(void* arg, grpc_error_handle /*error*/) {
+static void set_read_done(void* arg, absl::Status /*error*/) {
   gpr_event* read_done = static_cast<gpr_event*>(arg);
   gpr_event_set(read_done, reinterpret_cast<void*>(1));
 }

--- a/test/core/channel/channel_stack_builder_test.cc
+++ b/test/core/channel/channel_stack_builder_test.cc
@@ -39,13 +39,13 @@ namespace grpc_core {
 namespace testing {
 namespace {
 
-grpc_error_handle ChannelInitFunc(grpc_channel_element* /*elem*/,
-                                  grpc_channel_element_args* /*args*/) {
+absl::Status ChannelInitFunc(grpc_channel_element* /*elem*/,
+                             grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
-grpc_error_handle CallInitFunc(grpc_call_element* /*elem*/,
-                               const grpc_call_element_args* /*args*/) {
+absl::Status CallInitFunc(grpc_call_element* /*elem*/,
+                          const grpc_call_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/test/core/channel/channel_stack_test.cc
+++ b/test/core/channel/channel_stack_test.cc
@@ -30,8 +30,8 @@
 #include "src/core/lib/slice/slice_internal.h"
 #include "test/core/util/test_config.h"
 
-static grpc_error_handle channel_init_func(grpc_channel_element* elem,
-                                           grpc_channel_element_args* args) {
+static absl::Status channel_init_func(grpc_channel_element* elem,
+                                      grpc_channel_element_args* args) {
   EXPECT_EQ(args->channel_args->num_args, 1);
   EXPECT_EQ(args->channel_args->args[0].type, GRPC_ARG_INTEGER);
   EXPECT_STREQ(args->channel_args->args[0].key, "test_key");
@@ -42,8 +42,8 @@ static grpc_error_handle channel_init_func(grpc_channel_element* elem,
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error_handle call_init_func(
-    grpc_call_element* elem, const grpc_call_element_args* /*args*/) {
+static absl::Status call_init_func(grpc_call_element* elem,
+                                   const grpc_call_element_args* /*args*/) {
   ++*static_cast<int*>(elem->channel_data);
   *static_cast<int*>(elem->call_data) = 0;
   return GRPC_ERROR_NONE;
@@ -67,12 +67,12 @@ static void channel_func(grpc_channel_element* elem,
   ++*static_cast<int*>(elem->channel_data);
 }
 
-static void free_channel(void* arg, grpc_error_handle /*error*/) {
+static void free_channel(void* arg, absl::Status /*error*/) {
   grpc_channel_stack_destroy(static_cast<grpc_channel_stack*>(arg));
   gpr_free(arg);
 }
 
-static void free_call(void* arg, grpc_error_handle /*error*/) {
+static void free_call(void* arg, absl::Status /*error*/) {
   grpc_call_stack_destroy(static_cast<grpc_call_stack*>(arg), nullptr, nullptr);
   gpr_free(arg);
 }
@@ -134,7 +134,7 @@ TEST(ChannelStackTest, CreateChannelStack) {
       nullptr,                           /* arena */
       nullptr,                           /* call_combiner */
   };
-  grpc_error_handle error =
+  absl::Status error =
       grpc_call_stack_init(channel_stack, 1, free_call, call_stack, &args);
   ASSERT_TRUE(GRPC_ERROR_IS_NONE(error)) << grpc_error_std_string(error);
   EXPECT_EQ(call_stack->count, 1);

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -181,7 +181,7 @@ static gpr_timespec test_deadline(void) {
   return grpc_timeout_seconds_to_deadline(100);
 }
 
-static void do_nothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+static void do_nothing(void* /*arg*/, absl::Status /*error*/) {}
 
 static void iomgr_args_init(iomgr_args* args) {
   gpr_event_init(&args->ev);

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -58,6 +58,7 @@ grpc_cc_library(
     srcs = ["fixtures/http_proxy_fixture.cc"],
     hdrs = ["fixtures/http_proxy_fixture.h"],
     external_deps = [
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
     ],
@@ -110,6 +111,7 @@ grpc_cc_library(
 grpc_cc_test(
     name = "bad_server_response_test",
     srcs = ["bad_server_response_test.cc"],
+    external_deps = ["absl/status"],
     language = "C++",
     deps = [
         "cq_verifier",

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -105,13 +107,12 @@ static grpc_closure on_write;
 
 static void* tag(intptr_t t) { return reinterpret_cast<void*>(t); }
 
-static void done_write(void* /*arg*/, grpc_error_handle error) {
+static void done_write(void* /*arg*/, absl::Status error) {
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   gpr_atm_rel_store(&state.done_atm, 1);
 }
 
-static void done_writing_settings_frame(void* /* arg */,
-                                        grpc_error_handle error) {
+static void done_writing_settings_frame(void* /* arg */, absl::Status error) {
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   grpc_endpoint_read(state.tcp, &state.temp_incoming_buffer, &on_read,
                      /*urgent=*/false, /*min_progress_size=*/1);
@@ -127,7 +128,7 @@ static void handle_write() {
                       /*max_frame_size=*/INT_MAX);
 }
 
-static void handle_read(void* /*arg*/, grpc_error_handle error) {
+static void handle_read(void* /*arg*/, absl::Status error) {
   if (!GRPC_ERROR_IS_NONE(error)) {
     gpr_log(GPR_ERROR, "handle_read error: %s",
             grpc_error_std_string(error).c_str());

--- a/test/core/end2end/fixtures/h2_sockpair+trace.cc
+++ b/test/core/end2end/fixtures/h2_sockpair+trace.cc
@@ -66,7 +66,7 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
       static_cast<custom_fixture_data*>(f->fixture_data);
   grpc_endpoint_add_to_pollset(fixture_data->ep.server, grpc_cq_pollset(f->cq));
   grpc_core::Server* core_server = grpc_core::Server::FromC(f->server);
-  grpc_error_handle error = core_server->SetupTransport(
+  absl::Status error = core_server->SetupTransport(
       transport, nullptr, core_server->channel_args(), nullptr);
   if (GRPC_ERROR_IS_NONE(error)) {
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);

--- a/test/core/end2end/fixtures/h2_sockpair.cc
+++ b/test/core/end2end/fixtures/h2_sockpair.cc
@@ -59,7 +59,7 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
       static_cast<custom_fixture_data*>(f->fixture_data);
   grpc_endpoint_add_to_pollset(fixture_data->ep.server, grpc_cq_pollset(f->cq));
   grpc_core::Server* core_server = grpc_core::Server::FromC(f->server);
-  grpc_error_handle error = core_server->SetupTransport(
+  absl::Status error = core_server->SetupTransport(
       transport, nullptr, core_server->channel_args(), nullptr);
   if (GRPC_ERROR_IS_NONE(error)) {
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);

--- a/test/core/end2end/fixtures/h2_sockpair_1byte.cc
+++ b/test/core/end2end/fixtures/h2_sockpair_1byte.cc
@@ -60,7 +60,7 @@ static void server_setup_transport(void* ts, grpc_transport* transport) {
       static_cast<custom_fixture_data*>(f->fixture_data);
   grpc_endpoint_add_to_pollset(fixture_data->ep.server, grpc_cq_pollset(f->cq));
   grpc_core::Server* core_server = grpc_core::Server::FromC(f->server);
-  grpc_error_handle error = core_server->SetupTransport(
+  absl::Status error = core_server->SetupTransport(
       transport, nullptr, core_server->channel_args(), nullptr);
   if (GRPC_ERROR_IS_NONE(error)) {
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -115,7 +115,7 @@ typedef struct addr_req {
   std::unique_ptr<grpc_core::ServerAddressList>* addresses;
 } addr_req;
 
-static void finish_resolve(void* arg, grpc_error_handle error) {
+static void finish_resolve(void* arg, absl::Status error) {
   addr_req* r = static_cast<addr_req*>(arg);
 
   if (GRPC_ERROR_IS_NONE(error) && 0 == strcmp(r->addr, "server")) {
@@ -156,7 +156,7 @@ class FuzzerDNSResolver : public grpc_core::DNSResolver {
     }
 
    private:
-    static void FinishResolve(void* arg, grpc_error_handle error) {
+    static void FinishResolve(void* arg, absl::Status error) {
       FuzzerDNSRequest* self = static_cast<FuzzerDNSRequest*>(arg);
       if (GRPC_ERROR_IS_NONE(error) && self->name_ == "server") {
         std::vector<grpc_resolved_address> addrs;
@@ -267,7 +267,7 @@ typedef struct {
   gpr_timespec deadline;
 } future_connect;
 
-static void do_connect(void* arg, grpc_error_handle error) {
+static void do_connect(void* arg, absl::Status error) {
   future_connect* fc = static_cast<future_connect*>(arg);
   if (!GRPC_ERROR_IS_NONE(error)) {
     *fc->ep = nullptr;

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -179,7 +179,7 @@ static grpc_ares_request* my_dns_lookup_ares(
                                  query_timeout_ms);
   }
 
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   gpr_mu_lock(&g_mu);
   if (g_resolve_port < 0) {
     gpr_mu_unlock(&g_mu);

--- a/test/core/end2end/tests/filter_causes_close.cc
+++ b/test/core/end2end/tests/filter_causes_close.cc
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -201,7 +203,7 @@ typedef struct {
   uint8_t unused;
 } channel_data;
 
-static void recv_im_ready(void* arg, grpc_error_handle error) {
+static void recv_im_ready(void* arg, absl::Status error) {
   grpc_call_element* elem = static_cast<grpc_call_element*>(arg);
   call_data* calld = static_cast<call_data*>(elem->call_data);
   grpc_core::Closure::Run(
@@ -224,8 +226,8 @@ static void start_transport_stream_op_batch(
   grpc_call_next_op(elem, op);
 }
 
-static grpc_error_handle init_call_elem(
-    grpc_call_element* /*elem*/, const grpc_call_element_args* /*args*/) {
+static absl::Status init_call_elem(grpc_call_element* /*elem*/,
+                                   const grpc_call_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
@@ -233,8 +235,8 @@ static void destroy_call_elem(grpc_call_element* /*elem*/,
                               const grpc_call_final_info* /*final_info*/,
                               grpc_closure* /*ignored*/) {}
 
-static grpc_error_handle init_channel_elem(
-    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
+static absl::Status init_channel_elem(grpc_channel_element* /*elem*/,
+                                      grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/test/core/end2end/tests/filter_context.cc
+++ b/test/core/end2end/tests/filter_context.cc
@@ -24,6 +24,8 @@
 #include <initializer_list>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -234,8 +236,8 @@ struct call_data {
   grpc_call_context_element* context;
 };
 
-static grpc_error_handle init_call_elem(grpc_call_element* elem,
-                                        const grpc_call_element_args* args) {
+static absl::Status init_call_elem(grpc_call_element* elem,
+                                   const grpc_call_element_args* args) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->context = args->context;
   gpr_log(GPR_INFO, "init_call_elem(): context=%p", args->context);
@@ -260,8 +262,8 @@ static void destroy_call_elem(grpc_call_element* /*elem*/,
                               const grpc_call_final_info* /*final_info*/,
                               grpc_closure* /*ignored*/) {}
 
-static grpc_error_handle init_channel_elem(
-    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
+static absl::Status init_channel_elem(grpc_channel_element* /*elem*/,
+                                      grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/test/core/end2end/tests/filter_init_fails.cc
+++ b/test/core/end2end/tests/filter_init_fails.cc
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -421,8 +423,8 @@ static void test_client_subchannel_filter(grpc_end2end_test_config config) {
  * Test filter - always fails to initialize a call
  */
 
-static grpc_error_handle init_call_elem(
-    grpc_call_element* /*elem*/, const grpc_call_element_args* /*args*/) {
+static absl::Status init_call_elem(grpc_call_element* /*elem*/,
+                                   const grpc_call_element_args* /*args*/) {
   return grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("access denied"),
       GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_PERMISSION_DENIED);
@@ -432,8 +434,8 @@ static void destroy_call_elem(grpc_call_element* /*elem*/,
                               const grpc_call_final_info* /*final_info*/,
                               grpc_closure* /*ignored*/) {}
 
-static grpc_error_handle init_channel_elem(
-    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
+static absl::Status init_channel_elem(grpc_channel_element* /*elem*/,
+                                      grpc_channel_element_args* /*args*/) {
   if (g_channel_filter_init_failure) {
     return grpc_error_set_int(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test channel filter init error"),

--- a/test/core/end2end/tests/filter_latency.cc
+++ b/test/core/end2end/tests/filter_latency.cc
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -256,8 +258,8 @@ static void test_request(grpc_end2end_test_config config) {
  * Test latency filter
  */
 
-static grpc_error_handle init_call_elem(
-    grpc_call_element* /*elem*/, const grpc_call_element_args* /*args*/) {
+static absl::Status init_call_elem(grpc_call_element* /*elem*/,
+                                   const grpc_call_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
@@ -277,8 +279,8 @@ static void server_destroy_call_elem(grpc_call_element* /*elem*/,
   gpr_mu_unlock(&g_mu);
 }
 
-static grpc_error_handle init_channel_elem(
-    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
+static absl::Status init_channel_elem(grpc_channel_element* /*elem*/,
+                                      grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/test/core/end2end/tests/filter_status_code.cc
+++ b/test/core/end2end/tests/filter_status_code.cc
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
 #include <grpc/slice.h>
@@ -287,8 +289,8 @@ static void server_start_transport_stream_op_batch(
   grpc_call_next_op(elem, op);
 }
 
-static grpc_error_handle init_call_elem(grpc_call_element* elem,
-                                        const grpc_call_element_args* args) {
+static absl::Status init_call_elem(grpc_call_element* elem,
+                                   const grpc_call_element_args* args) {
   final_status_data* data = static_cast<final_status_data*>(elem->call_data);
   data->call = args->call_stack;
   return GRPC_ERROR_NONE;
@@ -324,8 +326,8 @@ static void server_destroy_call_elem(grpc_call_element* elem,
   gpr_mu_unlock(&g_mu);
 }
 
-static grpc_error_handle init_channel_elem(
-    grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
+static absl::Status init_channel_elem(grpc_channel_element* /*elem*/,
+                                      grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
+++ b/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
@@ -22,6 +22,7 @@
 #include <new>
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/optional.h"
@@ -252,8 +253,8 @@ class FailSendOpsFilter {
  private:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* args) {
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
       return GRPC_ERROR_NONE;
     }
@@ -288,8 +289,8 @@ class FailSendOpsFilter {
     grpc_core::CallCombiner* call_combiner_;
   };
 
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* /*args*/) {
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailSendOpsFilter();
     return GRPC_ERROR_NONE;
   }

--- a/test/core/end2end/tests/retry_recv_message_replay.cc
+++ b/test/core/end2end/tests/retry_recv_message_replay.cc
@@ -21,6 +21,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -278,8 +279,8 @@ class FailFirstSendOpFilter {
  public:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* args) {
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
       return GRPC_ERROR_NONE;
     }
@@ -319,8 +320,8 @@ class FailFirstSendOpFilter {
     bool fail_ = false;
   };
 
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* /*args*/) {
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstSendOpFilter();
     return GRPC_ERROR_NONE;
   }

--- a/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
+++ b/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -276,8 +277,8 @@ class InjectStatusFilter {
  private:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* /*args*/) {
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* /*args*/) {
       new (elem->call_data) CallData();
       return GRPC_ERROR_NONE;
     }
@@ -307,8 +308,7 @@ class InjectStatusFilter {
                         RecvTrailingMetadataReady, this, nullptr);
     }
 
-    static void RecvTrailingMetadataReady(void* arg,
-                                          grpc_error_handle /*error*/) {
+    static void RecvTrailingMetadataReady(void* arg, absl::Status /*error*/) {
       auto* calld = static_cast<CallData*>(arg);
       grpc_core::Closure::Run(
           DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready_,
@@ -321,8 +321,8 @@ class InjectStatusFilter {
     grpc_closure* original_recv_trailing_metadata_ready_ = nullptr;
   };
 
-  static grpc_error_handle Init(grpc_channel_element* /*elem*/,
-                                grpc_channel_element_args* /*args*/) {
+  static absl::Status Init(grpc_channel_element* /*elem*/,
+                           grpc_channel_element_args* /*args*/) {
     return GRPC_ERROR_NONE;
   }
 

--- a/test/core/end2end/tests/retry_send_op_fails.cc
+++ b/test/core/end2end/tests/retry_send_op_fails.cc
@@ -21,6 +21,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -293,8 +294,8 @@ class FailFirstCallFilter {
  private:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* args) {
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
       return GRPC_ERROR_NONE;
     }
@@ -334,8 +335,8 @@ class FailFirstCallFilter {
     bool fail_ = false;
   };
 
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* /*args*/) {
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstCallFilter();
     return GRPC_ERROR_NONE;
   }

--- a/test/core/end2end/tests/retry_transparent_goaway.cc
+++ b/test/core/end2end/tests/retry_transparent_goaway.cc
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -278,8 +279,8 @@ class FailFirstCallFilter {
  private:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* args) {
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
       return GRPC_ERROR_NONE;
     }
@@ -327,8 +328,8 @@ class FailFirstCallFilter {
     bool fail_ = false;
   };
 
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* /*args*/) {
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstCallFilter();
     return GRPC_ERROR_NONE;
   }

--- a/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
+++ b/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -279,8 +280,8 @@ class FailFirstTenCallsFilter {
  private:
   class CallData {
    public:
-    static grpc_error_handle Init(grpc_call_element* elem,
-                                  const grpc_call_element_args* args) {
+    static absl::Status Init(grpc_call_element* elem,
+                             const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
       return GRPC_ERROR_NONE;
     }
@@ -326,8 +327,8 @@ class FailFirstTenCallsFilter {
     bool fail_ = false;
   };
 
-  static grpc_error_handle Init(grpc_channel_element* elem,
-                                grpc_channel_element_args* /*args*/) {
+  static absl::Status Init(grpc_channel_element* elem,
+                           grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstTenCallsFilter();
     return GRPC_ERROR_NONE;
   }

--- a/test/core/filters/filter_fuzzer.cc
+++ b/test/core/filters/filter_fuzzer.cc
@@ -89,7 +89,7 @@ class FakeChannelSecurityConnector final
     abort();
   }
 
-  void cancel_check_peer(grpc_closure*, grpc_error_handle) override { abort(); }
+  void cancel_check_peer(grpc_closure*, absl::Status) override { abort(); }
 
   int cmp(const grpc_security_connector*) const override { abort(); }
 

--- a/test/core/handshake/readahead_handshaker_server_ssl.cc
+++ b/test/core/handshake/readahead_handshaker_server_ssl.cc
@@ -57,7 +57,7 @@ class ReadAheadHandshaker : public Handshaker {
  public:
   ~ReadAheadHandshaker() override {}
   const char* name() const override { return "read_ahead"; }
-  void Shutdown(grpc_error_handle /*why*/) override {}
+  void Shutdown(absl::Status /*why*/) override {}
   void DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                    grpc_closure* on_handshake_done,
                    HandshakerArgs* args) override {

--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -114,7 +114,7 @@ class HttpRequestTest : public ::testing::Test {
   static void TearDownTestSuite() { gpr_subprocess_destroy(g_server); }
 
  private:
-  static void DestroyPops(void* p, grpc_error_handle /*error*/) {
+  static void DestroyPops(void* p, absl::Status /*error*/) {
     grpc_polling_entity* pops = static_cast<grpc_polling_entity*>(p);
     grpc_pollset_destroy(grpc_polling_entity_pollset(pops));
     gpr_free(grpc_polling_entity_pollset(pops));
@@ -138,7 +138,7 @@ struct RequestState {
   grpc_pollset_set* pollset_set_to_destroy_eagerly = nullptr;
 };
 
-void OnFinish(void* arg, grpc_error_handle error) {
+void OnFinish(void* arg, absl::Status error) {
   RequestState* request_state = static_cast<RequestState*>(arg);
   if (request_state->pollset_set_to_destroy_eagerly != nullptr) {
     // Destroy the request's polling entity param. The goal is to try to catch a
@@ -160,7 +160,7 @@ void OnFinish(void* arg, grpc_error_handle error) {
       [request_state]() { request_state->done = true; });
 }
 
-void OnFinishExpectFailure(void* arg, grpc_error_handle error) {
+void OnFinishExpectFailure(void* arg, absl::Status error) {
   RequestState* request_state = static_cast<RequestState*>(arg);
   if (request_state->pollset_set_to_destroy_eagerly != nullptr) {
     // Destroy the request's polling entity param. The goal is to try to catch a

--- a/test/core/http/httpscli_test.cc
+++ b/test/core/http/httpscli_test.cc
@@ -114,7 +114,7 @@ class HttpsCliTest : public ::testing::Test {
   static void TearDownTestSuite() { gpr_subprocess_destroy(g_server); }
 
  private:
-  static void DestroyPops(void* p, grpc_error_handle /*error*/) {
+  static void DestroyPops(void* p, absl::Status /*error*/) {
     grpc_polling_entity* pops = static_cast<grpc_polling_entity*>(p);
     grpc_pollset_destroy(grpc_polling_entity_pollset(pops));
     gpr_free(grpc_polling_entity_pollset(pops));
@@ -137,7 +137,7 @@ struct RequestState {
   grpc_http_response response = {};
 };
 
-void OnFinish(void* arg, grpc_error_handle error) {
+void OnFinish(void* arg, absl::Status error) {
   RequestState* request_state = static_cast<RequestState*>(arg);
   const char* expect =
       "<html><head><title>Hello world!</title></head>"
@@ -153,7 +153,7 @@ void OnFinish(void* arg, grpc_error_handle error) {
       [request_state]() { request_state->done = true; });
 }
 
-void OnFinishExpectFailure(void* arg, grpc_error_handle error) {
+void OnFinishExpectFailure(void* arg, absl::Status error) {
   RequestState* request_state = static_cast<RequestState*>(arg);
   grpc_http_response response = request_state->response;
   gpr_log(GPR_INFO, "response status=%d error=%s", response.status,

--- a/test/core/http/parser_test.cc
+++ b/test/core/http/parser_test.cc
@@ -32,6 +32,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/iomgr/error.h"
 #include "test/core/util/slice_splitter.h"
 #include "test/core/util/test_config.h"
 
@@ -158,7 +159,7 @@ static void test_fails(grpc_slice_split_mode split_mode,
   size_t num_slices;
   size_t i;
   grpc_slice* slices;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_http_response response;
   response = {};
 
@@ -191,7 +192,7 @@ static void test_request_fails(grpc_slice_split_mode split_mode,
   size_t num_slices;
   size_t i;
   grpc_slice* slices;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_http_request request;
   memset(&request, 0, sizeof(request));
 

--- a/test/core/http/request_fuzzer.cc
+++ b/test/core/http/request_fuzzer.cc
@@ -24,6 +24,7 @@
 #include <grpc/support/alloc.h>
 
 #include "src/core/lib/http/parser.h"
+#include "src/core/lib/iomgr/error.h"
 
 bool squelch = true;
 bool leak_check = true;

--- a/test/core/http/response_fuzzer.cc
+++ b/test/core/http/response_fuzzer.cc
@@ -23,6 +23,7 @@
 #include <grpc/support/alloc.h>
 
 #include "src/core/lib/http/parser.h"
+#include "src/core/lib/iomgr/error.h"
 
 bool squelch = true;
 bool leak_check = true;

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -29,7 +29,7 @@
 
 static void TestShutdownFlushesListVerifier(void* arg,
                                             grpc_core::Timestamps* /*ts*/,
-                                            grpc_error_handle error) {
+                                            absl::Status error) {
   ASSERT_TRUE(GRPC_ERROR_IS_NONE(error));
   ASSERT_NE(arg, nullptr);
   gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
@@ -60,7 +60,7 @@ TEST(BufferListTest, Testshutdownflusheslist) {
 
 static void TestVerifierCalledOnAckVerifier(void* arg,
                                             grpc_core::Timestamps* ts,
-                                            grpc_error_handle error) {
+                                            absl::Status error) {
   ASSERT_TRUE(GRPC_ERROR_IS_NONE(error));
   ASSERT_NE(arg, nullptr);
   ASSERT_EQ(ts->acked_time.time.clock_type, GPR_CLOCK_REALTIME);

--- a/test/core/iomgr/combiner_test.cc
+++ b/test/core/iomgr/combiner_test.cc
@@ -34,7 +34,7 @@ TEST(CombinerTest, TestNoOp) {
   GRPC_COMBINER_UNREF(grpc_combiner_create(), "test_no_op");
 }
 
-static void set_event_to_true(void* value, grpc_error_handle /*error*/) {
+static void set_event_to_true(void* value, absl::Status /*error*/) {
   gpr_event_set(static_cast<gpr_event*>(value), reinterpret_cast<void*>(1));
 }
 
@@ -64,7 +64,7 @@ typedef struct {
   size_t value;
 } ex_args;
 
-static void check_one(void* a, grpc_error_handle /*error*/) {
+static void check_one(void* a, absl::Status /*error*/) {
   ex_args* args = static_cast<ex_args*>(a);
   ASSERT_EQ(*args->ctr, args->value - 1);
   *args->ctr = args->value;
@@ -116,11 +116,11 @@ TEST(CombinerTest, TestExecuteMany) {
 
 static gpr_event got_in_finally;
 
-static void in_finally(void* /*arg*/, grpc_error_handle /*error*/) {
+static void in_finally(void* /*arg*/, absl::Status /*error*/) {
   gpr_event_set(&got_in_finally, reinterpret_cast<void*>(1));
 }
 
-static void add_finally(void* arg, grpc_error_handle /*error*/) {
+static void add_finally(void* arg, absl::Status /*error*/) {
   static_cast<grpc_core::Combiner*>(arg)->Run(
       GRPC_CLOSURE_CREATE(in_finally, arg, nullptr), GRPC_ERROR_NONE);
 }

--- a/test/core/iomgr/endpoint_pair_test.cc
+++ b/test/core/iomgr/endpoint_pair_test.cc
@@ -56,7 +56,7 @@ static grpc_endpoint_test_config configs[] = {
     {"tcp/tcp_socketpair", create_fixture_endpoint_pair, clean_up},
 };
 
-static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
+static void destroy_pollset(void* p, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/test/core/iomgr/endpoint_tests.cc
+++ b/test/core/iomgr/endpoint_tests.cc
@@ -121,15 +121,14 @@ struct read_and_write_test_state {
   grpc_closure write_scheduler;
 };
 
-static void read_scheduler(void* data, grpc_error_handle /* error */) {
+static void read_scheduler(void* data, absl::Status /* error */) {
   struct read_and_write_test_state* state =
       static_cast<struct read_and_write_test_state*>(data);
   grpc_endpoint_read(state->read_ep, &state->incoming, &state->done_read,
                      /*urgent=*/false, /*min_progress_size=*/1);
 }
 
-static void read_and_write_test_read_handler(void* data,
-                                             grpc_error_handle error) {
+static void read_and_write_test_read_handler(void* data, absl::Status error) {
   struct read_and_write_test_state* state =
       static_cast<struct read_and_write_test_state*>(data);
 
@@ -150,15 +149,14 @@ static void read_and_write_test_read_handler(void* data,
   }
 }
 
-static void write_scheduler(void* data, grpc_error_handle /* error */) {
+static void write_scheduler(void* data, absl::Status /* error */) {
   struct read_and_write_test_state* state =
       static_cast<struct read_and_write_test_state*>(data);
   grpc_endpoint_write(state->write_ep, &state->outgoing, &state->done_write,
                       nullptr, /*max_frame_size=*/state->max_write_frame_size);
 }
 
-static void read_and_write_test_write_handler(void* data,
-                                              grpc_error_handle error) {
+static void read_and_write_test_write_handler(void* data, absl::Status error) {
   struct read_and_write_test_state* state =
       static_cast<struct read_and_write_test_state*>(data);
   grpc_slice* slices = nullptr;
@@ -279,7 +277,7 @@ static void read_and_write_test(grpc_endpoint_test_config config,
   grpc_endpoint_destroy(state.write_ep);
 }
 
-static void inc_on_failure(void* arg, grpc_error_handle error) {
+static void inc_on_failure(void* arg, absl::Status error) {
   gpr_mu_lock(g_mu);
   *static_cast<int*>(arg) += (!GRPC_ERROR_IS_NONE(error));
   GPR_ASSERT(GRPC_LOG_IF_ERROR("kick", grpc_pollset_kick(g_pollset, nullptr)));

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -29,7 +29,7 @@
 #include "test/core/util/test_config.h"
 
 TEST(ErrorTest, SetGetInt) {
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
+  absl::Status error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
   EXPECT_NE(error, GRPC_ERROR_NONE);
   intptr_t i = 0;
 #ifndef NDEBUG
@@ -54,7 +54,7 @@ TEST(ErrorTest, SetGetInt) {
 }
 
 TEST(ErrorTest, SetGetStr) {
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
+  absl::Status error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
 
   std::string str;
   EXPECT_TRUE(!grpc_error_get_str(error, GRPC_ERROR_STR_SYSCALL, &str));
@@ -80,7 +80,7 @@ TEST(ErrorTest, SetGetStr) {
 
 TEST(ErrorTest, CopyAndUnRef) {
   // error1 has one ref
-  grpc_error_handle error1 =
+  absl::Status error1 =
       grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test"),
                          GRPC_ERROR_STR_GRPC_MESSAGE, "message");
   std::string str;
@@ -90,7 +90,7 @@ TEST(ErrorTest, CopyAndUnRef) {
   // error 1 has two refs
   (void)GRPC_ERROR_REF(error1);
   // this gives error3 a ref to the new error, and decrements error1 to one ref
-  grpc_error_handle error3 =
+  absl::Status error3 =
       grpc_error_set_str(error1, GRPC_ERROR_STR_SYSCALL, "syscall");
   EXPECT_NE(error3, error1);  // should not be the same because of extra ref
   EXPECT_TRUE(grpc_error_get_str(error3, GRPC_ERROR_STR_GRPC_MESSAGE, &str));
@@ -106,10 +106,10 @@ TEST(ErrorTest, CopyAndUnRef) {
 }
 
 TEST(ErrorTest, CreateReferencing) {
-  grpc_error_handle child =
+  absl::Status child =
       grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child"),
                          GRPC_ERROR_STR_GRPC_MESSAGE, "message");
-  grpc_error_handle parent =
+  absl::Status parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", &child, 1);
   EXPECT_NE(parent, GRPC_ERROR_NONE);
 
@@ -118,7 +118,7 @@ TEST(ErrorTest, CreateReferencing) {
 }
 
 TEST(ErrorTest, CreateReferencingMany) {
-  grpc_error_handle children[3];
+  absl::Status children[3];
   children[0] =
       grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child1"),
                          GRPC_ERROR_STR_GRPC_MESSAGE, "message");
@@ -129,7 +129,7 @@ TEST(ErrorTest, CreateReferencingMany) {
       grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child3"),
                          GRPC_ERROR_STR_GRPC_MESSAGE, "message 3");
 
-  grpc_error_handle parent =
+  absl::Status parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 3);
   EXPECT_NE(parent, GRPC_ERROR_NONE);
 
@@ -140,7 +140,7 @@ TEST(ErrorTest, CreateReferencingMany) {
 }
 
 TEST(ErrorTest, PrintErrorString) {
-  grpc_error_handle error =
+  absl::Status error =
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"),
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNIMPLEMENTED);
   error = grpc_error_set_int(error, GRPC_ERROR_INT_SIZE, 666);
@@ -150,7 +150,7 @@ TEST(ErrorTest, PrintErrorString) {
 }
 
 TEST(ErrorTest, PrintErrorStringReference) {
-  grpc_error_handle children[2];
+  absl::Status children[2];
   children[0] = grpc_error_set_str(
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("1"),
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNIMPLEMENTED),
@@ -160,7 +160,7 @@ TEST(ErrorTest, PrintErrorStringReference) {
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_INTERNAL),
       GRPC_ERROR_STR_GRPC_MESSAGE, "message for child 2");
 
-  grpc_error_handle parent =
+  absl::Status parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 2);
 
   for (size_t i = 0; i < 2; ++i) {
@@ -172,7 +172,7 @@ TEST(ErrorTest, PrintErrorStringReference) {
 TEST(ErrorTest, TestOsError) {
   int fake_errno = 5;
   const char* syscall = "syscall name";
-  grpc_error_handle error = GRPC_OS_ERROR(fake_errno, syscall);
+  absl::Status error = GRPC_OS_ERROR(fake_errno, syscall);
 
   intptr_t i = 0;
   EXPECT_TRUE(grpc_error_get_int(error, GRPC_ERROR_INT_ERRNO, &i));

--- a/test/core/iomgr/fd_posix_test.cc
+++ b/test/core/iomgr/fd_posix_test.cc
@@ -125,7 +125,7 @@ static void session_shutdown_cb(void* arg, /*session */
 
 /* Called when data become readable in a session. */
 static void session_read_cb(void* arg, /*session */
-                            grpc_error_handle error) {
+                            absl::Status error) {
   session* se = static_cast<session*>(arg);
   int fd = grpc_fd_wrapped_fd(se->em_fd);
 
@@ -183,7 +183,7 @@ static void listen_shutdown_cb(void* arg /*server*/, int /*success*/) {
 
 /* Called when a new TCP connection request arrives in the listening port. */
 static void listen_cb(void* arg, /*=sv_arg*/
-                      grpc_error_handle error) {
+                      absl::Status error) {
   server* sv = static_cast<server*>(arg);
   int fd;
   int flags;
@@ -298,7 +298,7 @@ static void client_session_shutdown_cb(void* arg /*client*/, int /*success*/) {
 
 /* Write as much as possible, then register notify_on_write. */
 static void client_session_write(void* arg, /*client */
-                                 grpc_error_handle error) {
+                                 absl::Status error) {
   client* cl = static_cast<client*>(arg);
   int fd = grpc_fd_wrapped_fd(cl->em_fd);
   ssize_t write_once = 0;
@@ -405,7 +405,7 @@ void init_change_data(fd_change_data* fdc) { fdc->cb_that_ran = nullptr; }
 void destroy_change_data(fd_change_data* /*fdc*/) {}
 
 static void first_read_callback(void* arg /* fd_change_data */,
-                                grpc_error_handle /*error*/) {
+                                absl::Status /*error*/) {
   fd_change_data* fdc = static_cast<fd_change_data*>(arg);
 
   gpr_mu_lock(g_mu);
@@ -416,7 +416,7 @@ static void first_read_callback(void* arg /* fd_change_data */,
 }
 
 static void second_read_callback(void* arg /* fd_change_data */,
-                                 grpc_error_handle /*error*/) {
+                                 absl::Status /*error*/) {
   fd_change_data* fdc = static_cast<fd_change_data*>(arg);
 
   gpr_mu_lock(g_mu);
@@ -510,7 +510,7 @@ static void test_grpc_fd_change(void) {
   close(sv[1]);
 }
 
-static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
+static void destroy_pollset(void* p, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
@@ -47,7 +47,7 @@ static void finish_connection() {
   gpr_mu_unlock(&g_mu);
 }
 
-static void must_succeed(void* arg, grpc_error_handle error) {
+static void must_succeed(void* arg, absl::Status error) {
   GPR_ASSERT(g_connecting != nullptr);
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   grpc_endpoint_shutdown(g_connecting, GRPC_ERROR_CREATE_FROM_STATIC_STRING("must_succeed called"));
@@ -56,7 +56,7 @@ static void must_succeed(void* arg, grpc_error_handle error) {
   finish_connection();
 }
 
-static void must_fail(void* arg, grpc_error_handle error) {
+static void must_fail(void* arg, absl::Status error) {
   GPR_ASSERT(g_connecting == nullptr);
   GPR_ASSERT(!GRPC_ERROR_IS_NONE(error));
   NSLog(@"%s", grpc_error_std_string(error).c_str());

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -50,13 +50,12 @@ static const int kBufferSize = 10000;
 
 static const int kRunLoopTimeout = 1;
 
-static void set_error_handle_promise(void *arg, grpc_error_handle error) {
-  std::promise<grpc_error_handle> *p = static_cast<std::promise<grpc_error_handle> *>(arg);
+static void set_error_handle_promise(void *arg, absl::Status error) {
+  std::promise<absl::Status> *p = static_cast<std::promise<absl::Status> *>(arg);
   p->set_value(error);
 }
 
-static void init_event_closure(grpc_closure *closure,
-                               std::promise<grpc_error_handle> *error_handle) {
+static void init_event_closure(grpc_closure *closure, std::promise<absl::Status> *error_handle) {
   GRPC_CLOSURE_INIT(closure, set_error_handle_promise, static_cast<void *>(error_handle),
                     grpc_schedule_on_exec_ctx);
 }
@@ -87,7 +86,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   int svr_fd_;
 }
 
-- (BOOL)waitForEvent:(std::future<grpc_error_handle> *)event timeout:(int)timeout {
+- (BOOL)waitForEvent:(std::future<absl::Status> *)event timeout:(int)timeout {
   grpc_core::ExecCtx::Get()->Flush();
   return event->wait_for(std::chrono::seconds(timeout)) != std::future_status::timeout;
 }
@@ -109,7 +108,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   int svr_fd;
   int r;
-  std::promise<grpc_error_handle> connected_promise;
+  std::promise<absl::Status> connected_promise;
   grpc_closure done;
 
   gpr_log(GPR_DEBUG, "test_succeeds");
@@ -144,7 +143,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   svr_fd_ = r;
 
   /* wait for the connection callback to finish */
-  std::future<grpc_error_handle> connected_future = connected_promise.get_future();
+  std::future<absl::Status> connected_future = connected_promise.get_future();
   XCTAssertEqual([self waitForEvent:&connected_future timeout:kConnectTimeout], YES);
   XCTAssertEqual(connected_future.get(), GRPC_ERROR_NONE);
 }
@@ -161,7 +160,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   grpc_closure read_done;
   grpc_slice_buffer read_slices;
   grpc_slice_buffer read_one_slice;
-  std::promise<grpc_error_handle> write_promise;
+  std::promise<absl::Status> write_promise;
   grpc_closure write_done;
   grpc_slice_buffer write_slices;
 
@@ -176,7 +175,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   init_event_closure(&write_done, &write_promise);
   grpc_endpoint_write(ep_, &write_slices, &write_done, nullptr, /*max_frame_size=*/INT_MAX);
 
-  std::future<grpc_error_handle> write_future = write_promise.get_future();
+  std::future<absl::Status> write_future = write_promise.get_future();
   XCTAssertEqual([self waitForEvent:&write_future timeout:kWriteTimeout], YES);
   XCTAssertEqual(write_future.get(), GRPC_ERROR_NONE);
 
@@ -194,11 +193,11 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   grpc_slice_buffer_init(&read_slices);
   grpc_slice_buffer_init(&read_one_slice);
   while (read_slices.length < kBufferSize) {
-    std::promise<grpc_error_handle> read_promise;
+    std::promise<absl::Status> read_promise;
     init_event_closure(&read_done, &read_promise);
     grpc_endpoint_read(ep_, &read_one_slice, &read_done, /*urgent=*/false,
                        /*min_progress_size=*/1);
-    std::future<grpc_error_handle> read_future = read_promise.get_future();
+    std::future<absl::Status> read_future = read_promise.get_future();
     XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
     XCTAssertEqual(read_future.get(), GRPC_ERROR_NONE);
     grpc_slice_buffer_move_into(&read_one_slice, &read_slices);
@@ -215,10 +214,10 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 - (void)testShutdownBeforeRead {
   grpc_core::ExecCtx exec_ctx;
 
-  std::promise<grpc_error_handle> read_promise;
+  std::promise<absl::Status> read_promise;
   grpc_closure read_done;
   grpc_slice_buffer read_slices;
-  std::promise<grpc_error_handle> write_promise;
+  std::promise<absl::Status> write_promise;
   grpc_closure write_done;
   grpc_slice_buffer write_slices;
 
@@ -238,7 +237,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   init_event_closure(&write_done, &write_promise);
   grpc_endpoint_write(ep_, &write_slices, &write_done, nullptr, /*max_frame_size=*/INT_MAX);
 
-  std::future<grpc_error_handle> write_future = write_promise.get_future();
+  std::future<absl::Status> write_future = write_promise.get_future();
   XCTAssertEqual([self waitForEvent:&write_future timeout:kWriteTimeout], YES);
   XCTAssertEqual(write_future.get(), GRPC_ERROR_NONE);
 
@@ -251,7 +250,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   XCTAssertEqual(recv_size, kBufferSize);
   XCTAssertEqual(memcmp(read_buffer, write_buffer, kBufferSize), 0);
 
-  std::future<grpc_error_handle> read_future = read_promise.get_future();
+  std::future<absl::Status> read_future = read_promise.get_future();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], NO);
 
   grpc_endpoint_shutdown(ep_, GRPC_ERROR_NONE);
@@ -267,10 +266,10 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 - (void)testRemoteClosed {
   grpc_core::ExecCtx exec_ctx;
 
-  std::promise<grpc_error_handle> read_promise;
+  std::promise<absl::Status> read_promise;
   grpc_closure read_done;
   grpc_slice_buffer read_slices;
-  std::promise<grpc_error_handle> write_promise;
+  std::promise<absl::Status> write_promise;
   grpc_closure write_done;
   grpc_slice_buffer write_slices;
 
@@ -291,7 +290,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   init_event_closure(&write_done, &write_promise);
   grpc_endpoint_write(ep_, &write_slices, &write_done, nullptr, /*max_frame_size=*/INT_MAX);
 
-  std::future<grpc_error_handle> write_future = write_promise.get_future();
+  std::future<absl::Status> write_future = write_promise.get_future();
   XCTAssertEqual([self waitForEvent:&write_future timeout:kWriteTimeout], YES);
   XCTAssertEqual(write_future.get(), GRPC_ERROR_NONE);
 
@@ -306,7 +305,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   close(svr_fd_);
 
-  std::future<grpc_error_handle> read_future = read_promise.get_future();
+  std::future<absl::Status> read_future = read_promise.get_future();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
   XCTAssertNotEqual(read_future.get(), GRPC_ERROR_NONE);
 
@@ -318,7 +317,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 - (void)testRemoteReset {
   grpc_core::ExecCtx exec_ctx;
 
-  std::promise<grpc_error_handle> read_promise;
+  std::promise<absl::Status> read_promise;
   grpc_closure read_done;
   grpc_slice_buffer read_slices;
 
@@ -334,7 +333,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   close(svr_fd_);
 
-  std::future<grpc_error_handle> read_future = read_promise.get_future();
+  std::future<absl::Status> read_future = read_promise.get_future();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
   XCTAssertNotEqual(read_future.get(), GRPC_ERROR_NONE);
 

--- a/test/core/iomgr/load_file_test.cc
+++ b/test/core/iomgr/load_file_test.cc
@@ -40,7 +40,7 @@ TEST(LoadFileTest, TestLoadEmptyFile) {
   FILE* tmp = nullptr;
   grpc_slice slice;
   grpc_slice slice_with_null_term;
-  grpc_error_handle error;
+  absl::Status error;
   char* tmp_name;
 
   LOG_TEST_NAME("test_load_empty_file");
@@ -68,7 +68,7 @@ TEST(LoadFileTest, TestLoadEmptyFile) {
 TEST(LoadFileTest, TestLoadFailure) {
   FILE* tmp = nullptr;
   grpc_slice slice;
-  grpc_error_handle error;
+  absl::Status error;
   char* tmp_name;
 
   LOG_TEST_NAME("test_load_failure");
@@ -91,7 +91,7 @@ TEST(LoadFileTest, TestLoadSmallFile) {
   FILE* tmp = nullptr;
   grpc_slice slice;
   grpc_slice slice_with_null_term;
-  grpc_error_handle error;
+  absl::Status error;
   char* tmp_name;
   const char* blah = "blah";
 
@@ -122,7 +122,7 @@ TEST(LoadFileTest, TestLoadSmallFile) {
 TEST(LoadFileTest, TestLoadBigFile) {
   FILE* tmp = nullptr;
   grpc_slice slice;
-  grpc_error_handle error;
+  absl::Status error;
   char* tmp_name;
   static const size_t buffer_size = 124631;
   unsigned char* buffer = static_cast<unsigned char*>(gpr_malloc(buffer_size));

--- a/test/core/iomgr/pollset_windows_starvation_test.cc
+++ b/test/core/iomgr/pollset_windows_starvation_test.cc
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
 
           // Queue for work and once we're done, make sure to kick the remaining
           // threads.
-          grpc_error_handle error;
+          absl::Status error;
           error = grpc_pollset_work(&pollset, NULL,
                                     grpc_core::Timestamp::InfFuture());
           error = grpc_pollset_kick(&pollset, NULL);

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -60,7 +60,7 @@ typedef struct args_struct {
   grpc_pollset_set* pollset_set;
 } args_struct;
 
-static void do_nothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+static void do_nothing(void* /*arg*/, absl::Status /*error*/) {}
 
 void args_init(args_struct* args) {
   gpr_event_init(&args->ev);

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -167,7 +167,7 @@ class ResolveAddressTest : public ::testing::Test {
   grpc_pollset_set* pollset_set() const { return pollset_set_; }
 
  private:
-  static void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+  static void DoNothing(void* /*arg*/, absl::Status /*error*/) {}
 
   gpr_mu* mu_;
   bool done_ = false;      // guarded by mu

--- a/test/core/iomgr/tcp_client_posix_test.cc
+++ b/test/core/iomgr/tcp_client_posix_test.cc
@@ -66,7 +66,7 @@ static void finish_connection() {
   gpr_mu_unlock(g_mu);
 }
 
-static void must_succeed(void* /*arg*/, grpc_error_handle error) {
+static void must_succeed(void* /*arg*/, absl::Status error) {
   ASSERT_NE(g_connecting, nullptr);
   ASSERT_TRUE(GRPC_ERROR_IS_NONE(error));
   grpc_endpoint_shutdown(g_connecting, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
@@ -76,7 +76,7 @@ static void must_succeed(void* /*arg*/, grpc_error_handle error) {
   finish_connection();
 }
 
-static void must_fail(void* /*arg*/, grpc_error_handle error) {
+static void must_fail(void* /*arg*/, absl::Status error) {
   ASSERT_EQ(g_connecting, nullptr);
   ASSERT_FALSE(GRPC_ERROR_IS_NONE(error));
   finish_connection();
@@ -289,7 +289,7 @@ void test_fails_bad_addr_no_leak(void) {
   gpr_log(GPR_ERROR, "---- finished test_fails_bad_addr_no_leak() ----");
 }
 
-static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
+static void destroy_pollset(void* p, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/test/core/iomgr/tcp_posix_test.cc
+++ b/test/core/iomgr/tcp_posix_test.cc
@@ -178,7 +178,7 @@ static size_t count_slices(grpc_slice* slices, size_t nslices,
   return num_bytes;
 }
 
-static void read_cb(void* user_data, grpc_error_handle error) {
+static void read_cb(void* user_data, absl::Status error) {
   struct read_socket_state* state =
       static_cast<struct read_socket_state*>(user_data);
   size_t read_bytes;
@@ -369,7 +369,7 @@ static grpc_slice* allocate_blocks(size_t num_bytes, size_t slice_size,
 }
 
 static void write_done(void* user_data /* write_socket_state */,
-                       grpc_error_handle error) {
+                       absl::Status error) {
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   struct write_socket_state* state =
       static_cast<struct write_socket_state*>(user_data);
@@ -422,7 +422,7 @@ void drain_socket_blocking(int fd, size_t num_bytes, size_t read_size) {
 
 /* Verifier for timestamps callback for write_test */
 void timestamps_verifier(void* arg, grpc_core::Timestamps* ts,
-                         grpc_error_handle error) {
+                         absl::Status error) {
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   GPR_ASSERT(arg != nullptr);
   GPR_ASSERT(ts->sendmsg_time.time.clock_type == GPR_CLOCK_REALTIME);
@@ -523,7 +523,7 @@ static void write_test(size_t num_bytes, size_t slice_size,
       static_cast<grpc_resource_quota*>(a[1].value.pointer.p));
 }
 
-void on_fd_released(void* arg, grpc_error_handle /*errors*/) {
+void on_fd_released(void* arg, absl::Status /*errors*/) {
   int* done = static_cast<int*>(arg);
   *done = 1;
   GPR_ASSERT(
@@ -692,7 +692,7 @@ static grpc_endpoint_test_config configs[] = {
     {"tcp/tcp_socketpair", create_fixture_tcp_socketpair, clean_up},
 };
 
-static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
+static void destroy_pollset(void* p, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -117,7 +117,7 @@ static void on_connect_result_set(on_connect_result* result,
       result->server, acceptor->port_index, acceptor->fd_index);
 }
 
-static void server_weak_ref_shutdown(void* arg, grpc_error_handle /*error*/) {
+static void server_weak_ref_shutdown(void* arg, absl::Status /*error*/) {
   server_weak_ref* weak_ref = static_cast<server_weak_ref*>(arg);
   weak_ref->server = nullptr;
 }
@@ -257,8 +257,8 @@ static void test_no_op_with_port_and_start(void) {
   grpc_tcp_server_unref(s);
 }
 
-static grpc_error_handle tcp_connect(const test_addr* remote,
-                                     on_connect_result* result) {
+static absl::Status tcp_connect(const test_addr* remote,
+                                on_connect_result* result) {
   grpc_core::Timestamp deadline = grpc_core::Timestamp::FromTimespecRoundUp(
       grpc_timeout_seconds_to_deadline(10));
   int clifd;
@@ -286,7 +286,7 @@ static grpc_error_handle tcp_connect(const test_addr* remote,
   while (g_nconnects == nconnects_before &&
          deadline > grpc_core::Timestamp::Now()) {
     grpc_pollset_worker* worker = nullptr;
-    grpc_error_handle err;
+    absl::Status err;
     if ((err = grpc_pollset_work(g_pollset, &worker, deadline)) !=
         GRPC_ERROR_NONE) {
       gpr_mu_unlock(g_mu);
@@ -402,7 +402,7 @@ static void test_connect(size_t num_connects,
       for (dst_idx = 0; dst_idx < dst_addrs->naddrs; ++dst_idx) {
         test_addr dst = dst_addrs->addrs[dst_idx];
         on_connect_result result;
-        grpc_error_handle err;
+        absl::Status err;
         if (dst.addr.len == 0) {
           gpr_log(GPR_DEBUG, "Skipping test of non-functional local IP %s",
                   dst.str);
@@ -468,7 +468,7 @@ static void test_connect(size_t num_connects,
   ASSERT_EQ(weak_ref.server, nullptr);
 }
 
-static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
+static void destroy_pollset(void* p, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/test/core/iomgr/timer_list_test.cc
+++ b/test/core/iomgr/timer_list_test.cc
@@ -42,7 +42,7 @@ static const int64_t kHoursIn25Days = 25 * 24;
 static const grpc_core::Duration k25Days =
     grpc_core::Duration::Hours(kHoursIn25Days);
 
-static void cb(void* arg, grpc_error_handle error) {
+static void cb(void* arg, absl::Status error) {
   cb_called[reinterpret_cast<intptr_t>(arg)][GRPC_ERROR_IS_NONE(error)]++;
 }
 

--- a/test/core/resource_quota/BUILD
+++ b/test/core/resource_quota/BUILD
@@ -148,6 +148,7 @@ grpc_proto_fuzzer(
     srcs = ["memory_quota_fuzzer.cc"],
     corpus = "memory_quota_fuzzer_corpus",
     external_deps = [
+        "absl/status",
         "absl/strings",
         "absl/types:optional",
     ],

--- a/test/core/resource_quota/memory_quota_fuzzer.cc
+++ b/test/core/resource_quota/memory_quota_fuzzer.cc
@@ -21,6 +21,7 @@
 #include <memory>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 
@@ -134,7 +135,7 @@ class Fuzzer {
               };
               auto* args = new Args{std::move(sweep), cfg.msg(), this};
               auto* closure = GRPC_CLOSURE_CREATE(
-                  [](void* arg, grpc_error_handle) {
+                  [](void* arg, absl::Status) {
                     auto* args = static_cast<Args*>(arg);
                     args->fuzzer->RunMsg(args->msg);
                     delete args;

--- a/test/core/security/aws_request_signer_test.cc
+++ b/test/core/security/aws_request_signer_test.cc
@@ -20,6 +20,7 @@
 
 #include <grpc/grpc_security.h>
 
+#include "src/core/lib/iomgr/error.h"
 #include "test/core/util/test_config.h"
 
 namespace testing {
@@ -66,7 +67,7 @@ const char* kBotoTestDate = "Mon, 09 Sep 2011 23:36:00 GMT";
 // AWS official example from the developer doc.
 // https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
 TEST(GrpcAwsRequestSignerTest, AWSOfficialExample) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "", "GET",
       "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08",
@@ -84,7 +85,7 @@ TEST(GrpcAwsRequestSignerTest, AWSOfficialExample) {
 }
 
 TEST(GrpcAwsRequestSignerTest, GetDescribeRegions) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kAmzTestAccessKeyId, kAmzTestSecretAccessKey, kAmzTestToken, "GET",
       "https://"
@@ -101,7 +102,7 @@ TEST(GrpcAwsRequestSignerTest, GetDescribeRegions) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentity) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kAmzTestAccessKeyId, kAmzTestSecretAccessKey, kAmzTestToken, "POST",
       "https://"
@@ -118,7 +119,7 @@ TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentity) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentityNoToken) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kAmzTestAccessKeyId, kAmzTestSecretAccessKey, "", "POST",
       "https://"
@@ -135,7 +136,7 @@ TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentityNoToken) {
 }
 
 TEST(GrpcAwsRequestSignerTest, GetHost) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(kBotoTestAccessKeyId,
                                      kBotoTestSecretAccessKey, kBotoTestToken,
                                      "GET", "https://host.foo.com", "us-east-1",
@@ -150,7 +151,7 @@ TEST(GrpcAwsRequestSignerTest, GetHost) {
 }
 
 TEST(GrpcAwsRequestSignerTest, GetHostDuplicateQueryParam) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "GET",
       "https://host.foo.com/?foo=Zoo&foo=aha", "us-east-1", "",
@@ -165,7 +166,7 @@ TEST(GrpcAwsRequestSignerTest, GetHostDuplicateQueryParam) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderKey) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "",
@@ -180,7 +181,7 @@ TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderKey) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderValue) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "",
@@ -195,7 +196,7 @@ TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderValue) {
 }
 
 TEST(GrpcAwsRequestSignerTest, SignPostWithHeader) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "",
@@ -210,7 +211,7 @@ TEST(GrpcAwsRequestSignerTest, SignPostWithHeader) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostWithBodyNoCustomHeaders) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "foo=bar",
@@ -227,7 +228,7 @@ TEST(GrpcAwsRequestSignerTest, PostWithBodyNoCustomHeaders) {
 }
 
 TEST(GrpcAwsRequestSignerTest, SignPostWithQueryString) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/?foo=bar", "us-east-1", "",
@@ -242,7 +243,7 @@ TEST(GrpcAwsRequestSignerTest, SignPostWithQueryString) {
 }
 
 TEST(GrpcAwsRequestSignerTest, InvalidUrl) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer("access_key_id", "secret_access_key",
                                      "token", "POST", "invalid_url",
                                      "us-east-1", "", {}, &error);
@@ -254,7 +255,7 @@ TEST(GrpcAwsRequestSignerTest, InvalidUrl) {
 }
 
 TEST(GrpcAwsRequestSignerTest, DuplicateRequestDate) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_core::AwsRequestSigner signer(
       "access_key_id", "secret_access_key", "token", "POST", "invalid_url",
       "us-east-1", "", {{"date", kBotoTestDate}, {"x-amz-date", kAmzTestDate}},

--- a/test/core/security/certificate_provider_registry_test.cc
+++ b/test/core/security/certificate_provider_registry_test.cc
@@ -34,7 +34,7 @@ class FakeCertificateProviderFactory1 : public CertificateProviderFactory {
   const char* name() const override { return "fake1"; }
 
   RefCountedPtr<Config> CreateCertificateProviderConfig(
-      const Json& /*config_json*/, grpc_error_handle* /*error*/) override {
+      const Json& /*config_json*/, absl::Status* /*error*/) override {
     return nullptr;
   }
 
@@ -49,7 +49,7 @@ class FakeCertificateProviderFactory2 : public CertificateProviderFactory {
   const char* name() const override { return "fake2"; }
 
   RefCountedPtr<Config> CreateCertificateProviderConfig(
-      const Json& /*config_json*/, grpc_error_handle* /*error*/) override {
+      const Json& /*config_json*/, absl::Status* /*error*/) override {
     return nullptr;
   }
 

--- a/test/core/security/grpc_tls_certificate_distributor_test.cc
+++ b/test/core/security/grpc_tls_certificate_distributor_test.cc
@@ -130,8 +130,8 @@ class GrpcTlsCertificateDistributorTest : public ::testing::Test {
                                              std::move(updated_identity));
     }
 
-    void OnError(grpc_error_handle root_cert_error,
-                 grpc_error_handle identity_cert_error) override {
+    void OnError(absl::Status root_cert_error,
+                 absl::Status identity_cert_error) override {
       GPR_ASSERT(!GRPC_ERROR_IS_NONE(root_cert_error) ||
                  !GRPC_ERROR_IS_NONE(identity_cert_error));
       std::string root_error_str;

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -131,8 +131,8 @@ class GrpcTlsCertificateProviderTest : public ::testing::Test {
                                              std::move(updated_identity));
     }
 
-    void OnError(grpc_error_handle root_cert_error,
-                 grpc_error_handle identity_cert_error) override {
+    void OnError(absl::Status root_cert_error,
+                 absl::Status identity_cert_error) override {
       MutexLock lock(&state_->mu);
       GPR_ASSERT(!GRPC_ERROR_IS_NONE(root_cert_error) ||
                  !GRPC_ERROR_IS_NONE(identity_cert_error));

--- a/test/core/security/oauth2_utils.cc
+++ b/test/core/security/oauth2_utils.cc
@@ -100,7 +100,7 @@ char* grpc_test_fetch_oauth2_token_with_credentials(
 
   grpc_pollset_shutdown(
       grpc_polling_entity_pollset(&pops),
-      GRPC_CLOSURE_CREATE([](void*, grpc_error_handle) {}, nullptr, nullptr));
+      GRPC_CLOSURE_CREATE([](void*, absl::Status) {}, nullptr, nullptr));
   grpc_core::ExecCtx::Get()->Flush();
   grpc_pollset_destroy(grpc_polling_entity_pollset(&pops));
   gpr_free(pollset);

--- a/test/core/security/print_google_default_creds_token.cc
+++ b/test/core/security/print_google_default_creds_token.cc
@@ -41,7 +41,7 @@ typedef struct {
   grpc_closure on_request_metadata;
 } synchronizer;
 
-static void on_metadata_response(void* arg, grpc_error_handle error) {
+static void on_metadata_response(void* arg, absl::Status error) {
   synchronizer* sync = static_cast<synchronizer*>(arg);
   if (!GRPC_ERROR_IS_NONE(error)) {
     fprintf(stderr, "Fetching token failed: %s\n",
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
   grpc_auth_metadata_context context;
   gpr_cmdline* cl = gpr_cmdline_create("print_google_default_creds_token");
   grpc_pollset* pollset = nullptr;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   gpr_cmdline_add_string(cl, "service_url",
                          "Service URL for the token request.", &service_url);
   gpr_cmdline_parse(cl, argc, argv);

--- a/test/core/security/secure_endpoint_test.cc
+++ b/test/core/security/secure_endpoint_test.cc
@@ -80,7 +80,7 @@ static void me_add_to_pollset_set(grpc_endpoint* /*ep*/,
 static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
                                        grpc_pollset_set* /*pollset*/) {}
 
-static void me_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
+static void me_shutdown(grpc_endpoint* ep, absl::Status why) {
   intercept_endpoint* m = reinterpret_cast<intercept_endpoint*>(ep);
   grpc_endpoint_shutdown(m->wrapped_ep, why);
 }
@@ -268,7 +268,7 @@ static grpc_endpoint_test_config configs[] = {
      clean_up},
 };
 
-static void inc_call_ctr(void* arg, grpc_error_handle /*error*/) {
+static void inc_call_ctr(void* arg, absl::Status /*error*/) {
   ++*static_cast<int*>(arg);
 }
 
@@ -305,7 +305,7 @@ static void test_leftover(grpc_endpoint_test_config config, size_t slice_size) {
   clean_up();
 }
 
-static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
+static void destroy_pollset(void* p, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(p));
 }
 

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -719,7 +719,7 @@ static void test_peer_alpn_check(void) {
       tsi_construct_string_peer_property("wrong peer property name", alpn,
                                          strlen(alpn), &peer.properties[0]),
       TSI_OK);
-  grpc_error_handle error = grpc_ssl_check_alpn(&peer);
+  absl::Status error = grpc_ssl_check_alpn(&peer);
   ASSERT_FALSE(GRPC_ERROR_IS_NONE(error));
   tsi_peer_destruct(&peer);
   GRPC_ERROR_UNREF(error);

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -42,7 +42,7 @@ struct handshake_state {
   bool done_callback_called;
 };
 
-static void on_handshake_done(void* arg, grpc_error_handle error) {
+static void on_handshake_done(void* arg, absl::Status error) {
   grpc_core::HandshakerArgs* args =
       static_cast<grpc_core::HandshakerArgs*>(arg);
   struct handshake_state* state =

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -92,7 +92,7 @@ class TlsSecurityConnectorTest : public ::testing::Test {
     grpc_slice_unref(key_slice_0);
   }
 
-  static void VerifyExpectedErrorCallback(void* arg, grpc_error_handle error) {
+  static void VerifyExpectedErrorCallback(void* arg, absl::Status error) {
     const char* expected_error_msg = static_cast<const char*>(arg);
     if (expected_error_msg == nullptr) {
       EXPECT_EQ(error, GRPC_ERROR_NONE);
@@ -101,7 +101,7 @@ class TlsSecurityConnectorTest : public ::testing::Test {
     }
   }
 
-  static std::string GetErrorMsg(grpc_error_handle error) {
+  static std::string GetErrorMsg(absl::Status error) {
     std::string error_str;
     GPR_ASSERT(
         grpc_error_get_str(error, GRPC_ERROR_STR_DESCRIPTION, &error_str));

--- a/test/core/surface/concurrent_connectivity_test.cc
+++ b/test/core/surface/concurrent_connectivity_test.cc
@@ -142,7 +142,7 @@ void bad_server_thread(void* vargs) {
   auto channel_args = grpc_core::CoreConfiguration::Get()
                           .channel_args_preconditioning()
                           .PreconditionChannelArgs(nullptr);
-  grpc_error_handle error = grpc_tcp_server_create(
+  absl::Status error = grpc_tcp_server_create(
       nullptr,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(channel_args),
       &s);
@@ -177,7 +177,7 @@ void bad_server_thread(void* vargs) {
   grpc_tcp_server_unref(s);
 }
 
-static void done_pollset_shutdown(void* pollset, grpc_error_handle /*error*/) {
+static void done_pollset_shutdown(void* pollset, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(pollset));
   gpr_free(pollset);
 }

--- a/test/core/surface/lame_client_test.cc
+++ b/test/core/surface/lame_client_test.cc
@@ -43,7 +43,7 @@ static void* tag(intptr_t t) { return reinterpret_cast<void*>(t); }
 
 static grpc_closure transport_op_cb;
 
-static void do_nothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+static void do_nothing(void* /*arg*/, absl::Status /*error*/) {}
 
 void test_transport_op(grpc_channel* channel) {
   grpc_core::ExecCtx exec_ctx;

--- a/test/core/transport/binder/binder_transport_test.cc
+++ b/test/core/transport/binder/binder_transport_test.cc
@@ -107,7 +107,7 @@ class BinderTransportTest : public ::testing::Test {
   std::vector<grpc_binder_stream*> stream_buffer_;
 };
 
-void MockCallback(void* arg, grpc_error_handle error);
+void MockCallback(void* arg, absl::Status error);
 
 class MockGrpcClosure {
  public:
@@ -117,7 +117,7 @@ class MockGrpcClosure {
   }
 
   grpc_closure* GetGrpcClosure() { return &closure_; }
-  MOCK_METHOD(void, Callback, (grpc_error_handle), ());
+  MOCK_METHOD(void, Callback, (absl::Status), ());
 
   grpc_core::Notification* notification_;
 
@@ -125,7 +125,7 @@ class MockGrpcClosure {
   grpc_closure closure_;
 };
 
-void MockCallback(void* arg, grpc_error_handle error) {
+void MockCallback(void* arg, absl::Status error) {
   MockGrpcClosure* mock_closure = static_cast<MockGrpcClosure*>(arg);
   mock_closure->Callback(error);
   if (mock_closure->notification_) {

--- a/test/core/transport/binder/end2end/testing_channel_create.cc
+++ b/test/core/transport/binder/end2end/testing_channel_create.cc
@@ -121,7 +121,7 @@ grpc_channel* grpc_binder_channel_create_for_testing(
   grpc_transport *client_transport, *server_transport;
   std::tie(client_transport, server_transport) =
       grpc_binder::end2end_testing::CreateClientServerBindersPairForTesting();
-  grpc_error_handle error = grpc_core::Server::FromC(server)->SetupTransport(
+  absl::Status error = grpc_core::Server::FromC(server)->SetupTransport(
       server_transport, nullptr, server_args, nullptr);
   GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
   auto channel = grpc_core::Channel::Create(

--- a/test/core/transport/chttp2/context_list_test.cc
+++ b/test/core/transport/chttp2/context_list_test.cc
@@ -35,6 +35,7 @@
 #include "src/core/lib/channel/channel_args_preconditioning.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/iomgr/endpoint.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/transport/transport.h"
 #include "src/core/lib/transport/transport_fwd.h"
@@ -50,7 +51,7 @@ const uint32_t kByteOffset = 123;
 void* PhonyArgsCopier(void* arg) { return arg; }
 
 void TestExecuteFlushesListVerifier(void* arg, Timestamps* ts,
-                                    grpc_error_handle error) {
+                                    absl::Status error) {
   ASSERT_NE(arg, nullptr);
   EXPECT_EQ(error, GRPC_ERROR_NONE);
   if (ts) {

--- a/test/core/transport/chttp2/graceful_shutdown_test.cc
+++ b/test/core/transport/chttp2/graceful_shutdown_test.cc
@@ -155,7 +155,7 @@ class GracefulShutdownTest : public ::testing::Test {
     grpc_completion_queue_destroy(cq_);
   }
 
-  static void OnReadDone(void* arg, grpc_error_handle error) {
+  static void OnReadDone(void* arg, absl::Status error) {
     GracefulShutdownTest* self = static_cast<GracefulShutdownTest*>(arg);
     if (GRPC_ERROR_IS_NONE(error)) {
       {
@@ -235,7 +235,7 @@ class GracefulShutdownTest : public ::testing::Test {
         absl::Seconds(5)));
   }
 
-  static void OnWriteDone(void* arg, grpc_error_handle error) {
+  static void OnWriteDone(void* arg, absl::Status error) {
     GPR_ASSERT(GRPC_ERROR_IS_NONE(error));
     Notification* on_write_done_notification_ = static_cast<Notification*>(arg);
     on_write_done_notification_->Notify();

--- a/test/core/transport/chttp2/hpack_parser_table_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_table_test.cc
@@ -26,6 +26,7 @@
 
 #include <grpc/grpc.h>
 
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/slice/slice.h"
 #include "test/core/util/test_config.h"

--- a/test/core/transport/chttp2/hpack_parser_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_test.cc
@@ -35,6 +35,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/resource_quota/memory_quota.h"

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -205,10 +205,10 @@ class Client {
     bool done() const { return gpr_atm_acq_load(&done_atm_) != 0; }
 
     // Caller does NOT take ownership of the error.
-    grpc_error_handle error() const { return error_; }
+    absl::Status error() const { return error_; }
 
    private:
-    static void OnEventDone(void* arg, grpc_error_handle error) {
+    static void OnEventDone(void* arg, absl::Status error) {
       gpr_log(GPR_INFO, "OnEventDone(): %s",
               grpc_error_std_string(error).c_str());
       EventState* state = static_cast<EventState*>(arg);
@@ -218,7 +218,7 @@ class Client {
 
     grpc_closure closure_;
     gpr_atm done_atm_ = 0;
-    grpc_error_handle error_ = GRPC_ERROR_NONE;
+    absl::Status error_ = GRPC_ERROR_NONE;
   };
 
   // Returns true if done, or false if deadline exceeded.
@@ -238,7 +238,7 @@ class Client {
     }
   }
 
-  static void PollsetDestroy(void* arg, grpc_error_handle /*error*/) {
+  static void PollsetDestroy(void* arg, absl::Status /*error*/) {
     grpc_pollset* pollset = static_cast<grpc_pollset*>(arg);
     grpc_pollset_destroy(pollset);
     gpr_free(pollset);

--- a/test/core/transport/error_utils_test.cc
+++ b/test/core/transport/error_utils_test.cc
@@ -29,7 +29,7 @@
 namespace {
 
 TEST(ErrorUtilsTest, GetErrorGetStatusNone) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   grpc_status_code code;
   std::string message;
   grpc_error_get_status(error, grpc_core::Timestamp(), &code, &message, nullptr,
@@ -39,7 +39,7 @@ TEST(ErrorUtilsTest, GetErrorGetStatusNone) {
 }
 
 TEST(ErrorUtilsTest, GetErrorGetStatusFlat) {
-  grpc_error_handle error =
+  absl::Status error =
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Msg"),
                          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_CANCELLED);
   grpc_status_code code;
@@ -52,13 +52,13 @@ TEST(ErrorUtilsTest, GetErrorGetStatusFlat) {
 }
 
 TEST(ErrorUtilsTest, GetErrorGetStatusChild) {
-  std::vector<grpc_error_handle> children = {
+  std::vector<absl::Status> children = {
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child1"),
       grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child2"),
                          GRPC_ERROR_INT_GRPC_STATUS,
                          GRPC_STATUS_RESOURCE_EXHAUSTED),
   };
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_VECTOR("Parent", &children);
+  absl::Status error = GRPC_ERROR_CREATE_FROM_VECTOR("Parent", &children);
   grpc_status_code code;
   std::string message;
   grpc_error_get_status(error, grpc_core::Timestamp(), &code, &message, nullptr,
@@ -70,7 +70,7 @@ TEST(ErrorUtilsTest, GetErrorGetStatusChild) {
 
 // ---- Ok Status ----
 TEST(ErrorUtilsTest, AbslOkToGrpcError) {
-  grpc_error_handle error = absl_status_to_grpc_error(absl::OkStatus());
+  absl::Status error = absl_status_to_grpc_error(absl::OkStatus());
   ASSERT_EQ(GRPC_ERROR_NONE, error);
   GRPC_ERROR_UNREF(error);
 }
@@ -83,7 +83,7 @@ TEST(ErrorUtilsTest, GrpcSpecialErrorNoneToAbslStatus) {
 
 // ---- Asymmetry of conversions of "Special" errors ----
 TEST(ErrorUtilsTest, AbslStatusToGrpcErrorDoesNotReturnSpecialVariables) {
-  grpc_error_handle error =
+  absl::Status error =
       absl_status_to_grpc_error(absl::CancelledError("CANCELLED"));
   ASSERT_NE(error, GRPC_ERROR_CANCELLED);
   GRPC_ERROR_UNREF(error);
@@ -103,7 +103,7 @@ TEST(ErrorUtilsTest, GrpcSpecialErrorOOMToAbslStatus) {
 
 // ---- Ordinary statuses ----
 TEST(ErrorUtilsTest, AbslUnavailableToGrpcError) {
-  grpc_error_handle error =
+  absl::Status error =
       absl_status_to_grpc_error(absl::UnavailableError("Making tea"));
   // Status code checks
   intptr_t code;
@@ -117,7 +117,7 @@ TEST(ErrorUtilsTest, AbslUnavailableToGrpcError) {
 }
 
 TEST(ErrorUtilsTest, GrpcErrorUnavailableToAbslStatus) {
-  grpc_error_handle error = grpc_error_set_int(
+  absl::Status error = grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING(
           "weighted_target: all children report state TRANSIENT_FAILURE"),
       GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -97,7 +97,7 @@ FakeUdpAndTcpServer::FakeUdpAndTcpServer(
             port_, ERRNO);
     GPR_ASSERT(0);
   }
-  grpc_error_handle set_non_block_error;
+  absl::Status set_non_block_error;
   set_non_block_error = grpc_tcp_set_non_block(udp_socket_);
   if (!GRPC_ERROR_IS_NONE(set_non_block_error)) {
     gpr_log(GPR_ERROR, "Failed to configure non-blocking socket: %s",
@@ -257,7 +257,7 @@ void FakeUdpAndTcpServer::RunServerLoop() {
     if (p != BAD_SOCKET_RETURN_VAL) {
       gpr_log(GPR_DEBUG, "accepted peer socket: %d", p);
 #ifdef GPR_WINDOWS
-      grpc_error_handle set_non_block_error;
+      absl::Status set_non_block_error;
       set_non_block_error = grpc_tcp_set_non_block(p);
       if (!GRPC_ERROR_IS_NONE(set_non_block_error)) {
         gpr_log(GPR_ERROR, "Failed to configure non-blocking socket: %s",

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/util/mock_endpoint.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/slice_buffer.h>
@@ -73,7 +74,7 @@ static void me_add_to_pollset_set(grpc_endpoint* /*ep*/,
 static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
                                        grpc_pollset_set* /*pollset*/) {}
 
-static void me_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
+static void me_shutdown(grpc_endpoint* ep, absl::Status why) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   gpr_mu_lock(&m->mu);
   if (m->on_read) {

--- a/test/core/util/port_server_client.cc
+++ b/test/core/util/port_server_client.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
 #include "src/core/lib/gprpp/orphanable.h"
@@ -63,14 +64,14 @@ typedef struct freereq {
   int done = 0;
 } freereq;
 
-static void destroy_pops_and_shutdown(void* p, grpc_error_handle /*error*/) {
+static void destroy_pops_and_shutdown(void* p, absl::Status /*error*/) {
   grpc_pollset* pollset =
       grpc_polling_entity_pollset(static_cast<grpc_polling_entity*>(p));
   grpc_pollset_destroy(pollset);
   gpr_free(pollset);
 }
 
-static void freed_port_from_server(void* arg, grpc_error_handle /*error*/) {
+static void freed_port_from_server(void* arg, absl::Status /*error*/) {
   freereq* pr = static_cast<freereq*>(arg);
   gpr_mu_lock(pr->mu);
   pr->done = 1;
@@ -146,7 +147,7 @@ typedef struct portreq {
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request;
 } portreq;
 
-static void got_port_from_server(void* arg, grpc_error_handle error) {
+static void got_port_from_server(void* arg, absl::Status error) {
   size_t i;
   int port = 0;
   portreq* pr = static_cast<portreq*>(arg);

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -523,11 +523,11 @@ class FixedAddressFactory : public LoadBalancingPolicyFactory {
 
   absl::StatusOr<RefCountedPtr<LoadBalancingPolicy::Config>>
   ParseLoadBalancingConfig(const Json& json) const override {
-    std::vector<grpc_error_handle> error_list;
+    std::vector<absl::Status> error_list;
     std::string address;
     ParseJsonObjectField(json.object_value(), "address", &address, &error_list);
     if (!error_list.empty()) {
-      grpc_error_handle error = GRPC_ERROR_CREATE_FROM_VECTOR(
+      absl::Status error = GRPC_ERROR_CREATE_FROM_VECTOR(
           "errors parsing fixed_address_lb config", &error_list);
       absl::Status status =
           absl::InvalidArgumentError(grpc_error_std_string(error));

--- a/test/core/util/test_tcp_server.cc
+++ b/test/core/util/test_tcp_server.cc
@@ -23,6 +23,8 @@
 
 #include <algorithm>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -42,7 +44,7 @@
 #include "src/core/lib/iomgr/tcp_server.h"
 #include "test/core/util/test_config.h"
 
-static void on_server_destroyed(void* data, grpc_error_handle /*error*/) {
+static void on_server_destroyed(void* data, absl::Status /*error*/) {
   test_tcp_server* server = static_cast<test_tcp_server*>(data);
   server->shutdown = true;
 }
@@ -76,7 +78,7 @@ void test_tcp_server_start(test_tcp_server* server, int port) {
   auto args = grpc_core::CoreConfiguration::Get()
                   .channel_args_preconditioning()
                   .PreconditionChannelArgs(nullptr);
-  grpc_error_handle error = grpc_tcp_server_create(
+  absl::Status error = grpc_tcp_server_create(
       &server->shutdown_complete,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
       &server->tcp_server);
@@ -102,8 +104,8 @@ void test_tcp_server_poll(test_tcp_server* server, int milliseconds) {
   gpr_mu_unlock(server->mu);
 }
 
-static void do_nothing(void* /*arg*/, grpc_error_handle /*error*/) {}
-static void finish_pollset(void* arg, grpc_error_handle /*error*/) {
+static void do_nothing(void* /*arg*/, absl::Status /*error*/) {}
+static void finish_pollset(void* arg, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(arg));
 }
 

--- a/test/core/xds/certificate_provider_store_test.cc
+++ b/test/core/xds/certificate_provider_store_test.cc
@@ -72,7 +72,7 @@ class FakeCertificateProviderFactory1 : public CertificateProviderFactory {
 
   RefCountedPtr<CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const Json& /*config_json*/,
-                                  grpc_error_handle* /*error*/) override {
+                                  absl::Status* /*error*/) override {
     return MakeRefCounted<Config>();
   }
 
@@ -95,7 +95,7 @@ class FakeCertificateProviderFactory2 : public CertificateProviderFactory {
 
   RefCountedPtr<CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const Json& /*config_json*/,
-                                  grpc_error_handle* /*error*/) override {
+                                  absl::Status* /*error*/) override {
     return MakeRefCounted<Config>();
   }
 

--- a/test/core/xds/file_watcher_certificate_provider_factory_test.cc
+++ b/test/core/xds/file_watcher_certificate_provider_factory_test.cc
@@ -25,6 +25,7 @@
 
 #include <grpc/grpc.h>
 
+#include "src/core/lib/iomgr/error.h"
 #include "test/core/util/test_config.h"
 
 namespace grpc_core {
@@ -47,7 +48,7 @@ TEST(FileWatcherConfigTest, Basic) {
       kIdentityCertFile, kPrivateKeyFile, kRootCertFile, kRefreshInterval);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
@@ -67,7 +68,7 @@ TEST(FileWatcherConfigTest, DefaultRefreshInterval) {
       kIdentityCertFile, kPrivateKeyFile, kRootCertFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
@@ -85,7 +86,7 @@ TEST(FileWatcherConfigTest, OnlyRootCertificatesFileProvided) {
       kRootCertFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
@@ -104,7 +105,7 @@ TEST(FileWatcherConfigTest, OnlyIdenityCertificatesAndPrivateKeyProvided) {
       kIdentityCertFile, kPrivateKeyFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
@@ -124,7 +125,7 @@ TEST(FileWatcherConfigTest, WrongTypes) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -146,7 +147,7 @@ TEST(FileWatcherConfigTest, IdentityCertProvidedButPrivateKeyMissing) {
       kIdentityCertFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -164,7 +165,7 @@ TEST(FileWatcherConfigTest, PrivateKeyProvidedButIdentityCertMissing) {
       kPrivateKeyFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -178,7 +179,7 @@ TEST(FileWatcherConfigTest, EmptyJsonObject) {
   std::string json_str = absl::StrFormat("{}");
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(

--- a/test/core/xds/google_mesh_ca_certificate_provider_factory_test.cc
+++ b/test/core/xds/google_mesh_ca_certificate_provider_factory_test.cc
@@ -71,7 +71,7 @@ TEST(GoogleMeshCaConfigTest, Basic) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
@@ -124,7 +124,7 @@ TEST(GoogleMeshCaConfigTest, Defaults) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
@@ -176,7 +176,7 @@ TEST(GoogleMeshCaConfigTest, WrongExpectedValues) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -219,7 +219,7 @@ TEST(GoogleMeshCaConfigTest, WrongTypes) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -263,7 +263,7 @@ TEST(GoogleMeshCaConfigTest, GrpcServicesNotAnArray) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -288,7 +288,7 @@ TEST(GoogleMeshCaConfigTest, GoogleGrpcNotAnObject) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -315,7 +315,7 @@ TEST(GoogleMeshCaConfigTest, CallCredentialsNotAnArray) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -344,7 +344,7 @@ TEST(GoogleMeshCaConfigTest, StsServiceNotAnObject) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  absl::Status error = GRPC_ERROR_NONE;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -568,8 +568,8 @@ class FakeCertificateProviderFactory : public CertificateProviderFactory {
 
   RefCountedPtr<CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const Json& config_json,
-                                  grpc_error_handle* error) override {
-    std::vector<grpc_error_handle> error_list;
+                                  absl::Status* error) override {
+    std::vector<absl::Status> error_list;
     EXPECT_EQ(config_json.type(), Json::Type::OBJECT);
     auto it = config_json.object_value().find("value");
     if (it == config_json.object_value().end()) {

--- a/test/core/xds/xds_certificate_provider_test.cc
+++ b/test/core/xds/xds_certificate_provider_test.cc
@@ -74,8 +74,8 @@ class TestCertificatesWatcher
     }
   }
 
-  void OnError(grpc_error_handle root_cert_error,
-               grpc_error_handle identity_cert_error) override {
+  void OnError(absl::Status root_cert_error,
+               absl::Status identity_cert_error) override {
     GRPC_ERROR_UNREF(root_cert_error_);
     root_cert_error_ = root_cert_error;
     GRPC_ERROR_UNREF(identity_cert_error_);
@@ -88,15 +88,15 @@ class TestCertificatesWatcher
     return key_cert_pairs_;
   }
 
-  grpc_error_handle root_cert_error() const { return root_cert_error_; }
+  absl::Status root_cert_error() const { return root_cert_error_; }
 
-  grpc_error_handle identity_cert_error() const { return identity_cert_error_; }
+  absl::Status identity_cert_error() const { return identity_cert_error_; }
 
  private:
   absl::optional<std::string> root_certs_;
   absl::optional<PemKeyCertPairList> key_cert_pairs_;
-  grpc_error_handle root_cert_error_ = GRPC_ERROR_NONE;
-  grpc_error_handle identity_cert_error_ = GRPC_ERROR_NONE;
+  absl::Status root_cert_error_ = GRPC_ERROR_NONE;
+  absl::Status identity_cert_error_ = GRPC_ERROR_NONE;
 };
 
 TEST(

--- a/test/cpp/common/channel_filter_test.cc
+++ b/test/cpp/common/channel_filter_test.cc
@@ -29,8 +29,8 @@ class MyChannelData : public ChannelData {
  public:
   MyChannelData() {}
 
-  grpc_error_handle Init(grpc_channel_element* /*elem*/,
-                         grpc_channel_element_args* args) override {
+  absl::Status Init(grpc_channel_element* /*elem*/,
+                    grpc_channel_element_args* args) override {
     (void)args->channel_args;  // Make sure field is available.
     return GRPC_ERROR_NONE;
   }
@@ -40,8 +40,8 @@ class MyCallData : public CallData {
  public:
   MyCallData() {}
 
-  grpc_error_handle Init(grpc_call_element* /*elem*/,
-                         const grpc_call_element_args* args) override {
+  absl::Status Init(grpc_call_element* /*elem*/,
+                    const grpc_call_element_args* args) override {
     (void)args->path;  // Make sure field is available.
     return GRPC_ERROR_NONE;
   }

--- a/test/cpp/common/time_jump_test.cc
+++ b/test/cpp/common/time_jump_test.cc
@@ -93,7 +93,7 @@ TEST_P(TimeJumpTest, TimerRunning) {
   grpc_timer_init(&timer,
                   grpc_core::Timestamp::Now() + grpc_core::Duration::Seconds(3),
                   GRPC_CLOSURE_CREATE(
-                      [](void*, grpc_error_handle error) {
+                      [](void*, absl::Status error) {
                         GPR_ASSERT(error == GRPC_ERROR_CANCELLED);
                       },
                       nullptr, grpc_schedule_on_exec_ctx));

--- a/test/cpp/common/timer_test.cc
+++ b/test/cpp/common/timer_test.cc
@@ -89,7 +89,7 @@ TEST_F(TimerTest, OneTimerExpires) {
       &timer,
       grpc_core::Timestamp::Now() + grpc_core::Duration::Milliseconds(500),
       GRPC_CLOSURE_CREATE(
-          [](void* arg, grpc_error_handle) {
+          [](void* arg, absl::Status) {
             int* timer_fired = static_cast<int*>(arg);
             ++*timer_fired;
           },
@@ -117,7 +117,7 @@ TEST_F(TimerTest, MultipleTimersExpire) {
                         grpc_core::Duration::Milliseconds(500) +
                         grpc_core::Duration::Milliseconds(i),
                     GRPC_CLOSURE_CREATE(
-                        [](void* arg, grpc_error_handle) {
+                        [](void* arg, absl::Status) {
                           int* timer_fired = static_cast<int*>(arg);
                           ++*timer_fired;
                         },
@@ -152,7 +152,7 @@ TEST_F(TimerTest, CancelSomeTimers) {
                                   : grpc_core ::Duration::Milliseconds(100) +
                                         grpc_core::Duration::Milliseconds(i)),
         GRPC_CLOSURE_CREATE(
-            [](void* arg, grpc_error_handle error) {
+            [](void* arg, absl::Status error) {
               if (error == GRPC_ERROR_CANCELLED) {
                 return;
               }
@@ -184,7 +184,7 @@ TEST_F(TimerTest, DISABLED_TimerNotCanceled) {
   grpc_timer timer;
   grpc_timer_init(
       &timer, grpc_core::Timestamp::Now() + grpc_core::Duration::Seconds(10),
-      GRPC_CLOSURE_CREATE([](void*, grpc_error_handle) {}, nullptr,
+      GRPC_CLOSURE_CREATE([](void*, absl::Status) {}, nullptr,
                           grpc_schedule_on_exec_ctx));
 }
 
@@ -201,7 +201,7 @@ TEST_F(TimerTest, DISABLED_CancelRace) {
         &timers[i],
         grpc_core::Timestamp::Now() + grpc_core::Duration::Milliseconds(100),
         GRPC_CLOSURE_CREATE(
-            [](void* arg, grpc_error_handle /*error*/) {
+            [](void* arg, absl::Status /*error*/) {
               grpc_timer* timer = static_cast<grpc_timer*>(arg);
               if (timer) {
                 grpc_timer_cancel(timer);
@@ -233,7 +233,7 @@ TEST_F(TimerTest, DISABLED_CancelNextTimer) {
         &timers[i],
         grpc_core::Timestamp::Now() + grpc_core::Duration::Milliseconds(100),
         GRPC_CLOSURE_CREATE(
-            [](void* arg, grpc_error_handle /*error*/) {
+            [](void* arg, absl::Status /*error*/) {
               grpc_timer* timer = static_cast<grpc_timer*>(arg);
               if (timer) {
                 grpc_timer_cancel(timer);

--- a/test/cpp/end2end/connection_attempt_injector.cc
+++ b/test/cpp/end2end/connection_attempt_injector.cc
@@ -176,7 +176,7 @@ void ConnectionAttemptInjector::QueuedAttempt::Resume() {
   closure_ = nullptr;
 }
 
-void ConnectionAttemptInjector::QueuedAttempt::Fail(grpc_error_handle error) {
+void ConnectionAttemptInjector::QueuedAttempt::Fail(absl::Status error) {
   GPR_ASSERT(closure_ != nullptr);
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure_, error);
   closure_ = nullptr;
@@ -198,7 +198,7 @@ ConnectionAttemptInjector::InjectedDelay::InjectedDelay(
 }
 
 void ConnectionAttemptInjector::InjectedDelay::TimerCallback(
-    void* arg, grpc_error_handle /*error*/) {
+    void* arg, absl::Status /*error*/) {
   auto* self = static_cast<InjectedDelay*>(arg);
   self->attempt_.Resume();
   delete self;
@@ -234,7 +234,7 @@ void ConnectionAttemptInjector::Hold::Resume() {
   attempt->Resume();
 }
 
-void ConnectionAttemptInjector::Hold::Fail(grpc_error_handle error) {
+void ConnectionAttemptInjector::Hold::Fail(absl::Status error) {
   gpr_log(GPR_INFO, "=== FAILING CONNECTION ATTEMPT ON PORT %d ===", port_);
   grpc_core::ExecCtx exec_ctx;
   std::unique_ptr<QueuedAttempt> attempt;
@@ -261,7 +261,7 @@ bool ConnectionAttemptInjector::Hold::IsStarted() {
 }
 
 void ConnectionAttemptInjector::Hold::OnComplete(void* arg,
-                                                 grpc_error_handle error) {
+                                                 absl::Status error) {
   auto* self = static_cast<Hold*>(arg);
   grpc_closure* on_complete;
   {

--- a/test/cpp/end2end/connection_attempt_injector.h
+++ b/test/cpp/end2end/connection_attempt_injector.h
@@ -70,7 +70,7 @@ class ConnectionAttemptInjector final {
     void Resume();
 
     // Fails a connection attempt.  Must be called after Wait().
-    void Fail(grpc_error_handle error);
+    void Fail(absl::Status error);
 
     // If the hold was created with intercept_completion=true, then this
     // can be called after Resume() to wait for the connection attempt
@@ -83,7 +83,7 @@ class ConnectionAttemptInjector final {
    private:
     friend class ConnectionAttemptInjector;
 
-    static void OnComplete(void* arg, grpc_error_handle error);
+    static void OnComplete(void* arg, absl::Status error);
 
     ConnectionAttemptInjector* injector_;
     const int port_;
@@ -132,7 +132,7 @@ class ConnectionAttemptInjector final {
     void Resume();
 
     // Caller must invoke this from a thread with an ExecCtx.
-    void Fail(grpc_error_handle error);
+    void Fail(absl::Status error);
 
    private:
     grpc_closure* closure_;
@@ -155,7 +155,7 @@ class ConnectionAttemptInjector final {
                   grpc_core::Timestamp deadline);
 
    private:
-    static void TimerCallback(void* arg, grpc_error_handle /*error*/);
+    static void TimerCallback(void* arg, absl::Status /*error*/);
 
     QueuedAttempt attempt_;
     grpc_timer timer_;

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -101,8 +101,8 @@ int GetCallCounterValue() {
 
 class ChannelDataImpl : public ChannelData {
  public:
-  grpc_error_handle Init(grpc_channel_element* /*elem*/,
-                         grpc_channel_element_args* /*args*/) override {
+  absl::Status Init(grpc_channel_element* /*elem*/,
+                    grpc_channel_element_args* /*args*/) override {
     IncrementConnectionCounter();
     return GRPC_ERROR_NONE;
   }

--- a/test/cpp/end2end/port_sharing_end2end_test.cc
+++ b/test/cpp/end2end/port_sharing_end2end_test.cc
@@ -148,7 +148,7 @@ class TestTcpServer {
     self->OnConnect(tcp, accepting_pollset, acceptor);
   }
 
-  static void OnFdReleased(void* arg, grpc_error_handle err) {
+  static void OnFdReleased(void* arg, absl::Status err) {
     auto* self = static_cast<TestTcpServer*>(arg);
     self->OnFdReleased(err);
   }
@@ -165,7 +165,7 @@ class TestTcpServer {
     grpc_tcp_destroy_and_release_fd(tcp, &fd_, &on_fd_released_);
   }
 
-  void OnFdReleased(grpc_error_handle err) {
+  void OnFdReleased(absl::Status err) {
     EXPECT_EQ(GRPC_ERROR_NONE, err);
     experimental::ExternalConnectionAcceptor::NewConnectionParameters p;
     p.listener_fd = listener_fd_;

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -173,9 +173,8 @@ class FakeCertificateProvider final : public grpc_tls_certificate_provider {
       if (!root_being_watched && !identity_being_watched) return;
       auto it = cert_data_map_.find(cert_name);
       if (it == cert_data_map_.end()) {
-        grpc_error_handle error =
-            GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
-                "No certificates available for cert_name \"", cert_name, "\""));
+        absl::Status error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+            "No certificates available for cert_name \"", cert_name, "\""));
         distributor_->SetErrorForCert(cert_name, GRPC_ERROR_REF(error),
                                       GRPC_ERROR_REF(error));
         GRPC_ERROR_UNREF(error);
@@ -245,7 +244,7 @@ class FakeCertificateProviderFactory
 
   grpc_core::RefCountedPtr<grpc_core::CertificateProviderFactory::Config>
   CreateCertificateProviderConfig(const grpc_core::Json& /*config_json*/,
-                                  grpc_error_handle* /*error*/) override {
+                                  absl::Status* /*error*/) override {
     return grpc_core::MakeRefCounted<Config>(name_);
   }
 

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -324,11 +324,9 @@ static void BM_LameChannelCallCreateCoreSeparateBatch(benchmark::State& state) {
 }
 BENCHMARK(BM_LameChannelCallCreateCoreSeparateBatch);
 
-static void FilterDestroy(void* arg, grpc_error_handle /*error*/) {
-  gpr_free(arg);
-}
+static void FilterDestroy(void* arg, absl::Status /*error*/) { gpr_free(arg); }
 
-static void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+static void DoNothing(void* /*arg*/, absl::Status /*error*/) {}
 
 class FakeClientChannelFactory : public grpc_core::ClientChannelFactory {
  public:
@@ -358,8 +356,8 @@ static void StartTransportStreamOp(grpc_call_element* /*elem*/,
 static void StartTransportOp(grpc_channel_element* /*elem*/,
                              grpc_transport_op* /*op*/) {}
 
-static grpc_error_handle InitCallElem(grpc_call_element* /*elem*/,
-                                      const grpc_call_element_args* /*args*/) {
+static absl::Status InitCallElem(grpc_call_element* /*elem*/,
+                                 const grpc_call_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
@@ -370,8 +368,8 @@ static void DestroyCallElem(grpc_call_element* /*elem*/,
                             const grpc_call_final_info* /*final_info*/,
                             grpc_closure* /*then_sched_closure*/) {}
 
-grpc_error_handle InitChannelElem(grpc_channel_element* /*elem*/,
-                                  grpc_channel_element_args* /*args*/) {
+absl::Status InitChannelElem(grpc_channel_element* /*elem*/,
+                             grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 
@@ -666,8 +664,8 @@ static void StartTransportOp(grpc_channel_element* /*elem*/,
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
 }
 
-static grpc_error_handle InitCallElem(grpc_call_element* elem,
-                                      const grpc_call_element_args* args) {
+static absl::Status InitCallElem(grpc_call_element* elem,
+                                 const grpc_call_element_args* args) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->call_combiner = args->call_combiner;
   return GRPC_ERROR_NONE;
@@ -682,8 +680,8 @@ static void DestroyCallElem(grpc_call_element* /*elem*/,
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, then_sched_closure, GRPC_ERROR_NONE);
 }
 
-grpc_error_handle InitChannelElem(grpc_channel_element* /*elem*/,
-                                  grpc_channel_element_args* /*args*/) {
+absl::Status InitChannelElem(grpc_channel_element* /*elem*/,
+                             grpc_channel_element_args* /*args*/) {
   return GRPC_ERROR_NONE;
 }
 

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -52,7 +52,7 @@ static void BM_WellFlushed(benchmark::State& state) {
 }
 BENCHMARK(BM_WellFlushed);
 
-static void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+static void DoNothing(void* /*arg*/, absl::Status /*error*/) {}
 
 static void BM_ClosureInitAgainstExecCtx(benchmark::State& state) {
   TrackCounters track_counters;
@@ -370,7 +370,7 @@ class Rescheduler {
   benchmark::State& state_;
   grpc_closure closure_;
 
-  static void Step(void* arg, grpc_error_handle /*error*/) {
+  static void Step(void* arg, absl::Status /*error*/) {
     Rescheduler* self = static_cast<Rescheduler*>(arg);
     if (self->state_.KeepRunning()) {
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, &self->closure_, GRPC_ERROR_NONE);

--- a/test/cpp/microbenchmarks/bm_pollset.cc
+++ b/test/cpp/microbenchmarks/bm_pollset.cc
@@ -42,7 +42,7 @@
 #include <unistd.h>
 #endif
 
-static void shutdown_ps(void* ps, grpc_error_handle /*error*/) {
+static void shutdown_ps(void* ps, absl::Status /*error*/) {
   grpc_pollset_destroy(static_cast<grpc_pollset*>(ps));
 }
 
@@ -169,7 +169,7 @@ template <class F>
 TestClosure* MakeTestClosure(F f) {
   struct C : public TestClosure {
     explicit C(F f) : f_(f) { GRPC_CLOSURE_INIT(this, C::cbfn, this, nullptr); }
-    static void cbfn(void* arg, grpc_error_handle /*error*/) {
+    static void cbfn(void* arg, absl::Status /*error*/) {
       C* p = static_cast<C*>(arg);
       p->f_();
     }

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -102,7 +102,7 @@ void ArgsInit(ArgsStruct* args) {
   args->channel_args = nullptr;
 }
 
-void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+void DoNothing(void* /*arg*/, absl::Status /*error*/) {}
 
 void ArgsFinish(ArgsStruct* args) {
   grpc_pollset_set_del_pollset(args->pollset_set, args->pollset);

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -215,7 +215,7 @@ void ArgsInit(ArgsStruct* args) {
   args->channel_args = nullptr;
 }
 
-void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
+void DoNothing(void* /*arg*/, absl::Status /*error*/) {}
 
 void ArgsFinish(ArgsStruct* args) {
   GPR_ASSERT(gpr_event_wait(&args->ev, TestDeadline()));


### PR DESCRIPTION
Replacing `grpc_error_handle` with `absl::Status`. (This is the first step of https://github.com/grpc/grpc/pull/30325 to avoid merge conflict)