### PR TITLE
[iomgr] Reduce the size of combiner_test

### DIFF
--- a/test/core/iomgr/combiner_test.cc
+++ b/test/core/iomgr/combiner_test.cc
@@ -96,7 +96,7 @@ TEST(CombinerTest, TestExecuteMany) {
   gpr_log(GPR_DEBUG, "test_execute_many");
 
   grpc_core::Combiner* lock = grpc_combiner_create();
-  grpc_core::Thread thds[100];
+  grpc_core::Thread thds[10];
   thd_args ta[GPR_ARRAY_SIZE(thds)];
   for (size_t i = 0; i < GPR_ARRAY_SIZE(thds); i++) {
     ta[i].ctr = 0;


### PR DESCRIPTION
100 threads is probably excessive and we're seeing OOMs...

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

