### PR TITLE
Adjust slice buffer build target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2158,12 +2158,14 @@ grpc_cc_library(
     name = "slice_buffer",
     srcs = [
         "src/core/lib/slice/slice_buffer.cc",
+        "src/core/lib/slice/slice_buffer_api.cc",
     ],
     hdrs = [
         "include/grpc/slice_buffer.h",
         "src/core/lib/slice/slice_buffer.h",
     ],
     deps = [
+        "exec_ctx",
         "gpr",
         "slice",
         "slice_refcount",


### PR DESCRIPTION
This change enables some internal cleanup and avoids having to depend on whole of grpc to get definitions of functions defined in src/core/lib/slice/slice_buffer_api.cc
