### PR TITLE
Build with System OpenSSL on Mac OS arm64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,17 +133,20 @@ BUILD_OVERRIDE_BORING_SSL_ASM_PLATFORM = os.environ.get(
 # present, then it will still attempt to use Cython.
 BUILD_WITH_CYTHON = _env_bool_value('GRPC_PYTHON_BUILD_WITH_CYTHON', 'False')
 
+# Currently, boringssl does not support macOS arm64, so we try to use the system
+# installation of openssl to build gRPC locally by default.
+if "darwin" in sys.platform and "arm64" == platform.machine().lower():
+    sys.stderr.write("Boringssl currently does not support macOS arm64, so we'll try to use the system installation "
+                     "of 'openssl' to build by default, make sure you have 'openssl' installed in this case\n")
+    BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV = "True"
+else:
+    BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV = "False"
+
 # Export this variable to use the system installation of openssl. You need to
 # have the header files installed (in /usr/include/openssl) and during
 # runtime, the shared library must be installed
 BUILD_WITH_SYSTEM_OPENSSL = _env_bool_value('GRPC_PYTHON_BUILD_SYSTEM_OPENSSL',
-                                            'False')
-# Currently, boringssl does not support macOS arm64, so we MUST try to use the system
-# installation of openssl to build gRPC locally.
-if "darwin" in sys.platform and "arm64" == platform.machine().lower():
-    sys.stderr.write("Boringssl currently does not support macOS arm64, so we'll try to use the system "
-                     "installation of 'openssl' to build, make sure you have 'openssl' installed\n")
-    BUILD_WITH_SYSTEM_OPENSSL = True
+                                            BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV)
 
 # Export this variable to use the system installation of zlib. You need to
 # have the header files installed (in /usr/include/) and during

--- a/setup.py
+++ b/setup.py
@@ -136,8 +136,10 @@ BUILD_WITH_CYTHON = _env_bool_value('GRPC_PYTHON_BUILD_WITH_CYTHON', 'False')
 # Currently, boringssl does not support macOS arm64, so we try to use the system
 # installation of openssl to build gRPC locally by default.
 if "darwin" in sys.platform and "arm64" == platform.machine().lower():
-    sys.stderr.write("Boringssl currently does not support macOS arm64, so we'll try to use the system installation "
-                     "of 'openssl' to build by default, make sure you have 'openssl' installed in this case\n")
+    sys.stderr.write(
+        "Boringssl currently does not support macOS arm64, so we'll try to use the system installation "
+        "of 'openssl' to build by default, make sure you have 'openssl' installed in this case\n"
+    )
     BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV = "True"
 else:
     BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV = "False"
@@ -145,8 +147,8 @@ else:
 # Export this variable to use the system installation of openssl. You need to
 # have the header files installed (in /usr/include/openssl) and during
 # runtime, the shared library must be installed
-BUILD_WITH_SYSTEM_OPENSSL = _env_bool_value('GRPC_PYTHON_BUILD_SYSTEM_OPENSSL',
-                                            BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV)
+BUILD_WITH_SYSTEM_OPENSSL = _env_bool_value(
+    'GRPC_PYTHON_BUILD_SYSTEM_OPENSSL', BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV)
 
 # Export this variable to use the system installation of zlib. You need to
 # have the header files installed (in /usr/include/) and during

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,12 @@ BUILD_WITH_CYTHON = _env_bool_value('GRPC_PYTHON_BUILD_WITH_CYTHON', 'False')
 # runtime, the shared library must be installed
 BUILD_WITH_SYSTEM_OPENSSL = _env_bool_value('GRPC_PYTHON_BUILD_SYSTEM_OPENSSL',
                                             'False')
+# Currently, boringssl does not support macOS arm64, so we MUST try to use the system
+# installation of openssl to build gRPC locally.
+if "darwin" in sys.platform and "arm64" == platform.machine().lower():
+    sys.stderr.write("Boringssl currently does not support macOS arm64, so we'll try to use the system "
+                     "installation of 'openssl' to build, make sure you have 'openssl' installed\n")
+    BUILD_WITH_SYSTEM_OPENSSL = True
 
 # Export this variable to use the system installation of zlib. You need to
 # have the header files installed (in /usr/include/) and during


### PR DESCRIPTION
Boringssl currently does not support macOS arm64, so installation on these platform with default config will undoubtedly fail. That means the env var 'GRPC_PYTHON_BUILD_SYSTEM_OPENSSL' must be set to true, but `GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1` mentioned in this issue https://github.com/grpc/grpc/issues/25082, I think it ain't necessary, because:

1. zlib support build on macOS arm64, see https://github.com/madler/zlib/issues/559
2. I successfully built gRPC after uninstall system zlib (and not set `GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1`

I don't know when will grpc provide python wheel for macOS arm64, but at least I think installing grpcio from source by default should be not failed.

@gnossen 
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

