### PR TITLE
[flake] Reorder client/server shutdown

### DIFF
--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -81,8 +81,8 @@ static void shutdown_client(grpc_end2end_test_fixture* f) {
 }
 
 static void end_test(grpc_end2end_test_fixture* f) {
-  shutdown_server(f);
   shutdown_client(f);
+  shutdown_server(f);
 
   grpc_completion_queue_shutdown(f->cq);
   drain_cq(f->cq);


### PR DESCRIPTION
This test ends up relying on goaways to shutdown the client connection, but doesn't have a poller on the client connection, which means it's up to the backup poller and sometimes that doesn't kick in in time. Reorder client and server shutdown to make that instantaneous.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

