### PR TITLE
Update install_all_python_modules.sh to account for new packages

### DIFF
--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -18,7 +18,9 @@
 echo "It's recommended that you run this script from a virtual environment."
 
 function maybe_run_command () {
-  { python setup.py --help-commands | grep "$1" &>/dev/null  && python setup.py "$1"; } || true
+  if python setup.py --help-commands | grep "$1" &>/dev/null; then
+    python setup.py "$1";
+  fi
 }
 
 set -e

--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Integrate this into CI to avoid bitrot.
+
 echo "It's recommended that you run this script from a virtual environment."
+
+function maybe_run_command () {
+  { python setup.py --help-commands | grep "$1" &>/dev/null  && python setup.py "$1"; } || true
+}
 
 set -e
 
 BASEDIR=$(dirname "$0")
 BASEDIR=$(realpath "$BASEDIR")/../..
+
+PACKAGES="grpcio_channelz  grpcio_csds  grpcio_admin grpcio_health_checking  grpcio_reflection  grpcio_status  grpcio_testing  grpcio_tests"
 
 (cd "$BASEDIR";
   pip install --upgrade cython;
@@ -28,9 +36,11 @@ BASEDIR=$(realpath "$BASEDIR")/../..
     GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
   popd;
   pushd src/python;
-    for PACKAGE in ./grpcio_*; do
+    for PACKAGE in ${PACKAGES}; do
       pushd "${PACKAGE}";
-        python setup.py preprocess;
+        python setup.py clean;
+        maybe_run_command preprocess
+        maybe_run_command build_package_protos
         python setup.py install;
       popd;
     done


### PR DESCRIPTION
The script bitrotted when new packages were added in:

1. There is now an ordering dependency between the packages that must be enforced by a topological dependency ordering.
2. Not all packages have either the `preprocess` or the `build_package_protos` command, so these must be run conditionally.

Ultimately, we'll want to integrate this into CI somehow to keep the bitrot from happening. But that's a battle for another day.
