### PR TITLE
[gprpp] Per-cpu data structure

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3095,6 +3095,17 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "per_cpu",
+    hdrs = [
+        "src/core/lib/gprpp/per_cpu.h",
+    ],
+    deps = [
+        "exec_ctx",
+        "gpr",
+    ],
+)
+
+grpc_cc_library(
     name = "grpc_base",
     srcs = [
         "src/core/lib/address_utils/parse_address.cc",

--- a/src/core/lib/gprpp/per_cpu.h
+++ b/src/core/lib/gprpp/per_cpu.h
@@ -1,0 +1,46 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_CORE_LIB_GPRPP_PER_CPU_H
+#define GRPC_CORE_LIB_GPRPP_PER_CPU_H
+
+#include <grpc/support/port_platform.h>
+
+#include <cstddef>
+#include <memory>
+
+#include <grpc/support/cpu.h>
+
+#include "src/core/lib/iomgr/exec_ctx.h"
+
+namespace grpc_core {
+
+template <typename T>
+class PerCpu {
+ public:
+  T& this_cpu() { return data_[ExecCtx::Get()->starting_cpu()]; }
+
+  T* begin() { return data_.get(); }
+  T* end() { return data_.get() + cpus_; }
+  const T* begin() const { return data_.get(); }
+  const T* end() const { return data_.get() + cpus_; }
+
+ private:
+  const size_t cpus_ = gpr_cpu_num_cores();
+  std::unique_ptr<T[]> data_{new T[cpus_]};
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_CORE_LIB_GPRPP_PER_CPU_H


### PR DESCRIPTION
Add a helper type that tracks one copy of a data structure per cpu - I've been using this in #30936 and it's working out nicely, would like to use it in a few other projects - so sending out for review separately.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

