### PR TITLE
Update xds-protos package to pull in protobuf 4.X

### DIFF
--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -32,13 +32,13 @@ CLASSIFIERS = [
     'License :: OSI Approved :: Apache Software License',
 ]
 INSTALL_REQUIRES = [
-    'grpcio',
-    'protobuf',
+    'grpcio>=1.49.0',
+    'protobuf>=4.21.6,<5.0dev',
 ]
 SETUP_REQUIRES = INSTALL_REQUIRES + ['grpcio-tools']
 setuptools.setup(
     name='xds-protos',
-    version='0.0.11',
+    version='0.0.12',
     packages=PACKAGES,
     description='Generated Python code from envoyproxy/data-plane-api',
     long_description_content_type='text/x-rst',
@@ -47,7 +47,7 @@ setuptools.setup(
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',
     license='Apache License 2.0',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     install_requires=INSTALL_REQUIRES,
     setup_requires=SETUP_REQUIRES,
     classifiers=CLASSIFIERS)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/31064

If someone runs `pip install grpcio-csds` right now, they'll get

```
grpcio-csds==1.49.1
grpcio==1.49.1
xds-protos=0.0.11
protobuf==4.21.6
```

This combination does not work together because `xds-protos` 0.0.11 packages 3.X protobuf generated code.

The obvious fix here is to push an `xds-protos==0.0.12` with 4.X generated protos and with `protobuf~=4.0.0` range. How will this work for people who for whatever reason need to stick with old protos. At the top level, they'll have

```
grpcio-csds
protobuf~=3.0.0
```

This will give them

- `protobuf==3.20.2` (since it's the latest compatible with `protobuf~=3.0.0`)
- `grpcio-csds==1.48.2` (since it's the latest compatible with `protobuf==3.20.2`)
- `grpcio==1.48.2` (since it's the only compatible with `grpcio-csds==1.48.2`)
- `xds-protos==0.0.11` (since it's the latest compatible with `protobuf==3.20.2`)

So this should solve our problem. No backports needed.

Going forward though, we really need to do an atomic release containing both the new csds and the new xds-protos. We should probably just release one per grpcio version.

This did not fail in CI because the `grpcio-csds` tests were not properly set up to run with the `setup.py` test runner. I have a separate PR to correct that issue.