### PR TITLE
Update comment on GRPC_ARG_TSI_MAX_FRAME_SIZE

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -281,11 +281,7 @@ typedef struct {
 #define GRPC_SSL_SESSION_CACHE_ARG "grpc.ssl_session_cache"
 /** If non-zero, it will determine the maximum frame size used by TSI's frame
  *  protector.
- *
- *  NOTE: Be aware that using a large "max_frame_size" is memory inefficient
- *        for non-zerocopy protectors. Also, increasing this value above 1MiB
- *        can break old binaries that don't support larger than 1MiB frame
- *        size. */
+ */
 #define GRPC_ARG_TSI_MAX_FRAME_SIZE "grpc.tsi.max_frame_size"
 /** Maximum metadata size, in bytes. Note this limit applies to the max sum of
     all metadata key-value entries in a batch of headers. */


### PR DESCRIPTION
This comment was added before frame size negotiation.

With frame size negotiation we can have a larger value for max frame size. Negotiation takes into consideration old binaries and non-zerocopy protectors like gRPC Go, and makes sure to agree on a maximum frame size value that is acceptable at both endpoints.

