### PR TITLE
Upgrade gevent version in bazel requirement

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -14,7 +14,7 @@ chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
 googleapis-common-protos==1.5.5
-gevent==21.1.2
+gevent==21.12.0
 zope.event==4.5.0
 setuptools==44.1.1
 xds-protos==0.0.11


### PR DESCRIPTION
Some unit tests are failing in python3.10 environment (eg: `//src/python/grpcio_tests/tests_aio/unit:channel_test`) because current gevent version is not compatible with python3.10, this change upgrade gevent to 21.12.0 to fix this.

## Testing
- The above mentioned unit test passed with gevent 21.12.0.
- Existing Kokoro tests are all passing.
