### PR TITLE
[HTTP Proxy] Support CIDR blocks in `no_proxy` config

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2822,6 +2822,7 @@ grpc_cc_library(
         "http_connect_handshaker",
         "iomgr_timer",
         "orphanable",
+        "parse_address",
         "protobuf_duration_upb",
         "ref_counted_ptr",
         "server_address",

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -63,9 +63,9 @@ bool ServerInCIDRRange(absl::string_view server_host,
   if (!server_address.ok()) {
     return false;
   }
-
   std::pair<absl::string_view, absl::string_view> possible_cidr =
-    absl::StrSplit(no_proxy_entry, absl::MaxSplits('/', 2));
+      absl::StrSplit(no_proxy_entry, absl::MaxSplits('/', 2),
+                     absl::SkipEmpty());
   if (possible_cidr.first.empty() || possible_cidr.second.empty()) {
     return false;
   }

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/status/status.h"

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -20,6 +20,7 @@
 
 #include "src/core/ext/filters/client_channel/http_proxy.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #include <memory>
@@ -30,6 +31,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/match.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
@@ -55,12 +57,14 @@
 namespace grpc_core {
 namespace {
 
-static bool ServerInCIDRRange(std::string server_host, absl::string_view no_proxy_entry) {
+bool ServerInCIDRRange(std::string server_host,
+                       absl::string_view no_proxy_entry) {
   auto server_address = StringToSockaddr(server_host, 0);
   if (!server_address.ok()) {
     return false;
   }
-  std::vector<absl::string_view> cidr = absl::StrSplit(no_proxy_entry, '/', absl::SkipEmpty());
+  std::vector<absl::string_view> cidr =
+      absl::StrSplit(no_proxy_entry, '/', absl::SkipEmpty());
   if (cidr.size() != 2) {
     return false;
   }
@@ -71,7 +75,8 @@ static bool ServerInCIDRRange(std::string server_host, absl::string_view no_prox
   uint32_t mask_bits = 0;
   if (absl::SimpleAtoi(cidr[1], &mask_bits)) {
     grpc_sockaddr_mask_bits(&*proxy_address, mask_bits);
-    return grpc_sockaddr_match_subnet(&*server_address, &*proxy_address, mask_bits);
+    return grpc_sockaddr_match_subnet(&*server_address, &*proxy_address,
+                                      mask_bits);
   }
   return false;
 }

--- a/test/core/client_channel/http_proxy_mapper_test.cc
+++ b/test/core/client_channel/http_proxy_mapper_test.cc
@@ -70,6 +70,105 @@ TEST(NoProxyTest, EmptyEntries) {
   EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
 }
 
+// Test entries with CIDR blocks (Class A) in 'no_proxy' list.
+TEST(NoProxyTest, CIDRClassAEntries) {
+  ScopedSetEnv no_proxy("foo.com,192.168.0.255/8");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  // address matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.0.1.1:443", &args),
+            absl::nullopt);
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
+  // address not matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///193.0.1.1:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "193.0.1.1:443");
+}
+
+// Test entries with CIDR blocks (Class B) in 'no_proxy' list.
+TEST(NoProxyTest, CIDRClassBEntries) {
+  ScopedSetEnv no_proxy("foo.com,192.168.0.255/16");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  // address matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.5:443", &args),
+            absl::nullopt);
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
+  // address not matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.169.1.1:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "192.169.1.1:443");
+}
+
+// Test entries with CIDR blocks (Class C) in 'no_proxy' list.
+TEST(NoProxyTest, CIDRClassCEntries) {
+  ScopedSetEnv no_proxy("foo.com,192.168.0.255/24");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  // address matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.0.5:443", &args),
+            absl::nullopt);
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
+  // address not matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.1:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "192.168.1.1:443");
+}
+
+// Test entries with CIDR blocks (exact match) in 'no_proxy' list.
+TEST(NoProxyTest, CIDREntriesExactMatch) {
+  ScopedSetEnv no_proxy("foo.com,192.168.0.4/32");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  // address matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.0.4:443", &args),
+            absl::nullopt);
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
+  // address not matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.0.5:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "192.168.0.5:443");
+}
+
+// Test entries with IPv6 CIDR blocks in 'no_proxy' list.
+TEST(NoProxyTest, CIDREntriesIPv6ExactMatch) {
+  ScopedSetEnv no_proxy("foo.com,2002:db8:a::45/64");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  // address matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///[2002:0db8:000a:0000:0000:0000:0000:0001]:443", &args),
+            absl::nullopt);
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
+  // address not matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///[2003:0db8:000a:0000:0000:0000:0000:0000]:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "[2003:0db8:000a:0000:0000:0000:0000:0000]:443");
+}
+
+// Test entries with whitespaced CIDR blocks in 'no_proxy' list.
+TEST(NoProxyTest, WhitespacedEntries) {
+  ScopedSetEnv no_proxy("foo.com, 192.168.0.255/24");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  // address matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.0.5:443", &args),
+            absl::nullopt);
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
+  // address not matching no_proxy cidr block
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.0:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "192.168.1.0:443");
+}
+
+// Test entries with invalid CIDR blocks in 'no_proxy' list.
+TEST(NoProxyTest, InvalidCIDREntries) {
+  ScopedSetEnv no_proxy("foo.com, 192.168.0.255/33");
+  auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
+  EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.0:443", &args),
+            "proxy.google.com");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
+            "192.168.1.0:443");
+}
 }  // namespace
 }  // namespace testing
 }  // namespace grpc_core

--- a/test/core/client_channel/http_proxy_mapper_test.cc
+++ b/test/core/client_channel/http_proxy_mapper_test.cc
@@ -81,8 +81,7 @@ TEST(NoProxyTest, CIDRClassAEntries) {
   // address not matching no_proxy cidr block
   EXPECT_EQ(HttpProxyMapper().MapName("dns:///193.0.1.1:443", &args),
             "proxy.google.com");
-  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
-            "193.0.1.1:443");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), "193.0.1.1:443");
 }
 
 // Test entries with CIDR blocks (Class B) in 'no_proxy' list.
@@ -96,8 +95,7 @@ TEST(NoProxyTest, CIDRClassBEntries) {
   // address not matching no_proxy cidr block
   EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.169.1.1:443", &args),
             "proxy.google.com");
-  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
-            "192.169.1.1:443");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), "192.169.1.1:443");
 }
 
 // Test entries with CIDR blocks (Class C) in 'no_proxy' list.
@@ -111,8 +109,7 @@ TEST(NoProxyTest, CIDRClassCEntries) {
   // address not matching no_proxy cidr block
   EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.1:443", &args),
             "proxy.google.com");
-  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
-            "192.168.1.1:443");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), "192.168.1.1:443");
 }
 
 // Test entries with CIDR blocks (exact match) in 'no_proxy' list.
@@ -126,8 +123,7 @@ TEST(NoProxyTest, CIDREntriesExactMatch) {
   // address not matching no_proxy cidr block
   EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.0.5:443", &args),
             "proxy.google.com");
-  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
-            "192.168.0.5:443");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), "192.168.0.5:443");
 }
 
 // Test entries with IPv6 CIDR blocks in 'no_proxy' list.
@@ -135,11 +131,13 @@ TEST(NoProxyTest, CIDREntriesIPv6ExactMatch) {
   ScopedSetEnv no_proxy("foo.com,2002:db8:a::45/64");
   auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
   // address matching no_proxy cidr block
-  EXPECT_EQ(HttpProxyMapper().MapName("dns:///[2002:0db8:000a:0000:0000:0000:0000:0001]:443", &args),
+  EXPECT_EQ(HttpProxyMapper().MapName(
+                "dns:///[2002:0db8:000a:0000:0000:0000:0000:0001]:443", &args),
             absl::nullopt);
   EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), absl::nullopt);
   // address not matching no_proxy cidr block
-  EXPECT_EQ(HttpProxyMapper().MapName("dns:///[2003:0db8:000a:0000:0000:0000:0000:0000]:443", &args),
+  EXPECT_EQ(HttpProxyMapper().MapName(
+                "dns:///[2003:0db8:000a:0000:0000:0000:0000:0000]:443", &args),
             "proxy.google.com");
   EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
             "[2003:0db8:000a:0000:0000:0000:0000:0000]:443");
@@ -156,8 +154,7 @@ TEST(NoProxyTest, WhitespacedEntries) {
   // address not matching no_proxy cidr block
   EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.0:443", &args),
             "proxy.google.com");
-  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
-            "192.168.1.0:443");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), "192.168.1.0:443");
 }
 
 // Test entries with invalid CIDR blocks in 'no_proxy' list.
@@ -166,8 +163,7 @@ TEST(NoProxyTest, InvalidCIDREntries) {
   auto args = ChannelArgs().Set(GRPC_ARG_HTTP_PROXY, "http://proxy.google.com");
   EXPECT_EQ(HttpProxyMapper().MapName("dns:///192.168.1.0:443", &args),
             "proxy.google.com");
-  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER),
-            "192.168.1.0:443");
+  EXPECT_EQ(args.GetString(GRPC_ARG_HTTP_CONNECT_SERVER), "192.168.1.0:443");
 }
 }  // namespace
 }  // namespace testing


### PR DESCRIPTION
This commit adds support for using CIDR blocks defined in the `no_proxy` environment variable. For example:

```
http_proxy=http://localhost:8080 no_proxy=10.10.0.0/24
```

The example above would bypass the proxy if the server IP matched 10.10.0.0 - 10.10.0.255.

Closes #22681
