### PR TITLE
Fix ruby builds on kokoro macos monterey images

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -73,6 +73,8 @@ then
     sleep 3
   done
   [[ "$gpg_recv_keys_success" == 1 ]] || exit 1
+  # fix .rvm directory ownership on kokoro monterey image
+  sudo chown -R "${USER}" ~/.rvm
   rvm get stable # Per https://stackoverflow.com/questions/65477613/rvm-where-is-ruby-3-0-0
   # stop echoing bash commands temporarily to prevent rvm from polluting the logs
   set +x

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -84,8 +84,6 @@ then
   done;
   echo "Setting default ruby version."
   rvm use 2.7.0 --default
-  echo "Installing cocoapods."
-  time gem install cocoapods --version 1.3.1 --no-document --user-install
   echo "Updating osx-ssl-certs."
   rvm osx-ssl-certs status all
   rvm osx-ssl-certs update all


### PR DESCRIPTION
Prerequisite for migrating the ruby basictests to the kokoro macos monterey image.