### PR TITLE
chore(bazel): enable bazel for ARM-based Mac

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -62,6 +62,9 @@ case $(uname -sm) in
   "Darwin x86_64")
     suffix=darwin-x86_64
     ;;
+  "Darwin arm64")
+    suffix=darwin-arm64
+    ;;
   "MINGW"* | "MSYS_NT"*)
     suffix=windows-x86_64.exe
     ;;


### PR DESCRIPTION
I notice that the local bazel tools currently won't be able to run on ARM-based Darwin

This PR hopes to address that issue.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

