### PR TITLE
Removed GRPC_ERROR_NONE

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1688,6 +1688,7 @@ grpc_cc_library(
     hdrs = [
         "src/core/lib/promise/exec_ctx_wakeup_scheduler.h",
     ],
+    external_deps = ["absl/status"],
     language = "c++",
     deps = [
         "closure",
@@ -1837,6 +1838,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/container:inlined_vector",
+        "absl/status",
         "absl/strings:str_format",
     ],
     language = "c++",
@@ -1900,6 +1902,7 @@ grpc_cc_library(
     external_deps = [
         "absl/base:core_headers",
         "absl/memory",
+        "absl/status",
         "absl/strings",
         "absl/types:optional",
     ],
@@ -1935,6 +1938,7 @@ grpc_cc_library(
     external_deps = [
         "absl/base:core_headers",
         "absl/memory",
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
         "absl/types:optional",
@@ -5700,6 +5704,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/memory",
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
     ],

--- a/src/core/ext/filters/channel_idle/channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/channel_idle_filter.cc
@@ -158,7 +158,7 @@ void MaxAgeFilter::PostInit() {
   auto* startup =
       new StartupClosure{this->channel_stack()->Ref(), this, grpc_closure{}};
   GRPC_CLOSURE_INIT(&startup->closure, run_startup, startup, nullptr);
-  ExecCtx::Run(DEBUG_LOCATION, &startup->closure, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, &startup->closure, absl::OkStatus());
 
   auto channel_stack = this->channel_stack()->Ref();
 
@@ -187,7 +187,7 @@ void MaxAgeFilter::PostInit() {
               ExecCtx::Run(
                   DEBUG_LOCATION,
                   GRPC_CLOSURE_CREATE(fn, this->channel_stack(), nullptr),
-                  GRPC_ERROR_NONE);
+                  absl::OkStatus());
               return Immediate(absl::OkStatus());
             },
             // Sleep for the grace period

--- a/src/core/ext/filters/client_channel/backup_poller.cc
+++ b/src/core/ext/filters/client_channel/backup_poller.cc
@@ -118,7 +118,7 @@ static void g_poller_unref() {
 static void run_poller(void* arg, grpc_error_handle error) {
   backup_poller* p = static_cast<backup_poller*>(arg);
   if (!error.ok()) {
-    if (error != GRPC_ERROR_CANCELLED) {
+    if (error != absl::CancelledError()) {
       GRPC_LOG_IF_ERROR("run_poller", error);
     }
     backup_poller_shutdown_unref(p);

--- a/src/core/ext/filters/client_channel/channel_connectivity.cc
+++ b/src/core/ext/filters/client_channel/channel_connectivity.cc
@@ -18,6 +18,8 @@
 
 #include <inttypes.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/connectivity_state.h>
 #include <grpc/impl/codegen/gpr_types.h>
@@ -195,7 +197,7 @@ class StateWatcher : public DualRefCounted<StateWatcher> {
     grpc_error_handle error =
         timer_fired_ ? GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                            "Timed out waiting for connection state change")
-                     : GRPC_ERROR_NONE;
+                     : absl::OkStatus();
     grpc_cq_end_op(cq_, tag_, error, FinishedCompletion, this,
                    &completion_storage_);
   }

--- a/src/core/ext/filters/client_channel/client_channel.h
+++ b/src/core/ext/filters/client_channel/client_channel.h
@@ -362,8 +362,7 @@ class ClientChannel {
   std::set<SubchannelWrapper*> subchannel_wrappers_
       ABSL_GUARDED_BY(*work_serializer_);
   int keepalive_time_ ABSL_GUARDED_BY(*work_serializer_) = -1;
-  grpc_error_handle disconnect_error_ ABSL_GUARDED_BY(*work_serializer_) =
-      GRPC_ERROR_NONE;
+  grpc_error_handle disconnect_error_ ABSL_GUARDED_BY(*work_serializer_);
 
   //
   // Fields guarded by a mutex, since they need to be accessed
@@ -508,10 +507,10 @@ class ClientChannel::LoadBalancedCall
   gpr_cycle_counter lb_call_start_time_ = gpr_get_cycle_counter();
 
   // Set when we get a cancel_stream op.
-  grpc_error_handle cancel_error_ = GRPC_ERROR_NONE;
+  grpc_error_handle cancel_error_;
 
   // Set when we fail inside the LB call.
-  grpc_error_handle failure_error_ = GRPC_ERROR_NONE;
+  grpc_error_handle failure_error_;
 
   grpc_closure pick_closure_;
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
@@ -22,6 +22,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/log.h>
@@ -36,7 +37,7 @@
 
 static grpc_error_handle clr_init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void clr_destroy_channel_elem(grpc_channel_element* /*elem*/) {}
@@ -80,7 +81,7 @@ static grpc_error_handle clr_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   GPR_ASSERT(args->context != nullptr);
   new (elem->call_data) call_data();
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void clr_destroy_call_elem(grpc_call_element* elem,

--- a/src/core/ext/filters/client_channel/lb_policy/oob_backend_metric.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/oob_backend_metric.cc
@@ -263,7 +263,7 @@ class OrcaProducer::OrcaStreamEventHandler
     // BackendMetricAllocator object.
     void AsyncNotifyWatchersAndDelete() {
       GRPC_CLOSURE_INIT(&closure_, NotifyWatchersInExecCtx, this, nullptr);
-      ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+      ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
     }
 
    private:

--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -280,7 +280,7 @@ class RingHash : public LoadBalancingPolicy {
       void Orphan() override {
         // Hop into ExecCtx, so that we're not holding the data plane mutex
         // while we run control-plane code.
-        ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+        ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
       }
 
       // Will be invoked inside of the WorkSerializer.

--- a/src/core/ext/filters/client_channel/lb_policy/rls/rls.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/rls/rls.cc
@@ -1423,7 +1423,7 @@ void RlsLb::Cache::OnCleanupTimer(void* arg, grpc_error_handle error) {
           gpr_log(GPR_INFO, "[rlslb %p] cache cleanup timer fired (%s)",
                   cache->lb_policy_, grpc_error_std_string(error).c_str());
         }
-        if (error == GRPC_ERROR_CANCELLED) return;
+        if (error == absl::CancelledError()) return;
         MutexLock lock(&lb_policy->mu_);
         if (lb_policy->is_shutdown_) return;
         for (auto it = cache->map_.begin(); it != cache->map_.end();) {
@@ -1681,7 +1681,7 @@ RlsLb::RlsRequest::RlsRequest(RefCountedPtr<RlsLb> lb_policy, RequestKey key,
       DEBUG_LOCATION,
       GRPC_CLOSURE_INIT(&call_start_cb_, StartCall,
                         Ref(DEBUG_LOCATION, "StartCall").release(), nullptr),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 RlsLb::RlsRequest::~RlsRequest() { GPR_ASSERT(call_ == nullptr); }
@@ -2073,7 +2073,7 @@ void RlsLb::UpdatePickerAsync() {
       GRPC_CLOSURE_CREATE(UpdatePickerCallback,
                           Ref(DEBUG_LOCATION, "UpdatePickerCallback").release(),
                           grpc_schedule_on_exec_ctx),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 void RlsLb::UpdatePickerCallback(void* arg, grpc_error_handle /*error*/) {
@@ -2418,7 +2418,7 @@ void RlsLbConfig::JsonPostLoad(const Json& json, const JsonArgs&,
   if (it != json.object_value().end()) {
     ValidationErrors::ScopedField field(errors,
                                         ".routeLookupChannelServiceConfig");
-    grpc_error_handle child_error = GRPC_ERROR_NONE;
+    grpc_error_handle child_error;
     rls_channel_service_config_ = it->second.Dump();
     auto service_config = MakeRefCounted<ServiceConfigImpl>(
         ChannelArgs(), rls_channel_service_config_, it->second, &child_error);

--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -533,7 +533,7 @@ void CdsLb::OnClusterChanged(const std::string& name,
       gpr_log(GPR_INFO, "[cdslb %p] generated config for child policy: %s",
               this, json_str.c_str());
     }
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     auto config =
         CoreConfiguration::Get().lb_policy_registry().ParseLoadBalancingConfig(
             json);

--- a/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
@@ -16,6 +16,8 @@
 
 #include <algorithm>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/iomgr/port.h"  // IWYU pragma: keep
 
 #ifdef GRPC_HAVE_UNIX_SOCKET
@@ -113,7 +115,7 @@ class BinderResolverFactory : public ResolverFactory {
     memcpy(un->sun_path, path.data(), path.size());
     resolved_addr->len =
         static_cast<socklen_t>(sizeof(un->sun_family) + path.size() + 1);
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static bool ParseUri(const URI& uri, ServerAddressList* addresses) {

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -407,7 +407,7 @@ AresClientChannelDNSResolver::AresRequestWrapper::OnResolvedLocked(
       result.addresses = ServerAddressList();
     }
     if (service_config_json_ != nullptr) {
-      grpc_error_handle service_config_error = GRPC_ERROR_NONE;
+      grpc_error_handle service_config_error;
       std::string service_config_string =
           ChooseServiceConfig(service_config_json_, &service_config_error);
       if (!service_config_error.ok()) {
@@ -507,7 +507,7 @@ class AresDNSResolver : public DNSResolver {
         grpc_cancel_ares_request(grpc_ares_request_.get());
       } else {
         completed_ = true;
-        OnDnsLookupDone(this, GRPC_ERROR_CANCELLED);
+        OnDnsLookupDone(this, absl::CancelledError());
       }
       grpc_pollset_set_del_pollset_set(pollset_set_, interested_parties_);
       return true;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -223,13 +223,13 @@ class GrpcPolledFdWindows {
       return;
     }
     if (socket_type_ == SOCK_DGRAM) {
-      ScheduleAndNullWriteClosure(GRPC_ERROR_NONE);
+      ScheduleAndNullWriteClosure(absl::OkStatus());
     } else {
       GPR_ASSERT(socket_type_ == SOCK_STREAM);
       int wsa_error_code = 0;
       switch (tcp_write_state_) {
         case WRITE_IDLE:
-          ScheduleAndNullWriteClosure(GRPC_ERROR_NONE);
+          ScheduleAndNullWriteClosure(absl::OkStatus());
           break;
         case WRITE_REQUESTED:
           tcp_write_state_ = WRITE_PENDING;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -75,7 +75,7 @@ struct grpc_ares_request {
   /** number of ongoing queries */
   size_t pending_queries ABSL_GUARDED_BY(mu) = 0;
   /** the errors explaining query failures, appended to in query callbacks */
-  grpc_error_handle error ABSL_GUARDED_BY(mu) = GRPC_ERROR_NONE;
+  grpc_error_handle error ABSL_GUARDED_BY(mu);
 };
 
 /* Asynchronously resolve \a name (A/AAAA records only).

--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -88,7 +88,7 @@ class GoogleCloud2ProdResolver : public Resolver {
    private:
     static void OnHttpRequestDone(void* arg, grpc_error_handle error);
 
-    // If error is not GRPC_ERROR_NONE, then it's not safe to look at response.
+    // If error is not absl::OkStatus(), then it's not safe to look at response.
     virtual void OnDone(GoogleCloud2ProdResolver* resolver,
                         const grpc_http_response* response,
                         grpc_error_handle error) = 0;

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -793,7 +793,7 @@ ConfigSelector::CallConfig XdsResolver::XdsConfigSelector::GetCallConfig(
 //
 
 void XdsResolver::StartLocked() {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto xds_client = GrpcXdsClient::GetOrCreate(args_, "xds resolver");
   if (!xds_client.ok()) {
     gpr_log(GPR_ERROR,

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -128,7 +128,7 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const ChannelArgs& /*args*/,
   absl::optional<std::string> health_check_service_name;
   it = json.object_value().find("healthCheckConfig");
   if (it != json.object_value().end()) {
-    grpc_error_handle parsing_error = GRPC_ERROR_NONE;
+    grpc_error_handle parsing_error;
     health_check_service_name =
         ParseHealthCheckConfig(it->second, &parsing_error);
     if (!parsing_error.ok()) {

--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -148,7 +149,7 @@ class RetryFilter {
                                 grpc_channel_element_args* args) {
     GPR_ASSERT(args->is_last);
     GPR_ASSERT(elem->filter == &kRetryFilterVtable);
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     new (elem->channel_data) RetryFilter(args->channel_args, &error);
     return error;
   }
@@ -490,9 +491,9 @@ class RetryFilter::CallData {
     bool sent_cancel_stream_ : 1;
     // State for callback processing.
     RefCountedPtr<BatchData> recv_initial_metadata_ready_deferred_batch_;
-    grpc_error_handle recv_initial_metadata_error_ = GRPC_ERROR_NONE;
+    grpc_error_handle recv_initial_metadata_error_;
     RefCountedPtr<BatchData> recv_message_ready_deferred_batch_;
-    grpc_error_handle recv_message_error_ = GRPC_ERROR_NONE;
+    grpc_error_handle recv_message_error_;
     struct OnCompleteDeferredBatch {
       OnCompleteDeferredBatch(RefCountedPtr<BatchData> batch,
                               grpc_error_handle error)
@@ -504,7 +505,7 @@ class RetryFilter::CallData {
     absl::InlinedVector<OnCompleteDeferredBatch, 3>
         on_complete_deferred_batches_;
     RefCountedPtr<BatchData> recv_trailing_metadata_internal_batch_;
-    grpc_error_handle recv_trailing_metadata_error_ = GRPC_ERROR_NONE;
+    grpc_error_handle recv_trailing_metadata_error_;
     bool seen_recv_trailing_metadata_from_surface_ : 1;
     // NOTE: Do not move this next to the metadata bitfields above. That would
     //       save space but will also result in a data race because compiler
@@ -574,7 +575,7 @@ class RetryFilter::CallData {
   CallCombiner* call_combiner_;
   grpc_call_context_element* call_context_;
 
-  grpc_error_handle cancelled_from_surface_ = GRPC_ERROR_NONE;
+  grpc_error_handle cancelled_from_surface_;
 
   RefCountedPtr<CallStackDestructionBarrier> call_stack_destruction_barrier_;
 
@@ -662,7 +663,7 @@ class RetryFilter::CallData::CallStackDestructionBarrier
 
   ~CallStackDestructionBarrier() override {
     // TODO(yashkt) : This can potentially be a Closure::Run
-    ExecCtx::Run(DEBUG_LOCATION, on_call_stack_destruction_, GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, on_call_stack_destruction_, absl::OkStatus());
   }
 
   // Set the closure from the surface.  This closure will be invoked
@@ -900,7 +901,7 @@ void RetryFilter::CallData::CallAttempt::AddClosureForBatch(
   batch->handler_private.extra_arg = lb_call_.get();
   GRPC_CLOSURE_INIT(&batch->handler_private.closure, StartBatchInCallCombiner,
                     batch, grpc_schedule_on_exec_ctx);
-  closures->Add(&batch->handler_private.closure, GRPC_ERROR_NONE, reason);
+  closures->Add(&batch->handler_private.closure, absl::OkStatus(), reason);
 }
 
 void RetryFilter::CallData::CallAttempt::
@@ -1019,7 +1020,7 @@ void RetryFilter::CallData::CallAttempt::AddBatchesForPendingBatches(
                 "internally started recv_trailing_metadata batch pending and "
                 "recv_trailing_metadata started from surface");
           }
-          recv_trailing_metadata_error_ = GRPC_ERROR_NONE;
+          recv_trailing_metadata_error_ = absl::OkStatus();
         }
         // We don't want the fact that we've already started this op internally
         // to prevent us from adding a batch that may contain other ops.
@@ -1233,15 +1234,15 @@ void RetryFilter::CallData::CallAttempt::Abandon() {
         DEBUG_LOCATION,
         "unref internal recv_trailing_metadata_ready batch; attempt abandoned");
   }
-  recv_trailing_metadata_error_ = GRPC_ERROR_NONE;
+  recv_trailing_metadata_error_ = absl::OkStatus();
   recv_initial_metadata_ready_deferred_batch_.reset(
       DEBUG_LOCATION,
       "unref deferred recv_initial_metadata_ready batch; attempt abandoned");
-  recv_initial_metadata_error_ = GRPC_ERROR_NONE;
+  recv_initial_metadata_error_ = absl::OkStatus();
   recv_message_ready_deferred_batch_.reset(
       DEBUG_LOCATION,
       "unref deferred recv_message_ready batch; attempt abandoned");
-  recv_message_error_ = GRPC_ERROR_NONE;
+  recv_message_error_ = absl::OkStatus();
   for (auto& on_complete_deferred_batch : on_complete_deferred_batches_) {
     on_complete_deferred_batch.batch.reset(
         DEBUG_LOCATION, "unref deferred on_complete batch; attempt abandoned");
@@ -1654,7 +1655,7 @@ void RetryFilter::CallData::CallAttempt::BatchData::
         call_attempt_->recv_initial_metadata_error_, closures);
     call_attempt_->recv_initial_metadata_ready_deferred_batch_.reset(
         DEBUG_LOCATION, "resuming deferred recv_initial_metadata_ready");
-    call_attempt_->recv_initial_metadata_error_ = GRPC_ERROR_NONE;
+    call_attempt_->recv_initial_metadata_error_ = absl::OkStatus();
   }
   // Add closure for deferred recv_message_ready.
   if (GPR_UNLIKELY(call_attempt_->recv_message_ready_deferred_batch_ !=
@@ -1663,7 +1664,7 @@ void RetryFilter::CallData::CallAttempt::BatchData::
                                           closures);
     call_attempt_->recv_message_ready_deferred_batch_.reset(
         DEBUG_LOCATION, "resuming deferred recv_message_ready");
-    call_attempt_->recv_message_error_ = GRPC_ERROR_NONE;
+    call_attempt_->recv_message_error_ = absl::OkStatus();
   }
   // Add closures for deferred on_complete callbacks.
   for (auto& on_complete_deferred_batch :
@@ -2087,7 +2088,7 @@ grpc_error_handle RetryFilter::CallData::Init(
     gpr_log(GPR_INFO, "chand=%p calld=%p: created call", chand,
             elem->call_data);
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void RetryFilter::CallData::Destroy(grpc_call_element* elem,
@@ -2624,7 +2625,7 @@ void RetryFilter::CallData::AddClosureToStartTransparentRetry(
   }
   GRPC_CALL_STACK_REF(owning_call_, "OnRetryTimer");
   GRPC_CLOSURE_INIT(&retry_closure_, StartTransparentRetry, this, nullptr);
-  closures->Add(&retry_closure_, GRPC_ERROR_NONE, "start transparent retry");
+  closures->Add(&retry_closure_, absl::OkStatus(), "start transparent retry");
 }
 
 void RetryFilter::CallData::StartTransparentRetry(void* arg,

--- a/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
+++ b/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
@@ -114,7 +114,7 @@ grpc_error_handle ServiceConfigChannelArgInitCallElem(
   }
   new (calld) ServiceConfigChannelArgCallData(std::move(service_config),
                                               method_config, args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void ServiceConfigChannelArgDestroyCallElem(
@@ -130,7 +130,7 @@ grpc_error_handle ServiceConfigChannelArgInitChannelElem(
   ServiceConfigChannelArgChannelData* chand =
       static_cast<ServiceConfigChannelArgChannelData*>(elem->channel_data);
   new (chand) ServiceConfigChannelArgChannelData(args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void ServiceConfigChannelArgDestroyChannelElem(grpc_channel_element* elem) {

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -362,7 +362,7 @@ class Subchannel::AsyncWatcherNotifierLocked {
                        delete self;
                      },
                      this, nullptr),
-                 GRPC_ERROR_NONE);
+                 absl::OkStatus());
   }
 
  private:

--- a/src/core/ext/filters/deadline/deadline_filter.cc
+++ b/src/core/ext/filters/deadline/deadline_filter.cc
@@ -82,7 +82,7 @@ class TimerState {
     TimerState* self = static_cast<TimerState*>(arg);
     grpc_deadline_state* deadline_state =
         static_cast<grpc_deadline_state*>(self->elem_->call_data);
-    if (error != GRPC_ERROR_CANCELLED) {
+    if (error != absl::CancelledError()) {
       error = grpc_error_set_int(
           GRPC_ERROR_CREATE_FROM_STATIC_STRING("Deadline Exceeded"),
           GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_DEADLINE_EXCEEDED);
@@ -211,7 +211,7 @@ grpc_deadline_state::grpc_deadline_state(grpc_call_element* elem,
         new start_timer_after_init_state(elem, deadline);
     GRPC_CLOSURE_INIT(&state->closure, start_timer_after_init, state,
                       grpc_schedule_on_exec_ctx);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &state->closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &state->closure, absl::OkStatus());
   }
 }
 
@@ -248,7 +248,7 @@ void grpc_deadline_state_client_start_transport_stream_op_batch(
 static grpc_error_handle deadline_init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* args) {
   GPR_ASSERT(!args->is_last);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 // Destructor for channel_data.  Used for both client and server filters.
@@ -275,7 +275,7 @@ typedef struct server_call_data {
 static grpc_error_handle deadline_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   new (elem->call_data) grpc_deadline_state(elem, *args, args->deadline);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 // Destructor for call_data.  Used for both client and server filters.

--- a/src/core/ext/filters/http/message_compress/message_compress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.cc
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include "absl/meta/type_traits.h"
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/compression.h>
@@ -122,7 +123,7 @@ class CallData {
 
   grpc_core::CallCombiner* call_combiner_;
   grpc_compression_algorithm compression_algorithm_ = GRPC_COMPRESS_NONE;
-  grpc_error_handle cancel_error_ = GRPC_ERROR_NONE;
+  grpc_error_handle cancel_error_;
   grpc_transport_stream_op_batch* send_message_batch_ = nullptr;
   bool seen_initial_metadata_ = false;
   grpc_closure forward_send_message_batch_in_call_combiner_;
@@ -256,7 +257,8 @@ void CallData::CompressStartTransportStreamOpBatch(
     if (send_message_batch_ != nullptr) {
       GRPC_CALL_COMBINER_START(
           call_combiner_, &forward_send_message_batch_in_call_combiner_,
-          GRPC_ERROR_NONE, "starting send_message after send_initial_metadata");
+          absl::OkStatus(),
+          "starting send_message after send_initial_metadata");
     }
   }
   // Handle send_message.
@@ -288,7 +290,7 @@ void CompressStartTransportStreamOpBatch(
 grpc_error_handle CompressInitCallElem(grpc_call_element* elem,
                                        const grpc_call_element_args* args) {
   new (elem->call_data) CallData(elem, *args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Destructor for call_data */
@@ -303,7 +305,7 @@ void CompressDestroyCallElem(grpc_call_element* elem,
 grpc_error_handle CompressInitChannelElem(grpc_channel_element* elem,
                                           grpc_channel_element_args* args) {
   new (elem->channel_data) ChannelData(args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Destructor for channel data */

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -195,8 +195,8 @@ struct call_data {
   // call our next_recv_message_ready member after handling it.
   grpc_closure recv_message_ready;
   grpc_closure recv_trailing_metadata_ready;
-  // The error caused by a message that is too large, or GRPC_ERROR_NONE
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  // The error caused by a message that is too large, or absl::OkStatus()
+  grpc_error_handle error;
   // Used by recv_message_ready.
   absl::optional<grpc_core::SliceBuffer>* recv_message = nullptr;
   // Original recv_message_ready callback, invoked after our own.
@@ -305,7 +305,7 @@ static grpc_error_handle message_size_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   new (elem->call_data) call_data(elem, *chand, *args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 // Destructor for call_data.
@@ -332,7 +332,7 @@ static grpc_error_handle message_size_init_channel_elem(
   new (chand) channel_data();
   chand->limits = get_message_size_limits(
       grpc_core::ChannelArgs::FromC(args->channel_args));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 // Destructor for channel_data.

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -21,6 +21,8 @@
 #include <new>
 #include <utility>
 
+#include "absl/status/status.h"
+
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 
@@ -45,7 +47,7 @@ namespace grpc_core {
 grpc_error_handle RbacFilter::CallData::Init(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   new (elem->call_data) CallData(elem, *args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void RbacFilter::CallData::Destroy(grpc_call_element* elem,
@@ -157,7 +159,7 @@ grpc_error_handle RbacFilter::Init(grpc_channel_element* elem,
       grpc_channel_stack_filter_instance_number(args->channel_stack, elem),
       EvaluateArgs::PerChannelArgs(auth_context,
                                    grpc_transport_get_endpoint(transport)));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void RbacFilter::Destroy(grpc_channel_element* elem) {

--- a/src/core/ext/filters/server_config_selector/server_config_selector.h
+++ b/src/core/ext/filters/server_config_selector/server_config_selector.h
@@ -43,7 +43,7 @@ class ServerConfigSelector : public RefCounted<ServerConfigSelector> {
  public:
   // Configuration to apply to an incoming call
   struct CallConfig {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     const ServiceConfigParser::ParsedConfigVector* method_configs = nullptr;
     RefCountedPtr<ServiceConfig> service_config;
   };

--- a/src/core/ext/transport/binder/client/binder_connector.cc
+++ b/src/core/ext/transport/binder/client/binder_connector.cc
@@ -92,9 +92,9 @@ class BinderConnector : public grpc_core::SubchannelConnector {
     // might be invoked from non-gRPC code
     if (grpc_core::ExecCtx::Get() == nullptr) {
       grpc_core::ExecCtx exec_ctx;
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, notify_, GRPC_ERROR_NONE);
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, notify_, absl::OkStatus());
     } else {
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, notify_, GRPC_ERROR_NONE);
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, notify_, absl::OkStatus());
     }
 
     Unref();  // Was referenced in BinderConnector::Connect

--- a/src/core/ext/transport/binder/server/binder_server.cc
+++ b/src/core/ext/transport/binder/server/binder_server.cc
@@ -164,7 +164,7 @@ class BinderServerListener : public Server::ListenerInterface {
   ~BinderServerListener() override {
     ExecCtx::Get()->Flush();
     if (on_destroy_done_) {
-      ExecCtx::Run(DEBUG_LOCATION, on_destroy_done_, GRPC_ERROR_NONE);
+      ExecCtx::Run(DEBUG_LOCATION, on_destroy_done_, absl::OkStatus());
       ExecCtx::Get()->Flush();
     }
     grpc_remove_endpoint_binder(addr_);

--- a/src/core/ext/transport/binder/transport/binder_stream.h
+++ b/src/core/ext/transport/binder/transport/binder_stream.h
@@ -70,7 +70,7 @@ struct grpc_binder_stream {
   ~grpc_binder_stream() {
     if (destroy_stream_then_closure != nullptr) {
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, destroy_stream_then_closure,
-                              GRPC_ERROR_NONE);
+                              absl::OkStatus());
     }
   }
 
@@ -87,7 +87,7 @@ struct grpc_binder_stream {
   grpc_closure destroy_stream;
 
   // The reason why this stream is cancelled and closed.
-  grpc_error_handle cancel_self_error = GRPC_ERROR_NONE;
+  grpc_error_handle cancel_self_error;
 
   grpc_closure recv_initial_metadata_closure;
   RecvInitialMetadataArgs recv_initial_metadata_args;

--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -119,7 +119,7 @@ static int init_stream(grpc_transport* gt, grpc_stream* gs,
   t->combiner->Run(
       GRPC_CLOSURE_INIT(&gbs->register_stream_closure, register_stream_locked,
                         &gbs->register_stream_args, nullptr),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 
   return 0;
 }
@@ -217,7 +217,7 @@ static void recv_initial_metadata_locked(void* arg,
         }
       }
       AssignMetadata(gbs->recv_initial_metadata, *args->initial_metadata);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }();
 
     grpc_closure* cb = gbs->recv_initial_metadata_ready;
@@ -247,7 +247,7 @@ static void recv_message_locked(void* arg, grpc_error_handle /*error*/) {
           gpr_log(GPR_ERROR, "message cancelled gracefully");
           // Cancelled because we've already received trailing metadata.
           // It's not an error in this case.
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         } else {
           return absl_status_to_grpc_error(args->message.status());
         }
@@ -255,7 +255,7 @@ static void recv_message_locked(void* arg, grpc_error_handle /*error*/) {
       grpc_core::SliceBuffer buf;
       buf.Append(grpc_core::Slice(grpc_slice_from_cpp_string(*args->message)));
       *gbs->recv_message = std::move(buf);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }();
 
     if (!error.ok() && gbs->call_failed_before_recv_message != nullptr) {
@@ -291,7 +291,7 @@ static void recv_trailing_metadata_locked(void* arg,
         // Client will not send non-empty trailing metadata.
         if (!args->trailing_metadata.value().empty()) {
           gpr_log(GPR_ERROR, "Server receives non-empty trailing metadata.");
-          return GRPC_ERROR_CANCELLED;
+          return absl::CancelledError();
         }
       } else {
         AssignMetadata(gbs->recv_trailing_metadata, *args->trailing_metadata);
@@ -303,7 +303,7 @@ static void recv_trailing_metadata_locked(void* arg,
             grpc_core::GrpcStatusMetadata(),
             static_cast<grpc_status_code>(args->status));
       }
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }();
 
     if (gbs->is_client || gbs->trailing_metadata_sent) {
@@ -394,7 +394,8 @@ static void perform_stream_op_locked(void* stream_op,
     }
     cancel_stream_locked(gbt, gbs, op->payload->cancel_stream.cancel_error);
     if (op->on_complete != nullptr) {
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_complete, GRPC_ERROR_NONE);
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_complete,
+                              absl::OkStatus());
     }
     GRPC_BINDER_STREAM_UNREF(gbs, "perform_stream_op");
     return;
@@ -481,7 +482,7 @@ static void perform_stream_op_locked(void* stream_op,
               GRPC_CLOSURE_INIT(&gbs->recv_initial_metadata_closure,
                                 recv_initial_metadata_locked,
                                 &gbs->recv_initial_metadata_args, nullptr),
-              GRPC_ERROR_NONE);
+              absl::OkStatus());
         });
   }
   if (op->recv_message) {
@@ -499,7 +500,7 @@ static void perform_stream_op_locked(void* stream_op,
           gbt->combiner->Run(
               GRPC_CLOSURE_INIT(&gbs->recv_message_closure, recv_message_locked,
                                 &gbs->recv_message_args, nullptr),
-              GRPC_ERROR_NONE);
+              absl::OkStatus());
         });
   }
   if (op->recv_trailing_metadata) {
@@ -522,11 +523,11 @@ static void perform_stream_op_locked(void* stream_op,
               GRPC_CLOSURE_INIT(&gbs->recv_trailing_metadata_closure,
                                 recv_trailing_metadata_locked,
                                 &gbs->recv_trailing_metadata_args, nullptr),
-              GRPC_ERROR_NONE);
+              absl::OkStatus());
         });
   }
   // Only send transaction when there's a send op presented.
-  absl::Status status = absl::OkStatus();
+  absl::Status status;
   if (op->send_initial_metadata || op->send_message ||
       op->send_trailing_metadata) {
     status = gbt->wire_writer->RpcCall(std::move(tx));
@@ -541,7 +542,7 @@ static void perform_stream_op_locked(void* stream_op,
       if (gbs->need_to_call_trailing_metadata_callback) {
         grpc_closure* cb = gbs->recv_trailing_metadata_finished;
         gbs->recv_trailing_metadata_finished = nullptr;
-        grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
+        grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, absl::OkStatus());
         gbs->need_to_call_trailing_metadata_callback = false;
       }
     }
@@ -566,7 +567,7 @@ static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
   op->handler_private.extra_arg = gbs;
   gbt->combiner->Run(GRPC_CLOSURE_INIT(&op->handler_private.closure,
                                        perform_stream_op_locked, op, nullptr),
-                     GRPC_ERROR_NONE);
+                     absl::OkStatus());
 }
 
 static void close_transport_locked(grpc_binder_transport* gbt) {
@@ -599,7 +600,7 @@ static void perform_transport_op_locked(void* transport_op,
     gbt->accept_stream_user_data = op->set_accept_stream_user_data;
   }
   if (op->on_consumed) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, absl::OkStatus());
   }
   bool do_close = false;
   if (!op->disconnect_with_error.ok()) {
@@ -622,7 +623,7 @@ static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   gbt->combiner->Run(
       GRPC_CLOSURE_INIT(&op->handler_private.closure,
                         perform_transport_op_locked, op, nullptr),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 static void destroy_stream_locked(void* sp, grpc_error_handle /*error*/) {
@@ -642,7 +643,7 @@ static void destroy_stream(grpc_transport* /*gt*/, grpc_stream* gs,
   gbs->destroy_stream_then_closure = then_schedule_closure;
   gbs->t->combiner->Run(GRPC_CLOSURE_INIT(&gbs->destroy_stream,
                                           destroy_stream_locked, gbs, nullptr),
-                        GRPC_ERROR_NONE);
+                        absl::OkStatus());
 }
 
 static void destroy_transport_locked(void* gt, grpc_error_handle /*error*/) {
@@ -660,7 +661,7 @@ static void destroy_transport(grpc_transport* gt) {
   grpc_binder_transport* gbt = reinterpret_cast<grpc_binder_transport*>(gt);
   gbt->combiner->Run(
       GRPC_CLOSURE_CREATE(destroy_transport_locked, gbt, nullptr),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 static grpc_endpoint* get_endpoint(grpc_transport*) {
@@ -708,7 +709,7 @@ grpc_binder_transport::grpc_binder_transport(
             grpc_core::ExecCtx exec_ctx;
             combiner->Run(
                 GRPC_CLOSURE_CREATE(accept_stream_locked, this, nullptr),
-                GRPC_ERROR_NONE);
+                absl::OkStatus());
           });
   // WireReader holds a ref to grpc_binder_transport.
   GRPC_BINDER_REF_TRANSPORT(this, "wire reader");

--- a/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.h
+++ b/src/core/ext/transport/binder/utils/transport_stream_receiver_impl.h
@@ -58,7 +58,7 @@ class TransportStreamReceiverImpl : public TransportStreamReceiver {
   // never be in-coming message data anymore, and all recv_message callbacks
   // (as well as recv_initial_metadata callback, if there's any) registered will
   // never be satisfied. This function cancels all such callbacks gracefully
-  // (with GRPC_ERROR_NONE) to avoid being blocked waiting for them.
+  // (with absl::OkStatus()) to avoid being blocked waiting for them.
   void OnRecvTrailingMetadata(StreamIdentifier id);
 
   void CancelInitialMetadataCallback(StreamIdentifier id, absl::Status error);

--- a/src/core/ext/transport/binder/wire_format/wire_writer.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_writer.cc
@@ -301,7 +301,7 @@ absl::Status WireWriterImpl::SendAck(int64_t num_bytes) {
     args->tx = RunScheduledTxArgs::AckTx();
     absl::get<RunScheduledTxArgs::AckTx>(args->tx).num_bytes = num_bytes;
     auto cl = GRPC_CLOSURE_CREATE(RunScheduledTx, args, nullptr);
-    combiner_->Run(cl, GRPC_ERROR_NONE);
+    combiner_->Run(cl, absl::OkStatus());
     return absl::OkStatus();
   }
   // Otherwise, we can directly send ack.
@@ -378,7 +378,7 @@ void WireWriterImpl::TryScheduleTransaction() {
       num_non_acked_tx_in_combiner_++;
       combiner_->Run(GRPC_CLOSURE_CREATE(RunScheduledTx,
                                          pending_outgoing_tx_.front(), nullptr),
-                     GRPC_ERROR_NONE);
+                     absl::OkStatus());
       pending_outgoing_tx_.pop();
     } else {
       // It is common to fill `kFlowControlWindowSize` completely because

--- a/src/core/ext/transport/chttp2/client/chttp2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/chttp2_connector.cc
@@ -209,7 +209,7 @@ void Chttp2Connector::OnReceiveSettings(void* arg, grpc_error_handle error) {
     } else {
       // OnTimeout() was already invoked. Call Notify() again so that notify_
       // can be invoked.
-      self->MaybeNotify(GRPC_ERROR_NONE);
+      self->MaybeNotify(absl::OkStatus());
     }
   }
   self->Unref();
@@ -233,7 +233,7 @@ void Chttp2Connector::OnTimeout(void* arg, grpc_error_handle /*error*/) {
     } else {
       // OnReceiveSettings() was already invoked. Call Notify() again so that
       // notify_ can be invoked.
-      self->MaybeNotify(GRPC_ERROR_NONE);
+      self->MaybeNotify(absl::OkStatus());
     }
   }
   self->Unref();
@@ -344,7 +344,7 @@ grpc_channel* grpc_channel_create(const char* target,
   GRPC_API_TRACE("grpc_secure_channel_create(target=%s, creds=%p, args=%p)", 3,
                  (target, (void*)creds, (void*)c_args));
   grpc_channel* channel = nullptr;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   if (creds != nullptr) {
     // Add channel args containing the client channel factory and channel
     // credentials.

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -412,9 +412,9 @@ void Chttp2ServerListener::ActiveConnection::HandshakingState::Start(
 void Chttp2ServerListener::ActiveConnection::HandshakingState::OnTimeout(
     void* arg, grpc_error_handle error) {
   HandshakingState* self = static_cast<HandshakingState*>(arg);
-  // Note that we may be called with GRPC_ERROR_NONE when the timer fires
+  // Note that we may be called with absl::OkStatus() when the timer fires
   // or with an error indicating that the timer system is being shut down.
-  if (error != GRPC_ERROR_CANCELLED) {
+  if (error != absl::CancelledError()) {
     grpc_transport_op* op = grpc_make_transport_op(nullptr);
     op->disconnect_with_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Did not receive HTTP/2 settings before handshake timeout");
@@ -455,7 +455,7 @@ void Chttp2ServerListener::ActiveConnection::HandshakingState::OnHandshakeDone(
         // before destroying them, even if we know that there are no
         // pending read/write callbacks.  This should be fixed, at which
         // point this can be removed.
-        grpc_endpoint_shutdown(args->endpoint, GRPC_ERROR_NONE);
+        grpc_endpoint_shutdown(args->endpoint, absl::OkStatus());
         grpc_endpoint_destroy(args->endpoint);
         grpc_slice_buffer_destroy(args->read_buffer);
         gpr_free(args->read_buffer);
@@ -675,7 +675,7 @@ grpc_error_handle Chttp2ServerListener::Create(
   // The bulk of this method is inside of a lambda to make cleanup
   // easier without using goto.
   grpc_error_handle error = [&]() {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     // Create Chttp2ServerListener.
     listener = new Chttp2ServerListener(server, args, args_modifier);
     error = grpc_tcp_server_create(
@@ -706,7 +706,7 @@ grpc_error_handle Chttp2ServerListener::Create(
     }
     // Register with the server only upon success
     server->AddListener(OrphanablePtr<Server::ListenerInterface>(listener));
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }();
   if (!error.ok()) {
     if (listener != nullptr) {
@@ -738,7 +738,7 @@ grpc_error_handle Chttp2ServerListener::CreateWithAcceptor(
   TcpServerFdHandler** arg_val = args.GetPointer<TcpServerFdHandler*>(name);
   *arg_val = grpc_tcp_server_create_fd_handler(listener->tcp_server_);
   server->AddListener(OrphanablePtr<Server::ListenerInterface>(listener));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 Chttp2ServerListener::Chttp2ServerListener(
@@ -757,7 +757,7 @@ Chttp2ServerListener::~Chttp2ServerListener() {
   // may do a synchronous unref.
   ExecCtx::Get()->Flush();
   if (on_destroy_done_ != nullptr) {
-    ExecCtx::Run(DEBUG_LOCATION, on_destroy_done_, GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, on_destroy_done_, absl::OkStatus());
     ExecCtx::Get()->Flush();
   }
 }
@@ -822,7 +822,7 @@ void Chttp2ServerListener::OnAccept(void* arg, grpc_endpoint* tcp,
           GRPC_ERROR_CREATE_FROM_CPP_STRING(args_result.status().ToString()));
       return;
     }
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     args = self->args_modifier_(*args_result, &error);
     if (!error.ok()) {
       gpr_log(GPR_DEBUG, "Closing connection: %s",
@@ -857,7 +857,7 @@ void Chttp2ServerListener::OnAccept(void* arg, grpc_endpoint* tcp,
     }
   }
   if (connection != nullptr) {
-    endpoint_cleanup(GRPC_ERROR_NONE);
+    endpoint_cleanup(absl::OkStatus());
   } else {
     connection_ref->Start(std::move(listener_ref), tcp, args);
   }
@@ -923,7 +923,7 @@ grpc_error_handle Chttp2ServerAddPort(Server* server, const char* addr,
   absl::string_view parsed_addr_unprefixed{parsed_addr};
   // Using lambda to avoid use of goto.
   grpc_error_handle error = [&]() {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     if (absl::ConsumePrefix(&parsed_addr_unprefixed, kUnixUriPrefix)) {
       resolved_or = grpc_resolve_unix_domain_address(parsed_addr_unprefixed);
     } else if (absl::ConsumePrefix(&parsed_addr_unprefixed,
@@ -973,7 +973,7 @@ grpc_error_handle Chttp2ServerAddPort(Server* server, const char* addr,
       gpr_log(GPR_INFO, "WARNING: %s", grpc_error_std_string(error).c_str());
       // we managed to bind some addresses: continue without error
     }
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }();  // lambda end
   if (!error.ok()) *port_num = 0;
   return error;
@@ -1005,7 +1005,7 @@ ChannelArgs ModifyArgsForConnection(const ChannelArgs& args,
 int grpc_server_add_http2_port(grpc_server* server, const char* addr,
                                grpc_server_credentials* creds) {
   grpc_core::ExecCtx exec_ctx;
-  grpc_error_handle err = GRPC_ERROR_NONE;
+  grpc_error_handle err;
   grpc_core::RefCountedPtr<grpc_server_security_connector> sc;
   int port_num = 0;
   grpc_core::Server* core_server = grpc_core::Server::FromC(server);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -550,7 +550,7 @@ static void destroy_transport_locked(void* tp, grpc_error_handle /*error*/) {
 static void destroy_transport(grpc_transport* gt) {
   grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
   t->combiner->Run(GRPC_CLOSURE_CREATE(destroy_transport_locked, t, nullptr),
-                   GRPC_ERROR_NONE);
+                   absl::OkStatus());
 }
 
 static void close_transport_locked(grpc_chttp2_transport* t,
@@ -694,7 +694,7 @@ grpc_chttp2_stream::~grpc_chttp2_stream() {
   GPR_ASSERT(recv_trailing_metadata_finished == nullptr);
   grpc_slice_buffer_destroy(&flow_controlled_buffer);
   GRPC_CHTTP2_UNREF_TRANSPORT(t, "stream");
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, destroy_stream_arg, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, destroy_stream_arg, absl::OkStatus());
 }
 
 static int init_stream(grpc_transport* gt, grpc_stream* gs,
@@ -718,7 +718,7 @@ static void destroy_stream(grpc_transport* gt, grpc_stream* gs,
   s->destroy_stream_arg = then_schedule_closure;
   t->combiner->Run(
       GRPC_CLOSURE_INIT(&s->destroy_stream, destroy_stream_locked, s, nullptr),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 grpc_chttp2_stream* grpc_chttp2_parsing_accept_stream(grpc_chttp2_transport* t,
@@ -768,7 +768,7 @@ static void set_write_state(grpc_chttp2_transport* t,
     grpc_core::ExecCtx::RunList(DEBUG_LOCATION, &t->run_after_write);
     if (!t->close_transport_on_writes_finished.ok()) {
       grpc_error_handle err = t->close_transport_on_writes_finished;
-      t->close_transport_on_writes_finished = GRPC_ERROR_NONE;
+      t->close_transport_on_writes_finished = absl::OkStatus();
       close_transport_locked(t, err);
     }
   }
@@ -800,7 +800,7 @@ void grpc_chttp2_initiate_write(grpc_chttp2_transport* t,
       t->combiner->FinallyRun(
           GRPC_CLOSURE_INIT(&t->write_action_begin_locked,
                             write_action_begin_locked, t, nullptr),
-          GRPC_ERROR_NONE);
+          absl::OkStatus());
       break;
     case GRPC_CHTTP2_WRITE_STATE_WRITING:
       set_write_state(t, GRPC_CHTTP2_WRITE_STATE_WRITING_WITH_MORE,
@@ -841,7 +841,7 @@ static void write_action_begin_locked(void* gt,
                     r.partial ? GRPC_CHTTP2_WRITE_STATE_WRITING_WITH_MORE
                               : GRPC_CHTTP2_WRITE_STATE_WRITING,
                     begin_writing_desc(r.partial));
-    write_action(t, GRPC_ERROR_NONE);
+    write_action(t, absl::OkStatus());
     if (t->reading_paused_on_pending_induced_frames) {
       GPR_ASSERT(t->num_pending_induced_frames == 0);
       // We had paused reading, because we had many induced frames (SETTINGS
@@ -929,7 +929,7 @@ static void write_action_end_locked(void* tp, grpc_error_handle error) {
       t->combiner->FinallyRun(
           GRPC_CLOSURE_INIT(&t->write_action_begin_locked,
                             write_action_begin_locked, t, nullptr),
-          GRPC_ERROR_NONE);
+          absl::OkStatus());
       break;
   }
 
@@ -1111,7 +1111,7 @@ static void null_then_sched_closure(grpc_closure** closure) {
   // completion, have the application see it, and make a new operation on the
   // call which recycles the batch BEFORE the call to start_batch completes,
   // forcing a race.
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, c, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, c, absl::OkStatus());
 }
 
 void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
@@ -1294,7 +1294,7 @@ static void perform_stream_op_locked(void* stream_op,
       // started. The surface layer will notice that the stream has been closed
       // for writes and fail the send message op.
       grpc_chttp2_complete_closure_step(t, s, &s->send_message_finished,
-                                        GRPC_ERROR_NONE,
+                                        absl::OkStatus(),
                                         "fetching_send_message_finished");
     } else {
       uint8_t* frame_hdr = grpc_slice_buffer_tiny_add(
@@ -1329,7 +1329,7 @@ static void perform_stream_op_locked(void* stream_op,
       int64_t notify_offset = s->next_message_end_offset;
       if (notify_offset <= s->flow_controlled_bytes_written) {
         grpc_chttp2_complete_closure_step(t, s, &s->send_message_finished,
-                                          GRPC_ERROR_NONE,
+                                          absl::OkStatus(),
                                           "fetching_send_message_finished");
       } else {
         grpc_chttp2_write_cb* cb = t->write_cb_pool;
@@ -1374,7 +1374,7 @@ static void perform_stream_op_locked(void* stream_op,
       grpc_chttp2_complete_closure_step(
           t, s, &s->send_trailing_metadata_finished,
           op->payload->send_trailing_metadata.send_trailing_metadata->empty()
-              ? GRPC_ERROR_NONE
+              ? absl::OkStatus()
               : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                     "Attempt to send trailing metadata after "
                     "stream was closed"),
@@ -1427,7 +1427,7 @@ static void perform_stream_op_locked(void* stream_op,
   }
 
   if (on_complete != nullptr) {
-    grpc_chttp2_complete_closure_step(t, s, &on_complete, GRPC_ERROR_NONE,
+    grpc_chttp2_complete_closure_step(t, s, &on_complete, absl::OkStatus(),
                                       "op->on_complete");
   }
 
@@ -1461,7 +1461,7 @@ static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
   op->handler_private.extra_arg = gs;
   t->combiner->Run(GRPC_CLOSURE_INIT(&op->handler_private.closure,
                                      perform_stream_op_locked, op, nullptr),
-                   GRPC_ERROR_NONE);
+                   absl::OkStatus());
 }
 
 static void cancel_pings(grpc_chttp2_transport* t, grpc_error_handle error) {
@@ -1484,9 +1484,9 @@ static void send_ping_locked(grpc_chttp2_transport* t,
   }
   grpc_chttp2_ping_queue* pq = &t->ping_queue;
   grpc_closure_list_append(&pq->lists[GRPC_CHTTP2_PCL_INITIATE], on_initiate,
-                           GRPC_ERROR_NONE);
+                           absl::OkStatus());
   grpc_closure_list_append(&pq->lists[GRPC_CHTTP2_PCL_NEXT], on_ack,
-                           GRPC_ERROR_NONE);
+                           absl::OkStatus());
 }
 
 // Specialized form of send_ping_locked for keepalive ping. If there is already
@@ -1513,19 +1513,19 @@ static void send_keepalive_ping_locked(grpc_chttp2_transport* t) {
         &pq->lists[GRPC_CHTTP2_PCL_INFLIGHT],
         GRPC_CLOSURE_INIT(&t->finish_keepalive_ping_locked,
                           finish_keepalive_ping, t, grpc_schedule_on_exec_ctx),
-        GRPC_ERROR_NONE);
+        absl::OkStatus());
     return;
   }
   grpc_closure_list_append(
       &pq->lists[GRPC_CHTTP2_PCL_INITIATE],
       GRPC_CLOSURE_INIT(&t->start_keepalive_ping_locked, start_keepalive_ping,
                         t, grpc_schedule_on_exec_ctx),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
   grpc_closure_list_append(
       &pq->lists[GRPC_CHTTP2_PCL_NEXT],
       GRPC_CLOSURE_INIT(&t->finish_keepalive_ping_locked, finish_keepalive_ping,
                         t, grpc_schedule_on_exec_ctx),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 void grpc_chttp2_retry_initiate_ping(void* tp, grpc_error_handle error) {
@@ -1619,7 +1619,7 @@ class GracefulGoaway : public grpc_core::RefCounted<GracefulGoaway> {
     auto* self = static_cast<GracefulGoaway*>(arg);
     self->t_->combiner->Run(
         GRPC_CLOSURE_INIT(&self->on_ping_ack_, OnPingAckLocked, self, nullptr),
-        GRPC_ERROR_NONE);
+        absl::OkStatus());
   }
 
   static void OnPingAckLocked(void* arg, grpc_error_handle /* error */) {
@@ -1637,7 +1637,7 @@ class GracefulGoaway : public grpc_core::RefCounted<GracefulGoaway> {
     }
     self->t_->combiner->Run(
         GRPC_CLOSURE_INIT(&self->on_timer_, OnTimerLocked, self, nullptr),
-        GRPC_ERROR_NONE);
+        absl::OkStatus());
   }
 
   static void OnTimerLocked(void* arg, grpc_error_handle /* error */) {
@@ -1750,7 +1750,7 @@ static void perform_transport_op_locked(void* stream_op,
     close_transport_locked(t, op->disconnect_with_error);
   }
 
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, absl::OkStatus());
 
   GRPC_CHTTP2_UNREF_TRANSPORT(t, "transport_op");
 }
@@ -1765,7 +1765,7 @@ static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   GRPC_CHTTP2_REF_TRANSPORT(t, "transport_op");
   t->combiner->Run(GRPC_CLOSURE_INIT(&op->handler_private.closure,
                                      perform_transport_op_locked, op, nullptr),
-                   GRPC_ERROR_NONE);
+                   absl::OkStatus());
 }
 
 //
@@ -1800,7 +1800,7 @@ void grpc_chttp2_maybe_complete_recv_message(grpc_chttp2_transport* t,
 
   grpc_core::chttp2::StreamFlowControl::IncomingUpdateContext upd(
       &s->flow_control);
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   // Lambda is immediately invoked as a big scoped section that can be
   // exited out of at any point by returning.
@@ -1980,7 +1980,7 @@ static grpc_error_handle removal_error(grpc_error_handle extra_error,
   add_error(s->read_closed_error, refs, &nrefs);
   add_error(s->write_closed_error, refs, &nrefs);
   add_error(extra_error, refs, &nrefs);
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   if (nrefs > 0) {
     error = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(main_error_msg,
                                                              refs, nrefs);
@@ -2304,18 +2304,18 @@ void grpc_chttp2_act_on_flowctl_action(
 static grpc_error_handle try_http_parsing(grpc_chttp2_transport* t) {
   grpc_http_parser parser;
   size_t i = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_http_response response;
 
   grpc_http_parser_init(&parser, GRPC_HTTP_RESPONSE, &response);
 
-  grpc_error_handle parse_error = GRPC_ERROR_NONE;
+  grpc_error_handle parse_error;
   for (; i < t->read_buffer.count && parse_error.ok(); i++) {
     parse_error =
         grpc_http_parser_parse(&parser, t->read_buffer.slices[i], nullptr);
   }
   if (parse_error.ok() &&
-      (parse_error = grpc_http_parser_eof(&parser)) == GRPC_ERROR_NONE) {
+      (parse_error = grpc_http_parser_eof(&parser)) == absl::OkStatus()) {
     error = grpc_error_set_int(
         grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                                "Trying to connect an http1.x server"),
@@ -2349,11 +2349,11 @@ static void read_action_locked(void* tp, grpc_error_handle error) {
   std::swap(err, error);
   if (t->closed_with_error.ok()) {
     size_t i = 0;
-    grpc_error_handle errors[3] = {error, GRPC_ERROR_NONE, GRPC_ERROR_NONE};
-    for (; i < t->read_buffer.count && errors[1] == GRPC_ERROR_NONE; i++) {
+    grpc_error_handle errors[3] = {error, absl::OkStatus(), absl::OkStatus()};
+    for (; i < t->read_buffer.count && errors[1] == absl::OkStatus(); i++) {
       errors[1] = grpc_chttp2_perform_read(t, t->read_buffer.slices[i]);
     }
-    if (errors[1] != GRPC_ERROR_NONE) {
+    if (errors[1] != absl::OkStatus()) {
       errors[2] = try_http_parsing(t);
       error = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
           "Failed parsing HTTP/2", errors, GPR_ARRAY_SIZE(errors));
@@ -2609,7 +2609,7 @@ static void init_keepalive_ping_locked(void* arg, grpc_error_handle error) {
                       grpc_core::Timestamp::Now() + t->keepalive_time,
                       &t->init_keepalive_ping_locked);
     }
-  } else if (error == GRPC_ERROR_CANCELLED) {
+  } else if (error == absl::CancelledError()) {
     // The keepalive ping timer may be cancelled by bdp
     if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
         GRPC_TRACE_FLAG_ENABLED(grpc_keepalive_trace)) {
@@ -2717,7 +2717,7 @@ static void keepalive_watchdog_fired_locked(void* arg,
   } else {
     // The watchdog timer should have been cancelled by
     // finish_keepalive_ping_locked.
-    if (GPR_UNLIKELY(error != GRPC_ERROR_CANCELLED)) {
+    if (GPR_UNLIKELY(error != absl::CancelledError())) {
       gpr_log(GPR_ERROR, "keepalive_ping_end state error: %d (expect: %d)",
               t->keepalive_state, GRPC_CHTTP2_KEEPALIVE_STATE_PINGING);
     }
@@ -2770,7 +2770,7 @@ static void post_benign_reclaimer(grpc_chttp2_transport* t) {
                               benign_reclaimer_locked, t,
                               grpc_schedule_on_exec_ctx);
             t->active_reclamation = std::move(*sweep);
-            t->combiner->Run(&t->benign_reclaimer_locked, GRPC_ERROR_NONE);
+            t->combiner->Run(&t->benign_reclaimer_locked, absl::OkStatus());
           } else {
             GRPC_CHTTP2_UNREF_TRANSPORT(t, "benign_reclaimer");
           }
@@ -2790,7 +2790,8 @@ static void post_destructive_reclaimer(grpc_chttp2_transport* t) {
                               destructive_reclaimer_locked, t,
                               grpc_schedule_on_exec_ctx);
             t->active_reclamation = std::move(*sweep);
-            t->combiner->Run(&t->destructive_reclaimer_locked, GRPC_ERROR_NONE);
+            t->combiner->Run(&t->destructive_reclaimer_locked,
+                             absl::OkStatus());
           } else {
             GRPC_CHTTP2_UNREF_TRANSPORT(t, "benign_reclaimer");
           }
@@ -2820,7 +2821,7 @@ static void benign_reclaimer_locked(void* arg, grpc_error_handle error) {
             grpc_chttp2_stream_map_size(&t->stream_map));
   }
   t->benign_reclaimer_registered = false;
-  if (error != GRPC_ERROR_CANCELLED) {
+  if (error != absl::CancelledError()) {
     t->active_reclamation.Finish();
   }
   GRPC_CHTTP2_UNREF_TRANSPORT(t, "benign_reclaimer");
@@ -2850,7 +2851,7 @@ static void destructive_reclaimer_locked(void* arg, grpc_error_handle error) {
       post_destructive_reclaimer(t);
     }
   }
-  if (error != GRPC_ERROR_CANCELLED) {
+  if (error != absl::CancelledError()) {
     t->active_reclamation.Finish();
   }
   GRPC_CHTTP2_UNREF_TRANSPORT(t, "destructive_reclaimer");
@@ -2958,5 +2959,5 @@ void grpc_chttp2_transport_start_reading(
   t->notify_on_close = notify_on_close;
   t->combiner->Run(
       GRPC_CLOSURE_INIT(&t->read_action_locked, read_action_locked, t, nullptr),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -82,7 +82,7 @@ grpc_core::Poll<grpc_error_handle> grpc_deframe_unprocessed_incoming_frames(
     grpc_chttp2_stream* s, uint32_t* min_progress_size,
     grpc_core::SliceBuffer* stream_out, uint32_t* message_flags) {
   grpc_slice_buffer* slices = &s->frame_storage;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   if (slices->length < 5) {
     if (min_progress_size != nullptr) *min_progress_size = 5 - slices->length;
@@ -130,7 +130,7 @@ grpc_core::Poll<grpc_error_handle> grpc_deframe_unprocessed_incoming_frames(
     grpc_slice_buffer_move_first(slices, length, stream_out->c_slice_buffer());
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_chttp2_data_parser_parse(void* /*parser*/,
@@ -147,8 +147,8 @@ grpc_error_handle grpc_chttp2_data_parser_parse(void* /*parser*/,
         t, s, true, false,
         t->is_client ? GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                            "Data frame with END_STREAM flag received")
-                     : GRPC_ERROR_NONE);
+                     : absl::OkStatus());
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "absl/base/attributes.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 
@@ -52,7 +53,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_begin_frame(
   p->debug_data = static_cast<char*>(gpr_malloc(p->debug_length));
   p->debug_pos = 0;
   p->state = GRPC_CHTTP2_GOAWAY_LSI0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
@@ -70,7 +71,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_LSI0:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI0;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->last_stream_id = (static_cast<uint32_t>(*cur)) << 24;
       ++cur;
@@ -78,7 +79,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_LSI1:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI1;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->last_stream_id |= (static_cast<uint32_t>(*cur)) << 16;
       ++cur;
@@ -86,7 +87,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_LSI2:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI2;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->last_stream_id |= (static_cast<uint32_t>(*cur)) << 8;
       ++cur;
@@ -94,7 +95,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_LSI3:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI3;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->last_stream_id |= (static_cast<uint32_t>(*cur));
       ++cur;
@@ -102,7 +103,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_ERR0:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR0;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->error_code = (static_cast<uint32_t>(*cur)) << 24;
       ++cur;
@@ -110,7 +111,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_ERR1:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR1;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->error_code |= (static_cast<uint32_t>(*cur)) << 16;
       ++cur;
@@ -118,7 +119,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_ERR2:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR2;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->error_code |= (static_cast<uint32_t>(*cur)) << 8;
       ++cur;
@@ -126,7 +127,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
     case GRPC_CHTTP2_GOAWAY_ERR3:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR3;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       p->error_code |= (static_cast<uint32_t>(*cur));
       ++cur;
@@ -146,7 +147,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
         gpr_free(p->debug_data);
         p->debug_data = nullptr;
       }
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
   }
   GPR_UNREACHABLE_CODE(
       return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Should never reach here"));

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 
 #include <grpc/support/alloc.h>
@@ -69,7 +70,7 @@ grpc_error_handle grpc_chttp2_ping_parser_begin_frame(
   parser->byte = 0;
   parser->is_ack = flags;
   parser->opaque_8bytes = 0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
@@ -128,7 +129,7 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
     }
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void grpc_set_disable_ping_ack(bool disable_ping_ack) {

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -22,6 +22,7 @@
 
 #include <stddef.h>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -79,7 +80,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_begin_frame(
         "invalid rst_stream: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
@@ -111,7 +112,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
               "[chttp2 transport=%p stream=%p] received RST_STREAM(reason=%d)",
               t, s, reason);
     }
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     if (reason != GRPC_HTTP2_NO_ERROR || s->trailing_metadata_buffer.empty()) {
       error = grpc_error_set_int(
           grpc_error_set_str(
@@ -123,5 +124,5 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
     grpc_chttp2_mark_stream_closed(t, s, true, true, error);
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "absl/base/attributes.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 
 #include <grpc/slice_buffer.h>
@@ -105,7 +106,7 @@ grpc_error_handle grpc_chttp2_settings_parser_begin_frame(
       return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
           "non-empty settings ack frame received");
     }
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   } else if (flags != 0) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "invalid flags on settings frame");
@@ -113,7 +114,7 @@ grpc_error_handle grpc_chttp2_settings_parser_begin_frame(
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "settings frames must be a multiple of six bytes");
   } else {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 }
 
@@ -129,7 +130,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
   grpc_chttp2_setting_id id;
 
   if (parser->is_ack) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   for (;;) {
@@ -147,11 +148,11 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
             if (t->notify_on_receive_settings != nullptr) {
               grpc_core::ExecCtx::Run(DEBUG_LOCATION,
                                       t->notify_on_receive_settings,
-                                      GRPC_ERROR_NONE);
+                                      absl::OkStatus());
               t->notify_on_receive_settings = nullptr;
             }
           }
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         parser->id = static_cast<uint16_t>((static_cast<uint16_t>(*cur)) << 8);
         cur++;
@@ -159,7 +160,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
       case GRPC_CHTTP2_SPS_ID1:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_ID1;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         parser->id = static_cast<uint16_t>(parser->id | (*cur));
         cur++;
@@ -167,7 +168,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
       case GRPC_CHTTP2_SPS_VAL0:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL0;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         parser->value = (static_cast<uint32_t>(*cur)) << 24;
         cur++;
@@ -175,7 +176,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
       case GRPC_CHTTP2_SPS_VAL1:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL1;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         parser->value |= (static_cast<uint32_t>(*cur)) << 16;
         cur++;
@@ -183,7 +184,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
       case GRPC_CHTTP2_SPS_VAL2:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL2;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         parser->value |= (static_cast<uint32_t>(*cur)) << 8;
         cur++;
@@ -191,7 +192,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
       case GRPC_CHTTP2_SPS_VAL3:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL3;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         } else {
           parser->state = GRPC_CHTTP2_SPS_ID0;
         }

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -22,6 +22,7 @@
 
 #include <stddef.h>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -64,7 +65,7 @@ grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
   }
   parser->byte = 0;
   parser->amount = 0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_chttp2_window_update_parser_parse(
@@ -117,5 +118,5 @@ grpc_error_handle grpc_chttp2_window_update_parser_parse(
     }
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -586,7 +586,7 @@ class HPackParser::Input {
   // Extract the parse error, leaving the current error as NONE.
   grpc_error_handle TakeError() {
     grpc_error_handle out = error_;
-    error_ = GRPC_ERROR_NONE;
+    error_ = absl::OkStatus();
     return out;
   }
 
@@ -649,7 +649,7 @@ class HPackParser::Input {
   // Frontier denotes the first byte past successfully processed input
   const uint8_t* frontier_;
   // Current error
-  grpc_error_handle error_ = GRPC_ERROR_NONE;
+  grpc_error_handle error_;
   // If the error was EOF, we flag it here..
   bool eof_error_ = false;
 };
@@ -1281,7 +1281,7 @@ grpc_error_handle HPackParser::Parse(const grpc_slice& slice, bool is_last) {
 
 grpc_error_handle HPackParser::ParseInput(Input input, bool is_last) {
   if (ParseInputInner(&input)) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
   if (input.eof_error()) {
     if (GPR_UNLIKELY(is_last && is_boundary())) {
@@ -1289,7 +1289,7 @@ grpc_error_handle HPackParser::ParseInput(Input input, bool is_last) {
           "Incomplete header at the end of a header/continuation sequence");
     }
     unparsed_bytes_ = std::vector<uint8_t>(input.frontier(), input.end_ptr());
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
   return input.TakeError();
 }
@@ -1337,7 +1337,7 @@ static void force_client_rst_stream(void* sp, grpc_error_handle /*error*/) {
     grpc_chttp2_add_rst_stream_to_next_write(t, s->id, GRPC_HTTP2_NO_ERROR,
                                              &s->stats.outgoing);
     grpc_chttp2_initiate_write(t, GRPC_CHTTP2_INITIATE_WRITE_FORCE_RST_STREAM);
-    grpc_chttp2_mark_stream_closed(t, s, true, true, GRPC_ERROR_NONE);
+    grpc_chttp2_mark_stream_closed(t, s, true, true, absl::OkStatus());
   }
   GRPC_CHTTP2_STREAM_UNREF(s, "final_rst");
 }
@@ -1378,12 +1378,12 @@ grpc_error_handle grpc_chttp2_header_parser_parse(void* hpack_parser,
           GRPC_CHTTP2_STREAM_REF(s, "final_rst");
           t->combiner->FinallyRun(
               GRPC_CLOSURE_CREATE(force_client_rst_stream, s, nullptr),
-              GRPC_ERROR_NONE);
+              absl::OkStatus());
         }
-        grpc_chttp2_mark_stream_closed(t, s, true, false, GRPC_ERROR_NONE);
+        grpc_chttp2_mark_stream_closed(t, s, true, false, absl::OkStatus());
       }
     }
     parser->FinishFrame();
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 
@@ -100,7 +101,7 @@ void HPackTable::SetMaxBytes(uint32_t max_bytes) {
 
 grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
   if (current_table_bytes_ == bytes) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
   if (bytes > max_bytes_) {
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
@@ -117,7 +118,7 @@ grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
   uint32_t new_cap = std::max(hpack_constants::EntriesForBytes(bytes),
                               hpack_constants::kInitialTableEntries);
   entries_.Rebuild(new_cap);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle HPackTable::Add(Memento md) {
@@ -140,7 +141,7 @@ grpc_error_handle HPackTable::Add(Memento md) {
     while (entries_.num_entries()) {
       EvictOne();
     }
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   // evict entries to ensure no overflow
@@ -152,7 +153,7 @@ grpc_error_handle HPackTable::Add(Memento md) {
   // copy the finalized entry in
   mem_used_ += md.transport_size();
   entries_.Put(std::move(md));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 namespace {

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -261,7 +261,7 @@ struct grpc_chttp2_transport {
   /** is the transport destroying itself? */
   uint8_t destroying = false;
   /** has the upper layer closed the transport? */
-  grpc_error_handle closed_with_error = GRPC_ERROR_NONE;
+  grpc_error_handle closed_with_error;
 
   /** is there a read request to the endpoint outstanding? */
   uint8_t endpoint_reading = 1;
@@ -309,8 +309,8 @@ struct grpc_chttp2_transport {
   uint32_t write_buffer_size = grpc_core::chttp2::kDefaultWindow;
 
   /** Set to a grpc_error object if a goaway frame is received. By default, set
-   * to GRPC_ERROR_NONE */
-  grpc_error_handle goaway_error = GRPC_ERROR_NONE;
+   * to absl::OkStatus() */
+  grpc_error_handle goaway_error;
 
   grpc_chttp2_sent_goaway_state sent_goaway_state = GRPC_CHTTP2_NO_GOAWAY_SEND;
 
@@ -391,7 +391,7 @@ struct grpc_chttp2_transport {
 
   /* if non-NULL, close the transport with this error when writes are finished
    */
-  grpc_error_handle close_transport_on_writes_finished = GRPC_ERROR_NONE;
+  grpc_error_handle close_transport_on_writes_finished;
 
   /* a list of closures to run after writes are finished */
   grpc_closure_list run_after_write = GRPC_CLOSURE_LIST_INIT;
@@ -527,9 +527,9 @@ struct grpc_chttp2_stream {
   bool eos_sent = false;
 
   /** the error that resulted in this stream being read-closed */
-  grpc_error_handle read_closed_error = GRPC_ERROR_NONE;
+  grpc_error_handle read_closed_error;
   /** the error that resulted in this stream being write-closed */
-  grpc_error_handle write_closed_error = GRPC_ERROR_NONE;
+  grpc_error_handle write_closed_error;
 
   grpc_published_metadata_method published_metadata[2] = {};
   bool final_metadata_requested = false;
@@ -543,7 +543,7 @@ struct grpc_chttp2_stream {
   grpc_core::Timestamp deadline = grpc_core::Timestamp::InfFuture();
 
   /** saw some stream level error */
-  grpc_error_handle forced_close_error = GRPC_ERROR_NONE;
+  grpc_error_handle forced_close_error;
   /** how many header frames have we received? */
   uint8_t header_frames_received = 0;
   /** number of bytes received - reset at end of parse thread execution */

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -130,7 +130,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
   const uint8_t* cur = beg;
   grpc_error_handle err;
 
-  if (cur == end) return GRPC_ERROR_NONE;
+  if (cur == end) return absl::OkStatus();
 
   switch (t->deframe_state) {
     case GRPC_DTS_CLIENT_PREFIX_0:
@@ -175,7 +175,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
             1 + static_cast<int>(t->deframe_state));
       }
       if (cur == end) {
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
     dts_fh_0:
       ABSL_FALLTHROUGH_INTENDED;
@@ -184,7 +184,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_frame_size = (static_cast<uint32_t>(*cur)) << 16;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_1;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_1:
@@ -192,7 +192,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_frame_size |= (static_cast<uint32_t>(*cur)) << 8;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_2;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_2:
@@ -200,7 +200,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_frame_size |= *cur;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_3;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_3:
@@ -208,7 +208,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_frame_type = *cur;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_4;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_4:
@@ -216,7 +216,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_frame_flags = *cur;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_5;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_5:
@@ -224,7 +224,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_stream_id = ((static_cast<uint32_t>(*cur)) & 0x7f) << 24;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_6;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_6:
@@ -232,7 +232,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_stream_id |= (static_cast<uint32_t>(*cur)) << 16;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_7;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_7:
@@ -240,7 +240,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
       t->incoming_stream_id |= (static_cast<uint32_t>(*cur)) << 8;
       if (++cur == end) {
         t->deframe_state = GRPC_DTS_FH_8;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_8:
@@ -259,7 +259,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         t->incoming_stream = nullptr;
         if (++cur == end) {
           t->deframe_state = GRPC_DTS_FH_0;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         goto dts_fh_0; /* loop */
       } else if (t->incoming_frame_size >
@@ -272,7 +272,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
                                        [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE]));
       }
       if (++cur == end) {
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
       ABSL_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FRAME:
@@ -288,7 +288,7 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         }
         t->deframe_state = GRPC_DTS_FH_0;
         t->incoming_stream = nullptr;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       } else if (static_cast<uint32_t>(end - cur) > t->incoming_frame_size) {
         size_t cur_offset = static_cast<size_t>(cur - beg);
         err = parse_frame_slice(
@@ -312,12 +312,12 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
           return err;
         }
         t->incoming_frame_size -= static_cast<uint32_t>(end - cur);
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       }
-      GPR_UNREACHABLE_CODE(return GRPC_ERROR_NONE);
+      GPR_UNREACHABLE_CODE(return absl::OkStatus());
   }
 
-  GPR_UNREACHABLE_CODE(return GRPC_ERROR_NONE);
+  GPR_UNREACHABLE_CODE(return absl::OkStatus());
 }
 
 static grpc_error_handle init_frame_parser(grpc_chttp2_transport* t) {
@@ -373,7 +373,7 @@ static grpc_error_handle skip_parser(void* /*parser*/,
                                      grpc_chttp2_stream* /*s*/,
                                      const grpc_slice& /*slice*/,
                                      int /*is_last*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static HPackParser::Boundary hpack_boundary_type(grpc_chttp2_transport* t,
@@ -409,13 +409,13 @@ static grpc_error_handle init_header_skip_frame_parser(
                  [GRPC_CHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE],
       hpack_boundary_type(t, is_eoh), priority_type,
       hpack_parser_log_info(t, HPackParser::LogInfo::kDontKnow));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle init_non_header_skip_frame_parser(
     grpc_chttp2_transport* t) {
   t->parser = skip_parser;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void grpc_chttp2_parsing_become_skip_parser(grpc_chttp2_transport* t) {
@@ -473,7 +473,7 @@ error_handler:
     t->parser = grpc_chttp2_data_parser_parse;
     t->parser_data = nullptr;
     t->ping_state.last_ping_sent_time = grpc_core::Timestamp::InfPast();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   } else if (s != nullptr) {
     /* handle stream errors by closing the stream */
     grpc_chttp2_mark_stream_closed(t, s, true, false,
@@ -622,7 +622,7 @@ static grpc_error_handle init_header_frame_parser(grpc_chttp2_transport* t,
                  [GRPC_CHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE],
       hpack_boundary_type(t, is_eoh), priority_type,
       hpack_parser_log_info(t, frame_type));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle init_window_update_frame_parser(
@@ -641,7 +641,7 @@ static grpc_error_handle init_window_update_frame_parser(
   }
   t->parser = grpc_chttp2_window_update_parser_parse;
   t->parser_data = &t->simple.window_update;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle init_ping_parser(grpc_chttp2_transport* t) {
@@ -650,7 +650,7 @@ static grpc_error_handle init_ping_parser(grpc_chttp2_transport* t) {
   if (!err.ok()) return err;
   t->parser = grpc_chttp2_ping_parser_parse;
   t->parser_data = &t->simple.ping;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle init_rst_stream_parser(grpc_chttp2_transport* t) {
@@ -665,7 +665,7 @@ static grpc_error_handle init_rst_stream_parser(grpc_chttp2_transport* t) {
   s->stats.incoming.framing_bytes += 9;
   t->parser = grpc_chttp2_rst_stream_parser_parse;
   t->parser_data = &t->simple.rst_stream;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle init_goaway_parser(grpc_chttp2_transport* t) {
@@ -674,7 +674,7 @@ static grpc_error_handle init_goaway_parser(grpc_chttp2_transport* t) {
   if (!err.ok()) return err;
   t->parser = grpc_chttp2_goaway_parser_parse;
   t->parser_data = &t->goaway_parser;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle init_settings_frame_parser(grpc_chttp2_transport* t) {
@@ -702,7 +702,7 @@ static grpc_error_handle init_settings_frame_parser(grpc_chttp2_transport* t) {
   }
   t->parser = grpc_chttp2_settings_parser_parse;
   t->parser_data = &t->simple.settings;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle parse_frame_slice(grpc_chttp2_transport* t,

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/slice.h>
@@ -410,7 +411,7 @@ class DataSendContext {
             t_, s_,
             static_cast<int64_t>(s_->sending_bytes - sending_bytes_before_),
             &s_->on_flow_controlled_cbs, &s_->flow_controlled_bytes_flowed,
-            GRPC_ERROR_NONE)) {
+            absl::OkStatus())) {
       write_context_->NoteScheduledResults();
     }
   }
@@ -472,7 +473,7 @@ class StreamWriteContext {
     s_->sent_initial_metadata = true;
     write_context_->NoteScheduledResults();
     grpc_chttp2_complete_closure_step(
-        t_, s_, &s_->send_initial_metadata_finished, GRPC_ERROR_NONE,
+        t_, s_, &s_->send_initial_metadata_finished, absl::OkStatus(),
         "send_initial_metadata_finished");
   }
 
@@ -566,7 +567,7 @@ class StreamWriteContext {
 
     write_context_->NoteScheduledResults();
     grpc_chttp2_complete_closure_step(
-        t_, s_, &s_->send_trailing_metadata_finished, GRPC_ERROR_NONE,
+        t_, s_, &s_->send_trailing_metadata_finished, absl::OkStatus(),
         "send_trailing_metadata_finished");
   }
 
@@ -599,7 +600,7 @@ class StreamWriteContext {
                            s_->id, GRPC_HTTP2_NO_ERROR, &s_->stats.outgoing));
     }
     grpc_chttp2_mark_stream_closed(t_, s_, !t_->is_client, true,
-                                   GRPC_ERROR_NONE);
+                                   absl::OkStatus());
   }
 
   WriteContext* const write_context_;

--- a/src/core/ext/xds/certificate_provider_store.cc
+++ b/src/core/ext/xds/certificate_provider_store.cc
@@ -74,7 +74,7 @@ void CertificateProviderStore::PluginDefinition::JsonPostLoad(
     }
     if (factory == nullptr) return;
     // Use plugin to validate and parse config.
-    grpc_error_handle parse_error = GRPC_ERROR_NONE;
+    grpc_error_handle parse_error;
     config =
         factory->CreateCertificateProviderConfig(config_json, &parse_error);
     if (!parse_error.ok()) {

--- a/src/core/ext/xds/xds_client_grpc.cc
+++ b/src/core/ext/xds/xds_client_grpc.cc
@@ -205,7 +205,7 @@ void SetXdsFallbackBootstrapConfig(const char* config) {
 grpc_slice grpc_dump_xds_configs(void) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto xds_client = grpc_core::GrpcXdsClient::GetOrCreate(
       grpc_core::ChannelArgs(), "grpc_dump_xds_configs()");
   if (!xds_client.ok()) {

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -71,7 +71,6 @@
 #include "src/core/lib/gprpp/env.h"
 #include "src/core/lib/gprpp/match.h"
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/matchers/matchers.h"
 
 namespace grpc_core {
@@ -581,7 +580,7 @@ absl::Status RouteRuntimeFractionParse(
       route->matchers.fraction_per_million = numerator;
     }
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 template <typename ParentType, typename EntryType>

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -91,7 +91,7 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
   path.copy(un->sun_path, path.size());
   un->sun_path[path.size()] = '\0';
   resolved_addr->len = static_cast<socklen_t>(sizeof(*un));
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle UnixAbstractSockaddrPopulate(
@@ -109,7 +109,7 @@ grpc_error_handle UnixAbstractSockaddrPopulate(
   path.copy(un->sun_path + 1, path.size());
   resolved_addr->len =
       static_cast<socklen_t>(sizeof(un->sun_family) + path.size() + 1);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/channel/channel_stack.cc
+++ b/src/core/lib/channel/channel_stack.cc
@@ -134,7 +134,7 @@ grpc_error_handle grpc_channel_stack_init(
                                              sizeof(grpc_channel_element));
 
   /* init per-filter data */
-  grpc_error_handle first_error = GRPC_ERROR_NONE;
+  grpc_error_handle first_error;
   auto c_channel_args = channel_args.ToC();
   for (i = 0; i < filter_count; i++) {
     args.channel_stack = stack;
@@ -194,7 +194,7 @@ grpc_error_handle grpc_call_stack_init(
               GPR_ROUND_UP_TO_ALIGNMENT_SIZE(count * sizeof(grpc_call_element));
 
   /* init per-filter data */
-  grpc_error_handle first_error = GRPC_ERROR_NONE;
+  grpc_error_handle first_error;
   for (size_t i = 0; i < count; i++) {
     call_elems[i].filter = channel_elems[i].filter;
     call_elems[i].channel_data = channel_elems[i].channel_data;

--- a/src/core/lib/channel/connected_channel.cc
+++ b/src/core/lib/channel/connected_channel.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/channel/connected_channel.h"
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -156,7 +158,7 @@ static grpc_error_handle connected_channel_init_call_elem(
   int r = grpc_transport_init_stream(
       chand->transport, TRANSPORT_STREAM_FROM_CALL_DATA(calld),
       &args->call_stack->refcount, args->server_transport_data, args->arena);
-  return r == 0 ? GRPC_ERROR_NONE
+  return r == 0 ? absl::OkStatus()
                 : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                       "transport stream initialization failed");
 }
@@ -187,7 +189,7 @@ static grpc_error_handle connected_channel_init_channel_elem(
   GPR_ASSERT(args->is_last);
   cd->transport = grpc_channel_args_find_pointer<grpc_transport>(
       args->channel_args, GRPC_ARG_TRANSPORT);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Destructor for channel_data */

--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -75,7 +75,7 @@ void BaseCallData::Wakeup() {
     self->Drop();
   };
   auto* closure = GRPC_CLOSURE_CREATE(wakeup, this, nullptr);
-  GRPC_CALL_COMBINER_START(call_combiner_, closure, GRPC_ERROR_NONE, "wakeup");
+  GRPC_CALL_COMBINER_START(call_combiner_, closure, absl::OkStatus(), "wakeup");
 }
 
 void BaseCallData::Drop() { GRPC_CALL_STACK_UNREF(call_stack_, "waker"); }
@@ -196,7 +196,7 @@ BaseCallData::Flusher::~Flusher() {
     GRPC_CLOSURE_INIT(&batch->handler_private.closure, call_next_op, batch,
                       nullptr);
     GRPC_CALL_STACK_REF(call_->call_stack(), "flusher_batch");
-    call_closures_.Add(&batch->handler_private.closure, GRPC_ERROR_NONE,
+    call_closures_.Add(&batch->handler_private.closure, absl::OkStatus(),
                        "flusher_batch");
   }
   call_closures_.RunClosuresWithoutYielding(call_->call_combiner());
@@ -282,7 +282,7 @@ class ClientCallData::PollContext {
             flusher_->AddClosure(
                 std::exchange(self_->recv_initial_metadata_->original_on_ready,
                               nullptr),
-                GRPC_ERROR_NONE,
+                absl::OkStatus(),
                 "wake_inside_combiner:recv_initial_metadata_ready");
           }
         } break;
@@ -310,7 +310,7 @@ class ClientCallData::PollContext {
             flusher_->AddClosure(
                 std::exchange(self_->original_recv_trailing_metadata_ready_,
                               nullptr),
-                GRPC_ERROR_NONE, "wake_inside_combiner:recv_trailing_ready:1");
+                absl::OkStatus(), "wake_inside_combiner:recv_trailing_ready:1");
             if (self_->recv_initial_metadata_ != nullptr) {
               switch (self_->recv_initial_metadata_->state) {
                 case RecvInitialMetadata::kInitial:
@@ -335,7 +335,7 @@ class ClientCallData::PollContext {
                       std::exchange(
                           self_->recv_initial_metadata_->original_on_ready,
                           nullptr),
-                      GRPC_ERROR_CANCELLED,
+                      absl::CancelledError(),
                       "wake_inside_combiner:recv_initial_metadata_ready");
               }
             }
@@ -418,7 +418,7 @@ class ClientCallData::PollContext {
           flusher_->AddClosure(
               std::exchange(self_->original_recv_trailing_metadata_ready_,
                             nullptr),
-              GRPC_ERROR_NONE, "wake_inside_combiner:recv_trailing_ready:2");
+              absl::OkStatus(), "wake_inside_combiner:recv_trailing_ready:2");
         }
         break;
     }
@@ -448,7 +448,7 @@ class ClientCallData::PollContext {
       p->call_data = self_;
       GRPC_CALL_STACK_REF(self_->call_stack(), "re-poll");
       GRPC_CLOSURE_INIT(p, run, p, nullptr);
-      flusher_->AddClosure(p, GRPC_ERROR_NONE, "re-poll");
+      flusher_->AddClosure(p, absl::OkStatus(), "re-poll");
     }
   }
 
@@ -590,7 +590,7 @@ void ClientCallData::StartBatch(grpc_transport_stream_op_batch* b) {
     if (!is_last()) {
       batch.ResumeWith(&flusher);
     } else {
-      batch.CancelWith(GRPC_ERROR_CANCELLED, &flusher);
+      batch.CancelWith(absl::CancelledError(), &flusher);
     }
   }
 }
@@ -915,7 +915,7 @@ class ServerCallData::PollContext {
       p->call_data = self_;
       GRPC_CALL_STACK_REF(self_->call_stack(), "re-poll");
       GRPC_CLOSURE_INIT(p, run, p, nullptr);
-      flusher_->AddClosure(p, GRPC_ERROR_NONE, "re-poll");
+      flusher_->AddClosure(p, absl::OkStatus(), "re-poll");
     }
   }
 
@@ -1163,7 +1163,7 @@ void ServerCallData::RecvInitialMetadataReady(grpc_error_handle error) {
   WakeInsideCombiner(&flusher);
   if (auto* closure =
           std::exchange(original_recv_initial_metadata_ready_, nullptr)) {
-    flusher.AddClosure(closure, GRPC_ERROR_NONE,
+    flusher.AddClosure(closure, absl::OkStatus(),
                        "original_recv_initial_metadata");
   }
 }

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -30,6 +30,7 @@
 
 #include "absl/container/inlined_vector.h"
 #include "absl/meta/type_traits.h"
+#include "absl/status/status.h"
 
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/log.h>
@@ -181,7 +182,7 @@ class BaseCallData : public Activity, private Wakeable {
     }
 
     void Complete(grpc_transport_stream_op_batch* batch) {
-      call_closures_.Add(batch->on_complete, GRPC_ERROR_NONE,
+      call_closures_.Add(batch->on_complete, absl::OkStatus(),
                          "Flusher::Complete");
     }
 
@@ -360,7 +361,7 @@ class ClientCallData : public BaseCallData {
   // Our closure pointing to RecvTrailingMetadataReadyCallback.
   grpc_closure recv_trailing_metadata_ready_;
   // Error received during cancellation.
-  grpc_error_handle cancelled_error_ = GRPC_ERROR_NONE;
+  grpc_error_handle cancelled_error_;
   // State of the send_initial_metadata op.
   SendInitialState send_initial_state_ = SendInitialState::kInitial;
   // State of the recv_trailing_metadata op.
@@ -439,7 +440,7 @@ class ServerCallData : public BaseCallData {
   // Our closure pointing to RecvInitialMetadataReadyCallback.
   grpc_closure recv_initial_metadata_ready_;
   // Error received during cancellation.
-  grpc_error_handle cancelled_error_ = GRPC_ERROR_NONE;
+  grpc_error_handle cancelled_error_;
   // Trailing metadata batch
   CapturedBatch send_trailing_metadata_batch_;
   // State of the send_initial_metadata op.
@@ -510,7 +511,7 @@ MakePromiseBasedFilter(const char* name) {
       // init_call_elem
       [](grpc_call_element* elem, const grpc_call_element_args* args) {
         new (elem->call_data) CallData(elem, args, kFlags);
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       },
       // set_pollset_or_pollset_set
       [](grpc_call_element* elem, grpc_polling_entity* pollent) {
@@ -523,7 +524,7 @@ MakePromiseBasedFilter(const char* name) {
         cd->Finalize(final_info);
         cd->~CallData();
         if ((kFlags & kFilterIsLast) != 0) {
-          ExecCtx::Run(DEBUG_LOCATION, then_schedule_closure, GRPC_ERROR_NONE);
+          ExecCtx::Run(DEBUG_LOCATION, then_schedule_closure, absl::OkStatus());
         } else {
           GPR_ASSERT(then_schedule_closure == nullptr);
         }
@@ -544,7 +545,7 @@ MakePromiseBasedFilter(const char* name) {
           return absl_status_to_grpc_error(status.status());
         }
         new (elem->channel_data) F(std::move(*status));
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       },
       // post_init_channel_elem
       [](grpc_channel_stack*, grpc_channel_element* elem) {

--- a/src/core/lib/event_engine/posix_engine/timer.h
+++ b/src/core/lib/event_engine/posix_engine/timer.h
@@ -78,12 +78,12 @@ class TimerList {
   TimerList& operator=(const TimerList&) = delete;
 
   /* Initialize *timer. When expired or canceled, closure will be called with
-   error set to indicate if it expired (GRPC_ERROR_NONE) or was canceled
-   (GRPC_ERROR_CANCELLED). *closure is guaranteed to be called exactly once, and
-   application code should check the error to determine how it was invoked. The
-   application callback is also responsible for maintaining information about
-   when to free up any user-level state. Behavior is undefined for a deadline of
-   grpc_core::Timestamp::InfFuture(). */
+   error set to indicate if it expired (absl::OkStatus()) or was canceled
+   (absl::CancelledError()). *closure is guaranteed to be called exactly once,
+   and application code should check the error to determine how it was invoked.
+   The application callback is also responsible for maintaining information
+   about when to free up any user-level state. Behavior is undefined for a
+   deadline of grpc_core::Timestamp::InfFuture(). */
   void TimerInit(Timer* timer, grpc_core::Timestamp deadline,
                  experimental::EventEngine::Closure* closure);
 
@@ -103,8 +103,9 @@ class TimerList {
 
      In all of these cases, the cancellation is still considered successful.
      They are essentially distinguished in that the timer_cb will be run
-     exactly once from either the cancellation (with error GRPC_ERROR_CANCELLED)
-     or from the activation (with error GRPC_ERROR_NONE).
+     exactly once from either the cancellation (with error
+     absl::CancelledError()) or from the activation (with error
+     absl::OkStatus()).
 
      Note carefully that the callback function MAY occur in the same callstack
      as grpc_timer_cancel. It's expected that most timers will be cancelled

--- a/src/core/lib/event_engine/windows/win_socket.cc
+++ b/src/core/lib/event_engine/windows/win_socket.cc
@@ -151,7 +151,7 @@ grpc_error_handle grpc_tcp_set_non_block(SOCKET sock) {
   status = WSAIoctl(sock, GRPC_FIONBIO, &param, sizeof(param), NULL, 0, &ret,
                     NULL, NULL);
   return status == 0
-             ? GRPC_ERROR_NONE
+             ? absl::OkStatus()
              : GRPC_WSA_ERROR(WSAGetLastError(), "WSAIoctl(GRPC_FIONBIO)");
 }
 
@@ -161,7 +161,7 @@ static grpc_error_handle set_dualstack(SOCKET sock) {
   status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&param,
                       sizeof(param));
   return status == 0
-             ? GRPC_ERROR_NONE
+             ? absl::OkStatus()
              : GRPC_WSA_ERROR(WSAGetLastError(), "setsockopt(IPV6_V6ONLY)");
 }
 
@@ -173,7 +173,7 @@ static grpc_error_handle enable_socket_low_latency(SOCKET sock) {
   if (status == SOCKET_ERROR) {
     status = WSAGetLastError();
   }
-  return status == 0 ? GRPC_ERROR_NONE
+  return status == 0 ? absl::OkStatus()
                      : GRPC_WSA_ERROR(status, "setsockopt(TCP_NODELAY)");
 }
 
@@ -187,7 +187,7 @@ absl::Status PrepareSocket(SOCKET sock) {
   if (!err.ok()) return err;
   err = set_dualstack(sock);
   if (!err.ok()) return err;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 }  // namespace experimental

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -388,7 +388,7 @@ void HttpRequest::OnResolved(
   }
   addresses_ = std::move(*addresses_or);
   next_address_ = 0;
-  NextAddress(GRPC_ERROR_NONE);
+  NextAddress(absl::OkStatus());
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/http/httpcli.h
+++ b/src/core/lib/http/httpcli.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/types/optional.h"
 
@@ -259,7 +260,7 @@ class HttpRequest : public InternallyRefCounted<HttpRequest> {
   grpc_iomgr_object iomgr_obj_ ABSL_GUARDED_BY(mu_);
   grpc_slice_buffer incoming_ ABSL_GUARDED_BY(mu_);
   grpc_slice_buffer outgoing_ ABSL_GUARDED_BY(mu_);
-  grpc_error_handle overall_error_ ABSL_GUARDED_BY(mu_) = GRPC_ERROR_NONE;
+  grpc_error_handle overall_error_ ABSL_GUARDED_BY(mu_) = absl::OkStatus();
   absl::optional<DNSResolver::TaskHandle> dns_request_handle_
       ABSL_GUARDED_BY(mu_) = DNSResolver::kNullHandle;
 };

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -109,7 +109,7 @@ class grpc_httpcli_ssl_channel_security_connector final
                   const ChannelArgs& /*args*/,
                   RefCountedPtr<grpc_auth_context>* /*auth_context*/,
                   grpc_closure* on_peer_checked) override {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
 
     /* Check the peer name. */
     if (secure_peer_name_ != nullptr &&

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -24,6 +24,8 @@
 
 #include <algorithm>
 
+#include "absl/status/status.h"
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
@@ -86,7 +88,7 @@ static grpc_error_handle handle_response_line(grpc_http_parser* parser) {
 
   /* we don't really care about the status code message */
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
@@ -157,7 +159,7 @@ static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
         "Expected one of HTTP/1.0, HTTP/1.1, or HTTP/2.0");
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle handle_first_line(grpc_http_parser* parser) {
@@ -179,7 +181,7 @@ static grpc_error_handle add_header(grpc_http_parser* parser) {
   size_t size = 0;
   grpc_http_header** hdrs = nullptr;
   grpc_http_header hdr = {nullptr, nullptr};
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   GPR_ASSERT(cur != end);
 
@@ -275,7 +277,7 @@ static grpc_error_handle finish_line(grpc_http_parser* parser,
   }
 
   parser->cur_line_length = 0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
@@ -301,7 +303,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
           return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
               "Expected chunk size in hexadecimal");
         }
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       case GRPC_HTTP_CHUNKED_IGNORE_ALL_UNTIL_LF:
         if (byte == '\n') {
           if (parser->http.response->chunk_length == 0) {
@@ -310,7 +312,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
             parser->http.response->chunked_state = GRPC_HTTP_CHUNKED_BODY;
           }
         }
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       case GRPC_HTTP_CHUNKED_BODY:
         if (parser->http.response->chunk_length == 0) {
           if (byte != '\r') {
@@ -319,7 +321,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
           }
           parser->http.response->chunked_state = GRPC_HTTP_CHUNKED_CONSUME_LF;
           parser->http.response->chunk_length = 0;
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         } else {
           parser->http.response->chunk_length--;
           /* fallback to the normal body appending code below */
@@ -331,7 +333,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
               "Expected '\\r\\n' after chunk body");
         }
         parser->http.response->chunked_state = GRPC_HTTP_CHUNKED_LENGTH;
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       case GRPC_HTTP_CHUNKED_PLAIN:
         /* avoiding warning; just fallback to normal codepath */
         break;
@@ -353,7 +355,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
   (*body)[*body_length] = static_cast<char>(byte);
   (*body_length)++;
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static bool check_line(grpc_http_parser* parser) {
@@ -399,13 +401,13 @@ static grpc_error_handle addbyte(grpc_http_parser* parser, uint8_t byte,
       if (check_line(parser)) {
         return finish_line(parser, found_body_start);
       }
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     case GRPC_HTTP_BODY:
       return addbyte_body(parser, byte);
     case GRPC_HTTP_END:
       return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Unexpected byte after end");
   }
-  GPR_UNREACHABLE_CODE(return GRPC_ERROR_NONE);
+  GPR_UNREACHABLE_CODE(return absl::OkStatus());
 }
 
 void grpc_http_parser_init(grpc_http_parser* parser, grpc_http_type type,
@@ -451,12 +453,12 @@ grpc_error_handle grpc_http_parser_parse(grpc_http_parser* parser,
     if (!err.ok()) return err;
     if (found_body_start && start_of_body != nullptr) *start_of_body = i + 1;
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_http_parser_eof(grpc_http_parser* parser) {
   if ((parser->state != GRPC_HTTP_BODY) && (parser->state != GRPC_HTTP_END)) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Did not finish headers");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -254,7 +254,7 @@ void TracedBuffer::ProcessTimestamp(TracedBuffer** head,
           /* Got all timestamps. Do the callback and free this TracedBuffer.
            * The thing below can be passed by value if we don't want the
            * restriction on the lifetime. */
-          timestamps_callback(elem->arg_, &(elem->ts_), GRPC_ERROR_NONE);
+          timestamps_callback(elem->arg_, &(elem->ts_), absl::OkStatus());
           next = elem->next_;
           delete static_cast<TracedBuffer*>(elem);
           *head = elem = next;

--- a/src/core/lib/iomgr/call_combiner.cc
+++ b/src/core/lib/iomgr/call_combiner.cc
@@ -39,7 +39,7 @@ grpc_error_handle DecodeCancelStateError(gpr_atm cancel_state) {
   if (cancel_state & kErrorBit) {
     return internal::StatusGetFromHeapPtr(cancel_state & ~kErrorBit);
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 }  // namespace
@@ -209,7 +209,7 @@ void CallCombiner::SetNotifyOnCancel(grpc_closure* closure) {
                   this, closure);
         }
         // If we replaced an earlier closure, invoke the original
-        // closure with GRPC_ERROR_NONE.  This allows callers to clean
+        // closure with absl::OkStatus().  This allows callers to clean
         // up any resources they may be holding for the callback.
         if (original_state != 0) {
           closure = reinterpret_cast<grpc_closure*>(original_state);
@@ -218,7 +218,7 @@ void CallCombiner::SetNotifyOnCancel(grpc_closure* closure) {
                     "call_combiner=%p: scheduling old cancel callback=%p", this,
                     closure);
           }
-          ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+          ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
         }
         break;
       }

--- a/src/core/lib/iomgr/call_combiner.h
+++ b/src/core/lib/iomgr/call_combiner.h
@@ -80,7 +80,7 @@ class CallCombiner {
   /// once; this allows the closure to hold references that will be freed
   /// regardless of whether or not the call was cancelled.  If a cancellation
   /// does occur, the closure will be scheduled with the cancellation error;
-  /// otherwise, it will be scheduled with GRPC_ERROR_NONE.
+  /// otherwise, it will be scheduled with absl::OkStatus().
   ///
   /// The closure will be scheduled in the following cases:
   /// - If Cancel() was called prior to registering the closure, it will be
@@ -89,7 +89,7 @@ class CallCombiner {
   ///   be scheduled with the cancellation error.
   /// - If SetNotifyOnCancel() is called again to register a new cancellation
   ///   closure, the previous cancellation closure will be scheduled with
-  ///   GRPC_ERROR_NONE.
+  ///   absl::OkStatus().
   ///
   /// If \a closure is NULL, then no closure will be invoked on
   /// cancellation; this effectively unregisters the previously set closure.

--- a/src/core/lib/iomgr/closure.h
+++ b/src/core/lib/iomgr/closure.h
@@ -45,7 +45,7 @@ typedef struct grpc_closure_list {
 /** gRPC Callback definition.
  *
  * \param arg Arbitrary input.
- * \param error GRPC_ERROR_NONE if no error occurred, otherwise some grpc_error
+ * \param error absl::OkStatus() if no error occurred, otherwise some grpc_error
  *              describing what went wrong.
  *              Error contract: it is not the cb's job to unref this error;
  *              the closure scheduler will do that after the cb returns */

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -171,7 +171,7 @@ static void offload(void* arg, grpc_error_handle /*error*/) {
 static void queue_offload(grpc_core::Combiner* lock) {
   move_next();
   GRPC_COMBINER_TRACE(gpr_log(GPR_INFO, "C:%p queue_offload", lock));
-  grpc_core::Executor::Run(&lock->offload, GRPC_ERROR_NONE);
+  grpc_core::Executor::Run(&lock->offload, absl::OkStatus());
 }
 
 bool grpc_combiner_continue_exec_ctx() {

--- a/src/core/lib/iomgr/endpoint_cfstream.cc
+++ b/src/core/lib/iomgr/endpoint_cfstream.cc
@@ -181,7 +181,7 @@ static void ReadAction(void* arg, grpc_error_handle error) {
     if (read_size < static_cast<CFIndex>(len)) {
       grpc_slice_buffer_trim_end(ep->read_slices, len - read_size, nullptr);
     }
-    CallReadCb(ep, GRPC_ERROR_NONE);
+    CallReadCb(ep, absl::OkStatus());
     EP_UNREF(ep, "read");
   }
 }
@@ -219,7 +219,7 @@ static void WriteAction(void* arg, grpc_error_handle error) {
     if (ep->write_slices->length > 0) {
       ep->stream_sync->NotifyOnWrite(&ep->write_action);
     } else {
-      CallWriteCb(ep, GRPC_ERROR_NONE);
+      CallWriteCb(ep, absl::OkStatus());
       EP_UNREF(ep, "write");
     }
 

--- a/src/core/lib/iomgr/endpoint_pair_posix.cc
+++ b/src/core/lib/iomgr/endpoint_pair_posix.cc
@@ -50,8 +50,8 @@ static void create_sockets(int sv[2]) {
   GPR_ASSERT(fcntl(sv[0], F_SETFL, flags | O_NONBLOCK) == 0);
   flags = fcntl(sv[1], F_GETFL, 0);
   GPR_ASSERT(fcntl(sv[1], F_SETFL, flags | O_NONBLOCK) == 0);
-  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[0]) == GRPC_ERROR_NONE);
-  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[1]) == GRPC_ERROR_NONE);
+  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[0]) == absl::OkStatus());
+  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[1]) == absl::OkStatus());
 }
 
 grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(const char* name,

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -178,12 +178,12 @@ absl::Status grpc_status_create(absl::StatusCode code, absl::string_view msg,
                      errs)
 
 // Consumes all the errors in the vector and forms a referencing error from
-// them. If the vector is empty, return GRPC_ERROR_NONE.
+// them. If the vector is empty, return absl::OkStatus().
 template <typename VectorType>
 static absl::Status grpc_status_create_from_vector(
     const grpc_core::DebugLocation& location, absl::string_view desc,
     VectorType* error_list) {
-  absl::Status error = GRPC_ERROR_NONE;
+  absl::Status error;
   if (error_list->size() != 0) {
     error = grpc_status_create(absl::StatusCode::kUnknown, desc, location,
                                error_list->size(), error_list->data());
@@ -236,9 +236,9 @@ bool grpc_error_get_str(grpc_error_handle error, grpc_error_strs which,
 /// child error.
 ///
 /// Edge Conditions -
-/// 1) If either of \a src or \a child is GRPC_ERROR_NONE, returns a reference
-/// to the other argument. 2) If both \a src and \a child are GRPC_ERROR_NONE,
-/// returns GRPC_ERROR_NONE. 3) If \a src and \a child point to the same error,
+/// 1) If either of \a src or \a child is absl::OkStatus(), returns a reference
+/// to the other argument. 2) If both \a src and \a child are absl::OkStatus(),
+/// returns absl::OkStatus(). 3) If \a src and \a child point to the same error,
 /// returns a single reference. (Note that, 2 references should have been
 /// received to the error in this case.)
 grpc_error_handle grpc_error_add_child(
@@ -259,7 +259,7 @@ inline bool grpc_log_if_error(const char* what, grpc_error_handle error,
 class AtomicError {
  public:
   AtomicError() {
-    error_ = GRPC_ERROR_NONE;
+    error_ = absl::OkStatus();
     lock_ = GPR_SPINLOCK_STATIC_INITIALIZER;
   }
   explicit AtomicError(grpc_error_handle error) { error_ = error; }
@@ -268,7 +268,7 @@ class AtomicError {
   AtomicError(const AtomicError&) = delete;
   AtomicError& operator=(const AtomicError&) = delete;
 
-  /// returns get() == GRPC_ERROR_NONE
+  /// returns get() == absl::OkStatus()
   bool ok() {
     gpr_spinlock_lock(&lock_);
     bool ret = error_.ok();

--- a/src/core/lib/iomgr/ev_apple.cc
+++ b/src/core/lib/iomgr/ev_apple.cc
@@ -256,11 +256,11 @@ static grpc_error_handle pollset_work(grpc_pollset* pollset,
     // callback will be called.
     if (apple_pollset->is_shutdown && apple_pollset->workers.empty()) {
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, apple_pollset->shutdown_closure,
-                              GRPC_ERROR_NONE);
+                              absl::OkStatus());
     }
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /// Kick a specific worker. The caller must acquire the lock GrpcApplePollset.mu
@@ -297,7 +297,7 @@ static grpc_error_handle pollset_kick(grpc_pollset* pollset,
     kick_worker(actual_worker);
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
@@ -318,7 +318,7 @@ static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
 
   // If there is any worker blocked, shutdown will be done asynchronously.
   if (apple_pollset->workers.empty()) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
   } else {
     apple_pollset->shutdown_closure = closure;
   }

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -404,7 +404,7 @@ static void fd_shutdown(grpc_fd* fd, grpc_error_handle why) {
 
 static void fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
                       const char* reason) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   bool is_release_fd = (release_fd != nullptr);
 
   if (!fd->read_closure->IsShutdown()) {
@@ -529,7 +529,7 @@ static grpc_error_handle pollset_global_init(void) {
   for (size_t i = 0; i < g_num_neighborhoods; i++) {
     gpr_mu_init(&g_neighborhoods[i].mu);
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void pollset_global_shutdown(void) {
@@ -583,7 +583,7 @@ static void pollset_destroy(grpc_pollset* pollset) {
 }
 
 static grpc_error_handle pollset_kick_all(grpc_pollset* pollset) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   if (pollset->root_worker != nullptr) {
     grpc_pollset_worker* worker = pollset->root_worker;
     do {
@@ -615,7 +615,7 @@ static void pollset_maybe_finish_shutdown(grpc_pollset* pollset) {
   if (pollset->shutdown_closure != nullptr && pollset->root_worker == nullptr &&
       pollset->begin_refs == 0) {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, pollset->shutdown_closure,
-                            GRPC_ERROR_NONE);
+                            absl::OkStatus());
     pollset->shutdown_closure = nullptr;
   }
 }
@@ -651,7 +651,7 @@ static int poll_deadline_to_millis_timeout(grpc_core::Timestamp millis) {
    when accessing fields in g_epoll_set */
 static grpc_error_handle process_epoll_events(grpc_pollset* /*pollset*/) {
   static const char* err_desc = "process_events";
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   long num_events = gpr_atm_acq_load(&g_epoll_set.num_events);
   long cursor = gpr_atm_acq_load(&g_epoll_set.cursor);
   for (int idx = 0;
@@ -723,7 +723,7 @@ static grpc_error_handle do_epoll_wait(grpc_pollset* ps,
   gpr_atm_rel_store(&g_epoll_set.num_events, r);
   gpr_atm_rel_store(&g_epoll_set.cursor, 0);
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static bool begin_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
@@ -992,11 +992,11 @@ static grpc_error_handle pollset_work(grpc_pollset* ps,
                                       grpc_pollset_worker** worker_hdl,
                                       grpc_core::Timestamp deadline) {
   grpc_pollset_worker worker;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   static const char* err_desc = "pollset_work";
   if (ps->kicked_without_poller) {
     ps->kicked_without_poller = false;
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   if (begin_worker(ps, &worker, worker_hdl, deadline)) {
@@ -1040,7 +1040,7 @@ static grpc_error_handle pollset_work(grpc_pollset* ps,
 
 static grpc_error_handle pollset_kick(grpc_pollset* pollset,
                                       grpc_pollset_worker* specific_worker) {
-  grpc_error_handle ret_err = GRPC_ERROR_NONE;
+  grpc_error_handle ret_err;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     std::vector<std::string> log;
     log.push_back(absl::StrFormat(

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -440,7 +440,8 @@ static void close_fd_locked(grpc_fd* fd) {
   if (!fd->released) {
     close(fd->fd);
   }
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, fd->on_done_closure, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, fd->on_done_closure,
+                          absl::OkStatus());
 }
 
 static int fd_wrapped_fd(grpc_fd* fd) {
@@ -489,7 +490,7 @@ static void fd_unref(grpc_fd* fd) { unref_by(fd, 2); }
 
 static grpc_error_handle fd_shutdown_error(grpc_fd* fd) {
   if (!fd->shutdown) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   } else {
     return grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                   "FD shutdown", &fd->shutdown_error, 1),
@@ -577,7 +578,7 @@ static void fd_notify_on_error(grpc_fd* /*fd*/, grpc_closure* closure) {
   if (GRPC_TRACE_FLAG_ENABLED(grpc_polling_trace)) {
     gpr_log(GPR_ERROR, "Polling engine does not support tracking errors.");
   }
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_CANCELLED);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, absl::CancelledError());
 }
 
 static void fd_set_readable(grpc_fd* fd) {
@@ -764,7 +765,7 @@ static void kick_append_error(grpc_error_handle* composite,
 static grpc_error_handle pollset_kick_ext(grpc_pollset* p,
                                           grpc_pollset_worker* specific_worker,
                                           uint32_t flags) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   /* pollset->mu already held */
   if (specific_worker != nullptr) {
@@ -826,7 +827,7 @@ static grpc_error_handle pollset_kick(grpc_pollset* p,
 
 /* global state management */
 
-static grpc_error_handle pollset_global_init(void) { return GRPC_ERROR_NONE; }
+static grpc_error_handle pollset_global_init(void) { return absl::OkStatus(); }
 
 /* main interface */
 
@@ -885,7 +886,7 @@ static void finish_shutdown(grpc_pollset* pollset) {
   }
   pollset->fd_count = 0;
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, pollset->shutdown_done,
-                          GRPC_ERROR_NONE);
+                          absl::OkStatus());
 }
 
 static void work_combine_error(grpc_error_handle* composite,
@@ -902,7 +903,7 @@ static grpc_error_handle pollset_work(grpc_pollset* pollset,
                                       grpc_core::Timestamp deadline) {
   grpc_pollset_worker worker;
   if (worker_hdl) *worker_hdl = &worker;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   /* Avoid malloc for small number of elements. */
   enum { inline_elements = 96 };

--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -37,7 +37,7 @@ grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
   grpc_slice result = grpc_empty_slice();
   FILE* file;
   size_t bytes_read = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   GRPC_SCHEDULING_START_BLOCKING_REGION;
   file = fopen(filename, "rb");

--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -127,7 +127,7 @@ void LockfreeEvent::NotifyOn(grpc_closure* closure) {
            closure when transitioning out of CLOSURE_NO_READY state (i.e there
            is no other code that needs to 'happen-after' this) */
         if (gpr_atm_no_barrier_cas(&state_, kClosureReady, kClosureNotReady)) {
-          ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+          ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
           return; /* Successful. Return */
         }
 
@@ -246,7 +246,7 @@ void LockfreeEvent::SetReady() {
            notify_on (or set_shutdown) */
         else if (gpr_atm_full_cas(&state_, curr, kClosureNotReady)) {
           ExecCtx::Run(DEBUG_LOCATION, reinterpret_cast<grpc_closure*>(curr),
-                       GRPC_ERROR_NONE);
+                       absl::OkStatus());
           return;
         }
         /* else the state changed again (only possible by either a racing

--- a/src/core/lib/iomgr/pollset_windows.cc
+++ b/src/core/lib/iomgr/pollset_windows.cc
@@ -98,7 +98,7 @@ static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
   pollset->shutting_down = 1;
   grpc_pollset_kick(pollset, GRPC_POLLSET_KICK_BROADCAST);
   if (!pollset->is_iocp_worker) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
   } else {
     pollset->on_shutdown = closure;
   }
@@ -147,7 +147,7 @@ static grpc_error_handle pollset_work(grpc_pollset* pollset,
 
       if (pollset->shutting_down && pollset->on_shutdown != NULL) {
         grpc_core::ExecCtx::Run(DEBUG_LOCATION, pollset->on_shutdown,
-                                GRPC_ERROR_NONE);
+                                absl::OkStatus());
         pollset->on_shutdown = NULL;
       }
       goto done;
@@ -180,7 +180,7 @@ done:
   }
   gpr_cv_destroy(&worker.cv);
   if (worker_hdl) *worker_hdl = NULL;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle pollset_kick(grpc_pollset* p,
@@ -231,7 +231,7 @@ static grpc_error_handle pollset_kick(grpc_pollset* p,
       gpr_cv_signal(&next_global_worker->cv);
     }
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_pollset_vtable grpc_windows_pollset_vtable = {

--- a/src/core/lib/iomgr/resolve_address_impl.h
+++ b/src/core/lib/iomgr/resolve_address_impl.h
@@ -37,7 +37,7 @@ class DNSCallbackExecCtxScheduler {
       absl::StatusOr<std::vector<grpc_resolved_address>> param)
       : on_done_(std::move(on_done)), param_(std::move(param)) {
     GRPC_CLOSURE_INIT(&closure_, RunCallback, this, grpc_schedule_on_exec_ctx);
-    ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
   }
 
  private:

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -57,7 +57,7 @@ class NativeDNSRequest {
           on_done)
       : name_(name), default_port_(default_port), on_done_(std::move(on_done)) {
     GRPC_CLOSURE_INIT(&request_closure_, DoRequestThread, this, nullptr);
-    Executor::Run(&request_closure_, GRPC_ERROR_NONE, ExecutorType::RESOLVER);
+    Executor::Run(&request_closure_, absl::OkStatus(), ExecutorType::RESOLVER);
   }
 
  private:
@@ -165,7 +165,7 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
     addr.len = resp->ai_addrlen;
     addresses.push_back(addr);
   }
-  err = GRPC_ERROR_NONE;
+  err = absl::OkStatus();
 done:
   if (result) {
     freeaddrinfo(result);

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -60,7 +60,7 @@ class NativeDNSRequest {
           on_done)
       : name_(name), default_port_(default_port), on_done_(std::move(on_done)) {
     GRPC_CLOSURE_INIT(&request_closure_, DoRequestThread, this, nullptr);
-    Executor::Run(&request_closure_, GRPC_ERROR_NONE, ExecutorType::RESOLVER);
+    Executor::Run(&request_closure_, absl::OkStatus(), ExecutorType::RESOLVER);
   }
 
  private:
@@ -107,7 +107,7 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
   struct addrinfo *result = NULL, *resp;
   int s;
   size_t i;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   std::vector<grpc_resolved_address> addresses;
 
   // parse name, splitting it into host and port parts

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -60,7 +60,7 @@ grpc_error_handle grpc_set_socket_zerocopy(int fd) {
   if (err != 0) {
     return GRPC_OS_ERROR(errno, "setsockopt(SO_ZEROCOPY)");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 #else
   (void)fd;
   return GRPC_OS_ERROR(ENOSYS, "setsockopt(SO_ZEROCOPY)");
@@ -84,7 +84,7 @@ grpc_error_handle grpc_set_socket_nonblocking(int fd, int non_blocking) {
     return GRPC_OS_ERROR(errno, "fcntl");
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_set_socket_no_sigpipe_if_possible(int fd) {
@@ -105,7 +105,7 @@ grpc_error_handle grpc_set_socket_no_sigpipe_if_possible(int fd) {
   // Avoid unused parameter warning for conditional parameter
   (void)fd;
 #endif
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_set_socket_ip_pktinfo_if_possible(int fd) {
@@ -118,7 +118,7 @@ grpc_error_handle grpc_set_socket_ip_pktinfo_if_possible(int fd) {
     return GRPC_OS_ERROR(errno, "setsockopt(IP_PKTINFO)");
   }
 #endif
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
@@ -131,20 +131,20 @@ grpc_error_handle grpc_set_socket_ipv6_recvpktinfo_if_possible(int fd) {
     return GRPC_OS_ERROR(errno, "setsockopt(IPV6_RECVPKTINFO)");
   }
 #endif
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_set_socket_sndbuf(int fd, int buffer_size_bytes) {
   return 0 == setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &buffer_size_bytes,
                          sizeof(buffer_size_bytes))
-             ? GRPC_ERROR_NONE
+             ? absl::OkStatus()
              : GRPC_OS_ERROR(errno, "setsockopt(SO_SNDBUF)");
 }
 
 grpc_error_handle grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes) {
   return 0 == setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &buffer_size_bytes,
                          sizeof(buffer_size_bytes))
-             ? GRPC_ERROR_NONE
+             ? absl::OkStatus()
              : GRPC_OS_ERROR(errno, "setsockopt(SO_RCVBUF)");
 }
 
@@ -165,7 +165,7 @@ grpc_error_handle grpc_set_socket_cloexec(int fd, int close_on_exec) {
     return GRPC_OS_ERROR(errno, "fcntl");
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* set a socket to reuse old addresses */
@@ -183,7 +183,7 @@ grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_REUSEADDR");
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* set a socket to reuse old addresses */
@@ -205,7 +205,7 @@ grpc_error_handle grpc_set_socket_reuse_port(int fd, int reuse) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_REUSEPORT");
   }
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 #endif
 }
 
@@ -245,7 +245,7 @@ grpc_error_handle grpc_set_socket_low_latency(int fd, int low_latency) {
   if ((newval != 0) != val) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set TCP_NODELAY");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* The default values for TCP_USER_TIMEOUT are currently configured to be in
@@ -348,17 +348,17 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
                             sizeof(timeout))) {
           gpr_log(GPR_ERROR, "setsockopt(TCP_USER_TIMEOUT) %s",
                   strerror(errno));
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         if (0 != getsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &newval, &len)) {
           gpr_log(GPR_ERROR, "getsockopt(TCP_USER_TIMEOUT) %s",
                   strerror(errno));
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
         if (newval != timeout) {
           /* Do not fail on failing to set TCP_USER_TIMEOUT for now. */
           gpr_log(GPR_ERROR, "Failed to set TCP_USER_TIMEOUT");
-          return GRPC_ERROR_NONE;
+          return absl::OkStatus();
         }
       }
     }
@@ -367,7 +367,7 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
       gpr_log(GPR_INFO, "TCP_USER_TIMEOUT not supported for this platform");
     }
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* set a socket using a grpc_socket_mutator */
@@ -377,13 +377,13 @@ grpc_error_handle grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
   if (!grpc_socket_mutator_mutate_fd(mutator, fd, usage)) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("grpc_socket_mutator failed.");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_apply_socket_mutator_in_args(
     int fd, grpc_fd_usage usage, const grpc_core::PosixTcpOptions& options) {
   if (options.socket_mutator == nullptr) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
   return grpc_set_socket_with_mutator(fd, usage, options.socket_mutator);
 }
@@ -418,7 +418,7 @@ int grpc_ipv6_loopback_available(void) {
 
 static grpc_error_handle error_for_fd(int fd,
                                       const grpc_resolved_address* addr) {
-  if (fd >= 0) return GRPC_ERROR_NONE;
+  if (fd >= 0) return absl::OkStatus();
   auto addr_str = grpc_sockaddr_to_string(addr, false);
   grpc_error_handle err = grpc_error_set_str(
       GRPC_OS_ERROR(errno, "socket"), GRPC_ERROR_STR_TARGET_ADDRESS,
@@ -456,7 +456,7 @@ grpc_error_handle grpc_create_dualstack_socket_using_factory(
     /* Check if we've got a valid dualstack socket. */
     if (*newfd >= 0 && grpc_set_socket_dualstack(*newfd)) {
       *dsmode = GRPC_DSMODE_DUALSTACK;
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
     /* If this isn't an IPv4 address, then return whatever we've got. */
     if (!grpc_sockaddr_is_v4mapped(resolved_addr, nullptr)) {

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -123,7 +123,7 @@ static void socket_notify_on_iocp(grpc_winsocket* socket, grpc_closure* closure,
   gpr_mu_lock(&socket->state_mu);
   if (info->has_pending_iocp) {
     info->has_pending_iocp = 0;
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
   } else {
     info->closure = closure;
   }
@@ -144,7 +144,7 @@ void grpc_socket_become_ready(grpc_winsocket* socket,
   GPR_ASSERT(!info->has_pending_iocp);
   gpr_mu_lock(&socket->state_mu);
   if (info->closure) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, info->closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, info->closure, absl::OkStatus());
     info->closure = NULL;
   } else {
     info->has_pending_iocp = 1;

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -135,7 +135,7 @@ static int64_t tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   GUID guid = WSAID_CONNECTEX;
   DWORD ioctl_num_bytes;
   grpc_winsocket_callback_info* info;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   async_connect* ac = NULL;
   absl::StatusOr<std::string> addr_uri;
 

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -606,7 +606,7 @@ static void run_poller(void* bp, grpc_error_handle /*error_ignored*/) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
       gpr_log(GPR_INFO, "BACKUP_POLLER:%p reschedule", p);
     }
-    grpc_core::Executor::Run(&p->run_poller, GRPC_ERROR_NONE,
+    grpc_core::Executor::Run(&p->run_poller, absl::OkStatus(),
                              grpc_core::ExecutorType::DEFAULT,
                              grpc_core::ExecutorJobType::LONG);
   }
@@ -649,7 +649,7 @@ static void cover_self(grpc_tcp* tcp) {
     }
     grpc_core::Executor::Run(
         GRPC_CLOSURE_INIT(&p->run_poller, run_poller, p, nullptr),
-        GRPC_ERROR_NONE, grpc_core::ExecutorType::DEFAULT,
+        absl::OkStatus(), grpc_core::ExecutorType::DEFAULT,
         grpc_core::ExecutorJobType::LONG);
   } else {
     old_count = g_uncovered_notifications_pending++;
@@ -1011,7 +1011,7 @@ static bool tcp_do_read(grpc_tcp* tcp, grpc_error_handle* error)
   }
 
   GPR_DEBUG_ASSERT(total_read_bytes > 0);
-  *error = GRPC_ERROR_NONE;
+  *error = absl::OkStatus();
   if (tcp->frame_size_tuning_enabled) {
     // Update min progress size based on the total number of bytes read in
     // this round.
@@ -1176,7 +1176,7 @@ static void tcp_read(grpc_endpoint* ep, grpc_slice_buffer* incoming_buffer,
      * bytes or calls notify_on_read() to be notified when new bytes become
      * available */
     grpc_core::Closure::Run(DEBUG_LOCATION, &tcp->read_done_closure,
-                            GRPC_ERROR_NONE);
+                            absl::OkStatus());
   }
 }
 
@@ -1647,7 +1647,7 @@ static bool do_tcp_flush_zerocopy(grpc_tcp* tcp, TcpZerocopySendRecord* record,
     record->UpdateOffsetForBytesSent(sending_length,
                                      static_cast<size_t>(sent_length));
     if (record->AllSlicesSent()) {
-      *error = GRPC_ERROR_NONE;
+      *error = absl::OkStatus();
       return true;
     }
   }
@@ -1777,7 +1777,7 @@ static bool tcp_flush(grpc_tcp* tcp, grpc_error_handle* error) {
       }
     }
     if (outgoing_slice_idx == tcp->outgoing_buffer->count) {
-      *error = GRPC_ERROR_NONE;
+      *error = absl::OkStatus();
       grpc_slice_buffer_reset_and_unref(tcp->outgoing_buffer);
       return true;
     }
@@ -1828,7 +1828,7 @@ static void tcp_handle_write(void* arg /* grpc_tcp */,
 static void tcp_write(grpc_endpoint* ep, grpc_slice_buffer* buf,
                       grpc_closure* cb, void* arg, int /*max_frame_size*/) {
   grpc_tcp* tcp = reinterpret_cast<grpc_tcp*>(ep);
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   TcpZerocopySendRecord* zerocopy_send_record = nullptr;
 
   grpc_core::EventLog::Append("tcp-write-outstanding", buf->length);
@@ -1856,7 +1856,7 @@ static void tcp_write(grpc_endpoint* ep, grpc_slice_buffer* buf,
         grpc_fd_is_shutdown(tcp->em_fd)
             ? tcp_annotate_error(GRPC_ERROR_CREATE_FROM_STATIC_STRING("EOF"),
                                  tcp)
-            : GRPC_ERROR_NONE);
+            : absl::OkStatus());
     tcp_shutdown_buffer_list(tcp);
     return;
   }

--- a/src/core/lib/iomgr/tcp_server_utils_posix.h
+++ b/src/core/lib/iomgr/tcp_server_utils_posix.h
@@ -112,7 +112,7 @@ grpc_error_handle grpc_tcp_server_add_addr(grpc_tcp_server* s,
 /* Get all addresses assigned to network interfaces on the machine and create a
    listener for each. requested_port is the port to use for every listener, or 0
    to select one random port that will be used for every listener. Set *out_port
-   to the port selected. Return GRPC_ERROR_NONE only if all listeners were
+   to the port selected. Return absl::OkStatus() only if all listeners were
    added. */
 grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
                                                       unsigned port_index,

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -152,7 +152,7 @@ grpc_error_handle grpc_tcp_server_prepare_socket(
     grpc_tcp_server* s, int fd, const grpc_resolved_address* addr,
     bool so_reuseport, int* port) {
   grpc_resolved_address sockname_temp;
-  grpc_error_handle err = GRPC_ERROR_NONE;
+  grpc_error_handle err;
 
   GPR_ASSERT(fd >= 0);
 
@@ -208,7 +208,7 @@ grpc_error_handle grpc_tcp_server_prepare_socket(
   }
 
   *port = grpc_sockaddr_get_port(&sockname_temp);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 
 error:
   GPR_ASSERT(!err.ok());

--- a/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
@@ -86,7 +86,7 @@ static grpc_error_handle get_unused_port(int* port) {
   close(fd);
   *port = grpc_sockaddr_get_port(&wild);
   return *port <= 0 ? GRPC_ERROR_CREATE_FROM_STATIC_STRING("Bad port")
-                    : GRPC_ERROR_NONE;
+                    : absl::OkStatus();
 }
 
 grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
@@ -97,13 +97,13 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
   struct ifaddrs* ifa_it;
   unsigned fd_index = 0;
   grpc_tcp_listener* sp = nullptr;
-  grpc_error_handle err = GRPC_ERROR_NONE;
+  grpc_error_handle err;
   if (requested_port == 0) {
     /* Note: There could be a race where some local addrs can listen on the
        selected port and some can't. The sane way to handle this would be to
        retry by recreating the whole grpc_tcp_server. Backing out individual
        listeners and orphaning the FDs looks like too much trouble. */
-    if ((err = get_unused_port(&requested_port)) != GRPC_ERROR_NONE) {
+    if ((err = get_unused_port(&requested_port)) != absl::OkStatus()) {
       return err;
     } else if (requested_port <= 0) {
       return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Bad get_unused_port()");
@@ -148,7 +148,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
       continue;
     }
     if ((err = grpc_tcp_server_add_addr(s, &addr, port_index, fd_index, &dsmode,
-                                        &new_sp)) != GRPC_ERROR_NONE) {
+                                        &new_sp)) != absl::OkStatus()) {
       grpc_error_handle root_err = GRPC_ERROR_CREATE_FROM_CPP_STRING(
           absl::StrCat("Failed to add listener: ", addr_str.value()));
       err = grpc_error_add_child(root_err, err);
@@ -170,7 +170,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No local addresses");
   } else {
     *out_port = sp->port;
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 }
 

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -116,7 +116,7 @@ static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
   s->shutdown_starting.tail = NULL;
   s->shutdown_complete = shutdown_complete;
   *server = s;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_server(void* arg, grpc_error_handle error) {
@@ -139,13 +139,13 @@ static void destroy_server(void* arg, grpc_error_handle error) {
 static void finish_shutdown_locked(grpc_tcp_server* s) {
   if (s->shutdown_complete != NULL) {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, s->shutdown_complete,
-                            GRPC_ERROR_NONE);
+                            absl::OkStatus());
   }
 
   grpc_core::ExecCtx::Run(
       DEBUG_LOCATION,
       GRPC_CLOSURE_CREATE(destroy_server, s, grpc_schedule_on_exec_ctx),
-      GRPC_ERROR_NONE);
+      absl::OkStatus());
 }
 
 static grpc_tcp_server* tcp_server_ref(grpc_tcp_server* s) {
@@ -157,7 +157,7 @@ static void tcp_server_shutdown_starting_add(grpc_tcp_server* s,
                                              grpc_closure* shutdown_starting) {
   gpr_mu_lock(&s->mu);
   grpc_closure_list_append(&s->shutdown_starting, shutdown_starting,
-                           GRPC_ERROR_NONE);
+                           absl::OkStatus());
   gpr_mu_unlock(&s->mu);
 }
 
@@ -192,7 +192,7 @@ static grpc_error_handle prepare_socket(SOCKET sock,
                                         const grpc_resolved_address* addr,
                                         int* port) {
   grpc_resolved_address sockname_temp;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   int sockname_temp_len;
 
   error = grpc_tcp_prepare_socket(sock);
@@ -220,7 +220,7 @@ static grpc_error_handle prepare_socket(SOCKET sock,
   sockname_temp.len = (size_t)sockname_temp_len;
 
   *port = grpc_sockaddr_get_port(&sockname_temp);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 
 failure:
   GPR_ASSERT(!error.ok());
@@ -251,10 +251,10 @@ static grpc_error_handle start_accept_locked(grpc_tcp_listener* port) {
   BOOL success;
   DWORD addrlen = sizeof(grpc_sockaddr_in6) + 16;
   DWORD bytes_received = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   if (port->shutting_down) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
@@ -400,7 +400,7 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
   GUID guid = WSAID_ACCEPTEX;
   DWORD ioctl_num_bytes;
   LPFN_ACCEPTEX AcceptEx;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   /* We need to grab the AcceptEx pointer for that port, as it may be
      interface-dependent. We'll cache it to avoid doing that again. */
@@ -413,7 +413,7 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
     gpr_log(GPR_ERROR, "on_connect error: %s", utf8_message);
     gpr_free(utf8_message);
     closesocket(sock);
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   error = prepare_socket(sock, addr, &port);
@@ -445,7 +445,7 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
   gpr_mu_unlock(&s->mu);
   *listener = sp;
 
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
@@ -458,7 +458,7 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
   grpc_resolved_address* allocated_addr = NULL;
   grpc_resolved_address sockname_temp;
   unsigned port_index = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   if (s->tail != NULL) {
     port_index = s->tail->port_index + 1;

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -60,7 +60,7 @@ grpc_error_handle grpc_tcp_set_non_block(SOCKET sock) {
   status = WSAIoctl(sock, GRPC_FIONBIO, &param, sizeof(param), NULL, 0, &ret,
                     NULL, NULL);
   return status == 0
-             ? GRPC_ERROR_NONE
+             ? absl::OkStatus()
              : GRPC_WSA_ERROR(WSAGetLastError(), "WSAIoctl(GRPC_FIONBIO)");
 }
 
@@ -70,7 +70,7 @@ static grpc_error_handle set_dualstack(SOCKET sock) {
   status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&param,
                       sizeof(param));
   return status == 0
-             ? GRPC_ERROR_NONE
+             ? absl::OkStatus()
              : GRPC_WSA_ERROR(WSAGetLastError(), "setsockopt(IPV6_V6ONLY)");
 }
 
@@ -82,7 +82,7 @@ static grpc_error_handle enable_socket_low_latency(SOCKET sock) {
   if (status == SOCKET_ERROR) {
     status = WSAGetLastError();
   }
-  return status == 0 ? GRPC_ERROR_NONE
+  return status == 0 ? absl::OkStatus()
                      : GRPC_WSA_ERROR(status, "setsockopt(TCP_NODELAY)");
 }
 
@@ -94,7 +94,7 @@ grpc_error_handle grpc_tcp_prepare_socket(SOCKET sock) {
   if (!err.ok()) return err;
   err = enable_socket_low_latency(sock);
   if (!err.ok()) return err;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 typedef struct grpc_tcp {
@@ -288,7 +288,7 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
   /* Did we get data immediately ? Yay. */
   if (info->wsa_error != WSAEWOULDBLOCK) {
     info->bytes_transferred = bytes_read;
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &tcp->on_read, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &tcp->on_read, absl::OkStatus());
     return;
   }
 
@@ -398,7 +398,7 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
      avoid doing an async write operation at all. */
   if (info->wsa_error != WSAEWOULDBLOCK) {
     grpc_error_handle error = status == 0
-                                  ? GRPC_ERROR_NONE
+                                  ? absl::OkStatus()
                                   : GRPC_WSA_ERROR(info->wsa_error, "WSASend");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, error);
     if (allocated) gpr_free(allocated);

--- a/src/core/lib/iomgr/timer.h
+++ b/src/core/lib/iomgr/timer.h
@@ -70,12 +70,12 @@ typedef struct grpc_timer_vtable {
 } grpc_timer_vtable;
 
 /* Initialize *timer. When expired or canceled, closure will be called with
-   error set to indicate if it expired (GRPC_ERROR_NONE) or was canceled
-   (GRPC_ERROR_CANCELLED). *closure is guaranteed to be called exactly once, and
-   application code should check the error to determine how it was invoked. The
-   application callback is also responsible for maintaining information about
-   when to free up any user-level state. Behavior is undefined for a deadline of
-   grpc_core::Timestamp::InfFuture(). */
+   error set to indicate if it expired (absl::OkStatus()) or was canceled
+   (absl::CancelledError()). *closure is guaranteed to be called exactly once,
+   and application code should check the error to determine how it was invoked.
+   The application callback is also responsible for maintaining information
+   about when to free up any user-level state. Behavior is undefined for a
+   deadline of grpc_core::Timestamp::InfFuture(). */
 void grpc_timer_init(grpc_timer* timer, grpc_core::Timestamp deadline,
                      grpc_closure* closure);
 
@@ -99,8 +99,8 @@ void grpc_timer_init_unset(grpc_timer* timer);
 
    In all of these cases, the cancellation is still considered successful.
    They are essentially distinguished in that the timer_cb will be run
-   exactly once from either the cancellation (with error GRPC_ERROR_CANCELLED)
-   or from the activation (with error GRPC_ERROR_NONE).
+   exactly once from either the cancellation (with error absl::CancelledError())
+   or from the activation (with error absl::OkStatus()).
 
    Note carefully that the callback function MAY occur in the same callstack
    as grpc_timer_cancel. It's expected that most timers will be cancelled (their

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -360,7 +360,7 @@ static void timer_init(grpc_timer* timer, grpc_core::Timestamp deadline,
   grpc_core::Timestamp now = grpc_core::Timestamp::Now();
   if (deadline <= now) {
     timer->pending = false;
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, timer->closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, timer->closure, absl::OkStatus());
     gpr_mu_unlock(&shard->mu);
     /* early out */
     return;
@@ -450,7 +450,7 @@ static void timer_cancel(grpc_timer* timer) {
     REMOVE_FROM_HASH_TABLE(timer);
 
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, timer->closure,
-                            GRPC_ERROR_CANCELLED);
+                            absl::CancelledError());
     timer->pending = false;
     if (timer->heap_index == INVALID_HEAP_INDEX) {
       list_remove(timer);
@@ -683,7 +683,7 @@ static grpc_timer_check_result timer_check(grpc_core::Timestamp* next) {
 
   grpc_error_handle shutdown_error =
       now != grpc_core::Timestamp::InfFuture()
-          ? GRPC_ERROR_NONE
+          ? absl::OkStatus()
           : GRPC_ERROR_CREATE_FROM_STATIC_STRING("Shutting down timer system");
 
   // tracing

--- a/src/core/lib/iomgr/wakeup_fd_eventfd.cc
+++ b/src/core/lib/iomgr/wakeup_fd_eventfd.cc
@@ -36,7 +36,7 @@ static grpc_error_handle eventfd_create(grpc_wakeup_fd* fd_info) {
   if (fd_info->read_fd < 0) {
     return GRPC_OS_ERROR(errno, "eventfd");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle eventfd_consume(grpc_wakeup_fd* fd_info) {
@@ -48,7 +48,7 @@ static grpc_error_handle eventfd_consume(grpc_wakeup_fd* fd_info) {
   if (err < 0 && errno != EAGAIN) {
     return GRPC_OS_ERROR(errno, "eventfd_read");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle eventfd_wakeup(grpc_wakeup_fd* fd_info) {
@@ -59,7 +59,7 @@ static grpc_error_handle eventfd_wakeup(grpc_wakeup_fd* fd_info) {
   if (err < 0) {
     return GRPC_OS_ERROR(errno, "eventfd_write");
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void eventfd_destroy(grpc_wakeup_fd* fd_info) {

--- a/src/core/lib/iomgr/wakeup_fd_pipe.cc
+++ b/src/core/lib/iomgr/wakeup_fd_pipe.cc
@@ -46,7 +46,7 @@ static grpc_error_handle pipe_init(grpc_wakeup_fd* fd_info) {
   if (!err.ok()) return err;
   fd_info->read_fd = pipefd[0];
   fd_info->write_fd = pipefd[1];
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle pipe_consume(grpc_wakeup_fd* fd_info) {
@@ -56,10 +56,10 @@ static grpc_error_handle pipe_consume(grpc_wakeup_fd* fd_info) {
   for (;;) {
     r = read(fd_info->read_fd, buf, sizeof(buf));
     if (r > 0) continue;
-    if (r == 0) return GRPC_ERROR_NONE;
+    if (r == 0) return absl::OkStatus();
     switch (errno) {
       case EAGAIN:
-        return GRPC_ERROR_NONE;
+        return absl::OkStatus();
       case EINTR:
         continue;
       default:
@@ -72,7 +72,7 @@ static grpc_error_handle pipe_wakeup(grpc_wakeup_fd* fd_info) {
   char c = 0;
   while (write(fd_info->write_fd, &c, 1) != 1 && errno == EINTR) {
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void pipe_destroy(grpc_wakeup_fd* fd_info) {
@@ -84,7 +84,7 @@ static int pipe_check_availability(void) {
   grpc_wakeup_fd fd;
   fd.read_fd = fd.write_fd = -1;
 
-  if (pipe_init(&fd) == GRPC_ERROR_NONE) {
+  if (pipe_init(&fd) == absl::OkStatus()) {
     pipe_destroy(&fd);
     return 1;
   } else {

--- a/src/core/lib/load_balancing/lb_policy.cc
+++ b/src/core/lib/load_balancing/lb_policy.cc
@@ -85,7 +85,7 @@ LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
                            DEBUG_LOCATION);
                      },
                      parent, nullptr),
-                 GRPC_ERROR_NONE);
+                 absl::OkStatus());
   }
   return PickResult::Queue();
 }

--- a/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
+++ b/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
@@ -17,6 +17,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/status/status.h"
+
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/error.h"
@@ -36,7 +38,7 @@ class ExecCtxWakeupScheduler {
           static_cast<ActivityType*>(arg)->RunScheduledWakeup();
         },
         activity, grpc_schedule_on_exec_ctx);
-    ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
   }
 
  private:

--- a/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
@@ -461,7 +461,7 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
 }
 
 void AwsExternalAccountCredentials::BuildSubjectToken() {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   if (signer_ == nullptr) {
     cred_verification_url_ = absl::StrReplaceAll(
         regional_cred_verification_url_, {{"{region}", region_}});
@@ -501,7 +501,7 @@ void AwsExternalAccountCredentials::BuildSubjectToken() {
                       {"headers", Json(headers)}};
   Json subject_token_json(object);
   std::string subject_token = UrlEncode(subject_token_json.Dump());
-  FinishRetrieveSubjectToken(subject_token, GRPC_ERROR_NONE);
+  FinishRetrieveSubjectToken(subject_token, absl::OkStatus());
 }
 
 void AwsExternalAccountCredentials::FinishRetrieveSubjectToken(
@@ -515,7 +515,7 @@ void AwsExternalAccountCredentials::FinishRetrieveSubjectToken(
   if (!error.ok()) {
     cb("", error);
   } else {
-    cb(subject_token, GRPC_ERROR_NONE);
+    cb(subject_token, absl::OkStatus());
   }
 }
 

--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -387,7 +387,7 @@ void ExternalAccountCredentials::OnExchangeTokenInternal(
         metadata_req_->response.hdrs[i].value =
             gpr_strdup(ctx_->response.hdrs[i].value);
       }
-      FinishTokenFetch(GRPC_ERROR_NONE);
+      FinishTokenFetch(absl::OkStatus());
     } else {
       ImpersenateServiceAccount();
     }
@@ -525,7 +525,7 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
     metadata_req_->response.hdrs[i].value =
         gpr_strdup(ctx_->response.hdrs[i].value);
   }
-  FinishTokenFetch(GRPC_ERROR_NONE);
+  FinishTokenFetch(absl::OkStatus());
 }
 
 void ExternalAccountCredentials::FinishTokenFetch(grpc_error_handle error) {
@@ -555,7 +555,7 @@ grpc_call_credentials* grpc_external_account_credentials_create(
     return nullptr;
   }
   std::vector<std::string> scopes = absl::StrSplit(scopes_string, ',');
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = grpc_core::ExternalAccountCredentials::Create(
                    *json, std::move(scopes), &error)
                    .release();

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.cc
@@ -20,6 +20,7 @@
 #include <map>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
@@ -132,10 +133,10 @@ void FileExternalAccountCredentials::RetrieveSubjectToken(
                  "Subject token field must be a string."));
       return;
     }
-    cb(content_it->second.string_value(), GRPC_ERROR_NONE);
+    cb(content_it->second.string_value(), absl::OkStatus());
     return;
   }
-  cb(std::string(content), GRPC_ERROR_NONE);
+  cb(std::string(content), absl::OkStatus());
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/external/url_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/url_external_account_credentials.cc
@@ -225,7 +225,7 @@ void UrlExternalAccountCredentials::OnRetrieveSubjectTokenInternal(
     FinishRetrieveSubjectToken(response_it->second.string_value(), error);
     return;
   }
-  FinishRetrieveSubjectToken(std::string(response_body), GRPC_ERROR_NONE);
+  FinishRetrieveSubjectToken(std::string(response_body), absl::OkStatus());
 }
 
 void UrlExternalAccountCredentials::FinishRetrieveSubjectToken(
@@ -239,7 +239,7 @@ void UrlExternalAccountCredentials::FinishRetrieveSubjectToken(
   if (!error.ok()) {
     cb("", error);
   } else {
-    cb(subject_token, GRPC_ERROR_NONE);
+    cb(subject_token, absl::OkStatus());
   }
 }
 

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -306,7 +306,7 @@ static grpc_error_handle create_default_creds_from_path(
   grpc_auth_refresh_token token;
   grpc_core::RefCountedPtr<grpc_call_credentials> result;
   grpc_slice creds_data = grpc_empty_slice();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   Json json;
   if (creds_path.empty()) {
     error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("creds_path unset");
@@ -432,7 +432,7 @@ grpc_channel_credentials* grpc_google_default_credentials_create(
     grpc_call_credentials* call_credentials) {
   grpc_channel_credentials* result = nullptr;
   grpc_core::RefCountedPtr<grpc_call_credentials> call_creds(call_credentials);
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::ExecCtx exec_ctx;
 
   GRPC_API_TRACE("grpc_google_default_credentials_create(%p)", 1,

--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -77,7 +77,7 @@ grpc_auth_json_key grpc_auth_json_key_create_from_json(const Json& json) {
   BIO* bio = nullptr;
   const char* prop_value;
   int success = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   memset(&result, 0, sizeof(grpc_auth_json_key));
   result.type = GRPC_AUTH_JSON_TYPE_INVALID;

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -79,7 +79,7 @@ grpc_auth_refresh_token grpc_auth_refresh_token_create_from_json(
   grpc_auth_refresh_token result;
   const char* prop_value;
   int success = 0;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
 
   memset(&result, 0, sizeof(grpc_auth_refresh_token));
   result.type = GRPC_AUTH_JSON_TYPE_INVALID;
@@ -602,7 +602,7 @@ class StsTokenFetcherCredentials
     std::vector<std::string> body_parts;
     grpc_slice subject_token = grpc_empty_slice();
     grpc_slice actor_token = grpc_empty_slice();
-    grpc_error_handle err = GRPC_ERROR_NONE;
+    grpc_error_handle err;
 
     auto cleanup = [&body, &body_length, &body_parts, &subject_token,
                     &actor_token, &err]() {

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
@@ -21,6 +21,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc_security.h>
 #include <grpc/support/log.h>
 
@@ -32,7 +34,7 @@ void grpc_tls_certificate_distributor::SetKeyMaterials(
   auto& cert_info = certificate_info_map_[cert_name];
   if (pem_root_certs.has_value()) {
     // Successful credential updates will clear any pre-existing error.
-    cert_info.SetRootError(GRPC_ERROR_NONE);
+    cert_info.SetRootError(absl::OkStatus());
     for (auto* watcher_ptr : cert_info.root_cert_watchers) {
       GPR_ASSERT(watcher_ptr != nullptr);
       const auto watcher_it = watchers_.find(watcher_ptr);
@@ -57,7 +59,7 @@ void grpc_tls_certificate_distributor::SetKeyMaterials(
   }
   if (pem_key_cert_pairs.has_value()) {
     // Successful credential updates will clear any pre-existing error.
-    cert_info.SetIdentityError(GRPC_ERROR_NONE);
+    cert_info.SetIdentityError(absl::OkStatus());
     for (const auto watcher_ptr : cert_info.identity_cert_watchers) {
       GPR_ASSERT(watcher_ptr != nullptr);
       const auto watcher_it = watchers_.find(watcher_ptr);
@@ -113,7 +115,7 @@ void grpc_tls_certificate_distributor::SetErrorForCert(
       GPR_ASSERT(watcher_it != watchers_.end());
       // identity_cert_error_to_report is the error of the identity cert this
       // watcher is watching, if there is any.
-      grpc_error_handle identity_cert_error_to_report = GRPC_ERROR_NONE;
+      grpc_error_handle identity_cert_error_to_report;
       if (identity_cert_error.has_value() &&
           watcher_it->second.identity_cert_name == cert_name) {
         identity_cert_error_to_report = *identity_cert_error;
@@ -133,7 +135,7 @@ void grpc_tls_certificate_distributor::SetErrorForCert(
       GPR_ASSERT(watcher_it != watchers_.end());
       // root_cert_error_to_report is the error of the root cert this watcher is
       // watching, if there is any.
-      grpc_error_handle root_cert_error_to_report = GRPC_ERROR_NONE;
+      grpc_error_handle root_cert_error_to_report;
       if (root_cert_error.has_value() &&
           watcher_it->second.root_cert_name == cert_name) {
         // In this case, We've already sent the error updates at the time when
@@ -158,8 +160,8 @@ void grpc_tls_certificate_distributor::SetError(grpc_error_handle error) {
     GPR_ASSERT(watcher_ptr != nullptr);
     const auto& watcher_info = watcher.second;
     watcher_ptr->OnError(
-        watcher_info.root_cert_name.has_value() ? error : GRPC_ERROR_NONE,
-        watcher_info.identity_cert_name.has_value() ? error : GRPC_ERROR_NONE);
+        watcher_info.root_cert_name.has_value() ? error : absl::OkStatus(),
+        watcher_info.identity_cert_name.has_value() ? error : absl::OkStatus());
   }
   for (auto& cert_info_entry : certificate_info_map_) {
     auto& cert_info = cert_info_entry.second;
@@ -190,8 +192,8 @@ void grpc_tls_certificate_distributor::WatchTlsCertificates(
                               identity_cert_name};
     absl::optional<absl::string_view> updated_root_certs;
     absl::optional<grpc_core::PemKeyCertPairList> updated_identity_pairs;
-    grpc_error_handle root_error = GRPC_ERROR_NONE;
-    grpc_error_handle identity_error = GRPC_ERROR_NONE;
+    grpc_error_handle root_error;
+    grpc_error_handle identity_error;
     if (root_cert_name.has_value()) {
       CertificateInfo& cert_info = certificate_info_map_[*root_cert_name];
       start_watching_root_cert = cert_info.root_cert_watchers.empty();

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h
@@ -176,9 +176,9 @@ struct grpc_tls_certificate_distributor
     // The contents of the identity key-certificate pairs.
     grpc_core::PemKeyCertPairList pem_key_cert_pairs;
     // The root cert reloading error propagated by the caller.
-    grpc_error_handle root_cert_error = GRPC_ERROR_NONE;
+    grpc_error_handle root_cert_error;
     // The identity cert reloading error propagated by the caller.
-    grpc_error_handle identity_cert_error = GRPC_ERROR_NONE;
+    grpc_error_handle identity_cert_error;
     // The set of watchers watching root certificates.
     // This is mainly used for quickly looking up the affected watchers while
     // performing a credential reloading.

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -79,8 +79,8 @@ StaticDataCertificateProvider::StaticDataCertificateProvider(
       distributor_->SetKeyMaterials(cert_name, std::move(root_certificate),
                                     std::move(pem_key_cert_pairs));
     }
-    grpc_error_handle root_cert_error = GRPC_ERROR_NONE;
-    grpc_error_handle identity_cert_error = GRPC_ERROR_NONE;
+    grpc_error_handle root_cert_error;
+    grpc_error_handle identity_cert_error;
     if (root_being_watched && !root_has_update) {
       root_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
           "Unable to get latest root certificates.");
@@ -173,8 +173,8 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
       distributor_->SetKeyMaterials(cert_name, root_certificate,
                                     pem_key_cert_pairs);
     }
-    grpc_error_handle root_cert_error = GRPC_ERROR_NONE;
-    grpc_error_handle identity_cert_error = GRPC_ERROR_NONE;
+    grpc_error_handle root_cert_error;
+    grpc_error_handle identity_cert_error;
     if (root_being_watched && !root_certificate.has_value()) {
       root_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
           "Unable to get latest root certificates.");
@@ -267,8 +267,8 @@ void FileWatcherCertificateProvider::ForceUpdate() {
           info.identity_being_watched && pem_key_cert_pairs_.empty();
       if (report_root_error || report_identity_error) {
         distributor_->SetErrorForCert(
-            cert_name, report_root_error ? root_cert_error : GRPC_ERROR_NONE,
-            report_identity_error ? identity_cert_error : GRPC_ERROR_NONE);
+            cert_name, report_root_error ? root_cert_error : absl::OkStatus(),
+            report_identity_error ? identity_cert_error : absl::OkStatus());
       }
     }
   }

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
@@ -87,7 +87,7 @@ void ExternalCertificateVerifier::OnVerifyDone(
     }
   }
   if (callback != nullptr) {
-    absl::Status return_status = absl::OkStatus();
+    absl::Status return_status;
     if (status != GRPC_STATUS_OK) {
       return_status =
           absl::Status(static_cast<absl::StatusCode>(status), error_details);

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -76,7 +76,7 @@ void alts_check_peer(tsi_peer peer,
   tsi_peer_destruct(&peer);
   grpc_error_handle error =
       *auth_context != nullptr
-          ? GRPC_ERROR_NONE
+          ? absl::OkStatus()
           : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                 "Could not get ALTS auth context from TSI peer");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -210,7 +210,7 @@ void fake_check_peer(grpc_security_connector* /*sc*/, tsi_peer peer,
                      grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                      grpc_closure* on_peer_checked) {
   const char* prop_name;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   *auth_context = nullptr;
   if (peer.property_count != 2) {
     error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(

--- a/src/core/lib/security/security_connector/insecure/insecure_security_connector.cc
+++ b/src/core/lib/security/security_connector/insecure/insecure_security_connector.cc
@@ -81,7 +81,7 @@ void InsecureChannelSecurityConnector::check_peer(
     grpc_closure* on_peer_checked) {
   *auth_context = MakeAuthContext();
   tsi_peer_destruct(&peer);
-  ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, absl::OkStatus());
 }
 
 int InsecureChannelSecurityConnector::cmp(
@@ -108,7 +108,7 @@ void InsecureServerSecurityConnector::check_peer(
     grpc_closure* on_peer_checked) {
   *auth_context = MakeAuthContext();
   tsi_peer_destruct(&peer);
-  ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, absl::OkStatus());
 }
 
 int InsecureServerSecurityConnector::cmp(

--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -159,7 +159,7 @@ void local_check_peer(tsi_peer peer, grpc_endpoint* ep,
    */
   *auth_context = local_auth_context_create(&peer);
   tsi_peer_destruct(&peer);
-  error = *auth_context != nullptr ? GRPC_ERROR_NONE
+  error = *auth_context != nullptr ? absl::OkStatus()
                                    : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                                          "Could not create local auth context");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -71,7 +71,7 @@ grpc_error_handle ssl_check_peer(
   }
   *auth_context =
       grpc_ssl_peer_to_auth_context(peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 class grpc_ssl_channel_security_connector final

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -152,7 +152,7 @@ grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer) {
         "Cannot check peer: invalid ALPN value.");
   }
 #endif /* TSI_OPENSSL_ALPN_SUPPORT */
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle grpc_ssl_check_peer_name(absl::string_view peer_name,
@@ -162,7 +162,7 @@ grpc_error_handle grpc_ssl_check_peer_name(absl::string_view peer_name,
     return GRPC_ERROR_CREATE_FROM_CPP_STRING(
         absl::StrCat("Peer name ", peer_name, " is not in peer certificate"));
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void grpc_tsi_ssl_pem_key_cert_pairs_destroy(tsi_ssl_pem_key_cert_pair* kp,

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -502,7 +502,7 @@ void TlsChannelSecurityConnector::ChannelPendingVerifierRequest::OnVerifyDone(
     MutexLock lock(&security_connector_->verifier_request_map_mu_);
     security_connector_->pending_verifier_requests_.erase(on_peer_checked_);
   }
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   if (!status.ok()) {
     error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
         absl::StrCat("Custom verification check failed with error: ",
@@ -776,7 +776,7 @@ void TlsServerSecurityConnector::ServerPendingVerifierRequest::OnVerifyDone(
     MutexLock lock(&security_connector_->verifier_request_map_mu_);
     security_connector_->pending_verifier_requests_.erase(on_peer_checked_);
   }
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   if (!status.ok()) {
     error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
         absl::StrCat("Custom verification check failed with error: ",

--- a/src/core/lib/security/transport/secure_endpoint.cc
+++ b/src/core/lib/security/transport/secure_endpoint.cc
@@ -27,6 +27,7 @@
 #include <memory>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -346,7 +347,7 @@ static void on_read(void* user_data, grpc_error_handle error) {
     return;
   }
 
-  call_read_cb(ep, GRPC_ERROR_NONE);
+  call_read_cb(ep, absl::OkStatus());
 }
 
 static void endpoint_read(grpc_endpoint* secure_ep, grpc_slice_buffer* slices,
@@ -361,7 +362,7 @@ static void endpoint_read(grpc_endpoint* secure_ep, grpc_slice_buffer* slices,
   if (ep->leftover_bytes.count) {
     grpc_slice_buffer_swap(&ep->leftover_bytes, &ep->source_buffer);
     GPR_ASSERT(ep->leftover_bytes.count == 0);
-    on_read(ep, GRPC_ERROR_NONE);
+    on_read(ep, absl::OkStatus());
     return;
   }
 

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <new>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/impl/codegen/grpc_types.h>
@@ -101,7 +103,7 @@ struct call_data {
   grpc_transport_stream_op_batch* recv_initial_metadata_batch;
   grpc_closure* original_recv_initial_metadata_ready;
   grpc_closure recv_initial_metadata_ready;
-  grpc_error_handle recv_initial_metadata_error = GRPC_ERROR_NONE;
+  grpc_error_handle recv_initial_metadata_error;
   grpc_closure recv_trailing_metadata_ready;
   grpc_closure* original_recv_trailing_metadata_ready;
   grpc_error_handle recv_trailing_metadata_error;
@@ -200,7 +202,7 @@ static void on_md_processing_done(
   // If the call was not cancelled while we were in flight, process the result.
   if (gpr_atm_full_cas(&calld->state, static_cast<gpr_atm>(STATE_INIT),
                        static_cast<gpr_atm>(STATE_DONE))) {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     if (status != GRPC_STATUS_OK) {
       if (error_details == nullptr) {
         error_details = "Authentication metadata processing failed.";
@@ -311,7 +313,7 @@ static void server_auth_start_transport_stream_op_batch(
 static grpc_error_handle server_auth_init_call_elem(
     grpc_call_element* elem, const grpc_call_element_args* args) {
   new (elem->call_data) call_data(elem, *args);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Destructor for call_data */
@@ -332,7 +334,7 @@ static grpc_error_handle server_auth_init_channel_elem(
   grpc_server_credentials* creds =
       grpc_find_server_credentials_in_args(args->channel_args);
   new (elem->channel_data) channel_data(auth_context, creds);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Destructor for channel data */

--- a/src/core/lib/security/util/json_util.cc
+++ b/src/core/lib/security/util/json_util.cc
@@ -61,7 +61,7 @@ const char* grpc_json_get_string_property(const grpc_core::Json& json,
 bool grpc_copy_json_string_property(const grpc_core::Json& json,
                                     const char* prop_name,
                                     char** copied_value) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   const char* prop_value =
       grpc_json_get_string_property(json, prop_name, &error);
   GRPC_LOG_IF_ERROR("Could not copy JSON property", error);

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -508,7 +508,7 @@ void Call::PublishToParent(Call* parent) {
         cc->sibling_prev->child_->sibling_next = this;
   }
   if (parent->Completed()) {
-    CancelWithError(GRPC_ERROR_CANCELLED);
+    CancelWithError(absl::CancelledError());
   }
 }
 
@@ -527,7 +527,7 @@ grpc_error_handle FilterStackCall::Create(grpc_call_create_args* args,
 
   Arena* arena;
   FilterStackCall* call;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_channel_stack* channel_stack = channel->channel_stack();
   size_t initial_size = channel->CallSizeEstimate();
   GRPC_STATS_INC_CALL_INITIAL_SIZE(initial_size);
@@ -655,7 +655,7 @@ void FilterStackCall::DestroyCall(void* call, grpc_error_handle /*error*/) {
   grpc_error_get_status(status_error, c->send_deadline(),
                         &c->final_info_.final_status, nullptr, nullptr,
                         &(c->final_info_.error_string));
-  c->status_error_.set(GRPC_ERROR_NONE);
+  c->status_error_.set(absl::OkStatus());
   c->final_info_.stats.latency =
       gpr_cycle_counter_sub(gpr_get_cycle_counter(), c->start_time_);
   grpc_call_stack_destroy(c->call_stack(), &c->final_info_,
@@ -696,7 +696,7 @@ void FilterStackCall::ExternalUnref() {
   destroy_called_ = true;
   bool cancel = gpr_atm_acq_load(&received_final_op_atm_) == 0;
   if (cancel) {
-    CancelWithError(GRPC_ERROR_CANCELLED);
+    CancelWithError(absl::CancelledError());
   } else {
     // Unset the call combiner cancellation closure.  This has the
     // effect of scheduling the previously set cancellation closure, if
@@ -734,7 +734,7 @@ void FilterStackCall::ExecuteBatch(grpc_transport_stream_op_batch* batch,
   GRPC_CLOSURE_INIT(start_batch_closure, execute_batch_in_call_combiner, batch,
                     grpc_schedule_on_exec_ctx);
   GRPC_CALL_COMBINER_START(call_combiner(), start_batch_closure,
-                           GRPC_ERROR_NONE, "executing batch");
+                           absl::OkStatus(), "executing batch");
 }
 
 namespace {
@@ -948,7 +948,7 @@ void FilterStackCall::RecvTrailingFilter(grpc_metadata_batch* b,
         b->Take(GrpcStatusMetadata());
     if (grpc_status.has_value()) {
       grpc_status_code status_code = *grpc_status;
-      grpc_error_handle error = GRPC_ERROR_NONE;
+      grpc_error_handle error;
       if (status_code != GRPC_STATUS_OK) {
         char* peer = GetPeer();
         error = grpc_error_set_int(
@@ -966,7 +966,7 @@ void FilterStackCall::RecvTrailingFilter(grpc_metadata_batch* b,
       }
       SetFinalStatus(error);
     } else if (!is_client()) {
-      SetFinalStatus(GRPC_ERROR_NONE);
+      SetFinalStatus(absl::OkStatus());
     } else {
       gpr_log(GPR_DEBUG,
               "Received trailing metadata with no error and no status");
@@ -1047,7 +1047,7 @@ void Call::PropagateCancellationToChildren() {
         Call* next_child_call = child->child_->sibling_next;
         if (child->cancellation_is_inherited_) {
           child->InternalRef("propagate_cancel");
-          child->CancelWithError(GRPC_ERROR_CANCELLED);
+          child->CancelWithError(absl::CancelledError());
           child->InternalUnref("propagate_cancel");
         }
         child = next_child_call;
@@ -1079,13 +1079,13 @@ void FilterStackCall::BatchControl::PostCompletion() {
     /* propagate cancellation to any interested children */
     gpr_atm_rel_store(&call->received_final_op_atm_, 1);
     call->PropagateCancellationToChildren();
-    error = GRPC_ERROR_NONE;
+    error = absl::OkStatus();
   }
   if (!error.ok() && op_.recv_message && *call->receiving_buffer_ != nullptr) {
     grpc_byte_buffer_destroy(*call->receiving_buffer_);
     *call->receiving_buffer_ = nullptr;
   }
-  batch_error_.set(GRPC_ERROR_NONE);
+  batch_error_.set(absl::OkStatus());
 
   if (completion_data_.notify_tag.is_closure) {
     /* unrefs error */
@@ -1306,14 +1306,14 @@ grpc_call_error FilterStackCall::StartBatch(const grpc_op* ops, size_t nops,
     if (!is_notify_tag_closure) {
       GPR_ASSERT(grpc_cq_begin_op(cq_, notify_tag));
       grpc_cq_end_op(
-          cq_, notify_tag, GRPC_ERROR_NONE,
+          cq_, notify_tag, absl::OkStatus(),
           [](void*, grpc_cq_completion* completion) { gpr_free(completion); },
           nullptr,
           static_cast<grpc_cq_completion*>(
               gpr_malloc(sizeof(grpc_cq_completion))));
     } else {
       Closure::Run(DEBUG_LOCATION, static_cast<grpc_closure*>(notify_tag),
-                   GRPC_ERROR_NONE);
+                   absl::OkStatus());
     }
     error = GRPC_CALL_OK;
     goto done;
@@ -1496,7 +1496,7 @@ grpc_call_error FilterStackCall::StartBatch(const grpc_op* ops, size_t nops,
 
         grpc_error_handle status_error =
             op->data.send_status_from_server.status == GRPC_STATUS_OK
-                ? GRPC_ERROR_NONE
+                ? absl::OkStatus()
                 : grpc_error_set_int(
                       GRPC_ERROR_CREATE_FROM_STATIC_STRING(
                           "Server returned error"),
@@ -1770,7 +1770,7 @@ grpc_call_error grpc_call_cancel(grpc_call* call, void* reserved) {
   GPR_ASSERT(reserved == nullptr);
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::Call::FromC(call)->CancelWithError(GRPC_ERROR_CANCELLED);
+  grpc_core::Call::FromC(call)->CancelWithError(absl::CancelledError());
   return GRPC_CALL_OK;
 }
 
@@ -1790,7 +1790,7 @@ grpc_call_error grpc_call_cancel_with_status(grpc_call* c,
 }
 
 void grpc_call_cancel_internal(grpc_call* call) {
-  grpc_core::Call::FromC(call)->CancelWithError(GRPC_ERROR_CANCELLED);
+  grpc_core::Call::FromC(call)->CancelWithError(absl::CancelledError());
 }
 
 grpc_compression_algorithm grpc_call_test_only_get_compression_algorithm(

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -99,7 +99,7 @@ bool LameClientFilter::StartTransportOp(grpc_transport_op* op) {
                  GRPC_ERROR_CREATE_FROM_STATIC_STRING("lame client channel"));
   }
   if (op->on_consumed != nullptr) {
-    ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, absl::OkStatus());
   }
   return true;
 }

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -342,12 +342,12 @@ class Server : public InternallyRefCounted<Server>,
     grpc_metadata_batch* recv_initial_metadata_ = nullptr;
     grpc_closure recv_initial_metadata_ready_;
     grpc_closure* original_recv_initial_metadata_ready_;
-    grpc_error_handle recv_initial_metadata_error_ = GRPC_ERROR_NONE;
+    grpc_error_handle recv_initial_metadata_error_;
 
     bool seen_recv_trailing_metadata_ready_ = false;
     grpc_closure recv_trailing_metadata_ready_;
     grpc_closure* original_recv_trailing_metadata_ready_;
-    grpc_error_handle recv_trailing_metadata_error_ = GRPC_ERROR_NONE;
+    grpc_error_handle recv_trailing_metadata_error_;
 
     grpc_closure publish_;
 

--- a/src/core/lib/surface/validate_metadata.cc
+++ b/src/core/lib/surface/validate_metadata.cc
@@ -20,6 +20,7 @@
 
 #include "src/core/lib/surface/validate_metadata.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/grpc.h>
@@ -48,7 +49,7 @@ static grpc_error_handle conforms_to(const grpc_slice& slice,
       return error;
     }
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static int error2int(grpc_error_handle error) {

--- a/src/core/lib/transport/connectivity_state.cc
+++ b/src/core/lib/transport/connectivity_state.cc
@@ -64,12 +64,12 @@ class AsyncConnectivityStateWatcherInterface::Notifier {
       : watcher_(std::move(watcher)), state_(state), status_(status) {
     if (work_serializer != nullptr) {
       work_serializer->Run(
-          [this]() { SendNotification(this, GRPC_ERROR_NONE); },
+          [this]() { SendNotification(this, absl::OkStatus()); },
           DEBUG_LOCATION);
     } else {
       GRPC_CLOSURE_INIT(&closure_, SendNotification, this,
                         grpc_schedule_on_exec_ctx);
-      ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+      ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
     }
   }
 

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -43,7 +43,7 @@ static grpc_error_handle recursively_find_error_with_field(
     grpc_error_handle result = recursively_find_error_with_field(child, which);
     if (!result.ok()) return result;
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void grpc_error_get_status(grpc_error_handle error,
@@ -143,7 +143,7 @@ absl::Status grpc_error_to_absl_status(grpc_error_handle error) {
 grpc_error_handle absl_status_to_grpc_error(absl::Status status) {
   // Special error checks
   if (status.ok()) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
   return grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STRING_VIEW(status.message()),

--- a/src/core/lib/transport/error_utils.h
+++ b/src/core/lib/transport/error_utils.h
@@ -50,14 +50,14 @@ absl::Status grpc_error_to_absl_status(grpc_error_handle error);
 
 /// Utility function to convert an absl::Status \a status to grpc_error. Note
 /// that this method does not return "special case" errors such as
-/// GRPC_ERROR_CANCELLED, with the exception of GRPC_ERROR_NONE returned for
+/// absl::CancelledError(), with the exception of absl::OkStatus() returned for
 /// \a absl::OkStatus().
 grpc_error_handle absl_status_to_grpc_error(absl::Status status);
 
 /// A utility function to check whether there is a clear status code that
 /// doesn't need to be guessed in \a error. This means that \a error or some
-/// child has GRPC_ERROR_INT_GRPC_STATUS set, or that it is GRPC_ERROR_NONE or
-/// GRPC_ERROR_CANCELLED
+/// child has GRPC_ERROR_INT_GRPC_STATUS set, or that it is absl::OkStatus() or
+/// absl::CancelledError()
 bool grpc_error_has_clear_grpc_status(grpc_error_handle error);
 
 #endif /* GRPC_CORE_LIB_TRANSPORT_ERROR_UTILS_H */

--- a/src/core/lib/transport/handshaker.cc
+++ b/src/core/lib/transport/handshaker.cc
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 
 #include <grpc/impl/codegen/grpc_types.h>
@@ -205,7 +206,7 @@ void HandshakeManager::DoHandshake(grpc_endpoint* endpoint,
     grpc_timer_init(&deadline_timer_, deadline, &on_timeout_);
     // Start first handshaker, which also owns a ref.
     Ref().release();
-    done = CallNextHandshakerLocked(GRPC_ERROR_NONE);
+    done = CallNextHandshakerLocked(absl::OkStatus());
   }
   if (done) {
     Unref();

--- a/src/core/lib/transport/handshaker.h
+++ b/src/core/lib/transport/handshaker.h
@@ -117,7 +117,7 @@ class HandshakeManager : public RefCounted<HandshakeManager> {
   ///
   /// When done, invokes \a on_handshake_done with a HandshakerArgs
   /// object as its argument.  If the callback is invoked with error !=
-  /// GRPC_ERROR_NONE, then handshaking failed and the handshaker has done
+  /// absl::OkStatus(), then handshaking failed and the handshaker has done
   /// the necessary clean-up.  Otherwise, the callback takes ownership of
   /// the arguments.
   void DoHandshake(grpc_endpoint* endpoint, const ChannelArgs& channel_args,

--- a/src/core/lib/transport/http_connect_handshaker.cc
+++ b/src/core/lib/transport/http_connect_handshaker.cc
@@ -28,6 +28,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -303,7 +304,7 @@ void HttpConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
       MutexLock lock(&mu_);
       is_shutdown_ = true;
     }
-    ExecCtx::Run(DEBUG_LOCATION, on_handshake_done, GRPC_ERROR_NONE);
+    ExecCtx::Run(DEBUG_LOCATION, on_handshake_done, absl::OkStatus());
     return;
   }
   // Get headers from channel args.

--- a/src/core/lib/transport/tcp_connect_handshaker.cc
+++ b/src/core/lib/transport/tcp_connect_handshaker.cc
@@ -24,6 +24,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
@@ -191,7 +192,7 @@ void TCPConnectHandshaker::Connected(void* arg, grpc_error_handle error) {
       grpc_endpoint_add_to_pollset_set(self->args_->endpoint,
                                        self->interested_parties_);
     }
-    self->FinishLocked(GRPC_ERROR_NONE);
+    self->FinishLocked(absl::OkStatus());
   }
 }
 

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -44,10 +44,10 @@ void grpc_stream_destroy(grpc_stream_refcount* refcount) {
        cope with.
        Throw this over to the executor (on a core-owned thread) and process it
        there. */
-    grpc_core::Executor::Run(&refcount->destroy, GRPC_ERROR_NONE);
+    grpc_core::Executor::Run(&refcount->destroy, absl::OkStatus());
   } else {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, &refcount->destroy,
-                            GRPC_ERROR_NONE);
+                            absl::OkStatus());
   }
 }
 

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -433,7 +433,7 @@ struct grpc_transport_stream_op_batch_payload {
   struct {
     // Error contract: the transport that gets this op must cause cancel_error
     //                 to be unref'ed after processing it
-    grpc_error_handle cancel_error = GRPC_ERROR_NONE;
+    grpc_error_handle cancel_error;
   } cancel_stream;
 
   /* Indexes correspond to grpc_context_index enum values */
@@ -453,11 +453,11 @@ typedef struct grpc_transport_op {
   /** should the transport be disconnected
    * Error contract: the transport that gets this op must cause
    *                 disconnect_with_error to be unref'ed after processing it */
-  grpc_error_handle disconnect_with_error = GRPC_ERROR_NONE;
+  grpc_error_handle disconnect_with_error;
   /** what should the goaway contain?
    * Error contract: the transport that gets this op must cause
    *                 goaway_error to be unref'ed after processing it */
-  grpc_error_handle goaway_error = GRPC_ERROR_NONE;
+  grpc_error_handle goaway_error;
   /** set the callback for accepting new streams;
       this is a permanent callback, unlike the other one-shot closures.
       If true, the callback is set to set_accept_stream_fn, with its

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -692,7 +692,7 @@ static void handshaker_client_destruct(alts_handshaker_client* c) {
           DEBUG_LOCATION,
           GRPC_CLOSURE_CREATE(handshaker_call_unref, client->call,
                               grpc_schedule_on_exec_ctx),
-          GRPC_ERROR_NONE);
+          absl::OkStatus());
     }
   }
 }

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -407,7 +407,7 @@ static void on_handshaker_service_resp_recv_dedicated(
   alts_shared_resource_dedicated* resource =
       grpc_alts_get_shared_resource_dedicated();
   grpc_cq_end_op(
-      resource->cq, arg, GRPC_ERROR_NONE,
+      resource->cq, arg, absl::OkStatus(),
       [](void* /*done_arg*/, grpc_cq_completion* /*storage*/) {}, nullptr,
       &resource->storage);
 }
@@ -563,7 +563,7 @@ static tsi_result handshaker_next(
     // stack. Doing so avoids potential lock cycles between g_init_mu and other
     // mutexes within core that might be held on the current call stack
     // (note that g_init_mu gets acquired during channel creation).
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &args->closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &args->closure, absl::OkStatus());
   } else {
     tsi_result ok = alts_tsi_handshaker_continue_handshaker_next(
         handshaker, received_bytes, received_bytes_size, cb, user_data, error);

--- a/src/cpp/client/client_callback.cc
+++ b/src/cpp/client/client_callback.cc
@@ -17,6 +17,8 @@
 
 #include <utility>
 
+#include "absl/status/status.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpcpp/support/client_callback.h>
 #include <grpcpp/support/status.h>
@@ -51,7 +53,7 @@ void ClientReactor::InternalScheduleOnDone(grpc::Status s) {
     }
   };
   ClosureWithArg* arg = new ClosureWithArg(this, std::move(s));
-  grpc_core::Executor::Run(&arg->closure, GRPC_ERROR_NONE);
+  grpc_core::Executor::Run(&arg->closure, absl::OkStatus());
 }
 
 bool ClientReactor::InternalTrailersOnly(const grpc_call* call) const {

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -224,7 +224,7 @@ grpc::Status StsCredentialsOptionsFromEnv(StsCredentialsOptions* options) {
   ClearStsCredentialsOptions(options);
   grpc_slice json_string = grpc_empty_slice();
   auto sts_creds_path = grpc_core::GetEnv("STS_CREDENTIALS");
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc::Status status;
   // NOLINTNEXTLINE(clang-diagnostic-unused-lambda-capture)
   auto cleanup = [&json_string, &status]() {
@@ -432,7 +432,7 @@ void MetadataCredentialsPluginWrapper::Destroy(void* wrapper) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
   grpc_core::Executor::Run(GRPC_CLOSURE_CREATE(DeleteWrapper, wrapper, nullptr),
-                           GRPC_ERROR_NONE);
+                           absl::OkStatus());
 }
 
 int MetadataCredentialsPluginWrapper::GetMetadata(

--- a/src/cpp/common/channel_filter.h
+++ b/src/cpp/common/channel_filter.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/grpc.h>
@@ -201,7 +202,7 @@ class ChannelData {
   /// Initializes the channel data.
   virtual grpc_error_handle Init(grpc_channel_element* /*elem*/,
                                  grpc_channel_element_args* /*args*/) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   // Called before destruction.
@@ -224,7 +225,7 @@ class CallData {
   /// Initializes the call data.
   virtual grpc_error_handle Init(grpc_call_element* /*elem*/,
                                  const grpc_call_element_args* /*args*/) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   // Called before destruction.

--- a/src/cpp/ext/filters/census/channel_filter.cc
+++ b/src/cpp/ext/filters/census/channel_filter.cc
@@ -20,11 +20,13 @@
 
 #include "src/cpp/ext/filters/census/channel_filter.h"
 
+#include "absl/status/status.h"
+
 namespace grpc {
 
 grpc_error_handle CensusChannelData::Init(grpc_channel_element* /*elem*/,
                                           grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 }  // namespace grpc

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -91,7 +91,7 @@ grpc_error_handle CensusClientChannelData::CensusClientCallData::Init(
   args->context[GRPC_CONTEXT_CALL_TRACER].destroy = [](void* tracer) {
     (static_cast<OpenCensusCallTracer*>(tracer))->~OpenCensusCallTracer();
   };
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void CensusClientChannelData::CensusClientCallData::StartTransportStreamOpBatch(

--- a/src/cpp/ext/filters/census/server_filter.cc
+++ b/src/cpp/ext/filters/census/server_filter.cc
@@ -22,6 +22,7 @@
 
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
@@ -157,7 +158,7 @@ grpc_error_handle CensusServerCallData::Init(
   GRPC_CLOSURE_INIT(&on_done_recv_message_, OnDoneRecvMessageCb, elem,
                     grpc_schedule_on_exec_ctx);
   auth_context_ = grpc_call_auth_context(gc_);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void CensusServerCallData::Destroy(grpc_call_element* /*elem*/,

--- a/src/cpp/server/server_callback.cc
+++ b/src/cpp/server/server_callback.cc
@@ -15,7 +15,8 @@
  *
  */
 
-#include <grpcpp/impl/codegen/server_callback.h>
+#include "absl/status/status.h"
+
 #include <grpcpp/support/server_callback.h>
 
 #include "src/core/lib/iomgr/closure.h"
@@ -48,7 +49,7 @@ void ServerCallbackCall::ScheduleOnDone(bool inline_ondone) {
       }
     };
     ClosureWithArg* arg = new ClosureWithArg(this);
-    grpc_core::Executor::Run(&arg->closure, GRPC_ERROR_NONE);
+    grpc_core::Executor::Run(&arg->closure, absl::OkStatus());
   }
 }
 
@@ -78,7 +79,7 @@ void ServerCallbackCall::CallOnCancel(ServerReactor* reactor) {
       }
     };
     ClosureWithArg* arg = new ClosureWithArg(this, reactor);
-    grpc_core::Executor::Run(&arg->closure, GRPC_ERROR_NONE);
+    grpc_core::Executor::Run(&arg->closure, absl::OkStatus());
   }
 }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
@@ -70,7 +71,6 @@
 
 #include "src/core/ext/transport/inproc/inproc_transport.h"
 #include "src/core/lib/gprpp/manual_constructor.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/core/lib/resource_quota/api.h"
@@ -218,7 +218,7 @@ void ServerInterface::BaseAsyncRequest::
   grpc_core::ExecCtx exec_ctx;
   grpc_cq_begin_op(notification_cq_->cq(), this);
   grpc_cq_end_op(
-      notification_cq_->cq(), this, GRPC_ERROR_NONE,
+      notification_cq_->cq(), this, absl::OkStatus(),
       [](void* /*arg*/, grpc_cq_completion* completion) { delete completion; },
       nullptr, new grpc_cq_completion());
 }

--- a/test/core/address_utils/sockaddr_utils_test.cc
+++ b/test/core/address_utils/sockaddr_utils_test.cc
@@ -224,33 +224,33 @@ TEST(SockAddrUtilsTest, SockAddrToString) {
   grpc_resolved_address inputun;
   struct sockaddr_un* sock_un = reinterpret_cast<struct sockaddr_un*>(&inputun);
   ASSERT_EQ(grpc_core::UnixSockaddrPopulate("/some/unix/path", &inputun),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   EXPECT_EQ(grpc_sockaddr_to_string(&inputun, true).value(), "/some/unix/path");
 
   std::string max_filepath(sizeof(sock_un->sun_path) - 1, 'x');
   ASSERT_EQ(grpc_core::UnixSockaddrPopulate(max_filepath, &inputun),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   EXPECT_EQ(grpc_sockaddr_to_string(&inputun, true).value(), max_filepath);
 
   ASSERT_EQ(grpc_core::UnixSockaddrPopulate(max_filepath, &inputun),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   sock_un->sun_path[sizeof(sockaddr_un::sun_path) - 1] = 'x';
   EXPECT_EQ(grpc_sockaddr_to_string(&inputun, true).status(),
             absl::InvalidArgumentError("UDS path is not null-terminated"));
 
   ASSERT_EQ(grpc_core::UnixAbstractSockaddrPopulate("some_unix_path", &inputun),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   EXPECT_EQ(grpc_sockaddr_to_string(&inputun, true).value(),
             absl::StrCat(std::string(1, '\0'), "some_unix_path"));
 
   std::string max_abspath(sizeof(sock_un->sun_path) - 1, '\0');
   ASSERT_EQ(grpc_core::UnixAbstractSockaddrPopulate(max_abspath, &inputun),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   EXPECT_EQ(grpc_sockaddr_to_string(&inputun, true).value(),
             absl::StrCat(std::string(1, '\0'), max_abspath));
 
   ASSERT_EQ(grpc_core::UnixAbstractSockaddrPopulate("", &inputun),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   inputun.len = sizeof(sock_un->sun_family);
   EXPECT_EQ(grpc_sockaddr_to_string(&inputun, true).status(),
             absl::InvalidArgumentError("empty UDS abstract path"));
@@ -261,15 +261,15 @@ TEST(SockAddrUtilsTest, SockAddrToString) {
 
 TEST(SockAddrUtilsTest, UnixSockAddrToUri) {
   grpc_resolved_address addr;
-  ASSERT_TRUE(GRPC_ERROR_NONE ==
+  ASSERT_TRUE(absl::OkStatus() ==
               grpc_core::UnixSockaddrPopulate("sample-path", &addr));
   EXPECT_EQ(grpc_sockaddr_to_uri(&addr).value(), "unix:sample-path");
 
-  ASSERT_TRUE(GRPC_ERROR_NONE ==
+  ASSERT_TRUE(absl::OkStatus() ==
               grpc_core::UnixAbstractSockaddrPopulate("no-nulls", &addr));
   EXPECT_EQ(grpc_sockaddr_to_uri(&addr).value(), "unix-abstract:no-nulls");
 
-  ASSERT_TRUE(GRPC_ERROR_NONE ==
+  ASSERT_TRUE(absl::OkStatus() ==
               grpc_core::UnixAbstractSockaddrPopulate(
                   std::string("path_\0with_null", 15), &addr));
   EXPECT_EQ(grpc_sockaddr_to_uri(&addr).value(),

--- a/test/core/channel/channel_stack_builder_test.cc
+++ b/test/core/channel/channel_stack_builder_test.cc
@@ -41,12 +41,12 @@ namespace {
 
 grpc_error_handle ChannelInitFunc(grpc_channel_element* /*elem*/,
                                   grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 grpc_error_handle CallInitFunc(grpc_call_element* /*elem*/,
                                const grpc_call_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void ChannelDestroyFunc(grpc_channel_element* /*elem*/) {}

--- a/test/core/channel/channel_stack_test.cc
+++ b/test/core/channel/channel_stack_test.cc
@@ -39,14 +39,14 @@ static grpc_error_handle channel_init_func(grpc_channel_element* elem,
   EXPECT_TRUE(args->is_first);
   EXPECT_TRUE(args->is_last);
   *static_cast<int*>(elem->channel_data) = 0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_error_handle call_init_func(
     grpc_call_element* elem, const grpc_call_element_args* /*args*/) {
   ++*static_cast<int*>(elem->channel_data);
   *static_cast<int*>(elem->call_data) = 0;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void channel_destroy_func(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/fixtures/h2_fd.cc
+++ b/test/core/end2end/fixtures/h2_fd.cc
@@ -50,8 +50,8 @@ static void create_sockets(int sv[2]) {
   GPR_ASSERT(fcntl(sv[0], F_SETFL, flags | O_NONBLOCK) == 0);
   flags = fcntl(sv[1], F_GETFL, 0);
   GPR_ASSERT(fcntl(sv[1], F_SETFL, flags | O_NONBLOCK) == 0);
-  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[0]) == GRPC_ERROR_NONE);
-  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[1]) == GRPC_ERROR_NONE);
+  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[0]) == absl::OkStatus());
+  GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv[1]) == absl::OkStatus());
 }
 
 static grpc_end2end_test_fixture chttp2_create_fixture_socketpair(

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -125,7 +125,7 @@ static void finish_resolve(void* arg, grpc_error_handle error) {
         grpc_parse_ipv4_hostport("1.2.3.4:5", &fake_resolved_address, false));
     (*r->addresses)
         ->emplace_back(fake_resolved_address, grpc_core::ChannelArgs());
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, r->on_done, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, r->on_done, absl::OkStatus());
   } else {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, r->on_done,
                             GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
@@ -289,7 +289,7 @@ static void do_connect(void* arg, grpc_error_handle error) {
                                     core_server->channel_args(), nullptr)));
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
 
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, fc->closure, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, fc->closure, absl::OkStatus());
   } else {
     sched_connect(fc->closure, fc->ep, fc->deadline);
   }

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -179,7 +179,7 @@ static grpc_ares_request* my_dns_lookup_ares(
                                  query_timeout_ms);
   }
 
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   gpr_mu_lock(&g_mu);
   if (g_resolve_port < 0) {
     gpr_mu_unlock(&g_mu);

--- a/test/core/end2end/tests/filter_causes_close.cc
+++ b/test/core/end2end/tests/filter_causes_close.cc
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -226,7 +228,7 @@ static void start_transport_stream_op_batch(
 
 static grpc_error_handle init_call_elem(
     grpc_call_element* /*elem*/, const grpc_call_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_call_elem(grpc_call_element* /*elem*/,
@@ -235,7 +237,7 @@ static void destroy_call_elem(grpc_call_element* /*elem*/,
 
 static grpc_error_handle init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_channel_elem(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/tests/filter_context.cc
+++ b/test/core/end2end/tests/filter_context.cc
@@ -24,6 +24,8 @@
 #include <initializer_list>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -239,7 +241,7 @@ static grpc_error_handle init_call_elem(grpc_call_element* elem,
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->context = args->context;
   gpr_log(GPR_INFO, "init_call_elem(): context=%p", args->context);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void start_transport_stream_op_batch(
@@ -262,7 +264,7 @@ static void destroy_call_elem(grpc_call_element* /*elem*/,
 
 static grpc_error_handle init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_channel_elem(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/tests/filter_init_fails.cc
+++ b/test/core/end2end/tests/filter_init_fails.cc
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -439,7 +441,7 @@ static grpc_error_handle init_channel_elem(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test channel filter init error"),
         GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_INVALID_ARGUMENT);
   }
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_channel_elem(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/tests/filter_latency.cc
+++ b/test/core/end2end/tests/filter_latency.cc
@@ -23,6 +23,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
@@ -258,7 +260,7 @@ static void test_request(grpc_end2end_test_config config) {
 
 static grpc_error_handle init_call_elem(
     grpc_call_element* /*elem*/, const grpc_call_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void client_destroy_call_elem(grpc_call_element* /*elem*/,
@@ -279,7 +281,7 @@ static void server_destroy_call_elem(grpc_call_element* /*elem*/,
 
 static grpc_error_handle init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_channel_elem(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/tests/filter_status_code.cc
+++ b/test/core/end2end/tests/filter_status_code.cc
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/propagation_bits.h>
 #include <grpc/slice.h>
@@ -291,7 +293,7 @@ static grpc_error_handle init_call_elem(grpc_call_element* elem,
                                         const grpc_call_element_args* args) {
   final_status_data* data = static_cast<final_status_data*>(elem->call_data);
   data->call = args->call_stack;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void client_destroy_call_elem(grpc_call_element* elem,
@@ -326,7 +328,7 @@ static void server_destroy_call_elem(grpc_call_element* elem,
 
 static grpc_error_handle init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void destroy_channel_elem(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
+++ b/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
@@ -22,6 +22,7 @@
 #include <new>
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/optional.h"
@@ -255,7 +256,7 @@ class FailSendOpsFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -291,7 +292,7 @@ class FailSendOpsFilter {
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailSendOpsFilter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/test/core/end2end/tests/retry_recv_message_replay.cc
+++ b/test/core/end2end/tests/retry_recv_message_replay.cc
@@ -21,6 +21,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -281,7 +282,7 @@ class FailFirstSendOpFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -322,7 +323,7 @@ class FailFirstSendOpFilter {
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstSendOpFilter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
+++ b/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -279,7 +280,7 @@ class InjectStatusFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* /*args*/) {
       new (elem->call_data) CallData();
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -323,7 +324,7 @@ class InjectStatusFilter {
 
   static grpc_error_handle Init(grpc_channel_element* /*elem*/,
                                 grpc_channel_element_args* /*args*/) {
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* /*elem*/) {}

--- a/test/core/end2end/tests/retry_send_op_fails.cc
+++ b/test/core/end2end/tests/retry_send_op_fails.cc
@@ -21,6 +21,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -296,7 +297,7 @@ class FailFirstCallFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -337,7 +338,7 @@ class FailFirstCallFilter {
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstCallFilter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/test/core/end2end/tests/retry_transparent_goaway.cc
+++ b/test/core/end2end/tests/retry_transparent_goaway.cc
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -281,7 +282,7 @@ class FailFirstCallFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -330,7 +331,7 @@ class FailFirstCallFilter {
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstCallFilter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
+++ b/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
@@ -19,6 +19,7 @@
 
 #include <new>
 
+#include "absl/status/status.h"
 #include "absl/types/optional.h"
 
 #include <grpc/byte_buffer.h>
@@ -282,7 +283,7 @@ class FailFirstTenCallsFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -329,7 +330,7 @@ class FailFirstTenCallsFilter {
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) FailFirstTenCallsFilter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/test/core/filters/filter_fuzzer.cc
+++ b/test/core/filters/filter_fuzzer.cc
@@ -394,7 +394,7 @@ class MainLoop {
       }
 
       bool StartTransportOp(grpc_transport_op* op) override {
-        ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
+        ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, absl::OkStatus());
         return true;
       }
     };

--- a/test/core/gprpp/status_helper_test.cc
+++ b/test/core/gprpp/status_helper_test.cc
@@ -119,7 +119,7 @@ TEST(StatusUtilTest, ToAndFromProtoWithNonUTF8Characters) {
 }
 
 TEST(StatusUtilTest, OkToString) {
-  absl::Status s = absl::OkStatus();
+  absl::Status s;
   std::string t = StatusToString(s);
   EXPECT_EQ("OK", t);
 }

--- a/test/core/http/parser_test.cc
+++ b/test/core/http/parser_test.cc
@@ -57,10 +57,10 @@ static void test_request_succeeds(grpc_slice_split_mode split_mode,
 
   for (i = 0; i < num_slices; i++) {
     ASSERT_EQ(grpc_http_parser_parse(&parser, slices[i], nullptr),
-              GRPC_ERROR_NONE);
+              absl::OkStatus());
     grpc_slice_unref(slices[i]);
   }
-  ASSERT_EQ(grpc_http_parser_eof(&parser), GRPC_ERROR_NONE);
+  ASSERT_EQ(grpc_http_parser_eof(&parser), absl::OkStatus());
 
   ASSERT_EQ(GRPC_HTTP_REQUEST, parser.type);
   ASSERT_STREQ(expect_method, request.method);
@@ -115,10 +115,10 @@ static void test_succeeds(grpc_slice_split_mode split_mode,
 
   for (i = 0; i < num_slices; i++) {
     ASSERT_EQ(grpc_http_parser_parse(&parser, slices[i], nullptr),
-              GRPC_ERROR_NONE);
+              absl::OkStatus());
     grpc_slice_unref(slices[i]);
   }
-  ASSERT_EQ(grpc_http_parser_eof(&parser), GRPC_ERROR_NONE);
+  ASSERT_EQ(grpc_http_parser_eof(&parser), absl::OkStatus());
 
   ASSERT_EQ(GRPC_HTTP_RESPONSE, parser.type);
   ASSERT_EQ(expect_status, response.status);
@@ -158,7 +158,7 @@ static void test_fails(grpc_slice_split_mode split_mode,
   size_t num_slices;
   size_t i;
   grpc_slice* slices;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_http_response response;
   response = {};
 
@@ -168,12 +168,12 @@ static void test_fails(grpc_slice_split_mode split_mode,
   grpc_http_parser_init(&parser, GRPC_HTTP_RESPONSE, &response);
 
   for (i = 0; i < num_slices; i++) {
-    if (GRPC_ERROR_NONE == error) {
+    if (absl::OkStatus() == error) {
       error = grpc_http_parser_parse(&parser, slices[i], nullptr);
     }
     grpc_slice_unref(slices[i]);
   }
-  if (GRPC_ERROR_NONE == error) {
+  if (absl::OkStatus() == error) {
     error = grpc_http_parser_eof(&parser);
   }
   ASSERT_FALSE(error.ok());
@@ -190,7 +190,7 @@ static void test_request_fails(grpc_slice_split_mode split_mode,
   size_t num_slices;
   size_t i;
   grpc_slice* slices;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_http_request request;
   memset(&request, 0, sizeof(request));
 

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -51,7 +51,7 @@ TEST(BufferListTest, Testshutdownflusheslist) {
     grpc_core::TracedBuffer::AddNewEntry(
         &list, i, 0, static_cast<void*>(&verifier_called[i]));
   }
-  grpc_core::TracedBuffer::Shutdown(&list, nullptr, GRPC_ERROR_NONE);
+  grpc_core::TracedBuffer::Shutdown(&list, nullptr, absl::OkStatus());
   ASSERT_EQ(list, nullptr);
   for (auto i = 0; i < NUM_ELEM; i++) {
     ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
@@ -89,7 +89,7 @@ TEST(BufferListTest, Testverifiercalledonack) {
   grpc_core::TracedBuffer::ProcessTimestamp(&list, &serr, nullptr, &tss);
   ASSERT_EQ(gpr_atm_acq_load(&verifier_called), static_cast<gpr_atm>(1));
   ASSERT_EQ(list, nullptr);
-  grpc_core::TracedBuffer::Shutdown(&list, nullptr, GRPC_ERROR_NONE);
+  grpc_core::TracedBuffer::Shutdown(&list, nullptr, absl::OkStatus());
 }
 
 /** Tests that shutdown can be called repeatedly.
@@ -110,9 +110,9 @@ TEST(BufferListTest, Testrepeatedshutdown) {
   grpc_core::TracedBuffer::ProcessTimestamp(&list, &serr, nullptr, &tss);
   ASSERT_EQ(gpr_atm_acq_load(&verifier_called), static_cast<gpr_atm>(1));
   ASSERT_EQ(list, nullptr);
-  grpc_core::TracedBuffer::Shutdown(&list, nullptr, GRPC_ERROR_NONE);
-  grpc_core::TracedBuffer::Shutdown(&list, nullptr, GRPC_ERROR_NONE);
-  grpc_core::TracedBuffer::Shutdown(&list, nullptr, GRPC_ERROR_NONE);
+  grpc_core::TracedBuffer::Shutdown(&list, nullptr, absl::OkStatus());
+  grpc_core::TracedBuffer::Shutdown(&list, nullptr, absl::OkStatus());
+  grpc_core::TracedBuffer::Shutdown(&list, nullptr, absl::OkStatus());
 }
 
 int main(int argc, char** argv) {

--- a/test/core/iomgr/combiner_test.cc
+++ b/test/core/iomgr/combiner_test.cc
@@ -46,7 +46,7 @@ TEST(CombinerTest, TestExecuteOne) {
   gpr_event_init(&done);
   grpc_core::ExecCtx exec_ctx;
   lock->Run(GRPC_CLOSURE_CREATE(set_event_to_true, &done, nullptr),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   grpc_core::ExecCtx::Get()->Flush();
   ASSERT_NE(gpr_event_wait(&done, grpc_timeout_seconds_to_deadline(5)),
             nullptr);
@@ -81,7 +81,7 @@ static void execute_many_loop(void* a) {
       c->ctr = &args->ctr;
       c->value = n++;
       args->lock->Run(GRPC_CLOSURE_CREATE(check_one, c, nullptr),
-                      GRPC_ERROR_NONE);
+                      absl::OkStatus());
       grpc_core::ExecCtx::Get()->Flush();
     }
     // sleep for a little bit, to test a combiner draining and another thread
@@ -89,7 +89,7 @@ static void execute_many_loop(void* a) {
     gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(100));
   }
   args->lock->Run(GRPC_CLOSURE_CREATE(set_event_to_true, &args->done, nullptr),
-                  GRPC_ERROR_NONE);
+                  absl::OkStatus());
 }
 
 TEST(CombinerTest, TestExecuteMany) {
@@ -122,7 +122,7 @@ static void in_finally(void* /*arg*/, grpc_error_handle /*error*/) {
 
 static void add_finally(void* arg, grpc_error_handle /*error*/) {
   static_cast<grpc_core::Combiner*>(arg)->Run(
-      GRPC_CLOSURE_CREATE(in_finally, arg, nullptr), GRPC_ERROR_NONE);
+      GRPC_CLOSURE_CREATE(in_finally, arg, nullptr), absl::OkStatus());
 }
 
 TEST(CombinerTest, TestExecuteFinally) {
@@ -131,7 +131,7 @@ TEST(CombinerTest, TestExecuteFinally) {
   grpc_core::Combiner* lock = grpc_combiner_create();
   grpc_core::ExecCtx exec_ctx;
   gpr_event_init(&got_in_finally);
-  lock->Run(GRPC_CLOSURE_CREATE(add_finally, lock, nullptr), GRPC_ERROR_NONE);
+  lock->Run(GRPC_CLOSURE_CREATE(add_finally, lock, nullptr), absl::OkStatus());
   grpc_core::ExecCtx::Get()->Flush();
   ASSERT_NE(
       gpr_event_wait(&got_in_finally, grpc_timeout_seconds_to_deadline(5)),

--- a/test/core/iomgr/endpoint_tests.cc
+++ b/test/core/iomgr/endpoint_tests.cc
@@ -146,7 +146,7 @@ static void read_and_write_test_read_handler(void* data,
      * read_handler are both run inline, we might end up growing the stack
      * beyond the limit. Schedule the read on ExecCtx to avoid this. */
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, &state->read_scheduler,
-                            GRPC_ERROR_NONE);
+                            absl::OkStatus());
   }
 }
 
@@ -179,7 +179,7 @@ static void read_and_write_test_write_handler(void* data,
        * the write_handler are both run inline, we might end up growing the
        * stack beyond the limit. Schedule the write on ExecCtx to avoid this. */
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, &state->write_scheduler,
-                              GRPC_ERROR_NONE);
+                              absl::OkStatus());
       gpr_free(slices);
       return;
     }
@@ -247,7 +247,7 @@ static void read_and_write_test(grpc_endpoint_test_config config,
      for the first iteration as for later iterations. It does the right thing
      even when bytes_written is unsigned. */
   state.bytes_written -= state.current_write_size;
-  read_and_write_test_write_handler(&state, GRPC_ERROR_NONE);
+  read_and_write_test_write_handler(&state, absl::OkStatus());
   grpc_core::ExecCtx::Get()->Flush();
 
   grpc_endpoint_read(state.read_ep, &state.incoming, &state.done_read,

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -30,7 +30,7 @@
 
 TEST(ErrorTest, SetGetInt) {
   grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
-  EXPECT_NE(error, GRPC_ERROR_NONE);
+  EXPECT_NE(error, absl::OkStatus());
   intptr_t i = 0;
 #ifndef NDEBUG
   // GRPC_ERROR_INT_FILE_LINE is for debug only
@@ -102,7 +102,7 @@ TEST(ErrorTest, CreateReferencing) {
                          GRPC_ERROR_STR_GRPC_MESSAGE, "message");
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", &child, 1);
-  EXPECT_NE(parent, GRPC_ERROR_NONE);
+  EXPECT_NE(parent, absl::OkStatus());
 }
 
 TEST(ErrorTest, CreateReferencingMany) {
@@ -119,7 +119,7 @@ TEST(ErrorTest, CreateReferencingMany) {
 
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 3);
-  EXPECT_NE(parent, GRPC_ERROR_NONE);
+  EXPECT_NE(parent, absl::OkStatus());
 
   for (size_t i = 0; i < 3; ++i) {
   }

--- a/test/core/iomgr/fd_posix_test.cc
+++ b/test/core/iomgr/fd_posix_test.cc
@@ -67,8 +67,8 @@ static void create_test_socket(int port, int* socket_fd,
   setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
   /* Reset the size of socket send buffer to the minimal value to facilitate
      buffer filling up and triggering notify_on_write  */
-  ASSERT_EQ(grpc_set_socket_sndbuf(fd, buffer_size_bytes), GRPC_ERROR_NONE);
-  ASSERT_EQ(grpc_set_socket_rcvbuf(fd, buffer_size_bytes), GRPC_ERROR_NONE);
+  ASSERT_EQ(grpc_set_socket_sndbuf(fd, buffer_size_bytes), absl::OkStatus());
+  ASSERT_EQ(grpc_set_socket_rcvbuf(fd, buffer_size_bytes), absl::OkStatus());
   /* Make fd non-blocking */
   flags = fcntl(fd, F_GETFL, 0);
   ASSERT_EQ(fcntl(fd, F_SETFL, flags | O_NONBLOCK), 0);
@@ -357,7 +357,7 @@ static void client_start(client* cl, int port) {
   cl->em_fd = grpc_fd_create(fd, "client", false);
   grpc_pollset_add_fd(g_pollset, cl->em_fd);
 
-  client_session_write(cl, GRPC_ERROR_NONE);
+  client_session_write(cl, absl::OkStatus());
 }
 
 /* Wait for the signal to shutdown a client. */

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -146,7 +146,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   /* wait for the connection callback to finish */
   std::future<grpc_error_handle> connected_future = connected_promise.get_future();
   XCTAssertEqual([self waitForEvent:&connected_future timeout:kConnectTimeout], YES);
-  XCTAssertEqual(connected_future.get(), GRPC_ERROR_NONE);
+  XCTAssertEqual(connected_future.get(), absl::OkStatus());
 }
 
 - (void)tearDown {
@@ -178,7 +178,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   std::future<grpc_error_handle> write_future = write_promise.get_future();
   XCTAssertEqual([self waitForEvent:&write_future timeout:kWriteTimeout], YES);
-  XCTAssertEqual(write_future.get(), GRPC_ERROR_NONE);
+  XCTAssertEqual(write_future.get(), absl::OkStatus());
 
   while (recv_size < kBufferSize) {
     ssize_t size = recv(svr_fd_, read_buffer, kBufferSize, 0);
@@ -200,13 +200,13 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
                        /*min_progress_size=*/1);
     std::future<grpc_error_handle> read_future = read_promise.get_future();
     XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
-    XCTAssertEqual(read_future.get(), GRPC_ERROR_NONE);
+    XCTAssertEqual(read_future.get(), absl::OkStatus());
     grpc_slice_buffer_move_into(&read_one_slice, &read_slices);
     XCTAssertLessThanOrEqual(read_slices.length, kBufferSize);
   }
   XCTAssertTrue(compare_slice_buffer_with_buffer(&read_slices, read_buffer, kBufferSize));
 
-  grpc_endpoint_shutdown(ep_, GRPC_ERROR_NONE);
+  grpc_endpoint_shutdown(ep_, absl::OkStatus());
   grpc_slice_buffer_reset_and_unref(&read_slices);
   grpc_slice_buffer_reset_and_unref(&write_slices);
   grpc_slice_buffer_reset_and_unref(&read_one_slice);
@@ -240,7 +240,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   std::future<grpc_error_handle> write_future = write_promise.get_future();
   XCTAssertEqual([self waitForEvent:&write_future timeout:kWriteTimeout], YES);
-  XCTAssertEqual(write_future.get(), GRPC_ERROR_NONE);
+  XCTAssertEqual(write_future.get(), absl::OkStatus());
 
   while (recv_size < kBufferSize) {
     ssize_t size = recv(svr_fd_, read_buffer, kBufferSize, 0);
@@ -254,11 +254,11 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   std::future<grpc_error_handle> read_future = read_promise.get_future();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], NO);
 
-  grpc_endpoint_shutdown(ep_, GRPC_ERROR_NONE);
+  grpc_endpoint_shutdown(ep_, absl::OkStatus());
 
   grpc_core::ExecCtx::Get()->Flush();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
-  XCTAssertNotEqual(read_future.get(), GRPC_ERROR_NONE);
+  XCTAssertNotEqual(read_future.get(), absl::OkStatus());
 
   grpc_slice_buffer_reset_and_unref(&read_slices);
   grpc_slice_buffer_reset_and_unref(&write_slices);
@@ -293,7 +293,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   std::future<grpc_error_handle> write_future = write_promise.get_future();
   XCTAssertEqual([self waitForEvent:&write_future timeout:kWriteTimeout], YES);
-  XCTAssertEqual(write_future.get(), GRPC_ERROR_NONE);
+  XCTAssertEqual(write_future.get(), absl::OkStatus());
 
   while (recv_size < kBufferSize) {
     ssize_t size = recv(svr_fd_, read_buffer, kBufferSize, 0);
@@ -308,9 +308,9 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   std::future<grpc_error_handle> read_future = read_promise.get_future();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
-  XCTAssertNotEqual(read_future.get(), GRPC_ERROR_NONE);
+  XCTAssertNotEqual(read_future.get(), absl::OkStatus());
 
-  grpc_endpoint_shutdown(ep_, GRPC_ERROR_NONE);
+  grpc_endpoint_shutdown(ep_, absl::OkStatus());
   grpc_slice_buffer_reset_and_unref(&read_slices);
   grpc_slice_buffer_reset_and_unref(&write_slices);
 }
@@ -336,9 +336,9 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   std::future<grpc_error_handle> read_future = read_promise.get_future();
   XCTAssertEqual([self waitForEvent:&read_future timeout:kReadTimeout], YES);
-  XCTAssertNotEqual(read_future.get(), GRPC_ERROR_NONE);
+  XCTAssertNotEqual(read_future.get(), absl::OkStatus());
 
-  grpc_endpoint_shutdown(ep_, GRPC_ERROR_NONE);
+  grpc_endpoint_shutdown(ep_, absl::OkStatus());
   grpc_slice_buffer_reset_and_unref(&read_slices);
 }
 

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -172,7 +172,7 @@ static void test_no_op(void) {
                   .channel_args_preconditioning()
                   .PreconditionChannelArgs(nullptr);
   ASSERT_EQ(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
@@ -187,7 +187,7 @@ static void test_no_op_with_start(void) {
                   .channel_args_preconditioning()
                   .PreconditionChannelArgs(nullptr);
   ASSERT_EQ(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
@@ -208,7 +208,7 @@ static void test_no_op_with_port(void) {
                   .channel_args_preconditioning()
                   .PreconditionChannelArgs(nullptr);
   ASSERT_EQ(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
@@ -220,7 +220,7 @@ static void test_no_op_with_port(void) {
   addr->sin_family = AF_INET;
   int port = -1;
   ASSERT_EQ(grpc_tcp_server_add_port(s, &resolved_addr, &port),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   ASSERT_GT(port, 0);
 
   grpc_tcp_server_unref(s);
@@ -236,7 +236,7 @@ static void test_no_op_with_port_and_start(void) {
                   .channel_args_preconditioning()
                   .PreconditionChannelArgs(nullptr);
   ASSERT_EQ(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
@@ -248,7 +248,7 @@ static void test_no_op_with_port_and_start(void) {
   resolved_addr.len = static_cast<socklen_t>(sizeof(struct sockaddr_in));
   addr->sin_family = AF_INET;
   ASSERT_EQ(grpc_tcp_server_add_port(s, &resolved_addr, &port),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   ASSERT_GT(port, 0);
 
   std::vector<grpc_pollset*> empty_pollset;
@@ -288,7 +288,7 @@ static grpc_error_handle tcp_connect(const test_addr* remote,
     grpc_pollset_worker* worker = nullptr;
     grpc_error_handle err;
     if ((err = grpc_pollset_work(g_pollset, &worker, deadline)) !=
-        GRPC_ERROR_NONE) {
+        absl::OkStatus()) {
       gpr_mu_unlock(g_mu);
       close(clifd);
       return err;
@@ -310,7 +310,7 @@ static grpc_error_handle tcp_connect(const test_addr* remote,
   gpr_log(GPR_INFO, "Result (%d, %d) fd %d", result->port_index,
           result->fd_index, result->server_fd);
   grpc_tcp_server_unref(result->server);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Tests a tcp server on "::" listeners with multiple ports. If channel_args is
@@ -339,7 +339,7 @@ static void test_connect(size_t num_connects,
   auto new_channel_args = grpc_core::CoreConfiguration::Get()
                               .channel_args_preconditioning()
                               .PreconditionChannelArgs(channel_args);
-  ASSERT_EQ(GRPC_ERROR_NONE,
+  ASSERT_EQ(absl::OkStatus(),
             grpc_tcp_server_create(
                 nullptr,
                 grpc_event_engine::experimental::ChannelArgsEndpointConfig(
@@ -373,7 +373,7 @@ static void test_connect(size_t num_connects,
   gpr_log(GPR_INFO, "Picked unused port %d", svr1_port);
   grpc_sockaddr_set_port(&resolved_addr1, svr1_port);
   ASSERT_EQ(grpc_tcp_server_add_port(s, &resolved_addr1, &port),
-            GRPC_ERROR_NONE);
+            absl::OkStatus());
   ASSERT_EQ(port, svr1_port);
 
   /* Bad port_index. */
@@ -412,7 +412,7 @@ static void test_connect(size_t num_connects,
         test_addr_init_str(&dst);
         ++num_tested;
         on_connect_result_init(&result);
-        if ((err = tcp_connect(&dst, &result)) == GRPC_ERROR_NONE &&
+        if ((err = tcp_connect(&dst, &result)) == absl::OkStatus() &&
             result.server_fd >= 0 && result.server == s) {
           continue;
         }

--- a/test/core/resource_quota/BUILD
+++ b/test/core/resource_quota/BUILD
@@ -148,6 +148,7 @@ grpc_proto_fuzzer(
     srcs = ["memory_quota_fuzzer.cc"],
     corpus = "memory_quota_fuzzer_corpus",
     external_deps = [
+        "absl/status",
         "absl/strings",
         "absl/types:optional",
     ],

--- a/test/core/resource_quota/memory_quota_fuzzer.cc
+++ b/test/core/resource_quota/memory_quota_fuzzer.cc
@@ -21,6 +21,7 @@
 #include <memory>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 
@@ -140,7 +141,7 @@ class Fuzzer {
                     delete args;
                   },
                   args, nullptr);
-              ExecCtx::Get()->Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+              ExecCtx::Get()->Run(DEBUG_LOCATION, closure, absl::OkStatus());
             };
             auto pass = MapReclamationPass(cfg.pass());
             WithAllocator(

--- a/test/core/security/aws_request_signer_test.cc
+++ b/test/core/security/aws_request_signer_test.cc
@@ -66,7 +66,7 @@ const char* kBotoTestDate = "Mon, 09 Sep 2011 23:36:00 GMT";
 // AWS official example from the developer doc.
 // https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
 TEST(GrpcAwsRequestSignerTest, AWSOfficialExample) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       "AKIDEXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "", "GET",
       "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08",
@@ -74,7 +74,7 @@ TEST(GrpcAwsRequestSignerTest, AWSOfficialExample) {
       {{"content-type", "application/x-www-form-urlencoded; charset=utf-8"},
        {"x-amz-date", "20150830T123600Z"}},
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, "
@@ -84,13 +84,13 @@ TEST(GrpcAwsRequestSignerTest, AWSOfficialExample) {
 }
 
 TEST(GrpcAwsRequestSignerTest, GetDescribeRegions) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kAmzTestAccessKeyId, kAmzTestSecretAccessKey, kAmzTestToken, "GET",
       "https://"
       "ec2.us-east-2.amazonaws.com?Action=DescribeRegions&Version=2013-10-15",
       "us-east-2", "", {{"x-amz-date", kAmzTestDate}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(
       signer.GetSignedRequestHeaders()["Authorization"],
       "AWS4-HMAC-SHA256 "
@@ -101,13 +101,13 @@ TEST(GrpcAwsRequestSignerTest, GetDescribeRegions) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentity) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kAmzTestAccessKeyId, kAmzTestSecretAccessKey, kAmzTestToken, "POST",
       "https://"
       "sts.us-east-2.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
       "us-east-2", "", {{"x-amz-date", kAmzTestDate}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(
       signer.GetSignedRequestHeaders()["Authorization"],
       "AWS4-HMAC-SHA256 "
@@ -118,13 +118,13 @@ TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentity) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentityNoToken) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kAmzTestAccessKeyId, kAmzTestSecretAccessKey, "", "POST",
       "https://"
       "sts.us-east-2.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
       "us-east-2", "", {{"x-amz-date", kAmzTestDate}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(
       signer.GetSignedRequestHeaders()["Authorization"],
       "AWS4-HMAC-SHA256 "
@@ -135,12 +135,12 @@ TEST(GrpcAwsRequestSignerTest, PostGetCallerIdentityNoToken) {
 }
 
 TEST(GrpcAwsRequestSignerTest, GetHost) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(kBotoTestAccessKeyId,
                                      kBotoTestSecretAccessKey, kBotoTestToken,
                                      "GET", "https://host.foo.com", "us-east-1",
                                      "", {{"date", kBotoTestDate}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -150,12 +150,12 @@ TEST(GrpcAwsRequestSignerTest, GetHost) {
 }
 
 TEST(GrpcAwsRequestSignerTest, GetHostDuplicateQueryParam) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "GET",
       "https://host.foo.com/?foo=Zoo&foo=aha", "us-east-1", "",
       {{"date", kBotoTestDate}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -165,12 +165,12 @@ TEST(GrpcAwsRequestSignerTest, GetHostDuplicateQueryParam) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderKey) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "",
       {{"date", kBotoTestDate}, {"ZOO", "zoobar"}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -180,12 +180,12 @@ TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderKey) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderValue) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "",
       {{"date", kBotoTestDate}, {"zoo", "ZOOBAR"}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -195,12 +195,12 @@ TEST(GrpcAwsRequestSignerTest, PostWithUpperCaseHeaderValue) {
 }
 
 TEST(GrpcAwsRequestSignerTest, SignPostWithHeader) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "",
       {{"date", kBotoTestDate}, {"p", "phfft"}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -210,14 +210,14 @@ TEST(GrpcAwsRequestSignerTest, SignPostWithHeader) {
 }
 
 TEST(GrpcAwsRequestSignerTest, PostWithBodyNoCustomHeaders) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/", "us-east-1", "foo=bar",
       {{"date", kBotoTestDate},
        {"Content-Type", "application/x-www-form-urlencoded"}},
       &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -227,12 +227,12 @@ TEST(GrpcAwsRequestSignerTest, PostWithBodyNoCustomHeaders) {
 }
 
 TEST(GrpcAwsRequestSignerTest, SignPostWithQueryString) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       kBotoTestAccessKeyId, kBotoTestSecretAccessKey, kBotoTestToken, "POST",
       "https://host.foo.com/?foo=bar", "us-east-1", "",
       {{"date", kBotoTestDate}}, &error);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   EXPECT_EQ(signer.GetSignedRequestHeaders()["Authorization"],
             "AWS4-HMAC-SHA256 "
             "Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, "
@@ -242,7 +242,7 @@ TEST(GrpcAwsRequestSignerTest, SignPostWithQueryString) {
 }
 
 TEST(GrpcAwsRequestSignerTest, InvalidUrl) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer("access_key_id", "secret_access_key",
                                      "token", "POST", "invalid_url",
                                      "us-east-1", "", {}, &error);
@@ -253,7 +253,7 @@ TEST(GrpcAwsRequestSignerTest, InvalidUrl) {
 }
 
 TEST(GrpcAwsRequestSignerTest, DuplicateRequestDate) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_core::AwsRequestSigner signer(
       "access_key_id", "secret_access_key", "token", "POST", "invalid_url",
       "us-east-1", "", {{"date", kBotoTestDate}, {"x-amz-date", kAmzTestDate}},

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -549,7 +549,7 @@ class RequestMetadataState : public RefCounted<RequestMetadataState> {
 TEST(CredentialsTest, TestGoogleIamCreds) {
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       absl::StrCat(GRPC_IAM_AUTHORIZATION_TOKEN_METADATA_KEY, ": ",
                    test_google_iam_authorization_token, ", ",
                    GRPC_IAM_AUTHORITY_SELECTOR_METADATA_KEY, ": ",
@@ -566,7 +566,7 @@ TEST(CredentialsTest, TestGoogleIamCreds) {
 
 TEST(CredentialsTest, TestAccessTokenCreds) {
   ExecCtx exec_ctx;
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE,
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(),
                                                  "authorization: Bearer blah");
   grpc_call_credentials* creds =
       grpc_access_token_credentials_create("blah", nullptr);
@@ -622,7 +622,7 @@ TEST(CredentialsTest, TestChannelOauth2CompositeCreds) {
 TEST(CredentialsTest, TestOauth2GoogleIamCompositeCreds) {
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       absl::StrCat(GRPC_AUTHORIZATION_METADATA_KEY, ": ",
                    test_oauth2_bearer_token, ", ",
                    GRPC_IAM_AUTHORIZATION_TOKEN_METADATA_KEY, ": ",
@@ -737,7 +737,7 @@ int compute_engine_httpcli_get_success_override(
     grpc_http_response* response) {
   validate_compute_engine_http_request(request, host, path);
   *response = http_response(200, valid_oauth2_json_response);
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -747,7 +747,7 @@ int compute_engine_httpcli_get_failure_override(
     grpc_http_response* response) {
   validate_compute_engine_http_request(request, host, path);
   *response = http_response(403, "Not Authorized.");
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -792,7 +792,7 @@ TEST(CredentialsTest, TestComputeEngineCredsSuccess) {
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http get should be called. */
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(compute_engine_httpcli_get_success_override,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -801,7 +801,7 @@ TEST(CredentialsTest, TestComputeEngineCredsSuccess) {
   ExecCtx::Get()->Flush();
 
   /* Second request: the cached token should be served directly. */
-  state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -865,7 +865,7 @@ int refresh_token_httpcli_post_success(const grpc_http_request* request,
                                        grpc_http_response* response) {
   validate_refresh_token_http_request(request, host, path, body, body_size);
   *response = http_response(200, valid_oauth2_json_response);
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -875,7 +875,7 @@ int token_httpcli_post_failure(const grpc_http_request* /*request*/,
                                Timestamp /*deadline*/, grpc_closure* on_done,
                                grpc_http_response* response) {
   *response = http_response(403, "Not Authorized.");
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -892,7 +892,7 @@ TEST(CredentialsTest, TestRefreshTokenCredsSuccess) {
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            refresh_token_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -901,7 +901,7 @@ TEST(CredentialsTest, TestRefreshTokenCredsSuccess) {
   ExecCtx::Get()->Flush();
 
   /* Second request: the cached token should be served directly. */
-  state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -1092,7 +1092,7 @@ int sts_token_httpcli_post_success(const grpc_http_request* request,
                                    grpc_http_response* response) {
   validate_sts_token_http_request(request, host, path, body, body_size, true);
   *response = http_response(200, valid_sts_json_response);
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -1102,7 +1102,7 @@ int sts_token_httpcli_post_success_no_actor_token(
     grpc_closure* on_done, grpc_http_response* response) {
   validate_sts_token_http_request(request, host, path, body, body_size, false);
   *response = http_response(200, valid_sts_json_response);
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -1143,7 +1143,7 @@ TEST(CredentialsTest, TestStsCredsSuccess) {
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            sts_token_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -1152,7 +1152,7 @@ TEST(CredentialsTest, TestStsCredsSuccess) {
   ExecCtx::Get()->Flush();
 
   /* Second request: the cached token should be served directly. */
-  state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -1228,7 +1228,7 @@ TEST(CredentialsTest, TestStsCredsNoActorTokenSuccess) {
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   /* First request: http put should be called. */
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            sts_token_httpcli_post_success_no_actor_token,
                            httpcli_put_should_not_be_called);
@@ -1237,7 +1237,7 @@ TEST(CredentialsTest, TestStsCredsNoActorTokenSuccess) {
   ExecCtx::Get()->Flush();
 
   /* Second request: the cached token should be served directly. */
-  state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -1447,14 +1447,14 @@ TEST(CredentialsTest, TestJwtCredsSuccess) {
           json_key_string, grpc_max_auth_token_lifetime(), nullptr);
 
   /* First request: jwt_encode_and_sign should be called. */
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   grpc_jwt_encode_and_sign_set_override(encode_and_sign_jwt_success);
   state->RunRequestMetadataTest(creds, kTestUrlScheme, kTestAuthority,
                                 kTestPath);
   ExecCtx::Get()->Flush();
 
   /* Second request: the cached token should be served directly. */
-  state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   grpc_jwt_encode_and_sign_set_override(
       encode_and_sign_jwt_should_not_be_called);
   state->RunRequestMetadataTest(creds, kTestUrlScheme, kTestAuthority,
@@ -1463,7 +1463,7 @@ TEST(CredentialsTest, TestJwtCredsSuccess) {
 
   /* Third request: Different service url so jwt_encode_and_sign should be
      called again (no caching). */
-  state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, emd);
+  state = RequestMetadataState::NewInstance(absl::OkStatus(), emd);
   grpc_jwt_encode_and_sign_set_override(encode_and_sign_jwt_success);
   state->RunRequestMetadataTest(creds, kTestUrlScheme, kTestOtherAuthority,
                                 kTestOtherPath);
@@ -1661,14 +1661,14 @@ int default_creds_metadata_server_detection_httpcli_get_success_override(
   response->hdrs = headers;
   GPR_ASSERT(strcmp(path, "/") == 0);
   GPR_ASSERT(strcmp(host, "metadata.google.internal.") == 0);
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
 TEST(CredentialsTest, TestGoogleDefaultCredsGce) {
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       "authorization: Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_");
   grpc_flush_cached_google_default_credentials();
   SetEnv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
@@ -1704,7 +1704,7 @@ TEST(CredentialsTest, TestGoogleDefaultCredsGce) {
 TEST(CredentialsTest, TestGoogleDefaultCredsNonGce) {
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       "authorization: Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_");
   grpc_flush_cached_google_default_credentials();
   SetEnv(GRPC_GOOGLE_CREDENTIALS_ENV_VAR, ""); /* Reset. */
@@ -1744,7 +1744,7 @@ int default_creds_gce_detection_httpcli_get_failure_override(
   GPR_ASSERT(strcmp(path, "/") == 0);
   GPR_ASSERT(strcmp(host, "metadata.google.internal.") == 0);
   *response = http_response(200, "");
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -1772,7 +1772,7 @@ TEST(CredentialsTest, TestNoGoogleDefaultCreds) {
 
 TEST(CredentialsTest, TestGoogleDefaultCredsCallCredsSpecified) {
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       "authorization: Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_");
   ExecCtx exec_ctx;
   grpc_flush_cached_google_default_credentials();
@@ -1823,7 +1823,7 @@ struct fake_call_creds : public grpc_call_credentials {
 };
 
 TEST(CredentialsTest, TestGoogleDefaultCredsNotDefault) {
-  auto state = RequestMetadataState::NewInstance(GRPC_ERROR_NONE, "foo: oof");
+  auto state = RequestMetadataState::NewInstance(absl::OkStatus(), "foo: oof");
   ExecCtx exec_ctx;
   grpc_flush_cached_google_default_credentials();
   RefCountedPtr<grpc_call_credentials> call_creds =
@@ -1930,8 +1930,8 @@ TEST(CredentialsTest, TestMetadataPluginSuccess) {
   plugin_state state = PLUGIN_INITIAL_STATE;
   grpc_metadata_credentials_plugin plugin;
   ExecCtx exec_ctx;
-  auto md_state =
-      RequestMetadataState::NewInstance(GRPC_ERROR_NONE, "foo: bar, hi: there");
+  auto md_state = RequestMetadataState::NewInstance(absl::OkStatus(),
+                                                    "foo: bar, hi: there");
 
   plugin.state = &state;
   plugin.get_metadata = plugin_get_metadata_success;
@@ -2253,7 +2253,7 @@ int external_account_creds_httpcli_post_success(
     *response = http_response(
         200, valid_external_account_creds_token_exchange_response);
   }
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -2272,7 +2272,7 @@ int external_account_creds_httpcli_post_failure_token_exchange_response_missing_
         200,
         valid_external_account_creds_service_account_impersonation_response);
   }
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -2293,7 +2293,7 @@ int url_external_account_creds_httpcli_get_success(
         200,
         valid_url_external_account_creds_retrieve_subject_token_response_format_json);
   }
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -2344,7 +2344,7 @@ int aws_external_account_creds_httpcli_get_success(
     *response = http_response(
         200, valid_aws_external_account_creds_retrieve_signing_keys_response);
   }
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -2368,7 +2368,7 @@ int aws_imdsv2_external_account_creds_httpcli_put_success(
   GPR_ASSERT(strcmp(request->hdrs[0].value, "300") == 0);
   GPR_ASSERT(strcmp(path, "/imdsv2_session_token_url") == 0);
   *response = http_response(200, aws_imdsv2_session_token);
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -2382,7 +2382,7 @@ int aws_external_account_creds_httpcli_post_success(
     *response = http_response(
         200, valid_external_account_creds_token_exchange_response);
   }
-  ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -2399,7 +2399,7 @@ class TestExternalAccountCredentials final : public ExternalAccountCredentials {
   void RetrieveSubjectToken(
       HTTPRequestContext* /*ctx*/, const Options& /*options*/,
       std::function<void(std::string, grpc_error_handle)> cb) override {
-    cb("test_subject_token", GRPC_ERROR_NONE);
+    cb("test_subject_token", absl::OkStatus());
   }
 };
 
@@ -2424,7 +2424,7 @@ TEST(CredentialsTest, TestExternalAccountCredsSuccess) {
   GPR_ASSERT(creds.min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   /* First request: http put should be called. */
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2433,7 +2433,7 @@ TEST(CredentialsTest, TestExternalAccountCredsSuccess) {
   ExecCtx::Get()->Flush();
   /* Second request: the cached token should be served directly. */
   state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -2463,7 +2463,7 @@ TEST(CredentialsTest, TestExternalAccountCredsSuccessWithUrlEncode) {
   };
   TestExternalAccountCredentials creds(options, {});
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2495,7 +2495,7 @@ TEST(CredentialsTest,
   GPR_ASSERT(creds.min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   /* First request: http put should be called. */
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE,
+      absl::OkStatus(),
       "authorization: Bearer service_account_impersonation_access_token");
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            external_account_creds_httpcli_post_success,
@@ -2626,13 +2626,13 @@ TEST(CredentialsTest, TestUrlExternalAccountCredsSuccessFormatText) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = UrlExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(url_external_account_creds_httpcli_get_success,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2663,13 +2663,13 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = UrlExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(url_external_account_creds_httpcli_get_success,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2697,13 +2697,13 @@ TEST(CredentialsTest, TestUrlExternalAccountCredsSuccessFormatJson) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = UrlExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(url_external_account_creds_httpcli_get_success,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2731,7 +2731,7 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = UrlExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds == nullptr);
   std::string actual_error;
@@ -2760,13 +2760,13 @@ TEST(CredentialsTest, TestFileExternalAccountCredsSuccessFormatText) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = FileExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2805,13 +2805,13 @@ TEST(CredentialsTest, TestFileExternalAccountCredsSuccessFormatJson) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = FileExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2839,7 +2839,7 @@ TEST(CredentialsTest, TestFileExternalAccountCredsFailureFileNotFound) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = FileExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
@@ -2884,7 +2884,7 @@ TEST(CredentialsTest, TestFileExternalAccountCredsFailureInvalidJsonContent) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = FileExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
@@ -2922,13 +2922,13 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsSuccess) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -2956,13 +2956,13 @@ TEST(CredentialsTest, TestAwsImdsv2ExternalAccountCredsSuccess) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(
       aws_imdsv2_external_account_creds_httpcli_get_success,
       aws_external_account_creds_httpcli_post_success,
@@ -2992,13 +2992,13 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsSuccessPathRegionEnvKeysUrl) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3029,13 +3029,13 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3068,13 +3068,13 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3107,13 +3107,13 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsSuccessPathRegionUrlKeysEnv) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3148,13 +3148,13 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsSuccessPathRegionEnvKeysEnv) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3193,13 +3193,13 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3238,13 +3238,13 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_NONE, "authorization: Bearer token_exchange_access_token");
+      absl::OkStatus(), "authorization: Bearer token_exchange_access_token");
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
@@ -3277,7 +3277,7 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds == nullptr);
   std::string expected_error = "environment_id does not match.";
@@ -3305,7 +3305,7 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsFailureInvalidRegionUrl) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
@@ -3343,7 +3343,7 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsFailureInvalidUrl) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
@@ -3380,7 +3380,7 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsFailureMissingRoleName) {
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
@@ -3419,7 +3419,7 @@ TEST(CredentialsTest,
       "client_secret",                    // client_secret;
       "",                                 // workforce_pool_user_project;
   };
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto creds = AwsExternalAccountCredentials::Create(options, {}, &error);
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());

--- a/test/core/security/jwt_verifier_test.cc
+++ b/test/core/security/jwt_verifier_test.cc
@@ -343,7 +343,7 @@ static int httpcli_get_google_keys_for_email(
                "/robot/v1/metadata/x509/"
                "777-abaslkan11hlb6nmim3bpspl31ud@developer."
                "gserviceaccount.com");
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -388,7 +388,7 @@ static int httpcli_get_custom_keys_for_email(
   *response = http_response(200, gpr_strdup(good_jwk_set));
   EXPECT_STREQ(host, "keys.bar.com");
   EXPECT_STREQ(path, "/jwk/foo@bar.com");
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -424,7 +424,7 @@ static int httpcli_get_jwk_set(const grpc_http_request* /*request*/,
   *response = http_response(200, gpr_strdup(good_jwk_set));
   EXPECT_STREQ(host, "www.googleapis.com");
   EXPECT_STREQ(path, "/oauth2/v3/certs");
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -439,7 +439,7 @@ static int httpcli_get_openid_config(const grpc_http_request* /*request*/,
   grpc_core::HttpRequest::SetOverride(httpcli_get_jwk_set,
                                       httpcli_post_should_not_be_called,
                                       httpcli_put_should_not_be_called);
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 
@@ -481,7 +481,7 @@ static int httpcli_get_bad_json(const grpc_http_request* /* request */,
                                 grpc_closure* on_done,
                                 grpc_http_response* response) {
   *response = http_response(200, gpr_strdup("{\"bad\": \"stuff\"}"));
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_done, absl::OkStatus());
   return 1;
 }
 

--- a/test/core/security/print_google_default_creds_token.cc
+++ b/test/core/security/print_google_default_creds_token.cc
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
   grpc_auth_metadata_context context;
   gpr_cmdline* cl = gpr_cmdline_create("print_google_default_creds_token");
   grpc_pollset* pollset = nullptr;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   gpr_cmdline_add_string(cl, "service_url",
                          "Service URL for the token request.", &service_url);
   gpr_cmdline_parse(cl, argc, argv);
@@ -96,7 +96,7 @@ int main(int argc, char** argv) {
   GRPC_CLOSURE_INIT(&sync.on_request_metadata, on_metadata_response, &sync,
                     grpc_schedule_on_exec_ctx);
 
-  error = GRPC_ERROR_NONE;
+  error = absl::OkStatus();
   if (reinterpret_cast<grpc_composite_channel_credentials*>(creds)
           ->mutable_call_creds()
           ->get_request_metadata(&sync.pops, context, &sync.md_array,

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -739,10 +739,10 @@ static void test_peer_alpn_check(void) {
       tsi_construct_string_peer_property(TSI_SSL_ALPN_SELECTED_PROTOCOL, alpn,
                                          strlen(alpn), &peer.properties[0]),
       TSI_OK);
-  ASSERT_EQ(grpc_ssl_check_alpn(&peer), GRPC_ERROR_NONE);
+  ASSERT_EQ(grpc_ssl_check_alpn(&peer), absl::OkStatus());
   tsi_peer_destruct(&peer);
 #else
-  ASSERT_EQ(grpc_ssl_check_alpn(nullptr), GRPC_ERROR_NONE);
+  ASSERT_EQ(grpc_ssl_check_alpn(nullptr), absl::OkStatus());
 #endif
 }
 

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -95,7 +95,7 @@ class TlsSecurityConnectorTest : public ::testing::Test {
   static void VerifyExpectedErrorCallback(void* arg, grpc_error_handle error) {
     const char* expected_error_msg = static_cast<const char*>(arg);
     if (expected_error_msg == nullptr) {
-      EXPECT_EQ(error, GRPC_ERROR_NONE);
+      EXPECT_EQ(error, absl::OkStatus());
     } else {
       EXPECT_EQ(GetErrorMsg(error), expected_error_msg);
     }

--- a/test/core/surface/completion_queue_test.cc
+++ b/test/core/surface/completion_queue_test.cc
@@ -157,8 +157,8 @@ TEST(GrpcCompletionQueueTest, TestCqEndOp) {
         grpc_completion_queue_factory_lookup(&attr), &attr, nullptr);
 
     ASSERT_TRUE(grpc_cq_begin_op(cc, tag));
-    grpc_cq_end_op(cc, tag, GRPC_ERROR_NONE, do_nothing_end_completion, nullptr,
-                   &completion);
+    grpc_cq_end_op(cc, tag, absl::OkStatus(), do_nothing_end_completion,
+                   nullptr, &completion);
 
     ev = grpc_completion_queue_next(cc, gpr_inf_past(GPR_CLOCK_REALTIME),
                                     nullptr);
@@ -193,8 +193,8 @@ TEST(GrpcCompletionQueueTest, TestCqTlsCacheFull) {
 
     grpc_completion_queue_thread_local_cache_init(cc);
     ASSERT_TRUE(grpc_cq_begin_op(cc, tag));
-    grpc_cq_end_op(cc, tag, GRPC_ERROR_NONE, do_nothing_end_completion, nullptr,
-                   &completion);
+    grpc_cq_end_op(cc, tag, absl::OkStatus(), do_nothing_end_completion,
+                   nullptr, &completion);
 
     ev = grpc_completion_queue_next(cc, gpr_inf_past(GPR_CLOCK_REALTIME),
                                     nullptr);
@@ -314,7 +314,7 @@ TEST(GrpcCompletionQueueTest, TestPluck) {
 
     for (i = 0; i < GPR_ARRAY_SIZE(tags); i++) {
       ASSERT_TRUE(grpc_cq_begin_op(cc, tags[i]));
-      grpc_cq_end_op(cc, tags[i], GRPC_ERROR_NONE, do_nothing_end_completion,
+      grpc_cq_end_op(cc, tags[i], absl::OkStatus(), do_nothing_end_completion,
                      nullptr, &completions[i]);
     }
 
@@ -326,7 +326,7 @@ TEST(GrpcCompletionQueueTest, TestPluck) {
 
     for (i = 0; i < GPR_ARRAY_SIZE(tags); i++) {
       ASSERT_TRUE(grpc_cq_begin_op(cc, tags[i]));
-      grpc_cq_end_op(cc, tags[i], GRPC_ERROR_NONE, do_nothing_end_completion,
+      grpc_cq_end_op(cc, tags[i], absl::OkStatus(), do_nothing_end_completion,
                      nullptr, &completions[i]);
     }
 
@@ -451,7 +451,7 @@ TEST(GrpcCompletionQueueTest, TestCallback) {
 
       for (i = 0; i < GPR_ARRAY_SIZE(tags); i++) {
         ASSERT_TRUE(grpc_cq_begin_op(cc, tags[i]));
-        grpc_cq_end_op(cc, tags[i], GRPC_ERROR_NONE, do_nothing_end_completion,
+        grpc_cq_end_op(cc, tags[i], absl::OkStatus(), do_nothing_end_completion,
                        nullptr, &completions[i]);
       }
 

--- a/test/core/surface/completion_queue_threading_test.cc
+++ b/test/core/surface/completion_queue_threading_test.cc
@@ -112,7 +112,7 @@ static void test_too_many_plucks(void) {
 
   for (i = 0; i < GPR_ARRAY_SIZE(tags); i++) {
     ASSERT_TRUE(grpc_cq_begin_op(cc, tags[i]));
-    grpc_cq_end_op(cc, tags[i], GRPC_ERROR_NONE, do_nothing_end_completion,
+    grpc_cq_end_op(cc, tags[i], absl::OkStatus(), do_nothing_end_completion,
                    nullptr, &completions[i]);
   }
 
@@ -164,7 +164,7 @@ static void producer_thread(void* arg) {
   gpr_log(GPR_INFO, "producer %d phase 2", opt->id);
   for (i = 0; i < TEST_THREAD_EVENTS; i++) {
     grpc_core::ExecCtx exec_ctx;
-    grpc_cq_end_op(opt->cc, reinterpret_cast<void*>(1), GRPC_ERROR_NONE,
+    grpc_cq_end_op(opt->cc, reinterpret_cast<void*>(1), absl::OkStatus(),
                    free_completion, nullptr,
                    static_cast<grpc_cq_completion*>(
                        gpr_malloc(sizeof(grpc_cq_completion))));

--- a/test/core/transport/binder/binder_transport_test.cc
+++ b/test/core/transport/binder/binder_transport_test.cc
@@ -701,7 +701,7 @@ TEST_F(BinderTransportTest, WireWriterRpcCallErrorPropagates) {
   EXPECT_CALL(GetWireWriter(), RpcCall)
       .WillOnce(Return(absl::OkStatus()))
       .WillOnce(Return(absl::InternalError("WireWriter::RpcCall failed")));
-  EXPECT_CALL(mock_on_complete1, Callback(GRPC_ERROR_NONE));
+  EXPECT_CALL(mock_on_complete1, Callback(absl::OkStatus()));
   EXPECT_CALL(mock_on_complete2,
               Callback(GrpcErrorMessageContains("WireWriter::RpcCall failed")));
 

--- a/test/core/transport/chttp2/context_list_test.cc
+++ b/test/core/transport/chttp2/context_list_test.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "absl/status/status.h"
 #include "gtest/gtest.h"
 
 #include <grpc/grpc.h>
@@ -52,7 +53,7 @@ void* PhonyArgsCopier(void* arg) { return arg; }
 void TestExecuteFlushesListVerifier(void* arg, Timestamps* ts,
                                     grpc_error_handle error) {
   ASSERT_NE(arg, nullptr);
-  EXPECT_EQ(error, GRPC_ERROR_NONE);
+  EXPECT_EQ(error, absl::OkStatus());
   if (ts) {
     EXPECT_EQ(ts->byte_offset, kByteOffset);
   }
@@ -100,7 +101,7 @@ TEST_F(ContextListTest, ExecuteFlushesList) {
     ContextList::Append(&list, s[i]);
   }
   Timestamps ts;
-  ContextList::Execute(list, &ts, GRPC_ERROR_NONE);
+  ContextList::Execute(list, &ts, absl::OkStatus());
   for (auto i = 0; i < kNumElems; i++) {
     EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
     grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
@@ -117,14 +118,14 @@ TEST_F(ContextListTest, EmptyList) {
   ContextList* list = nullptr;
   ExecCtx exec_ctx;
   Timestamps ts;
-  ContextList::Execute(list, &ts, GRPC_ERROR_NONE);
+  ContextList::Execute(list, &ts, absl::OkStatus());
   exec_ctx.Flush();
 }
 
 TEST_F(ContextListTest, EmptyListEmptyTimestamp) {
   ContextList* list = nullptr;
   ExecCtx exec_ctx;
-  ContextList::Execute(list, nullptr, GRPC_ERROR_NONE);
+  ContextList::Execute(list, nullptr, absl::OkStatus());
   exec_ctx.Flush();
 }
 
@@ -153,7 +154,7 @@ TEST_F(ContextListTest, NonEmptyListEmptyTimestamp) {
     gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
     ContextList::Append(&list, s[i]);
   }
-  ContextList::Execute(list, nullptr, GRPC_ERROR_NONE);
+  ContextList::Execute(list, nullptr, absl::OkStatus());
   for (auto i = 0; i < kNumElems; i++) {
     EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
     grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),

--- a/test/core/transport/chttp2/graceful_shutdown_test.cc
+++ b/test/core/transport/chttp2/graceful_shutdown_test.cc
@@ -98,7 +98,7 @@ class GracefulShutdownTest : public ::testing::Test {
     grpc_endpoint_add_to_pollset(fds_.server, grpc_cq_pollset(cq_));
     GPR_ASSERT(core_server->SetupTransport(transport, nullptr,
                                            core_server->channel_args(),
-                                           nullptr) == GRPC_ERROR_NONE);
+                                           nullptr) == absl::OkStatus());
     grpc_chttp2_transport_start_reading(transport, nullptr, nullptr, nullptr);
     // Start polling on the client
     Notification client_poller_thread_started_notification;

--- a/test/core/transport/chttp2/hpack_parser_table_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_table_test.cc
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
@@ -121,7 +122,7 @@ TEST(HpackParserTableTest, ManyAdditions) {
     auto memento =
         HPackTable::Memento(std::move(key_slice), std::move(value_slice));
     auto add_err = tbl.Add(std::move(memento));
-    ASSERT_EQ(add_err, GRPC_ERROR_NONE);
+    ASSERT_EQ(add_err, absl::OkStatus());
     AssertIndex(&tbl, 1 + hpack_constants::kLastStaticEntry, key.c_str(),
                 value.c_str());
     if (i) {

--- a/test/core/transport/chttp2/hpack_parser_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_test.cc
@@ -80,7 +80,7 @@ class ParseTest : public ::testing::TestWithParam<Test> {
       parser_->hpack_table()->SetMaxBytes(GetParam().table_size.value());
       EXPECT_EQ(parser_->hpack_table()->SetCurrentTableSize(
                     GetParam().table_size.value()),
-                GRPC_ERROR_NONE);
+                absl::OkStatus());
     }
   }
 

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -147,7 +147,7 @@ class Client {
         grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
         addresses_or->data(), Timestamp::Now() + Duration::Seconds(1));
     ASSERT_TRUE(PollUntilDone(&state, Timestamp::InfFuture()));
-    ASSERT_EQ(GRPC_ERROR_NONE, state.error());
+    ASSERT_EQ(absl::OkStatus(), state.error());
     grpc_pollset_set_destroy(pollset_set);
     grpc_endpoint_add_to_pollset(endpoint_, pollset_);
   }
@@ -170,7 +170,7 @@ class Client {
         retval = false;
         break;
       }
-      if (state.error() != GRPC_ERROR_NONE) break;
+      if (state.error() != absl::OkStatus()) break;
       gpr_log(GPR_INFO, "client read %" PRIuPTR " bytes", read_buffer.length);
       grpc_slice_buffer_reset_and_unref(&read_buffer);
     }
@@ -217,7 +217,7 @@ class Client {
 
     grpc_closure closure_;
     gpr_atm done_atm_ = 0;
-    grpc_error_handle error_ = GRPC_ERROR_NONE;
+    grpc_error_handle error_;
   };
 
   // Returns true if done, or false if deadline exceeded.

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -33,6 +33,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/memory/memory.h"
+#include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -117,7 +118,7 @@ class TrailingMetadataRecordingFilter {
     static grpc_error_handle Init(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
       new (elem->call_data) CallData(args);
-      return GRPC_ERROR_NONE;
+      return absl::OkStatus();
     }
 
     static void Destroy(grpc_call_element* elem,
@@ -184,7 +185,7 @@ class TrailingMetadataRecordingFilter {
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* /*args*/) {
     new (elem->channel_data) TrailingMetadataRecordingFilter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/test/core/transport/error_utils_test.cc
+++ b/test/core/transport/error_utils_test.cc
@@ -29,7 +29,7 @@
 namespace {
 
 TEST(ErrorUtilsTest, GetErrorGetStatusNone) {
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   grpc_status_code code;
   std::string message;
   grpc_error_get_status(error, grpc_core::Timestamp(), &code, &message, nullptr,
@@ -69,11 +69,11 @@ TEST(ErrorUtilsTest, GetErrorGetStatusChild) {
 // ---- Ok Status ----
 TEST(ErrorUtilsTest, AbslOkToGrpcError) {
   grpc_error_handle error = absl_status_to_grpc_error(absl::OkStatus());
-  ASSERT_EQ(GRPC_ERROR_NONE, error);
+  ASSERT_EQ(absl::OkStatus(), error);
 }
 
 TEST(ErrorUtilsTest, GrpcSpecialErrorNoneToAbslStatus) {
-  absl::Status status = grpc_error_to_absl_status(GRPC_ERROR_NONE);
+  absl::Status status = grpc_error_to_absl_status(absl::OkStatus());
   ASSERT_TRUE(status.ok());
   ASSERT_EQ(status.message(), "");
 }
@@ -82,17 +82,18 @@ TEST(ErrorUtilsTest, GrpcSpecialErrorNoneToAbslStatus) {
 TEST(ErrorUtilsTest, AbslStatusToGrpcErrorDoesNotReturnSpecialVariables) {
   grpc_error_handle error =
       absl_status_to_grpc_error(absl::CancelledError("CANCELLED"));
-  ASSERT_NE(error, GRPC_ERROR_CANCELLED);
+  ASSERT_NE(error, absl::CancelledError());
 }
 
 TEST(ErrorUtilsTest, GrpcSpecialErrorCancelledToAbslStatus) {
-  absl::Status status = grpc_error_to_absl_status(GRPC_ERROR_CANCELLED);
+  absl::Status status = grpc_error_to_absl_status(absl::CancelledError());
   ASSERT_TRUE(absl::IsCancelled(status));
   ASSERT_EQ(status.message(), "CANCELLED");
 }
 
 TEST(ErrorUtilsTest, GrpcSpecialErrorOOMToAbslStatus) {
-  absl::Status status = grpc_error_to_absl_status(GRPC_ERROR_OOM);
+  absl::Status status =
+      grpc_error_to_absl_status(absl::ResourceExhaustedError(""));
   ASSERT_TRUE(absl::IsResourceExhausted(status));
   ASSERT_EQ(status.message(), "RESOURCE_EXHAUSTED");
 }

--- a/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
@@ -444,9 +444,9 @@ TEST(AltsHandshakerClientTest, ScheduleRequestSuccessTest) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        config->client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        config->client, GRPC_STATUS_OK, absl::OkStatus());
     alts_handshaker_client_on_status_received_for_testing(
-        config->server, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        config->server, GRPC_STATUS_OK, absl::OkStatus());
   }
   destroy_config(config);
 }
@@ -501,9 +501,9 @@ TEST(AltsHandshakerClientTest, ScheduleRequestGrpcCallFailureTest) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        config->client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        config->client, GRPC_STATUS_OK, absl::OkStatus());
     alts_handshaker_client_on_status_received_for_testing(
-        config->server, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        config->server, GRPC_STATUS_OK, absl::OkStatus());
   }
   destroy_config(config);
 }

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -787,7 +787,7 @@ TEST(AltsTsiHandshakerTest, CheckHandleResponseNullptrHandshaker) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Cleanup. */
   grpc_slice_unref(slice);
@@ -821,7 +821,7 @@ TEST(AltsTsiHandshakerTest, CheckHandleResponseNullptrRecvBytes) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -857,7 +857,7 @@ TEST(AltsTsiHandshakerTest,
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_UNKNOWN, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_UNKNOWN, absl::OkStatus());
   }
   /* Cleanup. */
   grpc_slice_unref(slice);
@@ -894,7 +894,7 @@ TEST(AltsTsiHandshakerTest,
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Cleanup. */
   grpc_slice_unref(slice);
@@ -940,7 +940,7 @@ TEST(AltsTsiHandshakerTest, CheckHandleResponseInvalidResp) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -959,7 +959,7 @@ static void check_handle_response_success(void* /*unused*/) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        cb_event, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Server start. */
   wait(&caller_to_tsi_notification);
@@ -971,7 +971,7 @@ static void check_handle_response_success(void* /*unused*/) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        cb_event, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        cb_event, GRPC_STATUS_OK, absl::OkStatus());
   }
 }
 
@@ -1012,7 +1012,7 @@ TEST(AltsTsiHandshakerTest, CheckHandleResponseFailure) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);
@@ -1058,7 +1058,7 @@ TEST(AltsTsiHandshakerTest, CheckHandleResponseAfterShutdown) {
   {
     grpc_core::ExecCtx exec_ctx;
     alts_handshaker_client_on_status_received_for_testing(
-        client, GRPC_STATUS_OK, GRPC_ERROR_NONE);
+        client, GRPC_STATUS_OK, absl::OkStatus());
   }
   /* Cleanup. */
   run_tsi_handshaker_destroy_with_exec_ctx(handshaker);

--- a/test/core/tsi/crl_ssl_transport_security_test.cc
+++ b/test/core/tsi/crl_ssl_transport_security_test.cc
@@ -228,7 +228,7 @@ class CrlSslTransportSecurityTest
     static char* LoadFile(absl::string_view file_path) {
       grpc_slice slice;
       GPR_ASSERT(grpc_load_file(file_path.data(), 1, &slice) ==
-                 GRPC_ERROR_NONE);
+                 absl::OkStatus());
       char* data = grpc_slice_to_c_string(slice);
       grpc_slice_unref(slice);
       return data;

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -445,7 +445,7 @@ static char* load_file(const char* dir_path, const char* file_name) {
   memcpy(file_path, dir_path, strlen(dir_path));
   memcpy(file_path + strlen(dir_path), file_name, strlen(file_name));
   grpc_slice slice;
-  EXPECT_EQ(grpc_load_file(file_path, 1, &slice), GRPC_ERROR_NONE);
+  EXPECT_EQ(grpc_load_file(file_path, 1, &slice), absl::OkStatus());
   char* data = grpc_slice_to_c_string(slice);
   grpc_slice_unref(slice);
   gpr_free(file_path);

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -65,7 +65,7 @@ static handshaker_args* handshaker_args_create(tsi_test_fixture* fixture,
   args->handshake_buffer =
       static_cast<unsigned char*>(gpr_zalloc(args->handshake_buffer_size));
   args->is_client = is_client;
-  args->error = GRPC_ERROR_NONE;
+  args->error = absl::OkStatus();
   return args;
 }
 
@@ -296,7 +296,7 @@ grpc_error_handle on_handshake_next_done(
   GPR_ASSERT(args != nullptr);
   GPR_ASSERT(args->fixture != nullptr);
   tsi_test_fixture* fixture = args->fixture;
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   /* Read more data if we need to. */
   if (result == TSI_INCOMPLETE_DATA) {
     GPR_ASSERT(bytes_to_send_size == 0);

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/util/mock_endpoint.h"
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/slice_buffer.h>
@@ -47,7 +48,7 @@ static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
   gpr_mu_lock(&m->mu);
   if (m->read_buffer.count > 0) {
     grpc_slice_buffer_swap(&m->read_buffer, slices);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, absl::OkStatus());
   } else {
     m->on_read = cb;
     m->on_read_out = slices;
@@ -61,7 +62,7 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   for (size_t i = 0; i < slices->count; i++) {
     m->on_write(slices->slices[i]);
   }
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, absl::OkStatus());
 }
 
 static void me_add_to_pollset(grpc_endpoint* /*ep*/,
@@ -131,7 +132,7 @@ void grpc_mock_endpoint_put_read(grpc_endpoint* ep, grpc_slice slice) {
   gpr_mu_lock(&m->mu);
   if (m->on_read != nullptr) {
     grpc_slice_buffer_add(m->on_read_out, slice);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->on_read, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->on_read, absl::OkStatus());
     m->on_read = nullptr;
   } else {
     grpc_slice_buffer_add(&m->read_buffer, slice);

--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 
+#include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 
@@ -135,7 +136,7 @@ static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
     m->pending_read_op.cb = cb;
     m->pending_read_op.ep = ep;
     m->pending_read_op.slices = slices;
-    do_pending_read_op_locked(m, GRPC_ERROR_NONE);
+    do_pending_read_op_locked(m, absl::OkStatus());
   } else {
     GPR_ASSERT(!m->pending_read_op.is_armed);
     m->on_read = cb;
@@ -292,10 +293,10 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
       m->pending_write_op.is_armed = true;
       m->pending_write_op.cb = cb;
       m->pending_write_op.ep = ep;
-      do_pending_write_op_locked(m, GRPC_ERROR_NONE);
+      do_pending_write_op_locked(m, absl::OkStatus());
     } else {
       // There is nothing to write. Schedule callback to be run right away.
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, absl::OkStatus());
     }
   }
   gpr_mu_unlock(&m->parent->mu);
@@ -321,7 +322,7 @@ static void me_delete_from_pollset_set(grpc_endpoint* /*ep*/,
 
 static void shutdown_locked(half* m, grpc_error_handle why) {
   m->parent->shutdown = true;
-  flush_pending_ops_locked(m, GRPC_ERROR_NONE);
+  flush_pending_ops_locked(m, absl::OkStatus());
   if (m->on_read) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, m->on_read,
@@ -329,7 +330,7 @@ static void shutdown_locked(half* m, grpc_error_handle why) {
     m->on_read = nullptr;
   }
   m = other_half(m);
-  flush_pending_ops_locked(m, GRPC_ERROR_NONE);
+  flush_pending_ops_locked(m, absl::OkStatus());
   if (m->on_read) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, m->on_read,

--- a/test/core/xds/file_watcher_certificate_provider_factory_test.cc
+++ b/test/core/xds/file_watcher_certificate_provider_factory_test.cc
@@ -47,10 +47,10 @@ TEST(FileWatcherConfigTest, Basic) {
       kIdentityCertFile, kPrivateKeyFile, kRootCertFile, kRefreshInterval);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
-  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
+  ASSERT_EQ(error, absl::OkStatus()) << grpc_error_std_string(error);
   EXPECT_EQ(config->identity_cert_file(), kIdentityCertFile);
   EXPECT_EQ(config->private_key_file(), kPrivateKeyFile);
   EXPECT_EQ(config->root_cert_file(), kRootCertFile);
@@ -67,10 +67,10 @@ TEST(FileWatcherConfigTest, DefaultRefreshInterval) {
       kIdentityCertFile, kPrivateKeyFile, kRootCertFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
-  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
+  ASSERT_EQ(error, absl::OkStatus()) << grpc_error_std_string(error);
   EXPECT_EQ(config->identity_cert_file(), kIdentityCertFile);
   EXPECT_EQ(config->private_key_file(), kPrivateKeyFile);
   EXPECT_EQ(config->root_cert_file(), kRootCertFile);
@@ -85,10 +85,10 @@ TEST(FileWatcherConfigTest, OnlyRootCertificatesFileProvided) {
       kRootCertFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
-  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
+  ASSERT_EQ(error, absl::OkStatus()) << grpc_error_std_string(error);
   EXPECT_TRUE(config->identity_cert_file().empty());
   EXPECT_TRUE(config->private_key_file().empty());
   EXPECT_EQ(config->root_cert_file(), kRootCertFile);
@@ -104,10 +104,10 @@ TEST(FileWatcherConfigTest, OnlyIdenityCertificatesAndPrivateKeyProvided) {
       kIdentityCertFile, kPrivateKeyFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
-  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
+  ASSERT_EQ(error, absl::OkStatus()) << grpc_error_std_string(error);
   EXPECT_EQ(config->identity_cert_file(), kIdentityCertFile);
   EXPECT_EQ(config->private_key_file(), kPrivateKeyFile);
   EXPECT_TRUE(config->root_cert_file().empty());
@@ -124,7 +124,7 @@ TEST(FileWatcherConfigTest, WrongTypes) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -145,7 +145,7 @@ TEST(FileWatcherConfigTest, IdentityCertProvidedButPrivateKeyMissing) {
       kIdentityCertFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -162,7 +162,7 @@ TEST(FileWatcherConfigTest, PrivateKeyProvidedButIdentityCertMissing) {
       kPrivateKeyFile);
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -175,7 +175,7 @@ TEST(FileWatcherConfigTest, EmptyJsonObject) {
   std::string json_str = absl::StrFormat("{}");
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       FileWatcherCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(

--- a/test/core/xds/google_mesh_ca_certificate_provider_factory_test.cc
+++ b/test/core/xds/google_mesh_ca_certificate_provider_factory_test.cc
@@ -71,10 +71,10 @@ TEST(GoogleMeshCaConfigTest, Basic) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
-  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
+  ASSERT_EQ(error, absl::OkStatus()) << grpc_error_std_string(error);
   EXPECT_EQ(config->endpoint(), "newmeshca.googleapis.com");
   EXPECT_EQ(config->sts_config().token_exchange_service_uri,
             "newsecuretoken.googleapis.com");
@@ -124,10 +124,10 @@ TEST(GoogleMeshCaConfigTest, Defaults) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
-  ASSERT_EQ(error, GRPC_ERROR_NONE) << grpc_error_std_string(error);
+  ASSERT_EQ(error, absl::OkStatus()) << grpc_error_std_string(error);
   EXPECT_EQ(config->endpoint(), "meshca.googleapis.com");
   EXPECT_EQ(config->sts_config().token_exchange_service_uri,
             "securetoken.googleapis.com");
@@ -176,7 +176,7 @@ TEST(GoogleMeshCaConfigTest, WrongExpectedValues) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -218,7 +218,7 @@ TEST(GoogleMeshCaConfigTest, WrongTypes) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -261,7 +261,7 @@ TEST(GoogleMeshCaConfigTest, GrpcServicesNotAnArray) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -285,7 +285,7 @@ TEST(GoogleMeshCaConfigTest, GoogleGrpcNotAnObject) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(
@@ -311,7 +311,7 @@ TEST(GoogleMeshCaConfigTest, CallCredentialsNotAnArray) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(grpc_error_std_string(error),
@@ -339,7 +339,7 @@ TEST(GoogleMeshCaConfigTest, StsServiceNotAnObject) {
       "}";
   auto json = Json::Parse(json_str);
   ASSERT_TRUE(json.ok()) << json.status();
-  grpc_error_handle error = GRPC_ERROR_NONE;
+  grpc_error_handle error;
   auto config =
       GoogleMeshCaCertificateProviderFactory::Config::Parse(*json, &error);
   EXPECT_THAT(

--- a/test/core/xds/xds_certificate_provider_test.cc
+++ b/test/core/xds/xds_certificate_provider_test.cc
@@ -57,13 +57,13 @@ class TestCertificatesWatcher
       if (!root_certs_.has_value() ||
           (root_certs_.has_value() &&
            std::string(root_certs.value()) != root_certs_.value())) {
-        root_cert_error_ = GRPC_ERROR_NONE;
+        root_cert_error_ = absl::OkStatus();
       }
       root_certs_.emplace(std::string(root_certs.value()));
     }
     if (key_cert_pairs.has_value()) {
       if (key_cert_pairs != key_cert_pairs_) {
-        identity_cert_error_ = GRPC_ERROR_NONE;
+        identity_cert_error_ = absl::OkStatus();
         key_cert_pairs_ = key_cert_pairs;
       }
     }
@@ -88,8 +88,8 @@ class TestCertificatesWatcher
  private:
   absl::optional<std::string> root_certs_;
   absl::optional<PemKeyCertPairList> key_cert_pairs_;
-  grpc_error_handle root_cert_error_ = GRPC_ERROR_NONE;
-  grpc_error_handle identity_cert_error_ = GRPC_ERROR_NONE;
+  grpc_error_handle root_cert_error_;
+  grpc_error_handle identity_cert_error_;
 };
 
 TEST(
@@ -108,32 +108,32 @@ TEST(
       std::unique_ptr<TestCertificatesWatcher>(watcher), "", "");
   EXPECT_EQ(watcher->root_certs(), absl::nullopt);
   EXPECT_EQ(watcher->key_cert_pairs(), absl::nullopt);
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Update both root certs and identity certs
   root_cert_distributor->SetKeyMaterials("root", kRootCert1, absl::nullopt);
   identity_cert_distributor->SetKeyMaterials("identity", absl::nullopt,
                                              MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for just root certs
   root_cert_distributor->SetKeyMaterials(
       "root", kRootCert2,
       MakeKeyCertPairsType2() /* does not have an effect */);
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for identity certs
   identity_cert_distributor->SetKeyMaterials(
       "identity", kRootCert1 /* does not have an effect */,
       MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for both root and identity
   root_cert_distributor->SetErrorForCert(
       "root", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
@@ -151,7 +151,7 @@ TEST(
   root_cert_distributor->SetKeyMaterials("root", kRootCert1, absl::nullopt);
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_THAT(grpc_error_std_string(watcher->identity_cert_error()),
               ::testing::HasSubstr(kIdentityErrorMessage));
   // Send an update for identity certs. Test that the identity cert error is
@@ -160,8 +160,8 @@ TEST(
                                              MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
 }
 
 TEST(XdsCertificateProviderTest,
@@ -179,29 +179,29 @@ TEST(XdsCertificateProviderTest,
       std::unique_ptr<TestCertificatesWatcher>(watcher), "", "");
   EXPECT_EQ(watcher->root_certs(), absl::nullopt);
   EXPECT_EQ(watcher->key_cert_pairs(), absl::nullopt);
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Update both root certs and identity certs
   root_cert_distributor->SetKeyMaterials("test", kRootCert1, absl::nullopt);
   identity_cert_distributor->SetKeyMaterials("test", absl::nullopt,
                                              MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for just root certs
   root_cert_distributor->SetKeyMaterials("test", kRootCert2, absl::nullopt);
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for identity certs
   identity_cert_distributor->SetKeyMaterials("test", absl::nullopt,
                                              MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for both root and identity
   root_cert_distributor->SetErrorForCert(
       "test", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
@@ -219,7 +219,7 @@ TEST(XdsCertificateProviderTest,
   root_cert_distributor->SetKeyMaterials("test", kRootCert1, absl::nullopt);
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_THAT(grpc_error_std_string(watcher->identity_cert_error()),
               ::testing::HasSubstr(kIdentityErrorMessage));
   // Send an update for identity certs. Test that the identity cert error is
@@ -228,8 +228,8 @@ TEST(XdsCertificateProviderTest,
                                              MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Test update on unwatched cert name
   identity_cert_distributor->SetKeyMaterials("identity", kRootCert2,
                                              MakeKeyCertPairsType2());
@@ -248,27 +248,27 @@ TEST(XdsCertificateProviderTest,
       std::unique_ptr<TestCertificatesWatcher>(watcher), "", "");
   EXPECT_EQ(watcher->root_certs(), absl::nullopt);
   EXPECT_EQ(watcher->key_cert_pairs(), absl::nullopt);
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Update both root certs and identity certs
   distributor->SetKeyMaterials("root", kRootCert1, MakeKeyCertPairsType2());
   distributor->SetKeyMaterials("identity", kRootCert2, MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for just root certs
   distributor->SetKeyMaterials("root", kRootCert2, MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for identity certs
   distributor->SetKeyMaterials("identity", kRootCert1, MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for root
   distributor->SetErrorForCert(
       "root", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
@@ -277,7 +277,7 @@ TEST(XdsCertificateProviderTest,
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
               ::testing::HasSubstr(kRootErrorMessage));
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   distributor->SetErrorForCert(
       "identity", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage),
       GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
@@ -291,15 +291,15 @@ TEST(XdsCertificateProviderTest,
   distributor->SetKeyMaterials("root", kRootCert1, MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_THAT(grpc_error_std_string(watcher->identity_cert_error()),
               ::testing::HasSubstr(kIdentityErrorMessage));
   // Send an update for identity
   distributor->SetKeyMaterials("identity", kRootCert2, MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
 }
 
 TEST(XdsCertificateProviderTest,
@@ -313,26 +313,26 @@ TEST(XdsCertificateProviderTest,
       std::unique_ptr<TestCertificatesWatcher>(watcher), "", "");
   EXPECT_EQ(watcher->root_certs(), absl::nullopt);
   EXPECT_EQ(watcher->key_cert_pairs(), absl::nullopt);
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Update both root certs and identity certs
   distributor->SetKeyMaterials("", kRootCert1, MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for just root certs
   distributor->SetKeyMaterials("", kRootCert2, absl::nullopt);
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Second update for identity certs
   distributor->SetKeyMaterials("", absl::nullopt, MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for root
   distributor->SetErrorForCert(
       "", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
@@ -341,7 +341,7 @@ TEST(XdsCertificateProviderTest,
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
               ::testing::HasSubstr(kRootErrorMessage));
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for identity
   distributor->SetErrorForCert(
       "", absl::nullopt,
@@ -356,15 +356,15 @@ TEST(XdsCertificateProviderTest,
   distributor->SetKeyMaterials("", kRootCert1, absl::nullopt);
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_THAT(grpc_error_std_string(watcher->identity_cert_error()),
               ::testing::HasSubstr(kIdentityErrorMessage));
   // Send an update for identity
   distributor->SetKeyMaterials("", absl::nullopt, MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
 }
 
 TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
@@ -388,7 +388,7 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
   provider.UpdateRootCertNameAndDistributor("", "", distributor);
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), absl::nullopt);
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_THAT(
       grpc_error_std_string(watcher->identity_cert_error()),
       ::testing::HasSubstr(
@@ -397,14 +397,14 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
   provider.UpdateIdentityCertNameAndDistributor("", "", distributor);
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Update both root and identity certs
   distributor->SetKeyMaterials("", kRootCert2, MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for both root and identity
   distributor->SetErrorForCert(
       "", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
@@ -419,8 +419,8 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
   distributor->SetKeyMaterials("", kRootCert1, MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Remove root cert provider
   provider.UpdateRootCertNameAndDistributor("", "", nullptr);
   distributor->SetKeyMaterials("", kRootCert2, MakeKeyCertPairsType2());
@@ -429,7 +429,7 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
               ::testing::HasSubstr(
                   "No certificate provider available for root certificates"));
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Remove identity cert provider too
   provider.UpdateIdentityCertNameAndDistributor("", "", nullptr);
   distributor->SetKeyMaterials("", kRootCert1, MakeKeyCertPairsType1());
@@ -460,8 +460,8 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
                                MakeKeyCertPairsType1());
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Swap in new certificate distributors with different certificate names and
   // existing updates.
   auto root_cert_distributor =
@@ -473,16 +473,16 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
                                                 identity_cert_distributor);
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Change certificate names without any certificate updates.
   provider.UpdateRootCertNameAndDistributor("", "test", root_cert_distributor);
   provider.UpdateIdentityCertNameAndDistributor("", "test",
                                                 identity_cert_distributor);
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Send out certificate updates.
   root_cert_distributor->SetKeyMaterials("test", kRootCert1,
                                          MakeKeyCertPairsType1());
@@ -490,8 +490,8 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
                                              MakeKeyCertPairsType2());
   EXPECT_EQ(watcher->root_certs(), kRootCert1);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
 }
 
 TEST(XdsCertificateProviderTest, MultipleCertNames) {
@@ -520,8 +520,8 @@ TEST(XdsCertificateProviderTest, MultipleCertNames) {
                                                 cert_distributor1);
   EXPECT_EQ(watcher1->root_certs(), kRootCert1);
   EXPECT_EQ(watcher1->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher1->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher1->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher1->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher1->identity_cert_error(), absl::OkStatus());
   // Add distributor for "test2".
   auto cert_distributor2 = MakeRefCounted<grpc_tls_certificate_distributor>();
   cert_distributor2->SetKeyMaterials("root2", kRootCert2, absl::nullopt);
@@ -537,13 +537,13 @@ TEST(XdsCertificateProviderTest, MultipleCertNames) {
       std::unique_ptr<TestCertificatesWatcher>(watcher2), "test2", "test2");
   EXPECT_EQ(watcher2->root_certs(), kRootCert2);
   EXPECT_EQ(watcher2->key_cert_pairs(), MakeKeyCertPairsType2());
-  EXPECT_EQ(watcher2->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher2->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher2->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher2->identity_cert_error(), absl::OkStatus());
   // The presence of "test2" should not affect "test1".
   EXPECT_EQ(watcher1->root_certs(), kRootCert1);
   EXPECT_EQ(watcher1->key_cert_pairs(), MakeKeyCertPairsType1());
-  EXPECT_EQ(watcher1->root_cert_error(), GRPC_ERROR_NONE);
-  EXPECT_EQ(watcher1->identity_cert_error(), GRPC_ERROR_NONE);
+  EXPECT_EQ(watcher1->root_cert_error(), absl::OkStatus());
+  EXPECT_EQ(watcher1->identity_cert_error(), absl::OkStatus());
 }
 
 TEST(XdsCertificateProviderTest, UnknownCertName) {

--- a/test/core/xds/xds_endpoint_resource_type_test.cc
+++ b/test/core/xds/xds_endpoint_resource_type_test.cc
@@ -42,7 +42,7 @@ class XdsEndpointTest : public ::testing::Test {
                         upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
-    grpc_error_handle error = GRPC_ERROR_NONE;
+    grpc_error_handle error;
     auto bootstrap = GrpcXdsBootstrap::Create(
         "{\n"
         "  \"xds_servers\": [\n"

--- a/test/cpp/common/channel_filter_test.cc
+++ b/test/cpp/common/channel_filter_test.cc
@@ -32,7 +32,7 @@ class MyChannelData : public ChannelData {
   grpc_error_handle Init(grpc_channel_element* /*elem*/,
                          grpc_channel_element_args* args) override {
     (void)args->channel_args;  // Make sure field is available.
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 };
 
@@ -43,7 +43,7 @@ class MyCallData : public CallData {
   grpc_error_handle Init(grpc_call_element* /*elem*/,
                          const grpc_call_element_args* args) override {
     (void)args->path;  // Make sure field is available.
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 };
 

--- a/test/cpp/common/time_jump_test.cc
+++ b/test/cpp/common/time_jump_test.cc
@@ -94,7 +94,7 @@ TEST_P(TimeJumpTest, TimerRunning) {
                   grpc_core::Timestamp::Now() + grpc_core::Duration::Seconds(3),
                   GRPC_CLOSURE_CREATE(
                       [](void*, grpc_error_handle error) {
-                        GPR_ASSERT(error == GRPC_ERROR_CANCELLED);
+                        GPR_ASSERT(error == absl::CancelledError());
                       },
                       nullptr, grpc_schedule_on_exec_ctx));
   gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(100));

--- a/test/cpp/common/timer_test.cc
+++ b/test/cpp/common/timer_test.cc
@@ -153,7 +153,7 @@ TEST_F(TimerTest, CancelSomeTimers) {
                                         grpc_core::Duration::Milliseconds(i)),
         GRPC_CLOSURE_CREATE(
             [](void* arg, grpc_error_handle error) {
-              if (error == GRPC_ERROR_CANCELLED) {
+              if (error == absl::CancelledError()) {
                 return;
               }
               std::atomic<int>* timer_fired =

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -765,9 +765,9 @@ class ParameterizedClientInterceptorsEnd2endTest
       flags = fcntl(sv_[1], F_GETFL, 0);
       GPR_ASSERT(fcntl(sv_[1], F_SETFL, flags | O_NONBLOCK) == 0);
       GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv_[0]) ==
-                 GRPC_ERROR_NONE);
+                 absl::OkStatus());
       GPR_ASSERT(grpc_set_socket_no_sigpipe_if_possible(sv_[1]) ==
-                 GRPC_ERROR_NONE);
+                 absl::OkStatus());
       server_ = builder.BuildAndStart();
       AddInsecureChannelFromFd(server_.get(), sv_[1]);
     }

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -104,7 +104,7 @@ class ChannelDataImpl : public ChannelData {
   grpc_error_handle Init(grpc_channel_element* /*elem*/,
                          grpc_channel_element_args* /*args*/) override {
     IncrementConnectionCounter();
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 };
 

--- a/test/cpp/end2end/port_sharing_end2end_test.cc
+++ b/test/cpp/end2end/port_sharing_end2end_test.cc
@@ -166,7 +166,7 @@ class TestTcpServer {
   }
 
   void OnFdReleased(grpc_error_handle err) {
-    EXPECT_EQ(GRPC_ERROR_NONE, err);
+    EXPECT_EQ(absl::OkStatus(), err);
     experimental::ExternalConnectionAcceptor::NewConnectionParameters p;
     p.listener_fd = listener_fd_;
     p.fd = fd_;

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -360,7 +360,7 @@ static void StartTransportOp(grpc_channel_element* /*elem*/,
 
 static grpc_error_handle InitCallElem(grpc_call_element* /*elem*/,
                                       const grpc_call_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void SetPollsetOrPollsetSet(grpc_call_element* /*elem*/,
@@ -372,7 +372,7 @@ static void DestroyCallElem(grpc_call_element* /*elem*/,
 
 grpc_error_handle InitChannelElem(grpc_channel_element* /*elem*/,
                                   grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void DestroyChannelElem(grpc_channel_element* /*elem*/) {}
@@ -418,7 +418,7 @@ void SetPollsetSet(grpc_transport* /*self*/, grpc_stream* /*stream*/,
 /* implementation of grpc_transport_perform_stream_op */
 void PerformStreamOp(grpc_transport* /*self*/, grpc_stream* /*stream*/,
                      grpc_transport_stream_op_batch* op) {
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_complete, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_complete, absl::OkStatus());
 }
 
 /* implementation of grpc_transport_perform_op */
@@ -640,19 +640,19 @@ static void StartTransportStreamOp(grpc_call_element* elem,
   grpc_core::CallCombinerClosureList closures;
   if (op->recv_initial_metadata) {
     closures.Add(op->payload->recv_initial_metadata.recv_initial_metadata_ready,
-                 GRPC_ERROR_NONE, "recv_initial_metadata");
+                 absl::OkStatus(), "recv_initial_metadata");
   }
   if (op->recv_message) {
-    closures.Add(op->payload->recv_message.recv_message_ready, GRPC_ERROR_NONE,
+    closures.Add(op->payload->recv_message.recv_message_ready, absl::OkStatus(),
                  "recv_message");
   }
   if (op->recv_trailing_metadata) {
     closures.Add(
         op->payload->recv_trailing_metadata.recv_trailing_metadata_ready,
-        GRPC_ERROR_NONE, "recv_trailing_metadata");
+        absl::OkStatus(), "recv_trailing_metadata");
   }
   if (op->on_complete != nullptr) {
-    closures.Add(op->on_complete, GRPC_ERROR_NONE, "on_complete");
+    closures.Add(op->on_complete, absl::OkStatus(), "on_complete");
   }
   // Execute closures.
   closures.RunClosures(calld->call_combiner);
@@ -662,14 +662,14 @@ static void StartTransportOp(grpc_channel_element* /*elem*/,
                              grpc_transport_op* op) {
   if (!op->disconnect_with_error.ok()) {
   }
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, absl::OkStatus());
 }
 
 static grpc_error_handle InitCallElem(grpc_call_element* elem,
                                       const grpc_call_element_args* args) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   calld->call_combiner = args->call_combiner;
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static void SetPollsetOrPollsetSet(grpc_call_element* /*elem*/,
@@ -678,12 +678,12 @@ static void SetPollsetOrPollsetSet(grpc_call_element* /*elem*/,
 static void DestroyCallElem(grpc_call_element* /*elem*/,
                             const grpc_call_final_info* /*final_info*/,
                             grpc_closure* then_sched_closure) {
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, then_sched_closure, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, then_sched_closure, absl::OkStatus());
 }
 
 grpc_error_handle InitChannelElem(grpc_channel_element* /*elem*/,
                                   grpc_channel_element_args* /*args*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 void DestroyChannelElem(grpc_channel_element* /*elem*/) {}

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -73,7 +73,7 @@ class PhonyEndpoint : public grpc_endpoint {
       return;
     }
     grpc_slice_buffer_add(slices_, slice);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, read_cb_, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, read_cb_, absl::OkStatus());
     read_cb_ = nullptr;
   }
 
@@ -88,7 +88,7 @@ class PhonyEndpoint : public grpc_endpoint {
     if (have_slice_) {
       have_slice_ = false;
       grpc_slice_buffer_add(slices, buffered_slice_);
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, absl::OkStatus());
       return;
     }
     read_cb_ = cb;
@@ -103,7 +103,7 @@ class PhonyEndpoint : public grpc_endpoint {
 
   static void write(grpc_endpoint* /*ep*/, grpc_slice_buffer* /*slices*/,
                     grpc_closure* cb, void* /*arg*/, int /*max_frame_size*/) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, absl::OkStatus());
   }
 
   static void add_to_pollset(grpc_endpoint* /*ep*/, grpc_pollset* /*pollset*/) {
@@ -273,7 +273,7 @@ static void BM_StreamCreateDestroy(benchmark::State& state) {
   op = {};
   op.cancel_stream = true;
   op.payload = &op_payload;
-  op_payload.cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
+  op_payload.cancel_stream.cancel_error = absl::CancelledError();
   std::unique_ptr<TestClosure> next =
       MakeTestClosure([&, s](grpc_error_handle /*error*/) {
         if (!state.KeepRunning()) {
@@ -284,7 +284,7 @@ static void BM_StreamCreateDestroy(benchmark::State& state) {
         s->Op(&op);
         s->DestroyThen(next.get());
       });
-  grpc_core::Closure::Run(DEBUG_LOCATION, next.get(), GRPC_ERROR_NONE);
+  grpc_core::Closure::Run(DEBUG_LOCATION, next.get(), absl::OkStatus());
   f.FlushExecCtx();
   track_counters.Finish(state);
 }
@@ -355,11 +355,11 @@ static void BM_StreamCreateSendInitialMetadataDestroy(benchmark::State& state) {
   done = MakeTestClosure([&](grpc_error_handle /*error*/) {
     reset_op();
     op.cancel_stream = true;
-    op.payload->cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
+    op.payload->cancel_stream.cancel_error = absl::CancelledError();
     s->Op(&op);
     s->DestroyThen(start.get());
   });
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, start.get(), GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, start.get(), absl::OkStatus());
   f.FlushExecCtx();
   gpr_event_wait(&bm_done, gpr_inf_future(GPR_CLOCK_REALTIME));
   track_counters.Finish(state);
@@ -386,11 +386,11 @@ static void BM_TransportEmptyOp(benchmark::State& state) {
         op.on_complete = c.get();
         s->Op(&op);
       });
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, c.get(), GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, c.get(), absl::OkStatus());
   f.FlushExecCtx();
   reset_op();
   op.cancel_stream = true;
-  op_payload.cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
+  op_payload.cancel_stream.cancel_error = absl::CancelledError();
   gpr_event* stream_cancel_done = new gpr_event;
   gpr_event_init(stream_cancel_done);
   std::unique_ptr<TestClosure> stream_cancel_closure =

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -86,7 +86,7 @@ static void BM_ClosureRun(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    grpc_core::Closure::Run(DEBUG_LOCATION, &c, GRPC_ERROR_NONE);
+    grpc_core::Closure::Run(DEBUG_LOCATION, &c, absl::OkStatus());
   }
 
   track_counters.Finish(state);
@@ -100,7 +100,7 @@ static void BM_ClosureCreateAndRun(benchmark::State& state) {
     grpc_core::Closure::Run(
         DEBUG_LOCATION,
         GRPC_CLOSURE_CREATE(DoNothing, nullptr, grpc_schedule_on_exec_ctx),
-        GRPC_ERROR_NONE);
+        absl::OkStatus());
   }
 
   track_counters.Finish(state);
@@ -115,7 +115,7 @@ static void BM_ClosureInitAndRun(benchmark::State& state) {
     grpc_core::Closure::Run(
         DEBUG_LOCATION,
         GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx),
-        GRPC_ERROR_NONE);
+        absl::OkStatus());
   }
 
   track_counters.Finish(state);
@@ -128,7 +128,7 @@ static void BM_ClosureSchedOnExecCtx(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
 
@@ -144,8 +144,8 @@ static void BM_ClosureSched2OnExecCtx(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c1, GRPC_ERROR_NONE);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c2, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c1, absl::OkStatus());
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c2, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
 
@@ -163,9 +163,9 @@ static void BM_ClosureSched3OnExecCtx(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c3, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c1, GRPC_ERROR_NONE);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c2, GRPC_ERROR_NONE);
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c3, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c1, absl::OkStatus());
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c2, absl::OkStatus());
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &c3, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
 
@@ -181,7 +181,7 @@ static void BM_AcquireMutex(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
     gpr_mu_lock(&mu);
-    DoNothing(nullptr, GRPC_ERROR_NONE);
+    DoNothing(nullptr, absl::OkStatus());
     gpr_mu_unlock(&mu);
   }
   gpr_mu_destroy(&mu);
@@ -198,7 +198,7 @@ static void BM_TryAcquireMutex(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
     if (gpr_mu_trylock(&mu)) {
-      DoNothing(nullptr, GRPC_ERROR_NONE);
+      DoNothing(nullptr, absl::OkStatus());
       gpr_mu_unlock(&mu);
     } else {
       abort();
@@ -217,7 +217,7 @@ static void BM_AcquireSpinlock(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
     gpr_spinlock_lock(&mu);
-    DoNothing(nullptr, GRPC_ERROR_NONE);
+    DoNothing(nullptr, absl::OkStatus());
     gpr_spinlock_unlock(&mu);
   }
 
@@ -232,7 +232,7 @@ static void BM_TryAcquireSpinlock(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
     if (gpr_spinlock_trylock(&mu)) {
-      DoNothing(nullptr, GRPC_ERROR_NONE);
+      DoNothing(nullptr, absl::OkStatus());
       gpr_spinlock_unlock(&mu);
     } else {
       abort();
@@ -250,7 +250,7 @@ static void BM_ClosureSchedOnCombiner(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, nullptr);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    combiner->Run(&c, GRPC_ERROR_NONE);
+    combiner->Run(&c, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
   GRPC_COMBINER_UNREF(combiner, "finished");
@@ -268,8 +268,8 @@ static void BM_ClosureSched2OnCombiner(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, nullptr);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    combiner->Run(&c1, GRPC_ERROR_NONE);
-    combiner->Run(&c2, GRPC_ERROR_NONE);
+    combiner->Run(&c1, absl::OkStatus());
+    combiner->Run(&c2, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
   GRPC_COMBINER_UNREF(combiner, "finished");
@@ -289,9 +289,9 @@ static void BM_ClosureSched3OnCombiner(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c3, DoNothing, nullptr, nullptr);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    combiner->Run(&c1, GRPC_ERROR_NONE);
-    combiner->Run(&c2, GRPC_ERROR_NONE);
-    combiner->Run(&c3, GRPC_ERROR_NONE);
+    combiner->Run(&c1, absl::OkStatus());
+    combiner->Run(&c2, absl::OkStatus());
+    combiner->Run(&c3, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
   GRPC_COMBINER_UNREF(combiner, "finished");
@@ -310,8 +310,8 @@ static void BM_ClosureSched2OnTwoCombiners(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, nullptr);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    combiner1->Run(&c1, GRPC_ERROR_NONE);
-    combiner2->Run(&c2, GRPC_ERROR_NONE);
+    combiner1->Run(&c1, absl::OkStatus());
+    combiner2->Run(&c2, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
   GRPC_COMBINER_UNREF(combiner1, "finished");
@@ -335,10 +335,10 @@ static void BM_ClosureSched4OnTwoCombiners(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c4, DoNothing, nullptr, nullptr);
   grpc_core::ExecCtx exec_ctx;
   for (auto _ : state) {
-    combiner1->Run(&c1, GRPC_ERROR_NONE);
-    combiner2->Run(&c2, GRPC_ERROR_NONE);
-    combiner1->Run(&c3, GRPC_ERROR_NONE);
-    combiner2->Run(&c4, GRPC_ERROR_NONE);
+    combiner1->Run(&c1, absl::OkStatus());
+    combiner2->Run(&c2, absl::OkStatus());
+    combiner1->Run(&c3, absl::OkStatus());
+    combiner2->Run(&c4, absl::OkStatus());
     grpc_core::ExecCtx::Get()->Flush();
   }
   GRPC_COMBINER_UNREF(combiner1, "finished");
@@ -357,13 +357,13 @@ class Rescheduler {
   }
 
   void ScheduleFirst() {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &closure_, GRPC_ERROR_NONE);
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
   }
 
   void ScheduleFirstAgainstDifferentScheduler() {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION,
                             GRPC_CLOSURE_CREATE(Step, this, nullptr),
-                            GRPC_ERROR_NONE);
+                            absl::OkStatus());
   }
 
  private:
@@ -373,7 +373,8 @@ class Rescheduler {
   static void Step(void* arg, grpc_error_handle /*error*/) {
     Rescheduler* self = static_cast<Rescheduler*>(arg);
     if (self->state_.KeepRunning()) {
-      grpc_core::ExecCtx::Run(DEBUG_LOCATION, &self->closure_, GRPC_ERROR_NONE);
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, &self->closure_,
+                              absl::OkStatus());
     }
   }
 };

--- a/test/cpp/microbenchmarks/bm_cq.cc
+++ b/test/cpp/microbenchmarks/bm_cq.cc
@@ -91,8 +91,8 @@ static void BM_Pass1Cpp(benchmark::State& state) {
     PhonyTag phony_tag;
     grpc_core::ExecCtx exec_ctx;
     GPR_ASSERT(grpc_cq_begin_op(c_cq, &phony_tag));
-    grpc_cq_end_op(c_cq, &phony_tag, GRPC_ERROR_NONE, DoneWithCompletionOnStack,
-                   nullptr, &completion);
+    grpc_cq_end_op(c_cq, &phony_tag, absl::OkStatus(),
+                   DoneWithCompletionOnStack, nullptr, &completion);
 
     void* tag;
     bool ok;
@@ -111,7 +111,7 @@ static void BM_Pass1Core(benchmark::State& state) {
     grpc_cq_completion completion;
     grpc_core::ExecCtx exec_ctx;
     GPR_ASSERT(grpc_cq_begin_op(cq, nullptr));
-    grpc_cq_end_op(cq, nullptr, GRPC_ERROR_NONE, DoneWithCompletionOnStack,
+    grpc_cq_end_op(cq, nullptr, absl::OkStatus(), DoneWithCompletionOnStack,
                    nullptr, &completion);
 
     grpc_completion_queue_next(cq, deadline, nullptr);
@@ -130,7 +130,7 @@ static void BM_Pluck1Core(benchmark::State& state) {
     grpc_cq_completion completion;
     grpc_core::ExecCtx exec_ctx;
     GPR_ASSERT(grpc_cq_begin_op(cq, nullptr));
-    grpc_cq_end_op(cq, nullptr, GRPC_ERROR_NONE, DoneWithCompletionOnStack,
+    grpc_cq_end_op(cq, nullptr, absl::OkStatus(), DoneWithCompletionOnStack,
                    nullptr, &completion);
 
     grpc_completion_queue_pluck(cq, nullptr, deadline, nullptr);
@@ -230,7 +230,7 @@ static void BM_Callback_CQ_Pass1Core(benchmark::State& state) {
     grpc_core::ExecCtx exec_ctx;
     grpc_cq_completion completion;
     GPR_ASSERT(grpc_cq_begin_op(cc, &tag_cb));
-    grpc_cq_end_op(cc, &tag_cb, GRPC_ERROR_NONE, DoneWithCompletionOnStack,
+    grpc_cq_end_op(cc, &tag_cb, absl::OkStatus(), DoneWithCompletionOnStack,
                    nullptr, &completion);
   }
   shutdown_and_destroy(cc);
@@ -275,7 +275,7 @@ static void BM_Callback_CQ_Pass1CoreHeapCompletion(benchmark::State& state) {
     grpc_core::ExecCtx exec_ctx;
     grpc_cq_completion* completion = new grpc_cq_completion;
     GPR_ASSERT(grpc_cq_begin_op(cc, &tag_cb));
-    grpc_cq_end_op(cc, &tag_cb, GRPC_ERROR_NONE, DoneWithCompletionOnHeap,
+    grpc_cq_end_op(cc, &tag_cb, absl::OkStatus(), DoneWithCompletionOnHeap,
                    nullptr, completion);
   }
   shutdown_and_destroy(cc);

--- a/test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
+++ b/test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
@@ -48,7 +48,7 @@ namespace testing {
 static grpc_completion_queue* g_cq;
 
 static void pollset_shutdown(grpc_pollset* /*ps*/, grpc_closure* closure) {
-  grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, GRPC_ERROR_NONE);
+  grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
 }
 
 static void pollset_init(grpc_pollset* ps, gpr_mu** mu) {
@@ -60,7 +60,7 @@ static void pollset_destroy(grpc_pollset* ps) { gpr_mu_destroy(&ps->mu); }
 
 static grpc_error_handle pollset_kick(grpc_pollset* /*p*/,
                                       grpc_pollset_worker* /*worker*/) {
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 /* Callback when the tag is dequeued from the completion queue. Does nothing */
@@ -75,7 +75,7 @@ static grpc_error_handle pollset_work(grpc_pollset* ps,
                                       grpc_core::Timestamp deadline) {
   if (deadline == grpc_core::Timestamp::ProcessEpoch()) {
     gpr_log(GPR_DEBUG, "no-op");
-    return GRPC_ERROR_NONE;
+    return absl::OkStatus();
   }
 
   gpr_mu_unlock(&ps->mu);
@@ -83,11 +83,11 @@ static grpc_error_handle pollset_work(grpc_pollset* ps,
   void* tag = reinterpret_cast<void*>(10);  // Some random number
   GPR_ASSERT(grpc_cq_begin_op(g_cq, tag));
   grpc_cq_end_op(
-      g_cq, tag, GRPC_ERROR_NONE, cq_done_cb, nullptr,
+      g_cq, tag, absl::OkStatus(), cq_done_cb, nullptr,
       static_cast<grpc_cq_completion*>(gpr_malloc(sizeof(grpc_cq_completion))));
   grpc_core::ExecCtx::Get()->Flush();
   gpr_mu_lock(&ps->mu);
-  return GRPC_ERROR_NONE;
+  return absl::OkStatus();
 }
 
 static grpc_event_engine_vtable make_engine_vtable(const char* name) {

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -315,7 +315,7 @@ void OpenAndCloseSocketsStressLoop(int phony_port, gpr_event* done_ev) {
                   SOCKET_ERROR)
           << "Failed to set socketopt reuseaddr. WSA error: " +
                  std::to_string(WSAGetLastError());
-      ASSERT_TRUE(grpc_tcp_set_non_block(s) == GRPC_ERROR_NONE)
+      ASSERT_TRUE(grpc_tcp_set_non_block(s) == absl::OkStatus())
           << "Failed to set socket non-blocking";
       ASSERT_TRUE(bind(s, (const sockaddr*)&addr, sizeof(addr)) != SOCKET_ERROR)
           << "Failed to bind socket " + std::to_string(s) +


### PR DESCRIPTION
This is the second step of cleaning-up `absl::Status` migration.

- Replacing `GRPC_ERROR_NONE` with `absl::OkStatus()`
- Replacing `GRPC_ERROR_OOM` with `absl::ResourceExhaustedError("")`
- Replacing `GRPC_ERROR_CANCELLED` with `absl::CancelledError()`
- Simplified `absl::Status e = absl::OkStatus();` to `absl::Status e;` 
