### PR TITLE
[Ruby] Stop stripping exported symbols

### DIFF
--- a/src/ruby/ext/grpc/ext-export-truffleruby.clang
+++ b/src/ruby/ext/grpc/ext-export-truffleruby.clang
@@ -1,2 +1,0 @@
-_Init_grpc_c
-_rb_tr_abi_version

--- a/src/ruby/ext/grpc/ext-export-truffleruby.gcc
+++ b/src/ruby/ext/grpc/ext-export-truffleruby.gcc
@@ -1,7 +1,0 @@
-grpc_1.0 { 
-  global: 
-    Init_grpc_c;
-    rb_tr_abi_version;
-  local: 
-    *;
-};

--- a/src/ruby/ext/grpc/ext-export.clang
+++ b/src/ruby/ext/grpc/ext-export.clang
@@ -1,2 +1,0 @@
-_Init_grpc_c
-_ruby_abi_version

--- a/src/ruby/ext/grpc/ext-export.gcc
+++ b/src/ruby/ext/grpc/ext-export.gcc
@@ -1,7 +1,0 @@
-grpc_1.0 { 
-  global: 
-    Init_grpc_c;
-    ruby_abi_version;
-  local: 
-    *;
-};

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -113,11 +113,6 @@ end
 $CFLAGS << ' -DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 $CFLAGS << ' -I' + File.join(grpc_root, 'include')
 
-ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', 'ext-export')
-ext_export_file += '-truffleruby' if RUBY_ENGINE == 'truffleruby'
-$LDFLAGS << ' -Wl,--version-script="' + ext_export_file + '.gcc"' if linux
-$LDFLAGS << ' -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"' if apple_toolchain
-
 $LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgrpc.a') unless windows
 if grpc_config == 'gcov'
   $CFLAGS << ' -O0 -fprofile-arcs -ftest-coverage'


### PR DESCRIPTION
This commit stops stripping exported symbols in the compiled binary. This will ensure that functions like `Init_grpc` and `ruby_abi_version` are not removed from the generated binary.

Fixes #30976.
