### PR TITLE
[PosixEventEngine] Ensure threads are shut down before destroying other engine state

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -38,11 +38,12 @@ struct PosixEventEngine::ClosureData final : public EventEngine::Closure {
   posix_engine::Timer timer;
   PosixEventEngine* engine;
   EventEngine::TaskHandle handle;
+  std::weak_ptr<bool> engine_spirit;
 
   void Run() override {
     GRPC_EVENT_ENGINE_TRACE("PosixEventEngine:%p executing callback:%s", engine,
                             HandleToString(handle).c_str());
-    {
+    if (!engine_spirit.expired()) {
       grpc_core::MutexLock lock(&engine->mu_);
       engine->known_handles_.erase(handle);
     }
@@ -98,6 +99,7 @@ EventEngine::TaskHandle PosixEventEngine::RunAfterInternal(
   auto* cd = new ClosureData;
   cd->cb = std::move(cb);
   cd->engine = this;
+  cd->engine_spirit = engine_spirit_;
   EventEngine::TaskHandle handle{reinterpret_cast<intptr_t>(cd),
                                  aba_token_.fetch_add(1)};
   grpc_core::MutexLock lock(&mu_);

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -113,6 +113,9 @@ class PosixEventEngine final : public EventEngine {
   grpc_core::Mutex mu_;
   TaskHandleSet known_handles_ ABSL_GUARDED_BY(mu_);
   std::atomic<intptr_t> aba_token_{0};
+  // closures are given weak_ptrs to this object to check if the engine pointers
+  // are still alive
+  std::shared_ptr<bool> engine_spirit_;
 };
 
 }  // namespace experimental

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -107,15 +107,11 @@ class PosixEventEngine final : public EventEngine {
   EventEngine::TaskHandle RunAfterInternal(Duration when,
                                            absl::AnyInvocable<void()> cb);
 
-  posix_engine::TimerManager timer_manager_;
-  ThreadedExecutor executor_{2};
-
   grpc_core::Mutex mu_;
   TaskHandleSet known_handles_ ABSL_GUARDED_BY(mu_);
   std::atomic<intptr_t> aba_token_{0};
-  // closures are given weak_ptrs to this object to check if the engine pointers
-  // are still alive
-  std::shared_ptr<bool> engine_spirit_{new bool(true)};
+  posix_engine::TimerManager timer_manager_;
+  ThreadedExecutor executor_{2};
 };
 
 }  // namespace experimental

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -115,7 +115,7 @@ class PosixEventEngine final : public EventEngine {
   std::atomic<intptr_t> aba_token_{0};
   // closures are given weak_ptrs to this object to check if the engine pointers
   // are still alive
-  std::shared_ptr<bool> engine_spirit_;
+  std::shared_ptr<bool> engine_spirit_{new bool(true)};
 };
 
 }  // namespace experimental


### PR DESCRIPTION
This fixes a race condition where closures attempt to deregister themselves after the engine's mutex and task_handle map have been destroyed. 0 failures in 120k runs (various asan, msan, tsan, opt, dbg builds).

The breakage was bisected to https://github.com/grpc/grpc/pull/30764


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

