### PR TITLE
Enable logs for error message in call_op_set.h.

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -27,6 +27,7 @@
 
 #include <grpc/impl/codegen/compression_types.h>
 #include <grpc/impl/codegen/grpc_types.h>
+#include <grpc/impl/codegen/log.h>
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/call_hook.h>
 #include <grpcpp/impl/codegen/call_op_set_interface.h>
@@ -980,8 +981,8 @@ class CallOpSet : public CallOpSetInterface,
       // A failure here indicates an API misuse; for example, doing a Write
       // while another Write is already pending on the same RPC or invoking
       // WritesDone multiple times
-      // gpr_log(GPR_ERROR, "API misuse of type %s observed",
-      //        g_core_codegen_interface->grpc_call_error_to_string(err));
+      gpr_log(GPR_ERROR, "API misuse of type %s observed",
+             g_core_codegen_interface->grpc_call_error_to_string(err));
       GPR_CODEGEN_ASSERT(false);
     }
   }

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -982,7 +982,7 @@ class CallOpSet : public CallOpSetInterface,
       // while another Write is already pending on the same RPC or invoking
       // WritesDone multiple times
       gpr_log(GPR_ERROR, "API misuse of type %s observed",
-             g_core_codegen_interface->grpc_call_error_to_string(err));
+              g_core_codegen_interface->grpc_call_error_to_string(err));
       GPR_CODEGEN_ASSERT(false);
     }
   }


### PR DESCRIPTION
The `gpr_log` was commented out from call_op_set.h at PR: https://github.com/grpc/grpc/pull/20681, because of the undefined error. It is probably just missing the header file. Adding the logs back for better error notification.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

