### PR TITLE
allow user to define it's own version of go toolchains at grpc_extra_deps invocation

### DIFF
--- a/bazel/grpc_extra_deps.bzl
+++ b/bazel/grpc_extra_deps.bzl
@@ -23,7 +23,7 @@ load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@upb//bazel:workspace_deps.bzl", "upb_deps")
 
-def grpc_extra_deps(ignore_version_differences = False):
+def grpc_extra_deps(ignore_version_differences = False, go_version="1.18"):
     """Loads the extra dependencies.
 
     These are necessary for using the external repositories defined in
@@ -45,6 +45,7 @@ def grpc_extra_deps(ignore_version_differences = False):
     Args:
       ignore_version_differences: Plumbed directly to the invocation of
         apple_rules_dependencies.
+      go_version: Version of go toolchains to use. If set to None, Bazel will try to use local version instead.
     """
     protobuf_deps()
 
@@ -53,7 +54,7 @@ def grpc_extra_deps(ignore_version_differences = False):
     api_dependencies()
 
     go_rules_dependencies()
-    go_register_toolchains(version = "1.18")
+    go_register_toolchains(version = go_version)
     gazelle_dependencies()
 
     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is

--- a/bazel/grpc_extra_deps.bzl
+++ b/bazel/grpc_extra_deps.bzl
@@ -56,7 +56,7 @@ def grpc_extra_deps(ignore_version_differences = False, go_version="1.18"):
     api_dependencies()
 
     go_rules_dependencies()
-    go_register_toolchains(version = "1.18" if go_version != "host" else None)
+    go_register_toolchains(version = go_version if go_version != "host" else None)
     gazelle_dependencies()
 
     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is

--- a/bazel/grpc_extra_deps.bzl
+++ b/bazel/grpc_extra_deps.bzl
@@ -56,7 +56,7 @@ def grpc_extra_deps(ignore_version_differences = False, go_version="1.18"):
     api_dependencies()
 
     go_rules_dependencies()
-    go_register_toolchains(version = go_version if go_version != "host" else None)
+    go_register_toolchains(version = "1.18" if go_version != "host" else None)
     gazelle_dependencies()
 
     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is

--- a/bazel/grpc_extra_deps.bzl
+++ b/bazel/grpc_extra_deps.bzl
@@ -45,7 +45,9 @@ def grpc_extra_deps(ignore_version_differences = False, go_version="1.18"):
     Args:
       ignore_version_differences: Plumbed directly to the invocation of
         apple_rules_dependencies.
-      go_version: Version of go toolchains to use. If set to None, Bazel will try to use local version instead.
+      go_version: Version of go toolchains to use.
+        If set to host, it will let Bazel provide it's own version.
+        It avoids providing multiple versions.
     """
     protobuf_deps()
 
@@ -54,7 +56,7 @@ def grpc_extra_deps(ignore_version_differences = False, go_version="1.18"):
     api_dependencies()
 
     go_rules_dependencies()
-    go_register_toolchains(version = go_version)
+    go_register_toolchains(version = go_version if go_version != "host" else None)
     gazelle_dependencies()
 
     # Pull-in the go 3rd party dependencies for protoc_gen_validate, which is


### PR DESCRIPTION
Fix #30965 and #31182

You can now set grpc_extra_deps go toolchains version to None and let Bazel use your version instead : 
```
grpc_extra_deps(go_version=None)
```