### PR TITLE
xDS interop GCE framework: pin grpcio-tools to use protobuf 3.x (v1.45.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -28,7 +28,9 @@ VIRTUAL_ENV=$(mktemp -d)
 python3 -m virtualenv "$VIRTUAL_ENV" -p python3
 PYTHON="$VIRTUAL_ENV"/bin/python
 "$PYTHON" -m pip install --upgrade pip==19.3.1
-"$PYTHON" -m pip install --upgrade grpcio-tools google-api-python-client google-auth-httplib2 oauth2client xds-protos
+# TODO(sergiitk): Unpin grpcio-tools when a version of xds-protos
+#   compatible with protobuf 4.X is uploaded to PyPi.
+"$PYTHON" -m pip install --upgrade grpcio-tools==1.48.1 google-api-python-client google-auth-httplib2 oauth2client xds-protos
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests


### PR DESCRIPTION
Backport of #31191 to v1.45.x.
---
https://source.cloud.google.com/results/invocations/ae6a6af2-f1d7-4982-9b4c-8edfa75d46d4