### PR TITLE
[promises] Always assert that contexts are non-null

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1393,7 +1393,7 @@ grpc_cc_library(
     public_hdrs = [
         "src/core/lib/promise/context.h",
     ],
-    deps = ["gpr_platform"],
+    deps = ["gpr"],
 )
 
 grpc_cc_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8562,6 +8562,7 @@ target_include_directories(context_test
 target_link_libraries(context_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  gpr
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5302,7 +5302,8 @@ targets:
   - src/core/lib/promise/context.h
   src:
   - test/core/promise/context_test.cc
-  deps: []
+  deps:
+  - gpr
   uses_polling: false
 - name: core_configuration_test
   gtest: true

--- a/src/core/lib/promise/context.h
+++ b/src/core/lib/promise/context.h
@@ -67,6 +67,12 @@ class WithContext {
 
 }  // namespace promise_detail
 
+// Return true if a context of type T is currently active.
+template <typename T>
+bool HasContext() {
+  return promise_detail::Context<T>::get() != nullptr;
+}
+
 // Retrieve the current value of a context.
 template <typename T>
 T* GetContext() {

--- a/src/core/lib/promise/context.h
+++ b/src/core/lib/promise/context.h
@@ -19,6 +19,8 @@
 
 #include <utility>
 
+#include <grpc/support/log.h>
+
 namespace grpc_core {
 
 // To avoid accidentally creating context types, we require an explicit
@@ -68,7 +70,9 @@ class WithContext {
 // Retrieve the current value of a context.
 template <typename T>
 T* GetContext() {
-  return promise_detail::Context<T>::get();
+  auto* p = promise_detail::Context<T>::get();
+  GPR_ASSERT(p != nullptr);
+  return p;
 }
 
 // Given a promise and a context, return a promise that has that context set.

--- a/src/core/lib/transport/call_fragments.h
+++ b/src/core/lib/transport/call_fragments.h
@@ -205,10 +205,10 @@ FragmentHandle<T>::FragmentHandle(const absl::Status& status) {
   // need to do the hacky thing promise_based_filter does.
   // This all goes away when promise_based_filter goes away, and this code will
   // just assume there's an allocator present and move forward.
-  if (auto* allocator = GetContext<FragmentAllocator>()) {
+  if (HasContext<FragmentAllocator>()) {
     handle_ = nullptr;
     allocated_by_allocator_ = false;
-    *this = allocator->MakeServerMetadata();
+    *this = GetContext<FragmentAllocator>()->MakeServerMetadata();
   } else {
     handle_ = GetContext<Arena>()->New<T>(GetContext<Arena>());
     allocated_by_allocator_ = false;

--- a/test/core/promise/context_test.cc
+++ b/test/core/promise/context_test.cc
@@ -26,11 +26,17 @@ template <>
 struct ContextType<TestContext> {};
 
 TEST(Context, WithContext) {
-  EXPECT_EQ(GetContext<TestContext>(), nullptr);
+  EXPECT_FALSE(HasContext<TestContext>());
   TestContext test;
-  EXPECT_EQ(GetContext<TestContext>(), nullptr);
+  EXPECT_FALSE(HasContext<TestContext>());
   EXPECT_EQ(test.done, false);
-  WithContext([]() { GetContext<TestContext>()->done = true; }, &test)();
+  WithContext(
+      []() {
+        EXPECT_TRUE(HasContext<TestContext>());
+        GetContext<TestContext>()->done = true;
+      },
+      &test)();
+  EXPECT_FALSE(HasContext<TestContext>());
   EXPECT_EQ(test.done, true);
 }
 


### PR DESCRIPTION
There's been a few instances where folks are starting to plant asserts around `GetContext<>` to ensure that the returned value is non-null. My view is that this should always be the case, so adding an assert within `GetContext<>` to prove that, in the hopes that we can have more readable consumption of contexts elsewhere.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

