### PR TITLE
[exec-ctx] Keep grpc alive if an exec ctx is on the stack

### DIFF
--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -186,7 +186,8 @@ void grpc_shutdown(void) {
             IsTimerManagerThread() &&
         (acec == nullptr ||
          (acec->Flags() & GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD) ==
-             0)) {
+             0) &&
+        grpc_core::ExecCtx::Get() == nullptr) {
       // just run clean-up when this is called on non-executor thread.
       gpr_log(GPR_DEBUG, "grpc_shutdown starts clean-up now");
       g_shutting_down = true;


### PR DESCRIPTION
~~This doesn't fix anything, but it might make an occurrence rarer whilst we get the correct fix in place.~~
This totally fixes a flakiness bug we've been seeing.

Problem:
1. `grpc_core::Channel` does a `grpc_init`/`grpc_shutdown`
2. `ExecCtx` destructor calls into `grpc_combiner_continue_exec_ctx` which in turn calls `Executor::IsThreadedDefault` which relies on iomgr being initialized.

These two combined mean that it's illegal to drop the last ref of a channel inside of an `ExecCtx`.

Any remedy that involves adding a branch to `ExecCtx` will likely hurt us in ways that are bad performance-wise.
This change says to kick off a thread to finish the shutdown in the hopes that that makes these circumstances rarer.

The ultimate fix is to finish the migration to `EventEngine` and anything we can do to accelerate that seems to be a net win.

For the moment:
If we see that we're shutting down from inside an `ExecCtx` spin off a thread to do the actual shutdown. This, rather importantly, causes the thread pool inside the current `EventEngine` to quiesce prior to shutting down that `EventEngine`, and in turn ensure that we don't crash at shutdown.

This will solve the high flakiness from the promise_based_call experiments (which are the first to heavily use `EventEngine::Run`)

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

