### PR TITLE
[flaky] Reduce test size

### DIFF
--- a/test/core/event_engine/thread_pool_test.cc
+++ b/test/core/event_engine/thread_pool_test.cc
@@ -107,9 +107,9 @@ void ScheduleTwiceUntilZero(ThreadPool* p, int n) {
 
 TEST(ThreadPoolTest, CanStartLotsOfClosures) {
   ThreadPool p(1);
-  // Our first thread pool implementation tried to create ~1M threads for this
+  // Our first thread pool implementation tried to create ~256k threads for this
   // test.
-  ScheduleTwiceUntilZero(&p, 20);
+  ScheduleTwiceUntilZero(&p, 18);
 }
 
 }  // namespace experimental


### PR DESCRIPTION
Seems to have gotten too big for CI in recent days:
https://dashboards.corp.google.com/stubby_team.bazel_test_details_dashboard?p=JOB_NAME_LIKE_PATTERN:%27grpc%2Fcore%2Fmaster%2Flinux%2Fbazel_rbe%2Fgrpc_bazel_rbe_tsan%27&p=TEST_TARGET_LIKE_PATTERN:%27%2F%2Ftest%2Fcore%2Fevent_engine:thread_pool_test@poller%3Depoll1%25%27&p=TEST_CLASS_NAME_LIKE_PATTERN:%27%25%27&p=TEST_CASE_LIKE_PATTERN:%27%25%27&p=JOB_NAME:%27grpc%2Fcore%2Fmaster%2Flinux%2Fbazel_rbe%2Fgrpc_bazel_rbe_tsan%27&p=TEST_TARGET:%27%2F%2Ftest%2Fcore%2Fevent_engine:thread_pool_test@poller%3Depoll1%27&p=TEST_CLASS_NAME:%27%27&p=TEST_CASE:%27CANNOT_DETERMINE%27&p=LOOKBACK_DAYS:2
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

