### PR TITLE
[experiments] Dont check expiry dates in sanity

### DIFF
--- a/tools/codegen/core/gen_experiments.py
+++ b/tools/codegen/core/gen_experiments.py
@@ -33,6 +33,11 @@ import sys
 
 import yaml
 
+# TODO(ctiller): if we ever add another argument switch this to argparse
+check_dates = True
+if sys.argv[1:] == ["--check"]:
+    check_dates = False  # for formatting checks we don't verify expiry dates
+
 with open('src/core/lib/experiments/experiments.yaml') as f:
     attrs = yaml.load(f.read(), Loader=yaml.FullLoader)
 
@@ -70,21 +75,22 @@ for attr in attrs:
         print("invalid default for experiment %s: %r" %
               (attr['name'], attr['default']))
         error = True
-    if 'expiry' not in attr:
-        print("no expiry for experiment %s" % attr['name'])
-        error = True
     if 'owner' not in attr:
         print("no owner for experiment %s" % attr['name'])
         error = True
+    if 'expiry' not in attr:
+        print("no expiry for experiment %s" % attr['name'])
+        error = True
     expiry = datetime.datetime.strptime(attr['expiry'], '%Y/%m/%d').date()
-    if expiry < today:
-        print("experiment %s expired on %s" % (attr['name'], attr['expiry']))
-        error = True
-    if expiry > two_quarters_from_now:
-        print("experiment %s expires far in the future on %s" %
-              (attr['name'], attr['expiry']))
-        print("expiry should be no more than two quarters from now")
-        error = True
+    if check_dates:
+        if expiry < today:
+            print("experiment %s expired on %s" % (attr['name'], attr['expiry']))
+            error = True
+        if expiry > two_quarters_from_now:
+            print("experiment %s expires far in the future on %s" %
+                (attr['name'], attr['expiry']))
+            print("expiry should be no more than two quarters from now")
+            error = True
 
 if error:
     sys.exit(1)

--- a/tools/distrib/gen_experiments_and_format.sh
+++ b/tools/distrib/gen_experiments_and_format.sh
@@ -15,7 +15,7 @@
 
 set -e
 cd $(dirname $0)/../..
-tools/codegen/core/gen_experiments.py
+tools/codegen/core/gen_experiments.py $@
 # clang format
 TEST='' \
     CHANGED_FILES="$(git status --porcelain | awk '{print $2}' | tr '\n' ' ')" \


### PR DESCRIPTION
The tool run from the command line fails when experiments are expired: this creates social pressure to keep them updated and is desirable until we have better tooling to create that pressure.

We should not however bomb our CI because of a date passing - doing so creates an unnecessary emergency and goes against the principle of being able to recreate our builds at any point.

Disable the expiry date check when run on CI.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

