### PR TITLE
[merged separately] Remove ResetDefaultEventEngine

### DIFF
--- a/src/core/lib/event_engine/default_event_engine.cc
+++ b/src/core/lib/event_engine/default_event_engine.cc
@@ -51,6 +51,7 @@ void SetEventEngineFactory(
 
 void EventEngineFactoryReset() {
   delete g_event_engine_factory.exchange(nullptr);
+  g_event_engine->reset();
 }
 
 std::unique_ptr<EventEngine> CreateEventEngine() {

--- a/src/core/lib/event_engine/default_event_engine.cc
+++ b/src/core/lib/event_engine/default_event_engine.cc
@@ -51,7 +51,6 @@ void SetEventEngineFactory(
 
 void EventEngineFactoryReset() {
   delete g_event_engine_factory.exchange(nullptr);
-  ResetDefaultEventEngine();
 }
 
 std::unique_ptr<EventEngine> CreateEventEngine() {
@@ -72,11 +71,6 @@ std::shared_ptr<EventEngine> GetDefaultEventEngine() {
   GRPC_EVENT_ENGINE_TRACE("Created DefaultEventEngine::%p", engine.get());
   *g_event_engine = engine;
   return engine;
-}
-
-void ResetDefaultEventEngine() {
-  grpc_core::MutexLock lock(&*g_mu);
-  g_event_engine->reset();
 }
 
 }  // namespace experimental

--- a/src/core/lib/event_engine/default_event_engine.h
+++ b/src/core/lib/event_engine/default_event_engine.h
@@ -37,9 +37,6 @@ namespace experimental {
 /// Strongly consider whether you could use \a CreateEventEngine instead.
 std::shared_ptr<EventEngine> GetDefaultEventEngine();
 
-/// Reset the default event engine
-void ResetDefaultEventEngine();
-
 }  // namespace experimental
 }  // namespace grpc_event_engine
 

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -37,7 +37,6 @@
 #include "src/core/lib/channel/channel_stack_builder.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/event_engine/forkable.h"
 #include "src/core/lib/event_engine/posix_engine/timer_manager.h"
 #include "src/core/lib/experiments/config.h"
@@ -156,7 +155,6 @@ void grpc_shutdown_internal_locked(void)
     grpc_iomgr_shutdown_background_closure();
     grpc_timer_manager_set_threading(false);  // shutdown timer_manager thread
     grpc_resolver_dns_ares_shutdown();
-    grpc_event_engine::experimental::ResetDefaultEventEngine();
     grpc_iomgr_shutdown();
   }
   g_shutting_down = false;

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -813,7 +813,6 @@ static grpc_channel_credentials* ReadChannelCreds(
 }
 
 DEFINE_PROTO_FUZZER(const api_fuzzer::Msg& msg) {
-  grpc_event_engine::experimental::ResetDefaultEventEngine();
   if (squelch && !grpc_core::GetEnv("GRPC_TRACE_FUZZER").has_value()) {
     gpr_set_log_function(dont_log);
   }

--- a/test/cpp/microbenchmarks/bm_event_engine_run.cc
+++ b/test/cpp/microbenchmarks/bm_event_engine_run.cc
@@ -33,7 +33,6 @@ namespace {
 using ::grpc_event_engine::experimental::AnyInvocableClosure;
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::GetDefaultEventEngine;
-using ::grpc_event_engine::experimental::ResetDefaultEventEngine;
 
 struct FanoutParameters {
   int depth;
@@ -58,7 +57,6 @@ void BM_EventEngine_RunSmallLambda(benchmark::State& state) {
     signal.WaitForNotification();
     count.store(0);
   }
-  ResetDefaultEventEngine();
   state.SetItemsProcessed(cb_count * state.iterations());
 }
 BENCHMARK(BM_EventEngine_RunSmallLambda)
@@ -86,7 +84,6 @@ void BM_EventEngine_RunLargeLambda(benchmark::State& state) {
     signal.WaitForNotification();
     count.store(0);
   }
-  ResetDefaultEventEngine();
   state.SetItemsProcessed(cb_count * state.iterations());
 }
 BENCHMARK(BM_EventEngine_RunLargeLambda)
@@ -116,7 +113,6 @@ void BM_EventEngine_RunClosure(benchmark::State& state) {
     state.ResumeTiming();
   }
   delete signal;
-  ResetDefaultEventEngine();
   state.SetItemsProcessed(cb_count * state.iterations());
 }
 BENCHMARK(BM_EventEngine_RunClosure)


### PR DESCRIPTION
Now that it is a weak_ptr, there's no need to explicitly reset it. When the tracked shared_ptr is deleted, the weak_ptr will fail to lock, and a new default EventEngine will be created from within `GetDefaultEventEngine`




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

