### PR TITLE
Simplified GRPC_ERROR_CREATE macros

### DIFF
--- a/src/core/ext/filters/channel_idle/channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/channel_idle_filter.cc
@@ -187,7 +187,7 @@ void MaxAgeFilter::PostInit() {
                 auto* channel_stack = static_cast<grpc_channel_stack*>(arg);
                 grpc_transport_op* op = grpc_make_transport_op(nullptr);
                 op->goaway_error = grpc_error_set_int(
-                    GRPC_ERROR_CREATE_FROM_STATIC_STRING("max_age"),
+                    GRPC_ERROR_CREATE("max_age"),
                     StatusIntProperty::kHttp2Error, GRPC_HTTP2_NO_ERROR);
                 grpc_channel_element* elem =
                     grpc_channel_stack_element(channel_stack, 0);
@@ -278,7 +278,7 @@ void ChannelIdleFilter::StartIdleTimer() {
 void ChannelIdleFilter::CloseChannel() {
   auto* op = grpc_make_transport_op(nullptr);
   op->disconnect_with_error = grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("enter idle"),
+      GRPC_ERROR_CREATE("enter idle"),
       StatusIntProperty::ChannelConnectivityState, GRPC_CHANNEL_IDLE);
   // Pass the transport op down to the channel stack.
   auto* elem = grpc_channel_stack_element(channel_stack_, 0);

--- a/src/core/ext/filters/client_channel/channel_connectivity.cc
+++ b/src/core/ext/filters/client_channel/channel_connectivity.cc
@@ -195,9 +195,9 @@ class StateWatcher : public DualRefCounted<StateWatcher> {
   void Orphan() override {
     WeakRef().release();  // Take a weak ref until completion is finished.
     grpc_error_handle error =
-        timer_fired_ ? GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                           "Timed out waiting for connection state change")
-                     : absl::OkStatus();
+        timer_fired_
+            ? GRPC_ERROR_CREATE("Timed out waiting for connection state change")
+            : absl::OkStatus();
     grpc_cq_end_op(cq_, tag_, error, FinishedCompletion, this,
                    &completion_storage_);
   }

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -996,7 +996,7 @@ ClientChannel::ClientChannel(grpc_channel_element_args* args,
   grpc_client_channel_start_backup_polling(interested_parties_);
   // Check client channel factory.
   if (client_channel_factory_ == nullptr) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "Missing client channel factory in args for client channel filter");
     return;
   }
@@ -1017,7 +1017,7 @@ ClientChannel::ClientChannel(grpc_channel_element_args* args,
   absl::optional<std::string> server_uri =
       channel_args_.GetOwnedString(GRPC_ARG_SERVER_URI);
   if (!server_uri.has_value()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "target URI channel arg missing or wrong type in client channel "
         "filter");
     return;
@@ -1030,7 +1030,7 @@ ClientChannel::ClientChannel(grpc_channel_element_args* args,
   // resolver creation will succeed later.
   if (!CoreConfiguration::Get().resolver_registry().IsValidTarget(
           uri_to_resolve_)) {
-    *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    *error = GRPC_ERROR_CREATE(
         absl::StrCat("the target uri is not valid: ", uri_to_resolve_));
     return;
   }
@@ -1628,7 +1628,7 @@ T HandlePickResult(
 
 grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
   if (state_tracker_.state() != GRPC_CHANNEL_READY) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("channel not connected");
+    return GRPC_ERROR_CREATE("channel not connected");
   }
   LoadBalancingPolicy::PickResult result;
   {
@@ -1645,8 +1645,7 @@ grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
             RefCountedPtr<ConnectedSubchannel> connected_subchannel =
                 subchannel->connected_subchannel();
             if (connected_subchannel == nullptr) {
-              return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                  "LB pick for ping not connected");
+              return GRPC_ERROR_CREATE("LB pick for ping not connected");
             }
             connected_subchannel->Ping(op->send_ping.on_initiate,
                                        op->send_ping.on_ack);
@@ -1654,7 +1653,7 @@ grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
           },
       // Queue pick.
       [](LoadBalancingPolicy::PickResult::Queue* /*queue_pick*/) {
-        return GRPC_ERROR_CREATE_FROM_STATIC_STRING("LB picker queued call");
+        return GRPC_ERROR_CREATE("LB picker queued call");
       },
       // Fail pick.
       [](LoadBalancingPolicy::PickResult::Fail* fail_pick) {

--- a/src/core/ext/filters/client_channel/connector.h
+++ b/src/core/ext/filters/client_channel/connector.h
@@ -74,7 +74,7 @@ class SubchannelConnector : public InternallyRefCounted<SubchannelConnector> {
   virtual void Shutdown(grpc_error_handle error) = 0;
 
   void Orphan() override {
-    Shutdown(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Subchannel disconnected"));
+    Shutdown(GRPC_ERROR_CREATE("Subchannel disconnected"));
     Unref();
   }
 };

--- a/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
@@ -95,7 +95,7 @@ class BinderResolverFactory : public ResolverFactory {
       absl::string_view path, grpc_resolved_address* resolved_addr) {
     path = absl::StripPrefix(path, "/");
     if (path.empty()) {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING("path is empty");
+      return GRPC_ERROR_CREATE("path is empty");
     }
     // Store parsed path in a unix socket so it can be reinterpreted as
     // sockaddr. An invalid address family (AF_MAX) is set to make sure it won't
@@ -107,7 +107,7 @@ class BinderResolverFactory : public ResolverFactory {
     static_assert(sizeof(un->sun_path) >= 101,
                   "unix socket path size is unexpectedly short");
     if (path.size() + 1 > sizeof(un->sun_path)) {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      return GRPC_ERROR_CREATE(
           absl::StrCat(path, " is too long to be handled"));
     }
     // `un` has already be set to zero, no need to append null after the string

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -259,7 +259,7 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
     return "";
   }
   if (json->type() != Json::Type::ARRAY) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "Service Config Choices, error: should be of type array");
     return "";
   }
@@ -267,7 +267,7 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
   std::vector<grpc_error_handle> error_list;
   for (const Json& choice : json->array_value()) {
     if (choice.type() != Json::Type::OBJECT) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "Service Config Choice, error: should be of type object"));
       continue;
     }
@@ -275,7 +275,7 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
     auto it = choice.object_value().find("clientLanguage");
     if (it != choice.object_value().end()) {
       if (it->second.type() != Json::Type::ARRAY) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:clientLanguage error:should be of type array"));
       } else if (!ValueInJsonArray(it->second.array_value(), "c++")) {
         continue;
@@ -285,7 +285,7 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
     it = choice.object_value().find("clientHostname");
     if (it != choice.object_value().end()) {
       if (it->second.type() != Json::Type::ARRAY) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:clientHostname error:should be of type array"));
       } else {
         char* hostname = grpc_gethostname();
@@ -299,13 +299,13 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
     it = choice.object_value().find("percentage");
     if (it != choice.object_value().end()) {
       if (it->second.type() != Json::Type::NUMBER) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:percentage error:should be of type number"));
       } else {
         int random_pct = rand() % 100;
         int percentage;
         if (sscanf(it->second.string_value().c_str(), "%d", &percentage) != 1) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          error_list.push_back(GRPC_ERROR_CREATE(
               "field:percentage error:should be of type integer"));
         } else if (random_pct > percentage || percentage == 0) {
           continue;
@@ -315,10 +315,10 @@ std::string ChooseServiceConfig(char* service_config_choice_json,
     // Found service config.
     it = choice.object_value().find("serviceConfig");
     if (it == choice.object_value().end()) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:serviceConfig error:required field missing"));
     } else if (it->second.type() != Json::Type::OBJECT) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:serviceConfig error:should be of type object"));
     } else if (service_config == nullptr) {
       service_config = &it->second;

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -794,7 +794,7 @@ class SockToPolledFdMap {
     // If a gRPC polled fd has not made it in to the driver's list yet, then
     // the driver has not and will never see this socket.
     if (!polled_fd->gotten_into_driver_list()) {
-      polled_fd->ShutdownLocked(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      polled_fd->ShutdownLocked(GRPC_ERROR_CREATE(
           "Shut down c-ares fd before without it ever having made it into the "
           "driver's list"));
     }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -225,8 +225,7 @@ static void fd_node_shutdown_locked(fd_node* fdn, const char* reason)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(&grpc_ares_request::mu) {
   if (!fdn->already_shutdown) {
     fdn->already_shutdown = true;
-    fdn->grpc_polled_fd->ShutdownLocked(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(reason));
+    fdn->grpc_polled_fd->ShutdownLocked(GRPC_ERROR_CREATE(reason));
   }
 }
 
@@ -527,7 +526,7 @@ grpc_error_handle grpc_ares_ev_driver_create_locked(
   grpc_ares_test_only_inject_config((*ev_driver)->channel);
   GRPC_CARES_TRACE_LOG("request:%p grpc_ares_ev_driver_create_locked", request);
   if (status != ARES_SUCCESS) {
-    grpc_error_handle err = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+    grpc_error_handle err = GRPC_ERROR_CREATE(absl::StrCat(
         "Failed to init ares channel. C-ares error: ", ares_strerror(status)));
     delete *ev_driver;
     return err;
@@ -709,7 +708,7 @@ static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
         hr->qtype, hr->host, hr->is_balancer, ares_strerror(status));
     GRPC_CARES_TRACE_LOG("request:%p on_hostbyname_done_locked: %s", r,
                          error_msg.c_str());
-    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(error_msg);
+    grpc_error_handle error = GRPC_ERROR_CREATE(error_msg);
     r->error = grpc_error_add_child(error, r->error);
   }
   destroy_hostbyname_request_locked(hr);
@@ -756,7 +755,7 @@ static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
         ares_strerror(status));
     GRPC_CARES_TRACE_LOG("request:%p on_srv_query_done_locked: %s", r,
                          error_msg.c_str());
-    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_CPP_STRING(error_msg);
+    grpc_error_handle error = GRPC_ERROR_CREATE(error_msg);
     r->error = grpc_error_add_child(error, r->error);
   }
   delete q;
@@ -819,7 +818,7 @@ fail:
                       q->name(), ares_strerror(status));
   GRPC_CARES_TRACE_LOG("request:%p on_txt_done_locked %s", r,
                        error_msg.c_str());
-  error = GRPC_ERROR_CREATE_FROM_CPP_STRING(error_msg);
+  error = GRPC_ERROR_CREATE(error_msg);
   r->error = grpc_error_add_child(error, r->error);
 }
 
@@ -847,13 +846,13 @@ grpc_error_handle set_request_dns_server(grpc_ares_request* r,
       r->dns_server_addr.tcp_port = grpc_sockaddr_get_port(&addr);
       r->dns_server_addr.udp_port = grpc_sockaddr_get_port(&addr);
     } else {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      return GRPC_ERROR_CREATE(
           absl::StrCat("cannot parse authority ", dns_server));
     }
     int status =
         ares_set_servers_ports(r->ev_driver->channel, &r->dns_server_addr);
     if (status != ARES_SUCCESS) {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+      return GRPC_ERROR_CREATE(absl::StrCat(
           "C-ares status is not ARES_SUCCESS: ", ares_strerror(status)));
     }
   }
@@ -871,15 +870,15 @@ grpc_error_handle grpc_dns_lookup_ares_continued(
   /* parse name, splitting it into host and port parts */
   grpc_core::SplitHostPort(name, host, port);
   if (host->empty()) {
-    error = grpc_error_set_str(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("unparseable host:port"),
-        grpc_core::StatusStrProperty::kTargetAddress, name);
+    error =
+        grpc_error_set_str(GRPC_ERROR_CREATE("unparseable host:port"),
+                           grpc_core::StatusStrProperty::kTargetAddress, name);
     return error;
   } else if (check_port && port->empty()) {
     if (default_port == nullptr || strlen(default_port) == 0) {
-      error = grpc_error_set_str(
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("no port in name"),
-          grpc_core::StatusStrProperty::kTargetAddress, name);
+      error = grpc_error_set_str(GRPC_ERROR_CREATE("no port in name"),
+                                 grpc_core::StatusStrProperty::kTargetAddress,
+                                 name);
       return error;
     }
     *port = default_port;
@@ -1190,7 +1189,7 @@ void (*grpc_cancel_ares_request)(grpc_ares_request* r) =
 grpc_error_handle grpc_ares_init(void) {
   int status = ares_library_init(ARES_LIB_INIT_ALL);
   if (status != ARES_SUCCESS) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    return GRPC_ERROR_CREATE(
         absl::StrCat("ares_library_init failed: ", ares_strerror(status)));
   }
   return absl::OkStatus();

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -58,7 +58,7 @@ absl::optional<std::string> ParseHealthCheckConfig(const Json& field,
                                                    grpc_error_handle* error) {
   GPR_DEBUG_ASSERT(error != nullptr && error->ok());
   if (field.type() != Json::Type::OBJECT) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "field:healthCheckConfig error:should be of type object");
     return absl::nullopt;
   }
@@ -67,7 +67,7 @@ absl::optional<std::string> ParseHealthCheckConfig(const Json& field,
   auto it = field.object_value().find("serviceName");
   if (it != field.object_value().end()) {
     if (it->second.type() != Json::Type::STRING) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:serviceName error:should be of type string"));
     } else {
       service_name = it->second.string_value();
@@ -92,7 +92,7 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const ChannelArgs& /*args*/,
   if (it != json.object_value().end()) {
     auto config = lb_policy_registry.ParseLoadBalancingConfig(it->second);
     if (!config.ok()) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+      error_list.push_back(GRPC_ERROR_CREATE(absl::StrCat(
           "field:loadBalancingConfig error:", config.status().message())));
     } else {
       parsed_lb_config = std::move(*config);
@@ -103,7 +103,7 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const ChannelArgs& /*args*/,
   it = json.object_value().find("loadBalancingPolicy");
   if (it != json.object_value().end()) {
     if (it->second.type() != Json::Type::STRING) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:loadBalancingPolicy error:type should be string"));
     } else {
       lb_policy_name = it->second.string_value();
@@ -113,10 +113,10 @@ ClientChannelServiceConfigParser::ParseGlobalParams(const ChannelArgs& /*args*/,
       bool requires_config = false;
       if (!lb_policy_registry.LoadBalancingPolicyExists(lb_policy_name.c_str(),
                                                         &requires_config)) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:loadBalancingPolicy error:Unknown lb policy"));
       } else if (requires_config) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             absl::StrCat("field:loadBalancingPolicy error:", lb_policy_name,
                          " requires a config. Please use loadBalancingConfig "
                          "instead.")));
@@ -160,7 +160,7 @@ ClientChannelServiceConfigParser::ParsePerMethodParams(
     } else if (it->second.type() == Json::Type::JSON_FALSE) {
       wait_for_ready.emplace(false);
     } else {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:waitForReady error:Type should be true/false"));
     }
   }

--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -192,15 +192,15 @@ class RetryFilter {
     const char* server_uri =
         grpc_channel_args_find_string(args, GRPC_ARG_SERVER_URI);
     if (server_uri == nullptr) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      *error = GRPC_ERROR_CREATE(
           "server URI channel arg missing or wrong type in client channel "
           "filter");
       return;
     }
     absl::StatusOr<URI> uri = URI::Parse(server_uri);
     if (!uri.ok() || uri->path().empty()) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "could not extract server name from target URI");
+      *error =
+          GRPC_ERROR_CREATE("could not extract server name from target URI");
       return;
     }
     std::string server_name(absl::StripPrefix(uri->path(), "/"));
@@ -1281,10 +1281,9 @@ void RetryFilter::CallData::CallAttempt::OnPerAttemptRecvTimerLocked(
     // TODO(roth): When implementing hedging, we should not cancel the
     // current attempt.
     call_attempt->MaybeAddBatchForCancelOp(
-        grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                               "retry perAttemptRecvTimeout exceeded"),
-                           StatusIntProperty::kRpcStatus,
-                           GRPC_STATUS_CANCELLED),
+        grpc_error_set_int(
+            GRPC_ERROR_CREATE("retry perAttemptRecvTimeout exceeded"),
+            StatusIntProperty::kRpcStatus, GRPC_STATUS_CANCELLED),
         &closures);
     // Check whether we should retry.
     if (call_attempt->ShouldRetry(/*status=*/absl::nullopt,
@@ -1781,11 +1780,10 @@ void RetryFilter::CallData::CallAttempt::BatchData::RecvTrailingMetadataReady(
       CallCombinerClosureList closures;
       // Cancel call attempt.
       call_attempt->MaybeAddBatchForCancelOp(
-          error.ok()
-              ? grpc_error_set_int(
-                    GRPC_ERROR_CREATE_FROM_STATIC_STRING("call attempt failed"),
-                    StatusIntProperty::kRpcStatus, GRPC_STATUS_CANCELLED)
-              : error,
+          error.ok() ? grpc_error_set_int(
+                           GRPC_ERROR_CREATE("call attempt failed"),
+                           StatusIntProperty::kRpcStatus, GRPC_STATUS_CANCELLED)
+                     : error,
           &closures);
       // For transparent retries, add a closure to immediately start a new
       // call attempt.

--- a/src/core/ext/filters/client_channel/retry_service_config.cc
+++ b/src/core/ext/filters/client_channel/retry_service_config.cc
@@ -64,24 +64,24 @@ grpc_error_handle ParseRetryThrottling(const Json& json,
                                        intptr_t* max_milli_tokens,
                                        intptr_t* milli_token_ratio) {
   if (json.type() != Json::Type::OBJECT) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    return GRPC_ERROR_CREATE(
         "field:retryThrottling error:Type should be object");
   }
   std::vector<grpc_error_handle> error_list;
   // Parse maxTokens.
   auto it = json.object_value().find("maxTokens");
   if (it == json.object_value().end()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "field:retryThrottling field:maxTokens error:Not found"));
   } else if (it->second.type() != Json::Type::NUMBER) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "field:retryThrottling field:maxTokens error:Type should be "
         "number"));
   } else {
     *max_milli_tokens =
         gpr_parse_nonnegative_int(it->second.string_value().c_str()) * 1000;
     if (*max_milli_tokens <= 0) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:retryThrottling field:maxTokens error:should be "
           "greater than zero"));
     }
@@ -89,10 +89,10 @@ grpc_error_handle ParseRetryThrottling(const Json& json,
   // Parse tokenRatio.
   it = json.object_value().find("tokenRatio");
   if (it == json.object_value().end()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "field:retryThrottling field:tokenRatio error:Not found"));
   } else if (it->second.type() != Json::Type::NUMBER) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "field:retryThrottling field:tokenRatio error:type should be "
         "number"));
   } else {
@@ -109,7 +109,7 @@ grpc_error_handle ParseRetryThrottling(const Json& json,
       if (decimal_len > 3) decimal_len = 3;
       if (!gpr_parse_bytes_to_uint32(decimal_point + 1, decimal_len,
                                      &decimal_value)) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:retryThrottling field:tokenRatio error:Failed "
             "parsing"));
         return GRPC_ERROR_CREATE_FROM_VECTOR("retryThrottling", &error_list);
@@ -122,7 +122,7 @@ grpc_error_handle ParseRetryThrottling(const Json& json,
     }
     uint32_t whole_value;
     if (!gpr_parse_bytes_to_uint32(value, whole_len, &whole_value)) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:retryThrottling field:tokenRatio error:Failed "
           "parsing"));
       return GRPC_ERROR_CREATE_FROM_VECTOR("retryThrottling", &error_list);
@@ -130,7 +130,7 @@ grpc_error_handle ParseRetryThrottling(const Json& json,
     *milli_token_ratio =
         static_cast<int>((whole_value * multiplier) + decimal_value);
     if (*milli_token_ratio <= 0) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:retryThrottling field:tokenRatio error:value should "
           "be greater than 0"));
     }
@@ -167,25 +167,25 @@ grpc_error_handle ParseRetryPolicy(
     StatusCodeSet* retryable_status_codes,
     absl::optional<Duration>* per_attempt_recv_timeout) {
   if (json.type() != Json::Type::OBJECT) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    return GRPC_ERROR_CREATE(
         "field:retryPolicy error:should be of type object");
   }
   std::vector<grpc_error_handle> error_list;
   // Parse maxAttempts.
   auto it = json.object_value().find("maxAttempts");
   if (it == json.object_value().end()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "field:maxAttempts error:required field missing"));
+    error_list.push_back(
+        GRPC_ERROR_CREATE("field:maxAttempts error:required field missing"));
   } else {
     if (it->second.type() != Json::Type::NUMBER) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:maxAttempts error:should be of type number"));
     } else {
       *max_attempts =
           gpr_parse_nonnegative_int(it->second.string_value().c_str());
       if (*max_attempts <= 1) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "field:maxAttempts error:should be at least 2"));
+        error_list.push_back(
+            GRPC_ERROR_CREATE("field:maxAttempts error:should be at least 2"));
       } else if (*max_attempts > MAX_MAX_RETRY_ATTEMPTS) {
         gpr_log(GPR_ERROR,
                 "service config: clamped retryPolicy.maxAttempts at %d",
@@ -198,32 +198,32 @@ grpc_error_handle ParseRetryPolicy(
   if (ParseJsonObjectFieldAsDuration(json.object_value(), "initialBackoff",
                                      initial_backoff, &error_list) &&
       *initial_backoff == Duration::Zero()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "field:initialBackoff error:must be greater than 0"));
+    error_list.push_back(
+        GRPC_ERROR_CREATE("field:initialBackoff error:must be greater than 0"));
   }
   // Parse maxBackoff.
   if (ParseJsonObjectFieldAsDuration(json.object_value(), "maxBackoff",
                                      max_backoff, &error_list) &&
       *max_backoff == Duration::Zero()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "field:maxBackoff error:must be greater than 0"));
+    error_list.push_back(
+        GRPC_ERROR_CREATE("field:maxBackoff error:must be greater than 0"));
   }
   // Parse backoffMultiplier.
   it = json.object_value().find("backoffMultiplier");
   if (it == json.object_value().end()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "field:backoffMultiplier error:required field missing"));
   } else {
     if (it->second.type() != Json::Type::NUMBER) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:backoffMultiplier error:should be of type number"));
     } else {
       if (sscanf(it->second.string_value().c_str(), "%f", backoff_multiplier) !=
           1) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "field:backoffMultiplier error:failed to parse"));
+        error_list.push_back(
+            GRPC_ERROR_CREATE("field:backoffMultiplier error:failed to parse"));
       } else if (*backoff_multiplier <= 0) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:backoffMultiplier error:must be greater than 0"));
       }
     }
@@ -232,12 +232,12 @@ grpc_error_handle ParseRetryPolicy(
   it = json.object_value().find("retryableStatusCodes");
   if (it != json.object_value().end()) {
     if (it->second.type() != Json::Type::ARRAY) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:retryableStatusCodes error:must be of type array"));
     } else {
       for (const Json& element : it->second.array_value()) {
         if (element.type() != Json::Type::STRING) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          error_list.push_back(GRPC_ERROR_CREATE(
               "field:retryableStatusCodes error:status codes should be of type "
               "string"));
           continue;
@@ -245,7 +245,7 @@ grpc_error_handle ParseRetryPolicy(
         grpc_status_code status;
         if (!grpc_status_code_from_string(element.string_value().c_str(),
                                           &status)) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          error_list.push_back(GRPC_ERROR_CREATE(
               "field:retryableStatusCodes error:failed to parse status code"));
           continue;
         }
@@ -259,7 +259,7 @@ grpc_error_handle ParseRetryPolicy(
     if (it != json.object_value().end()) {
       Duration per_attempt_recv_timeout_value;
       if (!ParseDurationFromJson(it->second, &per_attempt_recv_timeout_value)) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:perAttemptRecvTimeout error:type must be STRING of the "
             "form given by google.proto.Duration."));
       } else {
@@ -267,14 +267,14 @@ grpc_error_handle ParseRetryPolicy(
         // TODO(roth): As part of implementing hedging, relax this check such
         // that we allow a value of 0 if a hedging policy is specified.
         if (per_attempt_recv_timeout_value == Duration::Zero()) {
-          error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          error_list.push_back(GRPC_ERROR_CREATE(
               "field:perAttemptRecvTimeout error:must be greater than 0"));
         }
       }
     } else if (retryable_status_codes->Empty()) {
       // If perAttemptRecvTimeout not present, retryableStatusCodes must be
       // non-empty.
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:retryableStatusCodes error:must be non-empty if "
           "perAttemptRecvTimeout not present"));
     }
@@ -282,7 +282,7 @@ grpc_error_handle ParseRetryPolicy(
     // Hedging not enabled, so the error message for
     // retryableStatusCodes unset should be different.
     if (retryable_status_codes->Empty()) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:retryableStatusCodes error:must be non-empty"));
     }
   }

--- a/src/core/ext/filters/deadline/deadline_filter.cc
+++ b/src/core/ext/filters/deadline/deadline_filter.cc
@@ -84,9 +84,9 @@ class TimerState {
     grpc_deadline_state* deadline_state =
         static_cast<grpc_deadline_state*>(self->elem_->call_data);
     if (error != absl::CancelledError()) {
-      error = grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("Deadline Exceeded"),
-          StatusIntProperty::kRpcStatus, GRPC_STATUS_DEADLINE_EXCEEDED);
+      error = grpc_error_set_int(GRPC_ERROR_CREATE("Deadline Exceeded"),
+                                 StatusIntProperty::kRpcStatus,
+                                 GRPC_STATUS_DEADLINE_EXCEEDED);
       deadline_state->call_combiner->Cancel(error);
       GRPC_CLOSURE_INIT(&self->closure_, SendCancelOpInCallCombiner, self,
                         nullptr);

--- a/src/core/ext/filters/fault_injection/service_config_parser.cc
+++ b/src/core/ext/filters/fault_injection/service_config_parser.cc
@@ -44,7 +44,7 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
         fault_injection_policy;
     std::vector<grpc_error_handle> sub_error_list;
     if (policies_json_array[i].type() != Json::Type::OBJECT) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+      error_list->push_back(GRPC_ERROR_CREATE(absl::StrCat(
           "faultInjectionPolicy index ", i, " is not a JSON object")));
       continue;
     }
@@ -55,7 +55,7 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
                              &sub_error_list, false)) {
       if (!grpc_status_code_from_string(abort_code_string.c_str(),
                                         &(fault_injection_policy.abort_code))) {
-        sub_error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        sub_error_list.push_back(GRPC_ERROR_CREATE(
             "field:abortCode error:failed to parse status code"));
       }
     }
@@ -85,7 +85,7 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
       if (fault_injection_policy.abort_percentage_denominator != 100 &&
           fault_injection_policy.abort_percentage_denominator != 10000 &&
           fault_injection_policy.abort_percentage_denominator != 1000000) {
-        sub_error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        sub_error_list.push_back(GRPC_ERROR_CREATE(
             "field:abortPercentageDenominator error:Denominator can only be "
             "one of "
             "100, 10000, 1000000"));
@@ -115,7 +115,7 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
       if (fault_injection_policy.delay_percentage_denominator != 100 &&
           fault_injection_policy.delay_percentage_denominator != 10000 &&
           fault_injection_policy.delay_percentage_denominator != 1000000) {
-        sub_error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        sub_error_list.push_back(GRPC_ERROR_CREATE(
             "field:delayPercentageDenominator error:Denominator can only be "
             "one of "
             "100, 10000, 1000000"));
@@ -129,7 +129,7 @@ ParseFaultInjectionPolicy(const Json::Array& policies_json_array,
                          &fault_injection_policy.max_faults, &sub_error_list,
                          false);
     if (!sub_error_list.empty()) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
           absl::StrCat("failed to parse faultInjectionPolicy index ", i),
           &sub_error_list));
     }

--- a/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_decompress_filter.cc
@@ -176,7 +176,7 @@ void CallData::OnRecvMessageReady(void* arg, grpc_error_handle error) {
               static_cast<uint32_t>(calld->max_recv_message_length_)) {
         GPR_DEBUG_ASSERT(calld->error_.ok());
         calld->error_ = grpc_error_set_int(
-            GRPC_ERROR_CREATE_FROM_CPP_STRING(
+            GRPC_ERROR_CREATE(
                 absl::StrFormat("Received message larger than max (%u vs. %d)",
                                 (*calld->recv_message_)->Length(),
                                 calld->max_recv_message_length_)),
@@ -188,7 +188,7 @@ void CallData::OnRecvMessageReady(void* arg, grpc_error_handle error) {
                               (*calld->recv_message_)->c_slice_buffer(),
                               decompressed_slices.c_slice_buffer()) == 0) {
         GPR_DEBUG_ASSERT(calld->error_.ok());
-        calld->error_ = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        calld->error_ = GRPC_ERROR_CREATE(absl::StrCat(
             "Unexpected error decompressing data for algorithm with "
             "enum value ",
             calld->algorithm_));

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -85,13 +85,13 @@ MessageSizeParser::ParsePerMethodParams(const ChannelArgs& /*args*/,
   if (it != json.object_value().end()) {
     if (it->second.type() != Json::Type::STRING &&
         it->second.type() != Json::Type::NUMBER) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:maxRequestMessageBytes error:should be of type number"));
     } else {
       max_request_message_bytes =
           gpr_parse_nonnegative_int(it->second.string_value().c_str());
       if (max_request_message_bytes == -1) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:maxRequestMessageBytes error:should be non-negative"));
       }
     }
@@ -102,13 +102,13 @@ MessageSizeParser::ParsePerMethodParams(const ChannelArgs& /*args*/,
   if (it != json.object_value().end()) {
     if (it->second.type() != Json::Type::STRING &&
         it->second.type() != Json::Type::NUMBER) {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list.push_back(GRPC_ERROR_CREATE(
           "field:maxResponseMessageBytes error:should be of type number"));
     } else {
       max_response_message_bytes =
           gpr_parse_nonnegative_int(it->second.string_value().c_str());
       if (max_response_message_bytes == -1) {
-        error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        error_list.push_back(GRPC_ERROR_CREATE(
             "field:maxResponseMessageBytes error:should be non-negative"));
       }
     }
@@ -218,7 +218,7 @@ static void recv_message_ready(void* user_data, grpc_error_handle error) {
       (*calld->recv_message)->Length() >
           static_cast<size_t>(calld->limits.max_recv_size)) {
     grpc_error_handle new_error = grpc_error_set_int(
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        GRPC_ERROR_CREATE(absl::StrFormat(
             "Received message larger than max (%u vs. %d)",
             (*calld->recv_message)->Length(), calld->limits.max_recv_size)),
         grpc_core::StatusIntProperty::kRpcStatus,
@@ -274,7 +274,7 @@ static void message_size_start_transport_stream_op_batch(
           static_cast<size_t>(calld->limits.max_send_size)) {
     grpc_transport_stream_op_batch_finish_with_failure(
         op,
-        grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        grpc_error_set_int(GRPC_ERROR_CREATE(absl::StrFormat(
                                "Sent message larger than max (%u vs. %d)",
                                op->payload->send_message.send_message->Length(),
                                calld->limits.max_send_size)),

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -93,7 +93,7 @@ void RbacFilter::CallData::RecvInitialMetadataReady(void* user_data,
         service_config_call_data->GetMethodParsedConfig(
             filter->service_config_parser_index_));
     if (method_params == nullptr) {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("No RBAC policy found.");
+      error = GRPC_ERROR_CREATE("No RBAC policy found.");
     } else {
       RbacFilter* chand = static_cast<RbacFilter*>(elem->channel_data);
       auto* authorization_engine =
@@ -102,8 +102,7 @@ void RbacFilter::CallData::RecvInitialMetadataReady(void* user_data,
               ->Evaluate(EvaluateArgs(calld->recv_initial_metadata_,
                                       &chand->per_channel_evaluate_args_))
               .type == AuthorizationEngine::Decision::Type::kDeny) {
-        error =
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Unauthorized RPC rejected");
+        error = GRPC_ERROR_CREATE("Unauthorized RPC rejected");
       }
     }
     if (!error.ok()) {
@@ -147,14 +146,14 @@ grpc_error_handle RbacFilter::Init(grpc_channel_element* elem,
   GPR_ASSERT(elem->filter == &kFilterVtable);
   auto* auth_context = grpc_find_auth_context_in_args(args->channel_args);
   if (auth_context == nullptr) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No auth context found");
+    return GRPC_ERROR_CREATE("No auth context found");
   }
   auto* transport = grpc_channel_args_find_pointer<grpc_transport>(
       args->channel_args, GRPC_ARG_TRANSPORT);
   if (transport == nullptr) {
     // This should never happen since the transport is always set on the server
     // side.
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No transport configured");
+    return GRPC_ERROR_CREATE("No transport configured");
   }
   new (elem->channel_data) RbacFilter(
       grpc_channel_stack_filter_instance_number(args->channel_stack, elem),

--- a/src/core/ext/filters/rbac/rbac_service_config_parser.cc
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.cc
@@ -195,7 +195,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
         permissions.emplace_back(std::make_unique<Rbac::Permission>(
             ParsePermission(*permission_json, &permission_error_list)));
         if (!permission_error_list.empty()) {
-          error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+          error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
               absl::StrFormat("rules[%d]", i), &permission_error_list));
         }
       }
@@ -306,8 +306,7 @@ Rbac::Permission ParsePermission(const Json::Object& permission_json,
           "requestedServerName", &req_server_name_error_list));
     }
   } else {
-    error_list->push_back(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("No valid rule found"));
+    error_list->push_back(GRPC_ERROR_CREATE("No valid rule found"));
   }
   return permission;
 }
@@ -331,7 +330,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
         principals.emplace_back(std::make_unique<Rbac::Principal>(
             ParsePrincipal(*principal_json, &principal_error_list)));
         if (!principal_error_list.empty()) {
-          error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+          error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
               absl::StrFormat("ids[%d]", i), &principal_error_list));
         }
       }
@@ -467,8 +466,7 @@ Rbac::Principal ParsePrincipal(const Json::Object& principal_json,
           GRPC_ERROR_CREATE_FROM_VECTOR("notId", &not_rule_error_list));
     }
   } else {
-    error_list->push_back(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("No valid id found"));
+    error_list->push_back(GRPC_ERROR_CREATE("No valid id found"));
   }
   return principal;
 }
@@ -491,7 +489,7 @@ Rbac::Policy ParsePolicy(const Json::Object& policy_json,
       permissions.emplace_back(std::make_unique<Rbac::Permission>(
           ParsePermission(*permission_json, &permission_error_list)));
       if (!permission_error_list.empty()) {
-        error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+        error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
             absl::StrFormat("permissions[%d]", i), &permission_error_list));
       }
     }
@@ -511,7 +509,7 @@ Rbac::Policy ParsePolicy(const Json::Object& policy_json,
       principals.emplace_back(std::make_unique<Rbac::Principal>(
           ParsePrincipal(*principal_json, &principal_error_list)));
       if (!principal_error_list.empty()) {
-        error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+        error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
             absl::StrFormat("principals[%d]", i), &principal_error_list));
       }
     }
@@ -535,8 +533,7 @@ Rbac ParseRbac(const Json::Object& rbac_json,
   int action;
   if (ParseJsonObjectField(*rules_json, "action", &action, error_list)) {
     if (action > 1) {
-      error_list->push_back(
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("Unknown action"));
+      error_list->push_back(GRPC_ERROR_CREATE("Unknown action"));
     }
   }
   rbac.action = static_cast<Rbac::Action>(action);
@@ -549,7 +546,7 @@ Rbac ParseRbac(const Json::Object& rbac_json,
           entry.first,
           ParsePolicy(entry.second.object_value(), &policy_error_list));
       if (!policy_error_list.empty()) {
-        error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+        error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
             absl::StrFormat("policies key:'%s'", entry.first.c_str()),
             &policy_error_list));
       }
@@ -571,7 +568,7 @@ std::vector<Rbac> ParseRbacArray(const Json::Array& policies_json_array,
     std::vector<grpc_error_handle> rbac_policy_error_list;
     policies.emplace_back(ParseRbac(*rbac_json, &rbac_policy_error_list));
     if (!rbac_policy_error_list.empty()) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(
+      error_list->push_back(GRPC_ERROR_CREATE_FROM_VECTOR(
           absl::StrFormat("rbacPolicy[%d]", i), &rbac_policy_error_list));
     }
   }

--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -212,7 +212,7 @@ static void recv_initial_metadata_locked(void* arg,
       if (!gbs->is_client) {
         // For server, we expect :authority and :path in initial metadata.
         if (!ContainsAuthorityAndPath(*args->initial_metadata)) {
-          return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+          return GRPC_ERROR_CREATE(
               "Missing :authority or :path in initial metadata");
         }
       }
@@ -575,9 +575,9 @@ static void close_transport_locked(grpc_binder_transport* gbt) {
   while (!gbt->registered_stream.empty()) {
     cancel_stream_locked(
         gbt, gbt->registered_stream.begin()->second,
-        grpc_error_set_int(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("transport closed"),
-            grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE));
+        grpc_error_set_int(GRPC_ERROR_CREATE("transport closed"),
+                           grpc_core::StatusIntProperty::kRpcStatus,
+                           GRPC_STATUS_UNAVAILABLE));
   }
 }
 
@@ -630,7 +630,7 @@ static void destroy_stream_locked(void* sp, grpc_error_handle /*error*/) {
   grpc_binder_transport* gbt = gbs->t;
   cancel_stream_locked(
       gbt, gbs,
-      grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("destroy stream"),
+      grpc_error_set_int(GRPC_ERROR_CREATE("destroy stream"),
                          grpc_core::StatusIntProperty::kRpcStatus,
                          GRPC_STATUS_UNAVAILABLE));
   gbs->~grpc_binder_stream();

--- a/src/core/ext/transport/chttp2/client/chttp2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/chttp2_connector.cc
@@ -110,8 +110,7 @@ void Chttp2Connector::Connect(const Args& args, Result* result,
   }
   absl::StatusOr<std::string> address = grpc_sockaddr_to_uri(args.address);
   if (!address.ok()) {
-    grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(address.status().ToString());
+    grpc_error_handle error = GRPC_ERROR_CREATE(address.status().ToString());
     NullThenSchedClosure(DEBUG_LOCATION, &notify_, error);
     return;
   }
@@ -145,7 +144,7 @@ void Chttp2Connector::OnHandshakeDone(void* arg, grpc_error_handle error) {
     MutexLock lock(&self->mu_);
     if (!error.ok() || self->shutdown_) {
       if (error.ok()) {
-        error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("connector shutdown");
+        error = GRPC_ERROR_CREATE("connector shutdown");
         // We were shut down after handshaking completed successfully, so
         // destroy the endpoint here.
         if (args->endpoint != nullptr) {
@@ -229,7 +228,7 @@ void Chttp2Connector::OnTimeout(void* arg, grpc_error_handle /*error*/) {
       // SubchannelConnector::Result::Reset()
       grpc_transport_destroy(self->result_->transport);
       self->result_->Reset();
-      self->MaybeNotify(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      self->MaybeNotify(GRPC_ERROR_CREATE(
           "connection attempt timed out before receiving SETTINGS frame"));
     } else {
       // OnReceiveSettings() was already invoked. Call Notify() again so that

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -104,7 +104,7 @@ grpc_core::Poll<grpc_error_handle> grpc_deframe_unprocessed_incoming_frames(
       }
       break;
     default:
-      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      error = GRPC_ERROR_CREATE(
           absl::StrFormat("Bad GRPC frame type 0x%02x", header[0]));
       error = grpc_error_set_int(error, grpc_core::StatusIntProperty::kStreamId,
                                  static_cast<intptr_t>(s->id));
@@ -147,9 +147,9 @@ grpc_error_handle grpc_chttp2_data_parser_parse(void* /*parser*/,
   if (is_last && s->received_last_frame) {
     grpc_chttp2_mark_stream_closed(
         t, s, true, false,
-        t->is_client ? GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                           "Data frame with END_STREAM flag received")
-                     : absl::OkStatus());
+        t->is_client
+            ? GRPC_ERROR_CREATE("Data frame with END_STREAM flag received")
+            : absl::OkStatus());
   }
 
   return absl::OkStatus();

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -44,7 +44,7 @@ void grpc_chttp2_goaway_parser_destroy(grpc_chttp2_goaway_parser* p) {
 grpc_error_handle grpc_chttp2_goaway_parser_begin_frame(
     grpc_chttp2_goaway_parser* p, uint32_t length, uint8_t /*flags*/) {
   if (length < 8) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    return GRPC_ERROR_CREATE(
         absl::StrFormat("goaway frame too short (%d bytes)", length));
   }
 
@@ -149,8 +149,7 @@ grpc_error_handle grpc_chttp2_goaway_parser_parse(void* parser,
       }
       return absl::OkStatus();
   }
-  GPR_UNREACHABLE_CODE(
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Should never reach here"));
+  GPR_UNREACHABLE_CODE(return GRPC_ERROR_CREATE("Should never reach here"));
 }
 
 void grpc_chttp2_goaway_append(uint32_t last_stream_id, uint32_t error_code,

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -64,7 +64,7 @@ grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
 grpc_error_handle grpc_chttp2_ping_parser_begin_frame(
     grpc_chttp2_ping_parser* parser, uint32_t length, uint8_t flags) {
   if (flags & 0xfe || length != 8) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    return GRPC_ERROR_CREATE(
         absl::StrFormat("invalid ping: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -77,7 +77,7 @@ void grpc_chttp2_add_rst_stream_to_next_write(
 grpc_error_handle grpc_chttp2_rst_stream_parser_begin_frame(
     grpc_chttp2_rst_stream_parser* parser, uint32_t length, uint8_t flags) {
   if (length != 4) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    return GRPC_ERROR_CREATE(absl::StrFormat(
         "invalid rst_stream: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;
@@ -117,7 +117,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
     if (reason != GRPC_HTTP2_NO_ERROR || s->trailing_metadata_buffer.empty()) {
       error = grpc_error_set_int(
           grpc_error_set_str(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING("RST_STREAM"),
+              GRPC_ERROR_CREATE("RST_STREAM"),
               grpc_core::StatusStrProperty::kGrpcMessage,
               absl::StrCat("Received RST_STREAM with error code ", reason)),
           grpc_core::StatusIntProperty::kHttp2Error,

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -103,16 +103,13 @@ grpc_error_handle grpc_chttp2_settings_parser_begin_frame(
   if (flags == GRPC_CHTTP2_FLAG_ACK) {
     parser->is_ack = 1;
     if (length != 0) {
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "non-empty settings ack frame received");
+      return GRPC_ERROR_CREATE("non-empty settings ack frame received");
     }
     return absl::OkStatus();
   } else if (flags != 0) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "invalid flags on settings frame");
+    return GRPC_ERROR_CREATE("invalid flags on settings frame");
   } else if (length % 6 != 0) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "settings frames must be a multiple of six bytes");
+    return GRPC_ERROR_CREATE("settings frames must be a multiple of six bytes");
   } else {
     return absl::OkStatus();
   }
@@ -213,7 +210,7 @@ grpc_error_handle grpc_chttp2_settings_parser_parse(void* p,
                     t->last_new_stream_id, sp->error_value,
                     grpc_slice_from_static_string("HTTP2 settings error"),
                     &t->qbuf);
-                return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+                return GRPC_ERROR_CREATE(absl::StrFormat(
                     "invalid value %u passed for %s", parser->value, sp->name));
             }
           }

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -60,7 +60,7 @@ grpc_slice grpc_chttp2_window_update_create(
 grpc_error_handle grpc_chttp2_window_update_parser_begin_frame(
     grpc_chttp2_window_update_parser* parser, uint32_t length, uint8_t flags) {
   if (flags || length != 4) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    return GRPC_ERROR_CREATE(absl::StrFormat(
         "invalid window update: length=%d, flags=%02x", length, flags));
   }
   parser->byte = 0;
@@ -91,7 +91,7 @@ grpc_error_handle grpc_chttp2_window_update_parser_parse(
     // top bit is reserved and must be ignored.
     uint32_t received_update = p->amount & 0x7fffffffu;
     if (received_update == 0) {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      return GRPC_ERROR_CREATE(
           absl::StrCat("invalid window update bytes: ", p->amount));
     }
     GPR_ASSERT(is_last);

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -633,7 +633,7 @@ class HPackParser::Input {
                                                  uint8_t last_byte) {
     return MaybeSetErrorAndReturn(
         [value, last_byte] {
-          return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+          return GRPC_ERROR_CREATE(absl::StrFormat(
               "integer overflow in hpack integer decoding: have 0x%08x, "
               "got byte 0x%02x on byte 5",
               value, last_byte));
@@ -831,10 +831,7 @@ class HPackParser::String {
     }
     if (!result.has_value()) {
       return input->MaybeSetErrorAndReturn(
-          [] {
-            return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                "illegal base64 encoding");
-          },
+          [] { return GRPC_ERROR_CREATE("illegal base64 encoding"); },
           absl::optional<String>());
     }
     return String(std::move(*result));
@@ -1016,11 +1013,7 @@ class HPackParser::Parser {
         if (cur == 0x80) {
           // illegal value.
           return input_->MaybeSetErrorAndReturn(
-              [] {
-                return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                    "Illegal hpack op code");
-              },
-              false);
+              [] { return GRPC_ERROR_CREATE("Illegal hpack op code"); }, false);
         }
         ABSL_FALLTHROUGH_INTENDED;
       case 9:
@@ -1172,7 +1165,7 @@ class HPackParser::Parser {
     if (*dynamic_table_updates_allowed_ == 0) {
       return input_->MaybeSetErrorAndReturn(
           [] {
-            return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+            return GRPC_ERROR_CREATE(
                 "More than two max table size changes in a single frame");
           },
           false);
@@ -1193,10 +1186,9 @@ class HPackParser::Parser {
     return input_->MaybeSetErrorAndReturn(
         [this, index] {
           return grpc_error_set_int(
-              grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                     "Invalid HPACK index received"),
-                                 StatusIntProperty::kIndex,
-                                 static_cast<intptr_t>(index)),
+              grpc_error_set_int(
+                  GRPC_ERROR_CREATE("Invalid HPACK index received"),
+                  StatusIntProperty::kIndex, static_cast<intptr_t>(index)),
               StatusIntProperty::kSize,
               static_cast<intptr_t>(this->table_->num_entries()));
         },
@@ -1214,8 +1206,7 @@ class HPackParser::Parser {
     return input_->MaybeSetErrorAndReturn(
         [] {
           return grpc_error_set_int(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                  "received initial metadata size exceeds limit"),
+              GRPC_ERROR_CREATE("received initial metadata size exceeds limit"),
               StatusIntProperty::kRpcStatus, GRPC_STATUS_RESOURCE_EXHAUSTED);
         },
         false);
@@ -1289,7 +1280,7 @@ grpc_error_handle HPackParser::ParseInput(Input input, bool is_last) {
   }
   if (input.eof_error()) {
     if (GPR_UNLIKELY(is_last && is_boundary())) {
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      return GRPC_ERROR_CREATE(
           "Incomplete header at the end of a header/continuation sequence");
     }
     unparsed_bytes_ = std::vector<uint8_t>(input.frontier(), input.end_ptr());
@@ -1365,8 +1356,7 @@ grpc_error_handle grpc_chttp2_header_parser_parse(void* hpack_parser,
     if (s != nullptr) {
       if (parser->is_boundary()) {
         if (s->header_frames_received == 2) {
-          return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-              "Too many trailer frames");
+          return GRPC_ERROR_CREATE("Too many trailer frames");
         }
         s->published_metadata[s->header_frames_received] =
             GRPC_METADATA_PUBLISHED_FROM_WIRE;

--- a/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser_table.cc
@@ -104,7 +104,7 @@ grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
     return absl::OkStatus();
   }
   if (bytes > max_bytes_) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    return GRPC_ERROR_CREATE(absl::StrFormat(
         "Attempt to make hpack table %d bytes when max is %d bytes", bytes,
         max_bytes_));
   }
@@ -123,7 +123,7 @@ grpc_error_handle HPackTable::SetCurrentTableSize(uint32_t bytes) {
 
 grpc_error_handle HPackTable::Add(Memento md) {
   if (current_table_bytes_ > max_bytes_) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    return GRPC_ERROR_CREATE(absl::StrFormat(
         "HPACK max table size reduced to %d but not reflected by hpack "
         "stream (still at %d)",
         max_bytes_, current_table_bytes_));

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -319,7 +319,7 @@ static void read_grpc_header(stream_obj* s) {
 static grpc_error_handle make_error_with_desc(int error_code,
                                               int cronet_internal_error_code,
                                               const char* desc) {
-  return grpc_error_set_int(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+  return grpc_error_set_int(GRPC_ERROR_CREATE(absl::StrFormat(
                                 "Cronet error code:%d, Cronet error detail:%s",
                                 cronet_internal_error_code, desc)),
                             grpc_core::StatusIntProperty::kRpcStatus,

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -627,7 +627,7 @@ void op_state_machine_locked(inproc_stream* s, grpc_error_handle error) {
     if (*destfilled || s->trailing_md_sent) {
       // The buffer is already in use; that's an error!
       INPROC_LOG(GPR_INFO, "Extra trailing metadata %p", s);
-      new_err = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Extra trailing metadata");
+      new_err = GRPC_ERROR_CREATE("Extra trailing metadata");
       fail_helper_locked(s, new_err);
       goto done;
     } else {
@@ -666,8 +666,7 @@ void op_state_machine_locked(inproc_stream* s, grpc_error_handle error) {
   }
   if (s->recv_initial_md_op) {
     if (s->initial_md_recvd) {
-      new_err =
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("Already recvd initial md");
+      new_err = GRPC_ERROR_CREATE("Already recvd initial md");
       INPROC_LOG(
           GPR_INFO,
           "op_state_machine %p scheduling on_complete errors for already "
@@ -724,8 +723,7 @@ void op_state_machine_locked(inproc_stream* s, grpc_error_handle error) {
         s->to_read_trailing_md_filled = false;
         s->trailing_md_recvd_implicit_only = false;
       } else {
-        new_err =
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Already recvd trailing md");
+        new_err = GRPC_ERROR_CREATE("Already recvd trailing md");
         INPROC_LOG(
             GPR_INFO,
             "op_state_machine %p scheduling on_complete errors for already "
@@ -961,7 +959,7 @@ void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
   inproc_stream* other = s->other_side;
   if (error.ok() && (op->send_initial_metadata || op->send_trailing_metadata)) {
     if (s->t->is_closed) {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Endpoint already shutdown");
+      error = GRPC_ERROR_CREATE("Endpoint already shutdown");
     }
     if (error.ok() && op->send_initial_metadata) {
       grpc_metadata_batch* dest = (other == nullptr)
@@ -972,7 +970,7 @@ void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
       if (*destfilled || s->initial_md_sent) {
         // The buffer is already in use; that's an error!
         INPROC_LOG(GPR_INFO, "Extra initial metadata %p", s);
-        error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Extra initial metadata");
+        error = GRPC_ERROR_CREATE("Extra initial metadata");
       } else {
         if (!s->other_side_closed) {
           fill_in_metadata(
@@ -1100,10 +1098,9 @@ void close_transport_locked(inproc_transport* t) {
       // cancel_stream_locked also adjusts stream list
       cancel_stream_locked(
           t->stream_list,
-          grpc_error_set_int(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING("Transport closed"),
-              grpc_core::StatusIntProperty::kRpcStatus,
-              GRPC_STATUS_UNAVAILABLE));
+          grpc_error_set_int(GRPC_ERROR_CREATE("Transport closed"),
+                             grpc_core::StatusIntProperty::kRpcStatus,
+                             GRPC_STATUS_UNAVAILABLE));
     }
   }
 }

--- a/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
+++ b/src/core/ext/xds/file_watcher_certificate_provider_factory.cc
@@ -76,8 +76,7 @@ FileWatcherCertificateProviderFactory::Config::Parse(const Json& config_json,
                                                      grpc_error_handle* error) {
   auto config = MakeRefCounted<FileWatcherCertificateProviderFactory::Config>();
   if (config_json.type() != Json::Type::OBJECT) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "error:config type should be OBJECT.");
+    *error = GRPC_ERROR_CREATE("error:config type should be OBJECT.");
     return nullptr;
   }
   std::vector<grpc_error_handle> error_list;
@@ -87,14 +86,14 @@ FileWatcherCertificateProviderFactory::Config::Parse(const Json& config_json,
                        &config->private_key_file_, &error_list, false);
   if (config->identity_cert_file_.empty() !=
       config->private_key_file_.empty()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "fields \"certificate_file\" and \"private_key_file\" must be both set "
         "or both unset."));
   }
   ParseJsonObjectField(config_json.object_value(), "ca_certificate_file",
                        &config->root_cert_file_, &error_list, false);
   if (config->identity_cert_file_.empty() && config->root_cert_file_.empty()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         "At least one of \"certificate_file\" and \"ca_certificate_file\" must "
         "be specified."));
   }

--- a/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.cc
+++ b/src/core/ext/xds/google_mesh_ca_certificate_provider_factory.cc
@@ -112,7 +112,7 @@ GoogleMeshCaCertificateProviderFactory::Config::ParseJsonObjectGoogleGrpc(
   if (ParseJsonObjectField(google_grpc, "call_credentials",
                            &call_credentials_array, &error_list_google_grpc)) {
     if (call_credentials_array->size() != 1) {
-      error_list_google_grpc.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list_google_grpc.push_back(GRPC_ERROR_CREATE(
           "field:call_credentials error:Need exactly one entry."));
     } else {
       const Json::Object* call_credentials = nullptr;
@@ -160,15 +160,15 @@ GoogleMeshCaCertificateProviderFactory::Config::ParseJsonObjectServer(
   if (ParseJsonObjectField(server, "api_type", &api_type, &error_list_server,
                            false)) {
     if (api_type != "GRPC") {
-      error_list_server.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "field:api_type error:Only GRPC is supported"));
+      error_list_server.push_back(
+          GRPC_ERROR_CREATE("field:api_type error:Only GRPC is supported"));
     }
   }
   const Json::Array* grpc_services = nullptr;
   if (ParseJsonObjectField(server, "grpc_services", &grpc_services,
                            &error_list_server)) {
     if (grpc_services->size() != 1) {
-      error_list_server.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error_list_server.push_back(GRPC_ERROR_CREATE(
           "field:grpc_services error:Need exactly one entry"));
     } else {
       const Json::Object* grpc_service = nullptr;
@@ -192,8 +192,7 @@ GoogleMeshCaCertificateProviderFactory::Config::Parse(
   auto config =
       MakeRefCounted<GoogleMeshCaCertificateProviderFactory::Config>();
   if (config_json.type() != Json::Type::OBJECT) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "error:config type should be OBJECT.");
+    *error = GRPC_ERROR_CREATE("error:config type should be OBJECT.");
     return nullptr;
   }
   std::vector<grpc_error_handle> error_list;
@@ -221,8 +220,8 @@ GoogleMeshCaCertificateProviderFactory::Config::Parse(
   if (ParseJsonObjectField(config_json.object_value(), "key_type", &key_type,
                            &error_list, false)) {
     if (key_type != "RSA") {
-      error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "field:key_type error:Only RSA is supported."));
+      error_list.push_back(
+          GRPC_ERROR_CREATE("field:key_type error:Only RSA is supported."));
     }
   }
   if (!ParseJsonObjectField(config_json.object_value(), "key_size",

--- a/src/core/ext/xds/xds_certificate_provider.cc
+++ b/src/core/ext/xds/xds_certificate_provider.cc
@@ -146,7 +146,7 @@ void XdsCertificateProvider::ClusterCertificateState::
       root_cert_watcher_ = nullptr;
       xds_certificate_provider_->distributor_->SetErrorForCert(
           "",
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          GRPC_ERROR_CREATE(
               "No certificate provider available for root certificates"),
           absl::nullopt);
     }
@@ -177,7 +177,7 @@ void XdsCertificateProvider::ClusterCertificateState::
       identity_cert_watcher_ = nullptr;
       xds_certificate_provider_->distributor_->SetErrorForCert(
           "", absl::nullopt,
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          GRPC_ERROR_CREATE(
               "No certificate provider available for identity certificates"));
     }
   }
@@ -219,7 +219,7 @@ void XdsCertificateProvider::ClusterCertificateState::WatchStatusCallback(
     if (root_cert_distributor_ == nullptr) {
       xds_certificate_provider_->distributor_->SetErrorForCert(
           cert_name,
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          GRPC_ERROR_CREATE(
               "No certificate provider available for root certificates"),
           absl::nullopt);
     } else {
@@ -239,7 +239,7 @@ void XdsCertificateProvider::ClusterCertificateState::WatchStatusCallback(
     if (identity_cert_distributor_ == nullptr) {
       xds_certificate_provider_->distributor_->SetErrorForCert(
           cert_name, absl::nullopt,
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          GRPC_ERROR_CREATE(
               "No certificate provider available for identity certificates"));
     } else {
       UpdateIdentityCertWatcher(cert_name, identity_cert_distributor_.get());

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -449,7 +449,7 @@ HttpConnectionManagerParse(
           envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_rds(
               http_connection_manager_proto);
       if (rds == nullptr) {
-        return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        return GRPC_ERROR_CREATE(
             "HttpConnectionManager neither has inlined route_config nor RDS.");
       }
       // Check that the ConfigSource specifies ADS.

--- a/src/core/ext/xds/xds_server_config_fetcher.cc
+++ b/src/core/ext/xds/xds_server_config_fetcher.cc
@@ -1181,14 +1181,13 @@ ServerConfigSelector::CallConfig XdsServerConfigFetcher::ListenerWatcher::
         grpc_metadata_batch* metadata) {
   CallConfig call_config;
   if (metadata->get_pointer(HttpPathMetadata()) == nullptr) {
-    call_config.error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("No path found");
+    call_config.error = GRPC_ERROR_CREATE("No path found");
     return call_config;
   }
   absl::string_view path =
       metadata->get_pointer(HttpPathMetadata())->as_string_view();
   if (metadata->get_pointer(HttpAuthorityMetadata()) == nullptr) {
-    call_config.error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("No authority found");
+    call_config.error = GRPC_ERROR_CREATE("No authority found");
     return call_config;
   }
   absl::string_view authority =
@@ -1197,9 +1196,8 @@ ServerConfigSelector::CallConfig XdsServerConfigFetcher::ListenerWatcher::
       VirtualHostListIterator(&virtual_hosts_), authority);
   if (!vhost_index.has_value()) {
     call_config.error = grpc_error_set_int(
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(
-            absl::StrCat("could not find VirtualHost for ", authority,
-                         " in RouteConfiguration")),
+        GRPC_ERROR_CREATE(absl::StrCat("could not find VirtualHost for ",
+                                       authority, " in RouteConfiguration")),
         StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
     return call_config;
   }
@@ -1211,8 +1209,7 @@ ServerConfigSelector::CallConfig XdsServerConfigFetcher::ListenerWatcher::
     // Found the matching route
     if (route.unsupported_action) {
       call_config.error = grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-              "Matching route has unsupported action"),
+          GRPC_ERROR_CREATE("Matching route has unsupported action"),
           StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
       return call_config;
     }
@@ -1223,9 +1220,9 @@ ServerConfigSelector::CallConfig XdsServerConfigFetcher::ListenerWatcher::
     }
     return call_config;
   }
-  call_config.error = grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("No route matched"),
-      StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
+  call_config.error = grpc_error_set_int(GRPC_ERROR_CREATE("No route matched"),
+                                         StatusIntProperty::kRpcStatus,
+                                         GRPC_STATUS_UNAVAILABLE);
   return call_config;
 }
 

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -84,7 +84,7 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
       reinterpret_cast<struct sockaddr_un*>(resolved_addr->addr);
   const size_t maxlen = sizeof(un->sun_path) - 1;
   if (path.size() > maxlen) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+    return GRPC_ERROR_CREATE(absl::StrCat(
         "Path name should not have more than ", maxlen, " characters"));
   }
   un->sun_family = AF_UNIX;
@@ -101,7 +101,7 @@ grpc_error_handle UnixAbstractSockaddrPopulate(
       reinterpret_cast<struct sockaddr_un*>(resolved_addr->addr);
   const size_t maxlen = sizeof(un->sun_path) - 1;
   if (path.size() > maxlen) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+    return GRPC_ERROR_CREATE(absl::StrCat(
         "Path name should not have more than ", maxlen, " characters"));
   }
   un->sun_family = AF_UNIX;

--- a/src/core/lib/channel/connected_channel.cc
+++ b/src/core/lib/channel/connected_channel.cc
@@ -195,8 +195,7 @@ static grpc_error_handle connected_channel_init_call_elem(
       chand->transport, TRANSPORT_STREAM_FROM_CALL_DATA(calld),
       &args->call_stack->refcount, args->server_transport_data, args->arena);
   return r == 0 ? absl::OkStatus()
-                : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                      "transport stream initialization failed");
+                : GRPC_ERROR_CREATE("transport stream initialization failed");
 }
 
 static void set_pollset_or_pollset_set(grpc_call_element* elem,

--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -345,8 +345,7 @@ class ClientCallData::PollContext {
             GPR_ASSERT(*md->get_pointer(GrpcStatusMetadata()) !=
                        GRPC_STATUS_OK);
             grpc_error_handle error = grpc_error_set_int(
-                GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                    "early return from promise based filter"),
+                GRPC_ERROR_CREATE("early return from promise based filter"),
                 StatusIntProperty::kRpcStatus,
                 *md->get_pointer(GrpcStatusMetadata()));
             if (auto* message = md->get_pointer(GrpcMessageMetadata())) {
@@ -1221,11 +1220,10 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
           break;
         case SendTrailingState::kInitial: {
           GPR_ASSERT(*md->get_pointer(GrpcStatusMetadata()) != GRPC_STATUS_OK);
-          grpc_error_handle error =
-              grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                     "early return from promise based filter"),
-                                 StatusIntProperty::kRpcStatus,
-                                 *md->get_pointer(GrpcStatusMetadata()));
+          grpc_error_handle error = grpc_error_set_int(
+              GRPC_ERROR_CREATE("early return from promise based filter"),
+              StatusIntProperty::kRpcStatus,
+              *md->get_pointer(GrpcStatusMetadata()));
           if (auto* message = md->get_pointer(GrpcMessageMetadata())) {
             error = grpc_error_set_str(error, StatusStrProperty::kGrpcMessage,
                                        message->as_string_view());

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -223,18 +223,16 @@ void HttpRequest::Orphan() {
     // cancel potentially pending DNS resolution.
     if (dns_request_handle_.has_value() &&
         resolver_->Cancel(dns_request_handle_.value())) {
-      Finish(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "cancelled during DNS resolution"));
+      Finish(GRPC_ERROR_CREATE("cancelled during DNS resolution"));
       Unref();
     }
     if (handshake_mgr_ != nullptr) {
       // Shutdown will cancel any ongoing tcp connect.
-      handshake_mgr_->Shutdown(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "HTTP request cancelled during handshake"));
+      handshake_mgr_->Shutdown(
+          GRPC_ERROR_CREATE("HTTP request cancelled during handshake"));
     }
     if (own_endpoint_ && ep_ != nullptr) {
-      grpc_endpoint_shutdown(
-          ep_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("HTTP request cancelled"));
+      grpc_endpoint_shutdown(ep_, GRPC_ERROR_CREATE("HTTP request cancelled"));
     }
   }
   Unref();
@@ -242,8 +240,7 @@ void HttpRequest::Orphan() {
 
 void HttpRequest::AppendError(grpc_error_handle error) {
   if (overall_error_.ok()) {
-    overall_error_ =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed HTTP/1 client request");
+    overall_error_ = GRPC_ERROR_CREATE("Failed HTTP/1 client request");
   }
   const grpc_resolved_address* addr = &addresses_[next_address_ - 1];
   auto addr_text = grpc_sockaddr_to_uri(addr);
@@ -267,8 +264,8 @@ void HttpRequest::OnReadInternal(grpc_error_handle error) {
     }
   }
   if (cancelled_) {
-    Finish(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "HTTP1 request cancelled during read", &overall_error_, 1));
+    Finish(GRPC_ERROR_CREATE_REFERENCING("HTTP1 request cancelled during read",
+                                         &overall_error_, 1));
   } else if (error.ok()) {
     DoRead();
   } else if (!have_read_byte_) {
@@ -318,8 +315,8 @@ void HttpRequest::OnHandshakeDone(void* arg, grpc_error_handle error) {
   req->ep_ = args->endpoint;
   req->handshake_mgr_.reset();
   if (req->cancelled_) {
-    req->NextAddress(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "HTTP request cancelled during handshake"));
+    req->NextAddress(
+        GRPC_ERROR_CREATE("HTTP request cancelled during handshake"));
     return;
   }
   req->StartWrite();
@@ -332,14 +329,14 @@ void HttpRequest::DoHandshake(const grpc_resolved_address* addr) {
       channel_creds_->create_security_connector(
           nullptr /*call_creds*/, uri_.authority().c_str(), &args);
   if (sc == nullptr) {
-    Finish(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "failed to create security connector", &overall_error_, 1));
+    Finish(GRPC_ERROR_CREATE_REFERENCING("failed to create security connector",
+                                         &overall_error_, 1));
     return;
   }
   absl::StatusOr<std::string> address = grpc_sockaddr_to_uri(addr);
   if (!address.ok()) {
-    Finish(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "Failed to extract URI from address", &overall_error_, 1));
+    Finish(GRPC_ERROR_CREATE_REFERENCING("Failed to extract URI from address",
+                                         &overall_error_, 1));
     return;
   }
   args = args.SetObject(std::move(sc))
@@ -362,13 +359,13 @@ void HttpRequest::NextAddress(grpc_error_handle error) {
     AppendError(error);
   }
   if (cancelled_) {
-    Finish(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "HTTP request was cancelled", &overall_error_, 1));
+    Finish(GRPC_ERROR_CREATE_REFERENCING("HTTP request was cancelled",
+                                         &overall_error_, 1));
     return;
   }
   if (next_address_ == addresses_.size()) {
-    Finish(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "Failed HTTP requests to all targets", &overall_error_, 1));
+    Finish(GRPC_ERROR_CREATE_REFERENCING("Failed HTTP requests to all targets",
+                                         &overall_error_, 1));
     return;
   }
   const grpc_resolved_address* addr = &addresses_[next_address_++];
@@ -381,8 +378,7 @@ void HttpRequest::OnResolved(
   MutexLock lock(&mu_);
   dns_request_handle_.reset();
   if (cancelled_) {
-    Finish(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "cancelled during DNS resolution"));
+    Finish(GRPC_ERROR_CREATE("cancelled during DNS resolution"));
     return;
   }
   if (!addresses_or.ok()) {

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -114,8 +114,8 @@ class grpc_httpcli_ssl_channel_security_connector final
     /* Check the peer name. */
     if (secure_peer_name_ != nullptr &&
         !tsi_ssl_peer_matches_name(&peer, secure_peer_name_)) {
-      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
-          "Peer name ", secure_peer_name_, " is not in peer certificate"));
+      error = GRPC_ERROR_CREATE(absl::StrCat("Peer name ", secure_peer_name_,
+                                             " is not in peer certificate"));
     }
     ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
     tsi_peer_destruct(&peer);

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -44,46 +44,45 @@ static grpc_error_handle handle_response_line(grpc_http_parser* parser) {
   uint8_t* end = beg + parser->cur_line_length;
 
   if (cur == end || *cur++ != 'H') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'H'");
+    return GRPC_ERROR_CREATE("Expected 'H'");
   }
   if (cur == end || *cur++ != 'T') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
+    return GRPC_ERROR_CREATE("Expected 'T'");
   }
   if (cur == end || *cur++ != 'T') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
+    return GRPC_ERROR_CREATE("Expected 'T'");
   }
   if (cur == end || *cur++ != 'P') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'P'");
+    return GRPC_ERROR_CREATE("Expected 'P'");
   }
   if (cur == end || *cur++ != '/') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '/'");
+    return GRPC_ERROR_CREATE("Expected '/'");
   }
   if (cur == end || *cur++ != '1') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '1'");
+    return GRPC_ERROR_CREATE("Expected '1'");
   }
   if (cur == end || *cur++ != '.') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '.'");
+    return GRPC_ERROR_CREATE("Expected '.'");
   }
   if (cur == end || *cur < '0' || *cur++ > '1') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Expected HTTP/1.0 or HTTP/1.1");
+    return GRPC_ERROR_CREATE("Expected HTTP/1.0 or HTTP/1.1");
   }
   if (cur == end || *cur++ != ' ') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected ' '");
+    return GRPC_ERROR_CREATE("Expected ' '");
   }
   if (cur == end || *cur < '1' || *cur++ > '9') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
+    return GRPC_ERROR_CREATE("Expected status code");
   }
   if (cur == end || *cur < '0' || *cur++ > '9') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
+    return GRPC_ERROR_CREATE("Expected status code");
   }
   if (cur == end || *cur < '0' || *cur++ > '9') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
+    return GRPC_ERROR_CREATE("Expected status code");
   }
   parser->http.response->status =
       (cur[-3] - '0') * 100 + (cur[-2] - '0') * 10 + (cur[-1] - '0');
   if (cur == end || *cur++ != ' ') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected ' '");
+    return GRPC_ERROR_CREATE("Expected ' '");
   }
 
   /* we don't really care about the status code message */
@@ -101,8 +100,7 @@ static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
   while (cur != end && *cur++ != ' ') {
   }
   if (cur == end) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "No method on HTTP request line");
+    return GRPC_ERROR_CREATE("No method on HTTP request line");
   }
   parser->http.request->method =
       buf2str(beg, static_cast<size_t>(cur - beg - 1));
@@ -111,30 +109,29 @@ static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
   while (cur != end && *cur++ != ' ') {
   }
   if (cur == end) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No path on HTTP request line");
+    return GRPC_ERROR_CREATE("No path on HTTP request line");
   }
   parser->http.request->path = buf2str(beg, static_cast<size_t>(cur - beg - 1));
 
   if (cur == end || *cur++ != 'H') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'H'");
+    return GRPC_ERROR_CREATE("Expected 'H'");
   }
   if (cur == end || *cur++ != 'T') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
+    return GRPC_ERROR_CREATE("Expected 'T'");
   }
   if (cur == end || *cur++ != 'T') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
+    return GRPC_ERROR_CREATE("Expected 'T'");
   }
   if (cur == end || *cur++ != 'P') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'P'");
+    return GRPC_ERROR_CREATE("Expected 'P'");
   }
   if (cur == end || *cur++ != '/') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '/'");
+    return GRPC_ERROR_CREATE("Expected '/'");
   }
   vers_major = static_cast<uint8_t>(*cur++ - '1' + 1);
   ++cur;
   if (cur == end) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "End of line in HTTP version string");
+    return GRPC_ERROR_CREATE("End of line in HTTP version string");
   }
   vers_minor = static_cast<uint8_t>(*cur++ - '1' + 1);
 
@@ -144,19 +141,18 @@ static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
     } else if (vers_minor == 1) {
       parser->http.request->version = GRPC_HTTP_HTTP11;
     } else {
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      return GRPC_ERROR_CREATE(
           "Expected one of HTTP/1.0, HTTP/1.1, or HTTP/2.0");
     }
   } else if (vers_major == 2) {
     if (vers_minor == 0) {
       parser->http.request->version = GRPC_HTTP_HTTP20;
     } else {
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      return GRPC_ERROR_CREATE(
           "Expected one of HTTP/1.0, HTTP/1.1, or HTTP/2.0");
     }
   } else {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Expected one of HTTP/1.0, HTTP/1.1, or HTTP/2.0");
+    return GRPC_ERROR_CREATE("Expected one of HTTP/1.0, HTTP/1.1, or HTTP/2.0");
   }
 
   return absl::OkStatus();
@@ -169,8 +165,7 @@ static grpc_error_handle handle_first_line(grpc_http_parser* parser) {
     case GRPC_HTTP_RESPONSE:
       return handle_response_line(parser);
   }
-  GPR_UNREACHABLE_CODE(
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Should never reach here"));
+  GPR_UNREACHABLE_CODE(return GRPC_ERROR_CREATE("Should never reach here"));
 }
 
 static grpc_error_handle add_header(grpc_http_parser* parser) {
@@ -186,8 +181,7 @@ static grpc_error_handle add_header(grpc_http_parser* parser) {
   GPR_ASSERT(cur != end);
 
   if (*cur == ' ' || *cur == '\t') {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Continued header lines not supported yet");
+    error = GRPC_ERROR_CREATE("Continued header lines not supported yet");
     goto done;
   }
 
@@ -195,8 +189,7 @@ static grpc_error_handle add_header(grpc_http_parser* parser) {
     cur++;
   }
   if (cur == end) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Didn't find ':' in header string");
+    error = GRPC_ERROR_CREATE("Didn't find ':' in header string");
     goto done;
   }
   GPR_ASSERT(cur >= beg);
@@ -272,8 +265,7 @@ static grpc_error_handle finish_line(grpc_http_parser* parser,
       break;
     case GRPC_HTTP_BODY:
     case GRPC_HTTP_END:
-      GPR_UNREACHABLE_CODE(return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Should never reach here"));
+      GPR_UNREACHABLE_CODE(return GRPC_ERROR_CREATE("Should never reach here"));
   }
 
   parser->cur_line_length = 0;
@@ -300,8 +292,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
           parser->http.response->chunk_length *= 16;
           parser->http.response->chunk_length += byte - 'A' + 10;
         } else {
-          return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-              "Expected chunk size in hexadecimal");
+          return GRPC_ERROR_CREATE("Expected chunk size in hexadecimal");
         }
         return absl::OkStatus();
       case GRPC_HTTP_CHUNKED_IGNORE_ALL_UNTIL_LF:
@@ -316,8 +307,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
       case GRPC_HTTP_CHUNKED_BODY:
         if (parser->http.response->chunk_length == 0) {
           if (byte != '\r') {
-            return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                "Expected '\\r\\n' after chunk body");
+            return GRPC_ERROR_CREATE("Expected '\\r\\n' after chunk body");
           }
           parser->http.response->chunked_state = GRPC_HTTP_CHUNKED_CONSUME_LF;
           parser->http.response->chunk_length = 0;
@@ -329,8 +319,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
         break;
       case GRPC_HTTP_CHUNKED_CONSUME_LF:
         if (byte != '\n') {
-          return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-              "Expected '\\r\\n' after chunk body");
+          return GRPC_ERROR_CREATE("Expected '\\r\\n' after chunk body");
         }
         parser->http.response->chunked_state = GRPC_HTTP_CHUNKED_LENGTH;
         return absl::OkStatus();
@@ -344,8 +333,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
     body_length = &parser->http.request->body_length;
     body = &parser->http.request->body;
   } else {
-    GPR_UNREACHABLE_CODE(
-        return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Should never reach here"));
+    GPR_UNREACHABLE_CODE(return GRPC_ERROR_CREATE("Should never reach here"));
   }
 
   if (*body_length == parser->body_capacity) {
@@ -393,8 +381,7 @@ static grpc_error_handle addbyte(grpc_http_parser* parser, uint8_t byte,
           gpr_log(GPR_ERROR, "HTTP header max line length (%d) exceeded",
                   GRPC_HTTP_PARSER_MAX_HEADER_LENGTH);
         }
-        return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "HTTP header max line length exceeded");
+        return GRPC_ERROR_CREATE("HTTP header max line length exceeded");
       }
       parser->cur_line[parser->cur_line_length] = byte;
       parser->cur_line_length++;
@@ -405,7 +392,7 @@ static grpc_error_handle addbyte(grpc_http_parser* parser, uint8_t byte,
     case GRPC_HTTP_BODY:
       return addbyte_body(parser, byte);
     case GRPC_HTTP_END:
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Unexpected byte after end");
+      return GRPC_ERROR_CREATE("Unexpected byte after end");
   }
   GPR_UNREACHABLE_CODE(return absl::OkStatus());
 }
@@ -458,7 +445,7 @@ grpc_error_handle grpc_http_parser_parse(grpc_http_parser* parser,
 
 grpc_error_handle grpc_http_parser_eof(grpc_http_parser* parser) {
   if ((parser->state != GRPC_HTTP_BODY) && (parser->state != GRPC_HTTP_END)) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Did not finish headers");
+    return GRPC_ERROR_CREATE("Did not finish headers");
   }
   return absl::OkStatus();
 }

--- a/src/core/lib/iomgr/endpoint_cfstream.cc
+++ b/src/core/lib/iomgr/endpoint_cfstream.cc
@@ -168,15 +168,14 @@ static void ReadAction(void* arg, grpc_error_handle error) {
           GRPC_ERROR_CREATE_FROM_CFERROR(stream_error, "Read error"), ep);
       CFRelease(stream_error);
     } else {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Read error");
+      error = GRPC_ERROR_CREATE("Read error");
     }
     CallReadCb(ep, error);
     EP_UNREF(ep, "read");
   } else if (read_size == 0) {
     grpc_slice_buffer_reset_and_unref(ep->read_slices);
     CallReadCb(ep,
-               CFStreamAnnotateError(
-                   GRPC_ERROR_CREATE_FROM_STATIC_STRING("Socket closed"), ep));
+               CFStreamAnnotateError(GRPC_ERROR_CREATE("Socket closed"), ep));
     EP_UNREF(ep, "read");
   } else {
     if (read_size < static_cast<CFIndex>(len)) {
@@ -208,7 +207,7 @@ static void WriteAction(void* arg, grpc_error_handle error) {
           GRPC_ERROR_CREATE_FROM_CFERROR(stream_error, "write failed."), ep);
       CFRelease(stream_error);
     } else {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("write failed.");
+      error = GRPC_ERROR_CREATE("write failed.");
     }
     CallWriteCb(ep, error);
     EP_UNREF(ep, "write");

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -148,28 +148,34 @@ void grpc_enable_error_creation();
 
 #define GRPC_ERROR_IS_NONE(err) (err).ok()
 
-#define GRPC_ERROR_CREATE_FROM_STATIC_STRING(desc) \
+#define GRPC_ERROR_CREATE(desc) \
   StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
-#define GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc) \
-  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
-#define GRPC_ERROR_CREATE_FROM_CPP_STRING(desc) \
-  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
-#define GRPC_ERROR_CREATE_FROM_STRING_VIEW(desc) \
-  StatusCreate(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, {})
+
+// Deprecated: Please do not use these macros. begin
+// TODO(veblush): Remove this once migration is done.
+#define GRPC_ERROR_CREATE_FROM_STATIC_STRING(desc) GRPC_ERROR_CREATE(desc)
+#define GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc) GRPC_ERROR_CREATE(desc)
+#define GRPC_ERROR_CREATE_FROM_CPP_STRING(desc) GRPC_ERROR_CREATE(desc)
+#define GRPC_ERROR_CREATE_FROM_STRING_VIEW(desc) GRPC_ERROR_CREATE(desc)
+// Deprecated: end
 
 absl::Status grpc_status_create(absl::StatusCode code, absl::string_view msg,
                                 const grpc_core::DebugLocation& location,
                                 size_t children_count,
                                 absl::Status* children) GRPC_MUST_USE_RESULT;
 
-// Create an error that references some other errors. This function adds a
-// reference to each error in errs - it does not consume an existing reference
-#define GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(desc, errs, count)   \
+// Create an error that references some other errors.
+#define GRPC_ERROR_CREATE_REFERENCING(desc, errs, count)                      \
   grpc_status_create(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, count, \
                      errs)
-#define GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(desc, errs, count)   \
-  grpc_status_create(absl::StatusCode::kUnknown, desc, DEBUG_LOCATION, count, \
-                     errs)
+
+// Deprecated: Please do not use these macros. begin
+// TODO(veblush): Remove this once migration is done.
+#define GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(desc, errs, count) \
+  GRPC_ERROR_CREATE_REFERENCING(desc, errs, count)
+#define GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING(desc, errs, count) \
+  GRPC_ERROR_CREATE_REFERENCING(desc, errs, count)
+// Deprecated: end
 
 // Consumes all the errors in the vector and forms a referencing error from
 // them. If the vector is empty, return absl::OkStatus().
@@ -188,8 +194,12 @@ static absl::Status grpc_status_create_from_vector(
 
 #define GRPC_ERROR_CREATE_FROM_VECTOR(desc, error_list) \
   grpc_status_create_from_vector(DEBUG_LOCATION, desc, error_list)
+
+// Deprecated: Please do not use these macros. begin
+// TODO(veblush): Remove this once migration is done.
 #define GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING(desc, error_list) \
-  grpc_status_create_from_vector(DEBUG_LOCATION, desc, error_list)
+  GRPC_ERROR_CREATE_FROM_VECTOR(desc, error_list)
+// Deprecated: end
 
 absl::Status grpc_os_error(const grpc_core::DebugLocation& location, int err,
                            const char* call_name) GRPC_MUST_USE_RESULT;

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -243,7 +243,7 @@ static bool append_error(grpc_error_handle* composite, grpc_error_handle error,
                          const char* desc) {
   if (error.ok()) return true;
   if (composite->ok()) {
-    *composite = GRPC_ERROR_CREATE_FROM_COPIED_STRING(desc);
+    *composite = GRPC_ERROR_CREATE(desc);
   }
   *composite = grpc_error_add_child(*composite, error);
   return false;
@@ -411,8 +411,7 @@ static void fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
   bool is_release_fd = (release_fd != nullptr);
 
   if (!fd->read_closure->IsShutdown()) {
-    fd_shutdown_internal(fd, GRPC_ERROR_CREATE_FROM_COPIED_STRING(reason),
-                         is_release_fd);
+    fd_shutdown_internal(fd, GRPC_ERROR_CREATE(reason), is_release_fd);
   }
 
   /* If release_fd is not NULL, we should be relinquishing control of the file

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -491,10 +491,9 @@ static grpc_error_handle fd_shutdown_error(grpc_fd* fd) {
   if (!fd->shutdown) {
     return absl::OkStatus();
   } else {
-    return grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                                  "FD shutdown", &fd->shutdown_error, 1),
-                              grpc_core::StatusIntProperty::kRpcStatus,
-                              GRPC_STATUS_UNAVAILABLE);
+    return grpc_error_set_int(
+        GRPC_ERROR_CREATE_REFERENCING("FD shutdown", &fd->shutdown_error, 1),
+        grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
   }
 }
 
@@ -503,7 +502,7 @@ static void notify_on_locked(grpc_fd* fd, grpc_closure** st,
   if (fd->shutdown || gpr_atm_no_barrier_load(&fd->pollhup)) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, closure,
-        grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("FD shutdown"),
+        grpc_error_set_int(GRPC_ERROR_CREATE("FD shutdown"),
                            grpc_core::StatusIntProperty::kRpcStatus,
                            GRPC_STATUS_UNAVAILABLE));
   } else if (*st == CLOSURE_NOT_READY) {
@@ -756,7 +755,7 @@ static void kick_append_error(grpc_error_handle* composite,
                               grpc_error_handle error) {
   if (error.ok()) return;
   if (composite->ok()) {
-    *composite = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Kick Failure");
+    *composite = GRPC_ERROR_CREATE("Kick Failure");
   }
   *composite = grpc_error_add_child(*composite, error);
 }
@@ -892,7 +891,7 @@ static void work_combine_error(grpc_error_handle* composite,
                                grpc_error_handle error) {
   if (error.ok()) return;
   if (composite->ok()) {
-    *composite = GRPC_ERROR_CREATE_FROM_STATIC_STRING("pollset_work");
+    *composite = GRPC_ERROR_CREATE("pollset_work");
   }
   *composite = grpc_error_add_child(*composite, error);
 }

--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -67,10 +67,9 @@ end:
   *output = result;
   if (file != nullptr) fclose(file);
   if (!error.ok()) {
-    grpc_error_handle error_out =
-        grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                               "Failed to load file", &error, 1),
-                           grpc_core::StatusStrProperty::kFilename, filename);
+    grpc_error_handle error_out = grpc_error_set_str(
+        GRPC_ERROR_CREATE_REFERENCING("Failed to load file", &error, 1),
+        grpc_core::StatusStrProperty::kFilename, filename);
     error = error_out;
   }
   GRPC_SCHEDULING_END_BLOCKING_REGION_NO_EXEC_CTX;

--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -141,9 +141,9 @@ void LockfreeEvent::NotifyOn(grpc_closure* closure) {
         if ((curr & kShutdownBit) > 0) {
           grpc_error_handle shutdown_err =
               internal::StatusGetFromHeapPtr(curr & ~kShutdownBit);
-          ExecCtx::Run(DEBUG_LOCATION, closure,
-                       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                           "FD Shutdown", &shutdown_err, 1));
+          ExecCtx::Run(
+              DEBUG_LOCATION, closure,
+              GRPC_ERROR_CREATE_REFERENCING("FD Shutdown", &shutdown_err, 1));
           return;
         }
 
@@ -195,9 +195,9 @@ bool LockfreeEvent::SetShutdown(grpc_error_handle shutdown_error) {
            happens-after on that edge), and a release to pair with anything
            loading the shutdown state. */
         if (gpr_atm_full_cas(&state_, curr, new_state)) {
-          ExecCtx::Run(DEBUG_LOCATION, reinterpret_cast<grpc_closure*>(curr),
-                       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                           "FD Shutdown", &shutdown_error, 1));
+          ExecCtx::Run(
+              DEBUG_LOCATION, reinterpret_cast<grpc_closure*>(curr),
+              GRPC_ERROR_CREATE_REFERENCING("FD Shutdown", &shutdown_error, 1));
           return true;
         }
 

--- a/src/core/lib/iomgr/python_util.h
+++ b/src/core/lib/iomgr/python_util.h
@@ -31,7 +31,7 @@
 // because Cython doesn't handle #defines well.
 
 inline grpc_error_handle grpc_socket_error(char* error) {
-  return grpc_error_set_int(GRPC_ERROR_CREATE_FROM_COPIED_STRING(error),
+  return grpc_error_set_int(GRPC_ERROR_CREATE(error),
                             grpc_core::StatusIntProperty::kRpcStatus,
                             GRPC_STATUS_UNAVAILABLE);
 }

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -105,16 +105,14 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
   // parse name, splitting it into host and port parts
   SplitHostPort(name, &host, &port);
   if (host.empty()) {
-    err = grpc_error_set_str(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("unparseable host:port"),
-        StatusStrProperty::kTargetAddress, name);
+    err = grpc_error_set_str(GRPC_ERROR_CREATE("unparseable host:port"),
+                             StatusStrProperty::kTargetAddress, name);
     goto done;
   }
   if (port.empty()) {
     if (default_port.empty()) {
-      err = grpc_error_set_str(
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("no port in name"),
-          StatusStrProperty::kTargetAddress, name);
+      err = grpc_error_set_str(GRPC_ERROR_CREATE("no port in name"),
+                               StatusStrProperty::kTargetAddress, name);
       goto done;
     }
     port = std::string(default_port);
@@ -143,9 +141,8 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
     err = grpc_error_set_str(
         grpc_error_set_str(
             grpc_error_set_str(
-                grpc_error_set_int(
-                    GRPC_ERROR_CREATE_FROM_STATIC_STRING(gai_strerror(s)),
-                    StatusIntProperty::kErrorNo, s),
+                grpc_error_set_int(GRPC_ERROR_CREATE(gai_strerror(s)),
+                                   StatusIntProperty::kErrorNo, s),
                 StatusStrProperty::kOsError, gai_strerror(s)),
             StatusStrProperty::kSyscall, "getaddrinfo"),
         StatusStrProperty::kTargetAddress, name);

--- a/src/core/lib/iomgr/resolve_address_windows.cc
+++ b/src/core/lib/iomgr/resolve_address_windows.cc
@@ -111,14 +111,13 @@ NativeDNSResolver::LookupHostnameBlocking(absl::string_view name,
   std::string port;
   SplitHostPort(name, &host, &port);
   if (host.empty()) {
-    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
-        absl::StrFormat("unparseable host:port: '%s'", name));
+    error =
+        GRPC_ERROR_CREATE(absl::StrFormat("unparseable host:port: '%s'", name));
     goto done;
   }
   if (port.empty()) {
     if (default_port.empty()) {
-      error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
-          absl::StrFormat("no port in name '%s'", name));
+      error = GRPC_ERROR_CREATE(absl::StrFormat("no port in name '%s'", name));
       goto done;
     }
     port = std::string(default_port);

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -100,7 +100,7 @@ grpc_error_handle grpc_set_socket_no_sigpipe_if_possible(int fd) {
     return GRPC_OS_ERROR(errno, "getsockopt(SO_NOSIGPIPE)");
   }
   if ((newval != 0) != (val != 0)) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_NOSIGPIPE");
+    return GRPC_ERROR_CREATE("Failed to set SO_NOSIGPIPE");
   }
 #else
   // Avoid unused parameter warning for conditional parameter
@@ -181,7 +181,7 @@ grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse) {
     return GRPC_OS_ERROR(errno, "getsockopt(SO_REUSEADDR)");
   }
   if ((newval != 0) != val) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_REUSEADDR");
+    return GRPC_ERROR_CREATE("Failed to set SO_REUSEADDR");
   }
 
   return absl::OkStatus();
@@ -190,8 +190,7 @@ grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse) {
 /* set a socket to reuse old addresses */
 grpc_error_handle grpc_set_socket_reuse_port(int fd, int reuse) {
 #ifndef SO_REUSEPORT
-  return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-      "SO_REUSEPORT unavailable on compiling system");
+  return GRPC_ERROR_CREATE("SO_REUSEPORT unavailable on compiling system");
 #else
   int val = (reuse != 0);
   int newval;
@@ -203,7 +202,7 @@ grpc_error_handle grpc_set_socket_reuse_port(int fd, int reuse) {
     return GRPC_OS_ERROR(errno, "getsockopt(SO_REUSEPORT)");
   }
   if ((newval != 0) != val) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set SO_REUSEPORT");
+    return GRPC_ERROR_CREATE("Failed to set SO_REUSEPORT");
   }
 
   return absl::OkStatus();
@@ -244,7 +243,7 @@ grpc_error_handle grpc_set_socket_low_latency(int fd, int low_latency) {
     return GRPC_OS_ERROR(errno, "getsockopt(TCP_NODELAY)");
   }
   if ((newval != 0) != val) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set TCP_NODELAY");
+    return GRPC_ERROR_CREATE("Failed to set TCP_NODELAY");
   }
   return absl::OkStatus();
 }
@@ -376,7 +375,7 @@ grpc_error_handle grpc_set_socket_with_mutator(int fd, grpc_fd_usage usage,
                                                grpc_socket_mutator* mutator) {
   GPR_ASSERT(mutator);
   if (!grpc_socket_mutator_mutate_fd(mutator, fd, usage)) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("grpc_socket_mutator failed.");
+    return GRPC_ERROR_CREATE("grpc_socket_mutator failed.");
   }
   return absl::OkStatus();
 }

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -90,8 +90,7 @@ static void OnAlarm(void* arg, grpc_error_handle error) {
   if (done) {
     CFStreamConnectCleanup(connect);
   } else {
-    grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("connect() timed out");
+    grpc_error_handle error = GRPC_ERROR_CREATE("connect() timed out");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
   }
 }
@@ -154,8 +153,7 @@ static int64_t CFStreamClientConnect(
     const grpc_resolved_address* resolved_addr, grpc_core::Timestamp deadline) {
   auto addr_uri = grpc_sockaddr_to_uri(resolved_addr);
   if (!addr_uri.ok()) {
-    grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_uri.status().ToString());
+    grpc_error_handle error = GRPC_ERROR_CREATE(addr_uri.status().ToString());
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
     return 0;
   }

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -136,8 +136,7 @@ static void tc_on_alarm(void* acp, grpc_error_handle error) {
   }
   gpr_mu_lock(&ac->mu);
   if (ac->fd != nullptr) {
-    grpc_fd_shutdown(
-        ac->fd, GRPC_ERROR_CREATE_FROM_STATIC_STRING("connect() timed out"));
+    grpc_fd_shutdown(ac->fd, GRPC_ERROR_CREATE("connect() timed out"));
   }
   done = (--ac->refs == 0);
   gpr_mu_unlock(&ac->mu);
@@ -328,8 +327,7 @@ int64_t grpc_tcp_client_create_from_prepared_fd(
 
   auto addr_uri = grpc_sockaddr_to_uri(addr);
   if (!addr_uri.ok()) {
-    grpc_error_handle error =
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_uri.status().ToString());
+    grpc_error_handle error = GRPC_ERROR_CREATE(addr_uri.status().ToString());
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, error);
     return 0;
   }

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -108,7 +108,7 @@ static void on_connect(void* acp, grpc_error_handle error) {
         socket = nullptr;
       }
     } else {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("socket is null");
+      error = GRPC_ERROR_CREATE("socket is null");
     }
   }
 
@@ -141,7 +141,7 @@ static int64_t tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
 
   addr_uri = grpc_sockaddr_to_uri(addr);
   if (!addr_uri.ok()) {
-    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_uri.status().ToString());
+    error = GRPC_ERROR_CREATE(addr_uri.status().ToString());
     goto failure;
   }
 
@@ -219,8 +219,7 @@ static int64_t tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
 failure:
   GPR_ASSERT(!error.ok());
   grpc_error_handle final_error = grpc_error_set_str(
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Failed to connect",
-                                                       &error, 1),
+      GRPC_ERROR_CREATE_REFERENCING("Failed to connect", &error, 1),
       grpc_core::StatusStrProperty::kTargetAddress,
       addr_uri.ok() ? *addr_uri : addr_uri.status().ToString());
   if (socket != NULL) {

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -167,8 +167,7 @@ static void tcp_server_destroy(grpc_tcp_server* s) {
   if (s->active_ports) {
     grpc_tcp_listener* sp;
     for (sp = s->head; sp; sp = sp->next) {
-      grpc_fd_shutdown(
-          sp->emfd, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server destroyed"));
+      grpc_fd_shutdown(sp->emfd, GRPC_ERROR_CREATE("Server destroyed"));
     }
     gpr_mu_unlock(&s->mu);
   } else {
@@ -350,8 +349,8 @@ static grpc_error_handle add_wildcard_addrs_to_server(grpc_tcp_server* s,
     }
     return absl::OkStatus();
   } else {
-    grpc_error_handle root_err = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Failed to add any wildcard listeners");
+    grpc_error_handle root_err =
+        GRPC_ERROR_CREATE("Failed to add any wildcard listeners");
     GPR_ASSERT(!v6_err.ok() && !v4_err.ok());
     root_err = grpc_error_add_child(root_err, v6_err);
     root_err = grpc_error_add_child(root_err, v4_err);
@@ -382,7 +381,7 @@ static grpc_error_handle clone_port(grpc_tcp_listener* listener,
     listener->server->nports++;
     addr_str = grpc_sockaddr_to_string(&listener->addr, true);
     if (!addr_str.ok()) {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_str.status().ToString());
+      return GRPC_ERROR_CREATE(addr_str.status().ToString());
     }
     sp = static_cast<grpc_tcp_listener*>(gpr_malloc(sizeof(grpc_tcp_listener)));
     sp->next = listener->next;
@@ -576,8 +575,7 @@ static void tcp_server_shutdown_listeners(grpc_tcp_server* s) {
   if (s->active_ports) {
     grpc_tcp_listener* sp;
     for (sp = s->head; sp; sp = sp->next) {
-      grpc_fd_shutdown(sp->emfd,
-                       GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown"));
+      grpc_fd_shutdown(sp->emfd, GRPC_ERROR_CREATE("Server shutdown"));
     }
   }
   gpr_mu_unlock(&s->mu);

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -94,7 +94,7 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, int fd,
   GPR_ASSERT(port > 0);
   absl::StatusOr<std::string> addr_str = grpc_sockaddr_to_string(addr, true);
   if (!addr_str.ok()) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_str.status().ToString());
+    return GRPC_ERROR_CREATE(addr_str.status().ToString());
   }
   std::string name = absl::StrCat("tcp-server-listener:", addr_str.value());
   gpr_mu_lock(&s->mu);
@@ -215,10 +215,9 @@ error:
   if (fd >= 0) {
     close(fd);
   }
-  grpc_error_handle ret =
-      grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                             "Unable to configure socket", &err, 1),
-                         grpc_core::StatusIntProperty::kFd, fd);
+  grpc_error_handle ret = grpc_error_set_int(
+      GRPC_ERROR_CREATE_REFERENCING("Unable to configure socket", &err, 1),
+      grpc_core::StatusIntProperty::kFd, fd);
   return ret;
 }
 

--- a/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.cc
@@ -85,8 +85,7 @@ static grpc_error_handle get_unused_port(int* port) {
   }
   close(fd);
   *port = grpc_sockaddr_get_port(&wild);
-  return *port <= 0 ? GRPC_ERROR_CREATE_FROM_STATIC_STRING("Bad port")
-                    : absl::OkStatus();
+  return *port <= 0 ? GRPC_ERROR_CREATE("Bad port") : absl::OkStatus();
 }
 
 grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
@@ -106,7 +105,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     if ((err = get_unused_port(&requested_port)) != absl::OkStatus()) {
       return err;
     } else if (requested_port <= 0) {
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Bad get_unused_port()");
+      return GRPC_ERROR_CREATE("Bad get_unused_port()");
     }
     gpr_log(GPR_DEBUG, "Picked unused port %d", requested_port);
   }
@@ -130,12 +129,12 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     memcpy(addr.addr, ifa_it->ifa_addr, addr.len);
     if (!grpc_sockaddr_set_port(&addr, requested_port)) {
       /* Should never happen, because we check sa_family above. */
-      err = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to set port");
+      err = GRPC_ERROR_CREATE("Failed to set port");
       break;
     }
     auto addr_str = grpc_sockaddr_to_string(&addr, false);
     if (!addr_str.ok()) {
-      return GRPC_ERROR_CREATE_FROM_CPP_STRING(addr_str.status().ToString());
+      return GRPC_ERROR_CREATE(addr_str.status().ToString());
     }
     gpr_log(GPR_DEBUG,
             "Adding local addr from interface %s flags 0x%x to server: %s",
@@ -149,7 +148,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
     }
     if ((err = grpc_tcp_server_add_addr(s, &addr, port_index, fd_index, &dsmode,
                                         &new_sp)) != absl::OkStatus()) {
-      grpc_error_handle root_err = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      grpc_error_handle root_err = GRPC_ERROR_CREATE(
           absl::StrCat("Failed to add listener: ", addr_str.value()));
       err = grpc_error_add_child(root_err, err);
       break;
@@ -167,7 +166,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* s,
   if (!err.ok()) {
     return err;
   } else if (sp == nullptr) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No local addresses");
+    return GRPC_ERROR_CREATE("No local addresses");
   } else {
     *out_port = sp->port;
     return absl::OkStatus();

--- a/src/core/lib/iomgr/tcp_server_utils_posix_noifaddrs.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_noifaddrs.cc
@@ -28,7 +28,7 @@ grpc_error_handle grpc_tcp_server_add_all_local_addrs(grpc_tcp_server* /*s*/,
                                                       unsigned /*port_index*/,
                                                       int /*requested_port*/,
                                                       int* /*out_port*/) {
-  return GRPC_ERROR_CREATE_FROM_STATIC_STRING("no ifaddrs available");
+  return GRPC_ERROR_CREATE("no ifaddrs available");
 }
 
 bool grpc_tcp_server_have_ifaddrs(void) { return false; }

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -227,8 +227,8 @@ failure:
   auto addr_uri = grpc_sockaddr_to_uri(addr);
   grpc_error_set_int(
       grpc_error_set_str(
-          GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-              "Failed to prepare server socket", &error, 1),
+          GRPC_ERROR_CREATE_REFERENCING("Failed to prepare server socket",
+                                        &error, 1),
           grpc_core::StatusStrProperty::kTargetAddress,
           addr_uri.ok() ? *addr_uri : addr_uri.status().ToString()),
       grpc_core::StatusIntProperty::kFd, (intptr_t)sock);
@@ -510,9 +510,8 @@ done:
   gpr_free(allocated_addr);
 
   if (!error.ok()) {
-    grpc_error_handle error_out =
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-            "Failed to add port to server", &error, 1);
+    grpc_error_handle error_out = GRPC_ERROR_CREATE_REFERENCING(
+        "Failed to add port to server", &error, 1);
     error = error_out;
     *port = -1;
   } else {

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -186,7 +186,7 @@ static void on_read(void* tcpp, grpc_error_handle error) {
   if (error.ok()) {
     if (info->wsa_error != 0 && !tcp->shutting_down) {
       char* utf8_message = gpr_format_message(info->wsa_error);
-      error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(utf8_message);
+      error = GRPC_ERROR_CREATE(utf8_message);
       gpr_free(utf8_message);
       grpc_slice_buffer_reset_and_unref(tcp->read_slices);
     } else {
@@ -219,9 +219,9 @@ static void on_read(void* tcpp, grpc_error_handle error) {
         grpc_slice_buffer_reset_and_unref(tcp->read_slices);
         error = grpc_error_set_int(
             tcp->shutting_down
-                ? GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                      "TCP stream shutting down", &tcp->shutdown_error, 1)
-                : GRPC_ERROR_CREATE_FROM_STATIC_STRING("End of TCP stream"),
+                ? GRPC_ERROR_CREATE_REFERENCING("TCP stream shutting down",
+                                                &tcp->shutdown_error, 1)
+                : GRPC_ERROR_CREATE("End of TCP stream"),
             grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
       }
     }
@@ -253,8 +253,8 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
         grpc_error_set_int(
-            GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                "TCP socket is shutting down", &tcp->shutdown_error, 1),
+            GRPC_ERROR_CREATE_REFERENCING("TCP socket is shutting down",
+                                          &tcp->shutdown_error, 1),
             grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE));
     return;
   }
@@ -367,8 +367,8 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
         grpc_error_set_int(
-            GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                "TCP socket is shutting down", &tcp->shutdown_error, 1),
+            GRPC_ERROR_CREATE_REFERENCING("TCP socket is shutting down",
+                                          &tcp->shutdown_error, 1),
             grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE));
     return;
   }

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -273,9 +273,8 @@ static void timer_list_init() {
 
 static void timer_list_shutdown() {
   size_t i;
-  run_some_expired_timers(
-      grpc_core::Timestamp::InfFuture(), nullptr,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Timer list shutdown"));
+  run_some_expired_timers(grpc_core::Timestamp::InfFuture(), nullptr,
+                          GRPC_ERROR_CREATE("Timer list shutdown"));
   for (i = 0; i < g_num_shards; i++) {
     timer_shard* shard = &g_shards[i];
     gpr_mu_destroy(&shard->mu);
@@ -350,8 +349,7 @@ static void timer_init(grpc_timer* timer, grpc_core::Timestamp deadline,
     timer->pending = false;
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, timer->closure,
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "Attempt to create timer before initialization"));
+        GRPC_ERROR_CREATE("Attempt to create timer before initialization"));
     return;
   }
 
@@ -684,7 +682,7 @@ static grpc_timer_check_result timer_check(grpc_core::Timestamp* next) {
   grpc_error_handle shutdown_error =
       now != grpc_core::Timestamp::InfFuture()
           ? absl::OkStatus()
-          : GRPC_ERROR_CREATE_FROM_STATIC_STRING("Shutting down timer system");
+          : GRPC_ERROR_CREATE("Shutting down timer system");
 
   // tracing
   if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {

--- a/src/core/lib/json/json_util.cc
+++ b/src/core/lib/json/json_util.cc
@@ -45,7 +45,7 @@ bool ExtractJsonBool(const Json& json, absl::string_view field_name,
       *output = false;
       return true;
     default:
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      error_list->push_back(GRPC_ERROR_CREATE(
           absl::StrCat("field:", field_name, " error:type should be BOOLEAN")));
       return false;
   }
@@ -56,7 +56,7 @@ bool ExtractJsonArray(const Json& json, absl::string_view field_name,
                       std::vector<grpc_error_handle>* error_list) {
   if (json.type() != Json::Type::ARRAY) {
     *output = nullptr;
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error_list->push_back(GRPC_ERROR_CREATE(
         absl::StrCat("field:", field_name, " error:type should be ARRAY")));
     return false;
   }
@@ -69,7 +69,7 @@ bool ExtractJsonObject(const Json& json, absl::string_view field_name,
                        std::vector<grpc_error_handle>* error_list) {
   if (json.type() != Json::Type::OBJECT) {
     *output = nullptr;
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error_list->push_back(GRPC_ERROR_CREATE(
         absl::StrCat("field:", field_name, " error:type should be OBJECT")));
     return false;
   }
@@ -87,14 +87,14 @@ bool ParseJsonObjectFieldAsDuration(const Json::Object& object,
   auto it = object.find(std::string(field_name));
   if (it == object.end()) {
     if (required) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      error_list->push_back(GRPC_ERROR_CREATE(
           absl::StrCat("field:", field_name, " error:does not exist.")));
     }
     return false;
   }
   if (!ParseDurationFromJson(it->second, output)) {
     *output = Duration::NegativeInfinity();
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error_list->push_back(GRPC_ERROR_CREATE(
         absl::StrCat("field:", field_name,
                      " error:type should be STRING of the form given by "
                      "google.proto.Duration.")));

--- a/src/core/lib/json/json_util.h
+++ b/src/core/lib/json/json_util.h
@@ -55,12 +55,12 @@ bool ExtractJsonNumber(const Json& json, absl::string_view field_name,
                        std::vector<grpc_error_handle>* error_list) {
   static_assert(std::is_integral<NumericType>::value, "Integral required");
   if (json.type() != Json::Type::NUMBER && json.type() != Json::Type::STRING) {
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+    error_list->push_back(GRPC_ERROR_CREATE(absl::StrCat(
         "field:", field_name, " error:type should be NUMBER or STRING")));
     return false;
   }
   if (!absl::SimpleAtoi(json.string_value(), output)) {
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error_list->push_back(GRPC_ERROR_CREATE(
         absl::StrCat("field:", field_name, " error:failed to parse.")));
     return false;
   }
@@ -77,7 +77,7 @@ bool ExtractJsonString(const Json& json, absl::string_view field_name,
                        std::vector<grpc_error_handle>* error_list) {
   if (json.type() != Json::Type::STRING) {
     *output = "";
-    error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error_list->push_back(GRPC_ERROR_CREATE(
         absl::StrCat("field:", field_name, " error:type should be STRING")));
     return false;
   }
@@ -142,7 +142,7 @@ bool ParseJsonObjectField(const Json::Object& object,
   auto it = object.find(std::string(field_name));
   if (it == object.end()) {
     if (required) {
-      error_list->push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      error_list->push_back(GRPC_ERROR_CREATE(
           absl::StrCat("field:", field_name, " error:does not exist.")));
     }
     return false;

--- a/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/aws_external_account_credentials.cc
@@ -94,29 +94,24 @@ AwsExternalAccountCredentials::AwsExternalAccountCredentials(
   audience_ = options.audience;
   auto it = options.credential_source.object_value().find("environment_id");
   if (it == options.credential_source.object_value().end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "environment_id field not present.");
+    *error = GRPC_ERROR_CREATE("environment_id field not present.");
     return;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "environment_id field must be a string.");
+    *error = GRPC_ERROR_CREATE("environment_id field must be a string.");
     return;
   }
   if (it->second.string_value() != kExpectedEnvironmentId) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("environment_id does not match.");
+    *error = GRPC_ERROR_CREATE("environment_id does not match.");
     return;
   }
   it = options.credential_source.object_value().find("region_url");
   if (it == options.credential_source.object_value().end()) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("region_url field not present.");
+    *error = GRPC_ERROR_CREATE("region_url field not present.");
     return;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "region_url field must be a string.");
+    *error = GRPC_ERROR_CREATE("region_url field must be a string.");
     return;
   }
   region_url_ = it->second.string_value();
@@ -128,12 +123,12 @@ AwsExternalAccountCredentials::AwsExternalAccountCredentials(
   it = options.credential_source.object_value().find(
       "regional_cred_verification_url");
   if (it == options.credential_source.object_value().end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "regional_cred_verification_url field not present.");
+    *error =
+        GRPC_ERROR_CREATE("regional_cred_verification_url field not present.");
     return;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "regional_cred_verification_url field must be a string.");
     return;
   }
@@ -152,7 +147,7 @@ void AwsExternalAccountCredentials::RetrieveSubjectToken(
   if (ctx == nullptr) {
     FinishRetrieveSubjectToken(
         "",
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        GRPC_ERROR_CREATE(
             "Missing HTTPRequestContext to start subject token retrieval."));
     return;
   }
@@ -252,8 +247,8 @@ void AwsExternalAccountCredentials::RetrieveRegion() {
   absl::StatusOr<URI> uri = URI::Parse(region_url_);
   if (!uri.ok()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
-                "Invalid region url. %s", uri.status().ToString())));
+        "", GRPC_ERROR_CREATE(absl::StrFormat("Invalid region url. %s",
+                                              uri.status().ToString())));
     return;
   }
   grpc_http_request request;
@@ -305,7 +300,7 @@ void AwsExternalAccountCredentials::RetrieveRoleName() {
   absl::StatusOr<URI> uri = URI::Parse(url_);
   if (!uri.ok()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        "", GRPC_ERROR_CREATE(
                 absl::StrFormat("Invalid url: %s.", uri.status().ToString())));
     return;
   }
@@ -362,16 +357,16 @@ void AwsExternalAccountCredentials::RetrieveSigningKeys() {
   }
   if (role_name_.empty()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                "Missing role name when retrieving signing keys."));
+        "",
+        GRPC_ERROR_CREATE("Missing role name when retrieving signing keys."));
     return;
   }
   std::string url_with_role_name = absl::StrCat(url_, "/", role_name_);
   absl::StatusOr<URI> uri = URI::Parse(url_with_role_name);
   if (!uri.ok()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
-                "Invalid url with role name: %s.", uri.status().ToString())));
+        "", GRPC_ERROR_CREATE(absl::StrFormat("Invalid url with role name: %s.",
+                                              uri.status().ToString())));
     return;
   }
   grpc_http_request request;
@@ -414,16 +409,15 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
   auto json = Json::Parse(response_body);
   if (!json.ok()) {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(
+        "", GRPC_ERROR_CREATE(
                 absl::StrCat("Invalid retrieve signing keys response: ",
                              json.status().ToString())));
     return;
   }
   if (json->type() != Json::Type::OBJECT) {
-    FinishRetrieveSubjectToken("",
-                               GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                   "Invalid retrieve signing keys response: "
-                                   "JSON type is not object"));
+    FinishRetrieveSubjectToken(
+        "", GRPC_ERROR_CREATE("Invalid retrieve signing keys response: "
+                              "JSON type is not object"));
     return;
   }
   auto it = json->object_value().find("AccessKeyId");
@@ -432,7 +426,7 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
     access_key_id_ = it->second.string_value();
   } else {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "", GRPC_ERROR_CREATE(absl::StrFormat(
                 "Missing or invalid AccessKeyId in %s.", response_body)));
     return;
   }
@@ -442,7 +436,7 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
     secret_access_key_ = it->second.string_value();
   } else {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+        "", GRPC_ERROR_CREATE(absl::StrFormat(
                 "Missing or invalid SecretAccessKey in %s.", response_body)));
     return;
   }
@@ -452,8 +446,8 @@ void AwsExternalAccountCredentials::OnRetrieveSigningKeysInternal(
     token_ = it->second.string_value();
   } else {
     FinishRetrieveSubjectToken(
-        "", GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
-                "Missing or invalid Token in %s.", response_body)));
+        "", GRPC_ERROR_CREATE(absl::StrFormat("Missing or invalid Token in %s.",
+                                              response_body)));
     return;
   }
   BuildSubjectToken();
@@ -470,18 +464,17 @@ void AwsExternalAccountCredentials::BuildSubjectToken() {
         std::map<std::string, std::string>(), &error);
     if (!error.ok()) {
       FinishRetrieveSubjectToken(
-          "", GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+          "", GRPC_ERROR_CREATE_REFERENCING(
                   "Creating aws request signer failed.", &error, 1));
       return;
     }
   }
   auto signed_headers = signer_->GetSignedRequestHeaders();
   if (!error.ok()) {
-    FinishRetrieveSubjectToken("",
-                               GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                                   "Invalid getting signed request"
-                                   "headers.",
-                                   &error, 1));
+    FinishRetrieveSubjectToken(
+        "", GRPC_ERROR_CREATE_REFERENCING("Invalid getting signed request"
+                                          "headers.",
+                                          &error, 1));
     return;
   }
   // Construct subject token

--- a/src/core/lib/security/credentials/external/aws_request_signer.cc
+++ b/src/core/lib/security/credentials/external/aws_request_signer.cc
@@ -88,7 +88,7 @@ AwsRequestSigner::AwsRequestSigner(
   auto date_it = additional_headers_.find("date");
   if (amz_date_it != additional_headers_.end() &&
       date_it != additional_headers_.end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "Only one of {date, x-amz-date} can be specified, not both.");
     return;
   }
@@ -99,7 +99,7 @@ AwsRequestSigner::AwsRequestSigner(
     std::string err_str;
     if (!absl::ParseTime(kDateFormat, date_it->second, &request_date,
                          &err_str)) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(err_str.c_str());
+      *error = GRPC_ERROR_CREATE(err_str.c_str());
       return;
     }
     static_request_date_ =
@@ -107,7 +107,7 @@ AwsRequestSigner::AwsRequestSigner(
   }
   absl::StatusOr<URI> tmp_url = URI::Parse(url);
   if (!tmp_url.ok()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Invalid Aws request url.");
+    *error = GRPC_ERROR_CREATE("Invalid Aws request url.");
     return;
   }
   url_ = tmp_url.value();

--- a/src/core/lib/security/credentials/external/external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/external_account_credentials.cc
@@ -108,47 +108,41 @@ RefCountedPtr<ExternalAccountCredentials> ExternalAccountCredentials::Create(
   Options options;
   options.type = GRPC_AUTH_JSON_TYPE_INVALID;
   if (json.type() != Json::Type::OBJECT) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Invalid json to construct credentials options.");
+    *error =
+        GRPC_ERROR_CREATE("Invalid json to construct credentials options.");
     return nullptr;
   }
   auto it = json.object_value().find("type");
   if (it == json.object_value().end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("type field not present.");
+    *error = GRPC_ERROR_CREATE("type field not present.");
     return nullptr;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("type field must be a string.");
+    *error = GRPC_ERROR_CREATE("type field must be a string.");
     return nullptr;
   }
   if (it->second.string_value() != GRPC_AUTH_JSON_TYPE_EXTERNAL_ACCOUNT) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Invalid credentials json type.");
+    *error = GRPC_ERROR_CREATE("Invalid credentials json type.");
     return nullptr;
   }
   options.type = GRPC_AUTH_JSON_TYPE_EXTERNAL_ACCOUNT;
   it = json.object_value().find("audience");
   if (it == json.object_value().end()) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("audience field not present.");
+    *error = GRPC_ERROR_CREATE("audience field not present.");
     return nullptr;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "audience field must be a string.");
+    *error = GRPC_ERROR_CREATE("audience field must be a string.");
     return nullptr;
   }
   options.audience = it->second.string_value();
   it = json.object_value().find("subject_token_type");
   if (it == json.object_value().end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "subject_token_type field not present.");
+    *error = GRPC_ERROR_CREATE("subject_token_type field not present.");
     return nullptr;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "subject_token_type field must be a string.");
+    *error = GRPC_ERROR_CREATE("subject_token_type field must be a string.");
     return nullptr;
   }
   options.subject_token_type = it->second.string_value();
@@ -158,13 +152,11 @@ RefCountedPtr<ExternalAccountCredentials> ExternalAccountCredentials::Create(
   }
   it = json.object_value().find("token_url");
   if (it == json.object_value().end()) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("token_url field not present.");
+    *error = GRPC_ERROR_CREATE("token_url field not present.");
     return nullptr;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "token_url field must be a string.");
+    *error = GRPC_ERROR_CREATE("token_url field must be a string.");
     return nullptr;
   }
   options.token_url = it->second.string_value();
@@ -174,8 +166,7 @@ RefCountedPtr<ExternalAccountCredentials> ExternalAccountCredentials::Create(
   }
   it = json.object_value().find("credential_source");
   if (it == json.object_value().end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "credential_source field not present.");
+    *error = GRPC_ERROR_CREATE("credential_source field not present.");
     return nullptr;
   }
   options.credential_source = it->second;
@@ -196,7 +187,7 @@ RefCountedPtr<ExternalAccountCredentials> ExternalAccountCredentials::Create(
     if (MatchWorkforcePoolAudience(options.audience)) {
       options.workforce_pool_user_project = it->second.string_value();
     } else {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      *error = GRPC_ERROR_CREATE(
           "workforce_pool_user_project should not be set for non-workforce "
           "pool credentials");
       return nullptr;
@@ -216,7 +207,7 @@ RefCountedPtr<ExternalAccountCredentials> ExternalAccountCredentials::Create(
     creds = MakeRefCounted<UrlExternalAccountCredentials>(
         std::move(options), std::move(scopes), error);
   } else {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    *error = GRPC_ERROR_CREATE(
         "Invalid options credential source to create "
         "ExternalAccountCredentials.");
   }
@@ -283,7 +274,7 @@ void ExternalAccountCredentials::ExchangeToken(
     absl::string_view subject_token) {
   absl::StatusOr<URI> uri = URI::Parse(options_.token_url);
   if (!uri.ok()) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    FinishTokenFetch(GRPC_ERROR_CREATE(
         absl::StrFormat("Invalid token url: %s. Error: %s", options_.token_url,
                         uri.status().ToString())));
     return;
@@ -399,19 +390,19 @@ void ExternalAccountCredentials::ImpersenateServiceAccount() {
                                   ctx_->response.body_length);
   auto json = Json::Parse(response_body);
   if (!json.ok()) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+    FinishTokenFetch(GRPC_ERROR_CREATE(absl::StrCat(
         "Invalid token exchange response: ", json.status().ToString())));
     return;
   }
   if (json->type() != Json::Type::OBJECT) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    FinishTokenFetch(GRPC_ERROR_CREATE(
         "Invalid token exchange response: JSON type is not object"));
     return;
   }
   auto it = json->object_value().find("access_token");
   if (it == json->object_value().end() ||
       it->second.type() != Json::Type::STRING) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    FinishTokenFetch(GRPC_ERROR_CREATE(absl::StrFormat(
         "Missing or invalid access_token in %s.", response_body)));
     return;
   }
@@ -419,7 +410,7 @@ void ExternalAccountCredentials::ImpersenateServiceAccount() {
   absl::StatusOr<URI> uri =
       URI::Parse(options_.service_account_impersonation_url);
   if (!uri.ok()) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    FinishTokenFetch(GRPC_ERROR_CREATE(absl::StrFormat(
         "Invalid service account impersonation url: %s. Error: %s",
         options_.service_account_impersonation_url, uri.status().ToString())));
     return;
@@ -477,21 +468,21 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
                                   ctx_->response.body_length);
   auto json = Json::Parse(response_body);
   if (!json.ok()) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    FinishTokenFetch(GRPC_ERROR_CREATE(
         absl::StrCat("Invalid service account impersonation response: ",
                      json.status().ToString())));
     return;
   }
   if (json->type() != Json::Type::OBJECT) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Invalid service account impersonation response: "
-        "JSON type is not object"));
+    FinishTokenFetch(
+        GRPC_ERROR_CREATE("Invalid service account impersonation response: "
+                          "JSON type is not object"));
     return;
   }
   auto it = json->object_value().find("accessToken");
   if (it == json->object_value().end() ||
       it->second.type() != Json::Type::STRING) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    FinishTokenFetch(GRPC_ERROR_CREATE(absl::StrFormat(
         "Missing or invalid accessToken in %s.", response_body)));
     return;
   }
@@ -499,14 +490,14 @@ void ExternalAccountCredentials::OnImpersenateServiceAccountInternal(
   it = json->object_value().find("expireTime");
   if (it == json->object_value().end() ||
       it->second.type() != Json::Type::STRING) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+    FinishTokenFetch(GRPC_ERROR_CREATE(absl::StrFormat(
         "Missing or invalid expireTime in %s.", response_body)));
     return;
   }
   std::string expire_time = it->second.string_value();
   absl::Time t;
   if (!absl::ParseTime(absl::RFC3339_full, expire_time, &t, nullptr)) {
-    FinishTokenFetch(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    FinishTokenFetch(GRPC_ERROR_CREATE(
         "Invalid expire time of service account impersonation response."));
     return;
   }

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.cc
@@ -51,12 +51,11 @@ FileExternalAccountCredentials::FileExternalAccountCredentials(
     : ExternalAccountCredentials(options, std::move(scopes)) {
   auto it = options.credential_source.object_value().find("file");
   if (it == options.credential_source.object_value().end()) {
-    *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("file field not present.");
+    *error = GRPC_ERROR_CREATE("file field not present.");
     return;
   }
   if (it->second.type() != Json::Type::STRING) {
-    *error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("file field must be a string.");
+    *error = GRPC_ERROR_CREATE("file field must be a string.");
     return;
   }
   file_ = it->second.string_value();
@@ -64,32 +63,30 @@ FileExternalAccountCredentials::FileExternalAccountCredentials(
   if (it != options.credential_source.object_value().end()) {
     const Json& format_json = it->second;
     if (format_json.type() != Json::Type::OBJECT) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      *error = GRPC_ERROR_CREATE(
           "The JSON value of credential source format is not an object.");
       return;
     }
     auto format_it = format_json.object_value().find("type");
     if (format_it == format_json.object_value().end()) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "format.type field not present.");
+      *error = GRPC_ERROR_CREATE("format.type field not present.");
       return;
     }
     if (format_it->second.type() != Json::Type::STRING) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "format.type field must be a string.");
+      *error = GRPC_ERROR_CREATE("format.type field must be a string.");
       return;
     }
     format_type_ = format_it->second.string_value();
     if (format_type_ == "json") {
       format_it = format_json.object_value().find("subject_token_field_name");
       if (format_it == format_json.object_value().end()) {
-        *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        *error = GRPC_ERROR_CREATE(
             "format.subject_token_field_name field must be present if the "
             "format is in Json.");
         return;
       }
       if (format_it->second.type() != Json::Type::STRING) {
-        *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        *error = GRPC_ERROR_CREATE(
             "format.subject_token_field_name field must be a string.");
         return;
       }
@@ -118,20 +115,18 @@ void FileExternalAccountCredentials::RetrieveSubjectToken(
   if (format_type_ == "json") {
     auto content_json = Json::Parse(content);
     if (!content_json.ok() || content_json->type() != Json::Type::OBJECT) {
-      cb("", GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      cb("", GRPC_ERROR_CREATE(
                  "The content of the file is not a valid json object."));
       return;
     }
     auto content_it =
         content_json->object_value().find(format_subject_token_field_name_);
     if (content_it == content_json->object_value().end()) {
-      cb("", GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                 "Subject token field not present."));
+      cb("", GRPC_ERROR_CREATE("Subject token field not present."));
       return;
     }
     if (content_it->second.type() != Json::Type::STRING) {
-      cb("", GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                 "Subject token field must be a string."));
+      cb("", GRPC_ERROR_CREATE("Subject token field must be a string."));
       return;
     }
     cb(content_it->second.string_value(), absl::OkStatus());

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -311,7 +311,7 @@ static grpc_error_handle create_default_creds_from_path(
   grpc_error_handle error;
   Json json;
   if (creds_path.empty()) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("creds_path unset");
+    error = GRPC_ERROR_CREATE("creds_path unset");
     goto end;
   }
   error = grpc_load_file(creds_path.c_str(), 0, &creds_data);
@@ -325,10 +325,9 @@ static grpc_error_handle create_default_creds_from_path(
     json = std::move(*json_or);
   }
   if (json.type() != Json::Type::OBJECT) {
-    error = grpc_error_set_str(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to parse JSON"),
-        grpc_core::StatusStrProperty::kRawBytes,
-        grpc_core::StringViewFromSlice(creds_data));
+    error = grpc_error_set_str(GRPC_ERROR_CREATE("Failed to parse JSON"),
+                               grpc_core::StatusStrProperty::kRawBytes,
+                               grpc_core::StringViewFromSlice(creds_data));
     goto end;
   }
 
@@ -339,7 +338,7 @@ static grpc_error_handle create_default_creds_from_path(
         grpc_service_account_jwt_access_credentials_create_from_auth_json_key(
             key, grpc_max_auth_token_lifetime());
     if (result == nullptr) {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error = GRPC_ERROR_CREATE(
           "grpc_service_account_jwt_access_credentials_create_from_auth_json_"
           "key failed");
     }
@@ -352,7 +351,7 @@ static grpc_error_handle create_default_creds_from_path(
     result =
         grpc_refresh_token_credentials_create_from_auth_refresh_token(token);
     if (result == nullptr) {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      error = GRPC_ERROR_CREATE(
           "grpc_refresh_token_credentials_create_from_auth_refresh_token "
           "failed");
     }
@@ -361,8 +360,7 @@ static grpc_error_handle create_default_creds_from_path(
 
   /* Finally try an external account credentials.*/
   if (!ValidateExteralAccountCredentials(json)) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Invalid external account credentials format.");
+    error = GRPC_ERROR_CREATE("Invalid external account credentials format.");
     goto end;
   }
   result = grpc_core::ExternalAccountCredentials::Create(json, {}, &error);
@@ -420,11 +418,9 @@ static grpc_core::RefCountedPtr<grpc_call_credentials> make_default_call_creds(
     call_creds = grpc_core::RefCountedPtr<grpc_call_credentials>(
         grpc_google_compute_engine_credentials_create(nullptr));
     if (call_creds == nullptr) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          GRPC_GOOGLE_CREDENTIAL_CREATION_ERROR);
+      *error = GRPC_ERROR_CREATE(GRPC_GOOGLE_CREDENTIAL_CREATION_ERROR);
       *error = grpc_error_add_child(
-          *error, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                      "Failed to get credentials from network"));
+          *error, GRPC_ERROR_CREATE("Failed to get credentials from network"));
     }
   }
 

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.cc
@@ -273,7 +273,7 @@ void grpc_oauth2_token_fetcher_credentials::on_http_response(
           [](absl::string_view, const grpc_core::Slice&) { abort(); });
       pending_request->result = std::move(pending_request->md);
     } else {
-      auto err = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+      auto err = GRPC_ERROR_CREATE_REFERENCING(
           "Error occurred when fetching oauth2 token.", &error, 1);
       pending_request->result = grpc_error_to_absl_status(err);
     }
@@ -534,7 +534,7 @@ grpc_error_handle LoadTokenFile(const char* path, gpr_slice* token) {
   if (!err.ok()) return err;
   if (GRPC_SLICE_LENGTH(*token) == 0) {
     gpr_log(GPR_ERROR, "Token file %s is empty", path);
-    err = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Token file is empty.");
+    err = GRPC_ERROR_CREATE("Token file is empty.");
   }
   return err;
 }
@@ -662,22 +662,22 @@ absl::StatusOr<URI> ValidateStsCredentialsOptions(
                      ? ""
                      : options->token_exchange_service_uri);
   if (!sts_url.ok()) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error_list.push_back(GRPC_ERROR_CREATE(
         absl::StrFormat("Invalid or missing STS endpoint URL. Error: %s",
                         sts_url.status().ToString())));
   } else if (sts_url->scheme() != "https" && sts_url->scheme() != "http") {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Invalid URI scheme, must be https to http."));
+    error_list.push_back(
+        GRPC_ERROR_CREATE("Invalid URI scheme, must be https to http."));
   }
   if (options->subject_token_path == nullptr ||
       strlen(options->subject_token_path) == 0) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "subject_token needs to be specified"));
+    error_list.push_back(
+        GRPC_ERROR_CREATE("subject_token needs to be specified"));
   }
   if (options->subject_token_type == nullptr ||
       strlen(options->subject_token_type) == 0) {
-    error_list.push_back(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "subject_token_type needs to be specified"));
+    error_list.push_back(
+        GRPC_ERROR_CREATE("subject_token_type needs to be specified"));
   }
   if (error_list.empty()) {
     return sts_url;

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -83,12 +83,12 @@ StaticDataCertificateProvider::StaticDataCertificateProvider(
     grpc_error_handle root_cert_error;
     grpc_error_handle identity_cert_error;
     if (root_being_watched && !root_has_update) {
-      root_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Unable to get latest root certificates.");
+      root_cert_error =
+          GRPC_ERROR_CREATE("Unable to get latest root certificates.");
     }
     if (identity_being_watched && !identity_has_update) {
-      identity_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Unable to get latest identity certificates.");
+      identity_cert_error =
+          GRPC_ERROR_CREATE("Unable to get latest identity certificates.");
     }
     if (!root_cert_error.ok() || !identity_cert_error.ok()) {
       distributor_->SetErrorForCert(cert_name, root_cert_error,
@@ -177,12 +177,12 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
     grpc_error_handle root_cert_error;
     grpc_error_handle identity_cert_error;
     if (root_being_watched && !root_certificate.has_value()) {
-      root_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Unable to get latest root certificates.");
+      root_cert_error =
+          GRPC_ERROR_CREATE("Unable to get latest root certificates.");
     }
     if (identity_being_watched && !pem_key_cert_pairs.has_value()) {
-      identity_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Unable to get latest identity certificates.");
+      identity_cert_error =
+          GRPC_ERROR_CREATE("Unable to get latest identity certificates.");
     }
     if (!root_cert_error.ok() || !identity_cert_error.ok()) {
       distributor_->SetErrorForCert(cert_name, root_cert_error,
@@ -238,11 +238,10 @@ void FileWatcherCertificateProvider::ForceUpdate() {
   }
   if (root_cert_changed || identity_cert_changed) {
     ExecCtx exec_ctx;
-    grpc_error_handle root_cert_error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Unable to get latest root certificates.");
+    grpc_error_handle root_cert_error =
+        GRPC_ERROR_CREATE("Unable to get latest root certificates.");
     grpc_error_handle identity_cert_error =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "Unable to get latest identity certificates.");
+        GRPC_ERROR_CREATE("Unable to get latest identity certificates.");
     for (const auto& p : watcher_info_) {
       const std::string& cert_name = p.first;
       const WatcherInfo& info = p.second;

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -78,8 +78,7 @@ void alts_check_peer(tsi_peer peer,
   grpc_error_handle error =
       *auth_context != nullptr
           ? absl::OkStatus()
-          : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                "Could not get ALTS auth context from TSI peer");
+          : GRPC_ERROR_CREATE("Could not get ALTS auth context from TSI peer");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
 }
 

--- a/src/core/lib/security/security_connector/fake/fake_security_connector.cc
+++ b/src/core/lib/security/security_connector/fake/fake_security_connector.cc
@@ -213,36 +213,33 @@ void fake_check_peer(grpc_security_connector* /*sc*/, tsi_peer peer,
   grpc_error_handle error;
   *auth_context = nullptr;
   if (peer.property_count != 2) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Fake peers should only have 2 properties.");
+    error = GRPC_ERROR_CREATE("Fake peers should only have 2 properties.");
     goto end;
   }
   prop_name = peer.properties[0].name;
   if (prop_name == nullptr ||
       strcmp(prop_name, TSI_CERTIFICATE_TYPE_PEER_PROPERTY) != 0) {
-    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error = GRPC_ERROR_CREATE(
         absl::StrCat("Unexpected property in fake peer: ",
                      prop_name == nullptr ? "<EMPTY>" : prop_name));
     goto end;
   }
   if (strncmp(peer.properties[0].value.data, TSI_FAKE_CERTIFICATE_TYPE,
               peer.properties[0].value.length) != 0) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Invalid value for cert type property.");
+    error = GRPC_ERROR_CREATE("Invalid value for cert type property.");
     goto end;
   }
   prop_name = peer.properties[1].name;
   if (prop_name == nullptr ||
       strcmp(prop_name, TSI_SECURITY_LEVEL_PEER_PROPERTY) != 0) {
-    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    error = GRPC_ERROR_CREATE(
         absl::StrCat("Unexpected property in fake peer: ",
                      prop_name == nullptr ? "<EMPTY>" : prop_name));
     goto end;
   }
   if (strncmp(peer.properties[1].value.data, TSI_FAKE_SECURITY_LEVEL,
               peer.properties[1].value.length) != 0) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Invalid value for security level property.");
+    error = GRPC_ERROR_CREATE("Invalid value for security level property.");
     goto end;
   }
 

--- a/src/core/lib/security/security_connector/local/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local/local_security_connector.cc
@@ -130,8 +130,8 @@ void local_check_peer(tsi_peer peer, grpc_endpoint* ep,
   }
   grpc_error_handle error;
   if (!is_endpoint_local) {
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Endpoint is neither UDS or TCP loopback address.");
+    error =
+        GRPC_ERROR_CREATE("Endpoint is neither UDS or TCP loopback address.");
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
     return;
   }
@@ -159,9 +159,9 @@ void local_check_peer(tsi_peer peer, grpc_endpoint* ep,
    */
   *auth_context = local_auth_context_create(&peer);
   tsi_peer_destruct(&peer);
-  error = *auth_context != nullptr ? absl::OkStatus()
-                                   : GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                         "Could not create local auth context");
+  error = *auth_context != nullptr
+              ? absl::OkStatus()
+              : GRPC_ERROR_CREATE("Could not create local auth context");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, on_peer_checked, error);
 }
 

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -66,7 +66,7 @@ grpc_error_handle ssl_check_peer(
   }
   /* Check the peer name if specified. */
   if (peer_name != nullptr && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    return GRPC_ERROR_CREATE(
         absl::StrCat("Peer name ", peer_name, " is not in peer certificate"));
   }
   *auth_context =
@@ -163,8 +163,8 @@ class grpc_ssl_channel_security_connector final
       const tsi_peer_property* p =
           tsi_peer_get_property_by_name(&peer, TSI_X509_PEM_CERT_PROPERTY);
       if (p == nullptr) {
-        error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "Cannot check peer: missing pem cert property.");
+        error =
+            GRPC_ERROR_CREATE("Cannot check peer: missing pem cert property.");
       } else {
         char* peer_pem = static_cast<char*>(gpr_malloc(p->value.length + 1));
         memcpy(peer_pem, p->value.data, p->value.length);
@@ -174,7 +174,7 @@ class grpc_ssl_channel_security_connector final
             verify_options_->verify_peer_callback_userdata);
         gpr_free(peer_pem);
         if (callback_status) {
-          error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrFormat(
+          error = GRPC_ERROR_CREATE(absl::StrFormat(
               "Verify peer callback returned a failure (%d)", callback_status));
         }
       }

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -144,12 +144,11 @@ grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer) {
   const tsi_peer_property* p =
       tsi_peer_get_property_by_name(peer, TSI_SSL_ALPN_SELECTED_PROTOCOL);
   if (p == nullptr) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+    return GRPC_ERROR_CREATE(
         "Cannot check peer: missing selected ALPN property.");
   }
   if (!grpc_chttp2_is_alpn_version_supported(p->value.data, p->value.length)) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Cannot check peer: invalid ALPN value.");
+    return GRPC_ERROR_CREATE("Cannot check peer: invalid ALPN value.");
   }
 #endif /* TSI_OPENSSL_ALPN_SUPPORT */
   return absl::OkStatus();
@@ -159,7 +158,7 @@ grpc_error_handle grpc_ssl_check_peer_name(absl::string_view peer_name,
                                            const tsi_peer* peer) {
   /* Check the peer name if specified. */
   if (!peer_name.empty() && !grpc_ssl_host_matches_name(peer, peer_name)) {
-    return GRPC_ERROR_CREATE_FROM_CPP_STRING(
+    return GRPC_ERROR_CREATE(
         absl::StrCat("Peer name ", peer_name, " is not in peer certificate"));
   }
   return absl::OkStatus();

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -503,7 +503,7 @@ void TlsChannelSecurityConnector::ChannelPendingVerifierRequest::OnVerifyDone(
   }
   grpc_error_handle error;
   if (!status.ok()) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error = GRPC_ERROR_CREATE(
         absl::StrCat("Custom verification check failed with error: ",
                      status.ToString())
             .c_str());
@@ -777,7 +777,7 @@ void TlsServerSecurityConnector::ServerPendingVerifierRequest::OnVerifyDone(
   }
   grpc_error_handle error;
   if (!status.ok()) {
-    error = GRPC_ERROR_CREATE_FROM_COPIED_STRING(
+    error = GRPC_ERROR_CREATE(
         absl::StrCat("Custom verification check failed with error: ",
                      status.ToString())
             .c_str());

--- a/src/core/lib/security/transport/secure_endpoint.cc
+++ b/src/core/lib/security/transport/secure_endpoint.cc
@@ -263,8 +263,8 @@ static void on_read(void* user_data, grpc_error_handle error) {
 
     if (!error.ok()) {
       grpc_slice_buffer_reset_and_unref(ep->read_buffer);
-      call_read_cb(ep, GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                           "Secure read failed", &error, 1));
+      call_read_cb(
+          ep, GRPC_ERROR_CREATE_REFERENCING("Secure read failed", &error, 1));
       return;
     }
 
@@ -342,9 +342,8 @@ static void on_read(void* user_data, grpc_error_handle error) {
 
   if (result != TSI_OK) {
     grpc_slice_buffer_reset_and_unref(ep->read_buffer);
-    call_read_cb(
-        ep, grpc_set_tsi_error_result(
-                GRPC_ERROR_CREATE_FROM_STATIC_STRING("Unwrap failed"), result));
+    call_read_cb(ep, grpc_set_tsi_error_result(
+                         GRPC_ERROR_CREATE("Unwrap failed"), result));
     return;
   }
 
@@ -486,8 +485,7 @@ static void endpoint_write(grpc_endpoint* secure_ep, grpc_slice_buffer* slices,
     grpc_slice_buffer_reset_and_unref(&ep->output_buffer);
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
-        grpc_set_tsi_error_result(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("Wrap failed"), result));
+        grpc_set_tsi_error_result(GRPC_ERROR_CREATE("Wrap failed"), result));
     return;
   }
 

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -199,7 +199,7 @@ void SecurityHandshaker::HandshakeFailedLocked(grpc_error_handle error) {
   if (error.ok()) {
     // If we were shut down after the handshake succeeded but before an
     // endpoint callback was invoked, we need to generate our own error.
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshaker shutdown");
+    error = GRPC_ERROR_CREATE("Handshaker shutdown");
   }
   gpr_log(GPR_DEBUG, "Security handshake failed: %s",
           grpc_error_std_string(error).c_str());
@@ -259,7 +259,7 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error_handle error) {
       handshaker_result_, &unused_bytes, &unused_bytes_size);
   if (result != TSI_OK) {
     HandshakeFailedLocked(grpc_set_tsi_error_result(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        GRPC_ERROR_CREATE(
             "TSI handshaker result does not provide unused bytes"),
         result));
     return;
@@ -270,9 +270,8 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error_handle error) {
       handshaker_result_, &frame_protector_type);
   if (result != TSI_OK) {
     HandshakeFailedLocked(grpc_set_tsi_error_result(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "TSI handshaker result does not implement "
-            "get_frame_protector_type"),
+        GRPC_ERROR_CREATE("TSI handshaker result does not implement "
+                          "get_frame_protector_type"),
         result));
     return;
   }
@@ -288,8 +287,7 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error_handle error) {
           &zero_copy_protector);
       if (result != TSI_OK) {
         HandshakeFailedLocked(grpc_set_tsi_error_result(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                "Zero-copy frame protector creation failed"),
+            GRPC_ERROR_CREATE("Zero-copy frame protector creation failed"),
             result));
         return;
       }
@@ -300,10 +298,8 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error_handle error) {
           handshaker_result_, max_frame_size_ == 0 ? nullptr : &max_frame_size_,
           &protector);
       if (result != TSI_OK) {
-        HandshakeFailedLocked(
-            grpc_set_tsi_error_result(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                          "Frame protector creation failed"),
-                                      result));
+        HandshakeFailedLocked(grpc_set_tsi_error_result(
+            GRPC_ERROR_CREATE("Frame protector creation failed"), result));
         return;
       }
       break;
@@ -359,7 +355,7 @@ grpc_error_handle SecurityHandshaker::CheckPeerLocked() {
       tsi_handshaker_result_extract_peer(handshaker_result_, &peer);
   if (result != TSI_OK) {
     return grpc_set_tsi_error_result(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Peer extraction failed"), result);
+        GRPC_ERROR_CREATE("Peer extraction failed"), result);
   }
   connector_->check_peer(peer, args_->endpoint, args_->args, &auth_context_,
                          &on_peer_checked_);
@@ -372,7 +368,7 @@ grpc_error_handle SecurityHandshaker::OnHandshakeNextDoneLocked(
   grpc_error_handle error;
   // Handshaker was shutdown.
   if (is_shutdown_) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshaker shutdown");
+    return GRPC_ERROR_CREATE("Handshaker shutdown");
   }
   // Read more if we need to.
   if (result == TSI_INCOMPLETE_DATA) {
@@ -393,7 +389,7 @@ grpc_error_handle SecurityHandshaker::OnHandshakeNextDoneLocked(
       connector_type = security_connector->type().name();
     }
     return grpc_set_tsi_error_result(
-        GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+        GRPC_ERROR_CREATE(absl::StrCat(
             connector_type, " handshake failed",
             (tsi_handshake_error_.empty() ? "" : ": "), tsi_handshake_error_)),
         result);
@@ -486,8 +482,8 @@ void SecurityHandshaker::OnHandshakeDataReceivedFromPeerFn(
   RefCountedPtr<SecurityHandshaker> h(static_cast<SecurityHandshaker*>(arg));
   MutexLock lock(&h->mu_);
   if (!error.ok() || h->is_shutdown_) {
-    h->HandshakeFailedLocked(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "Handshake read failed", &error, 1));
+    h->HandshakeFailedLocked(
+        GRPC_ERROR_CREATE_REFERENCING("Handshake read failed", &error, 1));
     return;
   }
   // Copy all slices received.
@@ -519,8 +515,8 @@ void SecurityHandshaker::OnHandshakeDataSentToPeerFn(void* arg,
   RefCountedPtr<SecurityHandshaker> h(static_cast<SecurityHandshaker*>(arg));
   MutexLock lock(&h->mu_);
   if (!error.ok() || h->is_shutdown_) {
-    h->HandshakeFailedLocked(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-        "Handshake write failed", &error, 1));
+    h->HandshakeFailedLocked(
+        GRPC_ERROR_CREATE_REFERENCING("Handshake write failed", &error, 1));
     return;
   }
   // We may be done.
@@ -585,8 +581,8 @@ class FailHandshaker : public Handshaker {
   void DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
                    grpc_closure* on_handshake_done,
                    HandshakerArgs* args) override {
-    grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Failed to create security handshaker");
+    grpc_error_handle error =
+        GRPC_ERROR_CREATE("Failed to create security handshaker");
     grpc_endpoint_shutdown(args->endpoint, error);
     grpc_endpoint_destroy(args->endpoint);
     args->endpoint = nullptr;

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -208,9 +208,9 @@ static void on_md_processing_done(
       if (error_details == nullptr) {
         error_details = "Authentication metadata processing failed.";
       }
-      error = grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_COPIED_STRING(error_details),
-          grpc_core::StatusIntProperty::kRpcStatus, status);
+      error =
+          grpc_error_set_int(GRPC_ERROR_CREATE(error_details),
+                             grpc_core::StatusIntProperty::kRpcStatus, status);
     }
     on_md_processing_done_inner(elem, consumed_md, num_consumed_md, response_md,
                                 num_response_md, error);

--- a/src/core/lib/security/util/json_util.cc
+++ b/src/core/lib/security/util/json_util.cc
@@ -35,22 +35,21 @@ const char* grpc_json_get_string_property(const grpc_core::Json& json,
                                           grpc_error_handle* error) {
   if (json.type() != grpc_core::Json::Type::OBJECT) {
     if (error != nullptr) {
-      *error =
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("JSON value is not an object");
+      *error = GRPC_ERROR_CREATE("JSON value is not an object");
     }
     return nullptr;
   }
   auto it = json.object_value().find(prop_name);
   if (it == json.object_value().end()) {
     if (error != nullptr) {
-      *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      *error = GRPC_ERROR_CREATE(
           absl::StrCat("Property ", prop_name, " not found in JSON object."));
     }
     return nullptr;
   }
   if (it->second.type() != grpc_core::Json::Type::STRING) {
     if (error != nullptr) {
-      *error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
+      *error = GRPC_ERROR_CREATE(absl::StrCat(
           "Property ", prop_name, " n JSON object is not a string."));
     }
     return nullptr;

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -309,7 +309,7 @@ void Call::CancelWithStatus(grpc_status_code status, const char* description) {
   // copying 'description' is needed to ensure the grpc_call_cancel_with_status
   // guarantee that can be short-lived.
   CancelWithError(grpc_error_set_int(
-      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_COPIED_STRING(description),
+      grpc_error_set_str(GRPC_ERROR_CREATE(description),
                          StatusStrProperty::kGrpcMessage, description),
       StatusIntProperty::kRpcStatus, status));
 }
@@ -627,7 +627,7 @@ grpc_error_handle FilterStackCall::Create(grpc_call_create_args* args,
                            grpc_error_handle new_err) {
     if (new_err.ok()) return;
     if (composite->ok()) {
-      *composite = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Call creation failed");
+      *composite = GRPC_ERROR_CREATE("Call creation failed");
     }
     *composite = grpc_error_add_child(*composite, new_err);
   };
@@ -1018,8 +1018,7 @@ void FilterStackCall::RecvTrailingFilter(grpc_metadata_batch* b,
       if (status_code != GRPC_STATUS_OK) {
         char* peer = GetPeer();
         error = grpc_error_set_int(
-            GRPC_ERROR_CREATE_FROM_CPP_STRING(
-                absl::StrCat("Error received from peer ", peer)),
+            GRPC_ERROR_CREATE(absl::StrCat("Error received from peer ", peer)),
             StatusIntProperty::kRpcStatus, static_cast<intptr_t>(status_code));
         gpr_free(peer);
       }
@@ -1036,9 +1035,9 @@ void FilterStackCall::RecvTrailingFilter(grpc_metadata_batch* b,
     } else {
       gpr_log(GPR_DEBUG,
               "Received trailing metadata with no error and no status");
-      SetFinalStatus(grpc_error_set_int(
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("No status received"),
-          StatusIntProperty::kRpcStatus, GRPC_STATUS_UNKNOWN));
+      SetFinalStatus(grpc_error_set_int(GRPC_ERROR_CREATE("No status received"),
+                                        StatusIntProperty::kRpcStatus,
+                                        GRPC_STATUS_UNKNOWN));
     }
   }
   PublishAppMetadata(b, true);
@@ -1112,7 +1111,7 @@ void FilterStackCall::BatchControl::PostCompletion() {
   if (op_.send_message) {
     if (op_.payload->send_message.stream_write_closed && error.ok()) {
       error = grpc_error_add_child(
-          error, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+          error, GRPC_ERROR_CREATE(
                      "Attempt to send message after stream was closed."));
     }
     call->sending_message_ = false;
@@ -1552,8 +1551,7 @@ grpc_call_error FilterStackCall::StartBatch(const grpc_op* ops, size_t nops,
             op->data.send_status_from_server.status == GRPC_STATUS_OK
                 ? absl::OkStatus()
                 : grpc_error_set_int(
-                      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                          "Server returned error"),
+                      GRPC_ERROR_CREATE("Server returned error"),
                       StatusIntProperty::kRpcStatus,
                       static_cast<intptr_t>(
                           op->data.send_status_from_server.status));

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -429,8 +429,7 @@ void grpc_channel_destroy_internal(grpc_channel* c_channel) {
   grpc_transport_op* op = grpc_make_transport_op(nullptr);
   grpc_channel_element* elem;
   GRPC_API_TRACE("grpc_channel_destroy(channel=%p)", 1, (c_channel));
-  op->disconnect_with_error =
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Channel Destroyed");
+  op->disconnect_with_error = GRPC_ERROR_CREATE("Channel Destroyed");
   elem = grpc_channel_stack_element(channel->channel_stack(), 0);
   elem->filter->start_transport_op(elem, op);
 }

--- a/src/core/lib/surface/lame_client.cc
+++ b/src/core/lib/surface/lame_client.cc
@@ -96,11 +96,11 @@ bool LameClientFilter::StartTransportOp(grpc_transport_op* op) {
   }
   if (op->send_ping.on_initiate != nullptr) {
     ExecCtx::Run(DEBUG_LOCATION, op->send_ping.on_initiate,
-                 GRPC_ERROR_CREATE_FROM_STATIC_STRING("lame client channel"));
+                 GRPC_ERROR_CREATE("lame client channel"));
   }
   if (op->send_ping.on_ack != nullptr) {
     ExecCtx::Run(DEBUG_LOCATION, op->send_ping.on_ack,
-                 GRPC_ERROR_CREATE_FROM_STATIC_STRING("lame client channel"));
+                 GRPC_ERROR_CREATE("lame client channel"));
   }
   if (op->on_consumed != nullptr) {
     ExecCtx::Run(DEBUG_LOCATION, op->on_consumed, absl::OkStatus());

--- a/src/core/lib/surface/validate_metadata.cc
+++ b/src/core/lib/surface/validate_metadata.cc
@@ -43,7 +43,7 @@ static grpc_error_handle conforms_to(const grpc_slice& slice,
           reinterpret_cast<const char*> GRPC_SLICE_START_PTR(slice),
           GRPC_SLICE_LENGTH(slice), GPR_DUMP_HEX | GPR_DUMP_ASCII, &len));
       grpc_error_handle error = grpc_error_set_str(
-          grpc_error_set_int(GRPC_ERROR_CREATE_FROM_COPIED_STRING(err_desc),
+          grpc_error_set_int(GRPC_ERROR_CREATE(err_desc),
                              grpc_core::StatusIntProperty::kOffset,
                              p - GRPC_SLICE_START_PTR(slice)),
           grpc_core::StatusStrProperty::kRawBytes,
@@ -75,16 +75,13 @@ constexpr LegalHeaderKeyBits g_legal_header_key_bits;
 
 grpc_error_handle grpc_validate_header_key_is_legal(const grpc_slice& slice) {
   if (GRPC_SLICE_LENGTH(slice) == 0) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Metadata keys cannot be zero length");
+    return GRPC_ERROR_CREATE("Metadata keys cannot be zero length");
   }
   if (GRPC_SLICE_LENGTH(slice) > UINT32_MAX) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Metadata keys cannot be larger than UINT32_MAX");
+    return GRPC_ERROR_CREATE("Metadata keys cannot be larger than UINT32_MAX");
   }
   if (GRPC_SLICE_START_PTR(slice)[0] == ':') {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Metadata keys cannot start with :");
+    return GRPC_ERROR_CREATE("Metadata keys cannot start with :");
   }
   return conforms_to(slice, g_legal_header_key_bits, "Illegal header key");
 }

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -150,10 +150,9 @@ grpc_error_handle absl_status_to_grpc_error(absl::Status status) {
   if (status.ok()) {
     return absl::OkStatus();
   }
-  return grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STRING_VIEW(status.message()),
-      grpc_core::StatusIntProperty::kRpcStatus,
-      static_cast<grpc_status_code>(status.code()));
+  return grpc_error_set_int(GRPC_ERROR_CREATE(status.message()),
+                            grpc_core::StatusIntProperty::kRpcStatus,
+                            static_cast<grpc_status_code>(status.code()));
 }
 
 bool grpc_error_has_clear_grpc_status(grpc_error_handle error) {

--- a/src/core/lib/transport/handshaker.cc
+++ b/src/core/lib/transport/handshaker.cc
@@ -101,7 +101,7 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
   if (!error.ok() || is_shutdown_ || args_.exit_early ||
       index_ == handshakers_.size()) {
     if (error.ok() && is_shutdown_) {
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("handshaker shutdown");
+      error = GRPC_ERROR_CREATE("handshaker shutdown");
       // It is possible that the endpoint has already been destroyed by
       // a shutdown call while this callback was sitting on the ExecCtx
       // with no error.
@@ -163,7 +163,7 @@ void HandshakeManager::CallNextHandshakerFn(void* arg,
 void HandshakeManager::OnTimeoutFn(void* arg, grpc_error_handle error) {
   auto* mgr = static_cast<HandshakeManager*>(arg);
   if (error.ok()) {  // Timer fired, rather than being cancelled
-    mgr->Shutdown(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshake timed out"));
+    mgr->Shutdown(GRPC_ERROR_CREATE("Handshake timed out"));
   }
   mgr->Unref();
 }

--- a/src/core/lib/transport/http_connect_handshaker.cc
+++ b/src/core/lib/transport/http_connect_handshaker.cc
@@ -127,7 +127,7 @@ void HttpConnectHandshaker::HandshakeFailedLocked(grpc_error_handle error) {
     // If we were shut down after an endpoint operation succeeded but
     // before the endpoint callback was invoked, we need to generate our
     // own error.
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshaker shutdown");
+    error = GRPC_ERROR_CREATE("Handshaker shutdown");
   }
   if (!is_shutdown_) {
     // TODO(ctiller): It is currently necessary to shutdown endpoints
@@ -258,9 +258,8 @@ void HttpConnectHandshaker::OnReadDone(void* arg, grpc_error_handle error) {
   // Make sure we got a 2xx response.
   if (handshaker->http_response_.status < 200 ||
       handshaker->http_response_.status >= 300) {
-    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(
-        absl::StrCat("HTTP proxy returned response code ",
-                     handshaker->http_response_.status));
+    error = GRPC_ERROR_CREATE(absl::StrCat("HTTP proxy returned response code ",
+                                           handshaker->http_response_.status));
     handshaker->HandshakeFailedLocked(error);
     goto done;
   }

--- a/src/core/lib/transport/tcp_connect_handshaker.cc
+++ b/src/core/lib/transport/tcp_connect_handshaker.cc
@@ -113,8 +113,7 @@ void TCPConnectHandshaker::Shutdown(grpc_error_handle /*why*/) {
       // the necessary clean up.
       if (on_handshake_done_ != nullptr) {
         CleanupArgsForFailureLocked();
-        FinishLocked(
-            GRPC_ERROR_CREATE_FROM_STATIC_STRING("tcp handshaker shutdown"));
+        FinishLocked(GRPC_ERROR_CREATE("tcp handshaker shutdown"));
       }
     }
   }
@@ -133,8 +132,7 @@ void TCPConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
       args->args.GetString(GRPC_ARG_TCP_HANDSHAKER_RESOLVED_ADDRESS).value());
   if (!uri.ok() || !grpc_parse_uri(*uri, &addr_)) {
     MutexLock lock(&mu_);
-    FinishLocked(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-        "Resolved address in invalid format"));
+    FinishLocked(GRPC_ERROR_CREATE("Resolved address in invalid format"));
     return;
   }
   bind_endpoint_to_pollset_ =
@@ -168,7 +166,7 @@ void TCPConnectHandshaker::Connected(void* arg, grpc_error_handle error) {
     MutexLock lock(&self->mu_);
     if (!error.ok() || self->shutdown_) {
       if (error.ok()) {
-        error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("tcp handshaker shutdown");
+        error = GRPC_ERROR_CREATE("tcp handshaker shutdown");
       }
       if (self->endpoint_to_destroy_ != nullptr) {
         grpc_endpoint_shutdown(self->endpoint_to_destroy_, error);

--- a/test/core/bad_client/bad_client.cc
+++ b/test/core/bad_client/bad_client.cc
@@ -90,8 +90,7 @@ static void set_read_done(void* arg, grpc_error_handle /*error*/) {
 /* shutdown client */
 static void shutdown_client(grpc_endpoint** client_fd) {
   if (*client_fd != nullptr) {
-    grpc_endpoint_shutdown(
-        *client_fd, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Forced Disconnect"));
+    grpc_endpoint_shutdown(*client_fd, GRPC_ERROR_CREATE("Forced Disconnect"));
     grpc_endpoint_destroy(*client_fd);
     grpc_core::ExecCtx::Get()->Flush();
     *client_fd = nullptr;

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -343,8 +343,7 @@ static void run_test(bool http2_response, bool send_settings,
   /* Proof that the server accepted the TCP connection. */
   GPR_ASSERT(state.connection_attempt_made == true);
   /* clean up */
-  grpc_endpoint_shutdown(state.tcp,
-                         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+  grpc_endpoint_shutdown(state.tcp, GRPC_ERROR_CREATE("Test Shutdown"));
   grpc_endpoint_destroy(state.tcp);
   cleanup_rpc();
   grpc_core::ExecCtx::Get()->Flush();

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -503,8 +503,8 @@ static void on_read_request_done_locked(void* arg, grpc_error_handle error) {
   }
   // Make sure we got a CONNECT request.
   if (strcmp(conn->http_request.method, "CONNECT") != 0) {
-    error = GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
-        "HTTP proxy got request method ", conn->http_request.method));
+    error = GRPC_ERROR_CREATE(absl::StrCat("HTTP proxy got request method ",
+                                           conn->http_request.method));
     proxy_connection_failed(conn, SETUP_FAILED, "HTTP proxy read request",
                             error);
     return;
@@ -524,7 +524,7 @@ static void on_read_request_done_locked(void* arg, grpc_error_handle error) {
     }
     if (!client_authenticated) {
       const char* msg = "HTTP Connect could not verify authentication";
-      error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(msg);
+      error = GRPC_ERROR_CREATE(msg);
       proxy_connection_failed(conn, SETUP_FAILED, "HTTP proxy read request",
                               error);
       return;

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -126,9 +126,9 @@ static void finish_resolve(void* arg, grpc_error_handle error) {
         ->emplace_back(fake_resolved_address, grpc_core::ChannelArgs());
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, r->on_done, absl::OkStatus());
   } else {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, r->on_done,
-                            GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                                "Resolution failed", &error, 1));
+    grpc_core::ExecCtx::Run(
+        DEBUG_LOCATION, r->on_done,
+        GRPC_ERROR_CREATE_REFERENCING("Resolution failed", &error, 1));
   }
 
   gpr_free(r->addr);
@@ -299,9 +299,8 @@ static void sched_connect(grpc_closure* closure, grpc_endpoint** ep,
                           gpr_timespec deadline) {
   if (gpr_time_cmp(deadline, gpr_now(deadline.clock_type)) < 0) {
     *ep = nullptr;
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, closure,
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Connect deadline exceeded"));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure,
+                            GRPC_ERROR_CREATE("Connect deadline exceeded"));
     return;
   }
 

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -184,7 +184,7 @@ static grpc_ares_request* my_dns_lookup_ares(
   gpr_mu_lock(&g_mu);
   if (g_resolve_port < 0) {
     gpr_mu_unlock(&g_mu);
-    error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Forced Failure");
+    error = GRPC_ERROR_CREATE("Forced Failure");
   } else {
     *addresses = std::make_unique<grpc_core::ServerAddressList>();
     grpc_sockaddr_in sa;

--- a/test/core/end2end/tests/filter_causes_close.cc
+++ b/test/core/end2end/tests/filter_causes_close.cc
@@ -209,7 +209,7 @@ static void recv_im_ready(void* arg, grpc_error_handle error) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
   grpc_core::Closure::Run(
       DEBUG_LOCATION, calld->recv_im_ready,
-      grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+      grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING(
                              "Failure that's not preventable.", &error, 1),
                          grpc_core::StatusIntProperty::kRpcStatus,
                          GRPC_STATUS_PERMISSION_DENIED));

--- a/test/core/end2end/tests/filter_init_fails.cc
+++ b/test/core/end2end/tests/filter_init_fails.cc
@@ -426,9 +426,9 @@ static void test_client_subchannel_filter(grpc_end2end_test_config config) {
 
 static grpc_error_handle init_call_elem(
     grpc_call_element* /*elem*/, const grpc_call_element_args* /*args*/) {
-  return grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("access denied"),
-      grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_PERMISSION_DENIED);
+  return grpc_error_set_int(GRPC_ERROR_CREATE("access denied"),
+                            grpc_core::StatusIntProperty::kRpcStatus,
+                            GRPC_STATUS_PERMISSION_DENIED);
 }
 
 static void destroy_call_elem(grpc_call_element* /*elem*/,
@@ -439,7 +439,7 @@ static grpc_error_handle init_channel_elem(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* /*args*/) {
   if (g_channel_filter_init_failure) {
     return grpc_error_set_int(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test channel filter init error"),
+        GRPC_ERROR_CREATE("Test channel filter init error"),
         grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_INVALID_ARGUMENT);
   }
   return absl::OkStatus();

--- a/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
+++ b/test/core/end2end/tests/retry_cancel_with_multiple_send_batches.cc
@@ -274,10 +274,9 @@ class FailSendOpsFilter {
           batch->send_trailing_metadata) {
         grpc_transport_stream_op_batch_finish_with_failure(
             batch,
-            grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                   "FailSendOpsFilter failing batch"),
-                               grpc_core::StatusIntProperty::kRpcStatus,
-                               GRPC_STATUS_ABORTED),
+            grpc_error_set_int(
+                GRPC_ERROR_CREATE("FailSendOpsFilter failing batch"),
+                grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_ABORTED),
             calld->call_combiner_);
         return;
       }

--- a/test/core/end2end/tests/retry_recv_message_replay.cc
+++ b/test/core/end2end/tests/retry_recv_message_replay.cc
@@ -304,10 +304,9 @@ class FailFirstSendOpFilter {
       if (calld->fail_ && !batch->cancel_stream) {
         grpc_transport_stream_op_batch_finish_with_failure(
             batch,
-            grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                   "FailFirstSendOpFilter failing batch"),
-                               grpc_core::StatusIntProperty::kRpcStatus,
-                               GRPC_STATUS_ABORTED),
+            grpc_error_set_int(
+                GRPC_ERROR_CREATE("FailFirstSendOpFilter failing batch"),
+                grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_ABORTED),
             calld->call_combiner_);
         return;
       }

--- a/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
+++ b/test/core/end2end/tests/retry_recv_trailing_metadata_error.cc
@@ -314,10 +314,9 @@ class InjectStatusFilter {
       auto* calld = static_cast<CallData*>(arg);
       grpc_core::Closure::Run(
           DEBUG_LOCATION, calld->original_recv_trailing_metadata_ready_,
-          grpc_error_set_int(
-              GRPC_ERROR_CREATE_FROM_STATIC_STRING("injected error"),
-              grpc_core::StatusIntProperty::kRpcStatus,
-              GRPC_STATUS_INVALID_ARGUMENT));
+          grpc_error_set_int(GRPC_ERROR_CREATE("injected error"),
+                             grpc_core::StatusIntProperty::kRpcStatus,
+                             GRPC_STATUS_INVALID_ARGUMENT));
     }
 
     grpc_closure recv_trailing_metadata_ready_;

--- a/test/core/end2end/tests/retry_send_op_fails.cc
+++ b/test/core/end2end/tests/retry_send_op_fails.cc
@@ -319,10 +319,9 @@ class FailFirstCallFilter {
       if (calld->fail_ && !batch->cancel_stream) {
         grpc_transport_stream_op_batch_finish_with_failure(
             batch,
-            grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                   "FailFirstCallFilter failing batch"),
-                               grpc_core::StatusIntProperty::kRpcStatus,
-                               GRPC_STATUS_ABORTED),
+            grpc_error_set_int(
+                GRPC_ERROR_CREATE("FailFirstCallFilter failing batch"),
+                grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_ABORTED),
             calld->call_combiner_);
         return;
       }

--- a/test/core/end2end/tests/retry_transparent_goaway.cc
+++ b/test/core/end2end/tests/retry_transparent_goaway.cc
@@ -310,10 +310,10 @@ class FailFirstCallFilter {
         if (!batch->cancel_stream) {
           grpc_transport_stream_op_batch_finish_with_failure(
               batch,
-              grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                     "FailFirstCallFilter failing batch"),
-                                 grpc_core::StatusIntProperty::kRpcStatus,
-                                 GRPC_STATUS_UNAVAILABLE),
+              grpc_error_set_int(
+                  GRPC_ERROR_CREATE("FailFirstCallFilter failing batch"),
+                  grpc_core::StatusIntProperty::kRpcStatus,
+                  GRPC_STATUS_UNAVAILABLE),
               calld->call_combiner_);
           return;
         }

--- a/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
+++ b/test/core/end2end/tests/retry_transparent_not_sent_on_wire.cc
@@ -309,10 +309,10 @@ class FailFirstTenCallsFilter {
         if (!batch->cancel_stream) {
           grpc_transport_stream_op_batch_finish_with_failure(
               batch,
-              grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                     "FailFirstTenCallsFilter failing batch"),
-                                 grpc_core::StatusIntProperty::kRpcStatus,
-                                 GRPC_STATUS_UNAVAILABLE),
+              grpc_error_set_int(
+                  GRPC_ERROR_CREATE("FailFirstTenCallsFilter failing batch"),
+                  grpc_core::StatusIntProperty::kRpcStatus,
+                  GRPC_STATUS_UNAVAILABLE),
               calld->call_combiner_);
           return;
         }

--- a/test/core/iomgr/endpoint_tests.cc
+++ b/test/core/iomgr/endpoint_tests.cc
@@ -254,11 +254,9 @@ static void read_and_write_test(grpc_endpoint_test_config config,
                      /*urgent=*/false, /*min_progress_size=*/1);
   if (shutdown) {
     gpr_log(GPR_DEBUG, "shutdown read");
-    grpc_endpoint_shutdown(
-        state.read_ep, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+    grpc_endpoint_shutdown(state.read_ep, GRPC_ERROR_CREATE("Test Shutdown"));
     gpr_log(GPR_DEBUG, "shutdown write");
-    grpc_endpoint_shutdown(
-        state.write_ep, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+    grpc_endpoint_shutdown(state.write_ep, GRPC_ERROR_CREATE("Test Shutdown"));
   }
   grpc_core::ExecCtx::Get()->Flush();
 
@@ -318,8 +316,7 @@ static void multiple_shutdown_test(grpc_endpoint_test_config config) {
                                          grpc_schedule_on_exec_ctx),
                      /*urgent=*/false, /*min_progress_size=*/1);
   wait_for_fail_count(&fail_count, 0);
-  grpc_endpoint_shutdown(f.client_ep,
-                         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+  grpc_endpoint_shutdown(f.client_ep, GRPC_ERROR_CREATE("Test Shutdown"));
   wait_for_fail_count(&fail_count, 1);
   grpc_endpoint_read(f.client_ep, &slice_buffer,
                      GRPC_CLOSURE_CREATE(inc_on_failure, &fail_count,
@@ -332,8 +329,7 @@ static void multiple_shutdown_test(grpc_endpoint_test_config config) {
                                           grpc_schedule_on_exec_ctx),
                       nullptr, /*max_frame_size=*/INT_MAX);
   wait_for_fail_count(&fail_count, 3);
-  grpc_endpoint_shutdown(f.client_ep,
-                         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+  grpc_endpoint_shutdown(f.client_ep, GRPC_ERROR_CREATE("Test Shutdown"));
   wait_for_fail_count(&fail_count, 3);
 
   grpc_slice_buffer_destroy(&slice_buffer);

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -29,7 +29,7 @@
 #include "test/core/util/test_config.h"
 
 TEST(ErrorTest, SetGetInt) {
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
+  grpc_error_handle error = GRPC_ERROR_CREATE("Test");
   EXPECT_NE(error, absl::OkStatus());
   intptr_t i = 0;
 #ifndef NDEBUG
@@ -59,7 +59,7 @@ TEST(ErrorTest, SetGetInt) {
 }
 
 TEST(ErrorTest, SetGetStr) {
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test");
+  grpc_error_handle error = GRPC_ERROR_CREATE("Test");
 
   std::string str;
   EXPECT_TRUE(
@@ -89,7 +89,7 @@ TEST(ErrorTest, SetGetStr) {
 TEST(ErrorTest, CopyAndUnRef) {
   // error1 has one ref
   grpc_error_handle error1 =
-      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test"),
+      grpc_error_set_str(GRPC_ERROR_CREATE("Test"),
                          grpc_core::StatusStrProperty::kGrpcMessage, "message");
   std::string str;
   EXPECT_TRUE(grpc_error_get_str(
@@ -114,27 +114,26 @@ TEST(ErrorTest, CopyAndUnRef) {
 
 TEST(ErrorTest, CreateReferencing) {
   grpc_error_handle child =
-      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child"),
+      grpc_error_set_str(GRPC_ERROR_CREATE("Child"),
                          grpc_core::StatusStrProperty::kGrpcMessage, "message");
-  grpc_error_handle parent =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", &child, 1);
+  grpc_error_handle parent = GRPC_ERROR_CREATE_REFERENCING("Parent", &child, 1);
   EXPECT_NE(parent, absl::OkStatus());
 }
 
 TEST(ErrorTest, CreateReferencingMany) {
   grpc_error_handle children[3];
   children[0] =
-      grpc_error_set_str(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child1"),
+      grpc_error_set_str(GRPC_ERROR_CREATE("Child1"),
                          grpc_core::StatusStrProperty::kGrpcMessage, "message");
   children[1] =
-      grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child2"),
+      grpc_error_set_int(GRPC_ERROR_CREATE("Child2"),
                          grpc_core::StatusIntProperty::kHttp2Error, 5);
-  children[2] = grpc_error_set_str(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child3"),
-      grpc_core::StatusStrProperty::kGrpcMessage, "message 3");
+  children[2] = grpc_error_set_str(GRPC_ERROR_CREATE("Child3"),
+                                   grpc_core::StatusStrProperty::kGrpcMessage,
+                                   "message 3");
 
   grpc_error_handle parent =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 3);
+      GRPC_ERROR_CREATE_REFERENCING("Parent", children, 3);
   EXPECT_NE(parent, absl::OkStatus());
 
   for (size_t i = 0; i < 3; ++i) {
@@ -143,8 +142,8 @@ TEST(ErrorTest, CreateReferencingMany) {
 
 TEST(ErrorTest, PrintErrorString) {
   grpc_error_handle error = grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"),
-      grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNIMPLEMENTED);
+      GRPC_ERROR_CREATE("Error"), grpc_core::StatusIntProperty::kRpcStatus,
+      GRPC_STATUS_UNIMPLEMENTED);
   error = grpc_error_set_int(error, grpc_core::StatusIntProperty::kSize, 666);
   error = grpc_error_set_str(error, grpc_core::StatusStrProperty::kGrpcMessage,
                              "message");
@@ -154,18 +153,18 @@ TEST(ErrorTest, PrintErrorString) {
 TEST(ErrorTest, PrintErrorStringReference) {
   grpc_error_handle children[2];
   children[0] = grpc_error_set_str(
-      grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("1"),
+      grpc_error_set_int(GRPC_ERROR_CREATE("1"),
                          grpc_core::StatusIntProperty::kRpcStatus,
                          GRPC_STATUS_UNIMPLEMENTED),
       grpc_core::StatusStrProperty::kGrpcMessage, "message for child 1");
   children[1] = grpc_error_set_str(
-      grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("2sd"),
+      grpc_error_set_int(GRPC_ERROR_CREATE("2sd"),
                          grpc_core::StatusIntProperty::kRpcStatus,
                          GRPC_STATUS_INTERNAL),
       grpc_core::StatusStrProperty::kGrpcMessage, "message for child 2");
 
   grpc_error_handle parent =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Parent", children, 2);
+      GRPC_ERROR_CREATE_REFERENCING("Parent", children, 2);
 
   for (size_t i = 0; i < 2; ++i) {
   }

--- a/test/core/iomgr/fd_posix_test.cc
+++ b/test/core/iomgr/fd_posix_test.cc
@@ -120,8 +120,7 @@ static void session_shutdown_cb(void* arg, /*session */
   grpc_fd_orphan(se->em_fd, nullptr, nullptr, "a");
   gpr_free(se);
   /* Start to shutdown listen fd. */
-  grpc_fd_shutdown(sv->em_fd,
-                   GRPC_ERROR_CREATE_FROM_STATIC_STRING("session_shutdown_cb"));
+  grpc_fd_shutdown(sv->em_fd, GRPC_ERROR_CREATE("session_shutdown_cb"));
 }
 
 /* Called when data become readable in a session. */

--- a/test/core/iomgr/tcp_client_posix_test.cc
+++ b/test/core/iomgr/tcp_client_posix_test.cc
@@ -69,8 +69,8 @@ static void finish_connection() {
 static void must_succeed(void* /*arg*/, grpc_error_handle error) {
   ASSERT_NE(g_connecting, nullptr);
   ASSERT_TRUE(error.ok());
-  grpc_endpoint_shutdown(g_connecting, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                           "must_succeed called"));
+  grpc_endpoint_shutdown(g_connecting,
+                         GRPC_ERROR_CREATE("must_succeed called"));
   grpc_endpoint_destroy(g_connecting);
   g_connecting = nullptr;
   finish_connection();

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -150,8 +150,7 @@ static void test_addr_init_str(test_addr* addr) {
 static void on_connect(void* /*arg*/, grpc_endpoint* tcp,
                        grpc_pollset* /*pollset*/,
                        grpc_tcp_server_acceptor* acceptor) {
-  grpc_endpoint_shutdown(tcp,
-                         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Connected"));
+  grpc_endpoint_shutdown(tcp, GRPC_ERROR_CREATE("Connected"));
   grpc_endpoint_destroy(tcp);
 
   on_connect_result temp_result;
@@ -302,7 +301,7 @@ static grpc_error_handle tcp_connect(const test_addr* remote,
   if (g_nconnects != nconnects_before + 1) {
     gpr_mu_unlock(g_mu);
     close(clifd);
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Didn't connect");
+    return GRPC_ERROR_CREATE("Didn't connect");
   }
   close(clifd);
   *result = g_result;

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -821,9 +821,7 @@ TEST(CredentialsTest, TestComputeEngineCredsFailure) {
       "GoogleComputeEngineTokenFetcherCredentials{"
       "OAuth2TokenFetcherCredentials}";
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token."),
-      {});
+      GRPC_ERROR_CREATE("Error occurred when fetching oauth2 token."), {});
   grpc_call_credentials* creds =
       grpc_google_compute_engine_credentials_create(nullptr);
   HttpRequest::SetOverride(compute_engine_httpcli_get_failure_override,
@@ -921,9 +919,7 @@ TEST(CredentialsTest, TestRefreshTokenCredsFailure) {
       "GoogleRefreshToken{ClientID:32555999999.apps.googleusercontent.com,"
       "OAuth2TokenFetcherCredentials}";
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token."),
-      {});
+      GRPC_ERROR_CREATE("Error occurred when fetching oauth2 token."), {});
   grpc_call_credentials* creds = grpc_google_refresh_token_credentials_create(
       test_refresh_token_str, nullptr);
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
@@ -1188,9 +1184,7 @@ TEST(CredentialsTest, TestStsCredsTokenFileNotFound) {
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
 
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token."),
-      {});
+      GRPC_ERROR_CREATE("Error occurred when fetching oauth2 token."), {});
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
@@ -1258,9 +1252,7 @@ TEST(CredentialsTest, TestStsCredsLoadTokenFailure) {
       "token-exchange,Authority:foo.com:5555,OAuth2TokenFetcherCredentials}";
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token."),
-      {});
+      GRPC_ERROR_CREATE("Error occurred when fetching oauth2 token."), {});
   char* test_signed_jwt_path = write_tmp_jwt_file(test_signed_jwt);
   grpc_sts_credentials_options options = {
       test_sts_endpoint_url,       // sts_endpoint_url
@@ -1293,9 +1285,7 @@ TEST(CredentialsTest, TestStsCredsHttpFailure) {
       "token-exchange,Authority:foo.com:5555,OAuth2TokenFetcherCredentials}";
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token."),
-      {});
+      GRPC_ERROR_CREATE("Error occurred when fetching oauth2 token."), {});
   char* test_signed_jwt_path = write_tmp_jwt_file(test_signed_jwt);
   grpc_sts_credentials_options valid_options = {
       test_sts_endpoint_url,       // sts_endpoint_url
@@ -1483,7 +1473,7 @@ TEST(CredentialsTest, TestJwtCredsSigningFailure) {
   char* json_key_string = test_json_key_str();
   ExecCtx exec_ctx;
   auto state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Could not generate JWT."), {});
+      GRPC_ERROR_CREATE("Could not generate JWT."), {});
   grpc_call_credentials* creds =
       grpc_service_account_jwt_access_credentials_create(
           json_key_string, grpc_max_auth_token_lifetime(), nullptr);
@@ -1961,7 +1951,7 @@ TEST(CredentialsTest, TestMetadataPluginFailure) {
   grpc_metadata_credentials_plugin plugin;
   ExecCtx exec_ctx;
   auto md_state = RequestMetadataState::NewInstance(
-      GRPC_ERROR_CREATE_FROM_CPP_STRING(
+      GRPC_ERROR_CREATE(
           absl::StrCat("Getting metadata from plugin failed with error: ",
                        plugin_error_details)),
       {});
@@ -2526,11 +2516,10 @@ TEST(CredentialsTest, TestExternalAccountCredsFailureInvalidTokenUrl) {
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-      "Invalid token url: invalid_token_url.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  grpc_error_handle error =
+      GRPC_ERROR_CREATE("Invalid token url: invalid_token_url.");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   state->RunRequestMetadataTest(&creds, kTestUrlScheme, kTestAuthority,
                                 kTestPath);
@@ -2559,12 +2548,11 @@ TEST(CredentialsTest,
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            external_account_creds_httpcli_post_success,
                            httpcli_put_should_not_be_called);
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+  grpc_error_handle error = GRPC_ERROR_CREATE(
       "Invalid service account impersonation url: "
       "invalid_service_account_impersonation_url.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   state->RunRequestMetadataTest(&creds, kTestUrlScheme, kTestAuthority,
                                 kTestPath);
@@ -2594,13 +2582,12 @@ TEST(CredentialsTest,
       httpcli_get_should_not_be_called,
       external_account_creds_httpcli_post_failure_token_exchange_response_missing_access_token,
       httpcli_put_should_not_be_called);
-  grpc_error_handle error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+  grpc_error_handle error = GRPC_ERROR_CREATE(
       "Missing or invalid access_token in "
       "{\"not_access_token\":\"not_access_token\",\"expires_in\":3599,\"token_"
       "type\":\"Bearer\"}.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   state->RunRequestMetadataTest(&creds, kTestUrlScheme, kTestAuthority,
                                 kTestPath);
@@ -2846,10 +2833,9 @@ TEST(CredentialsTest, TestFileExternalAccountCredsFailureFileNotFound) {
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
-  error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Failed to load file");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  error = GRPC_ERROR_CREATE("Failed to load file");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   state->RunRequestMetadataTest(creds.get(), kTestUrlScheme, kTestAuthority,
                                 kTestPath);
@@ -2891,11 +2877,10 @@ TEST(CredentialsTest, TestFileExternalAccountCredsFailureInvalidJsonContent) {
   HttpRequest::SetOverride(httpcli_get_should_not_be_called,
                            httpcli_post_should_not_be_called,
                            httpcli_put_should_not_be_called);
-  error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-      "The content of the file is not a valid json object.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  error =
+      GRPC_ERROR_CREATE("The content of the file is not a valid json object.");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   state->RunRequestMetadataTest(creds.get(), kTestUrlScheme, kTestAuthority,
                                 kTestPath);
@@ -3310,11 +3295,9 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsFailureInvalidRegionUrl) {
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
-  error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-      "Invalid region url: invalid_region_url.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  error = GRPC_ERROR_CREATE("Invalid region url: invalid_region_url.");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
@@ -3348,10 +3331,9 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsFailureInvalidUrl) {
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
-  error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Invalid url: invalid_url.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  error = GRPC_ERROR_CREATE("Invalid url: invalid_url.");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
@@ -3385,11 +3367,9 @@ TEST(CredentialsTest, TestAwsExternalAccountCredsFailureMissingRoleName) {
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
-  error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-      "Missing role name when retrieving signing keys.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  error = GRPC_ERROR_CREATE("Missing role name when retrieving signing keys.");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,
@@ -3424,11 +3404,9 @@ TEST(CredentialsTest,
   GPR_ASSERT(creds != nullptr);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(creds->min_security_level() == GRPC_PRIVACY_AND_INTEGRITY);
-  error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-      "Creating aws request signer failed.");
-  grpc_error_handle expected_error =
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-          "Error occurred when fetching oauth2 token.", &error, 1);
+  error = GRPC_ERROR_CREATE("Creating aws request signer failed.");
+  grpc_error_handle expected_error = GRPC_ERROR_CREATE_REFERENCING(
+      "Error occurred when fetching oauth2 token.", &error, 1);
   auto state = RequestMetadataState::NewInstance(expected_error, {});
   HttpRequest::SetOverride(aws_external_account_creds_httpcli_get_success,
                            aws_external_account_creds_httpcli_post_success,

--- a/test/core/security/grpc_tls_certificate_distributor_test.cc
+++ b/test/core/security/grpc_tls_certificate_distributor_test.cc
@@ -628,25 +628,22 @@ TEST_F(GrpcTlsCertificateDistributorTest,
   WatcherState* watcher_state_1 = MakeWatcher(kCertName1, kCertName1);
   // Calling SetErrorForCert on both cert names should only call one OnError
   // on watcher 1.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(
                   ErrorInfo(kRootErrorMessage, kIdentityErrorMessage)));
   // Calling SetErrorForCert on root cert name should call OnError
   // on watcher 1 again.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage),
-      absl::nullopt);
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kErrorMessage),
+                               absl::nullopt);
   EXPECT_THAT(
       watcher_state_1->GetErrorQueue(),
       ::testing::ElementsAre(ErrorInfo(kErrorMessage, kIdentityErrorMessage)));
   // Calling SetErrorForCert on identity cert name should call OnError
   // on watcher 1 again.
-  distributor_.SetErrorForCert(
-      kCertName1, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, absl::nullopt,
+                               GRPC_ERROR_CREATE(kErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo(kErrorMessage, kErrorMessage)));
   distributor_.CancelTlsCertificatesWatch(watcher_state_1->watcher);
@@ -658,20 +655,17 @@ TEST_F(GrpcTlsCertificateDistributorTest, SetErrorForCertForRootOrIdentity) {
   WatcherState* watcher_state_1 = MakeWatcher(kCertName1, absl::nullopt);
   // Calling SetErrorForCert on root name should only call one OnError
   // on watcher 1.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               absl::nullopt);
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo(kRootErrorMessage, "")));
   // Calling SetErrorForCert on identity name should do nothing.
-  distributor_.SetErrorForCert(
-      kCertName1, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, absl::nullopt,
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(), ::testing::ElementsAre());
   // Calling SetErrorForCert on both names should still get one OnError call.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo(kRootErrorMessage, "")));
   CancelWatch(watcher_state_1);
@@ -679,20 +673,17 @@ TEST_F(GrpcTlsCertificateDistributorTest, SetErrorForCertForRootOrIdentity) {
   WatcherState* watcher_state_2 = MakeWatcher(absl::nullopt, kCertName1);
   // Calling SetErrorForCert on identity name should only call one OnError
   // on watcher 2.
-  distributor_.SetErrorForCert(
-      kCertName1, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, absl::nullopt,
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_2->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo("", kIdentityErrorMessage)));
   // Calling SetErrorForCert on root name should do nothing.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               absl::nullopt);
   EXPECT_THAT(watcher_state_2->GetErrorQueue(), ::testing::ElementsAre());
   // Calling SetErrorForCert on both names should still get one OnError call.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_2->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo("", kIdentityErrorMessage)));
   CancelWatch(watcher_state_2);
@@ -701,9 +692,8 @@ TEST_F(GrpcTlsCertificateDistributorTest, SetErrorForCertForRootOrIdentity) {
 TEST_F(GrpcTlsCertificateDistributorTest,
        SetErrorForIdentityNameWithPreexistingErrorForRootName) {
   // SetErrorForCert for kCertName1.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   // Register watcher 1 for kCertName1 as root and kCertName2 as identity.
   WatcherState* watcher_state_1 = MakeWatcher(kCertName1, kCertName2);
   // Should trigger OnError call right away since kCertName1 has error.
@@ -711,9 +701,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
               ::testing::ElementsAre(ErrorInfo(kRootErrorMessage, "")));
   // Calling SetErrorForCert on kCertName2 should trigger OnError with both
   // errors, because kCertName1 also has error.
-  distributor_.SetErrorForCert(
-      kCertName2, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName2, absl::nullopt,
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(
                   ErrorInfo(kRootErrorMessage, kIdentityErrorMessage)));
@@ -723,9 +712,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
 TEST_F(GrpcTlsCertificateDistributorTest,
        SetErrorForCertForRootNameWithSameNameForIdentityErrored) {
   // SetErrorForCert for kCertName1.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   // Register watcher 1 for kCertName2 as root and kCertName1 as identity.
   WatcherState* watcher_state_1 = MakeWatcher(kCertName2, kCertName1);
   // Should trigger OnError call right away since kCertName2 has error.
@@ -733,9 +721,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
               ::testing::ElementsAre(ErrorInfo("", kIdentityErrorMessage)));
   // Calling SetErrorForCert on kCertName2 should trigger OnError with both
   // errors, because kCertName1 also has error.
-  distributor_.SetErrorForCert(
-      kCertName2, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+  distributor_.SetErrorForCert(kCertName2, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               absl::nullopt);
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(
                   ErrorInfo(kRootErrorMessage, kIdentityErrorMessage)));
@@ -749,9 +736,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
   // Should not trigger OnError.
   EXPECT_THAT(watcher_state_1->GetErrorQueue(), ::testing::ElementsAre());
   // Calling SetErrorForCert on kCertName2 should trigger OnError.
-  distributor_.SetErrorForCert(
-      kCertName2, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName2, absl::nullopt,
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo("", kIdentityErrorMessage)));
   CancelWatch(watcher_state_1);
@@ -761,9 +747,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
   // Should not trigger OnError.
   EXPECT_THAT(watcher_state_2->GetErrorQueue(), ::testing::ElementsAre());
   // Calling SetErrorForCert on kCertName2 should trigger OnError.
-  distributor_.SetErrorForCert(
-      kCertName2, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName2, absl::nullopt,
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_2->error_queue,
               ::testing::ElementsAre(ErrorInfo("", kIdentityErrorMessage)));
   CancelWatch(watcher_state_2);
@@ -775,9 +760,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
   // Should not trigger OnError.
   EXPECT_THAT(watcher_state_1->GetErrorQueue(), ::testing::ElementsAre());
   // Calling SetErrorForCert on kCertName2 should trigger OnError.
-  distributor_.SetErrorForCert(
-      kCertName2, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+  distributor_.SetErrorForCert(kCertName2, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               absl::nullopt);
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo(kRootErrorMessage, "")));
   CancelWatch(watcher_state_1);
@@ -787,9 +771,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
   // Should not trigger OnError.
   EXPECT_THAT(watcher_state_2->GetErrorQueue(), ::testing::ElementsAre());
   // Calling SetErrorForCert on kCertName2 should trigger OnError.
-  distributor_.SetErrorForCert(
-      kCertName2, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+  distributor_.SetErrorForCert(kCertName2, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               absl::nullopt);
   EXPECT_THAT(watcher_state_2->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo(kRootErrorMessage, "")));
   CancelWatch(watcher_state_2);
@@ -801,9 +784,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
   WatcherState* watcher_state_1 = MakeWatcher(kCertName1, kCertName1);
   // Calling SetErrorForCert on both cert names should only call one OnError
   // on watcher 1.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(
                   ErrorInfo(kRootErrorMessage, kIdentityErrorMessage)));
@@ -823,9 +805,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
       kCertName1, kRootCert1Contents,
       MakeCertKeyPairs(kIdentityCert1PrivateKey, kIdentityCert1Contents));
   // Calling SetErrorForCert on both cert names.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   // Register watcher 1.
   WatcherState* watcher_state_1 = MakeWatcher(kCertName1, kCertName1);
   // watcher 1 should receive both the old credentials and the error right away.
@@ -843,9 +824,8 @@ TEST_F(GrpcTlsCertificateDistributorTest,
 TEST_F(GrpcTlsCertificateDistributorTest,
        SetErrorForCertThenSuccessfulCredentialUpdates) {
   // Calling SetErrorForCert on both cert names.
-  distributor_.SetErrorForCert(
-      kCertName1, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor_.SetErrorForCert(kCertName1, GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   // Push credential updates to kCertName1.
   distributor_.SetKeyMaterials(
       kCertName1, kRootCert1Contents,
@@ -871,7 +851,7 @@ TEST_F(GrpcTlsCertificateDistributorTest, WatchCertInfoThenInvokeSetError) {
   // Register watcher 3.
   WatcherState* watcher_state_3 =
       MakeWatcher(absl::nullopt, kIdentityCert1Name);
-  distributor_.SetError(GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage));
+  distributor_.SetError(GRPC_ERROR_CREATE(kErrorMessage));
   EXPECT_THAT(watcher_state_1->GetErrorQueue(),
               ::testing::ElementsAre(ErrorInfo(kErrorMessage, kErrorMessage)));
   EXPECT_THAT(watcher_state_2->GetErrorQueue(),
@@ -889,7 +869,7 @@ TEST_F(GrpcTlsCertificateDistributorTest, WatchErroredCertInfoBySetError) {
   // Register watcher 2 watching kCertName2 as identity.
   WatcherState* watcher_state_2 = MakeWatcher(absl::nullopt, kCertName2);
   // Call SetError and then cancel all watchers.
-  distributor_.SetError(GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage));
+  distributor_.SetError(GRPC_ERROR_CREATE(kErrorMessage));
   CancelWatch(watcher_state_1);
   CancelWatch(watcher_state_2);
   // Register watcher 3 watching kCertName1 as root and kCertName2 as identity
@@ -909,8 +889,8 @@ TEST_F(GrpcTlsCertificateDistributorTest, SetErrorForCertInCallback) {
                                              bool /*root_being_watched*/,
                                              bool /*identity_being_watched*/) {
     this->distributor_.SetErrorForCert(
-        cert_name, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+        cert_name, GRPC_ERROR_CREATE(kRootErrorMessage),
+        GRPC_ERROR_CREATE(kIdentityErrorMessage));
   });
   auto verify_function = [this](std::string cert_name) {
     WatcherState* watcher_state_1 = MakeWatcher(cert_name, cert_name);

--- a/test/core/security/secure_endpoint_test.cc
+++ b/test/core/security/secure_endpoint_test.cc
@@ -292,10 +292,8 @@ static void test_leftover(grpc_endpoint_test_config config, size_t slice_size) {
   ASSERT_EQ(incoming.count, 1);
   ASSERT_TRUE(grpc_slice_eq(s, incoming.slices[0]));
 
-  grpc_endpoint_shutdown(
-      f.client_ep, GRPC_ERROR_CREATE_FROM_STATIC_STRING("test_leftover end"));
-  grpc_endpoint_shutdown(
-      f.server_ep, GRPC_ERROR_CREATE_FROM_STATIC_STRING("test_leftover end"));
+  grpc_endpoint_shutdown(f.client_ep, GRPC_ERROR_CREATE("test_leftover end"));
+  grpc_endpoint_shutdown(f.server_ep, GRPC_ERROR_CREATE("test_leftover end"));
   grpc_endpoint_destroy(f.client_ep);
   grpc_endpoint_destroy(f.server_ep);
 

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -106,9 +106,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     // server will wait for more data. Explicitly fail the server by shutting
     // down the endpoint.
     if (!state.done_callback_called) {
-      grpc_endpoint_shutdown(
-          mock_endpoint,
-          GRPC_ERROR_CREATE_FROM_STATIC_STRING("Explicit close"));
+      grpc_endpoint_shutdown(mock_endpoint,
+                             GRPC_ERROR_CREATE("Explicit close"));
       grpc_core::ExecCtx::Get()->Flush();
     }
     GPR_ASSERT(state.done_callback_called);

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -324,12 +324,10 @@ TEST_F(TlsSecurityConnectorTest,
   EXPECT_EQ(tls_connector->KeyCertPairListForTesting(), identity_pairs_0_);
   // Calling SetErrorForCert on distributor shouldn't invalidate the previous
   // valid credentials.
-  distributor->SetErrorForCert(
-      kRootCertName, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage),
-      absl::nullopt);
-  distributor->SetErrorForCert(
-      kIdentityCertName, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage));
+  distributor->SetErrorForCert(kRootCertName, GRPC_ERROR_CREATE(kErrorMessage),
+                               absl::nullopt);
+  distributor->SetErrorForCert(kIdentityCertName, absl::nullopt,
+                               GRPC_ERROR_CREATE(kErrorMessage));
   EXPECT_NE(tls_connector->ClientHandshakerFactoryForTesting(), nullptr);
   EXPECT_EQ(tls_connector->RootCertsForTesting(), root_cert_0_);
   EXPECT_EQ(tls_connector->KeyCertPairListForTesting(), identity_pairs_0_);
@@ -877,12 +875,10 @@ TEST_F(TlsSecurityConnectorTest,
   EXPECT_EQ(tls_connector->KeyCertPairListForTesting(), identity_pairs_0_);
   // Calling SetErrorForCert on distributor shouldn't invalidate the previous
   // valid credentials.
-  distributor->SetErrorForCert(
-      kRootCertName, GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage),
-      absl::nullopt);
-  distributor->SetErrorForCert(
-      kIdentityCertName, absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kErrorMessage));
+  distributor->SetErrorForCert(kRootCertName, GRPC_ERROR_CREATE(kErrorMessage),
+                               absl::nullopt);
+  distributor->SetErrorForCert(kIdentityCertName, absl::nullopt,
+                               GRPC_ERROR_CREATE(kErrorMessage));
   EXPECT_NE(tls_connector->ServerHandshakerFactoryForTesting(), nullptr);
   EXPECT_EQ(tls_connector->RootCertsForTesting(), root_cert_0_);
   EXPECT_EQ(tls_connector->KeyCertPairListForTesting(), identity_pairs_0_);

--- a/test/core/surface/concurrent_connectivity_test.cc
+++ b/test/core/surface/concurrent_connectivity_test.cc
@@ -128,8 +128,7 @@ static void on_connect(void* vargs, grpc_endpoint* tcp,
                        grpc_tcp_server_acceptor* acceptor) {
   gpr_free(acceptor);
   struct ServerThreadArgs* args = static_cast<struct ServerThreadArgs*>(vargs);
-  grpc_endpoint_shutdown(tcp,
-                         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Connected"));
+  grpc_endpoint_shutdown(tcp, GRPC_ERROR_CREATE("Connected"));
   grpc_endpoint_destroy(tcp);
   gpr_mu_lock(args->mu);
   GRPC_LOG_IF_ERROR("pollset_kick",

--- a/test/core/transport/chttp2/graceful_shutdown_test.cc
+++ b/test/core/transport/chttp2/graceful_shutdown_test.cc
@@ -137,8 +137,7 @@ class GracefulShutdownTest : public ::testing::Test {
   void ShutdownAndDestroy() {
     shutdown_ = true;
     ExecCtx exec_ctx;
-    grpc_endpoint_shutdown(
-        fds_.client, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Client shutdown"));
+    grpc_endpoint_shutdown(fds_.client, GRPC_ERROR_CREATE("Client shutdown"));
     ExecCtx::Get()->Flush();
     client_poll_thread_->join();
     GPR_ASSERT(read_end_notification_.WaitForNotificationWithTimeout(

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -173,8 +173,7 @@ class Client {
       gpr_log(GPR_INFO, "client read %" PRIuPTR " bytes", read_buffer.length);
       grpc_slice_buffer_reset_and_unref(&read_buffer);
     }
-    grpc_endpoint_shutdown(endpoint_,
-                           GRPC_ERROR_CREATE_FROM_STATIC_STRING("shutdown"));
+    grpc_endpoint_shutdown(endpoint_, GRPC_ERROR_CREATE("shutdown"));
     grpc_slice_buffer_destroy(&read_buffer);
     return retval;
   }

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -276,8 +276,7 @@ class StreamsNotSeenTest : public ::testing::Test {
     } while (ev.type != GRPC_QUEUE_SHUTDOWN);
     grpc_completion_queue_destroy(cq_);
     grpc_channel_destroy(channel_);
-    grpc_endpoint_shutdown(
-        tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Test Shutdown"));
+    grpc_endpoint_shutdown(tcp_, GRPC_ERROR_CREATE("Test Shutdown"));
     ExecCtx::Get()->Flush();
     GPR_ASSERT(read_end_notification_.WaitForNotificationWithTimeout(
         absl::Seconds(5)));
@@ -538,8 +537,7 @@ TEST_F(StreamsNotSeenTest, TransportDestroyed) {
   cqv_->Expect(Tag(101), true);
   cqv_->Verify();
   // Shutdown the server endpoint
-  grpc_endpoint_shutdown(
-      tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown"));
+  grpc_endpoint_shutdown(tcp_, GRPC_ERROR_CREATE("Server shutdown"));
   memset(ops, 0, sizeof(ops));
   op = ops;
   op->op = GRPC_OP_RECV_INITIAL_METADATA;
@@ -764,8 +762,7 @@ TEST_F(ZeroConcurrencyTest, TransportDestroyed) {
   op++;
   error = grpc_call_start_batch(c, ops, static_cast<size_t>(op - ops), Tag(101),
                                 nullptr);
-  grpc_endpoint_shutdown(
-      tcp_, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Server shutdown"));
+  grpc_endpoint_shutdown(tcp_, GRPC_ERROR_CREATE("Server shutdown"));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cqv_->Expect(Tag(101), true);
   cqv_->Verify();

--- a/test/core/transport/error_utils_test.cc
+++ b/test/core/transport/error_utils_test.cc
@@ -41,8 +41,8 @@ TEST(ErrorUtilsTest, GetErrorGetStatusNone) {
 
 TEST(ErrorUtilsTest, GetErrorGetStatusFlat) {
   grpc_error_handle error = grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Msg"),
-      grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_CANCELLED);
+      GRPC_ERROR_CREATE("Msg"), grpc_core::StatusIntProperty::kRpcStatus,
+      GRPC_STATUS_CANCELLED);
   grpc_status_code code;
   std::string message;
   grpc_error_get_status(error, grpc_core::Timestamp(), &code, &message, nullptr,
@@ -53,8 +53,8 @@ TEST(ErrorUtilsTest, GetErrorGetStatusFlat) {
 
 TEST(ErrorUtilsTest, GetErrorGetStatusChild) {
   std::vector<grpc_error_handle> children = {
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child1"),
-      grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Child2"),
+      GRPC_ERROR_CREATE("Child1"),
+      grpc_error_set_int(GRPC_ERROR_CREATE("Child2"),
                          grpc_core::StatusIntProperty::kRpcStatus,
                          GRPC_STATUS_RESOURCE_EXHAUSTED),
   };
@@ -117,7 +117,7 @@ TEST(ErrorUtilsTest, AbslUnavailableToGrpcError) {
 
 TEST(ErrorUtilsTest, GrpcErrorUnavailableToAbslStatus) {
   grpc_error_handle error = grpc_error_set_int(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+      GRPC_ERROR_CREATE(
           "weighted_target: all children report state TRANSIENT_FAILURE"),
       grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
   absl::Status status = grpc_error_to_absl_status(error);

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -305,8 +305,8 @@ grpc_error_handle on_handshake_next_done(
   }
   if (result != TSI_OK) {
     notification_signal(fixture);
-    return grpc_set_tsi_error_result(
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshake failed"), result);
+    return grpc_set_tsi_error_result(GRPC_ERROR_CREATE("Handshake failed"),
+                                     result);
   }
   /* Update handshaker result. */
   if (handshaker_result != nullptr) {

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -78,9 +78,9 @@ static void me_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   gpr_mu_lock(&m->mu);
   if (m->on_read) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->on_read,
-                            GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                                "Endpoint Shutdown", &why, 1));
+    grpc_core::ExecCtx::Run(
+        DEBUG_LOCATION, m->on_read,
+        GRPC_ERROR_CREATE_REFERENCING("Endpoint Shutdown", &why, 1));
     m->on_read = nullptr;
   }
   gpr_mu_unlock(&m->mu);

--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -90,9 +90,8 @@ static void do_pending_read_op_locked(half* m, grpc_error_handle error) {
   GPR_ASSERT(m->bytes_read_so_far <=
              m->parent->channel_effects->allowed_read_bytes);
   if (m->parent->shutdown) {
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, m->pending_read_op.cb,
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Already shutdown"));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->pending_read_op.cb,
+                            GRPC_ERROR_CREATE("Already shutdown"));
     // Move any pending data into pending_read_op.slices so that it may be
     // free'ed by the executing callback.
     grpc_slice_buffer_move_into(&m->read_buffer, m->pending_read_op.slices);
@@ -126,9 +125,8 @@ static void me_read(grpc_endpoint* ep, grpc_slice_buffer* slices,
   half* m = reinterpret_cast<half*>(ep);
   gpr_mu_lock(&m->parent->mu);
   if (m->parent->shutdown) {
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, cb,
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Already shutdown"));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb,
+                            GRPC_ERROR_CREATE("Already shutdown"));
   } else if (m->read_buffer.count > 0) {
     GPR_ASSERT(!m->pending_read_op.is_armed);
     GPR_ASSERT(!m->on_read);
@@ -171,9 +169,8 @@ static void do_pending_write_op_locked(half* m, grpc_error_handle error) {
   GPR_ASSERT(m->bytes_written_so_far <=
              m->parent->channel_effects->allowed_write_bytes);
   if (m->parent->shutdown) {
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, m->pending_write_op.cb,
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Already shutdown"));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->pending_write_op.cb,
+                            GRPC_ERROR_CREATE("Already shutdown"));
     m->pending_write_op.is_armed = false;
     grpc_slice_buffer_reset_and_unref(m->pending_write_op.slices);
     return;
@@ -275,9 +272,8 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
   gpr_mu_lock(&m->parent->mu);
   gpr_atm_no_barrier_fetch_add(&m->parent->stats->num_writes, (gpr_atm)1);
   if (m->parent->shutdown) {
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, cb,
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Endpoint already shutdown"));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb,
+                            GRPC_ERROR_CREATE("Endpoint already shutdown"));
   } else {
     GPR_ASSERT(!m->pending_write_op.is_armed);
     // Copy slices into m->pending_write_op.slices
@@ -324,17 +320,15 @@ static void shutdown_locked(half* m, grpc_error_handle why) {
   m->parent->shutdown = true;
   flush_pending_ops_locked(m, absl::OkStatus());
   if (m->on_read) {
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, m->on_read,
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Shutdown", &why, 1));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->on_read,
+                            GRPC_ERROR_CREATE_REFERENCING("Shutdown", &why, 1));
     m->on_read = nullptr;
   }
   m = other_half(m);
   flush_pending_ops_locked(m, absl::OkStatus());
   if (m->on_read) {
-    grpc_core::ExecCtx::Run(
-        DEBUG_LOCATION, m->on_read,
-        GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Shutdown", &why, 1));
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, m->on_read,
+                            GRPC_ERROR_CREATE_REFERENCING("Shutdown", &why, 1));
     m->on_read = nullptr;
   }
 }
@@ -488,8 +482,7 @@ static void do_next_sched_channel_action(void* arg, grpc_error_handle error) {
 
 static void sched_next_channel_action_locked(half* m) {
   if (m->parent->channel_effects->actions.empty()) {
-    grpc_error_handle err =
-        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Channel actions complete");
+    grpc_error_handle err = GRPC_ERROR_CREATE("Channel actions complete");
     shutdown_locked(m, err);
     return;
   }

--- a/test/core/util/reconnect_server.cc
+++ b/test/core/util/reconnect_server.cc
@@ -67,8 +67,7 @@ static void on_connect(void* arg, grpc_endpoint* tcp,
   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
   timestamp_list* new_tail;
   peer = grpc_endpoint_get_peer(tcp);
-  grpc_endpoint_shutdown(tcp,
-                         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Connected"));
+  grpc_endpoint_shutdown(tcp, GRPC_ERROR_CREATE("Connected"));
   grpc_endpoint_destroy(tcp);
   last_colon = peer.rfind(':');
   if (server->peer == nullptr) {

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -598,8 +598,7 @@ class FakeCertificateProviderFactory : public CertificateProviderFactory {
     if (it == config_json.object_value().end()) {
       return MakeRefCounted<FakeCertificateProviderFactory::Config>(0);
     } else if (it->second.type() != Json::Type::NUMBER) {
-      *error = GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "field:config field:value not of type number");
+      *error = GRPC_ERROR_CREATE("field:config field:value not of type number");
     } else {
       int value = 0;
       EXPECT_TRUE(absl::SimpleAtoi(it->second.string_value(), &value));

--- a/test/core/xds/xds_certificate_provider_test.cc
+++ b/test/core/xds/xds_certificate_provider_test.cc
@@ -142,11 +142,9 @@ TEST(
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for both root and identity
   root_cert_distributor->SetErrorForCert(
-      "root", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+      "root", GRPC_ERROR_CREATE(kRootErrorMessage), absl::nullopt);
   identity_cert_distributor->SetErrorForCert(
-      "identity", absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+      "identity", absl::nullopt, GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
@@ -210,11 +208,9 @@ TEST(XdsCertificateProviderTest,
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for both root and identity
   root_cert_distributor->SetErrorForCert(
-      "test", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+      "test", GRPC_ERROR_CREATE(kRootErrorMessage), absl::nullopt);
   identity_cert_distributor->SetErrorForCert(
-      "test", absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+      "test", absl::nullopt, GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
@@ -276,17 +272,16 @@ TEST(XdsCertificateProviderTest,
   EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for root
-  distributor->SetErrorForCert(
-      "root", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage));
+  distributor->SetErrorForCert("root", GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kRootErrorMessage));
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
               ::testing::HasSubstr(kRootErrorMessage));
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
-  distributor->SetErrorForCert(
-      "identity", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor->SetErrorForCert("identity",
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
@@ -340,18 +335,16 @@ TEST(XdsCertificateProviderTest,
   EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for root
-  distributor->SetErrorForCert(
-      "", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      absl::nullopt);
+  distributor->SetErrorForCert("", GRPC_ERROR_CREATE(kRootErrorMessage),
+                               absl::nullopt);
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
               ::testing::HasSubstr(kRootErrorMessage));
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for identity
-  distributor->SetErrorForCert(
-      "", absl::nullopt,
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor->SetErrorForCert("", absl::nullopt,
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),
@@ -412,9 +405,8 @@ TEST(XdsCertificateProviderTest, SwapOutDistributorsMultipleTimes) {
   EXPECT_EQ(watcher->root_cert_error(), absl::OkStatus());
   EXPECT_EQ(watcher->identity_cert_error(), absl::OkStatus());
   // Set error for both root and identity
-  distributor->SetErrorForCert(
-      "", GRPC_ERROR_CREATE_FROM_STATIC_STRING(kRootErrorMessage),
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING(kIdentityErrorMessage));
+  distributor->SetErrorForCert("", GRPC_ERROR_CREATE(kRootErrorMessage),
+                               GRPC_ERROR_CREATE(kIdentityErrorMessage));
   EXPECT_EQ(watcher->root_certs(), kRootCert2);
   EXPECT_EQ(watcher->key_cert_pairs(), MakeKeyCertPairsType2());
   EXPECT_THAT(grpc_error_std_string(watcher->root_cert_error()),

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1821,7 +1821,7 @@ TEST_F(RoundRobinTest, ReportsLatestStatusInTransientFailure) {
   hold2->Wait();
   // Inject a custom failure message.
   hold1->Wait();
-  hold1->Fail(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Survey says... Bzzzzt!"));
+  hold1->Fail(GRPC_ERROR_CREATE("Survey says... Bzzzzt!"));
   // Wait until RPC fails with the right message.
   absl::Time deadline =
       absl::Now() + (absl::Seconds(5) * grpc_test_slowdown_factor());

--- a/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
@@ -449,8 +449,7 @@ TEST_P(AggregateClusterTest, FallBackWithConnectivityChurn) {
   channel_->GetState(/*try_to_connect=*/true);
   // Wait for backend 0 connection attempt to start, then fail it.
   hold0->Wait();
-  hold0->Fail(
-      GRPC_ERROR_CREATE_FROM_STATIC_STRING("injected connection failure"));
+  hold0->Fail(GRPC_ERROR_CREATE("injected connection failure"));
   // The channel should trigger a connection attempt for backend 1 now,
   // but we've added a hold for that, so it will not complete yet.
   // Meanwhile, the channel will also start a second attempt for backend

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -173,9 +173,8 @@ class FakeCertificateProvider final : public grpc_tls_certificate_provider {
       if (!root_being_watched && !identity_being_watched) return;
       auto it = cert_data_map_.find(cert_name);
       if (it == cert_data_map_.end()) {
-        grpc_error_handle error =
-            GRPC_ERROR_CREATE_FROM_CPP_STRING(absl::StrCat(
-                "No certificates available for cert_name \"", cert_name, "\""));
+        grpc_error_handle error = GRPC_ERROR_CREATE(absl::StrCat(
+            "No certificates available for cert_name \"", cert_name, "\""));
         distributor_->SetErrorForCert(cert_name, error, error);
       } else {
         absl::optional<std::string> root_certificate;


### PR DESCRIPTION
Old macros had to have multiple variants depending on the type of description (e.g. const char* or std::string) but new `absl::Status`-based one doesn't need to do this anymore so those macros can be consolidated into a single one. For example, `GRPC_ERROR_CREATE` would be enuogh for all variants for `STATIC_STRING`, `COPIED_STRING`, `CPP_STRING`, and `STRING_VIEW`. Since internal code still rely on these macros, old macros aren't removed in this PR but will be removed once internal references are massaged.

```
find . -type f -name '*.cc' -not -path './third_party/*' -print0 \
  | xargs -0 sed -i \
    -e 's/GRPC_ERROR_CREATE_FROM_STATIC_STRING/GRPC_ERROR_CREATE/g' \
    -e 's/GRPC_ERROR_CREATE_FROM_COPIED_STRING/GRPC_ERROR_CREATE/g' \
    -e 's/GRPC_ERROR_CREATE_FROM_CPP_STRING/GRPC_ERROR_CREATE/g' \
    -e 's/GRPC_ERROR_CREATE_FROM_STRING_VIEW/GRPC_ERROR_CREATE/g' \
    -e 's/GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING/GRPC_ERROR_CREATE_REFERENCING/g' \
    -e 's/GRPC_ERROR_CREATE_REFERENCING_FROM_COPIED_STRING/GRPC_ERROR_CREATE_REFERENCING/g' \
    -e 's/GRPC_ERROR_CREATE_FROM_VECTOR_AND_CPP_STRING/GRPC_ERROR_CREATE_FROM_VECTOR/g'
```
