### PR TITLE
Move PSM benchmarks to a separated cluster.

### DIFF
--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -26,7 +26,7 @@ gcloud auth configure-docker
 
 # Connect to benchmarks-prod2 cluster.
 gcloud config set project grpc-testing
-gcloud container clusters get-credentials benchmarks-prod2 \
+gcloud container clusters get-credentials psm-benchmarks-performance \
     --zone us-central1-b --project grpc-testing
 
 # Set up environment variables.


### PR DESCRIPTION
This PR moves the PSM benchmark away from the benchmark-prod2 cluster to psm-benchmarks-performance cluster. This is to avoid any unexpected change on the OSS benchmarks due to the tuning we may perform for PSM benchmarks.

The psm-benchmarks-performance cluster has 2 system nodes, 1 driver-ci and 2 worker-ci nodes. The node type is the same as the benchmark-prod2 cluster.
