### PR TITLE
[promises] Fix cronet tests

### DIFF
--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -229,6 +229,8 @@ struct ClientCallData::RecvInitialMetadata final {
     kCompleteAndSetLatch,
     // Called the original callback
     kResponded,
+    // Called the original callback with an error: still need to set the latch
+    kRespondedButNeedToSetLatch,
   };
 
   State state = kInitial;
@@ -264,6 +266,12 @@ class ClientCallData::PollContext {
         case RecvInitialMetadata::kCompleteWaitingForLatch:
         case RecvInitialMetadata::kResponded:
         case RecvInitialMetadata::kRespondedToTrailingMetadataPriorToHook:
+          break;
+        case RecvInitialMetadata::kRespondedButNeedToSetLatch:
+          self_->recv_initial_metadata_->server_initial_metadata_publisher->Set(
+              nullptr);
+          self_->recv_initial_metadata_->state =
+              RecvInitialMetadata::kResponded;
           break;
         case RecvInitialMetadata::kCompleteAndGotLatch:
           self_->recv_initial_metadata_->state =
@@ -322,6 +330,7 @@ class ClientCallData::PollContext {
                   break;
                 case RecvInitialMetadata::
                     kRespondedToTrailingMetadataPriorToHook:
+                case RecvInitialMetadata::kRespondedButNeedToSetLatch:
                   abort();  // not reachable
                   break;
                 case RecvInitialMetadata::kHookedWaitingForLatch:
@@ -367,6 +376,7 @@ class ClientCallData::PollContext {
                   break;
                 case RecvInitialMetadata::
                     kRespondedToTrailingMetadataPriorToHook:
+                case RecvInitialMetadata::kRespondedButNeedToSetLatch:
                   abort();  // not reachable
                   break;
                 case RecvInitialMetadata::kCompleteWaitingForLatch:
@@ -535,6 +545,7 @@ void ClientCallData::StartBatch(grpc_transport_stream_op_batch* b) {
       case RecvInitialMetadata::kCompleteAndGotLatch:
       case RecvInitialMetadata::kCompleteAndSetLatch:
       case RecvInitialMetadata::kResponded:
+      case RecvInitialMetadata::kRespondedButNeedToSetLatch:
         abort();  // unreachable
     }
     if (hook) {
@@ -651,6 +662,9 @@ void ClientCallData::Cancel(grpc_error_handle error) {
       case RecvInitialMetadata::kHookedAndGotLatch:
       case RecvInitialMetadata::kResponded:
         break;
+      case RecvInitialMetadata::kRespondedButNeedToSetLatch:
+        abort();
+        break;
     }
   }
 }
@@ -690,11 +704,13 @@ void ClientCallData::RecvInitialMetadataReady(grpc_error_handle error) {
     case RecvInitialMetadata::kCompleteAndSetLatch:
     case RecvInitialMetadata::kResponded:
     case RecvInitialMetadata::kRespondedToTrailingMetadataPriorToHook:
+    case RecvInitialMetadata::kRespondedButNeedToSetLatch:
       abort();  // unreachable
   }
   Flusher flusher(this);
   if (!error.ok()) {
-    recv_initial_metadata_->state = RecvInitialMetadata::kResponded;
+    recv_initial_metadata_->state =
+        RecvInitialMetadata::kRespondedButNeedToSetLatch;
     flusher.AddClosure(
         std::exchange(recv_initial_metadata_->original_on_ready, nullptr),
         error, "propagate cancellation");
@@ -758,6 +774,7 @@ ArenaPromise<ServerMetadataHandle> ClientCallData::MakeNextPromise(
       case RecvInitialMetadata::kCompleteAndSetLatch:
       case RecvInitialMetadata::kResponded:
       case RecvInitialMetadata::kRespondedToTrailingMetadataPriorToHook:
+      case RecvInitialMetadata::kRespondedButNeedToSetLatch:
         abort();  // unreachable
     }
   } else {


### PR DESCRIPTION
The change to call push/pull exposed a bug in promise based filter that surfaced only when using cronet: if we send initial metadata and a recv initial metadata in the same batch and the send fails in the transport then the http client filter would stick around forever because the receive initial metadata latch never completes.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

