### PR TITLE
[DO NOT MERGE]Kokoro run on psm-benchmarks-performance cluster.

### DIFF
--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -26,7 +26,7 @@ gcloud auth configure-docker
 
 # Connect to benchmarks-prod2 cluster.
 gcloud config set project grpc-testing
-gcloud container clusters get-credentials benchmarks-prod2 \
+gcloud container clusters get-credentials psm-benchmarks-performance \
     --zone us-central1-b --project grpc-testing
 
 # Set up environment variables.


### PR DESCRIPTION
This is a temp branch to see if we still get logs stored under cloud logging URL when the cloud logging is disabled.



