### PR TITLE
Use 64bit linker on windows even when creating 32bit targets

### DIFF
--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -45,7 +45,7 @@ If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (
 ) else (
   @rem Use one of the Visual Studio generators.
 
-  cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% %* ../.. || goto :error
+  cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64 -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% %* ../.. || goto :error
 
   @rem GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
   cmake --build . --target buildtests_%GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX% --config %MSBUILD_CONFIG% || goto :error

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -278,8 +278,8 @@ class CLanguage(object):
             self._cmake_architecture_windows = 'x64' if self.args.arch == 'x64' else 'Win32'
             # when builing with Ninja, the VS common tools need to be activated first
             self._activate_vs_tools_windows = activate_vs_tools
-            # always uses x64 host toolkits to secure more memory for the build
-            self._vs_tools_architecture_windows = 'x64' if self.args.arch == 'x64-x64' else 'x64-x86'
+            # "x64_x86" means create 32bit binaries, but use 64bit toolkit to secure more memory for the build
+            self._vs_tools_architecture_windows = 'x64' if self.args.arch == 'x64' else 'x64_x86'
 
         else:
             if self.platform == 'linux':

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -278,7 +278,8 @@ class CLanguage(object):
             self._cmake_architecture_windows = 'x64' if self.args.arch == 'x64' else 'Win32'
             # when builing with Ninja, the VS common tools need to be activated first
             self._activate_vs_tools_windows = activate_vs_tools
-            self._vs_tools_architecture_windows = 'x64' if self.args.arch == 'x64' else 'x86'
+            # always uses x64 host toolkits to secure more memory for the build
+            self._vs_tools_architecture_windows = 'x64' if self.args.arch == 'x64-x64' else 'x64-x86'
 
         else:
             if self.platform == 'linux':


### PR DESCRIPTION
To address occasional errors on Windows

```
LINK : the 32-bit linker (C:\PROGRA~2\MIB055~1\2017\COMMUN~1\VC\Tools\MSVC\1414~1.264\bin\Hostx86\x86\link.exe) failed to do memory mapped file I/O on `grpc.lib' and is going to restart linking with a 64-bit linker for better throughput
```

and from [this](https://developercommunity.visualstudio.com/t/memory-error-for-linker-in-vs-155-x64/160714), setting `PreferredToolArchitecture=x64` would be the right solution.
