### PR TITLE
Update stream leak test to use transport counter instead of iomgr object counter

### DIFF
--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -13,17 +13,8 @@
 // limitations under the License.
 
 #include <grpc/support/port_platform.h>
-
 #include <inttypes.h>
-#include <stdint.h>
 #include <string.h>
-
-#include <string>
-
-#include "absl/base/thread_annotations.h"
-#include "absl/strings/str_cat.h"
-#include "gtest/gtest.h"
-
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -32,7 +23,11 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include <string>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -196,13 +196,17 @@ class TransportCounter {
     grpc_core::MutexLock lock(&mu_);
     ++num_created_;
     ++num_live_;
-    gpr_log(GPR_INFO, "TransportCounter num_created_=%ld num_live_=%ld InitCallback", num_created_, num_live_);
+    gpr_log(GPR_INFO,
+            "TransportCounter num_created_=%ld num_live_=%ld InitCallback",
+            num_created_, num_live_);
   }
 
   void DestructCallback() {
     grpc_core::MutexLock lock(&mu_);
     --num_live_;
-    gpr_log(GPR_INFO, "TransportCounter num_created_=%ld num_live_=%ld DestructCallback", num_created_, num_live_);
+    gpr_log(GPR_INFO,
+            "TransportCounter num_created_=%ld num_live_=%ld DestructCallback",
+            num_created_, num_live_);
   }
 
   int64_t num_live() {
@@ -240,8 +244,11 @@ void EnsureConnectionsArentLeaked(grpc_completion_queue* cq) {
                  nullptr)
                  .type == GRPC_QUEUE_TIMEOUT);
   if (g_transport_counter->num_created() < 2) {
-    gpr_log(GPR_ERROR, "g_transport_counter->num_created() == %ld. This means that g_transport_counter isn't working and this test is broken. At least a couple of transport objects should have been created."
-            , g_transport_counter->num_created());
+    gpr_log(GPR_ERROR,
+            "g_transport_counter->num_created() == %ld. This means that "
+            "g_transport_counter isn't working and this test is broken. At "
+            "least a couple of transport objects should have been created.",
+            g_transport_counter->num_created());
     GPR_ASSERT(0);
   }
   gpr_timespec overall_deadline = grpc_timeout_seconds_to_deadline(120);
@@ -258,7 +265,8 @@ void EnsureConnectionsArentLeaked(grpc_completion_queue* cq) {
     }
     gpr_log(GPR_INFO,
             "g_transport_counter->num_live() returned %ld, keep waiting "
-            "until it reaches 0", live_transports);
+            "until it reaches 0",
+            live_transports);
     GPR_ASSERT(grpc_completion_queue_next(
                    cq,
                    gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
@@ -334,7 +342,8 @@ int main(int argc, char** argv) {
   grpc_init();
   g_transport_counter = new TransportCounter();
   grpc_core::TestOnlySetGlobalHttp2TransportInitCallback(CounterInitCallback);
-  grpc_core::TestOnlySetGlobalHttp2TransportDestructCallback(CounterDestructCallback);
+  grpc_core::TestOnlySetGlobalHttp2TransportDestructCallback(
+      CounterDestructCallback);
   auto result = RUN_ALL_TESTS();
   grpc_shutdown();
   return result;

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -13,7 +13,17 @@
 // limitations under the License.
 
 #include <grpc/support/port_platform.h>
+
+#include <stdint.h>
 #include <string.h>
+
+#include <string>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/str_cat.h"
+#include "absl/synchronization/mutex.h"
+#include "gtest/gtest.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -22,19 +32,13 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
-#include <stdint.h>
-#include <string>
 
-#include "absl/strings/str_cat.h"
-#include "gtest/gtest.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"
+#include "src/core/lib/gprpp/sync.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
-#include "absl/base/thread_annotations.h"
-#include "absl/synchronization/mutex.h"
-#include "src/core/lib/gprpp/sync.h"
 
 namespace {
 

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -213,17 +213,17 @@ class TransportCounter {
   }
 
   int64_t num_live() {
-    absl::MutexLock lock(&mu_);
+    grpc_core::MutexLock lock(&mu_);
     return num_live_;
   }
 
   size_t num_created() {
-    absl::MutexLock lock(&mu_);
+    grpc_core::MutexLock lock(&mu_);
     return num_created_;
   }
 
  private:
-  absl::Mutex mu_;
+  grpc_core::Mutex mu_;
   int64_t num_live_ ABSL_GUARDED_BY(mu_) = 0;
   size_t num_created_ ABSL_GUARDED_BY(mu_) = 0;
 };

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -13,14 +13,7 @@
 // limitations under the License.
 
 #include <grpc/support/port_platform.h>
-
 #include <string.h>
-
-#include <string>
-
-#include "absl/strings/str_cat.h"
-#include "gtest/gtest.h"
-
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -29,13 +22,19 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include <stdint.h>
+#include <string>
 
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"
-#include "src/core/lib/iomgr/iomgr.h"
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/synchronization/mutex.h"
+#include "src/core/lib/gprpp/sync.h"
 
 namespace {
 

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -21,7 +21,6 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/strings/str_cat.h"
-#include "absl/synchronization/mutex.h"
 #include "gtest/gtest.h"
 
 #include <grpc/byte_buffer.h>

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -199,7 +199,8 @@ class TransportCounter {
     ++num_created_;
     ++num_live_;
     gpr_log(GPR_INFO,
-            "TransportCounter num_created_=%ld num_live_=%ld InitCallback",
+            "TransportCounter num_created_=%ld num_live_=%" PRId64
+            " InitCallback",
             num_created_, num_live_);
   }
 
@@ -207,7 +208,8 @@ class TransportCounter {
     grpc_core::MutexLock lock(&mu_);
     --num_live_;
     gpr_log(GPR_INFO,
-            "TransportCounter num_created_=%ld num_live_=%ld DestructCallback",
+            "TransportCounter num_created_=%ld num_live_=%" PRId64
+            " DestructCallback",
             num_created_, num_live_);
   }
 
@@ -266,7 +268,8 @@ void EnsureConnectionsArentLeaked(grpc_completion_queue* cq) {
       GPR_ASSERT(0);
     }
     gpr_log(GPR_INFO,
-            "g_transport_counter->num_live() returned %ld, keep waiting "
+            "g_transport_counter->num_live() returned %" PRId64
+            ", keep waiting "
             "until it reaches 0",
             live_transports);
     GPR_ASSERT(grpc_completion_queue_next(

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -13,16 +13,8 @@
 // limitations under the License.
 
 #include <grpc/support/port_platform.h>
-
 #include <stdint.h>
 #include <string.h>
-
-#include <string>
-
-#include "absl/base/thread_annotations.h"
-#include "absl/strings/str_cat.h"
-#include "gtest/gtest.h"
-
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -31,7 +23,12 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include <inttypes.h>
+#include <string>
 
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -13,8 +13,16 @@
 // limitations under the License.
 
 #include <grpc/support/port_platform.h>
+
 #include <inttypes.h>
 #include <string.h>
+
+#include <string>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -23,11 +31,7 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
-#include <string>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/strings/str_cat.h"
-#include "gtest/gtest.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -13,8 +13,17 @@
 // limitations under the License.
 
 #include <grpc/support/port_platform.h>
+
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
+
+#include <string>
+
+#include "absl/base/thread_annotations.h"
+#include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
+
 #include <grpc/byte_buffer.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -23,12 +32,7 @@
 #include <grpc/status.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
-#include <inttypes.h>
-#include <string>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/strings/str_cat.h"
-#include "gtest/gtest.h"
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/host_port.h"


### PR DESCRIPTION
This is to allow `test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc` to stay around after the iomgr object count API is removed (in https://github.com/grpc/grpc/pull/31239).

I've confirmed this still repros the original issue (described in https://github.com/grpc/grpc/pull/30907) when the fix is removed. 

cc @ctiller 
