### PR TITLE
OpenCensus: Ability to globally disable stats and tracing

### DIFF
--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -101,7 +101,7 @@ void CensusClientChannelData::CensusClientCallData::StartTransportStreamOpBatch(
   // `grpc_census_call_set_context` which allows the application to set the
   // census context for a call anytime before the first call to
   // `grpc_call_start_batch`.
-  if (op->op()->send_initial_metadata &&
+  if (op->op()->send_initial_metadata && OpenCensusTracingEnabled() &&
       (static_cast<CensusClientChannelData*>(elem->channel_data))
           ->tracing_enabled_) {
     tracer_->GenerateContext();
@@ -120,19 +120,21 @@ OpenCensusCallTracer::OpenCensusCallAttemptTracer::OpenCensusCallAttemptTracer(
       arena_allocated_(arena_allocated),
       context_(parent_->CreateCensusContextForCallAttempt()),
       start_time_(absl::Now()) {
-  if (parent_->tracing_enabled_) {
+  if (OpenCensusTracingEnabled() && parent_->tracing_enabled_) {
     context_.AddSpanAttribute("previous-rpc-attempts", attempt_num);
     context_.AddSpanAttribute("transparent-retry", is_transparent_retry);
   }
-  std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
-      context_.tags().tags();
-  tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
-  ::opencensus::stats::Record({{RpcClientStartedRpcs(), 1}}, tags);
+  if (OpenCensusStatsEnabled()) {
+    std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
+        context_.tags().tags();
+    tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
+    ::opencensus::stats::Record({{RpcClientStartedRpcs(), 1}}, tags);
+  }
 }
 
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
     RecordSendInitialMetadata(grpc_metadata_batch* send_initial_metadata) {
-  if (parent_->tracing_enabled_) {
+  if (OpenCensusTracingEnabled() && parent_->tracing_enabled_) {
     char tracing_buf[kMaxTraceContextLen];
     size_t tracing_len = TraceContextSerialize(context_.Context(), tracing_buf,
                                                kMaxTraceContextLen);
@@ -141,6 +143,8 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
           grpc_core::GrpcTraceBinMetadata(),
           grpc_core::Slice::FromCopiedBuffer(tracing_buf, tracing_len));
     }
+  }
+  if (OpenCensusStatsEnabled()) {
     grpc_slice tags = grpc_empty_slice();
     // TODO(unknown): Add in tagging serialization.
     size_t encoded_tags_len = StatsContextSerialize(kMaxTagsLen, &tags);
@@ -164,12 +168,14 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordReceivedMessage(
 namespace {
 
 void FilterTrailingMetadata(grpc_metadata_batch* b, uint64_t* elapsed_time) {
-  absl::optional<grpc_core::Slice> grpc_server_stats_bin =
-      b->Take(grpc_core::GrpcServerStatsBinMetadata());
-  if (grpc_server_stats_bin.has_value()) {
-    ServerStatsDeserialize(
-        reinterpret_cast<const char*>(grpc_server_stats_bin->data()),
-        grpc_server_stats_bin->size(), elapsed_time);
+  if (OpenCensusStatsEnabled()) {
+    absl::optional<grpc_core::Slice> grpc_server_stats_bin =
+        b->Take(grpc_core::GrpcServerStatsBinMetadata());
+    if (grpc_server_stats_bin.has_value()) {
+      ServerStatsDeserialize(
+          reinterpret_cast<const char*>(grpc_server_stats_bin->data()),
+          grpc_server_stats_bin->size(), elapsed_time);
+    }
   }
 }
 
@@ -183,21 +189,23 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
   if (recv_trailing_metadata == nullptr || transport_stream_stats == nullptr) {
     return;
   }
-  uint64_t elapsed_time = 0;
-  FilterTrailingMetadata(recv_trailing_metadata, &elapsed_time);
-  std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
-      context_.tags().tags();
-  tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
-  std::string final_status = absl::StatusCodeToString(status_code_);
-  tags.emplace_back(ClientStatusTagKey(), final_status);
-  ::opencensus::stats::Record(
-      {{RpcClientSentBytesPerRpc(),
-        static_cast<double>(transport_stream_stats->outgoing.data_bytes)},
-       {RpcClientReceivedBytesPerRpc(),
-        static_cast<double>(transport_stream_stats->incoming.data_bytes)},
-       {RpcClientServerLatency(),
-        ToDoubleMilliseconds(absl::Nanoseconds(elapsed_time))}},
-      tags);
+  if (OpenCensusStatsEnabled()) {
+    uint64_t elapsed_time = 0;
+    FilterTrailingMetadata(recv_trailing_metadata, &elapsed_time);
+    std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
+        context_.tags().tags();
+    tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
+    std::string final_status = absl::StatusCodeToString(status_code_);
+    tags.emplace_back(ClientStatusTagKey(), final_status);
+    ::opencensus::stats::Record(
+        {{RpcClientSentBytesPerRpc(),
+          static_cast<double>(transport_stream_stats->outgoing.data_bytes)},
+         {RpcClientReceivedBytesPerRpc(),
+          static_cast<double>(transport_stream_stats->incoming.data_bytes)},
+         {RpcClientServerLatency(),
+          ToDoubleMilliseconds(absl::Nanoseconds(elapsed_time))}},
+        tags);
+  }
 }
 
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordCancel(
@@ -207,26 +215,28 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordCancel(
 
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordEnd(
     const gpr_timespec& /*latency*/) {
-  double latency_ms = absl::ToDoubleMilliseconds(absl::Now() - start_time_);
-  std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
-      context_.tags().tags();
-  tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
-  tags.emplace_back(ClientStatusTagKey(), StatusCodeToString(status_code_));
-  ::opencensus::stats::Record(
-      {{RpcClientRoundtripLatency(), latency_ms},
-       {RpcClientSentMessagesPerRpc(), sent_message_count_},
-       {RpcClientReceivedMessagesPerRpc(), recv_message_count_}},
-      tags);
-  if (parent_->tracing_enabled_) {
+  if (OpenCensusStatsEnabled()) {
+    double latency_ms = absl::ToDoubleMilliseconds(absl::Now() - start_time_);
+    std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
+        context_.tags().tags();
+    tags.emplace_back(ClientMethodTagKey(), std::string(parent_->method_));
+    tags.emplace_back(ClientStatusTagKey(), StatusCodeToString(status_code_));
+    ::opencensus::stats::Record(
+        {{RpcClientRoundtripLatency(), latency_ms},
+         {RpcClientSentMessagesPerRpc(), sent_message_count_},
+         {RpcClientReceivedMessagesPerRpc(), recv_message_count_}},
+        tags);
+    grpc_core::MutexLock lock(&parent_->mu_);
+    if (--parent_->num_active_rpcs_ == 0) {
+      parent_->time_at_last_attempt_end_ = absl::Now();
+    }
+  }
+  if (OpenCensusTracingEnabled() && parent_->tracing_enabled_) {
     if (status_code_ != absl::StatusCode::kOk) {
       context_.Span().SetStatus(opencensus::trace::StatusCode(status_code_),
                                 StatusCodeToString(status_code_));
     }
     context_.EndSpan();
-  }
-  grpc_core::MutexLock lock(&parent_->mu_);
-  if (--parent_->num_active_rpcs_ == 0) {
-    parent_->time_at_last_attempt_end_ = absl::Now();
   }
   if (arena_allocated_) {
     this->~OpenCensusCallAttemptTracer();
@@ -250,13 +260,15 @@ OpenCensusCallTracer::OpenCensusCallTracer(const grpc_call_element_args* args,
 OpenCensusCallTracer::~OpenCensusCallTracer() {
   std::vector<std::pair<opencensus::tags::TagKey, std::string>> tags =
       context_.tags().tags();
-  tags.emplace_back(ClientMethodTagKey(), std::string(method_));
-  ::opencensus::stats::Record(
-      {{RpcClientRetriesPerCall(), retries_ - 1},  // exclude first attempt
-       {RpcClientTransparentRetriesPerCall(), transparent_retries_},
-       {RpcClientRetryDelayPerCall(), ToDoubleMilliseconds(retry_delay_)}},
-      tags);
-  if (tracing_enabled_) {
+  if (OpenCensusStatsEnabled()) {
+    tags.emplace_back(ClientMethodTagKey(), std::string(method_));
+    ::opencensus::stats::Record(
+        {{RpcClientRetriesPerCall(), retries_ - 1},  // exclude first attempt
+         {RpcClientTransparentRetriesPerCall(), transparent_retries_},
+         {RpcClientRetryDelayPerCall(), ToDoubleMilliseconds(retry_delay_)}},
+        tags);
+  }
+  if (OpenCensusTracingEnabled() && tracing_enabled_) {
     context_.EndSpan();
   }
 }
@@ -279,7 +291,7 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
     grpc_core::MutexLock lock(&mu_);
     if (transparent_retries_ != 0 || retries_ != 0) {
       is_first_attempt = false;
-      if (num_active_rpcs_ == 0) {
+      if (OpenCensusStatsEnabled() && num_active_rpcs_ == 0) {
         retry_delay_ += absl::Now() - time_at_last_attempt_end_;
       }
     }
@@ -300,7 +312,7 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
 }
 
 CensusContext OpenCensusCallTracer::CreateCensusContextForCallAttempt() {
-  if (!tracing_enabled_) return CensusContext();
+  if (!OpenCensusTracingEnabled() || !tracing_enabled_) return CensusContext();
   GPR_DEBUG_ASSERT(context_.Context().IsValid());
   return CensusContext(absl::StrCat("Attempt.", method_), &(context_.Span()),
                        context_.tags());

--- a/src/cpp/ext/filters/census/grpc_plugin.cc
+++ b/src/cpp/ext/filters/census/grpc_plugin.cc
@@ -160,4 +160,20 @@ ABSL_CONST_INIT const absl::string_view kRpcServerServerLatencyMeasureName =
 
 ABSL_CONST_INIT const absl::string_view kRpcServerStartedRpcsMeasureName =
     "grpc.io/server/started_rpcs";
+
+bool g_open_census_stats_enabled = true;
+bool g_open_census_tracing_enabled = true;
+
+void EnableOpenCensusStats(bool enable) {
+  g_open_census_stats_enabled = enable;
+}
+
+void EnableOpenCensusTracing(bool enable) {
+  g_open_census_tracing_enabled = enable;
+}
+
+bool OpenCensusStatsEnabled() { return g_open_census_stats_enabled; }
+
+bool OpenCensusTracingEnabled() { return g_open_census_tracing_enabled; }
+
 }  // namespace grpc

--- a/src/cpp/ext/filters/census/grpc_plugin.h
+++ b/src/cpp/ext/filters/census/grpc_plugin.h
@@ -129,6 +129,14 @@ const ::opencensus::stats::ViewDescriptor& ServerStartedCountHour();
 const ::opencensus::stats::ViewDescriptor& ServerStartedRpcsHour();
 const ::opencensus::stats::ViewDescriptor& ServerCompletedRpcsHour();
 
+// Enables/Disables OpenCensus stats/tracing. It's only safe to do at the start
+// of a program, before any channels/servers are built.
+void EnableOpenCensusStats(bool enable);
+void EnableOpenCensusTracing(bool enable);
+// Gets the current status of OpenCensus stats/tracing
+bool OpenCensusStatsEnabled();
+bool OpenCensusTracingEnabled();
+
 }  // namespace grpc
 
 #endif /* GRPC_INTERNAL_CPP_EXT_FILTERS_CENSUS_GRPC_PLUGIN_H */

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -706,6 +706,7 @@ TEST_F(StatsPluginEnd2EndTest, TestAllSpansAreExported) {
     EXPECT_TRUE(status.ok());
   }
   absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
+  TestUtils::Flush();
   ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
   traces_recorder_->StopRecording();
   auto recorded_spans = traces_recorder_->GetAndClearSpans();
@@ -760,6 +761,7 @@ TEST_F(StatsPluginEnd2EndTest, TestObservabilityDisabledChannelArg) {
     EXPECT_TRUE(status.ok());
   }
   absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
+  TestUtils::Flush();
   ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
   traces_recorder_->StopRecording();
   auto recorded_spans = traces_recorder_->GetAndClearSpans();
@@ -779,6 +781,70 @@ TEST_F(StatsPluginEnd2EndTest, TestObservabilityDisabledChannelArg) {
   auto attempt_span_data =
       GetSpanByName(absl::StrCat("Attempt.", client_method_name_));
   ASSERT_EQ(attempt_span_data, recorded_spans.end());
+}
+
+// Test the working of EnableOpenCensusStats.
+TEST_F(StatsPluginEnd2EndTest, TestGlobalEnableOpenCensusStats) {
+  EnableOpenCensusStats(false);
+
+  View client_started_rpcs_view(ClientStartedRpcsCumulative());
+  View server_started_rpcs_view(ServerStartedRpcsCumulative());
+  View client_completed_rpcs_view(ClientCompletedRpcsCumulative());
+  View server_completed_rpcs_view(ServerCompletedRpcsCumulative());
+
+  EchoRequest request;
+  request.set_message("foo");
+  EchoResponse response;
+  {
+    grpc::ClientContext context;
+    grpc::Status status = stub_->Echo(&context, request, &response);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ("foo", response.message());
+  }
+  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
+  TestUtils::Flush();
+
+  EXPECT_TRUE(client_started_rpcs_view.GetData().int_data().empty());
+  EXPECT_TRUE(server_started_rpcs_view.GetData().int_data().empty());
+  EXPECT_TRUE(client_completed_rpcs_view.GetData().int_data().empty());
+  EXPECT_TRUE(server_completed_rpcs_view.GetData().int_data().empty());
+
+  EnableOpenCensusStats(true);
+}
+
+// Test the working of OpenCensusEnableStats.
+TEST_F(StatsPluginEnd2EndTest, TestGlobalEnableOpenCensusTracing) {
+  EnableOpenCensusTracing(false);
+
+  {
+    // Client spans are ended when the ClientContext's destructor is invoked.
+    EchoRequest request;
+    request.set_message("foo");
+    EchoResponse response;
+
+    grpc::ClientContext context;
+    ::opencensus::trace::AlwaysSampler always_sampler;
+    ::opencensus::trace::StartSpanOptions options;
+    options.sampler = &always_sampler;
+    auto sampling_span =
+        ::opencensus::trace::Span::StartSpan("sampling", nullptr, options);
+    grpc::CensusContext app_census_context("root", &sampling_span,
+                                           ::opencensus::tags::TagMap{});
+    context.set_census_context(
+        reinterpret_cast<census_context*>(&app_census_context));
+    traces_recorder_->StartRecording();
+    grpc::Status status = stub_->Echo(&context, request, &response);
+    EXPECT_TRUE(status.ok());
+  }
+  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
+  TestUtils::Flush();
+  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  traces_recorder_->StopRecording();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans();
+  // No span should be exported
+  ASSERT_EQ(0, recorded_spans.size());
+
+  EnableOpenCensusTracing(true);
 }
 
 }  // namespace

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -812,7 +812,7 @@ TEST_F(StatsPluginEnd2EndTest, TestGlobalEnableOpenCensusStats) {
   EnableOpenCensusStats(true);
 }
 
-// Test the working of OpenCensusEnableStats.
+// Test the working of EnableOpenCensusTracing.
 TEST_F(StatsPluginEnd2EndTest, TestGlobalEnableOpenCensusTracing) {
   EnableOpenCensusTracing(false);
 


### PR DESCRIPTION
This is needed as part of GCP Observability work where we optionally want to disable stats and tracing based on the config.

