### PR TITLE
OpenCensus: Tsan fix

### DIFF
--- a/src/cpp/ext/filters/census/grpc_plugin.cc
+++ b/src/cpp/ext/filters/census/grpc_plugin.cc
@@ -161,8 +161,8 @@ ABSL_CONST_INIT const absl::string_view kRpcServerServerLatencyMeasureName =
 ABSL_CONST_INIT const absl::string_view kRpcServerStartedRpcsMeasureName =
     "grpc.io/server/started_rpcs";
 
-bool g_open_census_stats_enabled = true;
-bool g_open_census_tracing_enabled = true;
+std::atomic<bool> g_open_census_stats_enabled(true);
+std::atomic<bool> g_open_census_tracing_enabled(true);
 
 void EnableOpenCensusStats(bool enable) {
   g_open_census_stats_enabled = enable;
@@ -172,8 +172,12 @@ void EnableOpenCensusTracing(bool enable) {
   g_open_census_tracing_enabled = enable;
 }
 
-bool OpenCensusStatsEnabled() { return g_open_census_stats_enabled; }
+bool OpenCensusStatsEnabled() {
+  return g_open_census_stats_enabled.load(std::memory_order_relaxed);
+}
 
-bool OpenCensusTracingEnabled() { return g_open_census_tracing_enabled; }
+bool OpenCensusTracingEnabled() {
+  return g_open_census_tracing_enabled.load(std::memory_order_relaxed);
+}
 
 }  // namespace grpc


### PR DESCRIPTION
Failure logs - https://source.cloud.google.com/results/invocations/b49a1538-b9cb-4301-902d-b89151c95680/targets/%2F%2Ftest%2Fcpp%2Fext%2Ffilters%2Fcensus:grpc_opencensus_plugin_test@poller%3Dpoll/log

Tested with 
```

bazel test --config=tsan --runs_per_test=100 --test_filter=StatsPluginEnd2EndTest.TestGlobalEnableOpenCensusTracing //test/cpp/ext/filters/census:grpc_opencensus_plugin_test@poller=epoll1

```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

