### PR TITLE
Bump timeouts in ruby end2end tests

### DIFF
--- a/src/ruby/end2end/channel_closing_test.rb
+++ b/src/ruby/end2end/channel_closing_test.rb
@@ -31,7 +31,7 @@ def main
   sleep 3
 
   begin
-    Timeout.timeout(20) do
+    Timeout.timeout(120) do
       loop do
         begin
           client_controller.stub.shutdown(ClientControl::Void.new)

--- a/src/ruby/end2end/channel_state_test.rb
+++ b/src/ruby/end2end/channel_state_test.rb
@@ -31,7 +31,7 @@ def main
   Process.kill('SIGTERM', client_controller.client_pid)
 
   begin
-    Timeout.timeout(10) { Process.wait(client_controller.client_pid) }
+    Timeout.timeout(120) { Process.wait(client_controller.client_pid) }
   rescue Timeout::Error
     STDERR.puts "timeout wait for client pid #{client_controller.client_pid}"
     Process.kill('SIGKILL', client_controller.client_pid)

--- a/src/ruby/end2end/end2end_common.rb
+++ b/src/ruby/end2end/end2end_common.rb
@@ -102,7 +102,7 @@ class ClientController < ClientControl::ParentController::Service
                                 "--parent_controller_port=#{port}",
                                 "--server_port=#{server_port}")
     begin
-      Timeout.timeout(10) do
+      Timeout.timeout(60) do
         @client_controller_port_mu.synchronize do
           while @client_controller_port.nil?
             @client_controller_port_cv.wait(@client_controller_port_mu)

--- a/src/ruby/end2end/forking_client_client.rb
+++ b/src/ruby/end2end/forking_client_client.rb
@@ -37,7 +37,7 @@ def main
   end
 
   begin
-    Timeout.timeout(10) do
+    Timeout.timeout(120) do
       Process.wait(p)
     end
   rescue Timeout::Error

--- a/src/ruby/end2end/forking_client_test.rb
+++ b/src/ruby/end2end/forking_client_test.rb
@@ -25,7 +25,7 @@ def main
     'forking_client_client.rb', server_port)
 
   begin
-    Timeout.timeout(10) do
+    Timeout.timeout(180) do
       Process.wait(client_controller.client_pid)
     end
   rescue Timeout::Error

--- a/src/ruby/end2end/grpc_class_init_test.rb
+++ b/src/ruby/end2end/grpc_class_init_test.rb
@@ -39,7 +39,7 @@ def main
                                    "--grpc_class=#{grpc_class}",
                                    "--stress_test=#{stress_test_type}")
         begin
-          Timeout.timeout(10) do
+          Timeout.timeout(120) do
             Process.wait(client_pid)
           end
         rescue Timeout::Error

--- a/src/ruby/end2end/killed_client_thread_test.rb
+++ b/src/ruby/end2end/killed_client_thread_test.rb
@@ -65,7 +65,7 @@ def main
   STDERR.puts 'sent shutdown'
 
   begin
-    Timeout.timeout(10) do
+    Timeout.timeout(120) do
       Process.wait(client_controller.client_pid)
     end
   rescue Timeout::Error

--- a/src/ruby/end2end/sig_int_during_channel_watch_test.rb
+++ b/src/ruby/end2end/sig_int_during_channel_watch_test.rb
@@ -32,7 +32,7 @@ def main
   sleep 1
   Process.kill('SIGINT', client_controller.client_pid)
   begin
-    Timeout.timeout(10) do
+    Timeout.timeout(120) do
       Process.wait(client_controller.client_pid)
     end
   rescue Timeout::Error


### PR DESCRIPTION
Might help in some flakiness of these tests like b/199888015

These timeouts are meant to catch broad issues like crashes, deadlocks, etc.

So let's make the timeouts more generous to rule out resource starvation as sources of failure.

