### PR TITLE
Remove `include/grpcpp/impl/codegen/serialization_traits.h`

### DIFF
--- a/include/grpcpp/impl/codegen/serialization_traits.h
+++ b/include/grpcpp/impl/codegen/serialization_traits.h
@@ -19,46 +19,9 @@
 #ifndef GRPCPP_IMPL_CODEGEN_SERIALIZATION_TRAITS_H
 #define GRPCPP_IMPL_CODEGEN_SERIALIZATION_TRAITS_H
 
-// IWYU pragma: private, include <grpcpp/impl/serialization_traits.h>
+// IWYU pragma: private
 
-namespace grpc {
-
-/// Defines how to serialize and deserialize some type.
-///
-/// Used for hooking different message serialization API's into GRPC.
-/// Each SerializationTraits<Message> implementation must provide the
-/// following functions:
-/// 1.  static Status Serialize(const Message& msg,
-///                             ByteBuffer* buffer,
-///                             bool* own_buffer);
-///     OR
-///     static Status Serialize(const Message& msg,
-///                             grpc_byte_buffer** buffer,
-///                             bool* own_buffer);
-///     The former is preferred; the latter is deprecated
-///
-/// 2.  static Status Deserialize(ByteBuffer* buffer,
-///                               Message* msg);
-///     OR
-///     static Status Deserialize(grpc_byte_buffer* buffer,
-///                               Message* msg);
-///     The former is preferred; the latter is deprecated
-///
-/// Serialize is required to convert message to a ByteBuffer, and
-/// return that byte buffer through *buffer. *own_buffer should
-/// be set to true if the caller owns said byte buffer, or false if
-/// ownership is retained elsewhere.
-///
-/// Deserialize is required to convert buffer into the message stored at
-/// msg. max_receive_message_size is passed in as a bound on the maximum
-/// number of message bytes Deserialize should accept.
-///
-/// Both functions return a Status, allowing them to explain what went
-/// wrong if required.
-template <class Message,
-          class UnusedButHereForPartialTemplateSpecialization = void>
-class SerializationTraits;
-
-}  // namespace grpc
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpcpp/impl/serialization_traits.h>
 
 #endif  // GRPCPP_IMPL_CODEGEN_SERIALIZATION_TRAITS_H

--- a/include/grpcpp/impl/serialization_traits.h
+++ b/include/grpcpp/impl/serialization_traits.h
@@ -19,6 +19,44 @@
 #ifndef GRPCPP_IMPL_SERIALIZATION_TRAITS_H
 #define GRPCPP_IMPL_SERIALIZATION_TRAITS_H
 
-#include <grpcpp/impl/codegen/serialization_traits.h>  // IWYU pragma: export
+namespace grpc {
+
+/// Defines how to serialize and deserialize some type.
+///
+/// Used for hooking different message serialization API's into GRPC.
+/// Each SerializationTraits<Message> implementation must provide the
+/// following functions:
+/// 1.  static Status Serialize(const Message& msg,
+///                             ByteBuffer* buffer,
+///                             bool* own_buffer);
+///     OR
+///     static Status Serialize(const Message& msg,
+///                             grpc_byte_buffer** buffer,
+///                             bool* own_buffer);
+///     The former is preferred; the latter is deprecated
+///
+/// 2.  static Status Deserialize(ByteBuffer* buffer,
+///                               Message* msg);
+///     OR
+///     static Status Deserialize(grpc_byte_buffer* buffer,
+///                               Message* msg);
+///     The former is preferred; the latter is deprecated
+///
+/// Serialize is required to convert message to a ByteBuffer, and
+/// return that byte buffer through *buffer. *own_buffer should
+/// be set to true if the caller owns said byte buffer, or false if
+/// ownership is retained elsewhere.
+///
+/// Deserialize is required to convert buffer into the message stored at
+/// msg. max_receive_message_size is passed in as a bound on the maximum
+/// number of message bytes Deserialize should accept.
+///
+/// Both functions return a Status, allowing them to explain what went
+/// wrong if required.
+template <class Message,
+          class UnusedButHereForPartialTemplateSpecialization = void>
+class SerializationTraits;
+
+}  // namespace grpc
 
 #endif  // GRPCPP_IMPL_SERIALIZATION_TRAITS_H


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR is a part of [b/196639718](http://b/196639718). It tries to move the content of `include/grpcpp/impl/codegen/serialization_traits.h` to `include/impl/serialization_traits.h`. We do not remove anything to achieve backward compatibility. The file `include/grpcpp/impl/codegen/serialization_traits.h` should be removed in the future.
