### PR TITLE
[Python]Replace Six with_metaclass method

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -24,7 +24,6 @@ from grpc._cython import cygrpc as _cygrpc
 from grpc._runtime_protos import protos
 from grpc._runtime_protos import protos_and_services
 from grpc._runtime_protos import services
-import six
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -45,7 +44,7 @@ class FutureCancelledError(Exception):
     """Indicates that the computation underlying a Future was cancelled."""
 
 
-class Future(six.with_metaclass(abc.ABCMeta)):
+class Future(abc.ABC):
     """A representation of a computation in another control flow.
 
     Computations represented by a Future may be yet to be begun,
@@ -283,7 +282,7 @@ class StatusCode(enum.Enum):
 #############################  gRPC Status  ################################
 
 
-class Status(six.with_metaclass(abc.ABCMeta)):
+class Status(abc.ABC):
     """Describes the status of an RPC.
 
     This is an EXPERIMENTAL API.
@@ -306,7 +305,7 @@ class RpcError(Exception):
 ##############################  Shared Context  ################################
 
 
-class RpcContext(six.with_metaclass(abc.ABCMeta)):
+class RpcContext(abc.ABC):
     """Provides RPC-related information and action."""
 
     @abc.abstractmethod
@@ -356,7 +355,7 @@ class RpcContext(six.with_metaclass(abc.ABCMeta)):
 #########################  Invocation-Side Context  ############################
 
 
-class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
+class Call(RpcContext, metaclass=abc.ABCMeta):
     """Invocation-side utility object for an RPC."""
 
     @abc.abstractmethod
@@ -407,7 +406,7 @@ class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
 ##############  Invocation-Side Interceptor Interfaces & Classes  ##############
 
 
-class ClientCallDetails(six.with_metaclass(abc.ABCMeta)):
+class ClientCallDetails(abc.ABC):
     """Describes an RPC to be invoked.
 
     Attributes:
@@ -423,7 +422,7 @@ class ClientCallDetails(six.with_metaclass(abc.ABCMeta)):
     """
 
 
-class UnaryUnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
+class UnaryUnaryClientInterceptor(abc.ABC):
     """Affords intercepting unary-unary invocations."""
 
     @abc.abstractmethod
@@ -457,7 +456,7 @@ class UnaryUnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class UnaryStreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
+class UnaryStreamClientInterceptor(abc.ABC):
     """Affords intercepting unary-stream invocations."""
 
     @abc.abstractmethod
@@ -491,7 +490,7 @@ class UnaryStreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamUnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
+class StreamUnaryClientInterceptor(abc.ABC):
     """Affords intercepting stream-unary invocations."""
 
     @abc.abstractmethod
@@ -525,7 +524,7 @@ class StreamUnaryClientInterceptor(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamStreamClientInterceptor(six.with_metaclass(abc.ABCMeta)):
+class StreamStreamClientInterceptor(abc.ABC):
     """Affords intercepting stream-stream invocations."""
 
     @abc.abstractmethod
@@ -592,7 +591,7 @@ class CallCredentials(object):
         self._credentials = credentials
 
 
-class AuthMetadataContext(six.with_metaclass(abc.ABCMeta)):
+class AuthMetadataContext(abc.ABC):
     """Provides information to call credentials metadata plugins.
 
     Attributes:
@@ -601,7 +600,7 @@ class AuthMetadataContext(six.with_metaclass(abc.ABCMeta)):
     """
 
 
-class AuthMetadataPluginCallback(six.with_metaclass(abc.ABCMeta)):
+class AuthMetadataPluginCallback(abc.ABC):
     """Callback object received by a metadata plugin."""
 
     def __call__(self, metadata, error):
@@ -614,7 +613,7 @@ class AuthMetadataPluginCallback(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class AuthMetadataPlugin(six.with_metaclass(abc.ABCMeta)):
+class AuthMetadataPlugin(abc.ABC):
     """A specification for custom authentication."""
 
     def __call__(self, context, callback):
@@ -660,7 +659,7 @@ class ServerCertificateConfiguration(object):
 ########################  Multi-Callable Interfaces  ###########################
 
 
-class UnaryUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class UnaryUnaryMultiCallable(abc.ABC):
     """Affords invoking a unary-unary RPC from client-side."""
 
     @abc.abstractmethod
@@ -762,7 +761,7 @@ class UnaryUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class UnaryStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class UnaryStreamMultiCallable(abc.ABC):
     """Affords invoking a unary-stream RPC from client-side."""
 
     @abc.abstractmethod
@@ -797,7 +796,7 @@ class UnaryStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class StreamUnaryMultiCallable(abc.ABC):
     """Affords invoking a stream-unary RPC from client-side."""
 
     @abc.abstractmethod
@@ -901,7 +900,7 @@ class StreamUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class StreamStreamMultiCallable(abc.ABC):
     """Affords invoking a stream-stream RPC on client-side."""
 
     @abc.abstractmethod
@@ -939,7 +938,7 @@ class StreamStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
 #############################  Channel Interface  ##############################
 
 
-class Channel(six.with_metaclass(abc.ABCMeta)):
+class Channel(abc.ABC):
     """Affords RPC invocation via generic methods on client-side.
 
     Channel objects implement the Context Manager type, although they need not
@@ -1080,7 +1079,7 @@ class Channel(six.with_metaclass(abc.ABCMeta)):
 ##########################  Service-Side Context  ##############################
 
 
-class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
+class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
     """A context object passed to method implementations."""
 
     @abc.abstractmethod
@@ -1285,7 +1284,7 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
 #####################  Service-Side Handler Interfaces  ########################
 
 
-class RpcMethodHandler(six.with_metaclass(abc.ABCMeta)):
+class RpcMethodHandler(abc.ABC):
     """An implementation of a single RPC method.
 
     Attributes:
@@ -1321,7 +1320,7 @@ class RpcMethodHandler(six.with_metaclass(abc.ABCMeta)):
     """
 
 
-class HandlerCallDetails(six.with_metaclass(abc.ABCMeta)):
+class HandlerCallDetails(abc.ABC):
     """Describes an RPC that has just arrived for service.
 
     Attributes:
@@ -1330,7 +1329,7 @@ class HandlerCallDetails(six.with_metaclass(abc.ABCMeta)):
     """
 
 
-class GenericRpcHandler(six.with_metaclass(abc.ABCMeta)):
+class GenericRpcHandler(abc.ABC):
     """An implementation of arbitrarily many RPC methods."""
 
     @abc.abstractmethod
@@ -1347,7 +1346,7 @@ class GenericRpcHandler(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class ServiceRpcHandler(six.with_metaclass(abc.ABCMeta, GenericRpcHandler)):
+class ServiceRpcHandler(GenericRpcHandler, metaclass=abc.ABCMeta):
     """An implementation of RPC methods belonging to a service.
 
     A service handles RPC methods with structured names of the form
@@ -1370,7 +1369,7 @@ class ServiceRpcHandler(six.with_metaclass(abc.ABCMeta, GenericRpcHandler)):
 ####################  Service-Side Interceptor Interfaces  #####################
 
 
-class ServerInterceptor(six.with_metaclass(abc.ABCMeta)):
+class ServerInterceptor(abc.ABC):
     """Affords intercepting incoming RPCs on the service-side."""
 
     @abc.abstractmethod
@@ -1395,7 +1394,7 @@ class ServerInterceptor(six.with_metaclass(abc.ABCMeta)):
 #############################  Server Interface  ###############################
 
 
-class Server(six.with_metaclass(abc.ABCMeta)):
+class Server(abc.ABC):
     """Services RPCs."""
 
     @abc.abstractmethod

--- a/src/python/grpcio/grpc/beta/interfaces.py
+++ b/src/python/grpcio/grpc/beta/interfaces.py
@@ -16,7 +16,6 @@
 import abc
 
 import grpc
-import six
 
 ChannelConnectivity = grpc.ChannelConnectivity
 # FATAL_FAILURE was a Beta-API name for SHUTDOWN
@@ -58,7 +57,7 @@ GRPCAuthMetadataPluginCallback = grpc.AuthMetadataPluginCallback
 GRPCAuthMetadataPlugin = grpc.AuthMetadataPlugin
 
 
-class GRPCServicerContext(six.with_metaclass(abc.ABCMeta)):
+class GRPCServicerContext(abc.ABC):
     """Exposes gRPC-specific options and behaviors to code servicing RPCs."""
 
     @abc.abstractmethod
@@ -76,7 +75,7 @@ class GRPCServicerContext(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class GRPCInvocationContext(six.with_metaclass(abc.ABCMeta)):
+class GRPCInvocationContext(abc.ABC):
     """Exposes gRPC-specific options and behaviors to code invoking RPCs."""
 
     @abc.abstractmethod
@@ -85,7 +84,7 @@ class GRPCInvocationContext(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Server(six.with_metaclass(abc.ABCMeta)):
+class Server(abc.ABC):
     """Services RPCs."""
 
     @abc.abstractmethod

--- a/src/python/grpcio/grpc/framework/foundation/callable_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/callable_util.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 """Utilities for working with callables."""
 
+from abc import ABC
 import collections
 import enum
 import functools
 import logging
-
-from abc import ABC
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio/grpc/framework/foundation/callable_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/callable_util.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 """Utilities for working with callables."""
 
-import abc
 import collections
 import enum
 import functools
 import logging
 
-import six
+from abc import ABC
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class Outcome(six.with_metaclass(abc.ABCMeta)):
+class Outcome(ABC):
     """A sum type describing the outcome of some call.
 
   Attributes:

--- a/src/python/grpcio/grpc/framework/foundation/future.py
+++ b/src/python/grpcio/grpc/framework/foundation/future.py
@@ -33,8 +33,6 @@ built-in-but-only-in-3.3-and-later TimeoutError.
 
 import abc
 
-import six
-
 
 class TimeoutError(Exception):
     """Indicates that a particular call timed out."""
@@ -44,7 +42,7 @@ class CancelledError(Exception):
     """Indicates that the computation underlying a Future was cancelled."""
 
 
-class Future(six.with_metaclass(abc.ABCMeta)):
+class Future(abc.ABC):
     """A representation of a computation in another control flow.
 
   Computations represented by a Future may be yet to be begun, may be ongoing,

--- a/src/python/grpcio/grpc/framework/foundation/stream.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Interfaces related to streams of values or objects."""
 
-from abc import ABC
+import ABC
 
 
 class Consumer(ABC):

--- a/src/python/grpcio/grpc/framework/foundation/stream.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 """Interfaces related to streams of values or objects."""
 
-import abc
-
-import six
+from abc import ABC
 
 
-class Consumer(six.with_metaclass(abc.ABCMeta)):
+class Consumer(ABC):
     """Interface for consumers of finite streams of values or objects."""
 
     @abc.abstractmethod

--- a/src/python/grpcio/grpc/framework/foundation/stream.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Interfaces related to streams of values or objects."""
 
-import ABC
+import abc
 
 
-class Consumer(ABC):
+class Consumer(abc.ABC):
     """Interface for consumers of finite streams of values or objects."""
 
     @abc.abstractmethod

--- a/src/python/grpcio/grpc/framework/interfaces/base/base.py
+++ b/src/python/grpcio/grpc/framework/interfaces/base/base.py
@@ -26,8 +26,6 @@ import abc
 import enum
 import threading  # pylint: disable=unused-import
 
-import six
-
 # pylint: disable=too-many-arguments
 
 
@@ -81,7 +79,7 @@ class Outcome(object):
         REMOTE_FAILURE = 'remote failure'
 
 
-class Completion(six.with_metaclass(abc.ABCMeta)):
+class Completion(abc.ABC):
     """An aggregate of the values exchanged upon operation completion.
 
   Attributes:
@@ -91,7 +89,7 @@ class Completion(six.with_metaclass(abc.ABCMeta)):
   """
 
 
-class OperationContext(six.with_metaclass(abc.ABCMeta)):
+class OperationContext(abc.ABC):
     """Provides operation-related information and action."""
 
     @abc.abstractmethod
@@ -146,7 +144,7 @@ class OperationContext(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Operator(six.with_metaclass(abc.ABCMeta)):
+class Operator(abc.ABC):
     """An interface through which to participate in an operation."""
 
     @abc.abstractmethod
@@ -170,7 +168,7 @@ class Operator(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class ProtocolReceiver(six.with_metaclass(abc.ABCMeta)):
+class ProtocolReceiver(abc.ABC):
     """A means of receiving protocol values during an operation."""
 
     @abc.abstractmethod
@@ -183,7 +181,7 @@ class ProtocolReceiver(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Subscription(six.with_metaclass(abc.ABCMeta)):
+class Subscription(abc.ABC):
     """Describes customer code's interest in values from the other side.
 
   Attributes:
@@ -210,7 +208,7 @@ class Subscription(six.with_metaclass(abc.ABCMeta)):
         FULL = 'full'
 
 
-class Servicer(six.with_metaclass(abc.ABCMeta)):
+class Servicer(abc.ABC):
     """Interface for service implementations."""
 
     @abc.abstractmethod
@@ -238,7 +236,7 @@ class Servicer(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class End(six.with_metaclass(abc.ABCMeta)):
+class End(abc.ABC):
     """Common type for entry-point objects on both sides of an operation."""
 
     @abc.abstractmethod

--- a/src/python/grpcio/grpc/framework/interfaces/face/face.py
+++ b/src/python/grpcio/grpc/framework/interfaces/face/face.py
@@ -23,7 +23,6 @@ from grpc.framework.common import cardinality  # pylint: disable=unused-import
 from grpc.framework.common import style  # pylint: disable=unused-import
 from grpc.framework.foundation import future  # pylint: disable=unused-import
 from grpc.framework.foundation import stream  # pylint: disable=unused-import
-import six
 
 # pylint: disable=too-many-arguments
 
@@ -89,7 +88,7 @@ class Abortion(
         REMOTE_FAILURE = 'remote failure'
 
 
-class AbortionError(six.with_metaclass(abc.ABCMeta, Exception)):
+class AbortionError(Exception, metaclass=abc.ABCMeta):
     """Common super type for exceptions indicating RPC abortion.
 
     initial_metadata: The initial metadata from the other side of the RPC or
@@ -142,7 +141,7 @@ class RemoteError(AbortionError):
     """Indicates that an RPC has terminated due to a remote defect."""
 
 
-class RpcContext(six.with_metaclass(abc.ABCMeta)):
+class RpcContext(abc.ABC):
     """Provides RPC-related information and action."""
 
     @abc.abstractmethod
@@ -190,7 +189,7 @@ class RpcContext(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
+class Call(RpcContext, metaclass=abc.ABCMeta):
     """Invocation-side utility object for an RPC."""
 
     @abc.abstractmethod
@@ -246,7 +245,7 @@ class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
         raise NotImplementedError()
 
 
-class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
+class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
     """A context object passed to method implementations."""
 
     @abc.abstractmethod
@@ -315,7 +314,7 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
         raise NotImplementedError()
 
 
-class ResponseReceiver(six.with_metaclass(abc.ABCMeta)):
+class ResponseReceiver(abc.ABC):
     """Invocation-side object used to accept the output of an RPC."""
 
     @abc.abstractmethod
@@ -350,7 +349,7 @@ class ResponseReceiver(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class UnaryUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class UnaryUnaryMultiCallable(abc.ABC):
     """Affords invoking a unary-unary RPC in any call style."""
 
     @abc.abstractmethod
@@ -428,7 +427,7 @@ class UnaryUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class UnaryStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class UnaryStreamMultiCallable(abc.ABC):
     """Affords invoking a unary-stream RPC in any call style."""
 
     @abc.abstractmethod
@@ -477,7 +476,7 @@ class UnaryStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class StreamUnaryMultiCallable(abc.ABC):
     """Affords invoking a stream-unary RPC in any call style."""
 
     @abc.abstractmethod
@@ -558,7 +557,7 @@ class StreamUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
+class StreamStreamMultiCallable(abc.ABC):
     """Affords invoking a stream-stream RPC in any call style."""
 
     @abc.abstractmethod
@@ -610,7 +609,7 @@ class StreamStreamMultiCallable(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class MethodImplementation(six.with_metaclass(abc.ABCMeta)):
+class MethodImplementation(abc.ABC):
     """A sum type that describes a method implementation.
 
   Attributes:
@@ -655,7 +654,7 @@ class MethodImplementation(six.with_metaclass(abc.ABCMeta)):
   """
 
 
-class MultiMethodImplementation(six.with_metaclass(abc.ABCMeta)):
+class MultiMethodImplementation(abc.ABC):
     """A general type able to service many methods."""
 
     @abc.abstractmethod
@@ -686,7 +685,7 @@ class MultiMethodImplementation(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class GenericStub(six.with_metaclass(abc.ABCMeta)):
+class GenericStub(abc.ABC):
     """Affords RPC invocation via generic methods."""
 
     @abc.abstractmethod
@@ -1032,7 +1031,7 @@ class GenericStub(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class DynamicStub(six.with_metaclass(abc.ABCMeta)):
+class DynamicStub(abc.ABC):
     """Affords RPC invocation via attributes corresponding to afforded methods.
 
   Instances of this type may be scoped to a single group so that attribute

--- a/src/python/grpcio_testing/grpc_testing/__init__.py
+++ b/src/python/grpcio_testing/grpc_testing/__init__.py
@@ -17,10 +17,9 @@ import abc
 
 from google.protobuf import descriptor
 import grpc
-import six
 
 
-class UnaryUnaryChannelRpc(six.with_metaclass(abc.ABCMeta)):
+class UnaryUnaryChannelRpc(abc.ABC):
     """Fixture for a unary-unary RPC invoked by a system under test.
 
     Enables users to "play server" for the RPC.
@@ -54,7 +53,7 @@ class UnaryUnaryChannelRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class UnaryStreamChannelRpc(six.with_metaclass(abc.ABCMeta)):
+class UnaryStreamChannelRpc(abc.ABC):
     """Fixture for a unary-stream RPC invoked by a system under test.
 
     Enables users to "play server" for the RPC.
@@ -96,7 +95,7 @@ class UnaryStreamChannelRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamUnaryChannelRpc(six.with_metaclass(abc.ABCMeta)):
+class StreamUnaryChannelRpc(abc.ABC):
     """Fixture for a stream-unary RPC invoked by a system under test.
 
     Enables users to "play server" for the RPC.
@@ -150,7 +149,7 @@ class StreamUnaryChannelRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamStreamChannelRpc(six.with_metaclass(abc.ABCMeta)):
+class StreamStreamChannelRpc(abc.ABC):
     """Fixture for a stream-stream RPC invoked by a system under test.
 
     Enables users to "play server" for the RPC.
@@ -212,7 +211,7 @@ class StreamStreamChannelRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Channel(six.with_metaclass(abc.ABCMeta, grpc.Channel)):
+class Channel(grpc.Channel, metaclass=abc.ABCMeta):
     """A grpc.Channel double with which to test a system that invokes RPCs."""
 
     @abc.abstractmethod
@@ -292,7 +291,7 @@ class Channel(six.with_metaclass(abc.ABCMeta, grpc.Channel)):
         raise NotImplementedError()
 
 
-class UnaryUnaryServerRpc(six.with_metaclass(abc.ABCMeta)):
+class UnaryUnaryServerRpc(abc.ABC):
     """Fixture for a unary-unary RPC serviced by a system under test.
 
     Enables users to "play client" for the RPC.
@@ -328,7 +327,7 @@ class UnaryUnaryServerRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class UnaryStreamServerRpc(six.with_metaclass(abc.ABCMeta)):
+class UnaryStreamServerRpc(abc.ABC):
     """Fixture for a unary-stream RPC serviced by a system under test.
 
     Enables users to "play client" for the RPC.
@@ -376,7 +375,7 @@ class UnaryStreamServerRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamUnaryServerRpc(six.with_metaclass(abc.ABCMeta)):
+class StreamUnaryServerRpc(abc.ABC):
     """Fixture for a stream-unary RPC serviced by a system under test.
 
     Enables users to "play client" for the RPC.
@@ -427,7 +426,7 @@ class StreamUnaryServerRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class StreamStreamServerRpc(six.with_metaclass(abc.ABCMeta)):
+class StreamStreamServerRpc(abc.ABC):
     """Fixture for a stream-stream RPC serviced by a system under test.
 
     Enables users to "play client" for the RPC.
@@ -490,7 +489,7 @@ class StreamStreamServerRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Server(six.with_metaclass(abc.ABCMeta)):
+class Server(abc.ABC):
     """A server with which to test a system that services RPCs."""
 
     @abc.abstractmethod
@@ -564,7 +563,7 @@ class Server(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Time(six.with_metaclass(abc.ABCMeta)):
+class Time(abc.ABC):
     """A simulation of time.
 
     Implementations needn't be connected with real time as provided by the

--- a/src/python/grpcio_testing/grpc_testing/_common.py
+++ b/src/python/grpcio_testing/grpc_testing/_common.py
@@ -16,8 +16,6 @@
 import abc
 import collections
 
-import six
-
 
 def _fuss(tuplified_metadata):
     return tuplified_metadata + ((
@@ -56,7 +54,7 @@ class ChannelRpcRead(
     pass
 
 
-class ChannelRpcHandler(six.with_metaclass(abc.ABCMeta)):
+class ChannelRpcHandler(abc.ABC):
 
     @abc.abstractmethod
     def initial_metadata(self):
@@ -95,7 +93,7 @@ class ChannelRpcHandler(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class ChannelHandler(six.with_metaclass(abc.ABCMeta)):
+class ChannelHandler(abc.ABC):
 
     @abc.abstractmethod
     def invoke_rpc(self, method_full_rpc_name, invocation_metadata, requests,
@@ -116,7 +114,7 @@ REQUESTS_CLOSED = ServerRpcRead(None, True, False)
 TERMINATED = ServerRpcRead(None, False, True)
 
 
-class ServerRpcHandler(six.with_metaclass(abc.ABCMeta)):
+class ServerRpcHandler(abc.ABC):
 
     @abc.abstractmethod
     def send_initial_metadata(self, initial_metadata):
@@ -139,7 +137,7 @@ class ServerRpcHandler(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Serverish(six.with_metaclass(abc.ABCMeta)):
+class Serverish(abc.ABC):
 
     @abc.abstractmethod
     def invoke_unary_unary(self, method_descriptor, handler,

--- a/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
@@ -178,7 +178,7 @@ _PROTOC_STYLES = (
 
 @unittest.skipIf(platform.python_implementation() == 'PyPy',
                  'Skip test if run with PyPy!')
-class _Test(six.with_metaclass(abc.ABCMeta, unittest.TestCase)):
+class _Test(unittest.TestCase, metaclass=abc.ABCMeta):
 
     def setUp(self):
         self._directory = tempfile.mkdtemp(suffix=self.NAME, dir='.')

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -38,7 +38,6 @@ import threading
 import unittest
 
 import grpc
-import six
 
 from tests.testing import _application_common
 from tests.testing import _server_application
@@ -118,8 +117,7 @@ class CertConfigFetcher(object):
                 return self._cert_config
 
 
-class _ServerSSLCertReloadTest(
-        six.with_metaclass(abc.ABCMeta, unittest.TestCase)):
+class _ServerSSLCertReloadTest(unittest.TestCase, metaclass=abc.ABCMeta):
 
     def __init__(self, *args, **kwargs):
         super(_ServerSSLCertReloadTest, self).__init__(*args, **kwargs)

--- a/src/python/grpcio_tests/tests/unit/framework/common/test_control.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/test_control.py
@@ -28,7 +28,7 @@ class Defect(Exception):
   """
 
 
-class Control(six.with_metaclass(abc.ABCMeta)):
+class Control(abc.ABC):
     """An object that accepts program control from a system under test.
 
   Systems under test passed a Control should call its control() method

--- a/src/python/grpcio_tests/tests/unit/framework/common/test_coverage.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/test_coverage.py
@@ -15,13 +15,11 @@
 
 import abc
 
-import six
-
 # This code is designed for use with the unittest module.
 # pylint: disable=invalid-name
 
 
-class Coverage(six.with_metaclass(abc.ABCMeta)):
+class Coverage(abc.ABC):
     """Specification of test coverage."""
 
     @abc.abstractmethod


### PR DESCRIPTION
### Description

Remove `six` dependency since now we only support Python3.

### Changes included
* Replace `six.with_metaclass()`.

### Testing
* Failed Tests:
  * Basic Tests C++ iOS
    * Also [failing in master](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_basictests_cpp_ios).
  * Basic Tests ObjC iOS
    * Also [failing in master](https://fusion.corp.google.com/projectanalysis/summary/KOKORO/prod:grpc%2Fcore%2Fmaster%2Fmacos%2Fgrpc_basictests_objc_ios).
