### PR TITLE
xDS: refactor code for handling xDS extensions and add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20629,6 +20629,10 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(xds_common_types_test
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1alpha/reflection.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1alpha/reflection.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/base.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/base.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/base.pb.h
@@ -20653,7 +20657,20 @@ add_executable(xds_common_types_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/tls.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/tls.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/tls.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/typed_struct.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/typed_struct.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/typed_struct.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/typed_struct.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/udpa_typed_struct.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/udpa_typed_struct.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/udpa_typed_struct.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/udpa_typed_struct.grpc.pb.h
   test/core/xds/xds_common_types_test.cc
+  test/cpp/util/cli_call.cc
+  test/cpp/util/cli_credentials.cc
+  test/cpp/util/proto_file_parser.cc
+  test/cpp/util/proto_reflection_descriptor_database.cc
+  test/cpp/util/service_describer.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
@@ -20680,6 +20697,8 @@ target_include_directories(xds_common_types_test
 target_link_libraries(xds_common_types_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  absl::flags
+  grpc++
   grpc_test_util
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -11080,16 +11080,32 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers: []
+  headers:
+  - test/cpp/util/cli_call.h
+  - test/cpp/util/cli_credentials.h
+  - test/cpp/util/config_grpc_cli.h
+  - test/cpp/util/proto_file_parser.h
+  - test/cpp/util/proto_reflection_descriptor_database.h
+  - test/cpp/util/service_describer.h
   src:
+  - src/proto/grpc/reflection/v1alpha/reflection.proto
   - src/proto/grpc/testing/xds/v3/base.proto
   - src/proto/grpc/testing/xds/v3/extension.proto
   - src/proto/grpc/testing/xds/v3/percent.proto
   - src/proto/grpc/testing/xds/v3/regex.proto
   - src/proto/grpc/testing/xds/v3/string.proto
   - src/proto/grpc/testing/xds/v3/tls.proto
+  - src/proto/grpc/testing/xds/v3/typed_struct.proto
+  - src/proto/grpc/testing/xds/v3/udpa_typed_struct.proto
   - test/core/xds/xds_common_types_test.cc
+  - test/cpp/util/cli_call.cc
+  - test/cpp/util/cli_credentials.cc
+  - test/cpp/util/proto_file_parser.cc
+  - test/cpp/util/proto_reflection_descriptor_database.cc
+  - test/cpp/util/service_describer.cc
   deps:
+  - absl/flags:flag
+  - grpc++
   - grpc_test_util
   uses_polling: false
 - name: xds_core_end2end_test

--- a/src/core/ext/xds/xds_cluster_specifier_plugin.cc
+++ b/src/core/ext/xds/xds_cluster_specifier_plugin.cc
@@ -50,10 +50,15 @@ void XdsRouteLookupClusterSpecifierPlugin::PopulateSymtab(
 
 absl::StatusOr<std::string>
 XdsRouteLookupClusterSpecifierPlugin::GenerateLoadBalancingPolicyConfig(
-    upb_StringView serialized_plugin_config, upb_Arena* arena,
-    upb_DefPool* symtab) const {
+    XdsExtension extension, upb_Arena* arena, upb_DefPool* symtab) const {
+  absl::string_view* serialized_plugin_config =
+      absl::get_if<absl::string_view>(&extension.value);
+  if (serialized_plugin_config == nullptr) {
+    return absl::InvalidArgumentError("could not parse plugin config");
+  }
   const auto* specifier = grpc_lookup_v1_RouteLookupClusterSpecifier_parse(
-      serialized_plugin_config.data, serialized_plugin_config.size, arena);
+      serialized_plugin_config->data(), serialized_plugin_config->size(),
+      arena);
   if (specifier == nullptr) {
     return absl::InvalidArgumentError("Could not parse plugin config");
   }

--- a/src/core/ext/xds/xds_cluster_specifier_plugin.h
+++ b/src/core/ext/xds/xds_cluster_specifier_plugin.h
@@ -28,6 +28,8 @@
 #include "upb/def.h"
 #include "upb/upb.h"
 
+#include "src/core/ext/xds/xds_common_types.h"
+
 namespace grpc_core {
 
 class XdsClusterSpecifierPluginImpl {
@@ -39,8 +41,7 @@ class XdsClusterSpecifierPluginImpl {
 
   // Returns the LB policy config in JSON form.
   virtual absl::StatusOr<std::string> GenerateLoadBalancingPolicyConfig(
-      upb_StringView serialized_plugin_config, upb_Arena* arena,
-      upb_DefPool* symtab) const = 0;
+      XdsExtension extension, upb_Arena* arena, upb_DefPool* symtab) const = 0;
 };
 
 class XdsRouteLookupClusterSpecifierPlugin
@@ -48,7 +49,7 @@ class XdsRouteLookupClusterSpecifierPlugin
   void PopulateSymtab(upb_DefPool* symtab) const override;
 
   absl::StatusOr<std::string> GenerateLoadBalancingPolicyConfig(
-      upb_StringView serialized_plugin_config, upb_Arena* arena,
+      XdsExtension extension, upb_Arena* arena,
       upb_DefPool* symtab) const override;
 };
 

--- a/src/core/ext/xds/xds_common_types.cc
+++ b/src/core/ext/xds/xds_common_types.cc
@@ -443,6 +443,10 @@ absl::StatusOr<Json> ParseProtobufStructToJson(
 absl::optional<XdsExtension> ExtractXdsExtension(
     const XdsResourceType::DecodeContext& context,
     const google_protobuf_Any* any, ValidationErrors* errors) {
+  if (any == nullptr) {
+    errors->AddError("field not present");
+    return absl::nullopt;
+  }
   XdsExtension extension;
   auto strip_type_prefix = [&]() {
     ValidationErrors::ScopedField field(errors, ".type_url");

--- a/src/core/ext/xds/xds_http_fault_filter.cc
+++ b/src/core/ext/xds/xds_http_fault_filter.cc
@@ -184,8 +184,8 @@ void XdsHttpFaultFilter::PopulateSymtab(upb_DefPool* symtab) const {
 }
 
 absl::StatusOr<XdsHttpFilterImpl::FilterConfig>
-XdsHttpFaultFilter::GenerateFilterConfig(
-    XdsExtension extension, upb_Arena* arena) const {
+XdsHttpFaultFilter::GenerateFilterConfig(XdsExtension extension,
+                                         upb_Arena* arena) const {
   absl::string_view* serialized_filter_config =
       absl::get_if<absl::string_view>(&extension.value);
   if (serialized_filter_config == nullptr) {
@@ -201,8 +201,8 @@ XdsHttpFaultFilter::GenerateFilterConfig(
 }
 
 absl::StatusOr<XdsHttpFilterImpl::FilterConfig>
-XdsHttpFaultFilter::GenerateFilterConfigOverride(
-    XdsExtension extension, upb_Arena* arena) const {
+XdsHttpFaultFilter::GenerateFilterConfigOverride(XdsExtension extension,
+                                                 upb_Arena* arena) const {
   // HTTPFault filter has the same message type in HTTP connection manager's
   // filter config and in overriding filter config field.
   return GenerateFilterConfig(std::move(extension), arena);

--- a/src/core/ext/xds/xds_http_fault_filter.cc
+++ b/src/core/ext/xds/xds_http_fault_filter.cc
@@ -74,9 +74,9 @@ uint32_t GetDenominator(const envoy_type_v3_FractionalPercent* fraction) {
 }
 
 absl::StatusOr<Json> ParseHttpFaultIntoJson(
-    upb_StringView serialized_http_fault, upb_Arena* arena) {
+    absl::string_view serialized_http_fault, upb_Arena* arena) {
   auto* http_fault = envoy_extensions_filters_http_fault_v3_HTTPFault_parse(
-      serialized_http_fault.data, serialized_http_fault.size, arena);
+      serialized_http_fault.data(), serialized_http_fault.size(), arena);
   if (http_fault == nullptr) {
     return absl::InvalidArgumentError(
         "could not parse fault injection filter config");
@@ -185,9 +185,15 @@ void XdsHttpFaultFilter::PopulateSymtab(upb_DefPool* symtab) const {
 
 absl::StatusOr<XdsHttpFilterImpl::FilterConfig>
 XdsHttpFaultFilter::GenerateFilterConfig(
-    upb_StringView serialized_filter_config, upb_Arena* arena) const {
+    XdsExtension extension, upb_Arena* arena) const {
+  absl::string_view* serialized_filter_config =
+      absl::get_if<absl::string_view>(&extension.value);
+  if (serialized_filter_config == nullptr) {
+    return absl::InvalidArgumentError(
+        "could not parse fault injection filter config");
+  }
   absl::StatusOr<Json> parse_result =
-      ParseHttpFaultIntoJson(serialized_filter_config, arena);
+      ParseHttpFaultIntoJson(*serialized_filter_config, arena);
   if (!parse_result.ok()) {
     return parse_result.status();
   }
@@ -196,10 +202,10 @@ XdsHttpFaultFilter::GenerateFilterConfig(
 
 absl::StatusOr<XdsHttpFilterImpl::FilterConfig>
 XdsHttpFaultFilter::GenerateFilterConfigOverride(
-    upb_StringView serialized_filter_config, upb_Arena* arena) const {
+    XdsExtension extension, upb_Arena* arena) const {
   // HTTPFault filter has the same message type in HTTP connection manager's
   // filter config and in overriding filter config field.
-  return GenerateFilterConfig(serialized_filter_config, arena);
+  return GenerateFilterConfig(std::move(extension), arena);
 }
 
 const grpc_channel_filter* XdsHttpFaultFilter::channel_filter() const {

--- a/src/core/ext/xds/xds_http_fault_filter.h
+++ b/src/core/ext/xds/xds_http_fault_filter.h
@@ -39,11 +39,11 @@ class XdsHttpFaultFilter : public XdsHttpFilterImpl {
 
   // Overrides the GenerateFilterConfig method
   absl::StatusOr<FilterConfig> GenerateFilterConfig(
-      upb_StringView serialized_filter_config, upb_Arena* arena) const override;
+      XdsExtension extension, upb_Arena* arena) const override;
 
   // Overrides the GenerateFilterConfigOverride method
   absl::StatusOr<FilterConfig> GenerateFilterConfigOverride(
-      upb_StringView serialized_filter_config, upb_Arena* arena) const override;
+      XdsExtension extension, upb_Arena* arena) const override;
 
   // Overrides the channel_filter method
   const grpc_channel_filter* channel_filter() const override;

--- a/src/core/ext/xds/xds_http_filters.cc
+++ b/src/core/ext/xds/xds_http_filters.cc
@@ -44,10 +44,14 @@ class XdsHttpRouterFilter : public XdsHttpFilterImpl {
   }
 
   absl::StatusOr<FilterConfig> GenerateFilterConfig(
-      upb_StringView serialized_filter_config,
-      upb_Arena* arena) const override {
+      XdsExtension extension, upb_Arena* arena) const override {
+    absl::string_view* serialized_filter_config =
+        absl::get_if<absl::string_view>(&extension.value);
+    if (serialized_filter_config == nullptr) {
+      return absl::InvalidArgumentError("could not parse router filter config");
+    }
     if (envoy_extensions_filters_http_router_v3_Router_parse(
-            serialized_filter_config.data, serialized_filter_config.size,
+            serialized_filter_config->data(), serialized_filter_config->size(),
             arena) == nullptr) {
       return absl::InvalidArgumentError("could not parse router filter config");
     }
@@ -55,8 +59,7 @@ class XdsHttpRouterFilter : public XdsHttpFilterImpl {
   }
 
   absl::StatusOr<FilterConfig> GenerateFilterConfigOverride(
-      upb_StringView /*serialized_filter_config*/,
-      upb_Arena* /*arena*/) const override {
+      XdsExtension /*extension*/, upb_Arena* /*arena*/) const override {
     return absl::InvalidArgumentError(
         "router filter does not support config override");
   }

--- a/src/core/ext/xds/xds_http_filters.h
+++ b/src/core/ext/xds/xds_http_filters.h
@@ -30,6 +30,7 @@
 #include "upb/def.h"
 #include "upb/upb.h"
 
+#include "src/core/ext/xds/xds_common_types.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/json/json.h"
@@ -75,12 +76,12 @@ class XdsHttpFilterImpl {
   // Generates a Config from the xDS filter config proto.
   // Used for the top-level config in the HCM HTTP filter list.
   virtual absl::StatusOr<FilterConfig> GenerateFilterConfig(
-      upb_StringView serialized_filter_config, upb_Arena* arena) const = 0;
+      XdsExtension extension, upb_Arena* arena) const = 0;
 
   // Generates a Config from the xDS filter config proto.
   // Used for the typed_per_filter_config override in VirtualHost and Route.
   virtual absl::StatusOr<FilterConfig> GenerateFilterConfigOverride(
-      upb_StringView serialized_filter_config, upb_Arena* arena) const = 0;
+      XdsExtension extension, upb_Arena* arena) const = 0;
 
   // C-core channel filter implementation.
   virtual const grpc_channel_filter* channel_filter() const = 0;

--- a/src/core/ext/xds/xds_http_rbac_filter.cc
+++ b/src/core/ext/xds/xds_http_rbac_filter.cc
@@ -520,8 +520,8 @@ XdsHttpRbacFilter::GenerateFilterConfig(XdsExtension extension,
 }
 
 absl::StatusOr<XdsHttpFilterImpl::FilterConfig>
-XdsHttpRbacFilter::GenerateFilterConfigOverride(
-    XdsExtension extension, upb_Arena* arena) const {
+XdsHttpRbacFilter::GenerateFilterConfigOverride(XdsExtension extension,
+                                                upb_Arena* arena) const {
   absl::string_view* serialized_filter_config =
       absl::get_if<absl::string_view>(&extension.value);
   if (serialized_filter_config == nullptr) {

--- a/src/core/ext/xds/xds_http_rbac_filter.h
+++ b/src/core/ext/xds/xds_http_rbac_filter.h
@@ -38,10 +38,10 @@ class XdsHttpRbacFilter : public XdsHttpFilterImpl {
   void PopulateSymtab(upb_DefPool* symtab) const override;
 
   absl::StatusOr<FilterConfig> GenerateFilterConfig(
-      upb_StringView serialized_filter_config, upb_Arena* arena) const override;
+      XdsExtension extension, upb_Arena* arena) const override;
 
   absl::StatusOr<FilterConfig> GenerateFilterConfigOverride(
-      upb_StringView serialized_filter_config, upb_Arena* arena) const override;
+      XdsExtension extension, upb_Arena* arena) const override;
 
   const grpc_channel_filter* channel_filter() const override;
 

--- a/src/core/ext/xds/xds_lb_policy_registry.cc
+++ b/src/core/ext/xds/xds_lb_policy_registry.cc
@@ -151,32 +151,6 @@ class WrrLocalityLbPolicyConfigFactory
   }
 };
 
-absl::StatusOr<Json> ParseStructToJson(
-    const XdsResourceType::DecodeContext& context,
-    const google_protobuf_Struct* resource) {
-  upb::Status status;
-  const auto* msg_def = google_protobuf_Struct_getmsgdef(context.symtab);
-  size_t json_size = upb_JsonEncode(resource, msg_def, context.symtab, 0,
-                                    nullptr, 0, status.ptr());
-  if (json_size == static_cast<size_t>(-1)) {
-    return absl::InvalidArgumentError(
-        absl::StrCat("Error parsing google::Protobuf::Struct: ",
-                     upb_Status_ErrorMessage(status.ptr())));
-  }
-  void* buf = upb_Arena_Malloc(context.arena, json_size + 1);
-  upb_JsonEncode(resource, msg_def, context.symtab, 0,
-                 reinterpret_cast<char*>(buf), json_size + 1, status.ptr());
-  auto json = Json::Parse(reinterpret_cast<char*>(buf));
-  if (!json.ok()) {
-    // This should not happen
-    return absl::InternalError(
-        absl::StrCat("Error parsing JSON form of google::Protobuf::Struct "
-                     "produced by upb library: ",
-                     json.status().ToString()));
-  }
-  return std::move(*json);
-}
-
 }  // namespace
 
 //
@@ -215,16 +189,18 @@ absl::StatusOr<Json::Array> XdsLbPolicyRegistry::ConvertXdsLbPolicyConfig(
           "Error parsing LoadBalancingPolicy::Policy - Missing "
           "TypedExtensionConfig::typed_config field");
     }
-    auto type = ExtractExtensionTypeName(context, typed_config);
-    if (!type.ok()) {
-      return absl::InvalidArgumentError(absl::StrCat(
+    ValidationErrors errors;
+    auto extension = ExtractXdsExtension(context, typed_config, &errors);
+    if (!errors.ok()) {
+      return errors.status(
           "Error parsing "
-          "LoadBalancingPolicy::Policy::TypedExtensionConfig::typed_config: ",
-          type.status().message()));
+          "LoadBalancingPolicy::Policy::TypedExtensionConfig::typed_config");
     }
+    GPR_ASSERT(extension.has_value());
     absl::string_view value =
         UpbStringToAbsl(google_protobuf_Any_value(typed_config));
-    auto config_factory_it = Get()->policy_config_factories_.find(type->type);
+    auto config_factory_it =
+        Get()->policy_config_factories_.find(extension->type);
     if (config_factory_it != Get()->policy_config_factories_.end()) {
       policy = config_factory_it->second->ConvertXdsLbPolicyConfig(
           context, value, recursion_depth);
@@ -235,29 +211,17 @@ absl::StatusOr<Json::Array> XdsLbPolicyRegistry::ConvertXdsLbPolicyConfig(
                          "typed_config to JSON: ",
                          policy.status().message()));
       }
-    } else if (type->typed_struct != nullptr) {
+    } else if (absl::holds_alternative<Json>(extension->value)) {
       // Custom lb policy config
-      std::string custom_type = std::string(type->type);
       if (!CoreConfiguration::Get()
                .lb_policy_registry()
-               .LoadBalancingPolicyExists(custom_type.c_str(), nullptr)) {
+               .LoadBalancingPolicyExists(extension->type, nullptr)) {
         // Skip unsupported custom lb policy.
         continue;
       }
-      // Convert typed struct to json.
-      auto value = xds_type_v3_TypedStruct_value(type->typed_struct);
-      if (value == nullptr) {
-        policy = Json::Object{{std::move(custom_type), Json() /* null */}};
-      } else {
-        auto parsed_value = ParseStructToJson(context, value);
-        if (!parsed_value.ok()) {
-          return absl::InvalidArgumentError(absl::StrCat(
-              "Error parsing LoadBalancingPolicy: Custom Policy: ", custom_type,
-              ": ", parsed_value.status().message()));
-        }
-        policy =
-            Json::Object{{std::move(custom_type), *(std::move(parsed_value))}};
-      }
+      Json* json = absl::get_if<Json>(&extension->value);
+      policy =
+          Json::Object{{std::string(extension->type), std::move(*json)}};
     } else {
       // Unsupported type. Skipping entry.
       continue;

--- a/src/core/ext/xds/xds_lb_policy_registry.cc
+++ b/src/core/ext/xds/xds_lb_policy_registry.cc
@@ -220,8 +220,7 @@ absl::StatusOr<Json::Array> XdsLbPolicyRegistry::ConvertXdsLbPolicyConfig(
         continue;
       }
       Json* json = absl::get_if<Json>(&extension->value);
-      policy =
-          Json::Object{{std::string(extension->type), std::move(*json)}};
+      policy = Json::Object{{std::string(extension->type), std::move(*json)}};
     } else {
       // Unsupported type. Skipping entry.
       continue;

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -358,18 +358,21 @@ HttpConnectionManagerParse(
         }
         continue;
       }
-      auto filter_type = ExtractExtensionTypeName(context, any);
-      if (!filter_type.ok()) {
-        errors.emplace_back(absl::StrCat("filter name ", name, ": ",
-                                         filter_type.status().message()));
+      ValidationErrors validation_errors;
+      auto extension = ExtractXdsExtension(context, any, &validation_errors);
+      if (!validation_errors.ok()) {
+        errors.emplace_back(
+            validation_errors.status(absl::StrCat("filter name ", name))
+                .message());
         continue;
       }
+      GPR_ASSERT(extension.has_value());
       const XdsHttpFilterImpl* filter_impl =
-          XdsHttpFilterRegistry::GetFilterForType(filter_type->type);
+          XdsHttpFilterRegistry::GetFilterForType(extension->type);
       if (filter_impl == nullptr) {
         if (!is_optional) {
           errors.emplace_back(absl::StrCat(
-              "no filter registered for config type ", filter_type->type));
+              "no filter registered for config type ", extension->type));
         }
         continue;
       }
@@ -377,17 +380,19 @@ HttpConnectionManagerParse(
           (!is_client && !filter_impl->IsSupportedOnServers())) {
         if (!is_optional) {
           errors.emplace_back(absl::StrFormat(
-              "Filter %s is not supported on %s", filter_type->type,
+              "Filter %s is not supported on %s", extension->type,
               is_client ? "clients" : "servers"));
         }
         continue;
       }
+      // TODO(roth): Use extension->value here instead of
+      // google_protobuf_Any_value(any).
       absl::StatusOr<XdsHttpFilterImpl::FilterConfig> filter_config =
           filter_impl->GenerateFilterConfig(google_protobuf_Any_value(any),
                                             context.arena);
       if (!filter_config.ok()) {
         errors.emplace_back(absl::StrCat(
-            "filter config for type ", filter_type->type,
+            "filter config for type ", extension->type,
             " failed to parse: ", StatusToString(filter_config.status())));
         continue;
       }

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -359,6 +359,9 @@ HttpConnectionManagerParse(
         continue;
       }
       ValidationErrors validation_errors;
+      ValidationErrors::ScopedField field(
+          &validation_errors,
+          absl::StrCat(".http_filters[", i, "].typed_config"));
       auto extension = ExtractXdsExtension(context, any, &validation_errors);
       if (!validation_errors.ok()) {
         errors.emplace_back(
@@ -385,10 +388,8 @@ HttpConnectionManagerParse(
         }
         continue;
       }
-      // TODO(roth): Use extension->value here instead of
-      // google_protobuf_Any_value(any).
       absl::StatusOr<XdsHttpFilterImpl::FilterConfig> filter_config =
-          filter_impl->GenerateFilterConfig(google_protobuf_Any_value(any),
+          filter_impl->GenerateFilterConfig(std::move(*extension),
                                             context.arena);
       if (!filter_config.ok()) {
         errors.emplace_back(absl::StrCat(

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -367,8 +367,9 @@ ClusterSpecifierPluginParse(
           "Could not obtrain TypedExtensionConfig for plugin config.");
     }
     ValidationErrors validation_errors;
-    ValidationErrors::ScopedField field(&validation_errors, absl::StrCat(
-        ".cluster_specifier_plugins[", i, "].extension.typed_config"));
+    ValidationErrors::ScopedField field(
+        &validation_errors, absl::StrCat(".cluster_specifier_plugins[", i,
+                                         "].extension.typed_config"));
     auto extension = ExtractXdsExtension(context, any, &validation_errors);
     if (!validation_errors.ok()) {
       return validation_errors.status("could not determine extension type");
@@ -648,8 +649,8 @@ ParseTypedPerFilterConfig(
           "no filter registered for config type ", extension->type));
     }
     absl::StatusOr<XdsHttpFilterImpl::FilterConfig> filter_config =
-        filter_impl->GenerateFilterConfigOverride(
-            std::move(*extension), context.arena);
+        filter_impl->GenerateFilterConfigOverride(std::move(*extension),
+                                                  context.arena);
     if (!filter_config.ok()) {
       return absl::InvalidArgumentError(
           absl::StrCat("filter config for type ", extension->type,

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -349,36 +349,43 @@ ClusterSpecifierPluginParse(
           envoy_config_route_v3_RouteConfiguration_cluster_specifier_plugins(
               route_config, &num_cluster_specifier_plugins);
   for (size_t i = 0; i < num_cluster_specifier_plugins; ++i) {
-    const envoy_config_core_v3_TypedExtensionConfig* extension =
+    const envoy_config_core_v3_TypedExtensionConfig* typed_extension_config =
         envoy_config_route_v3_ClusterSpecifierPlugin_extension(
             cluster_specifier_plugin[i]);
     std::string name = UpbStringToStdString(
-        envoy_config_core_v3_TypedExtensionConfig_name(extension));
+        envoy_config_core_v3_TypedExtensionConfig_name(typed_extension_config));
     if (cluster_specifier_plugin_map.find(name) !=
         cluster_specifier_plugin_map.end()) {
       return absl::InvalidArgumentError(absl::StrCat(
           "Duplicated definition of cluster_specifier_plugin ", name));
     }
     const google_protobuf_Any* any =
-        envoy_config_core_v3_TypedExtensionConfig_typed_config(extension);
+        envoy_config_core_v3_TypedExtensionConfig_typed_config(
+            typed_extension_config);
     if (any == nullptr) {
       return absl::InvalidArgumentError(
           "Could not obtrain TypedExtensionConfig for plugin config.");
     }
-    auto plugin_type = ExtractExtensionTypeName(context, any);
-    if (!plugin_type.ok()) return plugin_type.status();
+    ValidationErrors validation_errors;
+    auto extension = ExtractXdsExtension(context, any, &validation_errors);
+    if (!validation_errors.ok()) {
+      return validation_errors.status("could not determine extension type");
+    }
+    GPR_ASSERT(extension.has_value());
     bool is_optional = envoy_config_route_v3_ClusterSpecifierPlugin_is_optional(
         cluster_specifier_plugin[i]);
     const XdsClusterSpecifierPluginImpl* cluster_specifier_plugin_impl =
-        XdsClusterSpecifierPluginRegistry::GetPluginForType(plugin_type->type);
+        XdsClusterSpecifierPluginRegistry::GetPluginForType(extension->type);
     std::string lb_policy_config;
     if (cluster_specifier_plugin_impl == nullptr) {
       if (!is_optional) {
         return absl::InvalidArgumentError(absl::StrCat(
-            "Unknown ClusterSpecifierPlugin type ", plugin_type->type));
+            "Unknown ClusterSpecifierPlugin type ", extension->type));
       }
       // Optional plugin, leave lb_policy_config empty.
     } else {
+      // TODO(roth): Use extension->serialized_value here instead of
+      // google_protobuf_Any_value(any).
       auto config =
           cluster_specifier_plugin_impl->GenerateLoadBalancingPolicyConfig(
               google_protobuf_Any_value(any), context.arena, context.symtab);
@@ -625,21 +632,27 @@ ParseTypedPerFilterConfig(
             absl::StrCat("no filter config specified for filter name ", key));
       }
     }
-    auto type = ExtractExtensionTypeName(context, any);
-    if (!type.ok()) return type.status();
+    ValidationErrors errors;
+    auto extension = ExtractXdsExtension(context, any, &errors);
+    if (!errors.ok()) {
+      return errors.status("could not determine extension type");
+    }
+    GPR_ASSERT(extension.has_value());
     const XdsHttpFilterImpl* filter_impl =
-        XdsHttpFilterRegistry::GetFilterForType(type->type);
+        XdsHttpFilterRegistry::GetFilterForType(extension->type);
     if (filter_impl == nullptr) {
       if (is_optional) continue;
-      return absl::InvalidArgumentError(
-          absl::StrCat("no filter registered for config type ", type->type));
+      return absl::InvalidArgumentError(absl::StrCat(
+          "no filter registered for config type ", extension->type));
     }
+    // TODO(roth): Use extension->serialized_value here instead of
+    // google_protobuf_Any_value(any).
     absl::StatusOr<XdsHttpFilterImpl::FilterConfig> filter_config =
         filter_impl->GenerateFilterConfigOverride(
             google_protobuf_Any_value(any), context.arena);
     if (!filter_config.ok()) {
       return absl::InvalidArgumentError(
-          absl::StrCat("filter config for type ", type->type,
+          absl::StrCat("filter config for type ", extension->type,
                        " failed to parse: ", filter_config.status().message()));
     }
     typed_per_filter_config[std::string(key)] = std::move(*filter_config);

--- a/src/core/lib/gprpp/validation_errors.h
+++ b/src/core/lib/gprpp/validation_errors.h
@@ -69,7 +69,23 @@ class ValidationErrors {
         : errors_(errors) {
       errors_->PushField(field_name);
     }
-    ~ScopedField() { errors_->PopField(); }
+
+    // Not copyable.
+    ScopedField(const ScopedField& other) = delete;
+    ScopedField& operator=(const ScopedField& other) = delete;
+
+    // Movable.
+    ScopedField(ScopedField&& other) noexcept
+        : errors_(std::exchange(other.errors_, nullptr)) {}
+    ScopedField& operator=(ScopedField&& other) noexcept {
+      if (errors_ != nullptr) errors_->PopField();
+      errors_ = std::exchange(other.errors_, nullptr);
+      return *this;
+    }
+
+    ~ScopedField() {
+      if (errors_ != nullptr) errors_->PopField();
+    }
 
    private:
     ValidationErrors* errors_;

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -167,7 +167,10 @@ grpc_cc_test(
         "//:grpc",
         "//:grpc_xds_client",
         "//src/proto/grpc/testing/xds/v3:tls_proto",
+        "//src/proto/grpc/testing/xds/v3:typed_struct_proto",
+        "//src/proto/grpc/testing/xds/v3:udpa_typed_struct_proto",
         "//test/core/util:grpc_test_util",
+        "//test/cpp/util:grpc_cli_utils",
     ],
 )
 

--- a/test/core/xds/xds_common_types_test.cc
+++ b/test/core/xds/xds_common_types_test.cc
@@ -75,7 +75,6 @@ class XdsCommonTypesTest : public ::testing::Test {
                         upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
-    grpc_error_handle error = GRPC_ERROR_NONE;
     auto bootstrap = GrpcXdsBootstrap::Create(
         "{\n"
         "  \"xds_servers\": [\n"
@@ -671,6 +670,18 @@ TEST_F(ExtractXdsExtensionTest, TypedStructJsonConversion) {
             "\"string\":\"value\","
             "\"struct\":{\"key\":null}"
             "}");
+}
+
+TEST_F(ExtractXdsExtensionTest, FieldMissing) {
+  ValidationErrors errors;
+  ValidationErrors::ScopedField field(&errors, "any");
+  auto extension = ExtractXdsExtension(decode_context_, nullptr, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: [field:any error:field not present]")
+      << status;
 }
 
 TEST_F(ExtractXdsExtensionTest, TypeUrlMissing) {

--- a/test/core/xds/xds_common_types_test.cc
+++ b/test/core/xds/xds_common_types_test.cc
@@ -27,6 +27,7 @@
 #include "absl/status/statusor.h"
 #include "envoy/extensions/transport_sockets/tls/v3/tls.upb.h"
 #include "gmock/gmock.h"
+#include "google/protobuf/any.upb.h"
 #include "google/protobuf/duration.upb.h"
 #include "gtest/gtest.h"
 #include "re2/re2.h"
@@ -36,6 +37,7 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
+#include "src/core/ext/xds/upb_utils.h"
 #include "src/core/ext/xds/xds_bootstrap.h"
 #include "src/core/ext/xds/xds_bootstrap_grpc.h"
 #include "src/core/ext/xds/xds_client.h"
@@ -49,10 +51,14 @@
 #include "src/proto/grpc/testing/xds/v3/regex.pb.h"
 #include "src/proto/grpc/testing/xds/v3/string.pb.h"
 #include "src/proto/grpc/testing/xds/v3/tls.pb.h"
+#include "src/proto/grpc/testing/xds/v3/typed_struct.pb.h"
+#include "src/proto/grpc/testing/xds/v3/udpa_typed_struct.pb.h"
 #include "test/core/util/test_config.h"
+#include "test/cpp/util/config_grpc_cli.h"
 
 using CommonTlsContextProto =
     envoy::extensions::transport_sockets::tls::v3::CommonTlsContext;
+using xds::type::v3::TypedStruct;
 
 namespace grpc_core {
 namespace testing {
@@ -69,7 +75,7 @@ class XdsCommonTypesTest : public ::testing::Test {
                         upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
-    grpc_error_handle error;
+    grpc_error_handle error = GRPC_ERROR_NONE;
     auto bootstrap = GrpcXdsBootstrap::Create(
         "{\n"
         "  \"xds_servers\": [\n"
@@ -519,6 +525,308 @@ TEST_F(CommonTlsConfigTest, ValidationContextUnsupportedFields) {
             "field:validation_context.verify_certificate_spki "
             "error:feature unsupported]")
       << common_tls_context.status();
+}
+
+//
+// ExtractXdsExtension() tests
+//
+
+using ExtractXdsExtensionTest = XdsCommonTypesTest;
+
+TEST_F(ExtractXdsExtensionTest, Basic) {
+  constexpr absl::string_view kTypeUrl = "type.googleapis.com/MyType";
+  constexpr absl::string_view kValue = "foobar";
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(any_proto, StdStringToUpbString(kTypeUrl));
+  google_protobuf_Any_set_value(any_proto, StdStringToUpbString(kValue));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status("unexpected errors");
+  ASSERT_TRUE(extension.has_value());
+  EXPECT_EQ(extension->type, "MyType");
+  ASSERT_TRUE(absl::holds_alternative<absl::string_view>(extension->value));
+  EXPECT_EQ(absl::get<absl::string_view>(extension->value), kValue);
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStruct) {
+  TypedStruct typed_struct;
+  typed_struct.set_type_url("type.googleapis.com/MyType");
+  auto* fields = typed_struct.mutable_value()->mutable_fields();
+  (*fields)["foo"].set_string_value("bar");
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status("unexpected errors");
+  ASSERT_TRUE(extension.has_value());
+  EXPECT_EQ(extension->type, "MyType");
+  ASSERT_TRUE(absl::holds_alternative<Json>(extension->value));
+  EXPECT_EQ(absl::get<Json>(extension->value).Dump(), "{\"foo\":\"bar\"}");
+}
+
+TEST_F(ExtractXdsExtensionTest, UdpaTypedStruct) {
+  udpa::type::v1::TypedStruct typed_struct;
+  typed_struct.set_type_url("type.googleapis.com/MyType");
+  auto* fields = typed_struct.mutable_value()->mutable_fields();
+  (*fields)["foo"].set_string_value("bar");
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status("unexpected errors");
+  ASSERT_TRUE(extension.has_value());
+  EXPECT_EQ(extension->type, "MyType");
+  ASSERT_TRUE(absl::holds_alternative<Json>(extension->value));
+  EXPECT_EQ(absl::get<Json>(extension->value).Dump(), "{\"foo\":\"bar\"}");
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructWithoutValue) {
+  TypedStruct typed_struct;
+  typed_struct.set_type_url("type.googleapis.com/MyType");
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status("unexpected errors");
+  ASSERT_TRUE(extension.has_value());
+  EXPECT_EQ(extension->type, "MyType");
+  ASSERT_TRUE(absl::holds_alternative<Json>(extension->value));
+  EXPECT_EQ(absl::get<Json>(extension->value).Dump(), "{}");
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructJsonConversion) {
+  TypedStruct typed_struct;
+  ASSERT_TRUE(grpc::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        type_url: "type.googleapis.com/envoy.ExtensionType"
+        value {
+          fields {
+            key: "key"
+            value { null_value: NULL_VALUE }
+          }
+          fields {
+            key: "number"
+            value { number_value: 123 }
+          }
+          fields {
+            key: "string"
+            value { string_value: "value" }
+          }
+          fields {
+            key: "struct"
+            value {
+              struct_value {
+                fields {
+                  key: "key"
+                  value { null_value: NULL_VALUE }
+                }
+              }
+            }
+          }
+          fields {
+            key: "list"
+            value {
+              list_value {
+                values { null_value: NULL_VALUE }
+                values { number_value: 234 }
+              }
+            }
+          }
+        }
+      )pb",
+      &typed_struct));
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_TRUE(errors.ok()) << errors.status("unexpected errors");
+  ASSERT_TRUE(extension.has_value());
+  EXPECT_EQ(extension->type, "envoy.ExtensionType");
+  ASSERT_TRUE(absl::holds_alternative<Json>(extension->value));
+  EXPECT_EQ(absl::get<Json>(extension->value).Dump(),
+            "{"
+            "\"key\":null,"
+            "\"list\":[null,234],"
+            "\"number\":123,"
+            "\"string\":\"value\","
+            "\"struct\":{\"key\":null}"
+            "}");
+}
+
+TEST_F(ExtractXdsExtensionTest, TypeUrlMissing) {
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: [field:type_url error:field not present]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructTypeUrlMissing) {
+  TypedStruct typed_struct;
+  auto* fields = typed_struct.mutable_value()->mutable_fields();
+  (*fields)["foo"].set_string_value("bar");
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:value[xds.type.v3.TypedStruct].type_url "
+            "error:field not present]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypeUrlNoSlash) {
+  constexpr absl::string_view kTypeUrl = "MyType";
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(any_proto, StdStringToUpbString(kTypeUrl));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:type_url error:invalid value \"MyType\"]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructTypeUrlNoSlash) {
+  TypedStruct typed_struct;
+  typed_struct.set_type_url("MyType");
+  auto* fields = typed_struct.mutable_value()->mutable_fields();
+  (*fields)["foo"].set_string_value("bar");
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:value[xds.type.v3.TypedStruct].type_url "
+            "error:invalid value \"MyType\"]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypeUrlNothingAfterSlash) {
+  constexpr absl::string_view kTypeUrl = "type.googleapi.com/";
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(any_proto, StdStringToUpbString(kTypeUrl));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:type_url error:invalid value \"type.googleapi.com/\"]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructTypeUrlNothingAfterSlash) {
+  TypedStruct typed_struct;
+  typed_struct.set_type_url("type.googleapis.com/");
+  auto* fields = typed_struct.mutable_value()->mutable_fields();
+  (*fields)["foo"].set_string_value("bar");
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:value[xds.type.v3.TypedStruct].type_url "
+            "error:invalid value \"type.googleapis.com/\"]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructParseFailure) {
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(std::string("\0", 1)));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:value[xds.type.v3.TypedStruct] error:could not parse]")
+      << status;
+}
+
+TEST_F(ExtractXdsExtensionTest, TypedStructWithInvalidProtobufStruct) {
+  TypedStruct typed_struct;
+  typed_struct.set_type_url("type.googleapis.com/xds.MyType");
+  auto* fields = typed_struct.mutable_value()->mutable_fields();
+  (*fields)["foo"].mutable_list_value()->add_values();
+  std::string serialized_typed_struct = typed_struct.SerializeAsString();
+  google_protobuf_Any* any_proto = google_protobuf_Any_new(upb_arena_.ptr());
+  google_protobuf_Any_set_type_url(
+      any_proto, StdStringToUpbString(absl::string_view(
+                     "type.googleapis.com/xds.type.v3.TypedStruct")));
+  google_protobuf_Any_set_value(any_proto,
+                                StdStringToUpbString(serialized_typed_struct));
+  ValidationErrors errors;
+  auto extension = ExtractXdsExtension(decode_context_, any_proto, &errors);
+  ASSERT_FALSE(errors.ok());
+  absl::Status status = errors.status("validation errors");
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(status.message(),
+            "validation errors: ["
+            "field:value[xds.type.v3.TypedStruct].value[xds.MyType] "
+            "error:error encoding google::Protobuf::Struct as JSON: "
+            "No value set in Value proto]")
+      << status;
 }
 
 }  // namespace

--- a/test/cpp/end2end/xds/no_op_http_filter.h
+++ b/test/cpp/end2end/xds/no_op_http_filter.h
@@ -29,17 +29,18 @@ class NoOpHttpFilter : public grpc_core::XdsHttpFilterImpl {
         supported_on_servers_(supported_on_servers),
         is_terminal_filter_(is_terminal_filter) {}
 
-  void PopulateSymtab(upb_DefPool* /* symtab */) const override {}
+  void PopulateSymtab(upb_DefPool* /*symtab*/) const override {}
 
   absl::StatusOr<grpc_core::XdsHttpFilterImpl::FilterConfig>
-  GenerateFilterConfig(upb_StringView /* serialized_filter_config */,
-                       upb_Arena* /* arena */) const override {
+  GenerateFilterConfig(grpc_core::XdsExtension /*extension*/,
+                       upb_Arena* /*arena*/) const override {
     return grpc_core::XdsHttpFilterImpl::FilterConfig{name_, grpc_core::Json()};
   }
 
   absl::StatusOr<grpc_core::XdsHttpFilterImpl::FilterConfig>
-  GenerateFilterConfigOverride(upb_StringView /*serialized_filter_config*/,
-                               upb_Arena* /*arena*/) const override {
+  GenerateFilterConfigOverride(
+      grpc_core::XdsExtension /*serialized_filter_config*/,
+      upb_Arena* /*arena*/) const override {
     return grpc_core::XdsHttpFilterImpl::FilterConfig{name_, grpc_core::Json()};
   }
 


### PR DESCRIPTION
This is a prerequisite for both finishing the xDS custom LB policy work and for adding unit tests for the Listener and RouteConfig resource code.