### PR TITLE
fix broken objc test jobs

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -98,7 +98,8 @@ if [ "${PREPARE_BUILD_INSTALL_DEPS_OBJC}" == "true" ]
 then
   # cocoapods
   export LANG=en_US.UTF-8
-  time gem install cocoapods --version 1.7.2 --no-document --user-install
+  # use "sudo" to avoid permission error on kokoro monterey image
+  time sudo gem install cocoapods --version 1.7.2 --no-document --user-install
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master


### PR DESCRIPTION
There's currently a CBF for objc jobs:
```
++ LANG=en_US.UTF-8
++ gem install cocoapods --version 1.7.2 --no-document --user-install
WARNING:  You don't have /Users/kbuilder/.gem/ruby/2.6.0/bin in your PATH,
	  gem executables will not run.
ERROR:  While executing gem ... (Gem::FilePermissionError)
    You don't have write permissions for the /Library/Ruby/Gems/2.6.0/wrappers directory.
```
