### PR TITLE
Fix thread safety analysis warning from new Clang version

### DIFF
--- a/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
+++ b/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
@@ -118,7 +118,11 @@ grpc_core::RefCountedPtr<TlsSessionKeyLogger> TlsSessionKeyLoggerCache::Get(
     grpc_core::RefCountedPtr<TlsSessionKeyLoggerCache> cache;
     if (g_cache_instance == nullptr) {
       // This will automatically set g_cache_instance.
-      cache = grpc_core::MakeRefCounted<TlsSessionKeyLoggerCache>();
+      // Not using MakeRefCounted because to the thread safety analysis, which
+      // cannot see through calls, it would look like MakeRefCounted was
+      // calling TlsSessionKeyLoggerCache without holding a lock on
+      // g_tls_session_key_log_cache_mu.
+      cache.reset(new TlsSessionKeyLoggerCache());
     } else {
       cache = g_cache_instance->Ref();
     }


### PR DESCRIPTION
The `TlsSessionKeyLoggerCache` constructor is annotated with

```
  ABSL_EXCLUSIVE_LOCKS_REQUIRED(g_tls_session_key_log_cache_mu)
```

and in `TlsSessionKeyLoggerCache::Get` it gets called indirectly by:

```
  grpc_core::MutexLock lock(g_tls_session_key_log_cache_mu);
  ...
  cache = grpc_core::MakeRefCounted<TlsSessionKeyLoggerCache>()
```

New Clang versions started to analyze the constructor call in
`grpc_core::MakeRefCounted`, and since it cannot reason across function
boundaries it does not know that the lock is held at that point:

```
  ../../third_party/grpc/src/src/core/lib/gprpp/ref_counted_ptr.h:335:31:
  warning: calling function 'TlsSessionKeyLoggerCache' requires holding mutex
  'g_tls_session_key_log_cache_mu' exclusively [-Wthread-safety-analysis]
    return RefCountedPtr<T>(new T(std::forward<Args>(args)...));
				^
  ../../third_party/grpc/src/src/core/tsi/ssl/key_logging/ssl_key_logging.cc:121:26:
  note: in instantiation of function template specialization
  'grpc_core::MakeRefCounted<tsi::TlsSessionKeyLoggerCache>' requested here
	cache = grpc_core::MakeRefCounted<TlsSessionKeyLoggerCache>();
			   ^
  1 warning generated.
```

This change avoids the warning by calling the constructor directly.