### PR TITLE
[Python][Remove Six] Remove Six dependency part II

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -57,7 +57,7 @@ def _get_grpc_custom_bdist(decorated_basename, target_bdist_basename):
 
     # Break import style to ensure that setup.py has had a chance to install the
     # relevant package.
-    from six.moves.urllib import request
+    from urllib import request
     decorated_path = decorated_basename + GRPC_CUSTOM_BDIST_EXT
     try:
         url = BINARIES_REPOSITORY + '/{target}'.format(target=decorated_path)

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -15,13 +15,13 @@
 from __future__ import absolute_import
 
 import collections
+import io
 import itertools
 import traceback
 import unittest
 from xml.etree import ElementTree
 
 import coverage
-from six import moves
 
 from tests import _loader
 
@@ -338,7 +338,7 @@ def _traceback_string(type, value, trace):
   Returns:
     str: Formatted exception descriptive string.
   """
-    buffer = moves.cStringIO()
+    buffer = io.StringIO()
     traceback.print_exception(type, value, trace, file=buffer)
     return buffer.getvalue()
 

--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import collections
+import io
 import os
 import select
 import signal
@@ -24,9 +25,6 @@ import threading
 import time
 import unittest
 import uuid
-
-import six
-from six import moves
 
 from tests import _loader
 from tests import _result
@@ -79,7 +77,7 @@ class CaptureFile(object):
     Arguments:
       value (str): What to write to the original file.
     """
-        if six.PY3 and not isinstance(value, six.binary_type):
+        if not isinstance(value, bytes):
             value = value.encode('ascii')
         if self._saved_fd is None:
             os.write(self._redirect_fd, value)
@@ -147,7 +145,7 @@ class Runner(object):
         ]
         case_id_by_case = dict((augmented_case.case, augmented_case.id)
                                for augmented_case in augmented_cases)
-        result_out = moves.cStringIO()
+        result_out = io.StringIO()
         result = _result.TerminalResult(
             result_out, id_map=lambda case: case_id_by_case[case])
         stdout_pipe = CaptureFile(sys.stdout.fileno())

--- a/src/python/grpcio_tests/tests/_sanity/_sanity_test.py
+++ b/src/python/grpcio_tests/tests/_sanity/_sanity_test.py
@@ -16,8 +16,6 @@ import json
 import pkgutil
 import unittest
 
-import six
-
 import tests
 
 
@@ -38,8 +36,7 @@ class SanityTest(unittest.TestCase):
         })
 
         tests_json_string = pkgutil.get_data(self.TEST_PKG_PATH, 'tests.json')
-        tests_json = json.loads(
-            tests_json_string.decode() if six.PY3 else tests_json_string)
+        tests_json = tests_json_string.decode()
 
         self.assertSequenceEqual(tests_json, test_suite_names)
 

--- a/src/python/grpcio_tests/tests/csds/test_csds.py
+++ b/src/python/grpcio_tests/tests/csds/test_csds.py
@@ -16,6 +16,7 @@
 from concurrent.futures import ThreadPoolExecutor
 import logging
 import os
+import queue
 import sys
 import time
 import unittest
@@ -25,7 +26,6 @@ from envoy.service.status.v3 import csds_pb2_grpc
 from google.protobuf import json_format
 import grpc
 import grpc_csds
-from six.moves import queue
 
 _DUMMY_XDS_ADDRESS = 'xds:///foo.bar'
 _DUMMY_BOOTSTRAP_FILE = """

--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -20,7 +20,6 @@ import threading
 import unittest
 
 from grpc._cython import cygrpc
-import six
 
 from tests.fork import methods
 
@@ -49,7 +48,6 @@ _SUBPROCESS_TIMEOUT_S = 30
 @unittest.skipUnless(
     sys.platform.startswith("linux"),
     "not supported on windows, and fork+exec networking blocked on mac")
-@unittest.skipUnless(six.PY2, "https://github.com/grpc/grpc/issues/18075")
 class ForkInteropTest(unittest.TestCase):
 
     def setUp(self):

--- a/src/python/grpcio_tests/tests/fork/methods.py
+++ b/src/python/grpcio_tests/tests/fork/methods.py
@@ -18,11 +18,11 @@ import json
 import logging
 import multiprocessing
 import os
+import queue
 import threading
 import time
 
 import grpc
-from six.moves import queue
 
 from src.proto.grpc.testing import empty_pb2
 from src.proto.grpc.testing import messages_pb2

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -14,6 +14,7 @@
 """Tests of grpc_health.v1.health."""
 
 import logging
+import queue
 import sys
 import threading
 import time
@@ -23,7 +24,6 @@ import grpc
 from grpc_health.v1 import health
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
-from six.moves import queue
 
 from tests.unit import test_common
 from tests.unit import thread_pool

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -16,7 +16,7 @@ import collections
 import contextlib
 import distutils.spawn
 import errno
-from itertools import zip_longest
+import itertools
 import os
 import shutil
 import subprocess
@@ -308,8 +308,8 @@ class PythonPluginTest(unittest.TestCase):
         responses = service.stub.StreamingOutputCall(request)
         expected_responses = service.servicer_methods.StreamingOutputCall(
             request, 'not a real RpcContext!')
-        for expected_response, response in zip_longest(expected_responses,
-                                                       responses):
+        for expected_response, response in itertools.zip_longest(
+                expected_responses, responses):
             self.assertEqual(expected_response, response)
         service.server.stop(None)
 
@@ -408,8 +408,8 @@ class PythonPluginTest(unittest.TestCase):
         responses = service.stub.FullDuplexCall(_full_duplex_request_iterator())
         expected_responses = service.servicer_methods.FullDuplexCall(
             _full_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in zip_longest(expected_responses,
-                                                       responses):
+        for expected_response, response in itertools.zip_longest(
+                expected_responses, responses):
             self.assertEqual(expected_response, response)
         service.server.stop(None)
 
@@ -463,8 +463,8 @@ class PythonPluginTest(unittest.TestCase):
         responses = service.stub.HalfDuplexCall(half_duplex_request_iterator())
         expected_responses = service.servicer_methods.HalfDuplexCall(
             half_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in zip_longest(expected_responses,
-                                                       responses):
+        for expected_response, response in itertools.zip_longest(
+                expected_responses, responses):
             self.assertEqual(expected_response, response)
         service.server.stop(None)
 
@@ -575,8 +575,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
             channel_credentials=grpc.experimental.insecure_channel_credentials(
             ),
             wait_for_ready=True)
-        for expected_response, response in zip_longest(expected_responses,
-                                                       responses):
+        for expected_response, response in itertools.zip_longest(
+                expected_responses, responses):
             self.assertEqual(expected_response, response)
 
     def testStreamingInputCall(self):
@@ -599,8 +599,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
             wait_for_ready=True)
         expected_responses = self.servicer_methods.FullDuplexCall(
             _full_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in zip_longest(expected_responses,
-                                                       responses):
+        for expected_response, response in itertools.zip_longest(
+                expected_responses, responses):
             self.assertEqual(expected_response, response)
 
     def testHalfDuplexCall(self):
@@ -622,8 +622,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
             wait_for_ready=True)
         expected_responses = self.servicer_methods.HalfDuplexCall(
             half_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in zip_longest(expected_responses,
-                                                       responses):
+        for expected_response, response in itertools.zip_longest(
+                expected_responses, responses):
             self.assertEqual(expected_response, response)
 
 

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -16,6 +16,7 @@ import collections
 import contextlib
 import distutils.spawn
 import errno
+from itertools import zip_longest
 import os
 import shutil
 import subprocess
@@ -26,7 +27,6 @@ import unittest
 
 import grpc
 import grpc.experimental
-from six import moves
 
 import tests.protoc_plugin.protos.payload.test_payload_pb2 as payload_pb2
 import tests.protoc_plugin.protos.requests.r.test_requests_pb2 as request_pb2
@@ -308,8 +308,8 @@ class PythonPluginTest(unittest.TestCase):
         responses = service.stub.StreamingOutputCall(request)
         expected_responses = service.servicer_methods.StreamingOutputCall(
             request, 'not a real RpcContext!')
-        for expected_response, response in moves.zip_longest(
-                expected_responses, responses):
+        for expected_response, response in zip_longest(expected_responses,
+                                                       responses):
             self.assertEqual(expected_response, response)
         service.server.stop(None)
 
@@ -408,8 +408,8 @@ class PythonPluginTest(unittest.TestCase):
         responses = service.stub.FullDuplexCall(_full_duplex_request_iterator())
         expected_responses = service.servicer_methods.FullDuplexCall(
             _full_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in moves.zip_longest(
-                expected_responses, responses):
+        for expected_response, response in zip_longest(expected_responses,
+                                                       responses):
             self.assertEqual(expected_response, response)
         service.server.stop(None)
 
@@ -463,8 +463,8 @@ class PythonPluginTest(unittest.TestCase):
         responses = service.stub.HalfDuplexCall(half_duplex_request_iterator())
         expected_responses = service.servicer_methods.HalfDuplexCall(
             half_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in moves.zip_longest(
-                expected_responses, responses):
+        for expected_response, response in zip_longest(expected_responses,
+                                                       responses):
             self.assertEqual(expected_response, response)
         service.server.stop(None)
 
@@ -575,8 +575,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
             channel_credentials=grpc.experimental.insecure_channel_credentials(
             ),
             wait_for_ready=True)
-        for expected_response, response in moves.zip_longest(
-                expected_responses, responses):
+        for expected_response, response in zip_longest(expected_responses,
+                                                       responses):
             self.assertEqual(expected_response, response)
 
     def testStreamingInputCall(self):
@@ -599,8 +599,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
             wait_for_ready=True)
         expected_responses = self.servicer_methods.FullDuplexCall(
             _full_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in moves.zip_longest(
-                expected_responses, responses):
+        for expected_response, response in zip_longest(expected_responses,
+                                                       responses):
             self.assertEqual(expected_response, response)
 
     def testHalfDuplexCall(self):
@@ -622,8 +622,8 @@ class SimpleStubsPluginTest(unittest.TestCase):
             wait_for_ready=True)
         expected_responses = self.servicer_methods.HalfDuplexCall(
             half_duplex_request_iterator(), 'not a real RpcContext!')
-        for expected_response, response in moves.zip_longest(
-                expected_responses, responses):
+        for expected_response, response in zip_longest(expected_responses,
+                                                       responses):
             self.assertEqual(expected_response, response)
 
 

--- a/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
@@ -27,7 +27,6 @@ import unittest
 import grpc
 from grpc_tools import protoc
 import pkg_resources
-import six
 
 from tests.unit import test_common
 

--- a/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
@@ -14,7 +14,7 @@
 
 import contextlib
 import importlib
-from itertools import zip_longest
+import itertools
 import os
 from os import path
 import pkgutil
@@ -433,7 +433,7 @@ class PythonPluginTest(unittest.TestCase):
                                                  test_constants.LONG_TIMEOUT)
             expected_responses = methods.StreamingOutputCall(
                 request, 'not a real RpcContext!')
-            for expected_response, response in zip_longest(
+            for expected_response, response in itertools.zip_longest(
                     expected_responses, responses):
                 self.assertEqual(expected_response, response)
 
@@ -559,7 +559,7 @@ class PythonPluginTest(unittest.TestCase):
             expected_responses = methods.FullDuplexCall(
                 _full_duplex_request_iterator(self._requests_pb2),
                 'not a real RpcContext!')
-            for expected_response, response in zip_longest(
+            for expected_response, response in itertools.zip_longest(
                     expected_responses, responses):
                 self.assertEqual(expected_response, response)
 
@@ -620,7 +620,7 @@ class PythonPluginTest(unittest.TestCase):
                                             test_constants.LONG_TIMEOUT)
             expected_responses = methods.HalfDuplexCall(
                 half_duplex_request_iterator(), 'not a real RpcContext!')
-            for check in zip_longest(expected_responses, responses):
+            for check in itertools.zip_longest(expected_responses, responses):
                 expected_response, response = check
                 self.assertEqual(expected_response, response)
 

--- a/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import importlib
+from itertools import zip_longest
 import os
 from os import path
 import pkgutil
@@ -28,7 +29,6 @@ from grpc.beta import interfaces
 from grpc.framework.foundation import future
 from grpc.framework.interfaces.face import face
 from grpc_tools import protoc
-from six import moves
 
 from tests.unit.framework.common import test_constants
 
@@ -433,7 +433,7 @@ class PythonPluginTest(unittest.TestCase):
                                                  test_constants.LONG_TIMEOUT)
             expected_responses = methods.StreamingOutputCall(
                 request, 'not a real RpcContext!')
-            for expected_response, response in moves.zip_longest(
+            for expected_response, response in zip_longest(
                     expected_responses, responses):
                 self.assertEqual(expected_response, response)
 
@@ -559,7 +559,7 @@ class PythonPluginTest(unittest.TestCase):
             expected_responses = methods.FullDuplexCall(
                 _full_duplex_request_iterator(self._requests_pb2),
                 'not a real RpcContext!')
-            for expected_response, response in moves.zip_longest(
+            for expected_response, response in zip_longest(
                     expected_responses, responses):
                 self.assertEqual(expected_response, response)
 
@@ -620,7 +620,7 @@ class PythonPluginTest(unittest.TestCase):
                                             test_constants.LONG_TIMEOUT)
             expected_responses = methods.HalfDuplexCall(
                 half_duplex_request_iterator(), 'not a real RpcContext!')
-            for check in moves.zip_longest(expected_responses, responses):
+            for check in zip_longest(expected_responses, responses):
                 expected_response, response = check
                 self.assertEqual(expected_response, response)
 

--- a/src/python/grpcio_tests/tests/qps/benchmark_client.py
+++ b/src/python/grpcio_tests/tests/qps/benchmark_client.py
@@ -15,11 +15,11 @@
 
 import abc
 from concurrent import futures
+import queue
 import threading
 import time
 
 import grpc
-from six.moves import queue
 
 from src.proto.grpc.testing import benchmark_service_pb2_grpc
 from src.proto.grpc.testing import messages_pb2

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -15,10 +15,10 @@
 
 import argparse
 from concurrent import futures
+import queue
 import threading
 
 import grpc
-from six.moves import queue
 
 from src.proto.grpc.testing import metrics_pb2_grpc
 from src.proto.grpc.testing import test_pb2_grpc

--- a/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
+++ b/src/python/grpcio_tests/tests/unit/_contextvars_propagation_test.py
@@ -16,12 +16,12 @@
 import contextlib
 import logging
 import os
+import queue
 import sys
 import threading
 import unittest
 
 import grpc
-from six.moves import queue
 
 from tests.unit import test_common
 

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -17,7 +17,6 @@ import logging
 import unittest
 
 import grpc
-import six
 
 
 class CredentialsTest(unittest.TestCase):
@@ -54,7 +53,6 @@ class CredentialsTest(unittest.TestCase):
         self.assertIsInstance(channel_first_second_and_third,
                               grpc.ChannelCredentials)
 
-    @unittest.skipIf(six.PY2, 'only invalid in Python3')
     def test_invalid_string_certificate(self):
         self.assertRaises(
             TypeError,

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -49,12 +49,11 @@ class LoggingTest(unittest.TestCase):
     def test_can_configure_logger(self):
         script = """if True:
             import logging
-            import six
 
             import grpc
+            import io
 
-
-            intended_stream = six.StringIO()
+            intended_stream = io.StringIO()
             logging.basicConfig(stream=intended_stream)
 
             if len(logging.getLogger().handlers) != 1:

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -14,6 +14,7 @@
 """Tests metadata flags feature by testing wait-for-ready semantics"""
 
 import logging
+import queue
 import socket
 import threading
 import time
@@ -21,7 +22,6 @@ import unittest
 import weakref
 
 import grpc
-from six.moves import queue
 
 from tests.unit import test_common
 import tests.unit.framework.common

--- a/src/python/grpcio_tests/tests/unit/_server_shutdown_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_server_shutdown_scenarios.py
@@ -17,11 +17,11 @@ import argparse
 from concurrent import futures
 import logging
 import os
+import queue
 import threading
 import time
 
 import grpc
-from six.moves import queue
 
 from tests.unit import test_common
 

--- a/src/python/grpcio_tests/tests/unit/framework/common/test_control.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/test_control.py
@@ -17,8 +17,6 @@ import abc
 import contextlib
 import threading
 
-import six
-
 
 class Defect(Exception):
     """Simulates a programming defect raised into in a system under test.


### PR DESCRIPTION
### Description

Remove `six` dependency since now we only support Python3.

### Changes included
- Replace `six.moves.urllib` with `urllib`.
- Replace `six.moves.cStringIO()` with `io.StringIO()`.
- Replace `six.binary_type` with `bytes`.
- Replace `six.moves.queue` with `queue`.
- Replace `six.moves.zip_longest` with `itertools.zip_longest`.
- Remove unused `import six`.
- Remove `six.PY3` and `six.PY2` flag.

### Testing
- Passed all CI tests.
