### PR TITLE
Update visibility for `grpc_public_hdrs`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -654,6 +654,7 @@ grpc_cc_library(
         "avoid_dep",
         "nofixdeps",
     ],
+    visibility = ["@grpc:public"],
     deps = ["gpr_public_hdrs"],
 )
 


### PR DESCRIPTION
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

In #31100, we removed `grpc_codegen` and replace it with `grpc_public_hdrs`. However, `grpc_public_hdrs` does not get updated to get the same visibility as `grpc_codegen`. This PR does the job.
