### PR TITLE
xDS Interop: update default prefix in the cleanup script

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_resource_cleanup.cfg
+++ b/tools/internal_ci/linux/grpc_xds_resource_cleanup.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -55,7 +55,7 @@ GCLOUD_CMD_TIMEOUT_S = datetime.timedelta(seconds=5).total_seconds()
 ZONE = 'us-central1-a'
 SECONDARY_ZONE = 'us-west1-b'
 
-PSM_SECURITY_PREFIX = 'xds-k8s-security'  # Prefix for gke resources to delete.
+PSM_SECURITY_PREFIX = 'psm-interop'  # Prefix for gke resources to delete.
 URL_MAP_TEST_PREFIX = 'interop-psm-url-map'  # Prefix for url-map test resources to delete.
 
 KEEP_PERIOD_HOURS = flags.DEFINE_integer(


### PR DESCRIPTION
We don't have a separate security prefix anymore. The default script was updated in https://github.com/grpc/grpc/pull/30754.
