### PR TITLE
Cleanup grpc_sample_fuzzers job

### DIFF
--- a/tools/internal_ci/linux/pull_request/grpc_sample_fuzzers.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_sample_fuzzers.cfg
@@ -17,14 +17,6 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_sample_fuzzers.sh"
 timeout_mins: 120
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73836
-      keyname: "grpc_checks_private_key"
-    }
-  }
-}
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
AFAICT the job doesn't publish any "github checks", so it has no need to pull the "grpc_checks_private_key".