### PR TITLE
Ensure Full Build is Run for each Bazel Version in Bazel Distribtest

### DIFF
--- a/test/distrib/bazel/run_bazel_distrib_test.sh
+++ b/test/distrib/bazel/run_bazel_distrib_test.sh
@@ -24,12 +24,6 @@ FAILED_VERSIONS=""
 for VERSION in $VERSIONS; do
     echo "Running bazel distribtest with bazel version ${VERSION}"
     ./test_single_bazel_version.sh "${VERSION}" || FAILED_VERSIONS="${FAILED_VERSIONS}${VERSION} "
-
-  if [ -n "$KOKORO_ARTIFACTS_DIR" ]; then
-    # `bazel clean` is not sufficient.
-    rm -rf "$HOME/.cache/bazel"
-  fi
-
 done
 
 if [ "$FAILED_VERSIONS" != "" ]

--- a/test/distrib/bazel/run_bazel_distrib_test.sh
+++ b/test/distrib/bazel/run_bazel_distrib_test.sh
@@ -25,7 +25,7 @@ for VERSION in $VERSIONS; do
     echo "Running bazel distribtest with bazel version ${VERSION}"
     ./test_single_bazel_version.sh "${VERSION}" || FAILED_VERSIONS="${FAILED_VERSIONS}${VERSION} "
 
-  if [ ! -z "$KOKORO_ARTIFACTS_DIR" ]; then
+  if [ -n "$KOKORO_ARTIFACTS_DIR" ]; then
     # `bazel clean` is not sufficient.
     rm -rf "$HOME/.cache/bazel"
   fi

--- a/test/distrib/bazel/run_bazel_distrib_test.sh
+++ b/test/distrib/bazel/run_bazel_distrib_test.sh
@@ -24,6 +24,12 @@ FAILED_VERSIONS=""
 for VERSION in $VERSIONS; do
     echo "Running bazel distribtest with bazel version ${VERSION}"
     ./test_single_bazel_version.sh "${VERSION}" || FAILED_VERSIONS="${FAILED_VERSIONS}${VERSION} "
+
+  if [ ! -z "$KOKORO_ARTIFACTS_DIR" ]; then
+    # `bazel clean` is not sufficient.
+    rm -rf "$HOME/.cache/bazel"
+  fi
+
 done
 
 if [ "$FAILED_VERSIONS" != "" ]

--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -58,13 +58,13 @@ if [ ! -z "$KOKORO_ARTIFACTS_DIR" ]; then
   ACTION_ENV_FLAG="--action_env=bazel_cache_invalidate=version_${VERSION}"
 fi
 
+tools/bazel test ${ACTION_ENV_FLAG} --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
 tools/bazel build ${ACTION_ENV_FLAG} -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
 
 for TEST_DIRECTORY in "${TEST_DIRECTORIES[@]}"; do
   pushd "test/distrib/bazel/$TEST_DIRECTORY/"
 
   tools/bazel version | grep "$VERSION" || { echo "Detected bazel version did not match expected value of $VERSION" >/dev/stderr; exit 1; }
-  tools/bazel test ${ACTION_ENV_FLAG} --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
 
   popd
 done

--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -52,19 +52,15 @@ export OVERRIDE_BAZEL_VERSION="$VERSION"
 # when running under bazel docker image, the workspace is read only.
 export OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp
 
-ACTION_ENV_FLAG=""
-if [ ! -z "$KOKORO_ARTIFACTS_DIR" ]; then
-  # `bazel clean` is not sufficient.
-  ACTION_ENV_FLAG="--action_env=bazel_cache_invalidate=version_${VERSION}"
-fi
+ACTION_ENV_FLAG="--action_env=bazel_cache_invalidate=version_${VERSION}"
 
-tools/bazel test ${ACTION_ENV_FLAG} --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
-tools/bazel build ${ACTION_ENV_FLAG} -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
+tools/bazel build "${ACTION_ENV_FLAG}" -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
 
 for TEST_DIRECTORY in "${TEST_DIRECTORIES[@]}"; do
   pushd "test/distrib/bazel/$TEST_DIRECTORY/"
 
   tools/bazel version | grep "$VERSION" || { echo "Detected bazel version did not match expected value of $VERSION" >/dev/stderr; exit 1; }
+  tools/bazel test "${ACTION_ENV_FLAG}" --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
 
   popd
 done

--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -52,13 +52,19 @@ export OVERRIDE_BAZEL_VERSION="$VERSION"
 # when running under bazel docker image, the workspace is read only.
 export OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp
 
-bazel build -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
+ACTION_ENV_FLAG=""
+if [ ! -z "$KOKORO_ARTIFACTS_DIR" ]; then
+  # `bazel clean` is not sufficient.
+  ACTION_ENV_FLAG="--action_env=bazel_cache_invalidate=version_${VERSION}"
+fi
+
+tools/bazel build ${ACTION_ENV_FLAG} -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
 
 for TEST_DIRECTORY in "${TEST_DIRECTORIES[@]}"; do
   pushd "test/distrib/bazel/$TEST_DIRECTORY/"
 
   tools/bazel version | grep "$VERSION" || { echo "Detected bazel version did not match expected value of $VERSION" >/dev/stderr; exit 1; }
-  tools/bazel test --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
+  tools/bazel test ${ACTION_ENV_FLAG} --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
 
   popd
 done

--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -54,7 +54,8 @@ export OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp
 
 ACTION_ENV_FLAG="--action_env=bazel_cache_invalidate=version_${VERSION}"
 
-tools/bazel build "${ACTION_ENV_FLAG}" -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
+tools/bazel test "${ACTION_ENV_FLAG}" --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Build"
+tools/bazel build "${ACTION_ENV_FLAG}" -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS} Build"
 
 for TEST_DIRECTORY in "${TEST_DIRECTORIES[@]}"; do
   pushd "test/distrib/bazel/$TEST_DIRECTORY/"

--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -51,12 +51,14 @@ FAILED_TESTS=""
 export OVERRIDE_BAZEL_VERSION="$VERSION"
 # when running under bazel docker image, the workspace is read only.
 export OVERRIDE_BAZEL_WRAPPER_DOWNLOAD_DIR=/tmp
+
 bazel build -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}Build "
 
 for TEST_DIRECTORY in "${TEST_DIRECTORIES[@]}"; do
   pushd "test/distrib/bazel/$TEST_DIRECTORY/"
 
-  bazel test --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
+  tools/bazel version | grep "$VERSION" || { echo "Detected bazel version did not match expected value of $VERSION" >/dev/stderr; exit 1; }
+  tools/bazel test --test_output=all //:all || FAILED_TESTS="${FAILED_TESTS}${TEST_DIRECTORY} Distribtest"
 
   popd
 done


### PR DESCRIPTION
It looks like there were two issues here:

1. Bazel was not respecting the `tools/bazel` script. Bazel is supposed to check for this directory and run the script there as `bazel`. This should have been running the requested version. This appears not to have been happening. I have switched to invoking `tools/bazel` directly and have added a check to fail the test if Bazel does not report itself as running the expected version.

2. Bazel seems to have been caching _across versions_. That is, after a test was run on version A, it would not be re-run on version B but would instead report as passing. `bazel clean --expunge` did not resolve this issue. I had to resort to manually deleting the Bazel cache directory.

[Manual run layered on top of a commit known to be broken for Bazel 4.X failing as expected.](https://source.cloud.google.com/results/invocations/95010c23-07ae-4eef-aa40-cd65546b449c/log)