### PR TITLE
append TLS key entries into SSL key log file

### DIFF
--- a/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
+++ b/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
@@ -49,7 +49,7 @@ TlsSessionKeyLoggerCache::TlsSessionKeyLogger::TlsSessionKeyLogger(
       cache_(std::move(cache)) {
   GPR_ASSERT(!tls_session_key_log_file_path_.empty());
   GPR_ASSERT(cache_ != nullptr);
-  fd_ = fopen(tls_session_key_log_file_path_.c_str(), "w+");
+  fd_ = fopen(tls_session_key_log_file_path_.c_str(), "a");
   if (fd_ == nullptr) {
     grpc_error_handle error = GRPC_OS_ERROR(errno, "fopen");
     gpr_log(GPR_ERROR,


### PR DESCRIPTION
This corrects an issue where a developer is unable to decrypt live TLS captures in Wireshark. Instead the user must take multiple steps to be able to view decrypted TLS application data, including saving a capture on disk and reloading the capture.

By appending rather than overwriting the TLS key log file entries, it is possible to configure Wireshark TLS (Pre)-Master-Secret log filename before the capture is started (pointing to and empty or existing file). Then, when a packet capture is started, decrypted data is available immediately. Further, if the capture is restarted, no keys are lost and no Wireshark reconfiguration is required.

Appending rather than overwriting TLS key files follows the technique used by openssl binary, Chrome and others. All executables are able to append to the same keylog file simultaneously, and Wireshark is able to decrypt all apps simultaneously.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

