### PR TITLE
[flaky] Platform specific hack time?

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -238,6 +238,16 @@ typedef enum {
 } grpc_chttp2_keepalive_state;
 
 struct grpc_chttp2_transport
+// TODO(ctiller): #31319 fixed a crash on Linux & Mac whereby iomgr was
+// accessed after shutdown by chttp2. We've not seen similar behavior on
+// Windows afaik, but this fix has exposed another refcounting bug whereby
+// transports leak on Windows and prevent test shutdown.
+// This hack attempts to compromise between two things that are blocking our CI
+// from giving us a good quality signal, but are unlikely to be problems for
+// most customers. We should continue tracking down what's causing the failure,
+// but this gives us some runway to do so - and given that we're actively
+// working on removing the problematic code paths, it may be that effort brings
+// the result we need.
 #ifndef GPR_WINDOWS
     : public grpc_core::KeepsGrpcInitialized
 #endif

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -237,7 +237,11 @@ typedef enum {
   GRPC_CHTTP2_KEEPALIVE_STATE_DISABLED,
 } grpc_chttp2_keepalive_state;
 
-struct grpc_chttp2_transport : public grpc_core::KeepsGrpcInitialized {
+struct grpc_chttp2_transport
+#ifndef GPR_WINDOWS
+    : public grpc_core::KeepsGrpcInitialized
+#endif
+{
   grpc_chttp2_transport(const grpc_core::ChannelArgs& channel_args,
                         grpc_endpoint* ep, bool is_client);
   ~grpc_chttp2_transport();


### PR DESCRIPTION
#31319 fixed a crash on Linux & Mac whereby iomgr was accessed after shutdown by chttp2. We've not seen similar behavior on Windows afaik, but this fix has exposed another refcounting bug whereby transports leak on Windows and prevent test shutdown.

This patch attempts to compromise between two things that are blocking our CI from giving us a good quality signal, but are unlikely to be problems for most customers. We should continue tracking down what's causing the failure, but this gives us some runway to do so - and given that we're actively working on removing the problematic code paths, it may be that effort brings the result we need.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

