### PR TITLE
[C#] Move insecure compose validation into Channel

### DIFF
--- a/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core.Api/ChannelCredentials.cs
@@ -89,6 +89,11 @@ namespace Grpc.Core
         /// <summary>
         /// Returns <c>true</c> if this credential type allows being composed by <c>CompositeCredentials</c>.
         /// </summary>
+        /// <remark>
+        /// Note: No longer used. Decision on whether composition is allowed now happens in
+        /// <see cref="ChannelCredentialsConfiguratorBase.SetCompositeCredentials(object, ChannelCredentials, CallCredentials)"/>.
+        /// Internal property left for safety because Grpc.Core has internal access to Grpc.Core.Api.
+        /// </remark>
         internal virtual bool IsComposable => false;
 
         private sealed class InsecureCredentials : ChannelCredentials
@@ -118,11 +123,6 @@ namespace Grpc.Core
             {
                 this.channelCredentials = GrpcPreconditions.CheckNotNull(channelCredentials);
                 this.callCredentials = GrpcPreconditions.CheckNotNull(callCredentials);
-
-                if (!channelCredentials.IsComposable)
-                {
-                    throw new ArgumentException(string.Format("CallCredentials can't be composed with {0}. CallCredentials must be used with secure channel credentials like SslCredentials.", channelCredentials.GetType().Name));
-                }
             }
 
             public override void InternalPopulateConfiguration(ChannelCredentialsConfiguratorBase configurator, object state)

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -25,18 +25,6 @@ namespace Grpc.Core.Tests
     public class ChannelCredentialsTest
     {
         [Test]
-        public void InsecureCredentials_IsNonComposable()
-        {
-            Assert.IsFalse(ChannelCredentials.Insecure.IsComposable);
-        }
-
-        [Test]
-        public void SecureCredentials_IsComposable()
-        {
-            Assert.IsTrue(ChannelCredentials.SecureSsl.IsComposable);
-        }
-
-        [Test]
         public void ChannelCredentials_CreateComposite()
         {
             var composite = ChannelCredentials.Create(new FakeChannelCredentials(true), new FakeCallCredentials());
@@ -44,10 +32,6 @@ namespace Grpc.Core.Tests
 
             Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(null, new FakeCallCredentials()));
             Assert.Throws(typeof(ArgumentNullException), () => ChannelCredentials.Create(new FakeChannelCredentials(true), null));
-
-            // forbid composing non-composable
-            var ex = Assert.Throws(typeof(ArgumentException), () => ChannelCredentials.Create(new FakeChannelCredentials(false), new FakeCallCredentials()));
-            Assert.AreEqual("CallCredentials can't be composed with FakeChannelCredentials. CallCredentials must be used with secure channel credentials like SslCredentials.", ex.Message);
         }
 
         [Test]

--- a/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelCredentialsTest.cs
@@ -47,5 +47,16 @@ namespace Grpc.Core.Tests
             var nativeCreds4 = ChannelCredentials.SecureSsl.ToNativeCredentials();
             Assert.AreSame(nativeCreds3, nativeCreds4);
         }
+
+        [Test]
+        public void ChannelCredentials_MalformedSslCredentialsCanStillCreateNativeCredentials()
+        {
+            // pass malformed root pem certs, but creation of native credentials still passes,
+            // since the credentials are parsed lazily by the C core.
+            using (var nativeCreds = new SslCredentials("MALFORMED_ROOT_CERTS_THAT_WILL_THROW_WHEN_CREATING_NATIVE_CREDENTIALS").ToNativeCredentials())
+            {
+                Assert.IsFalse(nativeCreds.IsInvalid);
+            }
+        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ChannelTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelTest.cs
@@ -123,5 +123,16 @@ namespace Grpc.Core.Tests
             // check that Channel.ShutdownAsync has run
             Assert.AreEqual(ChannelState.Shutdown, channel.State);
         }
+
+        [Test]
+        public void CompositeCredentialsWithInsecureThrow()
+        {
+            var compositeCredentials = ChannelCredentials.Create(
+                ChannelCredentials.Insecure,
+                CallCredentials.FromInterceptor((context, metadata) => Task.CompletedTask));
+            var ex = Assert.Throws(typeof(InvalidOperationException), () => new Channel("localhost", compositeCredentials));
+            Assert.AreEqual("CallCredentials can't be composed with InsecureCredentials. " +
+                "CallCredentials must be used with secure channel credentials like SslCredentials.", ex.Message);
+        }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ChannelTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelTest.cs
@@ -129,7 +129,7 @@ namespace Grpc.Core.Tests
         {
             var compositeCredentials = ChannelCredentials.Create(
                 ChannelCredentials.Insecure,
-                CallCredentials.FromInterceptor((context, metadata) => Task.CompletedTask));
+                CallCredentials.FromInterceptor((context, metadata) => TaskUtils.CompletedTask));
             var ex = Assert.Throws(typeof(InvalidOperationException), () => new Channel("localhost", compositeCredentials));
             Assert.AreEqual("CallCredentials can't be composed with InsecureCredentials. " +
                 "CallCredentials must be used with secure channel credentials like SslCredentials.", ex.Message);

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -88,7 +88,8 @@ namespace Grpc.Core
             }
             catch (Exception)
             {
-                Task.Run(async () => await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false));
+                // Constructor can't be async.
+                _ = Task.Run(async () => await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false));
                 throw;
             }
         }

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -86,10 +86,10 @@ namespace Grpc.Core
                 }
                 GrpcEnvironment.RegisterChannel(this);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Task.Run(async () => await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false));
-                throw e;
+                throw;
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
@@ -83,6 +83,7 @@ namespace Grpc.Core.Internal
             using (var callCreds = callCredentials.ToNativeCredentials())
             {
                 var nativeChannelCredentials = channelCredentials.ToNativeCredentials();
+                // nativeChannelCredentials == null means insecure channel credentials were used.
                 if (nativeChannelCredentials == null)
                 {
                     throw new InvalidOperationException($"CallCredentials can't be composed with {channelCredentials.GetType().Name}. " +

--- a/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
@@ -80,15 +80,15 @@ namespace Grpc.Core.Internal
 
         private ChannelCredentialsSafeHandle CreateNativeCompositeCredentials(ChannelCredentials channelCredentials, CallCredentials callCredentials)
         {
-            var nativeChannelCredentials = channelCredentials.ToNativeCredentials();
-            if (nativeChannelCredentials == null)
-            {
-                throw new InvalidOperationException($"CallCredentials can't be composed with {channelCredentials.GetType().Name}. " +
-                    $"CallCredentials must be used with secure channel credentials like SslCredentials.");
-            }
-
             using (var callCreds = callCredentials.ToNativeCredentials())
             {
+                var nativeChannelCredentials = channelCredentials.ToNativeCredentials();
+                if (nativeChannelCredentials == null)
+                {
+                    throw new InvalidOperationException($"CallCredentials can't be composed with {channelCredentials.GetType().Name}. " +
+                        $"CallCredentials must be used with secure channel credentials like SslCredentials.");
+                }
+                
                 var nativeComposite = ChannelCredentialsSafeHandle.CreateComposite(nativeChannelCredentials, callCreds);
                 if (nativeComposite.IsInvalid)
                 {

--- a/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
@@ -82,7 +82,14 @@ namespace Grpc.Core.Internal
         {
             using (var callCreds = callCredentials.ToNativeCredentials())
             {
-                var nativeComposite = ChannelCredentialsSafeHandle.CreateComposite(channelCredentials.ToNativeCredentials(), callCreds);
+                var nativeChannelCredentials = channelCredentials.ToNativeCredentials();
+                if (nativeChannelCredentials == null)
+                {
+                    throw new InvalidOperationException($"CallCredentials can't be composed with {channelCredentials.GetType().Name}. " +
+                        $"CallCredentials must be used with secure channel credentials like SslCredentials.");
+                }
+                
+                var nativeComposite = ChannelCredentialsSafeHandle.CreateComposite(nativeChannelCredentials, callCreds);
                 if (nativeComposite.IsInvalid)
                 {
                     throw new ArgumentException("Error creating native composite credentials. Likely, this is because you are trying to compose incompatible credentials.");

--- a/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultChannelCredentialsConfigurator.cs
@@ -80,15 +80,15 @@ namespace Grpc.Core.Internal
 
         private ChannelCredentialsSafeHandle CreateNativeCompositeCredentials(ChannelCredentials channelCredentials, CallCredentials callCredentials)
         {
+            var nativeChannelCredentials = channelCredentials.ToNativeCredentials();
+            if (nativeChannelCredentials == null)
+            {
+                throw new InvalidOperationException($"CallCredentials can't be composed with {channelCredentials.GetType().Name}. " +
+                    $"CallCredentials must be used with secure channel credentials like SslCredentials.");
+            }
+
             using (var callCreds = callCredentials.ToNativeCredentials())
             {
-                var nativeChannelCredentials = channelCredentials.ToNativeCredentials();
-                if (nativeChannelCredentials == null)
-                {
-                    throw new InvalidOperationException($"CallCredentials can't be composed with {channelCredentials.GetType().Name}. " +
-                        $"CallCredentials must be used with secure channel credentials like SslCredentials.");
-                }
-                
                 var nativeComposite = ChannelCredentialsSafeHandle.CreateComposite(nativeChannelCredentials, callCreds);
                 if (nativeComposite.IsInvalid)
                 {


### PR DESCRIPTION
Related to https://github.com/grpc/grpc-dotnet/pull/1802

I tested what happens when validation was removed from creating channel credentials with Grpc.Core. The good news is that "invalid" calls (i.e. insecure + call credentials) don't succeed. The bad is the failure error isn't helpful. A channel would throw `ArgumentNullException` because it would attempt to compose null native credentials.

This PR makes the error message easy to understand. It's the same message that `ChannelCredentials.Compose` threw previously.

@jtattermusch 