### PR TITLE
Remove installation of go 1.17 in CIs

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -63,18 +63,13 @@ WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# Update go version.
-TEST_INFRA_GOVERSION=go1.17.1
-go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
-"${TEST_INFRA_GOVERSION}" download
-
 # Clone test-infra repository and build all tools.
 pushd ..
 git clone https://github.com/grpc/test-infra.git
 cd test-infra
 # Tools are built from HEAD.
 git checkout --detach
-make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
+make all-tools
 popd
 
 # Build test configurations.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -61,18 +61,13 @@ WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# Update go version.
-TEST_INFRA_GOVERSION=go1.17.1
-go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
-"${TEST_INFRA_GOVERSION}" download
-
 # Clone test-infra repository and build all tools.
 pushd ..
 git clone https://github.com/grpc/test-infra.git
 cd test-infra
 # Tools are built from HEAD.
 git checkout --detach
-make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
+make all-tools
 popd
 
 # Build test configurations.

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -56,18 +56,13 @@ WORKER_POOL_8CORE=workers-c2-8core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# Update go version.
-TEST_INFRA_GOVERSION=go1.17.1
-go get "golang.org/dl/${TEST_INFRA_GOVERSION}"
-"${TEST_INFRA_GOVERSION}" download
-
 # Clone test-infra repository and build all tools.
 pushd ..
 git clone https://github.com/grpc/test-infra.git
 cd test-infra
 # Tools are built from HEAD.
 git checkout --detach
-make GOCMD="${TEST_INFRA_GOVERSION}" all-tools
+make all-tools
 
 # Find latest release tag of test-infra.
 git fetch --all --tags


### PR DESCRIPTION
Current Kokoro workers have go version go1.17.13, we no longer need to install
go 1.17 manually, this PR is to remove this installation for all 3 CIs