### PR TITLE
C# generator - Add GeneratedCodeAttribute attribute to generated service class

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -23,6 +23,8 @@
 #include <sstream>
 #include <vector>
 
+#include <grpcpp/grpcpp.h>
+
 #include "src/compiler/config.h"
 #include "src/compiler/csharp_generator_helpers.h"
 
@@ -739,7 +741,8 @@ void GenerateService(Printer* out, const ServiceDescriptor* service,
                      bool internal_access) {
   GenerateDocCommentBody(out, service);
 
-  out->Print("[global::System.Runtime.CompilerServices.CompilerGenerated]");
+  out->Print("[global::System.CodeDom.Compiler.GeneratedCode(\"protocol buffer compiler\", \"$version$\")]",
+             "version", grpc::Version());
   out->Print("$access_level$ static partial class $classname$\n",
              "access_level", GetAccessLevel(internal_access), "classname",
              GetServiceClassName(service));

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -739,6 +739,7 @@ void GenerateService(Printer* out, const ServiceDescriptor* service,
                      bool internal_access) {
   GenerateDocCommentBody(out, service);
 
+  out->Print("[global::System.Runtime.CompilerServices.CompilerGenerated]");
   out->Print("$access_level$ static partial class $classname$\n",
              "access_level", GetAccessLevel(internal_access), "classname",
              GetServiceClassName(service));


### PR DESCRIPTION
`GeneratedCodeAttribute` is much easier to work with than some arbitrary region or xml-doc which are the measures used at the moment.

This improvement solves real world use case, if you check your codebase using Roslyn and try to filter out tool-generated code. It's quite clumsy to do it at the moment ( relying on regions or xml-doc ).

Using attribute `GeneratedCodeAttribute` is the usual way to mark such code in .NET world.