### PR TITLE
Add back Six for internal_ci scripts

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -41,6 +41,8 @@ export DOCKERHUB_ORGANIZATION=grpctesting
 
 git submodule update --init
 
+python3 -m pip install six
+
 # check whether /tmpfs is mounted correctly
 (mount | grep -q 'on /tmpfs ') || (mount; echo 'BAD KOKORO WORKER WARNING: it seems that /tmpfs volume with scratch disk is not mounted in the kokoro worker. This can result in unexpected "out of disk space" errors.')
 

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -48,7 +48,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 brew config
 
 # Add GCP credentials for BQ access
-pip install --user google-api-python-client oauth2client
+pip install --user google-api-python-client oauth2client six==1.16.0
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 

--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -85,7 +85,7 @@ If "%PREPARE_BUILD_INSTALL_DEPS_PYTHON%" == "true" (
 )
 
 @rem Needed for uploading test results to bigquery
-python -m pip install google-api-python-client oauth2client || goto :error
+python -m pip install google-api-python-client oauth2client six==1.16.0 || goto :error
 
 git submodule update --init || goto :error
 


### PR DESCRIPTION
### Description

Previous commit #31340 broke CI tests (https://github.com/grpc/grpc/pull/31340#issuecomment-1282393952), this commit fixed it by keep `six` in the following files used in internal CI:
- tools/internal_ci/helper_scripts/prepare_build_linux_rc
- tools/internal_ci/helper_scripts/prepare_build_macos_rc
- tools/internal_ci/helper_scripts/prepare_build_windows.bat

#### Testing
- Manually trigger [failed CI test](https://fusion2.corp.google.com/invocations/19225e83-af0a-4bca-b70b-8f97709cc0a5/targets) and it passed.