### PR TITLE
Re-enable and Fix WindowsEventEngine test suite

### DIFF
--- a/test/core/event_engine/test_suite/windows_event_engine_test.cc
+++ b/test/core/event_engine/test_suite/windows_event_engine_test.cc
@@ -11,8 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <grpc/support/port_platform.h>
 
 #ifdef GPR_WINDOWS
+
+#include <grpc/grpc.h>
+
+#include "src/core/lib/event_engine/windows/windows_engine.h"
+#include "test/core/event_engine/test_suite/event_engine_test.h"
+#include "test/core/util/test_config.h"
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
@@ -22,7 +29,12 @@ int main(int argc, char** argv) {
         grpc_event_engine::experimental::WindowsEventEngine>();
   };
   SetEventEngineFactories(factory, factory);
-  return RUN_ALL_TESTS();
+  // TODO(ctiller): EventEngine temporarily needs grpc to be initialized first
+  // until we clear out the iomgr shutdown code.
+  grpc_init();
+  int r = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return r;
 }
 
 #else  // not GPR_WINDOWS


### PR DESCRIPTION
This test was disabled (assumed inadvertently) in #30952, then the test itself was silently broken in #31265.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

