### PR TITLE
[promises] Cleanup: Always assert that contexts are non-null

### DIFF
--- a/src/core/lib/promise/context.h
+++ b/src/core/lib/promise/context.h
@@ -73,7 +73,7 @@ bool HasContext() {
   return promise_detail::Context<T>::get() != nullptr;
 }
 
-// Retrieve the current value of a context.
+// Retrieve the current value of a context, or abort if the value is unset.
 template <typename T>
 T* GetContext() {
   auto* p = promise_detail::Context<T>::get();

--- a/test/core/promise/context_test.cc
+++ b/test/core/promise/context_test.cc
@@ -29,7 +29,7 @@ TEST(Context, WithContext) {
   EXPECT_FALSE(HasContext<TestContext>());
   TestContext test;
   EXPECT_FALSE(HasContext<TestContext>());
-  EXPECT_EQ(test.done, false);
+  EXPECT_FALSE(test.done);
   WithContext(
       []() {
         EXPECT_TRUE(HasContext<TestContext>());
@@ -37,7 +37,7 @@ TEST(Context, WithContext) {
       },
       &test)();
   EXPECT_FALSE(HasContext<TestContext>());
-  EXPECT_EQ(test.done, true);
+  EXPECT_TRUE(test.done);
 }
 
 }  // namespace grpc_core


### PR DESCRIPTION
Addresses the cleanup suggested in #31205

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

