### PR TITLE
Introducing USDT DTrace Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1338,6 +1338,42 @@ if(gRPC_INSTALL)
   )
 endif()
 
+if (gRPC_DTRACE)
+  if (NOT _gRPC_PLATFORM_LINUX)
+    message(FATAL_ERROR "DTrace not supported on non-linux platforms.")
+  endif()
+
+  find_program(_gRPC_DTRACE_EXECUTABLE dtrace)
+
+  set(_gRPC_DTRACE_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/core/ext/dtrace)
+  set(_gRPC_DTRACE_PROVIDER_D ${_gRPC_DTRACE_SRC_DIR}/dtrace_provider.d)
+
+  set(_gRPC_DTRACE_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/dtrace)
+  file(MAKE_DIRECTORY ${_gRPC_DTRACE_GEN_DIR})
+  set(_gRPC_DTRACE_PROVIDER_H ${_gRPC_DTRACE_GEN_DIR}/dtrace_provider.h)
+  set(_gRPC_DTRACE_PROVIDER_O ${_gRPC_DTRACE_GEN_DIR}/dtrace_provider.o)  
+
+  add_custom_target(grpc_dtrace_provider_h
+    COMMAND ${_gRPC_DTRACE_EXECUTABLE} -h -s ${_gRPC_DTRACE_PROVIDER_D} -o ${_gRPC_DTRACE_PROVIDER_H}
+    SOURCES ${_gRPC_DTRACE_PROVIDER_D}
+    WORKING_DIRECTORY ${_gRPC_DTRACE_SRC_DIR}
+    COMMENT "Generating DTrace provider header file"
+    VERBATIM)
+
+  add_custom_command(
+    OUTPUT ${_gRPC_DTRACE_PROVIDER_O}
+    COMMAND ${_gRPC_DTRACE_EXECUTABLE}
+    ARGS -G -s ${_gRPC_DTRACE_PROVIDER_D} -o ${_gRPC_DTRACE_PROVIDER_O}
+    DEPENDS ${_gRPC_DTRACE_PROVIDER_D}
+    WORKING_DIRECTORY ${_gRPC_DTRACE_SRC_DIR}
+    COMMENT "Generating DTrace provider object file"
+    VERBATIM)
+
+  set(_gRPC_DTRACE_GEN_SOURCES ${_gRPC_DTRACE_PROVIDER_O})
+
+  add_definitions(-DGRPC_DTRACE)
+endif()
+
 if(gRPC_BUILD_TESTS)
 
 add_library(end2end_tests
@@ -1670,6 +1706,7 @@ endif()
 
 
 add_library(grpc
+  src/core/ext/dtrace/dtrace.cc
   src/core/ext/filters/census/grpc_context.cc
   src/core/ext/filters/channel_idle/channel_idle_filter.cc
   src/core/ext/filters/channel_idle/idle_filter_state.cc
@@ -2359,7 +2396,10 @@ add_library(grpc
   src/core/tsi/ssl_transport_security.cc
   src/core/tsi/transport_security.cc
   src/core/tsi/transport_security_grpc.cc
+  ${_gRPC_DTRACE_GEN_SOURCES}
 )
+
+add_dependencies(grpc grpc_dtrace_provider_h)
 
 set_target_properties(grpc PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
@@ -2389,6 +2429,7 @@ target_include_directories(grpc
     ${_gRPC_UPB_INCLUDE_DIR}
     ${_gRPC_XXHASH_INCLUDE_DIR}
     ${_gRPC_ZLIB_INCLUDE_DIR}
+    ${_gRPC_DTRACE_GEN_DIR}
 )
 target_link_libraries(grpc
   ${_gRPC_BASELIB_LIBRARIES}
@@ -15450,7 +15491,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
-  add_executable(resolve_address_using_native_resolver_posix_test
+add_executable(resolve_address_using_native_resolver_posix_test
     test/core/iomgr/resolve_address_posix_test.cc
     test/core/util/cmdline.cc
     test/core/util/fuzzer_util.cc

--- a/bazel/dtrace.bzl
+++ b/bazel/dtrace.bzl
@@ -1,0 +1,33 @@
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Custom rules for gRPC DTrace"""
+
+def dtrace_generate_provider(name, path):
+    '''
+    Generate header and object files for a DTrace provider.
+    '''
+
+    native.genrule(
+        name = name + "_h",
+        srcs = [path],
+        outs = ["dtrace_provider.h"],
+        cmd = "dtrace -h -s $< -o $@",
+    )
+
+    native.genrule(
+        name = name + "_o",
+        srcs = [path],
+        outs = ["dtrace_provider.o"],
+        cmd = "dtrace -G -s $< -o $@",
+    )

--- a/src/core/ext/dtrace/dtrace.cc
+++ b/src/core/ext/dtrace/dtrace.cc
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifdef GRPC_DTRACE
+#include "dtrace_provider.h"
+#else
+#define GRPC_TRANSPORT_SEND_INITIAL_METADATA_ENABLED() (0)
+#define GRPC_TRANSPORT_SEND_INITIAL_METADATA(...)
+#define GRPC_TRANSPORT_SEND_MESSAGE_ENABLED() (0)
+#define GRPC_TRANSPORT_SEND_MESSAGE(...)
+#define GRPC_TRANSPORT_SEND_TRAILING_METADATA_ENABLED() (0)
+#define GRPC_TRANSPORT_SEND_TRAILING_METADATA(...)
+#define GRPC_TRANSPORT_RECV_INITIAL_METADATA_ENABLED() (0)
+#define GRPC_TRANSPORT_RECV_INITIAL_METADATA(...)
+#define GRPC_TRANSPORT_RECV_MESSAGE_ENABLED() (0)
+#define GRPC_TRANSPORT_RECV_MESSAGE(...)
+#define GRPC_TRANSPORT_RECV_TRAILING_METADATA_ENABLED() (0)
+#define GRPC_TRANSPORT_RECV_TRAILING_METADATA(...)
+#define GRPC_TRANSPORT_CANCEL_STREAM_ENABLED() (0)
+#define GRPC_TRANSPORT_CANCEL_STREAM(...)
+#endif

--- a/src/core/ext/dtrace/dtrace.cc
+++ b/src/core/ext/dtrace/dtrace.cc
@@ -16,6 +16,12 @@
  *
  */
 
+#include "src/core/ext/dtrace/dtrace.h"
+#include "src/core/lib/iomgr/closure.h"
+#include "src/core/lib/transport/transport_impl.h"
+
+#include <vector>
+
 #ifdef GRPC_DTRACE
 #include "dtrace_provider.h"
 #else
@@ -34,3 +40,249 @@
 #define GRPC_TRANSPORT_CANCEL_STREAM_ENABLED() (0)
 #define GRPC_TRANSPORT_CANCEL_STREAM(...)
 #endif
+
+/* Layout-identical to `dtrace_provider.d` */
+typedef struct {
+  const char *key;
+  const char *value;
+} grpc_transport_metadata;
+
+/* Layout-identical to `dtrace_provider.d` */
+typedef struct {
+  void *opaque;
+  const char *transport;
+  const char *load_address;
+  const char *peer_address;
+} grpc_transport_stream;
+
+class DTraceStringStore {
+public:
+  const char *Store(absl::string_view s) {
+    std::vector<char> v;
+    v.insert(std::end(v), std::begin(s), std::end(s));
+    v.insert(std::end(v), '\0');
+
+    store_.emplace_back(std::move(v));
+    return store_.back().data();
+  }
+
+private:
+  // Storing this way is weirder than using std::vector<std::string>,
+  // but for some reason std::string storage for short strings causes issues when reading
+  // said data from eBPF. This does not happen for short strings when stored in std::vector<char>.
+  // Storing as a plain std::vector<char> will cause resizes, which we'd like to avoid.
+  std::vector<std::vector<char>> store_;
+};
+
+class DTraceStreamRegistry {
+public:
+  const grpc_transport_stream *Register(grpc_transport *transport, grpc_stream *stream) {
+    auto &registeree = streams_.emplace(stream, nullptr).first->second;
+    if (registeree == nullptr) {
+      auto ep = grpc_transport_get_endpoint(transport);
+      registeree = std::make_unique<grpc_transport_stream>();
+      registeree->transport = transport->vtable->name;
+      registeree->load_address = string_store_.Store(grpc_endpoint_get_local_address(ep));
+      registeree->peer_address = string_store_.Store(grpc_endpoint_get_peer(ep));
+    }
+
+    return registeree.get();
+  }
+
+  void Unregister(grpc_stream *stream) {
+    streams_.erase(stream);
+  }
+
+private:
+  std::map<grpc_stream *, std::unique_ptr<grpc_transport_stream>> streams_;
+  DTraceStringStore string_store_;
+} g_stream_registry;
+
+class DTraceMetadataEncoder {
+ public:
+
+  const void *data() const { return encoded_.data(); }
+  size_t size() const { return encoded_.size(); }
+
+  void Encode(const grpc_core::Slice& key, const grpc_core::Slice& value) {
+    encoded_.emplace_back(grpc_transport_metadata{
+      string_store_.Store(key.as_string_view()),
+      string_store_.Store(value.as_string_view())});
+  }
+
+  template<typename Key, typename Value>
+  void Encode(Key, const Value &value) {
+    encoded_.emplace_back(grpc_transport_metadata{
+      Key::key().data(), string_store_.Store(Key::Encode(value).as_string_view())});
+  }
+
+ private:
+  std::vector<grpc_transport_metadata> encoded_;
+  DTraceStringStore string_store_;
+};
+
+void grpc_dtrace_transport_on_stream_created(grpc_transport* transport,
+                                             grpc_stream* stream)
+{
+  if (!GRPC_TRANSPORT_STREAM_CREATED_ENABLED())
+    return;
+
+  GRPC_TRANSPORT_STREAM_CREATED(g_stream_registry.Register(transport, stream));
+}
+
+void grpc_dtrace_transport_on_stream_destroyed(grpc_transport* transport,
+                                               grpc_stream* stream)
+{
+  if (GRPC_TRANSPORT_STREAM_DESTROYED_ENABLED()) {
+    GRPC_TRANSPORT_STREAM_DESTROYED(g_stream_registry.Register(transport, stream));
+  }
+
+  // We don't have to register streams, but we have to unregister them
+  // to avoid stale pointers.
+  g_stream_registry.Unregister(stream);
+}
+
+typedef struct {
+  const grpc_transport_stream *stream;
+  grpc_transport_stream_op_batch* op;
+  grpc_closure * current;
+  grpc_closure * prev;
+} recv_closure_context;
+
+static void recv_initial_metadata_closure(void* opaque, grpc_error_handle error) {
+  auto context = reinterpret_cast<recv_closure_context*>(opaque);
+  DTraceMetadataEncoder encoder;
+  
+  if (context->op->payload && context->op->payload->recv_initial_metadata.recv_initial_metadata) {
+    context->op->payload->recv_initial_metadata.recv_initial_metadata->Encode(&encoder);
+  }
+
+  GRPC_TRANSPORT_RECV_INITIAL_METADATA(context->stream, encoder.data(), encoder.size());
+  
+  if (context->prev)
+    grpc_core::Closure::Run(DEBUG_LOCATION, context->prev, error);
+
+  delete context;
+};
+
+static void recv_message_closure(void* opaque, grpc_error_handle error) {
+  auto context = reinterpret_cast<recv_closure_context*>(opaque);
+  DTraceMetadataEncoder encoder;
+  std::vector<uint8_t> data;
+
+  if (context->op->payload && context->op->payload->recv_message.recv_message &&
+      context->op->payload->recv_message.recv_message->has_value()) {
+    const auto & message = context->op->payload->recv_message.recv_message->value();
+    data.resize(message.Length());
+    message.CopyFirstNBytesIntoBuffer(data.size(), data.data());
+  }
+
+  GRPC_TRANSPORT_RECV_MESSAGE(context->stream, data.data(), data.size());
+  
+  if (context->prev)
+    grpc_core::Closure::Run(DEBUG_LOCATION, context->prev, error);
+
+  delete context;
+};
+
+static void recv_trailing_metadata_closure(void* opaque, grpc_error_handle error) {
+  auto context = reinterpret_cast<recv_closure_context*>(opaque);
+  DTraceMetadataEncoder encoder;
+    
+  if (context->op->payload && context->op->payload->recv_trailing_metadata.recv_trailing_metadata) {
+    context->op->payload->recv_trailing_metadata.recv_trailing_metadata->Encode(&encoder);
+  }
+
+  GRPC_TRANSPORT_RECV_TRAILING_METADATA(context->stream, encoder.data(), encoder.size());
+
+  if (context->prev)
+    grpc_core::Closure::Run(DEBUG_LOCATION, context->prev, error);
+
+  delete context;
+};
+
+void grpc_dtrace_transport_on_perform_stream_op(grpc_transport* transport,
+                                                grpc_stream* stream,
+                                                grpc_transport_stream_op_batch* op) {
+  if (GRPC_TRANSPORT_SEND_INITIAL_METADATA_ENABLED() && op->send_initial_metadata) {
+    DTraceMetadataEncoder encoder;
+    
+    if (op->payload && op->payload->send_initial_metadata.send_initial_metadata) {
+      op->payload->send_initial_metadata.send_initial_metadata->Encode(&encoder);
+    }
+
+    GRPC_TRANSPORT_SEND_INITIAL_METADATA(g_stream_registry.Register(transport, stream),
+      encoder.data(), encoder.size());
+  }
+
+  if (GRPC_TRANSPORT_SEND_MESSAGE_ENABLED() && op->send_message) {
+    std::vector<uint8_t> data;
+
+    if (op->payload && op->payload->send_message.send_message) {
+      const auto & message = *op->payload->send_message.send_message;
+      data.resize(message.Length());
+      message.CopyFirstNBytesIntoBuffer(data.size(), data.data());
+    }
+
+    GRPC_TRANSPORT_SEND_MESSAGE(g_stream_registry.Register(transport, stream),
+      data.data(), data.size());
+  }
+
+  if (GRPC_TRANSPORT_SEND_TRAILING_METADATA_ENABLED() && op->send_trailing_metadata) {
+    DTraceMetadataEncoder encoder;
+    
+    if (op->payload && op->payload->send_trailing_metadata.send_trailing_metadata) {
+      op->payload->send_trailing_metadata.send_trailing_metadata->Encode(&encoder);
+    }
+
+    GRPC_TRANSPORT_SEND_TRAILING_METADATA(g_stream_registry.Register(transport, stream),
+      encoder.data(), encoder.size());
+  }
+
+  if (GRPC_TRANSPORT_RECV_INITIAL_METADATA_ENABLED() && op->recv_initial_metadata) {
+    if (op->payload) {
+      auto context = new recv_closure_context;
+
+      context->stream = g_stream_registry.Register(transport, stream);
+      context->op = op;
+      context->current = GRPC_CLOSURE_CREATE(recv_initial_metadata_closure, context, nullptr);
+      context->prev = op->payload->recv_initial_metadata.recv_initial_metadata_ready;
+      op->payload->recv_initial_metadata.recv_initial_metadata_ready = context->current;
+    }
+  }
+
+  if (GRPC_TRANSPORT_RECV_MESSAGE_ENABLED() && op->recv_message) {
+    if (op->payload) {
+      auto context = new recv_closure_context;
+
+      context->stream = g_stream_registry.Register(transport, stream);
+      context->op = op;
+      context->current = GRPC_CLOSURE_CREATE(recv_message_closure, context, nullptr);
+      context->prev = op->payload->recv_message.recv_message_ready;
+      op->payload->recv_message.recv_message_ready = context->current;
+    }
+  }
+
+  if (GRPC_TRANSPORT_RECV_TRAILING_METADATA_ENABLED() && op->recv_trailing_metadata) {
+    if (op->payload) {
+      auto context = new recv_closure_context;
+
+      context->stream = g_stream_registry.Register(transport, stream);
+      context->op = op;
+      context->current = GRPC_CLOSURE_CREATE(recv_trailing_metadata_closure, context, nullptr);
+      context->prev = op->payload->recv_trailing_metadata.recv_trailing_metadata_ready;
+      op->payload->recv_trailing_metadata.recv_trailing_metadata_ready = context->current;
+    }
+  }
+
+  if (GRPC_TRANSPORT_CANCEL_STREAM_ENABLED() && op->cancel_stream) {
+    const char *message = nullptr;
+    int status = -1;
+
+    if (op->payload) {
+      status = static_cast<int>(op->payload->cancel_stream.cancel_error.code());
+      message = op->payload->cancel_stream.cancel_error.message().data();
+    }
+    GRPC_TRANSPORT_CANCEL_STREAM(g_stream_registry.Register(transport, stream), status, message);
+  }
+}

--- a/src/core/ext/dtrace/dtrace.h
+++ b/src/core/ext/dtrace/dtrace.h
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright 2022 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_CORE_EXT_DTRACE_H
+#define GRPC_CORE_EXT_DTRACE_H
+
+#include "src/core/lib/transport/transport.h"
+#include "src/core/lib/transport/transport_fwd.h"
+
+#ifdef GRPC_DTRACE
+
+void grpc_dtrace_transport_on_stream_created(grpc_transport* transport,
+                                             grpc_stream* stream);
+
+void grpc_dtrace_transport_on_stream_destroyed(grpc_transport* transport,
+                                               grpc_stream* stream);
+
+void grpc_dtrace_transport_on_perform_stream_op(grpc_transport* transport,
+                                                grpc_stream* stream,
+                                                grpc_transport_stream_op_batch* op);
+
+#else
+#define grpc_dtrace_transport_on_stream_created(...)
+#define grpc_dtrace_transport_on_stream_destroyed(...)
+#define grpc_dtrace_transport_on_perform_stream_op(...)
+#endif
+
+#endif /* GRPC_CORE_EXT_DTRACE_H */

--- a/src/core/ext/dtrace/dtrace_provider.d
+++ b/src/core/ext/dtrace/dtrace_provider.d
@@ -1,0 +1,35 @@
+/*
+ * DTrace provider for gRPC probes.
+ */
+
+struct {
+	const char *key;
+	const char *value;
+} grpc_transport_metadata_t;
+
+struct {
+  void *opaque;
+  const char *transport;
+  const char *load_address;
+  const char *peer_address;
+} grpc_transport_stream_t;
+
+provider grpc {
+	probe transport_stream_created(grpc_transport_stream_t *stream);
+
+	probe transport_stream_destroyed(grpc_transport_stream_t *stream);
+
+	probe transport_send_initial_metadata(grpc_transport_stream_t *stream, const grpc_transport_metadata_t *metadata, uint32_t size);
+
+	probe transport_send_message(grpc_transport_stream_t *stream, void *data, uintptr_t size);
+
+	probe transport_send_trailing_metadata(grpc_transport_stream_t *stream, const grpc_transport_metadata_t *metadata, uintptr_t size);
+
+	probe transport_recv_initial_metadata(grpc_transport_stream_t *stream, const grpc_transport_metadata_t *metadata, uintptr_t size);
+
+	probe transport_recv_message(grpc_transport_stream_t *stream, void *data, uintptr_t size);
+
+	probe transport_recv_trailing_metadata(grpc_transport_stream_t *stream, const grpc_transport_metadata_t *metadata, uintptr_t size);
+
+	probe transport_cancel_stream(grpc_transport_stream_t *stream, int status, string message);
+};

--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -380,7 +380,7 @@ void grpc_slice_buffer_move_first_into_buffer(grpc_slice_buffer* src, size_t n,
   }
 }
 
-void grpc_slice_buffer_copy_first_into_buffer(grpc_slice_buffer* src, size_t n,
+void grpc_slice_buffer_copy_first_into_buffer(const grpc_slice_buffer* src, size_t n,
                                               void* dst) {
   uint8_t* dstp = static_cast<uint8_t*>(dst);
   GPR_ASSERT(src->length >= n);

--- a/src/core/lib/slice/slice_buffer.h
+++ b/src/core/lib/slice/slice_buffer.h
@@ -26,6 +26,10 @@
 
 #include "src/core/lib/slice/slice.h"
 
+// Copy the first n bytes of src into memory pointed to by dst.
+void grpc_slice_buffer_copy_first_into_buffer(const grpc_slice_buffer* src, size_t n,
+                                              void* dst);
+
 namespace grpc_core {
 
 /// A slice buffer holds the memory for a collection of slices.
@@ -73,6 +77,11 @@ class SliceBuffer {
   /// Removes/deletes the last n bytes in the SliceBuffer.
   void RemoveLastNBytes(size_t n) {
     grpc_slice_buffer_trim_end(&slice_buffer_, n, nullptr);
+  }
+
+  /// Copy the first n bytes of the SliceBuffer into a memory pointed to by dst.
+  void CopyFirstNBytesIntoBuffer(size_t n, void* dst) const {
+    grpc_slice_buffer_copy_first_into_buffer(&slice_buffer_, n, dst);
   }
 
   /// Move the first n bytes of the SliceBuffer into a memory pointed to by dst.
@@ -129,9 +138,5 @@ class SliceBuffer {
 };
 
 }  // namespace grpc_core
-
-// Copy the first n bytes of src into memory pointed to by dst.
-void grpc_slice_buffer_copy_first_into_buffer(grpc_slice_buffer* src, size_t n,
-                                              void* dst);
 
 #endif  // GRPC_CORE_LIB_SLICE_SLICE_BUFFER_H


### PR DESCRIPTION
Recent Linux versions have introduced the concept of eBPF USDT probes, which allows devs to instrument their libraries with tracepoints to be consumed by various eBPF tools.

This PR aims to:
1. Add the infrastructure for future USDT integration into gRPC, by integrating DTrace (the tool defining probe interfaces) into its build systems.
2. Introduce basic USDTs for gRPC's transport layer, allowing tracing of gRPC streams.

For now, DTrace support has been added as totally opt-in, only for cpp, with no runtime overhead if disabled and with minimal overhead when enabled but unused. In the future, we aim to continue improving USDT integration into gRPC to extend its usefulness and eventually turn it on by default. This will probably require additional testing infrastructure that's not part of this PR.

- In order to build grpc w/ USDT, add:
  - bazel: `--define GRPC_DTRACE=true`
  - CMake: `-DgRPC_DTRACE=ON`
  - make support was not implemented
- `dtrace` is invoked during build, and currently needs to be provided by the env
  - `apt install systemtap-sdt-dev` works for Ubuntu 20.04
- Here's [a quick bpftrace script](https://gist.github.com/ydinkin-gcv/6c5dab3a5336c21eeea797e9117d2be6) that traces gRPC streams, mainly for reference
  - Run it using `sudo ./bpftrace -p $(pidof <target process>) <path/to/grpc_transport_trace.bt>`
  - Note that. old bpftrace versions USDT support is flaky (did not work for me with `v0.9.4`, had to upgrade to `v0.16.0`)

I'd be happy to provide any additional context and motivation for the adding said probes :)