### PR TITLE
[event_engine/promises] Eliminate lock contention on call path for GetDefaultEventEngine

### DIFF
--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -25,7 +25,6 @@
 #include <grpc/status.h>
 
 #include "src/core/lib/channel/channel_stack.h"
-#include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/gprpp/manual_constructor.h"
 #include "src/core/lib/gprpp/status_helper.h"
 #include "src/core/lib/iomgr/error.h"

--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -45,7 +45,9 @@ BaseCallData::BaseCallData(grpc_call_element* elem,
       call_combiner_(args->call_combiner),
       deadline_(args->deadline),
       context_(args->context),
-      event_engine_(grpc_event_engine::experimental::GetDefaultEventEngine()) {
+      event_engine_(
+          static_cast<ChannelFilter*>(elem->channel_data)
+              ->hack_until_per_channel_stack_event_engines_land_get_event_engine()) {
   if (flags & kFilterExaminesServerInitialMetadata) {
     server_initial_metadata_latch_ = arena_->New<Latch<ServerMetadata*>>();
   }

--- a/test/core/filters/client_authority_filter_test.cc
+++ b/test/core/filters/client_authority_filter_test.cc
@@ -127,5 +127,10 @@ TEST(ClientAuthorityFilterTest,
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  // TODO(ctiller): promise_based_call currently demands to instantiate an event
+  // engine which needs grpc to be initialized.
+  grpc_init();
+  int r = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return r;
 }


### PR DESCRIPTION
`GetDefaultEventEngine` needs to have global synchronization, which makes it inappropriate to access on the per-call path.

For now, cache it on `ChannelFilter`, and when #31166 lands we can update to fetch this pointer directly from the channel stack. 



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

