### PR TITLE
Revert "[experiments] Enable tcp_read_chunks for debug builds (#31374)"

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -21,14 +21,8 @@ EXPERIMENTS = {
         "core_end2end_tests": [
             "new_hpack_huffman_decoder",
         ],
-        "endpoint_test": [
-            "tcp_read_chunks",
-        ],
         "event_engine_client_test": [
             "posix_event_engine_enable_polling",
-        ],
-        "flow_control_test": [
-            "tcp_read_chunks",
         ],
         "hpack_test": [
             "new_hpack_huffman_decoder",
@@ -41,6 +35,7 @@ EXPERIMENTS = {
         "endpoint_test": [
             "tcp_frame_size_tuning",
             "tcp_rcv_lowat",
+            "tcp_read_chunks",
         ],
         "event_engine_client_test": [
             "event_engine_client",
@@ -50,6 +45,7 @@ EXPERIMENTS = {
             "peer_state_based_framing",
             "tcp_frame_size_tuning",
             "tcp_rcv_lowat",
+            "tcp_read_chunks",
         ],
         "lame_client_test": [
             "promise_based_client_call",

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.h
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.h
@@ -576,6 +576,9 @@ class PosixEndpointImpl : public grpc_core::RefCounted<PosixEndpointImpl> {
   std::atomic<bool> stop_error_notification_{false};
   std::unique_ptr<TcpZerocopySendCtx> tcp_zerocopy_send_ctx_;
   TcpZerocopySendRecord* current_zerocopy_send_ = nullptr;
+  // If true, the size of buffers alloted for tcp reads will be based on the
+  // specified min_progress_size values conveyed by the upper layers.
+  bool frame_size_tuning_enabled_ = false;
   // A hint from upper layers specifying the minimum number of bytes that need
   // to be read to make meaningful progress.
   int min_progress_size_ = 1;

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -64,7 +64,7 @@ namespace grpc_core {
 
 const ExperimentMetadata g_experiment_metadata[] = {
     {"tcp_frame_size_tuning", description_tcp_frame_size_tuning, false},
-    {"tcp_read_chunks", description_tcp_read_chunks, kDefaultForDebugOnly},
+    {"tcp_read_chunks", description_tcp_read_chunks, false},
     {"tcp_rcv_lowat", description_tcp_rcv_lowat, false},
     {"peer_state_based_framing", description_peer_state_based_framing, false},
     {"flow_control_fixes", description_flow_control_fixes, false},

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -50,7 +50,7 @@
   description:
     Allocate only 8kb or 64kb chunks for TCP reads to reduce pressure on
     malloc to recycle arbitrary large blocks.
-  default: debug
+  default: false
   expiry: 2023/01/01
   owner: ctiller@google.com
   test_tags: ["endpoint_test", "flow_control_test"]


### PR DESCRIPTION
This reverts commit d05830cb023d43f458eee99a3d956fad97ddbef9.

Looks like this caused some flakiness with the graceful shutdown test.

Only experiments.bzl was a non-pure revert.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

