### PR TITLE
c-ares DNS resolver: remove unnecessary code in SRV callback

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -743,7 +743,6 @@ static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
             r, srv_it->host, htons(srv_it->port), true /* is_balancer */, "A");
         ares_gethostbyname(r->ev_driver->channel, hr->host, AF_INET,
                            on_hostbyname_done_locked, hr);
-        grpc_ares_notify_on_event_locked(r->ev_driver);
       }
     }
     if (reply != nullptr) {


### PR DESCRIPTION
This call to `grpc_ares_notify_on_event_locked` from the SRV callback is unnecessary:

There are only a few places that `on_srv_query_done_locked` callback can be invoked from, and we already call `notify_on_event_locked` (updating polled file descriptors) after each of them:

1) Within the call to [ares_query](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L1109) that initiated the SRV lookup

  - [notify_on_event_locked](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L484) is called afterwards

2) When [ares_process_fd](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L332) is called from the c-ares backup poller.

  - [notify_on_event_locked](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L351) is called afterwards

3) When [ares_process_fd](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L367) is called because an fd became readable.

  - [notify_on_event_locked](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L378) is called afterwards

4) When [ares_process_fd](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L392) is called because an fd became writable.

  - [notify_on_event_locked](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L402) is called afterwards

-----------------

Furthermore, this call to `grpc_ares_notify_on_event_locked` from the SRV callback was buggy, because in certain cases it could [destroy the fd](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L473) that generated the `on_readable_locked` callback it's being invoked from, which could then cause a use-after-free in [here](https://github.com/grpc/grpc/blob/5ec616e6a8f22cbf1e0613c6a0eae3107ede4d3a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L368). So it looks like the direct cause of b/243676671.
