### PR TITLE
XdsClient: add test for fix in #29604

### DIFF
--- a/src/core/ext/xds/xds_client.cc
+++ b/src/core/ext/xds/xds_client.cc
@@ -204,16 +204,15 @@ class XdsClient::ChannelState::AdsCallState
 
     void MaybeCancelTimer() ABSL_EXCLUSIVE_LOCKS_REQUIRED(&XdsClient::mu_) {
       // If the timer hasn't been started yet, make sure we don't start
-      // it later.  This can happen if the last watch for an LDS or CDS
-      // resource is cancelled and then restarted, both while an ADS
-      // request for a different resource type is being sent (causing
-      // the unsubscription and then resubscription requests to be
-      // queued), and then we get a response for the LDS or CDS resource.
-      // In that case, we would call MaybeCancelTimer() when we receive the
-      // response and then MaybeStartTimer() when we finally send the new
-      // LDS or CDS request, thus causing the timer to fire when it shouldn't.
-      // For details, see https://github.com/grpc/grpc/issues/29583.
-      // TODO(roth): Find a way to write a test for this case.
+      // it later.  This can happen if the last watch for a resource is
+      // cancelled and then restarted, both while an ADS request is
+      // being sent (causing the unsubscription and then resubscription
+      // requests to be queued), and then we get a response that
+      // contains that resource.  In that case, we would call
+      // MaybeCancelTimer() when we receive the response and then
+      // MaybeStartTimer() when we finally send the new request, thus
+      // causing the timer to fire when it shouldn't.  For details,
+      // see https://github.com/grpc/grpc/issues/29583.
       timer_start_needed_ = false;
       if (timer_handle_.has_value()) {
         ads_calld_->xds_client()->engine()->Cancel(*timer_handle_);

--- a/test/core/xds/xds_client_test.cc
+++ b/test/core/xds/xds_client_test.cc
@@ -1417,6 +1417,118 @@ TEST_F(XdsClientTest, ResourceDoesNotExist) {
   }
 }
 
+// In https://github.com/grpc/grpc/issues/29583, we ran into a case
+// where we wound up starting a timer after we had already received the
+// resource, thus incorrectly reporting the resource as not existing.
+// This happened when unsubscribing and then resubscribing to the same
+// resource a send_message op was already in flight and then receiving an
+// update containing that resource.
+TEST_F(XdsClientTest,
+       ResourceDoesNotExistUnsubscribeAndResubscribeWhileSendMessagePending) {
+  InitXdsClient(FakeXdsBootstrap::Builder(), Duration::Seconds(1));
+  // Tell transport to let us manually trigger completion of the
+  // send_message ops to XdsClient.
+  transport_factory_->SetAutoCompleteMessagesFromClient(false);
+  // Start a watch for "foo1".
+  auto watcher = StartFooWatch("foo1");
+  // Watcher should initially not see any resource reported.
+  EXPECT_FALSE(watcher->HasEvent());
+  // XdsClient should have created an ADS stream.
+  auto stream = WaitForAdsStream();
+  ASSERT_TRUE(stream != nullptr);
+  // XdsClient should have sent a subscription request on the ADS stream.
+  auto request = WaitForRequest(stream.get());
+  ASSERT_TRUE(request.has_value());
+  CheckRequest(*request, XdsFooResourceType::Get()->type_url(),
+               /*version_info=*/"", /*response_nonce=*/"",
+               /*error_detail=*/absl::OkStatus(),
+               /*resource_names=*/{"foo1"});
+  CheckRequestNode(*request);  // Should be present on the first request.
+  stream->CompleteSendMessageFromClient();
+  // Server sends a response.
+  stream->SendMessageToClient(
+      ResponseBuilder(XdsFooResourceType::Get()->type_url())
+          .set_version_info("1")
+          .set_nonce("A")
+          .AddFooResource(XdsFooResource("foo1", 6))
+          .Serialize());
+  // XdsClient should have delivered the response to the watchers.
+  auto resource = watcher->WaitForNextResource();
+  ASSERT_TRUE(resource.has_value());
+  EXPECT_EQ(resource->name, "foo1");
+  EXPECT_EQ(resource->value, 6);
+  // XdsClient should have sent an ACK message to the xDS server.
+  request = WaitForRequest(stream.get());
+  ASSERT_TRUE(request.has_value());
+  CheckRequest(*request, XdsFooResourceType::Get()->type_url(),
+               /*version_info=*/"1", /*response_nonce=*/"A",
+               /*error_detail=*/absl::OkStatus(),
+               /*resource_names=*/{"foo1"});
+  stream->CompleteSendMessageFromClient();
+  // Start a watch for a second resource.
+  auto watcher2 = StartFooWatch("foo2");
+  // Watcher should initially not see any resource reported.
+  EXPECT_FALSE(watcher2->HasEvent());
+  // XdsClient sends a request to subscribe to the new resource.
+  request = WaitForRequest(stream.get());
+  ASSERT_TRUE(request.has_value());
+  CheckRequest(*request, XdsFooResourceType::Get()->type_url(),
+               /*version_info=*/"1", /*response_nonce=*/"A",
+               /*error_detail=*/absl::OkStatus(),
+               /*resource_names=*/{"foo1", "foo2"});
+  // NOTE: We do NOT yet tell the XdsClient that the send_message op is
+  // complete.
+  // Unsubscribe from foo1 and then re-subscribe to it.
+  CancelFooWatch(watcher.get(), "foo1");
+  watcher = StartFooWatch("foo1");
+  // Now send a response from the server containing both foo1 and foo2.
+  stream->SendMessageToClient(
+      ResponseBuilder(XdsFooResourceType::Get()->type_url())
+          .set_version_info("1")
+          .set_nonce("B")
+          .AddFooResource(XdsFooResource("foo1", 6))
+          .AddFooResource(XdsFooResource("foo2", 7))
+          .Serialize());
+  // The watcher for foo1 will receive an update even if the resource
+  // has not changed, since the previous value was removed from the
+  // cache when we unsubscribed.
+  resource = watcher->WaitForNextResource();
+  ASSERT_TRUE(resource.has_value());
+  EXPECT_EQ(resource->name, "foo1");
+  EXPECT_EQ(resource->value, 6);
+  // For foo2, the watcher should receive notification for the new resource.
+  resource = watcher2->WaitForNextResource();
+  ASSERT_TRUE(resource.has_value());
+  EXPECT_EQ(resource->name, "foo2");
+  EXPECT_EQ(resource->value, 7);
+  // Now we finally tell XdsClient that its previous send_message op is
+  // complete.
+  stream->CompleteSendMessageFromClient();
+  // XdsClient should send an ACK with the updated subscription list
+  // (which happens to be identical to the old list), and it should not
+  // restart the does-not-exist timer.
+  request = WaitForRequest(stream.get());
+  ASSERT_TRUE(request.has_value());
+  CheckRequest(*request, XdsFooResourceType::Get()->type_url(),
+               /*version_info=*/"1", /*response_nonce=*/"B",
+               /*error_detail=*/absl::OkStatus(),
+               /*resource_names=*/{"foo1", "foo2"});
+  stream->CompleteSendMessageFromClient();
+  // Make sure the watcher for foo1 does not see a does-not-exist event.
+  EXPECT_TRUE(watcher->ExpectNoEvent(absl::Seconds(5)));
+  // Cancel watches.
+  CancelFooWatch(watcher.get(), "foo1", /*delay_unsubscription=*/true);
+  CancelFooWatch(watcher2.get(), "foo2");
+  // The XdsClient may or may not send an unsubscription message
+  // before it closes the transport, depending on callback timing.
+  request = WaitForRequest(stream.get());
+  if (request.has_value()) {
+    CheckRequest(*request, XdsFooResourceType::Get()->type_url(),
+                 /*version_info=*/"1", /*response_nonce=*/"B",
+                 /*error_detail=*/absl::OkStatus(), /*resource_names=*/{});
+  }
+}
+
 TEST_F(XdsClientTest, StreamClosedByServer) {
   InitXdsClient();
   // Start a watch for "foo1".

--- a/test/core/xds/xds_transport_fake.cc
+++ b/test/core/xds/xds_transport_fake.cc
@@ -66,15 +66,9 @@ void FakeXdsTransportFactory::FakeStreamingCall::SendMessage(
   MutexLock lock(&mu_);
   from_client_messages_.push_back(std::move(payload));
   cv_.Signal();
-  // Can't call event_handler_->OnRequestSent() synchronously, since that
-  // operation will trigger code in XdsClient that acquires its mutex, but it
-  // was already holding its mutex when it called us, so it would deadlock.
-  GetDefaultEventEngine()->Run(
-      [event_handler = event_handler_->Ref()]() mutable {
-        ExecCtx exec_ctx;
-        event_handler->OnRequestSent(/*ok=*/true);
-        event_handler.reset();
-      });
+  if (transport_->auto_complete_messages_from_client()) {
+    CompleteSendMessageFromClientLocked(/*ok=*/true);
+  }
 }
 
 bool FakeXdsTransportFactory::FakeStreamingCall::HaveMessageFromClient() {
@@ -94,6 +88,26 @@ FakeXdsTransportFactory::FakeStreamingCall::WaitForMessageFromClient(
   std::string payload = from_client_messages_.front();
   from_client_messages_.pop_front();
   return payload;
+}
+
+void FakeXdsTransportFactory::FakeStreamingCall::
+    CompleteSendMessageFromClientLocked(bool ok) {
+  // Can't call event_handler_->OnRequestSent() synchronously, since that
+  // operation will trigger code in XdsClient that acquires its mutex, but it
+  // was already holding its mutex when it called us, so it would deadlock.
+  GetDefaultEventEngine()->Run(
+      [event_handler = event_handler_->Ref(), ok]() mutable {
+        ExecCtx exec_ctx;
+        event_handler->OnRequestSent(ok);
+        event_handler.reset();
+      });
+}
+
+void FakeXdsTransportFactory::FakeStreamingCall::CompleteSendMessageFromClient(
+    bool ok) {
+  GPR_ASSERT(!transport_->auto_complete_messages_from_client());
+  MutexLock lock(&mu_);
+  CompleteSendMessageFromClientLocked(ok);
 }
 
 void FakeXdsTransportFactory::FakeStreamingCall::SendMessageToClient(
@@ -199,11 +213,11 @@ FakeXdsTransportFactory::Create(
     const XdsBootstrap::XdsServer& server,
     std::function<void(absl::Status)> on_connectivity_failure,
     absl::Status* /*status*/) {
-  auto transport =
-      MakeOrphanable<FakeXdsTransport>(std::move(on_connectivity_failure));
   MutexLock lock(&mu_);
   auto& entry = transport_map_[&server];
   GPR_ASSERT(entry == nullptr);
+  auto transport = MakeOrphanable<FakeXdsTransport>(
+      std::move(on_connectivity_failure), auto_complete_messages_from_client_);
   entry = transport->Ref();
   return transport;
 }
@@ -212,6 +226,11 @@ void FakeXdsTransportFactory::TriggerConnectionFailure(
     const XdsBootstrap::XdsServer& server, absl::Status status) {
   auto transport = GetTransport(server);
   transport->TriggerConnectionFailure(std::move(status));
+}
+
+void FakeXdsTransportFactory::SetAutoCompleteMessagesFromClient(bool value) {
+  MutexLock lock(&mu_);
+  auto_complete_messages_from_client_ = value;
 }
 
 RefCountedPtr<FakeXdsTransportFactory::FakeStreamingCall>

--- a/test/core/xds/xds_transport_fake.h
+++ b/test/core/xds/xds_transport_fake.h
@@ -71,6 +71,13 @@ class FakeXdsTransportFactory : public XdsTransportFactory {
     absl::optional<std::string> WaitForMessageFromClient(
         absl::Duration timeout);
 
+    // If FakeXdsTransportFactory::SetAutoCompleteMessagesFromClient()
+    // was called to set the value to false before the creation of the
+    // transport that underlies this stream, then this must be called
+    // to invoke EventHandler::OnRequestSent() for every message read
+    // via WaitForMessageFromClient().
+    void CompleteSendMessageFromClient(bool ok = true);
+
     void SendMessageToClient(absl::string_view payload);
     void MaybeSendStatusToClient(absl::Status status);
 
@@ -95,6 +102,9 @@ class FakeXdsTransportFactory : public XdsTransportFactory {
 
     void SendMessage(std::string payload) override;
 
+    void CompleteSendMessageFromClientLocked(bool ok)
+        ABSL_EXCLUSIVE_LOCKS_REQUIRED(&mu_);
+
     RefCountedPtr<FakeXdsTransport> transport_;
     const char* method_;
 
@@ -112,6 +122,17 @@ class FakeXdsTransportFactory : public XdsTransportFactory {
   void TriggerConnectionFailure(const XdsBootstrap::XdsServer& server,
                                 absl::Status status);
 
+  // By default, FakeStreamingCall will automatically invoke
+  // EventHandler::OnRequestSent() upon reading a request from the client.
+  // If this is set to false, that behavior will be inhibited, and
+  // EventHandler::OnRequestSent() will not be called until the test
+  // expicitly calls FakeStreamingCall::CompleteSendMessageFromClient().
+  //
+  // This value affects all transports created after this call is
+  // complete.  Any transport that already exists prior to this call
+  // will not be affected.
+  void SetAutoCompleteMessagesFromClient(bool value);
+
   RefCountedPtr<FakeStreamingCall> WaitForStream(
       const XdsBootstrap::XdsServer& server, const char* method,
       absl::Duration timeout);
@@ -121,13 +142,19 @@ class FakeXdsTransportFactory : public XdsTransportFactory {
  private:
   class FakeXdsTransport : public XdsTransport {
    public:
-    explicit FakeXdsTransport(
-        std::function<void(absl::Status)> on_connectivity_failure)
-        : on_connectivity_failure_(
+    FakeXdsTransport(std::function<void(absl::Status)> on_connectivity_failure,
+                     bool auto_complete_messages_from_client)
+        : auto_complete_messages_from_client_(
+              auto_complete_messages_from_client),
+          on_connectivity_failure_(
               MakeRefCounted<RefCountedOnConnectivityFailure>(
                   std::move(on_connectivity_failure))) {}
 
     void Orphan() override;
+
+    bool auto_complete_messages_from_client() const {
+      return auto_complete_messages_from_client_;
+    }
 
     using XdsTransport::Ref;  // Make it public.
 
@@ -160,6 +187,8 @@ class FakeXdsTransportFactory : public XdsTransportFactory {
 
     void ResetBackoff() override {}
 
+    const bool auto_complete_messages_from_client_;
+
     Mutex mu_;
     CondVar cv_;
     RefCountedPtr<RefCountedOnConnectivityFailure> on_connectivity_failure_
@@ -179,6 +208,7 @@ class FakeXdsTransportFactory : public XdsTransportFactory {
   Mutex mu_;
   std::map<const XdsBootstrap::XdsServer*, RefCountedPtr<FakeXdsTransport>>
       transport_map_ ABSL_GUARDED_BY(&mu_);
+  bool auto_complete_messages_from_client_ ABSL_GUARDED_BY(&mu_) = true;
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
When #29604 was written, we didn't have a good framework for testing the fix.  Now we do, so this PR adds that test.

I have verified that this test fails when I disable the code from both #29604 and #29668 (the latter of which is also a partial fix for this problem, but that code will be going away in a subsequent PR).