### PR TITLE
c-ares DNS resolver: fix logical race between resolution timeout/cancellation and fd readability

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -142,7 +142,7 @@ class AresClientChannelDNSResolver : public PollingResolver {
             &service_config_json_, resolver_->query_timeout_ms_));
         GRPC_CARES_TRACE_LOG(
             "resolver:%p Started resolving TXT records. txt_request_:%p",
-            resolver_.get(), srv_request_.get());
+            resolver_.get(), txt_request_.get());
       }
     }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -743,7 +743,6 @@ static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
             r, srv_it->host, htons(srv_it->port), true /* is_balancer */, "A");
         ares_gethostbyname(r->ev_driver->channel, hr->host, AF_INET,
                            on_hostbyname_done_locked, hr);
-        grpc_ares_notify_on_event_locked(r->ev_driver);
       }
     }
     if (reply != nullptr) {

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -362,17 +362,17 @@ static void on_readable(void* arg, grpc_error_handle error) {
   fdn->readable_registered = false;
   GRPC_CARES_TRACE_LOG("request:%p readable on %s", fdn->ev_driver->request,
                        fdn->grpc_polled_fd->GetName());
-  if (error.ok()) {
+  if (error.ok() && !ev_driver->shutting_down) {
     do {
       ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
     } while (fdn->grpc_polled_fd->IsFdStillReadableLocked());
   } else {
-    // If error is not absl::OkStatus(), it means the fd has been shutdown or
-    // timed out. The pending lookups made on this ev_driver will be cancelled
-    // by the following ares_cancel() and the on_done callbacks will be invoked
-    // with a status of ARES_ECANCELLED. The remaining file descriptors in this
-    // ev_driver will be cleaned up in the follwing
-    // grpc_ares_notify_on_event_locked().
+    // If error is not absl::OkStatus() or the resolution was cancelled, it
+    // means the fd has been shutdown or timed out. The pending lookups made on
+    // this ev_driver will be cancelled by the following ares_cancel() and the
+    // on_done callbacks will be invoked with a status of ARES_ECANCELLED. The
+    // remaining file descriptors in this ev_driver will be cleaned up in the
+    // follwing grpc_ares_notify_on_event_locked().
     ares_cancel(ev_driver->channel);
   }
   grpc_ares_notify_on_event_locked(ev_driver);
@@ -388,15 +388,15 @@ static void on_writable(void* arg, grpc_error_handle error) {
   fdn->writable_registered = false;
   GRPC_CARES_TRACE_LOG("request:%p writable on %s", ev_driver->request,
                        fdn->grpc_polled_fd->GetName());
-  if (error.ok()) {
+  if (error.ok() && !ev_driver->shutting_down) {
     ares_process_fd(ev_driver->channel, ARES_SOCKET_BAD, as);
   } else {
-    // If error is not absl::OkStatus(), it means the fd has been shutdown or
-    // timed out. The pending lookups made on this ev_driver will be cancelled
-    // by the following ares_cancel() and the on_done callbacks will be invoked
-    // with a status of ARES_ECANCELLED. The remaining file descriptors in this
-    // ev_driver will be cleaned up in the follwing
-    // grpc_ares_notify_on_event_locked().
+    // If error is not absl::OkStatus() or the resolution was cancelled, it
+    // means the fd has been shutdown or timed out. The pending lookups made on
+    // this ev_driver will be cancelled by the following ares_cancel() and the
+    // on_done callbacks will be invoked with a status of ARES_ECANCELLED. The
+    // remaining file descriptors in this ev_driver will be cleaned up in the
+    // follwing grpc_ares_notify_on_event_locked().
     ares_cancel(ev_driver->channel);
   }
   grpc_ares_notify_on_event_locked(ev_driver);

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -662,10 +662,10 @@ TEST(ResolverComponentTest, TestResolvesRelevantRecordsWithConcurrentFdStress) {
   socket_stress_thread.join();
 }
 
-TEST(ResolverComponentTest, TestResolvesRelevantRecordsWith1MsTimeout) {
+TEST(ResolverComponentTest, TestDoesntCrashOrHangWith1MsTimeout) {
   // Queries in this test could either complete successfully or time out
-  // show cancellation. This test doesn't care - we just care that the
-  // query completes and doesn't crash, leak, etc.
+  // and show cancellation. This test doesn't care - we just care that the
+  // query completes and doesn't crash, hang, leak, etc.
   RunResolvesRelevantRecordsTest(
       ResultHandler::Create,
       grpc_core::ChannelArgs().Set(GRPC_ARG_DNS_ARES_QUERY_TIMEOUT_MS, 1));

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -665,7 +665,7 @@ TEST(ResolverComponentTest, TestResolvesRelevantRecordsWithConcurrentFdStress) {
 TEST(ResolverComponentTest, TestDoesntCrashOrHangWith1MsTimeout) {
   // Queries in this test could either complete successfully or time out
   // and show cancellation. This test doesn't care - we just care that the
-  // query completes and doesn't crash, hang, leak, etc.
+  // query completes and doesn't crash, get stuck, leak, etc.
   RunResolvesRelevantRecordsTest(
       ResultHandler::Create,
       grpc_core::ChannelArgs().Set(GRPC_ARG_DNS_ARES_QUERY_TIMEOUT_MS, 1));


### PR DESCRIPTION
This PR adds a test originally meant to hit the bug described in https://github.com/grpc/grpc/pull/31426. This test caught a more general, long-standing bug which is fixed here:

If we:

1) Have more than one DNS query outstanding on the same file descriptor (for example, an `A` query and a `AAAA` query)
2) Cancel the overall resolution (for example due to the overall [timeout](https://github.com/grpc/grpc/blob/99aa924a5c7c813a3c0d647df34d10db1fec9cff/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L298) kicking in)
3) Concurrently with 2), receive data from the DNS server for **one** of those queries (for example, just the `A` query)

... then, we can hit a bug where we run the `on_readable` callback for the `A` query and [process the data as if the resolution hasn't been cancelled](https://github.com/grpc/grpc/blob/99aa924a5c7c813a3c0d647df34d10db1fec9cff/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L367). Even though we've already [shut down](https://github.com/grpc/grpc/blob/99aa924a5c7c813a3c0d647df34d10db1fec9cff/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L249) the file descriptor with the still-pending `AAAA` query, the c-ares library thinks we still want to wait for this `AAAA` query to finish. But it never will finish, because we'll stop polling I/O at this point without ever having told c-ares to cancel the query.

The fix is to explicitly check for overall cancellation in the I/O callbacks and tell c-ares to cancel everything in that case.

---------

While we're here:

- fix the same race in `resolver_component_test.cc` that was fixed for other tests in https://github.com/grpc/grpc/pull/25398
- fix a trace log

