### PR TITLE
Visibility change to ref_counted_ptr for xds_client_core

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2244,7 +2244,10 @@ grpc_cc_library(
     name = "ref_counted_ptr",
     language = "c++",
     public_hdrs = ["//src/core:lib/gprpp/ref_counted_ptr.h"],
-    visibility = ["@grpc:ref_counted_ptr"],
+    visibility = [
+        "@grpc:ref_counted_ptr",
+        "@grpc:xds_client_core",
+    ],
     deps = [
         "debug_location",
         "gpr_platform",


### PR DESCRIPTION
Hi @markdroth . I believe we need this for the Google internal project we are doing. I was running the IWYU tool and realized that ref_counted_ptr are currently only available accidentally through transitive dependencies.