### PR TITLE
Relax the benchmarks' default minimum execution time

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -45,7 +45,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_exec_ctx",
     srcs = ["bm_exec_ctx.cc"],
-    args = ["--benchmark_min_time=0.3"],
+    args = grpc_benchmark_args(),
     external_deps = [
         "benchmark",
     ],
@@ -74,7 +74,7 @@ grpc_cc_test(
     name = "bm_thread_pool",
     size = "small",
     srcs = ["bm_thread_pool.cc"],
-    args = ["--benchmark_min_time=0.1"],
+    args = grpc_benchmark_args(),
     external_deps = [
         "benchmark",
     ],


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

