### PR TITLE
xds_core_e2e_test: fix federation test flake

### DIFF
--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -714,7 +714,7 @@ TEST_P(XdsFederationTest, FederationTargetNoAuthorityWithResourceTemplate) {
       "xdstp://xds.example.com/envoy.config.listener.v3.Listener"
       "client/%s?client_listener_resource_name_template_not_in_use");
   InitClient(builder);
-  CreateAndStartBackends(2, /*xds_enabled=*/true);
+  CreateAndStartBackends(2);
   // Eds for the new authority balancer.
   EdsResourceArgs args =
       EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});
@@ -764,7 +764,7 @@ TEST_P(XdsFederationTest, FederationTargetAuthorityDefaultResourceTemplate) {
   builder.AddAuthority(kAuthority,
                        absl::StrCat("localhost:", authority_balancer_->port()));
   InitClient(builder);
-  CreateAndStartBackends(2, /*xds_enabled=*/true);
+  CreateAndStartBackends(2);
   // Eds for 2 balancers to ensure RPCs sent using current stub go to backend 0
   // and RPCs sent using the new stub go to backend 1.
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends(0, 1)}});
@@ -835,7 +835,7 @@ TEST_P(XdsFederationTest, FederationTargetAuthorityWithResourceTemplate) {
                        absl::StrCat("localhost:", authority_balancer_->port()),
                        kNewListenerTemplate);
   InitClient(builder);
-  CreateAndStartBackends(2, /*xds_enabled=*/true);
+  CreateAndStartBackends(2);
   // Eds for 2 balancers to ensure RPCs sent using current stub go to backend 0
   // and RPCs sent using the new stub go to backend 1.
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends(0, 1)}});


### PR DESCRIPTION
This fixes a flake in the `XdsFederationTest.FederationTargetNoAuthorityWithResourceTemplate` test where the client fails to connect to the backend:

https://source.cloud.google.com/results/invocations/257086e8-612e-413b-80ba-d5002dc8ab2d/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_core_end2end_test@poller%3Dpoll/tests

I have no idea what was actually causing the flake.  Just based on the time that the flake started, I suspect something in #31457, but I have no idea what in that PR could have caused this.

However, when I started looking at the tests, the first thing I noticed is that several of the tests that were covering only client-side xDS functionality were actually enabling xDS on the server side, when they don't actually need to.  This could conceivably cause the server to take longer to start up (which might imply that the flake was triggered by a subtle timing change rather than a real bug), so changing the tests to avoid use of xDS on the server side seemed like a good idea anyway.  And as soon as I did that, the flake disappeared.