### PR TITLE
RBAC service config parser: address clang-tidy warning

### DIFF
--- a/src/core/ext/filters/rbac/rbac_service_config_parser.cc
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.cc
@@ -775,6 +775,7 @@ const JsonLoaderInterface* RbacConfig::RbacPolicy::JsonLoader(const JsonArgs&) {
 
 std::vector<Rbac> RbacConfig::TakeAsRbacList() {
   std::vector<Rbac> rbac_list;
+  rbac_list.reserve(rbac_policies.size());
   for (auto& rbac_policy : rbac_policies) {
     rbac_list.emplace_back(rbac_policy.TakeAsRbac());
   }


### PR DESCRIPTION
Address comment noted upon import of #31486.