### PR TITLE
Update Clang 15

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,8 +17,9 @@
 # it's not activated yet due to the existing issues with the checks.
 # Once those issues are clear, these checks can be enabled later.
 #
+# - bugprone-assignment-in-if-condition
 # - bugprone-branch-clone
-# - bugprone-easily-swappable-parameters,
+# - bugprone-easily-swappable-parameters
 # - bugprone-implicit-widening-of-multiplication-result
 # - bugprone-infinite-loop
 # - bugprone-narrowing-conversions
@@ -26,9 +27,11 @@
 # - bugprone-signed-char-misuse
 # - bugprone-sizeof-expression
 # - bugprone-too-small-loop-variable
+# - bugprone-unchecked-optional-access
 # - clang-diagnostic-deprecated-declarations
 # - clang-diagnostic-unused-function
 # - google-readability-avoid-underscore-in-googletest-name
+# - google-readability-casting
 # - google-runtime-int
 # - google-runtime-references
 # - modernize-avoid-bind
@@ -55,6 +58,7 @@ Checks: '-*,
   abseil-*,
   -abseil-no-namespace,
   bugprone-*,
+  -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result,
@@ -65,8 +69,10 @@ Checks: '-*,
   -bugprone-signed-char-misuse,
   -bugprone-sizeof-expression,
   -bugprone-too-small-loop-variable,
+  -bugprone-unchecked-optional-access,
   google-*,
   -google-readability-avoid-underscore-in-googletest-name,
+  -google-readability-casting,
   -google-runtime-int,
   -google-runtime-references,
   -google-upgrade-googletest-case,
@@ -133,3 +139,5 @@ CheckOptions:
     value:  'absl/memory/memory.h'
   - key:    google-readability-braces-around-statements.ShortStatementLines
     value:  1
+  - key:    readability-simplify-boolean-expr.SimplifyDeMorgan
+    value:  false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14880,7 +14880,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(posix_engine_listener_utils_test
     src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
     src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
-    src/core/lib/iomgr/socket_mutator.cc
     test/core/event_engine/posix/posix_engine_listener_utils_test.cc
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -8638,11 +8638,9 @@ targets:
   headers:
   - src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.h
   - src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
-  - src/core/lib/iomgr/socket_mutator.h
   src:
   - src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
   - src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
-  - src/core/lib/iomgr/socket_mutator.cc
   - test/core/event_engine/posix/posix_engine_listener_utils_test.cc
   deps:
   - grpc_test_util

--- a/include/grpcpp/client_context.h
+++ b/include/grpcpp/client_context.h
@@ -373,9 +373,7 @@ class ClientContext {
   void set_census_context(struct census_context* ccp) { census_context_ = ccp; }
 
   /// Returns the census context that has been set, or nullptr if not set.
-  struct census_context* census_context() const {
-    return census_context_;
-  }
+  struct census_context* census_context() const { return census_context_; }
 
   /// Send a best-effort out-of-band cancel on the call associated with
   /// this client context.  The call could be in any stage; e.g., if it is

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -328,6 +328,7 @@ class ServerBuilder {
   /// Experimental, to be deprecated
   std::vector<NamedService*> services() {
     std::vector<NamedService*> service_refs;
+    service_refs.reserve(services_.size());
     for (auto& ptr : services_) {
       service_refs.push_back(ptr.get());
     }
@@ -337,6 +338,7 @@ class ServerBuilder {
   /// Experimental, to be deprecated
   std::vector<grpc::ServerBuilderOption*> options() {
     std::vector<grpc::ServerBuilderOption*> option_refs;
+    option_refs.reserve(options_.size());
     for (auto& ptr : options_) {
       option_refs.push_back(ptr.get());
     }

--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -438,7 +438,7 @@ void WeightedTargetLb::UpdateStateLocked() {
         break;
       }
       default:
-        GPR_UNREACHABLE_CODE(return );
+        GPR_UNREACHABLE_CODE(return);
     }
   }
   // Determine aggregated connectivity state.

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -374,7 +374,7 @@ void XdsClusterManagerLb::UpdateStateLocked() {
         break;
       }
       default:
-        GPR_UNREACHABLE_CODE(return );
+        GPR_UNREACHABLE_CODE(return);
     }
   }
   // Determine aggregated connectivity state.

--- a/src/core/ext/xds/xds_common_types.cc
+++ b/src/core/ext/xds/xds_common_types.cc
@@ -76,6 +76,7 @@ Duration ParseDuration(const google_protobuf_Duration* proto_duration,
 
 std::string CommonTlsContext::CertificateValidationContext::ToString() const {
   std::vector<std::string> contents;
+  contents.reserve(match_subject_alt_names.size());
   for (const auto& match : match_subject_alt_names) {
     contents.push_back(match.ToString());
   }

--- a/src/core/ext/xds/xds_endpoint.cc
+++ b/src/core/ext/xds/xds_endpoint.cc
@@ -83,6 +83,7 @@ bool XdsEndpointResource::Priority::operator==(const Priority& other) const {
 
 std::string XdsEndpointResource::Priority::ToString() const {
   std::vector<std::string> locality_strings;
+  locality_strings.reserve(localities.size());
   for (const auto& p : localities) {
     locality_strings.emplace_back(p.second.ToString());
   }

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -80,6 +80,7 @@ std::string XdsListenerResource::HttpConnectionManager::ToString() const {
                                   http_max_stream_duration.ToString()));
   if (!http_filters.empty()) {
     std::vector<std::string> filter_strings;
+    filter_strings.reserve(http_filters.size());
     for (const auto& http_filter : http_filters) {
       filter_strings.push_back(http_filter.ToString());
     }
@@ -164,6 +165,7 @@ std::string FilterChain::FilterChainMatch::ToString() const {
   }
   if (!prefix_ranges.empty()) {
     std::vector<std::string> prefix_ranges_content;
+    prefix_ranges_content.reserve(prefix_ranges.size());
     for (const auto& range : prefix_ranges) {
       prefix_ranges_content.push_back(range.ToString());
     }
@@ -179,6 +181,7 @@ std::string FilterChain::FilterChainMatch::ToString() const {
   }
   if (!source_prefix_ranges.empty()) {
     std::vector<std::string> source_prefix_ranges_content;
+    source_prefix_ranges_content.reserve(source_prefix_ranges.size());
     for (const auto& range : source_prefix_ranges) {
       source_prefix_ranges_content.push_back(range.ToString());
     }

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -231,6 +231,7 @@ XdsRouteConfigResource::Route::RouteAction::ClusterWeight::ToString() const {
 
 std::string XdsRouteConfigResource::Route::RouteAction::ToString() const {
   std::vector<std::string> contents;
+  contents.reserve(hash_policies.size());
   for (const HashPolicy& hash_policy : hash_policies) {
     contents.push_back(absl::StrCat("hash_policy=", hash_policy.ToString()));
   }

--- a/src/core/lib/event_engine/posix_engine/lockfree_event.cc
+++ b/src/core/lib/event_engine/posix_engine/lockfree_event.cc
@@ -157,7 +157,7 @@ void LockfreeEvent::NotifyOn(PosixEngineClosure* closure) {
     }
   }
 
-  GPR_UNREACHABLE_CODE(return );
+  GPR_UNREACHABLE_CODE(return);
 }
 
 bool LockfreeEvent::SetShutdown(absl::Status shutdown_error) {

--- a/src/core/lib/iomgr/cfstream_handle.cc
+++ b/src/core/lib/iomgr/cfstream_handle.cc
@@ -88,7 +88,7 @@ void CFStreamHandle::ReadCallback(CFReadStreamRef stream,
       handle->read_event_.SetShutdown(error);
       break;
     default:
-      GPR_UNREACHABLE_CODE(return );
+      GPR_UNREACHABLE_CODE(return);
   }
 }
 void CFStreamHandle::WriteCallback(CFWriteStreamRef stream,
@@ -122,7 +122,7 @@ void CFStreamHandle::WriteCallback(CFWriteStreamRef stream,
       handle->read_event_.SetShutdown(error);
       break;
     default:
-      GPR_UNREACHABLE_CODE(return );
+      GPR_UNREACHABLE_CODE(return);
   }
 }
 

--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -156,7 +156,7 @@ void LockfreeEvent::NotifyOn(grpc_closure* closure) {
     }
   }
 
-  GPR_UNREACHABLE_CODE(return );
+  GPR_UNREACHABLE_CODE(return);
 }
 
 bool LockfreeEvent::SetShutdown(grpc_error_handle shutdown_error) {

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -282,7 +282,7 @@ static void on_read(void* arg, grpc_error_handle err) {
         read_notifier_pollset, acceptor);
   }
 
-  GPR_UNREACHABLE_CODE(return );
+  GPR_UNREACHABLE_CODE(return);
 
 error:
   gpr_mu_lock(&sp->server->mu);

--- a/src/core/lib/promise/loop.h
+++ b/src/core/lib/promise/loop.h
@@ -118,7 +118,9 @@ class Loop {
 
  private:
   GPR_NO_UNIQUE_ADDRESS Factory factory_;
-  GPR_NO_UNIQUE_ADDRESS union { GPR_NO_UNIQUE_ADDRESS PromiseType promise_; };
+  GPR_NO_UNIQUE_ADDRESS union {
+    GPR_NO_UNIQUE_ADDRESS PromiseType promise_;
+  };
 };
 
 }  // namespace promise_detail

--- a/src/core/lib/resolver/server_address.cc
+++ b/src/core/lib/resolver/server_address.cc
@@ -164,6 +164,7 @@ std::string ServerAddress::ToString() const {
   }
   if (!attributes_.empty()) {
     std::vector<std::string> attrs;
+    attrs.reserve(attributes_.size());
     for (const auto& p : attributes_) {
       attrs.emplace_back(absl::StrCat(p.first, "=", p.second->ToString()));
     }

--- a/src/core/lib/security/authorization/matchers.cc
+++ b/src/core/lib/security/authorization/matchers.cc
@@ -38,6 +38,7 @@ std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
   switch (permission.type) {
     case Rbac::Permission::RuleType::kAnd: {
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
+      matchers.reserve(permission.permissions.size());
       for (const auto& rule : permission.permissions) {
         matchers.push_back(AuthorizationMatcher::Create(std::move(*rule)));
       }
@@ -45,6 +46,7 @@ std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
     }
     case Rbac::Permission::RuleType::kOr: {
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
+      matchers.reserve(permission.permissions.size());
       for (const auto& rule : permission.permissions) {
         matchers.push_back(AuthorizationMatcher::Create(std::move(*rule)));
       }
@@ -80,6 +82,7 @@ std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
   switch (principal.type) {
     case Rbac::Principal::RuleType::kAnd: {
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
+      matchers.reserve(principal.principals.size());
       for (const auto& id : principal.principals) {
         matchers.push_back(AuthorizationMatcher::Create(std::move(*id)));
       }
@@ -87,6 +90,7 @@ std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
     }
     case Rbac::Principal::RuleType::kOr: {
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
+      matchers.reserve(principal.principals.size());
       for (const auto& id : principal.principals) {
         matchers.push_back(AuthorizationMatcher::Create(std::move(*id)));
       }

--- a/src/core/lib/security/credentials/external/aws_request_signer.cc
+++ b/src/core/lib/security/credentials/external/aws_request_signer.cc
@@ -170,6 +170,7 @@ std::map<std::string, std::string> AwsRequestSigner::GetSignedRequestHeaders() {
   canonical_request_vector.emplace_back("\n");
   // 5. SignedHeaders
   std::vector<absl::string_view> signed_headers_vector;
+  signed_headers_vector.reserve(request_headers_.size());
   for (const auto& header : request_headers_) {
     signed_headers_vector.emplace_back(header.first);
   }

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -1134,7 +1134,7 @@ static void del_plucker(grpc_completion_queue* cq, void* tag,
       return;
     }
   }
-  GPR_UNREACHABLE_CODE(return );
+  GPR_UNREACHABLE_CODE(return);
 }
 
 class ExecCtxPluck : public grpc_core::ExecCtx {

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1238,7 +1238,7 @@ void Server::CallData::Publish(size_t cq_idx, RequestedCall* rc) {
       }
       break;
     default:
-      GPR_UNREACHABLE_CODE(return );
+      GPR_UNREACHABLE_CODE(return);
   }
   grpc_cq_end_op(cq_new_, rc->tag, absl::OkStatus(), Server::DoneRequestEvent,
                  rc, &rc->completion, true);

--- a/src/cpp/ext/proto_server_reflection.cc
+++ b/src/cpp/ext/proto_server_reflection.cc
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include <grpcpp/grpcpp.h>
-#include <grpcpp/support/interceptor.h>
 
 // IWYU pragma: no_include <google/protobuf/descriptor.h>
 

--- a/src/cpp/ext/proto_server_reflection.cc
+++ b/src/cpp/ext/proto_server_reflection.cc
@@ -26,8 +26,6 @@
 
 // IWYU pragma: no_include <google/protobuf/descriptor.h>
 
-using grpc::Status;
-using grpc::StatusCode;
 using grpc::reflection::v1alpha::ErrorResponse;
 using grpc::reflection::v1alpha::ExtensionNumberResponse;
 using grpc::reflection::v1alpha::ExtensionRequest;

--- a/src/objective-c/ProtoRPC/ProtoMethod.h
+++ b/src/objective-c/ProtoRPC/ProtoMethod.h
@@ -22,7 +22,8 @@
  * A fully-qualified proto service method name. Full qualification is needed because a gRPC endpoint
  * can implement multiple services.
  */
-__attribute__((deprecated("Please use GRPCProtoMethod."))) @interface ProtoMethod : NSObject
+__attribute__((deprecated("Please use GRPCProtoMethod.")))
+@interface ProtoMethod : NSObject
 @property(nonatomic, readonly) NSString *package;
 @property(nonatomic, readonly) NSString *service;
 @property(nonatomic, readonly) NSString *method;

--- a/src/objective-c/ProtoRPC/ProtoRPCLegacy.h
+++ b/src/objective-c/ProtoRPC/ProtoRPCLegacy.h
@@ -30,7 +30,8 @@
 @class GRXWriter;
 @protocol GRXWriteable;
 
-__attribute__((deprecated("Please use GRPCProtoCall."))) @interface ProtoRPC : GRPCCall
+__attribute__((deprecated("Please use GRPCProtoCall.")))
+@interface ProtoRPC : GRPCCall
 
 /**
  * host parameter should not contain the scheme (http:// or https://), only the name or IP

--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -28,7 +28,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 
-__attribute__((deprecated("Please use GRPCProtoService."))) @interface ProtoService : NSObject
+__attribute__((deprecated("Please use GRPCProtoService.")))
+@interface ProtoService : NSObject
 
 - (nullable instancetype)initWithHost:(nonnull NSString *)host
                           packageName:(nonnull NSString *)packageName

--- a/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM silkeh/clang:13
+  FROM silkeh/clang:15-bullseye
 
   ADD clang_format_all_the_things.sh /
   

--- a/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:13
+  FROM silkeh/clang:15-bullseye
   
   # Install prerequisites for the clang-tidy script
   RUN apt-get update && apt-get install -y python3 jq git && apt-get clean

--- a/templates/tools/dockerfile/grpc_iwyu/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_iwyu/Dockerfile.template
@@ -14,6 +14,9 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
+  # Docker file for running IWYU.
+  # Updated: 2022-11-03
+
   FROM silkeh/clang:15-bullseye
   
   # Install prerequisites for the iwyu script

--- a/templates/tools/dockerfile/grpc_iwyu/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_iwyu/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:13
+  FROM silkeh/clang:15-bullseye
   
   # Install prerequisites for the iwyu script
   RUN apt-get update && apt-get install -y python3 jq git cmake python zlib1g-dev libtinfo-dev && apt-get clean

--- a/templates/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:13
+  FROM silkeh/clang:15-bullseye
   
   RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
   <%include file="../../run_tests_python_deps.include"/>

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM silkeh/clang:13
+  FROM silkeh/clang:15-bullseye
 
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../cxx_deps.include"/>

--- a/test/core/end2end/cq_verifier.cc
+++ b/test/core/end2end/cq_verifier.cc
@@ -181,6 +181,7 @@ std::string CqVerifier::Expectation::ToString() const {
 
 std::string CqVerifier::ToString() const {
   std::vector<std::string> expectations;
+  expectations.reserve(expectations_.size());
   for (const auto& e : expectations_) {
     expectations.push_back(e.ToString());
   }

--- a/test/core/promise/sleep_test.cc
+++ b/test/core/promise/sleep_test.cc
@@ -51,7 +51,7 @@ TEST(Sleep, Zzzz) {
   ExecCtx exec_ctx;
   Notification done;
   Timestamp done_time = Timestamp::Now() + Duration::Seconds(1);
-  auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
+  auto engine = GetDefaultEventEngine();
   // Sleep for one second then set done to true.
   auto activity = MakeActivity(
       Sleep(done_time), InlineWakeupScheduler(),
@@ -96,7 +96,7 @@ TEST(Sleep, AlreadyDone) {
   ExecCtx exec_ctx;
   Notification done;
   Timestamp done_time = Timestamp::Now() - Duration::Seconds(1);
-  auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
+  auto engine = GetDefaultEventEngine();
   // Sleep for no time at all then set done to true.
   auto activity = MakeActivity(
       Sleep(done_time), InlineWakeupScheduler(),
@@ -112,7 +112,7 @@ TEST(Sleep, Cancel) {
   ExecCtx exec_ctx;
   Notification done;
   Timestamp done_time = Timestamp::Now() + Duration::Seconds(1);
-  auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
+  auto engine = GetDefaultEventEngine();
   // Sleep for one second but race it to complete immediately
   auto activity = MakeActivity(
       Race(Sleep(done_time), [] { return absl::CancelledError(); }),
@@ -134,7 +134,7 @@ TEST(Sleep, MoveSemantics) {
   Timestamp done_time = Timestamp::Now() + Duration::Milliseconds(111);
   Sleep donor(done_time);
   Sleep sleeper = std::move(donor);
-  auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
+  auto engine = GetDefaultEventEngine();
   auto activity = MakeActivity(
       std::move(sleeper), InlineWakeupScheduler(),
       [&done](absl::Status r) {
@@ -153,7 +153,7 @@ TEST(Sleep, StressTest) {
   ExecCtx exec_ctx;
   std::vector<std::shared_ptr<Notification>> notifications;
   std::vector<ActivityPtr> activities;
-  auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
+  auto engine = GetDefaultEventEngine();
   gpr_log(GPR_INFO, "Starting %d sleeps for 1sec", kNumActivities);
   for (int i = 0; i < kNumActivities; i++) {
     auto notification = std::make_shared<Notification>();

--- a/test/cpp/end2end/client_crash_test.cc
+++ b/test/cpp/end2end/client_crash_test.cc
@@ -36,9 +36,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/subprocess.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 static std::string g_root;
 
 namespace grpc {

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -76,9 +76,6 @@
 #include "test/cpp/end2end/connection_attempt_injector.h"
 #include "test/cpp/end2end/test_service_impl.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 namespace grpc {
 namespace testing {
 namespace {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -60,9 +60,6 @@
 
 #include <gtest/gtest.h>
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-using grpc::testing::kTlsCredentialsType;
 using std::chrono::system_clock;
 
 namespace grpc {

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -44,9 +44,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/byte_buffer_proto_helper.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 namespace grpc {
 namespace testing {
 namespace {

--- a/test/cpp/end2end/flaky_network_test.cc
+++ b/test/cpp/end2end/flaky_network_test.cc
@@ -51,8 +51,6 @@
 #include "test/cpp/util/test_credentials_provider.h"
 
 #ifdef GPR_LINUX
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
 
 namespace grpc {
 namespace testing {

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -41,9 +41,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/byte_buffer_proto_helper.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 namespace grpc {
 namespace testing {
 namespace {

--- a/test/cpp/end2end/mock_test.cc
+++ b/test/cpp/end2end/mock_test.cc
@@ -42,11 +42,6 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-using grpc::testing::DefaultReactorTestPeer;
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-using grpc::testing::EchoTestService;
-using grpc::testing::MockClientReaderWriter;
 using std::vector;
 using ::testing::_;
 using ::testing::AtLeast;

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -65,9 +65,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/end2end/test_service_impl.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 namespace grpc {
 namespace testing {
 namespace {

--- a/test/cpp/end2end/shutdown_test.cc
+++ b/test/cpp/end2end/shutdown_test.cc
@@ -36,9 +36,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/test_credentials_provider.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 namespace grpc {
 namespace testing {
 

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -40,9 +40,6 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 #if defined(__APPLE__)
 // Use less # of threads on Mac because its test machines are less powerful
 // to finish the test on time. (context: b/185231823)

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -41,9 +41,6 @@
 #include "test/cpp/end2end/test_service_impl.h"
 #include "test/cpp/util/subprocess.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 static std::string g_root;
 
 static gpr_mu g_mu;

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -111,7 +111,6 @@ namespace {
 
 using ::envoy::config::listener::v3::FilterChainMatch;
 using ::envoy::config::rbac::v3::Policy;
-using ::envoy::config::rbac::v3::RBAC_Action;
 using ::envoy::config::rbac::v3::RBAC_Action_ALLOW;
 using ::envoy::config::rbac::v3::RBAC_Action_DENY;
 using ::envoy::config::rbac::v3::RBAC_Action_LOG;
@@ -2029,7 +2028,7 @@ TEST_P(XdsRbacTest, AbsentRbacPolicy) {
 TEST_P(XdsRbacTest, LogAction) {
   RBAC rbac;
   auto* rules = rbac.mutable_rules();
-  rules->set_action(envoy::config::rbac::v3::RBAC_Action_LOG);
+  rules->set_action(RBAC_Action_LOG);
   SetServerRbacPolicy(rbac);
   backends_[0]->Start();
   backends_[0]->notifier()->WaitOnServingStatusChange(

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -47,7 +47,6 @@ ABSL_FLAG(int32_t, port, 0, "Server port.");
 ABSL_FLAG(int32_t, max_send_message_size, -1, "The maximum send message size.");
 
 using grpc::Server;
-using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::ServerCredentials;
 using grpc::ServerReader;

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -129,7 +129,7 @@ void RunServer(bool secure_mode, const int port, const int maintenance_port,
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
   if (secure_mode) {
-    grpc::XdsServerBuilder xds_builder;
+    XdsServerBuilder xds_builder;
     xds_builder.RegisterService(&service);
     xds_builder.AddListeningPort(
         absl::StrCat("0.0.0.0:", port),

--- a/test/cpp/ios/CronetTests/CppCronetEnd2EndTests.mm
+++ b/test/cpp/ios/CronetTests/CppCronetEnd2EndTests.mm
@@ -39,10 +39,10 @@
 #import <vector>
 
 using namespace grpc::testing;
-using std::chrono::system_clock;
-using grpc::Status;
-using grpc::ServerContext;
 using grpc::ClientContext;
+using grpc::ServerContext;
+using grpc::Status;
+using std::chrono::system_clock;
 
 @interface CppCronetEnd2EndTests : XCTestCase
 

--- a/test/cpp/ios/CronetTests/TestHelper.mm
+++ b/test/cpp/ios/CronetTests/TestHelper.mm
@@ -21,12 +21,12 @@
 #import <grpcpp/impl/codegen/string_ref.h>
 #import <grpcpp/support/config.h>
 
-using std::chrono::system_clock;
+using grpc::ServerContext;
+using grpc::Status;
 using grpc::testing::EchoRequest;
 using grpc::testing::EchoResponse;
 using grpc::testing::EchoTestService;
-using grpc::ServerContext;
-using grpc::Status;
+using std::chrono::system_clock;
 
 std::atomic<int> PhonyInterceptor::num_times_run_;
 std::atomic<int> PhonyInterceptor::num_times_run_reverse_;

--- a/test/cpp/naming/resolver_component_tests_runner_invoker.cc
+++ b/test/cpp/naming/resolver_component_tests_runner_invoker.cc
@@ -61,8 +61,6 @@ ABSL_FLAG(std::string, extra_args, "",
           "Comma-separated list of opaque command args to plumb through to "
           "the binary pointed at by --test_bin_name");
 
-using grpc::SubProcess;
-
 namespace grpc {
 
 namespace testing {

--- a/test/cpp/server/load_reporter/load_reporter_test.cc
+++ b/test/cpp/server/load_reporter/load_reporter_test.cc
@@ -58,8 +58,7 @@ class MockCensusViewProvider : public CensusViewProvider {
  public:
   MOCK_METHOD0(FetchViewData, CensusViewProvider::ViewDataMap());
 
-  const ::opencensus::stats::ViewDescriptor& FindViewDescriptor(
-      const std::string& view_name) {
+  const ViewDescriptor& FindViewDescriptor(const std::string& view_name) {
     auto it = view_descriptor_map().find(view_name);
     GPR_ASSERT(it != view_descriptor_map().end());
     return it->second;

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -69,7 +69,7 @@ std::string output_json("output.json");
 
 // Creata an echo server
 class EchoServerImpl final : public grpc::testing::TestService::Service {
-  Status EmptyCall(grpc::ServerContext* /*context*/,
+  Status EmptyCall(ServerContext* /*context*/,
                    const grpc::testing::Empty* /*request*/,
                    grpc::testing::Empty* /*response*/) override {
     return Status::OK;
@@ -118,7 +118,7 @@ TEST(ChannelzSamplerTest, SimpleTest) {
   // start server
   grpc::channelz::experimental::InitChannelzService();
   EchoServerImpl service;
-  grpc::ServerBuilder builder;
+  ServerBuilder builder;
   auto server_creds =
       grpc::testing::GetCredentialsProvider()->GetServerCredentials(
           custom_credentials_type);

--- a/test/cpp/util/cli_call_test.cc
+++ b/test/cpp/util/cli_call_test.cc
@@ -33,9 +33,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/string_ref_helper.h"
 
-using grpc::testing::EchoRequest;
-using grpc::testing::EchoResponse;
-
 namespace grpc {
 namespace testing {
 

--- a/test/cpp/util/tls_test_utils.cc
+++ b/test/cpp/util/tls_test_utils.cc
@@ -22,7 +22,6 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-using ::grpc::experimental::ExternalCertificateVerifier;
 using ::grpc::experimental::TlsCustomVerificationCheckRequest;
 
 namespace grpc {

--- a/tools/dockerfile/grpc_clang_format/Dockerfile
+++ b/tools/dockerfile/grpc_clang_format/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:13
+FROM silkeh/clang:15-bullseye
 
 ADD clang_format_all_the_things.sh /
 

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:13
+FROM silkeh/clang:15-bullseye
 
 # Install prerequisites for the clang-tidy script
 RUN apt-get update && apt-get install -y python3 jq git && apt-get clean

--- a/tools/dockerfile/grpc_iwyu/Dockerfile
+++ b/tools/dockerfile/grpc_iwyu/Dockerfile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Docker file for running IWYU.
+# Updated: 2022-11-03
+
 FROM silkeh/clang:15-bullseye
 
 # Install prerequisites for the iwyu script

--- a/tools/dockerfile/grpc_iwyu/Dockerfile
+++ b/tools/dockerfile/grpc_iwyu/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:13
+FROM silkeh/clang:15-bullseye
 
 # Install prerequisites for the iwyu script
 RUN apt-get update && apt-get install -y python3 jq git cmake python zlib1g-dev libtinfo-dev && apt-get clean

--- a/tools/dockerfile/grpc_iwyu/iwyu.sh
+++ b/tools/dockerfile/grpc_iwyu/iwyu.sh
@@ -24,12 +24,12 @@ CPU_COUNT=`nproc`
 
 rm -rf iwyu || true
 git clone https://github.com/include-what-you-use/include-what-you-use.git iwyu
-# latest commit on the clang 14 branch
+# latest commit on the clang 15 branch
 cd ${IWYU_ROOT}/iwyu
-git checkout abd5d2bd6320867d3605227a7f798a4e08fef896
+git checkout f20eadd2060103543dac46732cb4dd7dbed970e2
 mkdir -p ${IWYU_ROOT}/iwyu_build
 cd ${IWYU_ROOT}/iwyu_build
-cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ROOT_DIR=/usr/lib/llvm-14 ${IWYU_ROOT}/iwyu 
+cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ROOT_DIR=/usr/lib/llvm-15 ${IWYU_ROOT}/iwyu 
 make -j $CPU_COUNT
 cd ${IWYU_ROOT}
 

--- a/tools/dockerfile/grpc_iwyu/iwyu.sh
+++ b/tools/dockerfile/grpc_iwyu/iwyu.sh
@@ -24,12 +24,12 @@ CPU_COUNT=`nproc`
 
 rm -rf iwyu || true
 git clone https://github.com/include-what-you-use/include-what-you-use.git iwyu
-# latest commit on the clang 13 branch
+# latest commit on the clang 14 branch
 cd ${IWYU_ROOT}/iwyu
-git checkout fbd921d6640bf1b18fe5a8a895636215367eb6b9
+git checkout abd5d2bd6320867d3605227a7f798a4e08fef896
 mkdir -p ${IWYU_ROOT}/iwyu_build
 cd ${IWYU_ROOT}/iwyu_build
-cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ROOT_DIR=/usr/lib/llvm-13 ${IWYU_ROOT}/iwyu 
+cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DLLVM_ROOT_DIR=/usr/lib/llvm-14 ${IWYU_ROOT}/iwyu 
 make -j $CPU_COUNT
 cd ${IWYU_ROOT}
 

--- a/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:13
+FROM silkeh/clang:15-bullseye
 
 RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
 #====================

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:13
+FROM silkeh/clang:15-bullseye
 
 #=================
 # Basic C core dependencies

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -492,8 +492,8 @@ class CLanguage(object):
             return ('alpine', [])
         elif compiler == 'clang6':
             return ('clang_6', self._clang_cmake_configure_extra_args())
-        elif compiler == 'clang13':
-            return ('clang_13', self._clang_cmake_configure_extra_args())
+        elif compiler == 'clang15':
+            return ('clang_15', self._clang_cmake_configure_extra_args())
         else:
             raise Exception('Compiler %s not supported.' % compiler)
 
@@ -1463,7 +1463,7 @@ argp.add_argument(
         'gcc12',
         'gcc_musl',
         'clang6',
-        'clang13',
+        'clang15',
         'python2.7',
         'python3.5',
         'python3.7',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -301,7 +301,7 @@ def _create_portability_test_jobs(extra_args=[],
     # portability C and C++ on x64
     for compiler in [
             'gcc7', 'gcc10.2_openssl102', 'gcc12', 'gcc_musl', 'clang6',
-            'clang13'
+            'clang15'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],
                                     configs=['dbg'],


### PR DESCRIPTION
Update all docker images using clang from 13 to 15.

A few changes:
- clang_format slightly changes how to format code.
- clang_tidy introduced new following checks which had to be disabled because they needed significant code changes;
   - `bugprone-assignment-in-if-condition`
   - `bugprone-easily-swappable-parameters`
   - `bugprone-unchecked-optional-access`
- Following checks of clang_tidy became more strict so some changes are made to accommodate them;
  - `google-readability-casting`: It started having a few false positives so I disabled it. We may want to revisit this check.
  - `performance-inefficient-vector-operation`: It started catching more so I ran autofix to change suggested fixes.
  - `readability-simplify-boolean-expr`: It introduced more checks (DeMorgan) but its suggestion might not be ideal so I added a new option to exclude DeMorgan case.

This PR deprecates https://github.com/grpc/grpc/pull/30300