### PR TITLE
DRAFT: Helper scripts and a single test for csharp Grpc.Tools distrib testing 

### DIFF
--- a/src/csharp/nuget_helpers/create_dev_patched_grpc_tools.sh
+++ b/src/csharp/nuget_helpers/create_dev_patched_grpc_tools.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ***** FOR DEV TESTING ONLY *****
+# Create a grpc.tools NuGet package by patching an existing NuGet package
+# and replacing some of the files with dev files.
+# At the moment this just replaces the MSBuild files.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# parse args
+# -p original package
+# -w working directory (optional - default: /tmp)
+# -d destination directory (optional - default: . )
+# -v new package version number (optional - default: 9.99.0-dev)
+# -s grpc.tools source directory (optional - default: ../Grpc.Tools relative to this dir)
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p)
+            ORIG_PACKAGE="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -w)
+            WORKING_DIR="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -d)
+            DESTINATION_DIR="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -v)
+            VERSION_NUMBER="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -s)
+            SRC_DIR="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        *)
+            echo "Unknown argument $1"
+            exit 1
+    esac
+done
+
+[[ ! -f $ORIG_PACKAGE ]] && { echo "-p original package '$ORIG_PACKAGE' not found"; exit 1; }
+
+if [[ ! -d $DESTINATION_DIR ]];
+then
+    DESTINATION_DIR=.
+fi
+
+if [[ -z $SRC_DIR ]];
+then
+    SRC_DIR=$(realpath $SCRIPT_DIR/../Grpc.Tools)
+fi
+
+[[ ! -d $SRC_DIR ]] && { echo "Source directory '$SRC_DIR' not found"; exit 1; }
+
+if [[ -z $WORKING_DIR ]];
+then
+    WORKING_DIR=$TMPDIR
+fi
+
+[[ ! -d $WORKING_DIR ]] && { echo "-w working directory '$WORKING_DIR' not found"; exit 1; }
+
+if [[ -z $VERSION_NUMBER ]];
+then
+    VERSION_NUMBER=9.99.0-dev
+fi
+
+echo "Using"
+echo "     Original package: $ORIG_PACKAGE"
+echo " Dest dir for package: $DESTINATION_DIR"
+echo "           Source dir: $SRC_DIR"
+echo "       Version number: $VERSION_NUMBER"
+echo "          Working dir: $WORKING_DIR"
+
+set -ex
+
+UNPACK_DIR=$WORKING_DIR/toolspatch
+# clean working dir
+if [[ -n "$UNPACK_DIR" && -d $UNPACK_DIR ]];
+then
+    if [[ -d $UNPACK_DIR.bak ]];
+    then
+        rm -rf $UNPACK_DIR.bak
+    fi
+    mv $UNPACK_DIR $UNPACK_DIR.bak
+fi
+
+# extract files from original
+unzip $ORIG_PACKAGE -d $UNPACK_DIR
+
+# remove some files
+rm -rf $UNPACK_DIR/package
+rm -rf $UNPACK_DIR/_rels
+rm $UNPACK_DIR/'[Content_Types].xml'
+rm $UNPACK_DIR/.signature.p7s
+
+# edit version number in NuSpec
+sed -i "s/<version>.*<\/version>/<version>$VERSION_NUMBER<\/version>/" $UNPACK_DIR/Grpc.Tools.nuspec
+
+# copy in new files
+cp -fv $SRC_DIR/build/_grpc/_Grpc.Tools.props $UNPACK_DIR/build/_grpc/
+cp -fv $SRC_DIR/build/_grpc/_Grpc.Tools.targets $UNPACK_DIR/build/_grpc/
+cp -fv $SRC_DIR/build/_protobuf/Google.Protobuf.Tools.props $UNPACK_DIR/build/_protobuf/
+cp -fv $SRC_DIR/build/_protobuf/Google.Protobuf.Tools.targets $UNPACK_DIR/build/_protobuf/
+
+# build the new package
+nuget pack -OutputDirectory "$DESTINATION_DIR" $UNPACK_DIR/Grpc.Tools.nuspec

--- a/test/distrib/csharp/.gitignore
+++ b/test/distrib/csharp/.gitignore
@@ -1,0 +1,6 @@
+packages
+*.userprefs
+*.csproj.user
+*.suo
+/TestNugetFeed
+

--- a/test/distrib/csharp/NuGet.Config
+++ b/test/distrib/csharp/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="https://www.nuget.org/api/v2/" value="https://www.nuget.org/api/v2/" />
+    <add key="TestNugetFeed" value="TestNugetFeed" />
+  </packageSources>
+</configuration>

--- a/test/distrib/csharp/TestAtPath/.gitignore
+++ b/test/distrib/csharp/TestAtPath/.gitignore
@@ -1,0 +1,5 @@
+bin
+obj
+*.lock.json
+net5_singlefile_publish
+

--- a/test/distrib/csharp/TestAtPath/@duplicate_proto/testcodegen.proto
+++ b/test/distrib/csharp/TestAtPath/@duplicate_proto/testcodegen.proto
@@ -1,0 +1,23 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test that codegen works well in case the .csproj has .proto files
+// of the same name, but under different directories (see #17672).
+syntax = "proto3";
+
+package grpc_csharp_distribtest.duplicate_proto;
+
+message MessageFromDuplicateProto {
+  string name = 1;
+}

--- a/test/distrib/csharp/TestAtPath/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/TestAtPath/DistribTestDotNet.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <!-- <PackageReference Include="Grpc.Tools" Version="2.99.0-dev" /> -->
-    <PackageReference Include="Grpc.Tools" Version="2.99.0-dev" />
+    <PackageReference Include="Grpc.Tools" Version="__GRPC_NUGET_VERSION__" />
     <!-- Grpc.Core.Api is not the package under test, it's included only so that gRPC generated service stubs can compile. -->
     <PackageReference Include="Grpc.Core.Api" Version="2.46.5" />
     <PackageReference Include="Google.Protobuf" Version="3.21.8" />

--- a/test/distrib/csharp/TestAtPath/DistribTestDotNet.csproj
+++ b/test/distrib/csharp/TestAtPath/DistribTestDotNet.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+
+    <!-- set TargetFrameworks, but allow skipping selected frameworks by setting env variables -->
+    <TargetFrameworks></TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NET45_DISTRIBTEST)' == ''">$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NETCOREAPP21_DISTRIBTEST)' == ''">$(TargetFrameworks);netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NETCOREAPP31_DISTRIBTEST)' == ''">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(SKIP_NET50_DISTRIBTEST)' == ''">$(TargetFrameworks);net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- <PackageReference Include="Grpc.Tools" Version="2.99.0-dev" /> -->
+    <PackageReference Include="Grpc.Tools" Version="2.99.0-dev" />
+    <!-- Grpc.Core.Api is not the package under test, it's included only so that gRPC generated service stubs can compile. -->
+    <PackageReference Include="Grpc.Core.Api" Version="2.46.5" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="**\*.proto" />
+  </ItemGroup>
+
+  <!-- Needed for the net45 build to work on Unix. See https://github.com/dotnet/designs/pull/33 -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/test/distrib/csharp/TestAtPath/Program.cs
+++ b/test/distrib/csharp/TestAtPath/Program.cs
@@ -1,0 +1,63 @@
+#region Copyright notice and license
+
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Grpc.Core;
+using GrpcCsharpDistribtest.Helloworld;
+
+namespace TestGrpcPackage
+{
+    class MainClass
+    {
+        public static void Main(string[] args)
+        {
+            CheckGreeterProtobufCodegenWorks();
+            CheckGreeterGrpcProtobufPluginCodegenWorks();
+            CheckDuplicateProtoFilesAreOk();
+        }
+
+        private static object CheckGreeterProtobufCodegenWorks()
+        {
+            return new HelloRequest { Name = "ABC" };
+        }
+
+        private static object CheckGreeterGrpcProtobufPluginCodegenWorks()
+        {
+            return typeof(GreeterImpl);
+        }
+
+        // Test that codegen works well in case the .csproj has .proto files
+        // of the same name, but under different directories (see #17672).
+        // This method doesn't need to be used, it is enough to check that it builds.
+        private static object CheckDuplicateProtoFilesAreOk()
+        {
+            return new GrpcCsharpDistribtest.DuplicateProto.MessageFromDuplicateProto();
+        }
+    }
+
+    class GreeterImpl : Greeter.GreeterBase
+    {
+        // Server side handler of the SayHello RPC
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+        }
+    }
+}

--- a/test/distrib/csharp/TestAtPath/testcodegen.proto
+++ b/test/distrib/csharp/TestAtPath/testcodegen.proto
@@ -1,0 +1,29 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc_csharp_distribtest.helloworld;
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/test/distrib/csharp/dev_run_distrib_test_dotnetcli.sh
+++ b/test/distrib/csharp/dev_run_distrib_test_dotnetcli.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#           ***** HELPER SCRIPT FOR DEV TESTING ONLY ******
+#
+# Run the C# distrib tests in a dev environment
+#
+# ** PRE-REQUISITES **
+#
+# - Assumes you have already copied a dev version of Grpc.Tools nuget package
+#   to the TestNugetFeed directory.
+#   NOTE: one way to create a dev nuget package is to use the script
+#      src/csharp/nuget_helpers/create_dev_patched_grpc_tools.sh
+#
+# - You may want to clear the local NuGet cache to make sure the tests use
+#   the correct nuget package if you have made changes but not changed the
+#   version number:
+#      dotnet nuget locals all --clear
+#   or
+#      nuget locals all -clear
+#   Alternatively set a different directory for the local NuGet cache
+#      export NUGET_PACKAGES=<some directory>
+
+# Parameters
+# -v nuget package version number
+#     default: 9.99.0-dev
+# -t test to run (can repeat multiple -t params)
+#     detault: DistribTest
+# -f frameworks (can repeat multiple -f params)
+#     default frameworks: net45 netcoreapp21 netcoreapp31 net50
+#
+# On Windows use Git Bash or Cygwin terminal
+#
+# E.g.  ./dev_run_distrib_test_dotnetcli.sh -v 2.99.0-dev -f netcoreapp31 -t TestAtPath
+#
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# determine OS
+OS="unknown"
+case "$OSTYPE" in
+  darwin*)  OS="OSX" ;;
+  linux*)   OS="LINUX" ;;
+  msys*)    OS="WINDOWS" ;; # Git Bash
+  cygwin*)  OS="WINDOWS" ;; # Cygwin
+  *)        OS="unknown" ;;
+esac
+
+TEST_DIRS=()
+FRAMEWORKS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -t)
+            TEST_DIRS+=("$2")
+            shift # past argument
+            shift # past value
+            ;;
+        -v)
+            VERSION_NUMBER="$2"
+            shift # past argument
+            shift # past value
+            ;;
+        -f)
+            FRAMEWORKS+=("$2")
+            shift # past argument
+            shift # past value
+            ;;
+        *)
+            echo "Unknown argument $1"
+            exit 1
+    esac
+done
+
+if [[ -z $VERSION_NUMBER ]];
+then
+    VERSION_NUMBER=9.99.0-dev
+fi
+
+if [[ ${#TEST_DIRS[*]} == 0 ]];
+then
+  TEST_DIRS=("DistribTest")
+fi
+
+if [[ ${#FRAMEWORKS[*]} == 0 ]];
+then
+  FRAMEWORKS=("net45" "netcoreapp21" "netcoreapp31" "net50")
+fi
+
+echo "Using test parameters:"
+echo "    Version number: $VERSION_NUMBER"
+echo "  Test directories: ${TEST_DIRS[*]}"
+echo "        Frameworks: ${FRAMEWORKS[*]}"
+echo ""
+
+#set -ex
+
+# set environment variables expected in the proj files for each framework
+export SKIP_NET45_DISTRIBTEST=1
+export SKIP_NETCOREAPP21_DISTRIBTEST=1
+export SKIP_NETCOREAPP31_DISTRIBTEST=1
+export SKIP_NET50_DISTRIBTEST=1
+
+for framework in ${FRAMEWORKS}; do
+  if [[ $framework == "net45" ]]
+  then
+    unset SKIP_NET45_DISTRIBTEST
+  elif [[ $framework == "netcoreapp21" ]]
+  then
+    unset SKIP_NETCOREAPP21_DISTRIBTEST
+  elif [[ $framework == "netcoreapp31" ]]
+  then
+    unset SKIP_NETCOREAPP31_DISTRIBTEST
+  elif [[ $framework == "net50" ]]
+  then
+    unset SKIP_NET50_DISTRIBTEST
+  fi
+done
+
+echo "Framework env variables:"
+echo "SKIP_NET45_DISTRIBTEST=$SKIP_NET45_DISTRIBTEST"
+echo "SKIP_NETCOREAPP21_DISTRIBTEST=$SKIP_NETCOREAPP21_DISTRIBTEST"
+echo "SKIP_NETCOREAPP31_DISTRIBTEST=$SKIP_NETCOREAPP31_DISTRIBTEST"
+echo "SKIP_NET50_DISTRIBTEST=$SKIP_NET50_DISTRIBTEST"
+echo ""
+
+# run test in each test directory
+for test_dir in ${TEST_DIRS}; do
+  dir=$(realpath $SCRIPT_DIR/$test_dir)
+  echo ">>>>> Test directory: $dir"
+  echo ""
+  [[ ! -d $dir ]] && { echo "Test dir '$dir' not found"; exit 1; }
+  cd $dir
+
+  # update version number for Grpc.Tools in project file
+  sed -ibak "s/Include=\"Grpc.Tools\" Version=\".*\"/Include=\"Grpc.Tools\" Version=\"$VERSION_NUMBER\"/g" DistribTestDotNet.csproj
+
+  # restore the project
+  echo "Restore..."
+  dotnet restore DistribTestDotNet.csproj
+  [[ $? -ne 0 ]] && { echo "dotnet restore command failed"; exit 1; }
+
+  # clean
+  echo "Clean..."
+  dotnet clean DistribTestDotNet.csproj
+  [[ $? -ne 0 ]] && { echo "dotnet clean command failed"; exit 1; }
+
+  # build
+  echo "Build..."
+  dotnet build DistribTestDotNet.csproj
+  [[ $? -ne 0 ]] && { echo "dotnet build command failed"; exit 1; }
+
+  # check what was build
+  echo "Generated CS files..."
+  find obj -name "Test*.cs"
+  echo "Output files..."
+  ls -R bin
+  echo ""
+
+  # publish and run for each framework
+
+  if [ "${SKIP_NET45_DISTRIBTEST}" != "1" ]
+  then
+    echo ""
+    echo ">>>>> Framework net45 (mono)"
+    echo "publish..."
+    dotnet publish -f net45 DistribTestDotNet.csproj
+    [[ $? -ne 0 ]] && { echo "dotnet publish command failed"; exit 1; }
+
+    # .NET 4.5 target after dotnet build
+    echo "running..."
+    mono bin/Debug/net45/DistribTestDotNet.exe
+    [[ $? -ne 0 ]] && { echo "mono running DistribTestDotNet.exe command failed"; exit 1; }
+
+    # .NET 4.5 target after dotnet publish
+    echo "running publish..."
+    mono bin/Debug/net45/publish/DistribTestDotNet.exe
+    [[ $? -ne 0 ]] && { echo "mono running published DistribTestDotNet.exe command failed"; exit 1; }
+  fi
+
+  if [ "${SKIP_NETCOREAPP21_DISTRIBTEST}" != "1" ]
+  then
+    echo ""
+    echo ">>>>> Framework netcoreapp21"
+    echo "publish..."
+    dotnet publish -f netcoreapp2.1 DistribTestDotNet.csproj
+    [[ $? -ne 0 ]] && { echo "dotnet publish command failed"; exit 1; }
+
+    # .NET Core target after dotnet build
+    echo "running..."
+    dotnet exec bin/Debug/netcoreapp2.1/DistribTestDotNet.dll
+    [[ $? -ne 0 ]] && { echo "running DistribTestDotNet.dll command failed"; exit 1; }
+
+    # .NET Core target after dotnet publish
+    echo "running publish..."
+    dotnet exec bin/Debug/netcoreapp2.1/publish/DistribTestDotNet.dll
+    [[ $? -ne 0 ]] && { echo "running published DistribTestDotNet.dll command failed"; exit 1; }
+  fi
+
+  if [ "${SKIP_NETCOREAPP31_DISTRIBTEST}" != "1" ]
+  then
+    echo ""
+    echo ">>>>> Framework netcoreapp31"
+    echo "publish..."
+    dotnet publish -f netcoreapp3.1 DistribTestDotNet.csproj
+    [[ $? -ne 0 ]] && { echo "dotnet publish command failed"; exit 1; }
+
+    # .NET Core target after dotnet build
+    echo "running..."
+    dotnet exec bin/Debug/netcoreapp3.1/DistribTestDotNet.dll
+    [[ $? -ne 0 ]] && { echo "running DistribTestDotNet.dll command failed"; exit 1; }
+
+    # .NET Core target after dotnet publish
+    echo "running publish..."
+    dotnet exec bin/Debug/netcoreapp3.1/publish/DistribTestDotNet.dll
+    [[ $? -ne 0 ]] && { echo "running published DistribTestDotNet.dll command failed"; exit 1; }
+  fi
+
+  if [ "${SKIP_NET50_DISTRIBTEST}" != "1" ]
+  then
+    echo ""
+    echo ">>>>> Framework net50"
+    echo "publish..."
+    dotnet publish -f net5.0 DistribTestDotNet.csproj
+    [[ $? -ne 0 ]] && { echo "dotnet publish command failed"; exit 1; }
+
+    # .NET Core target after dotnet build
+    echo "running..."
+    dotnet exec bin/Debug/net5.0/DistribTestDotNet.dll
+    [[ $? -ne 0 ]] && { echo "running DistribTestDotNet.dll command failed"; exit 1; }
+
+    # .NET Core target after dotnet publish
+    echo "running published..."
+    dotnet exec bin/Debug/net5.0/publish/DistribTestDotNet.dll
+    [[ $? -ne 0 ]] && { echo "running published DistribTestDotNet.dll command failed"; exit 1; }
+
+    if [[ $OS == "LINUX" ]]
+    then
+      echo "publish single binary..."
+      dotnet publish -r linux-x64 -f net5.0 DistribTestDotNet.csproj -p:PublishSingleFile=true --self-contained true --output net5_singlefile_publish
+      [[ $? -ne 0 ]] && { echo "dotnet publish to single file command failed"; exit 1; }
+
+      # binary generated by the single file publish
+      echo "running single binary..."
+      ./net5_singlefile_publish/DistribTestDotNet
+      [[ $? -ne 0 ]] && { echo "running single file command failed"; exit 1; }
+
+    elif [[ $OS == "WINDOWS" ]]
+    then
+      echo "publish single binary..."
+      dotnet publish -r win-x64 -f net5.0 DistribTestDotNet.csproj -p:PublishSingleFile=true --self-contained true --output net5_singlefile_publish
+      [[ $? -ne 0 ]] && { echo "dotnet publish to single file command failed"; exit 1; }
+
+      # binary generated by the single file publish
+      echo "running single binary..."
+      ./net5_singlefile_publish/DistribTestDotNet.exe
+      [[ $? -ne 0 ]] && { echo "running single file command failed"; exit 1; }
+    fi
+  fi
+
+  echo "Finished test $dir"
+
+done # tests loop


### PR DESCRIPTION
Based on the csharp distrib tests (**which are currently not in master**) - some helper scripts for running developer tests for Grpc.Tools on Linux and Windows.  Windows requires Git Bash or Cygwin.

- `src/csharp/nuget_helpers/create_dev_patched_grpc_tools.sh` - script for patching a Grpc.Tools NuGet package
- `test/distrib/csharp/dev_run_distrib_test_dotnetcli.sh` - script for running tests. There are some pre-requisites that the developer needs to set up first. These are in the script's comments.
- ` test/distrib/csharp/TestAtPath/` - an exampe test that tests proto files with '@' in path names

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

