### PR TITLE
Remove remaining XDS dependencies when `grpc_no_xds=true` is specified

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2602,7 +2602,6 @@ grpc_cc_library(
         "//src/core:ext/filters/client_channel/health/health_check_client.cc",
         "//src/core:ext/filters/client_channel/http_proxy.cc",
         "//src/core:ext/filters/client_channel/lb_policy/child_policy_handler.cc",
-        "//src/core:ext/filters/client_channel/lb_policy/oob_backend_metric.cc",
         "//src/core:ext/filters/client_channel/local_subchannel_pool.cc",
         "//src/core:ext/filters/client_channel/retry_filter.cc",
         "//src/core:ext/filters/client_channel/retry_service_config.cc",
@@ -2611,7 +2610,12 @@ grpc_cc_library(
         "//src/core:ext/filters/client_channel/subchannel.cc",
         "//src/core:ext/filters/client_channel/subchannel_pool_interface.cc",
         "//src/core:ext/filters/client_channel/subchannel_stream_client.cc",
-    ],
+    ] + select({
+        "grpc_no_xds": [],
+        "//conditions:default": [
+            "//src/core:ext/filters/client_channel/lb_policy/oob_backend_metric.cc",
+        ],
+    }),
     hdrs = [
         "//src/core:ext/filters/client_channel/backend_metric.h",
         "//src/core:ext/filters/client_channel/backup_poller.h",
@@ -2626,7 +2630,6 @@ grpc_cc_library(
         "//src/core:ext/filters/client_channel/health/health_check_client.h",
         "//src/core:ext/filters/client_channel/http_proxy.h",
         "//src/core:ext/filters/client_channel/lb_policy/child_policy_handler.h",
-        "//src/core:ext/filters/client_channel/lb_policy/oob_backend_metric.h",
         "//src/core:ext/filters/client_channel/local_subchannel_pool.h",
         "//src/core:ext/filters/client_channel/retry_filter.h",
         "//src/core:ext/filters/client_channel/retry_service_config.h",
@@ -2635,7 +2638,16 @@ grpc_cc_library(
         "//src/core:ext/filters/client_channel/subchannel_interface_internal.h",
         "//src/core:ext/filters/client_channel/subchannel_pool_interface.h",
         "//src/core:ext/filters/client_channel/subchannel_stream_client.h",
-    ],
+    ] + select({
+        "grpc_no_xds": [],
+        "//conditions:default": [
+            "//src/core:ext/filters/client_channel/lb_policy/oob_backend_metric.h",
+        ],
+    }),
+    defines = select({
+        "grpc_no_xds": ["GRPC_NO_XDS"],
+        "//conditions:default": [],
+    }),
     external_deps = [
         "absl/base:core_headers",
         "absl/container:inlined_vector",
@@ -2670,8 +2682,6 @@ grpc_cc_library(
         "stats",
         "uri_parser",
         "work_serializer",
-        "xds_orca_service_upb",
-        "xds_orca_upb",
         "//src/core:arena",
         "//src/core:channel_fwd",
         "//src/core:channel_init",
@@ -2710,7 +2720,13 @@ grpc_cc_library(
         "//src/core:unique_type_name",
         "//src/core:useful",
         "//src/core:validation_errors",
-    ],
+    ] + select({
+        "grpc_no_xds": [],
+        "//conditions:default": [
+            "xds_orca_service_upb",
+            "xds_orca_upb",
+        ],
+    }),
 )
 
 grpc_cc_library(

--- a/src/core/ext/filters/client_channel/backend_metric.cc
+++ b/src/core/ext/filters/client_channel/backend_metric.cc
@@ -25,12 +25,16 @@
 #include "absl/strings/string_view.h"
 #include "upb/upb.h"
 #include "upb/upb.hpp"
+
+#ifndef GRPC_NO_XDS
 #include "xds/data/orca/v3/orca_load_report.upb.h"
+#endif
 
 namespace grpc_core {
 
 namespace {
 
+#ifndef GRPC_NO_XDS
 template <typename EntryType>
 std::map<absl::string_view, double> ParseMap(
     xds_data_orca_v3_OrcaLoadReport* msg,
@@ -51,12 +55,16 @@ std::map<absl::string_view, double> ParseMap(
   }
   return result;
 }
+#endif
 
 }  // namespace
 
 const BackendMetricData* ParseBackendMetricData(
     absl::string_view serialized_load_report,
     BackendMetricAllocatorInterface* allocator) {
+#ifdef GRPC_NO_XDS
+  return nullptr;
+#else
   upb::Arena upb_arena;
   xds_data_orca_v3_OrcaLoadReport* msg = xds_data_orca_v3_OrcaLoadReport_parse(
       serialized_load_report.data(), serialized_load_report.size(),
@@ -79,6 +87,7 @@ const BackendMetricData* ParseBackendMetricData(
           xds_data_orca_v3_OrcaLoadReport_UtilizationEntry_key,
           xds_data_orca_v3_OrcaLoadReport_UtilizationEntry_value, allocator);
   return backend_metric_data;
+#endif
 }
 
 }  // namespace grpc_core

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -30,7 +30,6 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
-#include "src/core/ext/filters/client_channel/lb_policy/oob_backend_metric.h"
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/config/core_configuration.h"
@@ -48,6 +47,10 @@
 #include "src/core/lib/load_balancing/lb_policy_registry.h"
 #include "src/core/lib/load_balancing/subchannel_interface.h"
 #include "src/core/lib/uri/uri_parser.h"
+
+#ifndef GRPC_NO_XDS
+#include "src/core/ext/filters/client_channel/lb_policy/oob_backend_metric.h"
+#endif
 
 namespace grpc_core {
 
@@ -553,6 +556,7 @@ class FixedAddressFactory : public LoadBalancingPolicyFactory {
   }
 };
 
+#ifndef GRPC_NO_XDS
 //
 // OobBackendMetricTestLoadBalancingPolicy
 //
@@ -674,6 +678,7 @@ class OobBackendMetricTestFactory : public LoadBalancingPolicyFactory {
  private:
   OobBackendMetricCallback cb_;
 };
+#endif  // !defined(GRPC_NO_XDS)
 
 //
 // FailLoadBalancingPolicy
@@ -776,11 +781,13 @@ void RegisterFixedAddressLoadBalancingPolicy(
       std::make_unique<FixedAddressFactory>());
 }
 
+#ifndef GRPC_NO_XDS
 void RegisterOobBackendMetricTestLoadBalancingPolicy(
     CoreConfiguration::Builder* builder, OobBackendMetricCallback cb) {
   builder->lb_policy_registry()->RegisterLoadBalancingPolicyFactory(
       std::make_unique<OobBackendMetricTestFactory>(std::move(cb)));
 }
+#endif
 
 void RegisterFailLoadBalancingPolicy(CoreConfiguration::Builder* builder,
                                      absl::Status status,

--- a/test/core/util/test_lb_policies.h
+++ b/test/core/util/test_lb_policies.h
@@ -79,10 +79,12 @@ void RegisterFixedAddressLoadBalancingPolicy(
 using OobBackendMetricCallback =
     std::function<void(ServerAddress, const BackendMetricData&)>;
 
+#ifndef GRPC_NO_XDS
 // Registers an LB policy called "oob_backend_metric_test_lb" that invokes
 // cb for each OOB backend metric report on each subchannel.
 void RegisterOobBackendMetricTestLoadBalancingPolicy(
     CoreConfiguration::Builder* builder, OobBackendMetricCallback cb);
+#endif
 
 // Registers an LB policy called "fail_lb" that fails all picks with the
 // specified status.  If pick_counter is non-null, it will be

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -2632,6 +2632,7 @@ TEST_F(ClientLbAddressTest, Basic) {
   EXPECT_EQ(addresses_seen(), expected);
 }
 
+#ifndef GRPC_NO_XDS
 //
 // tests OOB backend metric API
 //
@@ -2742,6 +2743,7 @@ TEST_F(OobBackendMetricTest, Basic) {
     gpr_sleep_until(grpc_timeout_seconds_to_deadline(1));
   }
 }
+#endif  // !defined(GRPC_NO_XDS)
 
 //
 // tests rewriting of control plane status codes


### PR DESCRIPTION
Previously, gRPC still pulled in XDS dependencies even when `grpc_no_xds=true` was specified.
