### PR TITLE
Fix lack of cooldown between poll attempts

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pxd.pxi
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cdef int g_interrupt_check_period_ms = 200
+cdef int g_interrupt_check_period_ms
 
 cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline) except *
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+g_interrupt_check_period_ms = 200
+
 cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline) except *:
   global g_interrupt_check_period_ms
   cdef gpr_timespec c_increment


### PR DESCRIPTION
Cython was previously ignoring the value in the `pxd` file and zero-initializing the period. Meanwhile, an issue with our continuous benchmarks meant that this was not noticed until now. This should result in a significant decrease in CPU usage.
