### PR TITLE
Actually record CPU usage in Python Benchmark worker

### DIFF
--- a/src/python/grpcio_tests/tests/qps/worker_server.py
+++ b/src/python/grpcio_tests/tests/qps/worker_server.py
@@ -17,7 +17,13 @@ import multiprocessing
 import random
 import threading
 import time
-import resource
+
+try:
+    # The resource module is not available on Windows. While this server only
+    # supports Linux, we must still be _importable_ on Windows.
+    import resource
+except ImportError:
+    pass
 
 import grpc
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -109,13 +109,13 @@ trap deleteImages EXIT
 
 # Build and push prebuilt images for running tests.
 time ../test-infra/bin/prepare_prebuilt_workers \
-    -l "cxx:${GRPC_CORE_GITREF}" \
+    -l "cxx:${GRPC_GITREF}" \
     -l "dotnet:${GRPC_DOTNET_GITREF}" \
     -l "go:${GRPC_GO_GITREF}" \
     -l "java:${GRPC_JAVA_GITREF}" \
-    -l "php7:${GRPC_CORE_GITREF}" \
-    -l "python:${GRPC_CORE_GITREF}" \
-    -l "ruby:${GRPC_CORE_GITREF}" \
+    -l "php7:${GRPC_GITREF}" \
+    -l "python:${GRPC_GITREF}" \
+    -l "ruby:${GRPC_GITREF}" \
     -p "${PREBUILT_IMAGE_PREFIX}" \
     -t "${UNIQUE_IDENTIFIER}" \
     -r "${ROOT_DIRECTORY_OF_DOCKERFILES}"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -109,13 +109,13 @@ trap deleteImages EXIT
 
 # Build and push prebuilt images for running tests.
 time ../test-infra/bin/prepare_prebuilt_workers \
-    -l "cxx:${GRPC_GITREF}" \
+    -l "cxx:${GRPC_CORE_GITREF}" \
     -l "dotnet:${GRPC_DOTNET_GITREF}" \
     -l "go:${GRPC_GO_GITREF}" \
     -l "java:${GRPC_JAVA_GITREF}" \
-    -l "php7:${GRPC_GITREF}" \
-    -l "python:${GRPC_GITREF}" \
-    -l "ruby:${GRPC_GITREF}" \
+    -l "php7:${GRPC_CORE_GITREF}" \
+    -l "python:${GRPC_CORE_GITREF}" \
+    -l "ruby:${GRPC_CORE_GITREF}" \
     -p "${PREBUILT_IMAGE_PREFIX}" \
     -t "${UNIQUE_IDENTIFIER}" \
     -r "${ROOT_DIRECTORY_OF_DOCKERFILES}"


### PR DESCRIPTION
The Python benchmark work has been reporting [a phony CPU usage of 200%](https://github.com/grpc/grpc/blob/7c5e3267981b5cdef015438040ad6d5e62ff4044/src/python/grpcio_tests/tests/qps/worker_server.py#L61) for... [7 years](https://github.com/grpc/grpc/commit/0482c1046b837be17c3a056af6569d84b8f52c23)? Hoo boy.

![nZ9zVvSWqJcDEj5](https://user-images.githubusercontent.com/1644595/199866703-b16a9beb-e48d-4b8b-8461-1318e6315ca5.png)

This PR actually collects and reports CPU usage.
