### PR TITLE
[EventEngine] Fix race on popping WorkQueue's most-recent element

### DIFF
--- a/src/core/lib/event_engine/work_queue.cc
+++ b/src/core/lib/event_engine/work_queue.cc
@@ -147,15 +147,7 @@ EventEngine::Closure* WorkQueue::PopLocked(bool front)
             std::memory_order_relaxed) == kInvalidTimestamp) {
       return nullptr;
     }
-    if (!most_recent_element_lock_.TryLock()) return nullptr;
-    absl::optional<Storage> ret;
-    if (GPR_LIKELY(most_recent_element_.has_value())) {
-      most_recent_element_enqueue_timestamp_.store(kInvalidTimestamp,
-                                                   std::memory_order_relaxed);
-      ret = std::exchange(most_recent_element_, absl::nullopt);
-    }
-    most_recent_element_lock_.Unlock();
-    return ret->closure();
+    return TryPopMostRecentElement();
   }
   // the queue has elements, let's pop one and update timestamps
   Storage ret_s;


### PR DESCRIPTION
The major difference between the deleted code and `TryPopMostRecentElement` is that `TryPopMostRecentElement` returns a nullptr if there is no most-recent element. The failure to check that condition resulted in a rare flake (1/100 to 1/10000 depending on the build configuration). The race involves two or more threads in `PopLocked` seeing a valid `most_recent_element_enqueue_timestamp_`, where one of those threads take the lock and exchanges the most recent element with nullopt, and another thread _also successfully takes the lock afterwards_ but finds a nullopt that is assumed to have a value.

Once fixed, that code was identical to `TryPopMostRecentElement`.

This bug was identified via EventEngine stress tests after integrating the WorkQueue. These tests will land soon.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

