### PR TITLE
Fix PHP distribtest on monterey

### DIFF
--- a/test/distrib/php/run_distrib_test.sh
+++ b/test/distrib/php/run_distrib_test.sh
@@ -19,7 +19,10 @@ cd "$(dirname "$0")"
 
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
-find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
-    MAKEFLAGS=-j xargs pecl install
+# get name of the PHP package archive to test (we don't know
+# the exact version string in advance)
+GRPC_PEAR_PACKAGE_NAME=$(find . -regex '.*/grpc-[0-9].*.tgz' | sed 's|./||')
+
+MAKEFLAGS=-j pecl install "${GRPC_PEAR_PACKAGE_NAME}"
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php

--- a/test/distrib/php/run_distrib_test_macos.sh
+++ b/test/distrib/php/run_distrib_test_macos.sh
@@ -19,7 +19,12 @@ cd "$(dirname "$0")"
 
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
-find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
-    xargs sudo MAKEFLAGS=-j pecl install
+# get name of the PHP package archive to test (we don't know
+# the exact version string in advance)
+GRPC_PEAR_PACKAGE_NAME=$(find . -regex '.*/grpc-[0-9].*.tgz' | sed 's|./||')
+
+# Use -j4 since higher parallelism can lead to "resource unavailable"
+# errors during the build. See b/257261061#comment4
+sudo MAKEFLAGS=-j4 pecl install "${GRPC_PEAR_PACKAGE_NAME}"
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php


### PR DESCRIPTION
This is a prerequisite to switching php distribtests job to kokoro monterey workers.
- make sure the PHP distribtests work fine on MacOS monterey workers as well (see b/257261061#comment4)
- do some cleanup to improve the readability of the test scripts (e.g. make it clear what's the purpose of find and get rid of a complicated piped command).

With the setup as-is, the distribtests should be passing on both macos mojave and macos monterey.

