### PR TITLE
Switch PHP distribtests to php7.4 (with significant speedup)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -188,24 +188,16 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PHP}" == "true" ]
 then
-  # It's required to update homebrew because it won't work with the default version Kokoro has.
-  # This can be fragile though because the future version of brew can break - consider pinning
-  # the formulas if that happens (see https://github.com/grpc/grpc/pull/24837).
-  brew update || true
-  # macos mojave support for php7.3 brew formula removed MacOS Mojave support here: https://github.com/Homebrew/homebrew-core/commit/d8496609d310a233bfb46272ec7948845f32d7c5#diff-df64282b6e4230b6f35468dfbbd500fcd62b0f93b01b2b161e92f512b7feb1a3
-  # so we need earlier version of the formulata than that. See https://github.com/grpc/grpc/pull/24837 for an example of pinning homebrew formulas to a specific commit.
-  (cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core; git checkout 10b1944581fbbdc216057fd70e89dbbe3d04161e)
-  brew config
+  # php7.4 should already be installed on kokoro monterey image, so this should be instantaneous.
+  time brew install php@7.4 || true
+  export LDFLAGS="-L/usr/local/opt/php@7.4/lib ${LDFLAGS}"
+  export CPPFLAGS="-I/usr/local/opt/php@7.4/include ${CPPFLAGS}"
+  export PATH="/usr/local/opt/php@7.4/bin:/usr/local/opt/php@7.4/sbin:${PATH}"
 
-  brew install php@7.3 || true
-  export LDFLAGS="-L/usr/local/opt/php@7.3/lib ${LDFLAGS}"
-  export CPPFLAGS="-I/usr/local/opt/php@7.3/include ${CPPFLAGS}"
-  export PATH="/usr/local/opt/php@7.3/bin:/usr/local/opt/php@7.3/sbin:${PATH}"
-
-  # the exit code from "brew install php@7.3" is useless
+  # the exit code from "brew install php@7.4" is useless
   # so instead we check if PHP was indeed installed successfully.
   # Failing early is better than cryptic errors later in the build process.
-  /usr/local/opt/php@7.3/bin/php --version
+  /usr/local/opt/php@7.4/bin/php --version
 
   # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081
   mkdir -p /usr/local/lib/php/pecl


### PR DESCRIPTION
Based on https://github.com/grpc/grpc/pull/31567.
Leads to significant speedup on the kokoro monterey workers, as they come with php7.4 pre-installed.
The simplification of the prepare script is also nice.