### PR TITLE
PSM Interop: add missing GCP service account to the cleanup job

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
+++ b/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
@@ -35,6 +35,7 @@ python3 -m bin.cleanup.cleanup \
     --project=grpc-testing \
     --network=default-vpc \
     --kube_context="${KUBE_CONTEXT}" \
+    --gcp_service_account=xds-k8s-interop-tests@grpc-testing.iam.gserviceaccount.com \
     --resource_prefix='required-but-does-not-matter' \
     --td_bootstrap_image='required-but-does-not-matter' --server_image='required-but-does-not-matter' --client_image='required-but-does-not-matter'
 
@@ -52,6 +53,7 @@ python3 -m bin.cleanup.namespace \
     --network=default-vpc \
     --keep_hours=6 \
     --kube_context="${TARGET_KUBE_CONTEXT}" \
+    --gcp_service_account=xds-k8s-interop-tests@grpc-testing.iam.gserviceaccount.com \
     --resource_prefix='required-but-does-not-matter' \
     --td_bootstrap_image='required-but-does-not-matter' --server_image='required-but-does-not-matter' --client_image='required-but-does-not-matter'
 
@@ -66,5 +68,6 @@ python3 -m bin.cleanup.namespace \
     --network=default-vpc \
     --keep_hours=6 \
     --kube_context="${TARGET_KUBE_CONTEXT}" \
+    --gcp_service_account=xds-k8s-interop-tests@grpc-testing.iam.gserviceaccount.com \
     --resource_prefix='required-but-does-not-matter' \
     --td_bootstrap_image='required-but-does-not-matter' --server_image='required-but-does-not-matter' --client_image='required-but-does-not-matter'


### PR DESCRIPTION
Recently we had an issue with Service Account IAM policy getting too large. RC is the cleanup script missing GCP SA account:

>  `Revoking roles/iam.workloadIdentityUser from serviceAccount:grpc-testing.svc.id.goog[psm-interop-client-20221107-0833-otg33/psm-grpc-client] for GCP Service Account None`  
> `Failed  roles/iam.workloadIdentityUser from serviceAccount:grpc-testing.svc.id.goog[psm-interop-client-20221107-0833-otg33/psm-grpc-client] for Service Account None: <ResponseError 404 when requesting https://iam.googleapis.com/v1/projects/grpc-testing/serviceAccounts/None:getIamPolicy?options.requestedPolicyVersion=3&alt=json returned "Unknown service account". Details: "Unknown service account"> `  
> — https://source.cloud.google.com/results/invocations/1a5f6c90-5148-4359-9052-8b167f411283

Ref b/255787902