### PR TITLE
[c++] Using namespace instead nested class to allow forward declaration

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1333,8 +1333,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
 
   printer->Print(service->GetLeadingComments("//").c_str());
   printer->Print(*vars,
-                 "class $Service$ final {\n"
-                 " public:\n");
+                 "namespace $Service$ {\n");
   printer->Indent();
 
   // Service metadata
@@ -1402,7 +1401,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
   printer->Outdent();
   printer->Print("};\n");
   printer->Print(
-      "static std::unique_ptr<Stub> NewStub(const std::shared_ptr< "
+      "std::unique_ptr<Stub> NewStub(const std::shared_ptr< "
       "::grpc::ChannelInterface>& channel, "
       "const ::grpc::StubOptions& options = ::grpc::StubOptions());\n");
 


### PR DESCRIPTION
### Problem description

gRPC generates service RPCs (eg, the `StubInterface` and `Stub` classes) inside a no-op class declaration. This prevents forward declaration of these nested RPC classes, because even C++20 does not yet allow forward declaration of nested classes and it appears the C++ standards committee is unenthusiastic about fixing this.

The inability to use forward declarations leads to either header pollution or suboptimal/cumbersome solutions for preventing header pollution. The header pollution from gRPC generated service headers is sizeable enough to be quite undesirable from both a header-interface and compile-time perspective. The header pollution can lead to potential headache for applications which (for whatever reason) may need to compile against different sets of gRPC headers from different versions of gRPC.

The generated service RPC class itself appears to be a no-op: It does not appear to have any of its own non-static data members or non-static functions and has no purpose for instantiation. It appears that its only purpose is just to provide unique name-scoping for the .proto-defined service name. It is not clear why a class declaration was originally chosen (is this a protobuf plugin limitation?).

### Desired solution

The generated service RPC code should be within a namespace declaration for scoping, not a class. From an API perspective, this should be entirely backwards compatible with existing code, as namespace scoping and public class nested member scoping use the exact same syntax.

Eg, the proto code:
`service Foo { ... }`
currently leads to this code in the .grpc.pb.h:
`class Foo final { ... class Stub { ... }; ... }`
whereas this would be preferable:
`namespace Foo { ... class Stub { ... }; ... }`
Because then forward declarations of the service class would work:
`namespace Foo { class Stub; }`

Existing code like:
`std::unique_ptr<Foo::Stub>(Foo::NewStub(...))`
would still compile exactly the same without modification.

Thus, it initially seems this should be a trivial fix with little/no knock-on effects.

### Current workarounds

Avoiding header pollution at current requires one of these suboptimal C++ patterns for code which wraps gRPC calls:
1. storage of `Stub*` as a `void*` in the headers and using `static_cast<Foo::Stub*>` everywhere the service interfaces are used, requiring explicit resource management of the `Stub`;
2. virtual interface with private implementation, incurring the runtime cost of a vtable and doubling code maintenance;
3. pImpl-pattern interface and private implementation, incurring the runtime cost of an extra dereference and doubling code maintenance;
4. any number of other antiquated patterns depending on translation unit context and usage.

https://github.com/grpc/grpc/issues/25995




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

