### PR TITLE
Use correct namespace for checking if the isDefaultRootsPemSet method exists.

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -43,7 +43,7 @@ class BaseStub
      */
     public function __construct($hostname, $opts, $channel = null)
     {
-        if (!method_exists('ChannelCredentials', 'isDefaultRootsPemSet') ||
+        if (!method_exists('Grpc\ChannelCredentials', 'isDefaultRootsPemSet') ||
             !ChannelCredentials::isDefaultRootsPemSet()) {
             $ssl_roots = file_get_contents(
                 dirname(__FILE__).'/../../../../etc/roots.pem'


### PR DESCRIPTION
The `method_exists` function requires a fully qualified class name to be sent to check if a method exists. The current class was missing the namespace, which means the function always returns `false`. In our application this caused the credentials to be loaded many times over, which ate up some CPU. This bug fix ensures that this is only run once per request.

I'm figuring out how to sign the CLA, please bear with me :)