### PR TITLE
Adding C++ x86 portability test

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -930,9 +930,8 @@ bool PosixEndpointImpl::DoFlushZerocopy(TcpZerocopySendRecord* record,
             "Tx0cp encountered an ENOBUFS error possibly because one or "
             "both of RLIMIT_MEMLOCK or hard memlock ulimit values are too "
             "small for the intended user. Current system value of "
-            "RLIMIT_MEMLOCK is %" PRIu64 " and hard memlock ulimit is %" PRIu64
-            ".Consider increasing these values appropriately for the intended "
-            "user.",
+            "RLIMIT_MEMLOCK is %lu and hard memlock ulimit is %lu. Consider "
+            "increasing these values appropriately for the intended user.",
             GetRLimitMemLockMax(), GetUlimitHardMemLock());
 #endif
       }
@@ -1203,7 +1202,7 @@ PosixEndpointImpl::PosixEndpointImpl(EventHandle* handle,
     if (zerocopy_enabled) {
       gpr_log(GPR_INFO,
               "Tx-zero copy enabled for gRPC sends. RLIMIT_MEMLOCK value = "
-              "%" PRIu64 ",ulimit hard memlock value = %" PRIu64,
+              "%lu, ulimit hard memlock value = %lu",
               GetRLimitMemLockMax(), GetUlimitHardMemLock());
     }
   }

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -288,7 +288,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
 def _create_portability_test_jobs(extra_args=[],
                                   inner_jobs=_DEFAULT_INNER_JOBS):
     test_jobs = []
-    # portability C and C++ x86
+    # portability C and C++ on x86
     test_jobs += _generate_jobs(languages=['c', 'c++'],
                                 configs=['dbg'],
                                 platforms=['linux'],
@@ -314,7 +314,7 @@ def _create_portability_test_jobs(extra_args=[],
                                     timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     # portability C on Windows 64-bit (x86 is the default)
-    test_jobs += _generate_jobs(languages=['c',],
+    test_jobs += _generate_jobs(languages=['c'],
                                 configs=['dbg'],
                                 platforms=['windows'],
                                 arch='x64',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -288,8 +288,8 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
 def _create_portability_test_jobs(extra_args=[],
                                   inner_jobs=_DEFAULT_INNER_JOBS):
     test_jobs = []
-    # portability C x86
-    test_jobs += _generate_jobs(languages=['c'],
+    # portability C and C++ x86
+    test_jobs += _generate_jobs(languages=['c', 'c++'],
                                 configs=['dbg'],
                                 platforms=['linux'],
                                 arch='x86',
@@ -314,7 +314,7 @@ def _create_portability_test_jobs(extra_args=[],
                                     timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     # portability C on Windows 64-bit (x86 is the default)
-    test_jobs += _generate_jobs(languages=['c'],
+    test_jobs += _generate_jobs(languages=['c',],
                                 configs=['dbg'],
                                 platforms=['windows'],
                                 arch='x64',


### PR DESCRIPTION
This is expected to prevent it from having x86 specific issue. (Recent one was https://github.com/grpc/grpc/pull/31576 which just fixed the problem)