### PR TITLE
explain that keys must be lower cased

### DIFF
--- a/examples/python/auth/customized_auth_client.py
+++ b/examples/python/auth/customized_auth_client.py
@@ -48,6 +48,7 @@ class AuthGateway(grpc.AuthMetadataPlugin):
         #     service_url=u'https://localhost:50051/helloworld.Greeter',
         #     method_name=u'SayHello')
         signature = context.method_name[::-1]
+        # NOTE: The metadata keys provided to the callback must be lower-cased.
         callback(((_SIGNATURE_HEADER_KEY, signature),), None)
 
 


### PR DESCRIPTION
* Upper case labels can cause the metadata to be rejected by certain servers
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

