### PR TITLE
Add a check to flush stale TracedBuffer entries to prevent them growing too long.

### DIFF
--- a/src/core/lib/event_engine/posix_engine/traced_buffer_list.cc
+++ b/src/core/lib/event_engine/posix_engine/traced_buffer_list.cc
@@ -293,12 +293,12 @@ void TracedBufferList::ProcessTimestamp(struct sock_extended_err* serr,
       elem = head_;
     }
   }
-  tail_ = head_ == nullptr ? head_ : prev;
+  tail_ = (head_ == nullptr) ? head_ : prev;
 }
 
 void TracedBufferList::Shutdown(void* remaining, absl::Status shutdown_err) {
   grpc_core::MutexLock lock(&mu_);
-  while (head_ != nullptr) {
+  while (head_) {
     TracedBuffer* elem = head_;
     g_timestamps_callback(elem->arg_, &(elem->ts_), shutdown_err);
     head_ = head_->next_;
@@ -307,7 +307,7 @@ void TracedBufferList::Shutdown(void* remaining, absl::Status shutdown_err) {
   if (remaining != nullptr) {
     g_timestamps_callback(remaining, nullptr, shutdown_err);
   }
-  tail_ = head_ = nullptr;
+  tail_ = head_;
 }
 
 void TcpSetWriteTimestampsCallback(

--- a/src/core/lib/event_engine/posix_engine/traced_buffer_list.h
+++ b/src/core/lib/event_engine/posix_engine/traced_buffer_list.h
@@ -112,6 +112,8 @@ struct Timestamps {
 
 class TracedBufferList {
  public:
+  TracedBufferList() = default;
+  ~TracedBufferList() = default;
   // Add a new entry in the TracedBuffer list pointed to by head. Also saves
   // sendmsg_time with the current timestamp.
   void AddNewEntry(int32_t seq_no, int fd, void* arg);
@@ -141,8 +143,11 @@ class TracedBufferList {
    public:
     TracedBuffer(uint32_t seq_no, void* arg) : seq_no_(seq_no), arg_(arg) {}
 
+    bool Finished();
+
    private:
     friend class TracedBufferList;
+    gpr_timespec last_timestamp_;
     TracedBuffer* next_ = nullptr;
     uint32_t seq_no_; /* The sequence number for the last byte in the buffer */
     void* arg_;       /* The arg to pass to timestamps_callback */

--- a/src/core/lib/event_engine/posix_engine/traced_buffer_list.h
+++ b/src/core/lib/event_engine/posix_engine/traced_buffer_list.h
@@ -142,8 +142,9 @@ class TracedBufferList {
   class TracedBuffer {
    public:
     TracedBuffer(uint32_t seq_no, void* arg) : seq_no_(seq_no), arg_(arg) {}
-
-    bool Finished();
+    // Returns true if the TracedBuffer is considered stale at the given
+    // timestamp.
+    bool Finished(gpr_timespec ts);
 
    private:
     friend class TracedBufferList;

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -20,8 +20,8 @@
 
 #include "src/core/lib/iomgr/buffer_list.h"
 
-#include "grpc/support/time.h"
 #include <grpc/support/log.h>
+#include <grpc/support/time.h>
 
 #include "src/core/lib/gprpp/global_config.h"
 #include "src/core/lib/gprpp/sync.h"

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -20,8 +20,10 @@
 
 #include "src/core/lib/iomgr/buffer_list.h"
 
+#include "grpc/support/time.h"
 #include <grpc/support/log.h>
 
+#include "src/core/lib/gprpp/global_config.h"
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/port.h"
 
@@ -29,6 +31,10 @@
 #include <netinet/in.h>
 #include <string.h>
 #include <time.h>
+
+GPR_GLOBAL_CONFIG_DEFINE_INT32(
+    grpc_max_pending_ack_time_millis, 10000,
+    "Maximum time to wait (in milliseconds) for an ack of a pending trace.");
 
 namespace grpc_core {
 namespace {
@@ -195,6 +201,14 @@ int GetSocketTcpInfo(struct tcp_info* info, int fd) {
 
 }  // namespace.
 
+bool TracedBufferList::TracedBuffer::Finished() {
+  static const int kGrpcMaxPendingAckTimeMillis =
+      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  return gpr_time_to_millis(
+             gpr_time_sub(gpr_now(GPR_CLOCK_REALTIME), last_timestamp_)) >
+         kGrpcMaxPendingAckTimeMillis;
+}
+
 void TracedBufferList::AddNewEntry(int32_t seq_no, int fd, void* arg) {
   TracedBuffer* new_elem = new TracedBuffer(seq_no, arg);
   // Store the current time as the sendmsg time.
@@ -206,6 +220,7 @@ void TracedBufferList::AddNewEntry(int32_t seq_no, int fd, void* arg) {
     ExtractOptStatsFromTcpInfo(&(new_elem->ts_.sendmsg_time.metrics),
                                &(new_elem->ts_.info));
   }
+  new_elem->last_timestamp_ = new_elem->ts_.sendmsg_time.time;
   MutexLock lock(&mu_);
   if (!head_) {
     head_ = tail_ = new_elem;
@@ -220,6 +235,7 @@ void TracedBufferList::ProcessTimestamp(struct sock_extended_err* serr,
                                         struct scm_timestamping* tss) {
   MutexLock lock(&mu_);
   TracedBuffer* elem = head_;
+  TracedBuffer* prev = nullptr;
   while (elem != nullptr) {
     // The byte number refers to the sequence number of the last byte which this
     // timestamp relates to.
@@ -229,11 +245,13 @@ void TracedBufferList::ProcessTimestamp(struct sock_extended_err* serr,
           FillGprFromTimestamp(&(elem->ts_.scheduled_time.time), &(tss->ts[0]));
           ExtractOptStatsFromCmsg(&(elem->ts_.scheduled_time.metrics),
                                   opt_stats);
+          elem->last_timestamp_ = elem->ts_.scheduled_time.time;
           elem = elem->next_;
           break;
         case SCM_TSTAMP_SND:
           FillGprFromTimestamp(&(elem->ts_.sent_time.time), &(tss->ts[0]));
           ExtractOptStatsFromCmsg(&(elem->ts_.sent_time.metrics), opt_stats);
+          elem->last_timestamp_ = elem->ts_.sent_time.time;
           elem = elem->next_;
           break;
         case SCM_TSTAMP_ACK:
@@ -257,12 +275,30 @@ void TracedBufferList::ProcessTimestamp(struct sock_extended_err* serr,
       break;
     }
   }
-  tail_ = !head_ ? head_ : tail_;
+
+  elem = head_;
+  while (elem != nullptr) {
+    if (!elem->Finished()) {
+      prev = elem;
+      elem = elem->next_;
+      continue;
+    }
+    if (prev != nullptr) {
+      prev->next_ = elem->next_;
+      delete elem;
+      elem = prev->next_;
+    } else {
+      head_ = elem->next_;
+      delete elem;
+      elem = head_;
+    }
+  }
+  tail_ = head_ == nullptr ? head_ : prev;
 }
 
 void TracedBufferList::Shutdown(void* remaining, absl::Status shutdown_err) {
   MutexLock lock(&mu_);
-  while (head_) {
+  while (head_ != nullptr) {
     TracedBuffer* elem = head_;
     g_timestamps_callback(elem->arg_, &(elem->ts_), shutdown_err);
     head_ = head_->next_;
@@ -271,7 +307,7 @@ void TracedBufferList::Shutdown(void* remaining, absl::Status shutdown_err) {
   if (remaining != nullptr) {
     g_timestamps_callback(remaining, nullptr, shutdown_err);
   }
-  tail_ = head_;
+  tail_ = head_ = nullptr;
 }
 
 void grpc_tcp_set_write_timestamps_callback(

--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -293,12 +293,12 @@ void TracedBufferList::ProcessTimestamp(struct sock_extended_err* serr,
       elem = head_;
     }
   }
-  tail_ = head_ == nullptr ? head_ : prev;
+  tail_ = (head_ == nullptr) ? head_ : prev;
 }
 
 void TracedBufferList::Shutdown(void* remaining, absl::Status shutdown_err) {
   MutexLock lock(&mu_);
-  while (head_ != nullptr) {
+  while (head_) {
     TracedBuffer* elem = head_;
     g_timestamps_callback(elem->arg_, &(elem->ts_), shutdown_err);
     head_ = head_->next_;
@@ -307,7 +307,7 @@ void TracedBufferList::Shutdown(void* remaining, absl::Status shutdown_err) {
   if (remaining != nullptr) {
     g_timestamps_callback(remaining, nullptr, shutdown_err);
   }
-  tail_ = head_ = nullptr;
+  tail_ = head_;
 }
 
 void grpc_tcp_set_write_timestamps_callback(

--- a/src/core/lib/iomgr/buffer_list.h
+++ b/src/core/lib/iomgr/buffer_list.h
@@ -143,7 +143,7 @@ class TracedBufferList {
    public:
     TracedBuffer(uint32_t seq_no, void* arg) : seq_no_(seq_no), arg_(arg) {}
 
-    bool Finished();
+    bool Finished(gpr_timespec ts);
 
    private:
     friend class TracedBufferList;

--- a/src/core/lib/iomgr/buffer_list.h
+++ b/src/core/lib/iomgr/buffer_list.h
@@ -23,6 +23,7 @@
 
 #include "absl/types/optional.h"
 
+#include <grpc/grpc.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/gprpp/sync.h"
@@ -111,6 +112,8 @@ struct Timestamps {
 
 class TracedBufferList {
  public:
+  TracedBufferList() = default;
+  ~TracedBufferList() = default;
   // Add a new entry in the TracedBuffer list pointed to by head. Also saves
   // sendmsg_time with the current timestamp.
   void AddNewEntry(int32_t seq_no, int fd, void* arg);
@@ -140,8 +143,11 @@ class TracedBufferList {
    public:
     TracedBuffer(uint32_t seq_no, void* arg) : seq_no_(seq_no), arg_(arg) {}
 
+    bool Finished();
+
    private:
     friend class TracedBufferList;
+    gpr_timespec last_timestamp_;
     TracedBuffer* next_ = nullptr;
     uint32_t seq_no_; /* The sequence number for the last byte in the buffer */
     void* arg_;       /* The arg to pass to timestamps_callback */

--- a/test/core/event_engine/posix/traced_buffer_list_test.cc
+++ b/test/core/event_engine/posix/traced_buffer_list_test.cc
@@ -20,7 +20,6 @@
 
 #include <grpc/grpc.h>
 
-#include "src/core/lib/gprpp/global_config.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/port.h"
@@ -30,8 +29,6 @@
 #include <linux/errqueue.h>
 
 #define NUM_ELEM 5
-
-GPR_GLOBAL_CONFIG_DECLARE_INT32(grpc_max_pending_ack_time_millis);
 
 extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
@@ -163,8 +160,7 @@ TEST(BufferListTest, TestProcessTimestampAfterShutdown) {
 }
 
 TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
-  int kMaxPendingAckMillis =
-      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  constexpr int kMaxPendingAckMillis = 10000;
   struct sock_extended_err serr[3];
   gpr_atm verifier_called[3];
   struct scm_timestamping tss;
@@ -225,8 +221,7 @@ TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
 
 TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
   constexpr int kNumTracedBuffers = 10;
-  int kMaxPendingAckMillis =
-      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  constexpr int kMaxPendingAckMillis = 10000;
   struct sock_extended_err serr[kNumTracedBuffers];
   gpr_atm verifier_called[kNumTracedBuffers];
   struct scm_timestamping tss;

--- a/test/core/event_engine/posix/traced_buffer_list_test.cc
+++ b/test/core/event_engine/posix/traced_buffer_list_test.cc
@@ -24,7 +24,6 @@
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/port.h"
-#include "test/core/util/test_config.h"
 
 #ifdef GRPC_LINUX_ERRQUEUE
 
@@ -42,7 +41,7 @@ namespace {
 
 constexpr uint64_t kMaxAdvanceTimeMillis = 24ull * 365 * 3600 * 1000;
 
-static gpr_timespec g_now;
+gpr_timespec g_now;
 gpr_timespec now_impl(gpr_clock_type clock_type) {
   GPR_ASSERT(clock_type != GPR_TIMESPAN);
   gpr_timespec ts = g_now;
@@ -275,7 +274,6 @@ TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {
-  grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   grpc_event_engine::posix_engine::InitGlobals();
   return RUN_ALL_TESTS();

--- a/test/core/event_engine/posix/traced_buffer_list_test.cc
+++ b/test/core/event_engine/posix/traced_buffer_list_test.cc
@@ -56,13 +56,6 @@ void InitGlobals() {
   gpr_now_impl = now_impl;
 }
 
-void ResetClock() {
-  grpc_core::ExecCtx exec_ctx;
-  g_now = {1, 0, GPR_CLOCK_MONOTONIC};
-  grpc_core::TestOnlySetProcessEpoch(g_now);
-  exec_ctx.InvalidateNow();
-}
-
 void AdvanceClockMillis(uint64_t millis) {
   grpc_core::ExecCtx exec_ctx;
   g_now = gpr_time_add(
@@ -176,7 +169,6 @@ TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
   struct sock_extended_err serr[3];
   gpr_atm verifier_called[3];
   struct scm_timestamping tss;
-  ResetClock();
   TcpSetWriteTimestampsCallback(TestVerifierCalledOnDelayedAckVerifier);
   TracedBufferList tb_list;
   serr[0].ee_data = 1;
@@ -241,7 +233,6 @@ TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
   struct scm_timestamping tss;
   tss.ts[0].tv_sec = 123;
   tss.ts[0].tv_nsec = 456;
-  ResetClock();
   TcpSetWriteTimestampsCallback(TestVerifierCalledOnAckVerifier);
   TracedBufferList tb_list;
   for (int i = 0; i < kNumTracedBuffers; i++) {

--- a/test/core/event_engine/posix/traced_buffer_list_test.cc
+++ b/test/core/event_engine/posix/traced_buffer_list_test.cc
@@ -20,6 +20,9 @@
 
 #include <grpc/grpc.h>
 
+#include "src/core/lib/gprpp/global_config.h"
+#include "src/core/lib/gprpp/time.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/port.h"
 #include "test/core/util/test_config.h"
 
@@ -29,9 +32,45 @@
 
 #define NUM_ELEM 5
 
+GPR_GLOBAL_CONFIG_DECLARE_INT32(grpc_max_pending_ack_time_millis);
+
+extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+
 namespace grpc_event_engine {
 namespace posix_engine {
 namespace {
+
+constexpr uint64_t kMaxAdvanceTimeMillis = 24ull * 365 * 3600 * 1000;
+
+static gpr_timespec g_now;
+gpr_timespec now_impl(gpr_clock_type clock_type) {
+  GPR_ASSERT(clock_type != GPR_TIMESPAN);
+  gpr_timespec ts = g_now;
+  ts.clock_type = clock_type;
+  return ts;
+}
+
+void InitGlobals() {
+  g_now = {1, 0, GPR_CLOCK_MONOTONIC};
+  grpc_core::TestOnlySetProcessEpoch(g_now);
+  gpr_now_impl = now_impl;
+}
+
+void ResetClock() {
+  grpc_core::ExecCtx exec_ctx;
+  g_now = {1, 0, GPR_CLOCK_MONOTONIC};
+  grpc_core::TestOnlySetProcessEpoch(g_now);
+  exec_ctx.InvalidateNow();
+}
+
+void AdvanceClockMillis(uint64_t millis) {
+  grpc_core::ExecCtx exec_ctx;
+  g_now = gpr_time_add(
+      g_now, gpr_time_from_millis(
+                 grpc_core::Clamp(millis, uint64_t(1), kMaxAdvanceTimeMillis),
+                 GPR_TIMESPAN));
+  exec_ctx.InvalidateNow();
+}
 
 void TestShutdownFlushesListVerifier(void* arg, Timestamps* /*ts*/,
                                      absl::Status status) {
@@ -51,6 +90,18 @@ void TestVerifierCalledOnAckVerifier(void* arg, Timestamps* ts,
   ASSERT_GT(ts->info.length, 0);
   int* done = reinterpret_cast<int*>(arg);
   *done = 1;
+}
+
+void TestVerifierCalledOnDelayedAckVerifier(void* arg, Timestamps* ts,
+                                            absl::Status error) {
+  ASSERT_TRUE(error.ok());
+  ASSERT_NE(arg, nullptr);
+  ASSERT_EQ(ts->acked_time.time.clock_type, GPR_CLOCK_REALTIME);
+  ASSERT_EQ(ts->acked_time.time.tv_sec, g_now.tv_sec);
+  ASSERT_EQ(ts->acked_time.time.tv_nsec, g_now.tv_nsec);
+  ASSERT_GT(ts->info.length, 0);
+  gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
+  gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
 }
 
 }  // namespace
@@ -119,12 +170,123 @@ TEST(BufferListTest, TestProcessTimestampAfterShutdown) {
   ASSERT_EQ(verifier_called, 0);
 }
 
+TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
+  int kMaxPendingAckMillis =
+      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  struct sock_extended_err serr[3];
+  gpr_atm verifier_called[3];
+  struct scm_timestamping tss;
+  ResetClock();
+  TcpSetWriteTimestampsCallback(TestVerifierCalledOnDelayedAckVerifier);
+  TracedBufferList tb_list;
+  serr[0].ee_data = 1;
+  serr[0].ee_info = SCM_TSTAMP_SCHED;
+  serr[1].ee_data = 1;
+  serr[1].ee_info = SCM_TSTAMP_SND;
+  serr[2].ee_data = 1;
+  serr[2].ee_info = SCM_TSTAMP_ACK;
+  gpr_atm_rel_store(&verifier_called[0], static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&verifier_called[1], static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&verifier_called[2], static_cast<gpr_atm>(0));
+
+  //  Add 3 traced buffers
+  tb_list.AddNewEntry(1, 0, &verifier_called[0]);
+  tb_list.AddNewEntry(2, 0, &verifier_called[1]);
+  tb_list.AddNewEntry(3, 0, &verifier_called[2]);
+
+  AdvanceClockMillis(kMaxPendingAckMillis);
+  tss.ts[0].tv_sec = g_now.tv_sec;
+  tss.ts[0].tv_nsec = g_now.tv_nsec;
+
+  // Process SCHED Timestamp for 1st traced buffer.
+  tb_list.ProcessTimestamp(&serr[0], nullptr, &tss);
+  ASSERT_EQ(tb_list.Size(), 3);
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[0]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[1]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[2]), static_cast<gpr_atm>(0));
+
+  AdvanceClockMillis(kMaxPendingAckMillis);
+  tss.ts[0].tv_sec = g_now.tv_sec;
+  tss.ts[0].tv_nsec = g_now.tv_nsec;
+
+  // Process SND Timestamp for 1st traced buffer. The second and third traced
+  // buffers must have been flushed because the max pending ack time would have
+  // elapsed for them.
+  tb_list.ProcessTimestamp(&serr[1], nullptr, &tss);
+  ASSERT_EQ(tb_list.Size(), 1);
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[0]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[1]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[2]), static_cast<gpr_atm>(0));
+
+  AdvanceClockMillis(kMaxPendingAckMillis);
+  tss.ts[0].tv_sec = g_now.tv_sec;
+  tss.ts[0].tv_nsec = g_now.tv_nsec;
+
+  // Process ACK Timestamp for 1st traced buffer.
+  tb_list.ProcessTimestamp(&serr[2], nullptr, &tss);
+  ASSERT_EQ(tb_list.Size(), 0);
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[0]), static_cast<gpr_atm>(1));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[1]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[2]), static_cast<gpr_atm>(0));
+
+  tb_list.Shutdown(nullptr, absl::OkStatus());
+}
+
+TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
+  constexpr int kNumTracedBuffers = 10;
+  int kMaxPendingAckMillis =
+      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  struct sock_extended_err serr[kNumTracedBuffers];
+  gpr_atm verifier_called[kNumTracedBuffers];
+  struct scm_timestamping tss;
+  tss.ts[0].tv_sec = 123;
+  tss.ts[0].tv_nsec = 456;
+  ResetClock();
+  TcpSetWriteTimestampsCallback(TestVerifierCalledOnAckVerifier);
+  TracedBufferList tb_list;
+  for (int i = 0; i < kNumTracedBuffers; i++) {
+    serr[i].ee_data = i + 1;
+    serr[i].ee_info = SCM_TSTAMP_ACK;
+    gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
+    tb_list.AddNewEntry(i + 1, 0, &verifier_called[i]);
+  }
+  int elapsed_time_millis = 0;
+  int increment_millis = (2 * kMaxPendingAckMillis) / 10;
+  for (int i = 0; i < kNumTracedBuffers; i++) {
+    AdvanceClockMillis(increment_millis);
+    elapsed_time_millis += increment_millis;
+    tb_list.ProcessTimestamp(&serr[i], nullptr, &tss);
+    if (elapsed_time_millis > kMaxPendingAckMillis) {
+      // MaxPendingAckMillis has elapsed. the rest of tb_list must have been
+      // flushed now.
+      ASSERT_EQ(tb_list.Size(), 0);
+      if (elapsed_time_millis - kMaxPendingAckMillis == increment_millis) {
+        // The first ProcessTimestamp just after kMaxPendingAckMillis would have
+        // still successfully processed the head traced buffer entry and then
+        // discarded all the other remaining traced buffer entries. The first
+        // traced buffer entry would have been processed because the ACK
+        // timestamp was received for it.
+        ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]),
+                  static_cast<gpr_atm>(1));
+      } else {
+        ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]),
+                  static_cast<gpr_atm>(0));
+      }
+    } else {
+      ASSERT_EQ(tb_list.Size(), kNumTracedBuffers - (i + 1));
+      ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
+    }
+  }
+  tb_list.Shutdown(nullptr, absl::OkStatus());
+}
+
 }  // namespace posix_engine
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_event_engine::posix_engine::InitGlobals();
   return RUN_ALL_TESTS();
 }
 

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -30,7 +30,6 @@
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/internal_errqueue.h"
 #include "src/core/lib/iomgr/port.h"
-#include "test/core/util/test_config.h"
 
 #ifdef GRPC_LINUX_ERRQUEUE
 
@@ -271,10 +270,8 @@ TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
 }
 
 int main(int argc, char** argv) {
-  grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   InitGlobals();
-  grpc::testing::TestGrpcScope grpc_scope;
   return RUN_ALL_TESTS();
 }
 

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -20,18 +20,74 @@
 
 #include <gtest/gtest.h>
 
+#include "grpc/support/time.h"
 #include <grpc/grpc.h>
 
+#include "src/core/lib/gpr/useful.h"
+#include "src/core/lib/gprpp/global_config.h"
+#include "src/core/lib/gprpp/global_config_generic.h"
+#include "src/core/lib/gprpp/time.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/internal_errqueue.h"
 #include "src/core/lib/iomgr/port.h"
 #include "test/core/util/test_config.h"
 
 #ifdef GRPC_LINUX_ERRQUEUE
+
+GPR_GLOBAL_CONFIG_DECLARE_INT32(grpc_max_pending_ack_time_millis);
+
+constexpr uint64_t kMaxAdvanceTimeMillis = 24ull * 365 * 3600 * 1000;
+
+extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+
+static gpr_timespec g_now;
+gpr_timespec now_impl(gpr_clock_type clock_type) {
+  GPR_ASSERT(clock_type != GPR_TIMESPAN);
+  gpr_timespec ts = g_now;
+  ts.clock_type = clock_type;
+  return ts;
+}
+
+void InitGlobals() {
+  g_now = {1, 0, GPR_CLOCK_MONOTONIC};
+  grpc_core::TestOnlySetProcessEpoch(g_now);
+  gpr_now_impl = now_impl;
+}
+
+void ResetClock() {
+  grpc_core::ExecCtx exec_ctx;
+  g_now = {1, 0, GPR_CLOCK_MONOTONIC};
+  grpc_core::TestOnlySetProcessEpoch(g_now);
+  exec_ctx.InvalidateNow();
+}
+
+void AdvanceClockMillis(uint64_t millis) {
+  grpc_core::ExecCtx exec_ctx;
+  g_now = gpr_time_add(
+      g_now, gpr_time_from_millis(
+                 grpc_core::Clamp(millis, uint64_t(1), kMaxAdvanceTimeMillis),
+                 GPR_TIMESPAN));
+  exec_ctx.InvalidateNow();
+}
 
 static void TestShutdownFlushesListVerifier(void* arg,
                                             grpc_core::Timestamps* /*ts*/,
                                             grpc_error_handle error) {
   ASSERT_TRUE(error.ok());
   ASSERT_NE(arg, nullptr);
+  gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
+  gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
+}
+
+static void TestVerifierCalledOnDelayedAckVerifier(void* arg,
+                                                   grpc_core::Timestamps* ts,
+                                                   grpc_error_handle error) {
+  ASSERT_TRUE(error.ok());
+  ASSERT_NE(arg, nullptr);
+  ASSERT_EQ(ts->acked_time.time.clock_type, GPR_CLOCK_REALTIME);
+  ASSERT_EQ(ts->acked_time.time.tv_sec, g_now.tv_sec);
+  ASSERT_EQ(ts->acked_time.time.tv_nsec, g_now.tv_nsec);
+  ASSERT_GT(ts->info.length, 0);
   gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
   gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
 }
@@ -111,9 +167,122 @@ TEST(BufferListTest, Testrepeatedshutdown) {
   tb_list.Shutdown(nullptr, absl::OkStatus());
 }
 
+TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
+  int kMaxPendingAckMillis =
+      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  struct sock_extended_err serr[3];
+  gpr_atm verifier_called[3];
+  struct grpc_core::scm_timestamping tss;
+  ResetClock();
+  grpc_core::grpc_tcp_set_write_timestamps_callback(
+      TestVerifierCalledOnDelayedAckVerifier);
+  grpc_core::TracedBufferList tb_list;
+  serr[0].ee_data = 1;
+  serr[0].ee_info = grpc_core::SCM_TSTAMP_SCHED;
+  serr[1].ee_data = 1;
+  serr[1].ee_info = grpc_core::SCM_TSTAMP_SND;
+  serr[2].ee_data = 1;
+  serr[2].ee_info = grpc_core::SCM_TSTAMP_ACK;
+  gpr_atm_rel_store(&verifier_called[0], static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&verifier_called[1], static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&verifier_called[2], static_cast<gpr_atm>(0));
+
+  //  Add 3 traced buffers
+  tb_list.AddNewEntry(1, 0, &verifier_called[0]);
+  tb_list.AddNewEntry(2, 0, &verifier_called[1]);
+  tb_list.AddNewEntry(3, 0, &verifier_called[2]);
+
+  AdvanceClockMillis(kMaxPendingAckMillis);
+  tss.ts[0].tv_sec = g_now.tv_sec;
+  tss.ts[0].tv_nsec = g_now.tv_nsec;
+
+  // Process SCHED Timestamp for 1st traced buffer.
+  tb_list.ProcessTimestamp(&serr[0], nullptr, &tss);
+  ASSERT_EQ(tb_list.Size(), 3);
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[0]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[1]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[2]), static_cast<gpr_atm>(0));
+
+  AdvanceClockMillis(kMaxPendingAckMillis);
+  tss.ts[0].tv_sec = g_now.tv_sec;
+  tss.ts[0].tv_nsec = g_now.tv_nsec;
+
+  // Process SND Timestamp for 1st traced buffer. The second and third traced
+  // buffers must have been flushed because the max pending ack time would have
+  // elapsed for them.
+  tb_list.ProcessTimestamp(&serr[1], nullptr, &tss);
+  ASSERT_EQ(tb_list.Size(), 1);
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[0]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[1]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[2]), static_cast<gpr_atm>(0));
+
+  AdvanceClockMillis(kMaxPendingAckMillis);
+  tss.ts[0].tv_sec = g_now.tv_sec;
+  tss.ts[0].tv_nsec = g_now.tv_nsec;
+
+  // Process ACK Timestamp for 1st traced buffer.
+  tb_list.ProcessTimestamp(&serr[2], nullptr, &tss);
+  ASSERT_EQ(tb_list.Size(), 0);
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[0]), static_cast<gpr_atm>(1));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[1]), static_cast<gpr_atm>(0));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called[2]), static_cast<gpr_atm>(0));
+
+  tb_list.Shutdown(nullptr, absl::OkStatus());
+}
+
+TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
+  constexpr int kNumTracedBuffers = 10;
+  int kMaxPendingAckMillis =
+      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  struct sock_extended_err serr[kNumTracedBuffers];
+  gpr_atm verifier_called[kNumTracedBuffers];
+  struct grpc_core::scm_timestamping tss;
+  tss.ts[0].tv_sec = 123;
+  tss.ts[0].tv_nsec = 456;
+  ResetClock();
+  grpc_core::grpc_tcp_set_write_timestamps_callback(
+      TestVerifierCalledOnAckVerifier);
+  grpc_core::TracedBufferList tb_list;
+  for (int i = 0; i < kNumTracedBuffers; i++) {
+    serr[i].ee_data = i + 1;
+    serr[i].ee_info = grpc_core::SCM_TSTAMP_ACK;
+    gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
+    tb_list.AddNewEntry(i + 1, 0, &verifier_called[i]);
+  }
+  int elapsed_time_millis = 0;
+  int increment_millis = (2 * kMaxPendingAckMillis) / 10;
+  for (int i = 0; i < kNumTracedBuffers; i++) {
+    AdvanceClockMillis(increment_millis);
+    elapsed_time_millis += increment_millis;
+    tb_list.ProcessTimestamp(&serr[i], nullptr, &tss);
+    if (elapsed_time_millis > kMaxPendingAckMillis) {
+      // MaxPendingAckMillis has elapsed. the rest of tb_list must have been
+      // flushed now.
+      ASSERT_EQ(tb_list.Size(), 0);
+      if (elapsed_time_millis - kMaxPendingAckMillis == increment_millis) {
+        // The first ProcessTimestamp just after kMaxPendingAckMillis would have
+        // still successfully processed the head traced buffer entry and then
+        // discarded all the other remaining traced buffer entries. The first
+        // traced buffer entry would have been processed because the ACK
+        // timestamp was received for it.
+        ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]),
+                  static_cast<gpr_atm>(1));
+      } else {
+        ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]),
+                  static_cast<gpr_atm>(0));
+      }
+    } else {
+      ASSERT_EQ(tb_list.Size(), kNumTracedBuffers - (i + 1));
+      ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
+    }
+  }
+  tb_list.Shutdown(nullptr, absl::OkStatus());
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  InitGlobals();
   grpc::testing::TestGrpcScope grpc_scope;
   return RUN_ALL_TESTS();
 }

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -24,7 +24,6 @@
 #include <grpc/support/time.h>
 
 #include "src/core/lib/gpr/useful.h"
-#include "src/core/lib/gprpp/global_config.h"
 #include "src/core/lib/gprpp/global_config_generic.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -32,8 +31,6 @@
 #include "src/core/lib/iomgr/port.h"
 
 #ifdef GRPC_LINUX_ERRQUEUE
-
-GPR_GLOBAL_CONFIG_DECLARE_INT32(grpc_max_pending_ack_time_millis);
 
 constexpr uint64_t kMaxAdvanceTimeMillis = 24ull * 365 * 3600 * 1000;
 
@@ -160,8 +157,7 @@ TEST(BufferListTest, Testrepeatedshutdown) {
 }
 
 TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
-  int kMaxPendingAckMillis =
-      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  constexpr int kMaxPendingAckMillis = 10000;
   struct sock_extended_err serr[3];
   gpr_atm verifier_called[3];
   struct grpc_core::scm_timestamping tss;
@@ -223,8 +219,7 @@ TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
 
 TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
   constexpr int kNumTracedBuffers = 10;
-  int kMaxPendingAckMillis =
-      GPR_GLOBAL_CONFIG_GET(grpc_max_pending_ack_time_millis);
+  constexpr int kMaxPendingAckMillis = 10000;
   struct sock_extended_err serr[kNumTracedBuffers];
   gpr_atm verifier_called[kNumTracedBuffers];
   struct grpc_core::scm_timestamping tss;

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -20,8 +20,8 @@
 
 #include <gtest/gtest.h>
 
-#include "grpc/support/time.h"
 #include <grpc/grpc.h>
+#include <grpc/support/time.h>
 
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/global_config.h"
@@ -52,13 +52,6 @@ void InitGlobals() {
   g_now = {1, 0, GPR_CLOCK_MONOTONIC};
   grpc_core::TestOnlySetProcessEpoch(g_now);
   gpr_now_impl = now_impl;
-}
-
-void ResetClock() {
-  grpc_core::ExecCtx exec_ctx;
-  g_now = {1, 0, GPR_CLOCK_MONOTONIC};
-  grpc_core::TestOnlySetProcessEpoch(g_now);
-  exec_ctx.InvalidateNow();
 }
 
 void AdvanceClockMillis(uint64_t millis) {
@@ -173,7 +166,6 @@ TEST(BufferListTest, TestLongPendingAckForOneTracedBuffer) {
   struct sock_extended_err serr[3];
   gpr_atm verifier_called[3];
   struct grpc_core::scm_timestamping tss;
-  ResetClock();
   grpc_core::grpc_tcp_set_write_timestamps_callback(
       TestVerifierCalledOnDelayedAckVerifier);
   grpc_core::TracedBufferList tb_list;
@@ -239,7 +231,6 @@ TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
   struct grpc_core::scm_timestamping tss;
   tss.ts[0].tv_sec = 123;
   tss.ts[0].tv_nsec = 456;
-  ResetClock();
   grpc_core::grpc_tcp_set_write_timestamps_callback(
       TestVerifierCalledOnAckVerifier);
   grpc_core::TracedBufferList tb_list;


### PR DESCRIPTION
By default, any traced buffer entry more than 10secs old is considered stale. 10sec value is hard-coded for now.