### PR TITLE
Move docker images from dockerhub to artifact registry.

### DIFF
--- a/third_party/rake-compiler-dock/rake_arm64-darwin/.current_version
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:69742889e98f7c0dc2d26cc89a43017179515167@sha256:d1b0c35c651a1911ba290184f63c5e81b17fd20291acea20c91e9f2c2d7c8d50

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:0b8bed3e125d8952ccc8938f905d9792c84077f5@sha256:ab967122a47b0385a1e66b5b91693d971468a276000ac1c066c54bef577ef4b7

--- a/third_party/rake-compiler-dock/rake_x64-mingw32/.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32:47e598526ac5068d348e29237e1dc84e3d01afab@sha256:6f4386f2954821c199d104e9dfe250ef99fdb74f4840311f8a7812c462629a83

--- a/third_party/rake-compiler-dock/rake_x86-linux/.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-linux/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux:e8ffbe97d21d829ae38ab10ef65cf38e542ee8b9@sha256:dab334b2c651e78f82c9ff7141699ac23365676f3972cff07382f7146702b88f

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:91c4f180dce2a3f4fc9bcf66dc0818f0d8c81415@sha256:09b3f47c5eb8f6b686af4d6cba636637ab310ef1dcfa30e05bb00b183b1b619b

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:56f7dd2c720f4c10a6d4be6a869b11ec1e39a0f3@sha256:b086e560ef215180b843d1d7fe48e2cfbed3112ec4ab57e655ad5dfb61090726

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux:47c34d44a509c824ae84aaff82c14de5aa3bdc12@sha256:5c485b0a0e6bf5e0fc87122b3d49003a0d0aa30cbaca7250902f53823e50bc9c

--- a/tools/docker_runners/run_in_docker.sh
+++ b/tools/docker_runners/run_in_docker.sh
@@ -47,7 +47,5 @@ DOCKER_NONROOT_ARGS=(
 
 # the original DOCKER_EXTRA_ARGS + all the args defined in this script
 export DOCKER_EXTRA_ARGS="${DOCKER_NONROOT_ARGS[@]} ${DOCKER_EXTRA_ARGS}"
-# download the docker images from dockerhub instead of building them locally
-export DOCKERHUB_ORGANIZATION=grpctesting
 
 exec tools/run_tests/dockerize/build_and_run_docker.sh "$@"

--- a/tools/dockerfile/README.md
+++ b/tools/dockerfile/README.md
@@ -1,0 +1,63 @@
+# Docker images used for gRPC testing
+
+Most of our linux tests on the CI run under a docker container, since that makes it easier
+to maintain the test environment and the dependencies. Having an easily reproducible test
+environment also make it easier to reproduce issues we see on CI locally.
+
+The docker image definitions we use live under `tools/dockerfile` directory (with the
+exception of `third_party/rake-compiler-dock` docker images).
+
+## Version management
+
+The docker images we use for testing evolve over time (and newer/older versions of it
+might not work with newer/older revisions of our code).
+
+For each dockerfile (which is identified by the directory in which is it located),
+the "current version" that's being used by testing is determined by the
+corresponding `.current_version` file, which contains the full docker image name,
+including artifact registry location, docker image name, the current tag and the
+SHA256 image digest.
+
+Example:
+For `tools/dockerfile/test/cxx_debian11_x64/Dockerfile`, there is a
+`tools/dockerfile/test/cxx_debian11_x64.current_version` file which contains info
+as follows:
+```
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_x64:[CURRENT_CHECKSUM]@sha256:[CURRENT_SHA256_DIGEST]
+```
+This info can be passed directly to `docker run` command to get an environment
+that's identical what what we use when testing on CI.
+
+## Updating the images
+
+The authoritative version of docker images we use for testing is stored in artifact registry,
+under the repository `us-docker.pkg.dev/grpc-testing/testing-images-public`.
+
+If you've made modifications to a dockerfile, you can upload the new version of the artifact
+registry as follows:
+
+Rebuild the docker images that have been modified locally and upload the docker images to
+artifact registry (note that this won't overwrite the "old" versions of the docker image
+that are already in artifact registry)
+```
+tools/dockerfile/push_testing_images.sh
+```
+
+Build modified docker images locally and don't push to artifact registry. This option is
+very useful for quick local experiments. The script is much faster if it doesn't have to
+interact with artifact registry:
+```
+# very useful for local experiments
+LOCAL_ONLY_MODE=true tools/dockerfile/push_testing_images.sh
+```
+
+## Migrating from dockerhub
+
+In the past, our testing docker images were [hosted on dockerhub](https://hub.docker.com/u/grpctesting),
+but we are in the process of migrating them artifact registry now.
+
+This temporary feature might simplify the migration:
+```
+# try pull existing images from dockerhub instead of building the from scratch locally.
+TRANSFER_FROM_DOCKERHUB=true tools/dockerfile/push_testing_images.sh
+```

--- a/tools/dockerfile/distribtest/cpp_stretch_aarch64_cross_x64.current_version
+++ b/tools/dockerfile/distribtest/cpp_stretch_aarch64_cross_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_stretch_aarch64_cross_x64:936bd8a34fcd95c00b40e1e08ad31a39fb5211a6@sha256:5f43add221246deb62fbdff53fe3819c66c854a3913bf77f2f5b785b6a94900b

--- a/tools/dockerfile/distribtest/cpp_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/cpp_stretch_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_stretch_x64:02187d31870bf506ac5868b46c2192e01e94fa0a@sha256:1711316cc325618ca43e1d04804833d373166f8313bf439eb4c33e4dbaa905e9

--- a/tools/dockerfile/distribtest/csharp_alpine_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_alpine_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_alpine_x64:ad69c44d058b83910b333f0c2ede094e73af465b@sha256:d018105349fcabdc3aa0649c1381d840c613df6b442a53a751d7dc839a80d429

--- a/tools/dockerfile/distribtest/csharp_centos7_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_centos7_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_centos7_x64:7164f429291fadec4421d129f196b2d720471dd0@sha256:ec715dd5fbd621789e7598c8d4ac346a7b4037b0cc83fbb29990dc8e4c1f1a13

--- a/tools/dockerfile/distribtest/csharp_dotnet31_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_dotnet31_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_dotnet31_x64:335b31cb83d37a68034cc26b3baf3302f4f6633f@sha256:fee52df6064ff84bc9af644c2ea17ab579de3401e3a167d0d43383c24f0d500f

--- a/tools/dockerfile/distribtest/csharp_dotnet5_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_dotnet5_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_dotnet5_x64:bd7cd75510186f6b39f54d22b610b70fd2c43e09@sha256:408425cd74bb8b79a3b09a64ea6c54f6cdc0e757a3469f31effc017a7187e442

--- a/tools/dockerfile/distribtest/csharp_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_stretch_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_stretch_x64:d2178edef3faf5fb811b8c4d10fa98ab8e8bd189@sha256:fec8c0637c0163308ba1e2b2592dfbabba8d89c0391e58065bf10ea2659d9d59

--- a/tools/dockerfile/distribtest/csharp_ubuntu1604_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1604_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_ubuntu1604_x64:055154ec1a27322dfe63008dfb2fe067eb095f86@sha256:e0f44406df14a28ce0a0f4e26c74c95f0fa5dddadf1fdbb2a3793b7c8ef8fa63

--- a/tools/dockerfile/distribtest/php7_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/php7_stretch_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/php7_stretch_x64:6cb7b602cb33592b27bd512966d6f8f93687d349@sha256:ac384de1434b4f922a0b68c7acde5c5811fc89b8f78a67d195222487c0f83fa5

--- a/tools/dockerfile/distribtest/python_alpine_x64.current_version
+++ b/tools/dockerfile/distribtest/python_alpine_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_alpine_x64:c2730a0e20e7951f1f6fa792dc380aba1d6ba4cc@sha256:699ac7b86199406fa27e88f30a1c623ef34ac33f6d9330fd13a6f6457ee4e19f

--- a/tools/dockerfile/distribtest/python_arch_x64.current_version
+++ b/tools/dockerfile/distribtest/python_arch_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_arch_x64:cc4a1b3dc7fb06a013d6dd6a1105292ecf4e72de@sha256:2c1adadeb010e107132cf5137f32a2d18727796631245b110cc74f69c07502e1

--- a/tools/dockerfile/distribtest/python_buster_x64.current_version
+++ b/tools/dockerfile/distribtest/python_buster_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_buster_x64:e5ed17c49c3b3ea2476c09c249ee99615e2a2744@sha256:e501dc8e2f4ab9cd4382974759a879a27c065c8fed5327f538764298fc5c4972

--- a/tools/dockerfile/distribtest/python_buster_x86.current_version
+++ b/tools/dockerfile/distribtest/python_buster_x86.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_buster_x86:c6c77a4a3d0f571e7b96269f193eb5b6bc68b40d@sha256:185fbb174525d67b6146f4d233c804c589b0b57d783bb1bf95bc47cfe792754e

--- a/tools/dockerfile/distribtest/python_centos7_x64.current_version
+++ b/tools/dockerfile/distribtest/python_centos7_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_centos7_x64:649034b24ad02199a707399333bfff0bab474ee0@sha256:39afaa687cb8516eef1621ed789326fdde2014fd3c81d11a1ded72f2d5285fe1

--- a/tools/dockerfile/distribtest/python_dev_alpine3.7_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_alpine3.7_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_alpine3.7_x64:2872be8abc221922814403d8c793b95f7542f7e7@sha256:7c08f67211a49eb72ad08c29de5c64a914c066d9c1670b712e717571b8d5c7e2

--- a/tools/dockerfile/distribtest/python_dev_arch_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_arch_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_arch_x64:22457118c8bc1cc74d46633edcad62f36f715b16@sha256:29f179ef2083ee6addd57e90f58781fdc1cb5dc3dd3e228da1af38785b921f35

--- a/tools/dockerfile/distribtest/python_dev_buster_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_buster_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_buster_x64:f72da78097dfc18225ef0da25da07a5c220bdd47@sha256:e30d6efdeac24e5136cc169d503a239df22147bfb121d27feb1f87d58a8fe64e

--- a/tools/dockerfile/distribtest/python_dev_buster_x86.current_version
+++ b/tools/dockerfile/distribtest/python_dev_buster_x86.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_buster_x86:9966610e9ebd738965baa64ba7230385e088db5b@sha256:179146fd5d5cc15846c6bf0284c2e261f383caf944559d2d9f7a5af0e0f7152d

--- a/tools/dockerfile/distribtest/python_dev_centos7_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_centos7_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_centos7_x64:787884c8ee2f40f546004dc358d87c2bd6ee8ba7@sha256:e6e9a1b23a0a543050db91e17d621aa899bad04308adaf961c11fa88ba941a95

--- a/tools/dockerfile/distribtest/python_dev_fedora34_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_fedora34_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_fedora34_x64:5b754243660c2e5e03ac90bd2efa476cde04bc5c@sha256:20bc3a6283a99407eb637b3cde1ff3e1288a1e21388a1dc385c2b4df5a1eb1c2

--- a/tools/dockerfile/distribtest/python_dev_ubuntu1604_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_ubuntu1604_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_ubuntu1604_x64:7ba01be86cef2719c5c258a767e9c3144e8f7092@sha256:167134c3a43e7d2608c893cc98a5066eae93c6af97ef5a1e69d643cbc7fefc43

--- a/tools/dockerfile/distribtest/python_dev_ubuntu1804_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_ubuntu1804_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_ubuntu1804_x64:483ff054a378bc704ae38ff1e1713947472c60d6@sha256:157a89cd6d0e69b89ac1975e0314aade556a35aafbaa5fe9f9890f90321d6c89

--- a/tools/dockerfile/distribtest/python_dev_ubuntu2004_x64.current_version
+++ b/tools/dockerfile/distribtest/python_dev_ubuntu2004_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_dev_ubuntu2004_x64:e862792c549045d62ffd4ae0ad6271f8a8a0c11a@sha256:91f0d88c43ec52ecd63f99acb424c88ff9a67fa046fae207a75e99bee37eef11

--- a/tools/dockerfile/distribtest/python_fedora34_x64.current_version
+++ b/tools/dockerfile/distribtest/python_fedora34_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_fedora34_x64:f46b89fcfbd8d29b98310b614356a29e5488a3b4@sha256:5aa8e41d627ddd6bc10aae6b12d25ded90ba8554a63b279f43f44e0d6cf001dd

--- a/tools/dockerfile/distribtest/python_opensuse_x64.current_version
+++ b/tools/dockerfile/distribtest/python_opensuse_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_opensuse_x64:6fdd85c75f65e17226b8443a88e552a4f39d0c0f@sha256:da52566b078d10e537aa219e59641731a57e5dc7d17d6737f5e5a7d447acf5cc

--- a/tools/dockerfile/distribtest/python_python38_buster_aarch64.current_version
+++ b/tools/dockerfile/distribtest/python_python38_buster_aarch64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_python38_buster_aarch64:edf5161ef67ec611c2a94177ac002f18e39402fd@sha256:487b9af2ad1459ee2630694e61074d4ac525d4f90b2bdb026dbf6f77fb3e9878

--- a/tools/dockerfile/distribtest/python_ubuntu1604_x64.current_version
+++ b/tools/dockerfile/distribtest/python_ubuntu1604_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_ubuntu1604_x64:371e156fc47905c855f002c5dbd5eae63467f36c@sha256:44a821a9f5431122c2e239ba35cf181c2fde84a5d866e8add338599565881492

--- a/tools/dockerfile/distribtest/python_ubuntu1804_x64.current_version
+++ b/tools/dockerfile/distribtest/python_ubuntu1804_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_ubuntu1804_x64:ee3ea8950f46d21ef06d3848294ae518c68f144f@sha256:edcd5f342d77ad9129cc0a0e6988b47b144815e7a93091d5b45e850111eefbcf

--- a/tools/dockerfile/distribtest/python_ubuntu2004_x64.current_version
+++ b/tools/dockerfile/distribtest/python_ubuntu2004_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_ubuntu2004_x64:88ff5e0c024db7aa193869378a9c22d08e795b8d@sha256:342e9dc23b674ad256b220745745be818708a1baa25a2690f0d4f777e28a22a3

--- a/tools/dockerfile/distribtest/ruby_centos7_x64.current_version
+++ b/tools/dockerfile/distribtest/ruby_centos7_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_centos7_x64:b37e078e920ba1f75bd26bc67c2d3496432e36af@sha256:4d529b984b78ca179086f7f9b416605e2d9a96ca0a28a71f4421bb5ffdc18f96

--- a/tools/dockerfile/distribtest/ruby_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64:10177ff0d2d316c3bb7552726524137c2ae19c90@sha256:fb3c9a4fb54aaf0c2e759be4b544cce7a8c9e115902f8f80b5e5992dcf110021

--- a/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_6.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_6.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64_ruby_2_6:4b215aa6d7029aaa63679881d54b8ca620e2d775@sha256:b9cc471908386767a9dbf3baffb7a67aa93c4cd1057c4ba8572c691c8ba4b3e6

--- a/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_7.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_7.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64_ruby_2_7:ab78ab5469a4245bff384c61814f940403206afe@sha256:086280e74db8a0f3c4bdc54626f94011284f02d5e787d9d55413261c35526394

--- a/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_3_0.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_3_0.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64_ruby_3_0:bbc6812686a00d8f9d1254acdbe86e0ef0d00d28@sha256:a28654540308499bc45592118f115fbdbf4813fd692438219bbe8574235c902e

--- a/tools/dockerfile/distribtest/ruby_ubuntu1604_x64.current_version
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1604_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_ubuntu1604_x64:b40136d20b396dfaf37d5bc30bebf00218fb1b0f@sha256:e0276968184a6c1e16de4e6afbbd469df91b27e40d061340841c76e864fdcb50

--- a/tools/dockerfile/distribtest/ruby_ubuntu1804_x64.current_version
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1804_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_ubuntu1804_x64:aca247e97f04a9cd5922a310337a4b5ee646fb9d@sha256:d38b3dd34cffc027e9a1bf82bc7ace75b8a9829c2d04d5cf7cc8323655edd27a

--- a/tools/dockerfile/grpc_artifact_centos6_x64.current_version
+++ b/tools/dockerfile/grpc_artifact_centos6_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_centos6_x64:7ae552ec1e2da47be72c96997cbb687fe031ce72@sha256:3285047265ea2b7c5d4df4c769b2d05f56288d947c75e16d27ae2dee693f791b

--- a/tools/dockerfile/grpc_artifact_centos6_x86.current_version
+++ b/tools/dockerfile/grpc_artifact_centos6_x86.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_centos6_x86:c0dfebb86cfaf2a3db97d9dc470010a219584b6e@sha256:19783239da92208f0f39cf563529cd02e889920497ef81c60d20391fa998af62

--- a/tools/dockerfile/grpc_artifact_protoc_aarch64.current_version
+++ b/tools/dockerfile/grpc_artifact_protoc_aarch64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_protoc_aarch64:546950fbd4e0dbe42286217a7c2fe6d262e153ab@sha256:1a3957f32e81259e6f3c602bd67feb132ebc5a5f23e9cb0bf63ba34b91185982

--- a/tools/dockerfile/grpc_artifact_python_linux_armv7.current_version
+++ b/tools/dockerfile/grpc_artifact_python_linux_armv7.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_linux_armv7:e083630fb0d91e534b69f2f64dbd47f79ce977e2@sha256:4f817dece74bbdc7c4fccdc9b0a25cefb9101781a60bf0bb827e533e79f9b1f2

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64.current_version
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_manylinux2014_aarch64:664dcb74d271052b45a3f6b0bacc8fb215f294f1@sha256:35470bd34b7ad6c05c397495c4d537400f78c82256d7c7e79b25d9f5ab651c8c

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_manylinux2014_x64:1949ee70cc9de7ec0ed7ed3c209c0a67a3c17778@sha256:84e0b37c7f61aebff44877993ec678f0e34869e70bca651f1cbd0e46485454b4

--- a/tools/dockerfile/grpc_artifact_python_manylinux2014_x86.current_version
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2014_x86.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_manylinux2014_x86:49c7d242fed1a39ec7fe70c4be38de0cf4cb3006@sha256:c8789d88510b51b24bfaa21a91f0d21a4a5269f800bafd2c6c9626d628e93a6a

--- a/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x64.current_version
+++ b/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_musllinux_1_1_x64:4b82ff22628795496952f54307ac84e3e82feca3@sha256:d357a7d75a41261251db35a41e8fbcef5c710e1b39d91f1c3d9503bf738b8203

--- a/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x86.current_version
+++ b/tools/dockerfile/grpc_artifact_python_musllinux_1_1_x86.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_musllinux_1_1_x86:178208f98536cdd71ebdfff92fd81b0a8f77c326@sha256:5f323fa0e66211a8f8c836cac34e7f95eec233e0a3248ea191bb5231588c5efa

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_aspnetcore:ff27c667aea48cc8232a236c5c52a90b9fd7f4bc@sha256:8e2e732e78724a8382c340dca72e7653c5f82c251a3110fa2874cc00ba538878

--- a/tools/dockerfile/interoptest/grpc_interop_cxx.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_cxx:47b0a0916781ab659c049d44efb3f1496dae4660@sha256:a69a1ed729137c3ea347f0a3488524573285be7832dd74cec830db57b61a9b8c

--- a/tools/dockerfile/interoptest/grpc_interop_dart.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_dart.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_dart:116ea85562d6b32270d1744a14f63667b83c0649@sha256:0f37aef8cf8e0e418a3b8097c985cc7c0525dcbdb3bc08f9267b9e46add36d49

--- a/tools/dockerfile/interoptest/grpc_interop_go.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_go.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go:5634d60fe93a78b23d8fb00f31228f94dd1c1849@sha256:d5b2b0c02e7a8196fea704196a8221994983c22eece2ac2324e095e8972a957f

--- a/tools/dockerfile/interoptest/grpc_interop_go1.11.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.11.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.11:e6f2d28a2807d82b6c7e2627181cd8cd1623603b@sha256:29cde59287843a3208c0cabeaf430cf813846a738c8a1b9692e68b54bbbdcc2d

--- a/tools/dockerfile/interoptest/grpc_interop_go1.16.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.16.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.16:5634d60fe93a78b23d8fb00f31228f94dd1c1849@sha256:d5b2b0c02e7a8196fea704196a8221994983c22eece2ac2324e095e8972a957f

--- a/tools/dockerfile/interoptest/grpc_interop_go1.8.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.8.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.8:2774616b814793b38eb3314efa6285faeef07034@sha256:7830a301b37539252c592b9cd7fa30a6142d0afc717a05fc8d2b82c74fb45efe

--- a/tools/dockerfile/interoptest/grpc_interop_http2.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_http2.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_http2:8be59842ce13c47a631ef13353091499f2b085d8@sha256:e3f247d8038374848fadf7215b841e3575c0b2a4217feb503a79b8004b164c5a

--- a/tools/dockerfile/interoptest/grpc_interop_java.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_java.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_java:84573d964578d9d9db8a30ecf41a9f7cedaa5ff6@sha256:d9210764071662ba2f377dafcaff4b743f41e4dff1876dd47df7b1c6950f88af

--- a/tools/dockerfile/interoptest/grpc_interop_node.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_node.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_node:588bbc800e64843fe041421a85771d33a7214ee4@sha256:337e9995563e4f569b4daf843d0a2af0619e086481ce3ba3f888434eb2ddc28b

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_nodepurejs:b1a78b7d071d903d410c18b42441423538ff5e3c@sha256:9061077a17eb6f2306af563ed85c12630480f6d6ce15919d67ef5567dbab559e

--- a/tools/dockerfile/interoptest/grpc_interop_php7.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_php7.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_php7:deaa60781bea3d05894752b68751070d815b3539@sha256:09f4b895117c81506c423360b617917d06d3f7f0b78e4cca25eaec547ba6991e

--- a/tools/dockerfile/interoptest/grpc_interop_python.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_python.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_python:2a3ad8e13c089a75f6b1bf88b42522aa6072c4f9@sha256:fef1247f8256be2b9841331e7d21b0046da21a4a6d34a62addb36f62124725cf

--- a/tools/dockerfile/interoptest/grpc_interop_pythonasyncio.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_pythonasyncio.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_pythonasyncio:f8a911c5794bebb74e7effbf10f1c98477871da8@sha256:bd4cdc8a71ef339193e178ce20d2b47a0b2aa25fc86c0b5740b9d86a2d4a0caa

--- a/tools/dockerfile/interoptest/grpc_interop_ruby.current_version
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_ruby:4abe304d586e1bc862cb85e9ac5e9c7b2f7ae73c@sha256:0de52450b29cf91365e623b020cd97722c307510ba1813bee09264e0a49acdbc

--- a/tools/dockerfile/interoptest/lb_interop_fake_servers.current_version
+++ b/tools/dockerfile/interoptest/lb_interop_fake_servers.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/lb_interop_fake_servers:07ef60e1692bfbfd8aab9283c6d29c7d277144ff@sha256:b89a51dd9147e1293f50ee64dd719fce5929ca7894d3770a3d80dbdecb99fd52

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -35,18 +35,23 @@ cd -
 # Login with gcloud:
 # $ gcloud auth login
 
-# Check that docker is installed and sudoless docker works.
-docker run --rm -it debian:11 bash -c 'echo "sudoless docker run works!"' || \
-    (echo "Error: docker not installed or sudoless docker doesn't work?" && exit 1)
+# Various check that the environment is setup correctly.
+# The enviroment checks are skipped when running as a sanity check on CI.
+if [ "${CHECK_MODE}" == "" ]
+then
+  # Check that docker is installed and sudoless docker works.
+  docker run --rm -it debian:11 bash -c 'echo "sudoless docker run works!"' || \
+      (echo "Error: docker not installed or sudoless docker doesn't work?" && exit 1)
 
-# Some of the images we build are for arm64 architecture and the easiest
-# way of allowing them to build locally on x64 machine is to use
-# qemu binfmt-misc hook that automatically runs arm64 binaries under
-# an emulator.
-# Perform a check that "qemu-user-static" with binfmt-misc hook
-# is installed, to give an early warning (otherwise building arm64 images won't work)
-docker run --rm -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"' || \
-    (echo "Error: can't run arm64 images under an emulator. Have you run 'sudo apt-get install qemu-user-static'?" && exit 1)
+  # Some of the images we build are for arm64 architecture and the easiest
+  # way of allowing them to build locally on x64 machine is to use
+  # qemu binfmt-misc hook that automatically runs arm64 binaries under
+  # an emulator.
+  # Perform a check that "qemu-user-static" with binfmt-misc hook
+  # is installed, to give an early warning (otherwise building arm64 images won't work)
+  docker run --rm -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"' || \
+      (echo "Error: can't run arm64 images under an emulator. Have you run 'sudo apt-get install qemu-user-static'?" && exit 1)
+fi
 
 ARTIFACT_REGISTRY_PREFIX=us-docker.pkg.dev/grpc-testing/testing-images-public
 

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -13,22 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Builds selected testing docker images and pushes them to dockerhub.
-# Useful for testing environments where it's impractical (or impossible)
-# to rely on docker images being cached locally after they've been built
-# for the first time (which might be costly especially for some images).
-# NOTE: gRPC docker images intended to be used by end users are NOT
-# pushed using this script (they're built automatically by dockerhub).
-# This script is only for "internal" images we use when testing gRPC.  
+# Builds selected testing docker images and pushes them to artifact registry.
+# NOTE: These images are not intended to be used by gRPC end users,
+# they simply provide an easily reproducible environment for running gRPC
+# tests.
 
-set -ex
+set -e
 
 cd $(dirname $0)/../..
 git_root=$(pwd)
 cd -
 
+# How to configure docker before running this script for the first time:
+# Configure docker:
+# $ gcloud auth configure-docker us-docker.pkg.dev
+# Login with gcloud:
+# $ gcloud auth login
+
 # Check that docker is installed and sudoless docker works.
-docker run -it debian:11 bash -c 'echo "sudoless docker run works!"' || \
+docker run --rm -it debian:11 bash -c 'echo "sudoless docker run works!"' || \
     (echo "Error: docker not installed or sudoless docker doesn't work?" && exit 1)
 
 # Some of the images we build are for arm64 architecture and the easiest
@@ -37,12 +40,21 @@ docker run -it debian:11 bash -c 'echo "sudoless docker run works!"' || \
 # an emulator.
 # Perform a check that "qemu-user-static" with binfmt-misc hook
 # is installed, to give an early warning (otherwise building arm64 images won't work)
-docker run -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"' || \
+docker run --rm -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"' || \
     (echo "Error: can't run arm64 images under an emulator. Have you run 'sudo apt-get install qemu-user-static'?" && exit 1)
 
-DOCKERHUB_ORGANIZATION=grpctesting
+ARTIFACT_REGISTRY_PREFIX=us-docker.pkg.dev/grpc-testing/testing-images-public
 
-for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* tools/dockerfile/distribtest/* third_party/rake-compiler-dock/*/
+# all dockerfile definitions we use for testing and for which we push an image to the registry
+ALL_DOCKERFILE_DIRS=(
+  tools/dockerfile/test/*
+  tools/dockerfile/grpc_artifact_*
+  tools/dockerfile/interoptest/*
+  tools/dockerfile/distribtest/*
+  third_party/rake-compiler-dock/*/
+)
+
+for DOCKERFILE_DIR in "${ALL_DOCKERFILE_DIRS[@]}"
 do
   # Generate image name based on Dockerfile checksum. That works well as long
   # as can count on dockerfiles being written in a way that changing the logical 
@@ -57,12 +69,70 @@ do
     DOCKER_IMAGE_TAG=$(sha1sum $DOCKERFILE_DIR/Dockerfile | cut -f1 -d\ )
   fi
 
-  # skip the image if it already exists in the repo 
-  curl --silent -f -lSL https://registry.hub.docker.com/v2/repositories/${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}/tags/${DOCKER_IMAGE_TAG} > /dev/null \
-      && continue
+  echo "Visiting ${DOCKERFILE_DIR}"
 
-  docker build -t ${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKERFILE_DIR}
+  # SKIP_REMOTE controls whether artifact registry are going to be queried at all.
+  if [ "${SKIP_REMOTE}" == "" ]
+  then
+    DOCKER_IMAGE_DIGEST_REMOTE=$(gcloud artifacts docker images describe "${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" --format=json | jq -r '.image_summary.digest')
 
-  # "docker login" needs to be run in advance
-  docker push ${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+    if [ "${DOCKER_IMAGE_DIGEST_REMOTE}" != "" ]
+    then
+      # skip building the image if it already exists in the destination registry
+      echo "Docker image ${DOCKER_IMAGE_NAME} already exists in artifact registry at the right version (tag ${DOCKER_IMAGE_TAG})."
+
+      # TODO: (sanity check) if remote check requested, check that the remote digest matches what's currently in the .current_version file.
+
+      # update info on what we consider to be the current version of the docker image (which will be used to run tests)
+      # we consider the sha256 image digest info from the artifact registry to be the canonical one
+      echo -n "${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}@${DOCKER_IMAGE_DIGEST_REMOTE}" >${DOCKERFILE_DIR}.current_version
+
+      continue
+    fi
+
+    # TODO: (sanity check) if remote check requested, fail here since not all images have been uploaded to artifact registry
+  fi
+
+  # if the .current_version file doesn't exist or it doesn't contain the right SHA checksum,
+  # it is out of date and we will need to rebuild the docker image locally.
+  LOCAL_BUILD_REQUIRED=""
+  grep "^${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}@sha256:.*" ${DOCKERFILE_DIR}.current_version >/dev/null && LOCAL_BUILD_REQUIRED=true
+
+  if [ "${LOCAL_BUILD_REQUIRED}" != "" ]
+  then
+    echo "Dockerfile for ${DOCKER_IMAGE_NAME} hasn't changed. Will skip 'docker build'."
+    continue
+  fi
+
+  # TODO: (sanity check) if in check mode, fail here since the .current_version file is either missing or out of date
+
+  if [ "${TRANSFER_FROM_DOCKERHUB}" == "" ]
+  then
+    echo "Running 'docker build' for ${DOCKER_IMAGE_NAME}"
+    echo "=========="
+    docker build -t ${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${DOCKERFILE_DIR}
+    echo "=========="
+  else
+    # TRANSFER_FROM_DOCKERHUB is a temporary feature that pulls the corresponding image from dockerhub instead
+    # of building it from scratch locally. This should simplify the dockerhub -> artifact registry migration.
+    DOCKERHUB_ORGANIZATION=grpctesting
+    # pull image from dockerhub
+    docker pull ${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+    # add the artifact registry tag
+    docker tag ${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} ${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+  fi
+
+  DOCKER_IMAGE_DIGEST_LOCAL=$(docker image inspect "${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" | jq -e -r '.[0].Id')
+
+  # update info on what we consider to be the current version of the docker image (which will be used to run tests)
+  echo -n "${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}@${DOCKER_IMAGE_DIGEST_LOCAL}" >${DOCKERFILE_DIR}.current_version
+
+  if [ "${SKIP_UPLOAD}" == "" ]
+  then
+    docker push ${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}
+  fi
 done
+
+# TODO: extra sanity checks - check there are no extra current_version files (for which there isn't a corresponding Dockerfile)
+
+echo "All done."

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -28,6 +28,7 @@ cd -
 #  LOCAL_ONLY_MODE: if set (e.g. LOCAL_ONLY_MODE=true), script will only operate locally and it won't query artifact registry and won't upload to it.
 #  CHECK_MODE: if set, the script will check that all the .current_version files are up-to-date (used by sanity tests).
 #  SKIP_UPLOAD: if set, script won't push docker images it built to artifact registry.
+#  TRANSFER_FROM_DOCKERHUB: if set, will attempt to grab docker images missing in artifact registry from dockerhub instead of building them from scratch locally.
 
 # How to configure docker before running this script for the first time:
 # Configure docker:
@@ -153,6 +154,7 @@ do
   else
     # TRANSFER_FROM_DOCKERHUB is a temporary feature that pulls the corresponding image from dockerhub instead
     # of building it from scratch locally. This should simplify the dockerhub -> artifact registry migration.
+    # TODO(jtattermusch): remove this feature in Q1 2023.
     DOCKERHUB_ORGANIZATION=grpctesting
     # pull image from dockerhub
     docker pull ${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}

--- a/tools/dockerfile/test/android_ndk.current_version
+++ b/tools/dockerfile/test/android_ndk.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:fbf61e53ebd3588252f88a355c9afe9119013338@sha256:0778ede020d2af6bcc76d8d40a3fabcfeef5fd492515da5518ec29079fd45f89

--- a/tools/dockerfile/test/bazel.current_version
+++ b/tools/dockerfile/test/bazel.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:2345e87c22697f699d33a64d305a0177ce77e5f5@sha256:b42f10625321296c7f646e1e82023d0b46e4f9b6d2205cff2b49352c5dc1ce9f

--- a/tools/dockerfile/test/bazel_arm64.current_version
+++ b/tools/dockerfile/test/bazel_arm64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/bazel_arm64:9517bfbd2d0cf0f6a830e8d8e152c85f2f94ec1d@sha256:4c860be7b181655be5067bd7676c384552b2fe55ee3cbcc800888322dd8380b9

--- a/tools/dockerfile/test/binder_transport_apk.current_version
+++ b/tools/dockerfile/test/binder_transport_apk.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/binder_transport_apk:7a0e59e4e89958d4eb461dda14e6197951c28e43@sha256:f098ac40d4819b21b4ba8fc8f7715039e7c4285be736813f2aeb8e00e158ca12

--- a/tools/dockerfile/test/csharp_debian11_arm64.current_version
+++ b/tools/dockerfile/test/csharp_debian11_arm64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_debian11_arm64:31749e35f65ff63a4965ac306d96b447e9811fb5@sha256:e1345c81aaab856eab0635ddbe612294bee9ee38d4938d3434eab277de6029b8

--- a/tools/dockerfile/test/csharp_debian11_x64.current_version
+++ b/tools/dockerfile/test/csharp_debian11_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_debian11_x64:4eead6ba66c39598d9bb9f5b8e46e114c460c717@sha256:a38ffe41c25486ad0624f54b4a5fa11e74772a06f537c553b3ae3944511ef348

--- a/tools/dockerfile/test/cxx_alpine_x64.current_version
+++ b/tools/dockerfile/test/cxx_alpine_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_alpine_x64:97eceae8524fcb5489cce962bc4d36cbdd2b36ec@sha256:b75ee67e3a268f5d7ffaa58f09bc1e3059349153135e5de8753907fee7fda26d

--- a/tools/dockerfile/test/cxx_clang_15_x64.current_version
+++ b/tools/dockerfile/test/cxx_clang_15_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:890005619b89999b0bb3256a3f13d8bda9a1560a@sha256:cb24820cb9c660220495317c519d93c34374f7d6dd152e89723734b298dbd0ea

--- a/tools/dockerfile/test/cxx_clang_6_x64.current_version
+++ b/tools/dockerfile/test/cxx_clang_6_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_6_x64:78958e51f94dfb5c8c5e0a1fde2cfa4ccf0fee02@sha256:c5cec74947c06174b21188eb9565f322a8543cd4878dc40b34cfcaee9a5fd94a

--- a/tools/dockerfile/test/cxx_debian11_openssl102_x64.current_version
+++ b/tools/dockerfile/test/cxx_debian11_openssl102_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_openssl102_x64:af647277e5acb05a89769f23a73a763be7423c53@sha256:15af353947cad7d7bead70ddb1e43a20cfa561de8e894aa7f92e320f55673959

--- a/tools/dockerfile/test/cxx_debian11_x64.current_version
+++ b/tools/dockerfile/test/cxx_debian11_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_x64:47b0a0916781ab659c049d44efb3f1496dae4660@sha256:a69a1ed729137c3ea347f0a3488524573285be7832dd74cec830db57b61a9b8c

--- a/tools/dockerfile/test/cxx_debian11_x86.current_version
+++ b/tools/dockerfile/test/cxx_debian11_x86.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_x86:7b84ff94b76bcf1e67126468bcb816cd1badc859@sha256:fcb11fd175ef153f7abddf25d1f71e338d1874a4075287dcf3af765ea6226a98

--- a/tools/dockerfile/test/cxx_gcc_12_x64.current_version
+++ b/tools/dockerfile/test/cxx_gcc_12_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_gcc_12_x64:6c0ab4904f3c9aa9a38ba29f14c94dfc3e7901b2@sha256:a6d9f04d8075e697e16245004ab22bf22dd972c9724ecb750919816396186c09

--- a/tools/dockerfile/test/cxx_gcc_7_x64.current_version
+++ b/tools/dockerfile/test/cxx_gcc_7_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_gcc_7_x64:953aea35378bad8c12f2513c0dc6199bed1ca11d@sha256:7d33f341c7f7a5f358943c1f0b887de756079f406b7c7794e76cb0e42439c95b

--- a/tools/dockerfile/test/php73_zts_debian11_x64.current_version
+++ b/tools/dockerfile/test/php73_zts_debian11_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/php73_zts_debian11_x64:dc72ed4ad9a2a61dbaa410e266deff9c0c2765ac@sha256:db46a738bf187ffcabbd278a716930c87f90dec2599349c5a52937f9a17e96f8

--- a/tools/dockerfile/test/php7_debian11_arm64.current_version
+++ b/tools/dockerfile/test/php7_debian11_arm64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/php7_debian11_arm64:20fabcbf3bf31bdaf412fad5b504d466b5aab245@sha256:444e25f9e3a89c2438e4d5e6f3904c5a1f4d1fb961f8456333ebe3e36e301a4e

--- a/tools/dockerfile/test/php7_debian11_x64.current_version
+++ b/tools/dockerfile/test/php7_debian11_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/php7_debian11_x64:e6b7ccb98f6834b0cc7f01dff4e9694dd22d7d85@sha256:018d422abf144fc93e9027fd994f7d6aab453fffbe4a669d622dd3d1c1fe9ee7

--- a/tools/dockerfile/test/python_alpine_x64.current_version
+++ b/tools/dockerfile/test/python_alpine_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_alpine_x64:bcf3cc18ff2b548834691242537d226466e9e513@sha256:08a2428ed1a24d1eaae58091cc5c74329387fb3200ad89299916406be0b7852c

--- a/tools/dockerfile/test/python_debian11_default_arm64.current_version
+++ b/tools/dockerfile/test/python_debian11_default_arm64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_debian11_default_arm64:faff3d19982d4a3f479a4d9633d28028834bc4df@sha256:868cfb50e465f086b75bb65a7fab6d15b1edefabcd8c1826340acefb6ea1737f

--- a/tools/dockerfile/test/python_debian11_default_x64.current_version
+++ b/tools/dockerfile/test/python_debian11_default_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_debian11_default_x64:ee6a567ba2dee1502abec2d08b87b0c0caba8a42@sha256:df00d587bda7cbe4308e18def313fe893cffbeb5a807ab14a90ff0d87b1a001c

--- a/tools/dockerfile/test/ruby_debian11_arm64.current_version
+++ b/tools/dockerfile/test/ruby_debian11_arm64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_debian11_arm64:215df896c707f55c3092a64afc4075c7a408b516@sha256:9503d80a40555aba4dd531b64354ad8036c6b37e162c93e7994ca23d89bc7d41

--- a/tools/dockerfile/test/ruby_debian11_x64.current_version
+++ b/tools/dockerfile/test/ruby_debian11_x64.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_debian11_x64:05ff6c04182addf087f77b2515992e98b9c7a171@sha256:3f01369c3e5707fa63007820b30461b9e32a4b729d81cb92d19669d7966a8584

--- a/tools/dockerfile/test/sanity.current_version
+++ b/tools/dockerfile/test/sanity.current_version
@@ -1,0 +1,1 @@
+us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:bd9373552b2f61d381ccc777ede10b71b6d99656@sha256:d1a021e272d33520c4f22a6924b8f21f4daaeef7769ba22020f21787afa76927

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -27,22 +27,12 @@ cd -
 # Inputs
 # DOCKERFILE_DIR - Directory in which Dockerfile file is located.
 # OUTPUT_DIR - (optional) Directory under the git repo root that will be copied from inside docker container after finishing.
-# DOCKERHUB_ORGANIZATION - (optional) If set, pull a prebuilt image from given dockerhub org (instead of with "docker build" locally)
 # DOCKER_RUN_SCRIPT - (optional) Script to run under docker (relative to grpc repo root). If specified, the cmdline args
 #     passed on the commadline (a.k.a. $@) will be interpreted as extra args to pass to the "docker run" command.
 #     If DOCKER_RUN_SCRIPT is not set, $@ will be interpreted as the command and args to run under the docker container.
 
-# Use image name based on Dockerfile location checksum
-DOCKER_IMAGE_NAME=$(basename "$DOCKERFILE_DIR"):$(sha1sum "$DOCKERFILE_DIR/Dockerfile" | cut -f1 -d\ )
-
-if [ "$DOCKERHUB_ORGANIZATION" != "" ]
-then
-  DOCKER_IMAGE_NAME=$DOCKERHUB_ORGANIZATION/$DOCKER_IMAGE_NAME
-  time docker pull "$DOCKER_IMAGE_NAME"
-else
-  # Make sure docker image has been built. Should be instantaneous if so.
-  docker build -t "$DOCKER_IMAGE_NAME" "$DOCKERFILE_DIR"
-fi
+# The exact docker image to use and its version is determined by the corresponding .current_version file
+DOCKER_IMAGE_NAME="$(cat "${DOCKERFILE_DIR}.current_version")"
 
 # If TTY is available, the running container can be conveniently terminated with Ctrl+C.
 if [[ -t 0 ]]; then

--- a/tools/run_tests/dockerize/build_interop_image.sh
+++ b/tools/run_tests/dockerize/build_interop_image.sh
@@ -79,23 +79,9 @@ then
   MOUNT_ARGS+=" -v $HOME/service_account:/var/local/jenkins/service_account:ro"
 fi
 
-# Use image name based on Dockerfile checksum
-# on OSX use md5 instead of sha1sum
-if command -v sha1sum > /dev/null;
-then
-  BASE_IMAGE=${BASE_NAME}:$(sha1sum "tools/dockerfile/interoptest/$BASE_NAME/Dockerfile" | cut -f1 -d\ )
-else
-  BASE_IMAGE=${BASE_NAME}:$(md5 -r "tools/dockerfile/interoptest/$BASE_NAME/Dockerfile" | cut -f1 -d\ )
-fi
-
-if [ "$DOCKERHUB_ORGANIZATION" != "" ]
-then
-  BASE_IMAGE=$DOCKERHUB_ORGANIZATION/$BASE_IMAGE
-  time docker pull "$BASE_IMAGE"
-else
-  # Make sure docker image has been built. Should be instantaneous if so.
-  docker build -t "$BASE_IMAGE" --force-rm=true "tools/dockerfile/interoptest/$BASE_NAME" || exit $?
-fi
+BASE_IMAGE_DIR="tools/dockerfile/interoptest/$BASE_NAME"
+# The exact base docker image to use and its version is determined by the corresponding .current_version file
+BASE_IMAGE="$(cat "${BASE_IMAGE_DIR}.current_version")"
 
 # If TTY is available, the running container can be conveniently terminated with Ctrl+C.
 if [[ -t 0 ]]; then

--- a/tools/run_tests/sanity/check_testing_docker_images.sh
+++ b/tools/run_tests/sanity/check_testing_docker_images.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Copyright 2022 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+cd "$(dirname "$0")/../../.."
+
+# for now we are not running "remote" check because we'd need access to gcloud CLI
+# and the check is also slower.
+CHECK_MODE=true LOCAL_ONLY_MODE=true tools/dockerfile/push_testing_images.sh

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -15,6 +15,7 @@
 - script: tools/run_tests/sanity/check_shellcheck.sh
 - script: tools/run_tests/sanity/check_submodules.sh
 - script: tools/run_tests/sanity/check_test_filtering.py
+- script: tools/run_tests/sanity/check_testing_docker_images.sh
 - script: tools/run_tests/sanity/check_tracer_sanity.py
 - script: tools/run_tests/sanity/check_version.sh
 - script: tools/run_tests/sanity/core_banned_functions.py


### PR DESCRIPTION
- from now on, the public testing images (the ones managed by `tools/dockerfile/push_testing_image.sh`) will be hosted on Google artifact registry, under `us-docker.pkg.dev/grpc-testing/testing-images-public` repository (which is already setup and made public).
- for each dockerfile we have in our repo, there will be `.current_version` file in the same location and it contains the exact version of the docker image to run when running tests (including the sha256 digest, which pretty much guarantees everyone will run the tests with an identical image). The "checksum" of the dockerfile is no longer computed when running  tests (reading the info from `.current_version` is enough).
      - I like that the `.current_version` file solution is also quite straightforward to interpret without needing too much context. In the repo the contributors (internal or external) can simply see a Dockerfile image recipe and a `.current_version` file right next to it . The file always has the info on which image version to use (and you can copypaste the info and do `docker run` directly with it and it will work).
 - the DOCKERHUB_ORGANIZATION variable is no longer used to determine whether to build locally or pull from registry. If the docker image is available locally with the right sha256 digest, it will be used. Otherwise it is pulled from the registry. The docker image is guaranteed to be identical since we use the sha256 image digest to identify it.
- there's some extra complexity in the `push_testing_images.sh` script. This script is what generates the `.current_version` files for all the dockerimages, can push the image to artifact registry and also can build the images  locally (if their dockerfile has changed)
- added a feature for `push_testing_images.sh` which can copy the current version of docker images from dockerhub and upload them to artifact registry (and I did that for the current version of the testing images).

TODO: more cleanup is definitely needed, but the "build_and_run_in_docker.sh" and "build_interop_image.sh" script have already been updated and they are what's used to start most of our tests that run under docker.

When reviewing, please ignore the "add generated .current_version files for docker images" commit.