### PR TITLE
xDS: fix error message when the request does not match any route

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1446,8 +1446,8 @@ void ClientChannel::UpdateServiceConfigInDataPlaneLocked() {
     config_selector =
         MakeRefCounted<DefaultConfigSelector>(saved_service_config_);
   }
-  ChannelArgs new_args = config_selector->ModifyChannelArgs(
-      channel_args_.SetObject(this).SetObject(service_config));
+  ChannelArgs new_args =
+      channel_args_.SetObject(this).SetObject(service_config);
   bool enable_retries =
       !new_args.WantMinimalStack() &&
       new_args.GetBool(GRPC_ARG_ENABLE_RETRIES).value_or(true);
@@ -2172,11 +2172,11 @@ grpc_error_handle ClientChannel::CallData::ApplyServiceConfigToCallLocked(
   ConfigSelector* config_selector = chand->config_selector_.get();
   if (config_selector != nullptr) {
     // Use the ConfigSelector to determine the config for the call.
-    ConfigSelector::CallConfig call_config =
+    auto call_config =
         config_selector->GetCallConfig({&path_, initial_metadata, arena_});
-    if (!call_config.status.ok()) {
+    if (!call_config.ok()) {
       return absl_status_to_grpc_error(MaybeRewriteIllegalStatusCode(
-          std::move(call_config.status), "ConfigSelector"));
+          call_config.status(), "ConfigSelector"));
     }
     // Create a ClientChannelServiceConfigCallData for the call.  This stores
     // a ref to the ServiceConfig and caches the right set of parsed configs
@@ -2185,9 +2185,9 @@ grpc_error_handle ClientChannel::CallData::ApplyServiceConfigToCallLocked(
     // below us in the stack, and it will be cleaned up when the call ends.
     auto* service_config_call_data =
         arena_->New<ClientChannelServiceConfigCallData>(
-            std::move(call_config.service_config), call_config.method_configs,
-            std::move(call_config.call_attributes),
-            call_config.call_dispatch_controller, call_context_);
+            std::move(call_config->service_config), call_config->method_configs,
+            std::move(call_config->call_attributes),
+            call_config->call_dispatch_controller, call_context_);
     // Apply our own method params to the call.
     auto* method_params = static_cast<ClientChannelMethodParsedConfig*>(
         service_config_call_data->GetMethodParsedConfig(

--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -673,7 +673,10 @@ ConfigSelector::CallConfig XdsResolver::XdsConfigSelector::GetCallConfig(
       RouteListIterator(&route_table_), StringViewFromSlice(*args.path),
       args.initial_metadata);
   if (!route_index.has_value()) {
-    return CallConfig();
+    CallConfig call_config;
+    call_config.status =
+        absl::UnavailableError("No matching route found in xDS route config");
+    return call_config;
   }
   auto& entry = route_table_[*route_index];
   // Found a route match

--- a/test/cpp/end2end/xds/xds_routing_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_routing_end2end_test.cc
@@ -215,6 +215,20 @@ TEST_P(LdsRdsTest, ChooseLastRoute) {
   EXPECT_EQ(response_state->state, AdsServiceImpl::ResponseState::ACKED);
 }
 
+TEST_P(LdsRdsTest, NoMatchingRoute) {
+  RouteConfiguration route_config = default_route_config_;
+  route_config.mutable_virtual_hosts(0)->mutable_routes(0)->mutable_match()
+      ->set_prefix("/unknown/method");
+  SetRouteConfiguration(balancer_.get(), route_config);
+  CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE,
+                      "No matching route found in xDS route config");
+  // Do a bit of polling, to allow the ACK to get to the ADS server.
+  channel_->WaitForConnected(grpc_timeout_milliseconds_to_deadline(100));
+  auto response_state = RouteConfigurationResponseState(balancer_.get());
+  ASSERT_TRUE(response_state.has_value());
+  EXPECT_EQ(response_state->state, AdsServiceImpl::ResponseState::ACKED);
+}
+
 // Tests that LDS client should ignore route which has query_parameters.
 TEST_P(LdsRdsTest, RouteMatchHasQueryParameters) {
   RouteConfiguration route_config = default_route_config_;

--- a/test/cpp/end2end/xds/xds_routing_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_routing_end2end_test.cc
@@ -217,7 +217,9 @@ TEST_P(LdsRdsTest, ChooseLastRoute) {
 
 TEST_P(LdsRdsTest, NoMatchingRoute) {
   RouteConfiguration route_config = default_route_config_;
-  route_config.mutable_virtual_hosts(0)->mutable_routes(0)->mutable_match()
+  route_config.mutable_virtual_hosts(0)
+      ->mutable_routes(0)
+      ->mutable_match()
       ->set_prefix("/unknown/method");
   SetRouteConfiguration(balancer_.get(), route_config);
   CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE,


### PR DESCRIPTION
Previously, we were just returning an empty `CallConfig`, which resulted in the call being forwarded to the xds_cluster_manager LB policy without any cluster being specified, so the xds_cluster_manager failed the call with status INTERNAL and a message about not finding the cluster.  This fixes the xDS config selector to instead return an explicit status in that case, so the call fails with status UNAVAILABLE and with an appropriate error message.

I've also taken the opportunity to clean up the `ConfigSelector` API a bit:
- change `GetCallConfig()` to return a `StatusOr<>` rather than including the `Status` in the `CallConfig` struct
- remove the used `ModifyChannelArgs()` method
- move the virtual `Equals()` method to be private