### PR TITLE
Revived google-readability-casting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,7 +31,6 @@
 # - clang-diagnostic-deprecated-declarations
 # - clang-diagnostic-unused-function
 # - google-readability-avoid-underscore-in-googletest-name
-# - google-readability-casting
 # - google-runtime-int
 # - google-runtime-references
 # - modernize-avoid-bind
@@ -72,7 +71,6 @@ Checks: '-*,
   -bugprone-unchecked-optional-access,
   google-*,
   -google-readability-avoid-underscore-in-googletest-name,
-  -google-readability-casting,
   -google-runtime-int,
   -google-runtime-references,
   -google-upgrade-googletest-case,

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -379,11 +379,10 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
   /// registration must take place before CQ shutdown (which must be maintained
   /// elsehwere)
   void InitialAvalanching() {
-    gpr_atm_rel_store(&avalanches_in_flight_, static_cast<gpr_atm>(1));
+    gpr_atm_rel_store(&avalanches_in_flight_, gpr_atm{1});
   }
   void RegisterAvalanching() {
-    gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_,
-                                 static_cast<gpr_atm>(1));
+    gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_, gpr_atm{1});
   }
   void CompleteAvalanching() {
     if (gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_,

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -385,8 +385,8 @@ class CompletionQueue : private grpc::GrpcLibraryCodegen {
     gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_, gpr_atm{1});
   }
   void CompleteAvalanching() {
-    if (gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_,
-                                     static_cast<gpr_atm>(-1)) == 1) {
+    if (gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_, gpr_atm{-1}) ==
+        1) {
       grpc::g_core_codegen_interface->grpc_completion_queue_shutdown(cq_);
     }
   }

--- a/src/core/ext/filters/channel_idle/idle_filter_state.h
+++ b/src/core/ext/filters/channel_idle/idle_filter_state.h
@@ -58,7 +58,7 @@ class IdleFilterState {
   static constexpr uintptr_t kCallsInProgressShift = 2;
   // How much to increment/decrement the state_ when a call is started/stopped.
   // Ensures we don't clobber the preceding bits.
-  static constexpr uintptr_t kCallIncrement = uintptr_t(1)
+  static constexpr uintptr_t kCallIncrement = uintptr_t{1}
                                               << kCallsInProgressShift;
   std::atomic<uintptr_t> state_;
 };

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
@@ -65,7 +65,7 @@ grpc_slice GrpcLbRequestCreate(const char* lb_service_name, upb_Arena* arena) {
   grpc_lb_v1_InitialLoadBalanceRequest* initial_request =
       grpc_lb_v1_LoadBalanceRequest_mutable_initial_request(req, arena);
   size_t name_len = std::min(strlen(lb_service_name),
-                             size_t(GRPC_GRPCLB_SERVICE_NAME_MAX_LENGTH));
+                             size_t{GRPC_GRPCLB_SERVICE_NAME_MAX_LENGTH});
   grpc_lb_v1_InitialLoadBalanceRequest_set_name(
       initial_request,
       upb_StringView_FromDataAndSize(lb_service_name, name_len));

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -324,8 +324,8 @@ void SubchannelData<SubchannelListType,
   pending_watcher_ =
       new Watcher(this, subchannel_list()->WeakRef(DEBUG_LOCATION, "Watcher"));
   subchannel_->WatchConnectivityState(
-      std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>(
-          pending_watcher_));
+      std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>{
+          pending_watcher_});
 }
 
 template <typename SubchannelListType, typename SubchannelDataType>

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -324,8 +324,9 @@ void SubchannelData<SubchannelListType,
   pending_watcher_ =
       new Watcher(this, subchannel_list()->WeakRef(DEBUG_LOCATION, "Watcher"));
   subchannel_->WatchConnectivityState(
-      std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>{
-          pending_watcher_});
+      // NOLINTNEXTLINE(google-readability-casting)
+      std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>(
+          pending_watcher_));
 }
 
 template <typename SubchannelListType, typename SubchannelDataType>

--- a/src/core/ext/filters/client_channel/retry_throttle.cc
+++ b/src/core/ext/filters/client_channel/retry_throttle.cc
@@ -89,8 +89,7 @@ bool ServerRetryThrottleData::RecordFailure() {
   const uintptr_t new_value =
       static_cast<uintptr_t>(gpr_atm_no_barrier_clamped_add(
           &throttle_data->milli_tokens_, static_cast<gpr_atm>(-1000),
-          static_cast<gpr_atm>(0),
-          static_cast<gpr_atm>(throttle_data->max_milli_tokens_)));
+          gpr_atm{0}, static_cast<gpr_atm>(throttle_data->max_milli_tokens_)));
   // Retries are allowed as long as the new value is above the threshold
   // (max_milli_tokens / 2).
   return new_value > throttle_data->max_milli_tokens_ / 2;
@@ -103,8 +102,7 @@ void ServerRetryThrottleData::RecordSuccess() {
   // We increment milli_tokens by milli_token_ratio for each success.
   gpr_atm_no_barrier_clamped_add(
       &throttle_data->milli_tokens_,
-      static_cast<gpr_atm>(throttle_data->milli_token_ratio_),
-      static_cast<gpr_atm>(0),
+      static_cast<gpr_atm>(throttle_data->milli_token_ratio_), gpr_atm{0},
       static_cast<gpr_atm>(throttle_data->max_milli_tokens_));
 }
 

--- a/src/core/ext/filters/client_channel/retry_throttle.cc
+++ b/src/core/ext/filters/client_channel/retry_throttle.cc
@@ -88,8 +88,8 @@ bool ServerRetryThrottleData::RecordFailure() {
   // We decrement milli_tokens by 1000 (1 token) for each failure.
   const uintptr_t new_value =
       static_cast<uintptr_t>(gpr_atm_no_barrier_clamped_add(
-          &throttle_data->milli_tokens_, static_cast<gpr_atm>(-1000),
-          gpr_atm{0}, static_cast<gpr_atm>(throttle_data->max_milli_tokens_)));
+          &throttle_data->milli_tokens_, gpr_atm{-1000}, gpr_atm{0},
+          static_cast<gpr_atm>(throttle_data->max_milli_tokens_)));
   // Retries are allowed as long as the new value is above the threshold
   // (max_milli_tokens / 2).
   return new_value > throttle_data->max_milli_tokens_ / 2;

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -206,7 +206,7 @@ FaultInjectionFilter::MakeInjectionDecision(
           initial_metadata->GetStringValue(fi_policy->delay_header, &buffer);
       if (value.has_value()) {
         delay = Duration::Milliseconds(
-            std::max(AsInt<int64_t>(*value).value_or(0), int64_t(0)));
+            std::max(AsInt<int64_t>(*value).value_or(0), int64_t{0}));
       }
     }
     if (!fi_policy->delay_percentage_header.empty()) {

--- a/src/core/ext/transport/binder/server/binder_server.cc
+++ b/src/core/ext/transport/binder/server/binder_server.cc
@@ -174,7 +174,7 @@ class BinderServerListener : public Server::ListenerInterface {
   absl::Status OnSetupTransport(transaction_code_t code,
                                 grpc_binder::ReadableParcel* parcel, int uid) {
     ExecCtx exec_ctx;
-    if (grpc_binder::BinderTransportTxCode(code) !=
+    if (static_cast<grpc_binder::BinderTransportTxCode>(code) !=
         grpc_binder::BinderTransportTxCode::SETUP_TRANSPORT) {
       return absl::InvalidArgumentError("Not a SETUP_TRANSPORT request");
     }

--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
@@ -156,7 +156,8 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
 
   {
     grpc_core::MutexLock lock(&mu_);
-    if (BinderTransportTxCode(code) != BinderTransportTxCode::SETUP_TRANSPORT &&
+    if (static_cast<BinderTransportTxCode>(code) !=
+            BinderTransportTxCode::SETUP_TRANSPORT &&
         !connected_) {
       return absl::InvalidArgumentError("Transports not connected yet");
     }
@@ -165,7 +166,7 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
   // TODO(mingcl): See if we want to check the security policy for every RPC
   // call or just during transport setup.
 
-  switch (BinderTransportTxCode(code)) {
+  switch (static_cast<BinderTransportTxCode>(code)) {
     case BinderTransportTxCode::SETUP_TRANSPORT: {
       grpc_core::MutexLock lock(&mu_);
       if (recvd_setup_transport_) {

--- a/src/core/ext/transport/binder/wire_format/wire_writer.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_writer.cc
@@ -126,7 +126,7 @@ absl::Status WireWriterImpl::MakeBinderTransaction(
 
 absl::Status WireWriterImpl::RpcCallFastPath(std::unique_ptr<Transaction> tx) {
   return MakeBinderTransaction(
-      BinderTransportTxCode(tx->GetTxCode()),
+      static_cast<BinderTransportTxCode>(tx->GetTxCode()),
       [this, tx = tx.get()](
           WritableParcel* parcel) ABSL_EXCLUSIVE_LOCKS_REQUIRED(write_mu_) {
         RETURN_IF_ERROR(parcel->WriteInt32(tx->GetFlags()));
@@ -244,7 +244,7 @@ void WireWriterImpl::RunScheduledTxInternal(RunScheduledTxArgs* args) {
   }
   bool is_last_chunk = true;
   absl::Status result = MakeBinderTransaction(
-      BinderTransportTxCode(stream_tx->tx->GetTxCode()),
+      static_cast<BinderTransportTxCode>(stream_tx->tx->GetTxCode()),
       [stream_tx, &is_last_chunk, this](WritableParcel* parcel)
           ABSL_EXCLUSIVE_LOCKS_REQUIRED(write_mu_) {
             return RunStreamTx(stream_tx, parcel, &is_last_chunk);
@@ -305,12 +305,12 @@ absl::Status WireWriterImpl::SendAck(int64_t num_bytes) {
     return absl::OkStatus();
   }
   // Otherwise, we can directly send ack.
-  absl::Status result = MakeBinderTransaction(
-      BinderTransportTxCode(BinderTransportTxCode::ACKNOWLEDGE_BYTES),
-      [num_bytes](WritableParcel* parcel) {
-        RETURN_IF_ERROR(parcel->WriteInt64(num_bytes));
-        return absl::OkStatus();
-      });
+  absl::Status result =
+      MakeBinderTransaction((BinderTransportTxCode::ACKNOWLEDGE_BYTES),
+                            [num_bytes](WritableParcel* parcel) {
+                              RETURN_IF_ERROR(parcel->WriteInt64(num_bytes));
+                              return absl::OkStatus();
+                            });
   if (!result.ok()) {
     gpr_log(GPR_ERROR, "Failed to make binder transaction %s",
             result.ToString().c_str());

--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -255,8 +255,7 @@ TransportFlowControl::TargetInitialWindowSizeBasedOnMemoryPressureAndBdp()
   //                                                                pressure
   const double kAnythingGoesPressure = 0.2;
   const double kAdjustedToBdpPressure = 0.5;
-  const double kAnythingGoesWindow =
-      std::max(static_cast<double>(1 << 24), bdp);
+  const double kAnythingGoesWindow = std::max(double{1 << 24}, bdp);
   if (memory_pressure < kAnythingGoesPressure) {
     return kAnythingGoesWindow;
   } else if (memory_pressure < kAdjustedToBdpPressure) {

--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -122,7 +122,7 @@ uint32_t TransportFlowControl::MaybeSendUpdate(bool writing_anyway) {
       announced_window_ != target_announced_window) {
     const uint32_t announce =
         static_cast<uint32_t>(Clamp(target_announced_window - announced_window_,
-                                    int64_t(0), kMaxWindowUpdateSize));
+                                    int64_t{0}, kMaxWindowUpdateSize));
     announced_window_ += announce;
     return announce;
   }
@@ -255,7 +255,8 @@ TransportFlowControl::TargetInitialWindowSizeBasedOnMemoryPressureAndBdp()
   //                                                                pressure
   const double kAnythingGoesPressure = 0.2;
   const double kAdjustedToBdpPressure = 0.5;
-  const double kAnythingGoesWindow = std::max(double(1 << 24), bdp);
+  const double kAnythingGoesWindow =
+      std::max(static_cast<double>(1 << 24), bdp);
   if (memory_pressure < kAnythingGoesPressure) {
     return kAnythingGoesWindow;
   } else if (memory_pressure < kAdjustedToBdpPressure) {
@@ -347,23 +348,24 @@ FlowControlAction TransportFlowControl::PeriodicUpdate() {
       }
       // Though initial window 'could' drop to 0, we keep the floor at
       // kMinInitialWindowSize
-      UpdateSetting(
-          GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
-          &target_initial_window_size_,
-          static_cast<int32_t>(Clamp(target, double(kMinInitialWindowSize),
-                                     double(kMaxInitialWindowSize))),
-          &action, &FlowControlAction::set_send_initial_window_update);
+      UpdateSetting(GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE,
+                    &target_initial_window_size_,
+                    static_cast<int32_t>(Clamp(
+                        target, static_cast<double>(kMinInitialWindowSize),
+                        static_cast<double>(kMaxInitialWindowSize))),
+                    &action,
+                    &FlowControlAction::set_send_initial_window_update);
       // get bandwidth estimate and update max_frame accordingly.
       double bw_dbl = bdp_estimator_.EstimateBandwidth();
       // we target the max of BDP or bandwidth in microseconds.
       UpdateSetting(
           GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE, &target_frame_size_,
-          static_cast<int32_t>(Clamp(
-              std::max(
-                  static_cast<int32_t>(Clamp(bw_dbl, 0.0, double(INT_MAX))) /
-                      1000,
-                  static_cast<int32_t>(target_initial_window_size_)),
-              16384, 16777215)),
+          static_cast<int32_t>(
+              Clamp(std::max(static_cast<int32_t>(Clamp(
+                                 bw_dbl, 0.0, static_cast<double>(INT_MAX))) /
+                                 1000,
+                             static_cast<int32_t>(target_initial_window_size_)),
+                    16384, 16777215)),
           &action, &FlowControlAction::set_send_max_frame_size_update);
     }
 
@@ -409,7 +411,7 @@ int64_t StreamFlowControl::DesiredAnnounceSize() const {
       return std::min(min_progress_size_, kMaxWindowDelta);
     }
   }();
-  return Clamp(desired_window_delta - announced_window_delta_, int64_t(0),
+  return Clamp(desired_window_delta - announced_window_delta_, int64_t{0},
                kMaxWindowUpdateSize);
 }
 
@@ -423,9 +425,8 @@ FlowControlAction StreamFlowControl::UpdateAction(FlowControlAction action) {
     // Currently set at half the initial window size or 8kb (whichever is
     // greater). 8kb means we don't send rapidly unnecessarily when the initial
     // window size is small.
-    const int64_t hurry_up_size =
-        std::max(static_cast<int64_t>(tfc_->sent_init_window()) / 2,
-                 static_cast<int64_t>(8192));
+    const int64_t hurry_up_size = std::max(
+        static_cast<int64_t>(tfc_->sent_init_window()) / 2, int64_t{8192});
     if (desired_announce_size > hurry_up_size) {
       urgency = FlowControlAction::Urgency::UPDATE_IMMEDIATELY;
     }

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -118,7 +118,7 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
       if (!g_disable_ping_ack) {
         if (t->ping_ack_count == t->ping_ack_capacity) {
           t->ping_ack_capacity =
-              std::max(t->ping_ack_capacity * 3 / 2, size_t(3));
+              std::max(t->ping_ack_capacity * 3 / 2, static_cast<size_t>(3));
           t->ping_acks = static_cast<uint64_t*>(gpr_realloc(
               t->ping_acks, t->ping_ack_capacity * sizeof(*t->ping_acks)));
         }

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -118,7 +118,7 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
       if (!g_disable_ping_ack) {
         if (t->ping_ack_count == t->ping_ack_capacity) {
           t->ping_ack_capacity =
-              std::max(t->ping_ack_capacity * 3 / 2, static_cast<size_t>(3));
+              std::max(t->ping_ack_capacity * 3 / 2, size_t{3});
           t->ping_acks = static_cast<uint64_t*>(gpr_realloc(
               t->ping_acks, t->ping_ack_capacity * sizeof(*t->ping_acks)));
         }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -220,7 +220,7 @@ static void report_stall(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                    [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE],
         t->flow_control.remote_window(),
         static_cast<uint32_t>(std::max(
-            int64_t(0),
+            int64_t{0},
             s->flow_control.remote_window_delta() +
                 static_cast<int64_t>(
                     t->settings[GRPC_PEER_SETTINGS]
@@ -378,7 +378,7 @@ class DataSendContext {
 
   uint32_t stream_remote_window() const {
     return static_cast<uint32_t>(std::max(
-        int64_t(0),
+        int64_t{0},
         s_->flow_control.remote_window_delta() +
             static_cast<int64_t>(
                 t_->settings[GRPC_PEER_SETTINGS]
@@ -388,15 +388,17 @@ class DataSendContext {
   uint32_t max_outgoing() const {
     return static_cast<uint32_t>(std::min(
         t_->settings[GRPC_PEER_SETTINGS][GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
-        static_cast<uint32_t>(std::min(int64_t(stream_remote_window()),
-                                       t_->flow_control.remote_window()))));
+        static_cast<uint32_t>(
+            std::min(static_cast<int64_t>(stream_remote_window()),
+                     t_->flow_control.remote_window()))));
   }
 
   bool AnyOutgoing() const { return max_outgoing() > 0; }
 
   void FlushBytes() {
-    uint32_t send_bytes = static_cast<uint32_t>(
-        std::min(size_t(max_outgoing()), s_->flow_controlled_buffer.length));
+    uint32_t send_bytes =
+        static_cast<uint32_t>(std::min(static_cast<size_t>(max_outgoing()),
+                                       s_->flow_controlled_buffer.length));
     is_last_frame_ = send_bytes == s_->flow_controlled_buffer.length &&
                      s_->send_trailing_metadata != nullptr &&
                      s_->send_trailing_metadata->empty();

--- a/src/core/ext/xds/xds_cluster_specifier_plugin.cc
+++ b/src/core/ext/xds/xds_cluster_specifier_plugin.cc
@@ -80,7 +80,7 @@ XdsRouteLookupClusterSpecifierPlugin::GenerateLoadBalancingPolicyConfig(
       grpc_lookup_v1_RouteLookupConfig_getmsgdef(symtab);
   size_t json_size = upb_JsonEncode(plugin_config, msg_type, symtab, 0, nullptr,
                                     0, status.ptr());
-  if (json_size == static_cast<size_t>(-1)) {
+  if (json_size == size_t{-1}) {
     return absl::InvalidArgumentError(
         absl::StrCat("failed to dump proto to JSON: ",
                      upb_Status_ErrorMessage(status.ptr())));

--- a/src/core/ext/xds/xds_cluster_specifier_plugin.cc
+++ b/src/core/ext/xds/xds_cluster_specifier_plugin.cc
@@ -80,7 +80,7 @@ XdsRouteLookupClusterSpecifierPlugin::GenerateLoadBalancingPolicyConfig(
       grpc_lookup_v1_RouteLookupConfig_getmsgdef(symtab);
   size_t json_size = upb_JsonEncode(plugin_config, msg_type, symtab, 0, nullptr,
                                     0, status.ptr());
-  if (json_size == size_t{-1}) {
+  if (json_size == static_cast<size_t>(-1)) {
     return absl::InvalidArgumentError(
         absl::StrCat("failed to dump proto to JSON: ",
                      upb_Status_ErrorMessage(status.ptr())));

--- a/src/core/ext/xds/xds_common_types.cc
+++ b/src/core/ext/xds/xds_common_types.cc
@@ -421,7 +421,7 @@ absl::StatusOr<Json> ParseProtobufStructToJson(
   const auto* msg_def = google_protobuf_Struct_getmsgdef(context.symtab);
   size_t json_size = upb_JsonEncode(resource, msg_def, context.symtab, 0,
                                     nullptr, 0, status.ptr());
-  if (json_size == static_cast<size_t>(-1)) {
+  if (json_size == size_t{-1}) {
     return absl::InvalidArgumentError(
         absl::StrCat("error encoding google::Protobuf::Struct as JSON: ",
                      upb_Status_ErrorMessage(status.ptr())));

--- a/src/core/ext/xds/xds_common_types.cc
+++ b/src/core/ext/xds/xds_common_types.cc
@@ -421,7 +421,7 @@ absl::StatusOr<Json> ParseProtobufStructToJson(
   const auto* msg_def = google_protobuf_Struct_getmsgdef(context.symtab);
   size_t json_size = upb_JsonEncode(resource, msg_def, context.symtab, 0,
                                     nullptr, 0, status.ptr());
-  if (json_size == size_t{-1}) {
+  if (json_size == static_cast<size_t>(-1)) {
     return absl::InvalidArgumentError(
         absl::StrCat("error encoding google::Protobuf::Struct as JSON: ",
                      upb_Status_ErrorMessage(status.ptr())));

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -628,8 +628,8 @@ absl::optional<XdsListenerResource::FilterChainMap::CidrRange> CidrRangeParse(
         google_protobuf_UInt32Value_value(prefix_len_proto),
         (reinterpret_cast<const grpc_sockaddr*>(cidr_range.address.addr))
                     ->sa_family == GRPC_AF_INET
-            ? uint32_t(32)
-            : uint32_t(128));
+            ? static_cast<uint32_t>(32)
+            : static_cast<uint32_t>(128));
   }
   // Normalize the network address by masking it with prefix_len
   grpc_sockaddr_mask_bits(&cidr_range.address, cidr_range.prefix_len);

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -628,8 +628,8 @@ absl::optional<XdsListenerResource::FilterChainMap::CidrRange> CidrRangeParse(
         google_protobuf_UInt32Value_value(prefix_len_proto),
         (reinterpret_cast<const grpc_sockaddr*>(cidr_range.address.addr))
                     ->sa_family == GRPC_AF_INET
-            ? static_cast<uint32_t>(32)
-            : static_cast<uint32_t>(128));
+            ? uint32_t{32}
+            : uint32_t{128});
   }
   // Normalize the network address by masking it with prefix_len
   grpc_sockaddr_mask_bits(&cidr_range.address, cidr_range.prefix_len);

--- a/src/core/lib/address_utils/sockaddr_utils.cc
+++ b/src/core/lib/address_utils/sockaddr_utils.cc
@@ -371,7 +371,7 @@ void grpc_sockaddr_mask_bits(grpc_resolved_address* address,
     } else if (mask_bits >= 32) {
       return;
     }
-    uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
+    uint32_t mask_ip_addr = (~(uint32_t{0})) << (32 - mask_bits);
     addr4->sin_addr.s_addr &= grpc_htonl(mask_ip_addr);
   } else if (addr->sa_family == GRPC_AF_INET6) {
     grpc_sockaddr_in6* addr6 = reinterpret_cast<grpc_sockaddr_in6*>(addr);
@@ -387,25 +387,25 @@ void grpc_sockaddr_mask_bits(grpc_resolved_address* address,
     GPR_ASSERT(sizeof(addr6->sin6_addr) == sizeof(address_parts));
     memcpy(address_parts, &addr6->sin6_addr, sizeof(grpc_in6_addr));
     if (mask_bits <= 32) {
-      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(uint32_t{0})) << (32 - mask_bits);
       address_parts[0] &= grpc_htonl(mask_ip_addr);
       memset(&address_parts[1], 0, sizeof(uint32_t));
       memset(&address_parts[2], 0, sizeof(uint32_t));
       memset(&address_parts[3], 0, sizeof(uint32_t));
     } else if (mask_bits <= 64) {
       mask_bits -= 32;
-      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(uint32_t{0})) << (32 - mask_bits);
       address_parts[1] &= grpc_htonl(mask_ip_addr);
       memset(&address_parts[2], 0, sizeof(uint32_t));
       memset(&address_parts[3], 0, sizeof(uint32_t));
     } else if (mask_bits <= 96) {
       mask_bits -= 64;
-      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(uint32_t{0})) << (32 - mask_bits);
       address_parts[2] &= grpc_htonl(mask_ip_addr);
       memset(&address_parts[3], 0, sizeof(uint32_t));
     } else {
       mask_bits -= 96;
-      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(uint32_t{0})) << (32 - mask_bits);
       address_parts[3] &= grpc_htonl(mask_ip_addr);
     }
     memcpy(&addr6->sin6_addr, address_parts, sizeof(grpc_in6_addr));

--- a/src/core/lib/address_utils/sockaddr_utils.cc
+++ b/src/core/lib/address_utils/sockaddr_utils.cc
@@ -371,7 +371,7 @@ void grpc_sockaddr_mask_bits(grpc_resolved_address* address,
     } else if (mask_bits >= 32) {
       return;
     }
-    uint32_t mask_ip_addr = (~(uint32_t(0))) << (32 - mask_bits);
+    uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
     addr4->sin_addr.s_addr &= grpc_htonl(mask_ip_addr);
   } else if (addr->sa_family == GRPC_AF_INET6) {
     grpc_sockaddr_in6* addr6 = reinterpret_cast<grpc_sockaddr_in6*>(addr);
@@ -387,25 +387,25 @@ void grpc_sockaddr_mask_bits(grpc_resolved_address* address,
     GPR_ASSERT(sizeof(addr6->sin6_addr) == sizeof(address_parts));
     memcpy(address_parts, &addr6->sin6_addr, sizeof(grpc_in6_addr));
     if (mask_bits <= 32) {
-      uint32_t mask_ip_addr = (~(uint32_t(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
       address_parts[0] &= grpc_htonl(mask_ip_addr);
       memset(&address_parts[1], 0, sizeof(uint32_t));
       memset(&address_parts[2], 0, sizeof(uint32_t));
       memset(&address_parts[3], 0, sizeof(uint32_t));
     } else if (mask_bits <= 64) {
       mask_bits -= 32;
-      uint32_t mask_ip_addr = (~(uint32_t(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
       address_parts[1] &= grpc_htonl(mask_ip_addr);
       memset(&address_parts[2], 0, sizeof(uint32_t));
       memset(&address_parts[3], 0, sizeof(uint32_t));
     } else if (mask_bits <= 96) {
       mask_bits -= 64;
-      uint32_t mask_ip_addr = (~(uint32_t(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
       address_parts[2] &= grpc_htonl(mask_ip_addr);
       memset(&address_parts[3], 0, sizeof(uint32_t));
     } else {
       mask_bits -= 96;
-      uint32_t mask_ip_addr = (~(uint32_t(0))) << (32 - mask_bits);
+      uint32_t mask_ip_addr = (~(static_cast<uint32_t>(0))) << (32 - mask_bits);
       address_parts[3] &= grpc_htonl(mask_ip_addr);
     }
     memcpy(&addr6->sin6_addr, address_parts, sizeof(grpc_in6_addr));

--- a/src/core/lib/compression/message_compress.cc
+++ b/src/core/lib/compression/message_compress.cc
@@ -40,7 +40,7 @@ static int zlib_body(z_stream* zs, grpc_slice_buffer* input,
   int flush;
   size_t i;
   grpc_slice outbuf = GRPC_SLICE_MALLOC(OUTPUT_BLOCK_SIZE);
-  const uInt uint_max = ~static_cast<uInt>(0);
+  const uInt uint_max = ~uInt{0};
 
   GPR_ASSERT(GRPC_SLICE_LENGTH(outbuf) <= uint_max);
   zs->avail_out = static_cast<uInt> GRPC_SLICE_LENGTH(outbuf);

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -437,9 +437,8 @@ bool Epoll1Poller::ProcessEpollEvents(int max_epoll_events_to_handle,
       was_kicked = true;
     } else {
       Epoll1EventHandle* handle = reinterpret_cast<Epoll1EventHandle*>(
-          reinterpret_cast<intptr_t>(data_ptr) & ~static_cast<intptr_t>(1));
-      bool track_err =
-          reinterpret_cast<intptr_t>(data_ptr) & static_cast<intptr_t>(1);
+          reinterpret_cast<intptr_t>(data_ptr) & ~intptr_t{1});
+      bool track_err = reinterpret_cast<intptr_t>(data_ptr) & intptr_t{1};
       bool cancel = (ev->events & EPOLLHUP) != 0;
       bool error = (ev->events & EPOLLERR) != 0;
       bool read_ev = (ev->events & (EPOLLIN | EPOLLPRI)) != 0;

--- a/src/core/lib/gpr/string.cc
+++ b/src/core/lib/gpr/string.cc
@@ -89,7 +89,7 @@ static dump_out dump_out_create(void) {
 
 static void dump_out_append(dump_out* out, char c) {
   if (out->length == out->capacity) {
-    out->capacity = std::max(size_t(8), 2 * out->capacity);
+    out->capacity = std::max(static_cast<size_t>(8), 2 * out->capacity);
     out->data = static_cast<char*>(gpr_realloc(out->data, out->capacity));
   }
   out->data[out->length++] = c;
@@ -290,7 +290,7 @@ static void add_string_to_split(const char* beg, const char* end, char*** strs,
   memcpy(out, beg, static_cast<size_t>(end - beg));
   out[end - beg] = 0;
   if (*nstrs == *capstrs) {
-    *capstrs = std::max(size_t(8), 2 * *capstrs);
+    *capstrs = std::max(static_cast<size_t>(8), 2 * *capstrs);
     *strs = static_cast<char**>(gpr_realloc(*strs, sizeof(*strs) * *capstrs));
   }
   (*strs)[*nstrs] = out;

--- a/src/core/lib/gpr/string.cc
+++ b/src/core/lib/gpr/string.cc
@@ -89,7 +89,7 @@ static dump_out dump_out_create(void) {
 
 static void dump_out_append(dump_out* out, char c) {
   if (out->length == out->capacity) {
-    out->capacity = std::max(static_cast<size_t>(8), 2 * out->capacity);
+    out->capacity = std::max(size_t{8}, 2 * out->capacity);
     out->data = static_cast<char*>(gpr_realloc(out->data, out->capacity));
   }
   out->data[out->length++] = c;
@@ -290,7 +290,7 @@ static void add_string_to_split(const char* beg, const char* end, char*** strs,
   memcpy(out, beg, static_cast<size_t>(end - beg));
   out[end - beg] = 0;
   if (*nstrs == *capstrs) {
-    *capstrs = std::max(static_cast<size_t>(8), 2 * *capstrs);
+    *capstrs = std::max(size_t{8}, 2 * *capstrs);
     *strs = static_cast<char**>(gpr_realloc(*strs, sizeof(*strs) * *capstrs));
   }
   (*strs)[*nstrs] = out;

--- a/src/core/lib/gpr/useful.h
+++ b/src/core/lib/gpr/useful.h
@@ -80,15 +80,28 @@ inline constexpr uint32_t BitCount(uint32_t i) {
 }
 
 inline constexpr uint32_t BitCount(uint64_t i) {
-  return BitCount(uint32_t(i)) + BitCount(uint32_t(i >> 32));
+  return BitCount(static_cast<uint32_t>(i)) +
+         BitCount(static_cast<uint32_t>(i >> 32));
 }
 
-inline constexpr uint32_t BitCount(uint16_t i) { return BitCount(uint32_t(i)); }
-inline constexpr uint32_t BitCount(uint8_t i) { return BitCount(uint32_t(i)); }
-inline constexpr uint32_t BitCount(int64_t i) { return BitCount(uint64_t(i)); }
-inline constexpr uint32_t BitCount(int32_t i) { return BitCount(uint32_t(i)); }
-inline constexpr uint32_t BitCount(int16_t i) { return BitCount(uint16_t(i)); }
-inline constexpr uint32_t BitCount(int8_t i) { return BitCount(uint8_t(i)); }
+inline constexpr uint32_t BitCount(uint16_t i) {
+  return BitCount(static_cast<uint32_t>(i));
+}
+inline constexpr uint32_t BitCount(uint8_t i) {
+  return BitCount(static_cast<uint32_t>(i));
+}
+inline constexpr uint32_t BitCount(int64_t i) {
+  return BitCount(static_cast<uint64_t>(i));
+}
+inline constexpr uint32_t BitCount(int32_t i) {
+  return BitCount(static_cast<uint32_t>(i));
+}
+inline constexpr uint32_t BitCount(int16_t i) {
+  return BitCount(static_cast<uint16_t>(i));
+}
+inline constexpr uint32_t BitCount(int8_t i) {
+  return BitCount(static_cast<uint8_t>(i));
+}
 
 // This function uses operator< to implement a qsort-style comparison, whereby:
 // if a is smaller than b, a number smaller than 0 is returned.

--- a/src/core/lib/gprpp/status_helper.cc
+++ b/src/core/lib/gprpp/status_helper.cc
@@ -141,8 +141,9 @@ void EncodeUInt32ToBytes(uint32_t v, char* buf) {
 
 uint32_t DecodeUInt32FromBytes(const char* buf) {
   const unsigned char* ubuf = reinterpret_cast<const unsigned char*>(buf);
-  return ubuf[0] | (uint32_t(ubuf[1]) << 8) | (uint32_t(ubuf[2]) << 16) |
-         (uint32_t(ubuf[3]) << 24);
+  return ubuf[0] | (static_cast<uint32_t>(ubuf[1]) << 8) |
+         (static_cast<uint32_t>(ubuf[2]) << 16) |
+         (static_cast<uint32_t>(ubuf[3]) << 24);
 }
 
 std::vector<absl::Status> ParseChildren(absl::Cord children) {
@@ -353,7 +354,7 @@ namespace internal {
 
 google_rpc_Status* StatusToProto(const absl::Status& status, upb_Arena* arena) {
   google_rpc_Status* msg = google_rpc_Status_new(arena);
-  google_rpc_Status_set_code(msg, int32_t(status.code()));
+  google_rpc_Status_set_code(msg, static_cast<int32_t>(status.code()));
   // Protobuf string field requires to be utf-8 encoding but C++ string doesn't
   // this requirement so it can be a non utf-8 string. So it should be converted
   // to a percent-encoded string to keep it as a utf-8 string.

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -337,7 +337,8 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
   }
 
   if (*body_length == parser->body_capacity) {
-    parser->body_capacity = std::max(size_t(8), parser->body_capacity * 3 / 2);
+    parser->body_capacity =
+        std::max(static_cast<size_t>(8), parser->body_capacity * 3 / 2);
     *body = static_cast<char*>(gpr_realloc(*body, parser->body_capacity));
   }
   (*body)[*body_length] = static_cast<char>(byte);

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -337,8 +337,7 @@ static grpc_error_handle addbyte_body(grpc_http_parser* parser, uint8_t byte) {
   }
 
   if (*body_length == parser->body_capacity) {
-    parser->body_capacity =
-        std::max(static_cast<size_t>(8), parser->body_capacity * 3 / 2);
+    parser->body_capacity = std::max(size_t{8}, parser->body_capacity * 3 / 2);
     *body = static_cast<char*>(gpr_realloc(*body, parser->body_capacity));
   }
   (*body)[*body_length] = static_cast<char>(byte);

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -669,9 +669,8 @@ static grpc_error_handle process_epoll_events(grpc_pollset* /*pollset*/) {
                    err_desc);
     } else {
       grpc_fd* fd = reinterpret_cast<grpc_fd*>(
-          reinterpret_cast<intptr_t>(data_ptr) & ~static_cast<intptr_t>(1));
-      bool track_err =
-          reinterpret_cast<intptr_t>(data_ptr) & static_cast<intptr_t>(1);
+          reinterpret_cast<intptr_t>(data_ptr) & ~intptr_t{1});
+      bool track_err = reinterpret_cast<intptr_t>(data_ptr) & intptr_t{1};
       bool cancel = (ev->events & EPOLLHUP) != 0;
       bool error = (ev->events & EPOLLERR) != 0;
       bool read_ev = (ev->events & (EPOLLIN | EPOLLPRI)) != 0;

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1193,7 +1193,7 @@ static void pollset_set_add_pollset(grpc_pollset_set* pollset_set,
   gpr_mu_lock(&pollset_set->mu);
   if (pollset_set->pollset_count == pollset_set->pollset_capacity) {
     pollset_set->pollset_capacity =
-        std::max(size_t(8), 2 * pollset_set->pollset_capacity);
+        std::max(static_cast<size_t>(8), 2 * pollset_set->pollset_capacity);
     pollset_set->pollsets = static_cast<grpc_pollset**>(gpr_realloc(
         pollset_set->pollsets,
         pollset_set->pollset_capacity * sizeof(*pollset_set->pollsets)));
@@ -1243,7 +1243,7 @@ static void pollset_set_add_pollset_set(grpc_pollset_set* bag,
   gpr_mu_lock(&bag->mu);
   if (bag->pollset_set_count == bag->pollset_set_capacity) {
     bag->pollset_set_capacity =
-        std::max(size_t(8), 2 * bag->pollset_set_capacity);
+        std::max(static_cast<size_t>(8), 2 * bag->pollset_set_capacity);
     bag->pollset_sets = static_cast<grpc_pollset_set**>(
         gpr_realloc(bag->pollset_sets,
                     bag->pollset_set_capacity * sizeof(*bag->pollset_sets)));
@@ -1281,7 +1281,7 @@ static void pollset_set_add_fd(grpc_pollset_set* pollset_set, grpc_fd* fd) {
   gpr_mu_lock(&pollset_set->mu);
   if (pollset_set->fd_count == pollset_set->fd_capacity) {
     pollset_set->fd_capacity =
-        std::max(size_t(8), 2 * pollset_set->fd_capacity);
+        std::max(static_cast<size_t>(8), 2 * pollset_set->fd_capacity);
     pollset_set->fds = static_cast<grpc_fd**>(
         gpr_realloc(pollset_set->fds,
                     pollset_set->fd_capacity * sizeof(*pollset_set->fds)));

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1193,7 +1193,7 @@ static void pollset_set_add_pollset(grpc_pollset_set* pollset_set,
   gpr_mu_lock(&pollset_set->mu);
   if (pollset_set->pollset_count == pollset_set->pollset_capacity) {
     pollset_set->pollset_capacity =
-        std::max(static_cast<size_t>(8), 2 * pollset_set->pollset_capacity);
+        std::max(size_t{8}, 2 * pollset_set->pollset_capacity);
     pollset_set->pollsets = static_cast<grpc_pollset**>(gpr_realloc(
         pollset_set->pollsets,
         pollset_set->pollset_capacity * sizeof(*pollset_set->pollsets)));
@@ -1243,7 +1243,7 @@ static void pollset_set_add_pollset_set(grpc_pollset_set* bag,
   gpr_mu_lock(&bag->mu);
   if (bag->pollset_set_count == bag->pollset_set_capacity) {
     bag->pollset_set_capacity =
-        std::max(static_cast<size_t>(8), 2 * bag->pollset_set_capacity);
+        std::max(size_t{8}, 2 * bag->pollset_set_capacity);
     bag->pollset_sets = static_cast<grpc_pollset_set**>(
         gpr_realloc(bag->pollset_sets,
                     bag->pollset_set_capacity * sizeof(*bag->pollset_sets)));
@@ -1281,7 +1281,7 @@ static void pollset_set_add_fd(grpc_pollset_set* pollset_set, grpc_fd* fd) {
   gpr_mu_lock(&pollset_set->mu);
   if (pollset_set->fd_count == pollset_set->fd_capacity) {
     pollset_set->fd_capacity =
-        std::max(static_cast<size_t>(8), 2 * pollset_set->fd_capacity);
+        std::max(size_t{8}, 2 * pollset_set->fd_capacity);
     pollset_set->fds = static_cast<grpc_fd**>(
         gpr_realloc(pollset_set->fds,
                     pollset_set->fd_capacity * sizeof(*pollset_set->fds)));

--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -371,8 +371,7 @@ void BasicMemoryQuota::Start() {
           std::tuple<const char*, RefCountedPtr<ReclaimerQueue::Handle>> arg) {
         auto reclaimer = std::move(std::get<1>(arg));
         if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-          double free =
-              std::max(static_cast<intptr_t>(0), self->free_bytes_.load());
+          double free = std::max(intptr_t{0}, self->free_bytes_.load());
           size_t quota_size = self->quota_size_.load();
           gpr_log(GPR_INFO,
                   "RQ: %s perform %s reclamation. Available free bytes: %f, "
@@ -436,7 +435,7 @@ void BasicMemoryQuota::FinishReclamation(uint64_t token, Waker waker) {
                                                    std::memory_order_relaxed,
                                                    std::memory_order_relaxed)) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-      double free = std::max(static_cast<intptr_t>(0), free_bytes_.load());
+      double free = std::max(intptr_t{0}, free_bytes_.load());
       size_t quota_size = quota_size_.load();
       gpr_log(GPR_INFO,
               "RQ: %s reclamation complete. Available free bytes: %f, "

--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -371,7 +371,8 @@ void BasicMemoryQuota::Start() {
           std::tuple<const char*, RefCountedPtr<ReclaimerQueue::Handle>> arg) {
         auto reclaimer = std::move(std::get<1>(arg));
         if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-          double free = std::max(intptr_t(0), self->free_bytes_.load());
+          double free =
+              std::max(static_cast<intptr_t>(0), self->free_bytes_.load());
           size_t quota_size = self->quota_size_.load();
           gpr_log(GPR_INFO,
                   "RQ: %s perform %s reclamation. Available free bytes: %f, "
@@ -435,7 +436,7 @@ void BasicMemoryQuota::FinishReclamation(uint64_t token, Waker waker) {
                                                    std::memory_order_relaxed,
                                                    std::memory_order_relaxed)) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-      double free = std::max(intptr_t(0), free_bytes_.load());
+      double free = std::max(static_cast<intptr_t>(0), free_bytes_.load());
       size_t quota_size = quota_size_.load();
       gpr_log(GPR_INFO,
               "RQ: %s reclamation complete. Available free bytes: %f, "

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -462,7 +462,7 @@ int grpc_completion_queue_thread_local_cache_flush(grpc_completion_queue* cq,
   if (storage != nullptr && g_cached_cq == cq) {
     *tag = storage->tag;
     grpc_core::ExecCtx exec_ctx;
-    *ok = (storage->next & static_cast<uintptr_t>(1)) == 1;
+    *ok = (storage->next & uintptr_t{1}) == 1;
     storage->done(storage->done_arg, storage);
     ret = 1;
     cq_next_data* cqd = static_cast<cq_next_data*> DATA_FROM_CQ(cq);
@@ -1159,11 +1159,9 @@ class ExecCtxPluck : public grpc_core::ExecCtx {
       grpc_cq_completion* c;
       grpc_cq_completion* prev = &cqd->completed_head;
       while ((c = reinterpret_cast<grpc_cq_completion*>(
-                  prev->next & ~static_cast<uintptr_t>(1))) !=
-             &cqd->completed_head) {
+                  prev->next & ~uintptr_t{1})) != &cqd->completed_head) {
         if (c->tag == a->tag) {
-          prev->next = (prev->next & static_cast<uintptr_t>(1)) |
-                       (c->next & ~static_cast<uintptr_t>(1));
+          prev->next = (prev->next & uintptr_t{1}) | (c->next & ~uintptr_t{1});
           if (c == cqd->completed_tail) {
             cqd->completed_tail = prev;
           }
@@ -1230,11 +1228,9 @@ static grpc_event cq_pluck(grpc_completion_queue* cq, void* tag,
     }
     prev = &cqd->completed_head;
     while ((c = reinterpret_cast<grpc_cq_completion*>(
-                prev->next & ~static_cast<uintptr_t>(1))) !=
-           &cqd->completed_head) {
+                prev->next & ~uintptr_t{1})) != &cqd->completed_head) {
       if (c->tag == tag) {
-        prev->next = (prev->next & static_cast<uintptr_t>(1)) |
-                     (c->next & ~static_cast<uintptr_t>(1));
+        prev->next = (prev->next & uintptr_t{1}) | (c->next & ~uintptr_t{1});
         if (c == cqd->completed_tail) {
           cqd->completed_tail = prev;
         }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -466,7 +466,7 @@ static tsi_result peer_from_x509(X509* cert, int include_certificate_type,
   size_t property_count;
   tsi_result result;
   GPR_ASSERT(subject_alt_name_count >= 0);
-  property_count = (include_certificate_type ? static_cast<size_t>(1) : 0) +
+  property_count = (include_certificate_type ? size_t{1} : 0) +
                    3 /* subject, common name, certificate */ +
                    static_cast<size_t>(subject_alt_name_count);
   for (int i = 0; i < subject_alt_name_count; i++) {

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -233,8 +233,9 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordEnd(
   }
   if (OpenCensusTracingEnabled() && parent_->tracing_enabled_) {
     if (status_code_ != absl::StatusCode::kOk) {
-      context_.Span().SetStatus(opencensus::trace::StatusCode(status_code_),
-                                StatusCodeToString(status_code_));
+      context_.Span().SetStatus(
+          static_cast<opencensus::trace::StatusCode>(status_code_),
+          StatusCodeToString(status_code_));
     }
     context_.EndSpan();
   }

--- a/src/cpp/server/csds/csds.cc
+++ b/src/cpp/server/csds/csds.cc
@@ -66,7 +66,8 @@ Status ClientStatusDiscoveryService::StreamClientStatus(
         stream->Write(response);
         continue;
       }
-      return Status(StatusCode(s.status().raw_code()), s.status().ToString());
+      return Status(static_cast<StatusCode>(s.status().raw_code()),
+                    s.status().ToString());
     }
     *response.add_config() = std::move(s.value());
     stream->Write(response);
@@ -83,7 +84,8 @@ Status ClientStatusDiscoveryService::FetchClientStatus(
       // If the xDS client is not initialized, return empty response
       return Status::OK;
     }
-    return Status(StatusCode(s.status().raw_code()), s.status().ToString());
+    return Status(static_cast<StatusCode>(s.status().raw_code()),
+                  s.status().ToString());
   }
   *response->add_config() = std::move(s.value());
   return Status::OK;

--- a/src/cpp/util/string_ref.cc
+++ b/src/cpp/util/string_ref.cc
@@ -22,6 +22,6 @@
 
 namespace grpc {
 
-const size_t string_ref::npos = static_cast<size_t>(-1);
+const size_t string_ref::npos = size_t{-1};
 
 }  // namespace grpc

--- a/src/cpp/util/string_ref.cc
+++ b/src/cpp/util/string_ref.cc
@@ -22,6 +22,6 @@
 
 namespace grpc {
 
-const size_t string_ref::npos = size_t{-1};
+const size_t string_ref::npos = static_cast<size_t>(-1);
 
 }  // namespace grpc

--- a/src/cpp/util/string_ref.cc
+++ b/src/cpp/util/string_ref.cc
@@ -22,6 +22,6 @@
 
 namespace grpc {
 
-const size_t string_ref::npos = size_t(-1);
+const size_t string_ref::npos = static_cast<size_t>(-1);
 
 }  // namespace grpc

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -449,8 +449,8 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMoreGaps) {
   Json array = (*parsed_json->mutable_object())["channel"];
   ValidateJsonArraySize(array, 2);
   std::vector<intptr_t> uuids = GetUuidListFromArray(array.array_value());
-  EXPECT_EQ(intptr_t{3}, uuids[0]);
-  EXPECT_EQ(intptr_t{5}, uuids[1]);
+  EXPECT_EQ(3, uuids[0]);
+  EXPECT_EQ(5, uuids[1]);
   json_str = ChannelzRegistry::GetTopChannels(4);
   parsed_json = Json::Parse(json_str);
   ASSERT_TRUE(parsed_json.ok()) << parsed_json.status();
@@ -458,7 +458,7 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMoreGaps) {
   array = (*parsed_json->mutable_object())["channel"];
   ValidateJsonArraySize(array, 1);
   uuids = GetUuidListFromArray(array.array_value());
-  EXPECT_EQ(intptr_t{5}, uuids[0]);
+  EXPECT_EQ(5, uuids[0]);
 }
 
 TEST_F(ChannelzRegistryBasedTest, GetTopChannelsUuidAfterCompaction) {

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -449,8 +449,8 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMoreGaps) {
   Json array = (*parsed_json->mutable_object())["channel"];
   ValidateJsonArraySize(array, 2);
   std::vector<intptr_t> uuids = GetUuidListFromArray(array.array_value());
-  EXPECT_EQ(static_cast<intptr_t>(3), uuids[0]);
-  EXPECT_EQ(static_cast<intptr_t>(5), uuids[1]);
+  EXPECT_EQ(intptr_t{3}, uuids[0]);
+  EXPECT_EQ(intptr_t{5}, uuids[1]);
   json_str = ChannelzRegistry::GetTopChannels(4);
   parsed_json = Json::Parse(json_str);
   ASSERT_TRUE(parsed_json.ok()) << parsed_json.status();
@@ -458,7 +458,7 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMoreGaps) {
   array = (*parsed_json->mutable_object())["channel"];
   ValidateJsonArraySize(array, 1);
   uuids = GetUuidListFromArray(array.array_value());
-  EXPECT_EQ(static_cast<intptr_t>(5), uuids[0]);
+  EXPECT_EQ(intptr_t{5}, uuids[0]);
 }
 
 TEST_F(ChannelzRegistryBasedTest, GetTopChannelsUuidAfterCompaction) {

--- a/test/core/filters/filter_fuzzer.cc
+++ b/test/core/filters/filter_fuzzer.cc
@@ -218,9 +218,9 @@ struct GlobalObjects {
       case filter_fuzzer::GlobalObjectAction::kFinishCheckCallHost:
         channel_security_connector->FinishCheckCallHost(
             action.finish_check_call_host().qry(),
-            absl::Status(
-                absl::StatusCode(action.finish_check_call_host().status()),
-                action.finish_check_call_host().message()));
+            absl::Status(static_cast<absl::StatusCode>(
+                             action.finish_check_call_host().status()),
+                         action.finish_check_call_host().message()));
         break;
     }
   }

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -52,7 +52,7 @@ TEST(BufferListTest, Testshutdownflusheslist) {
   }
   tb_list.Shutdown(nullptr, absl::OkStatus());
   for (auto i = 0; i < NUM_ELEM; i++) {
-    ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), gpr_atm{1});
+    ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), 1);
   }
 }
 
@@ -85,7 +85,7 @@ TEST(BufferListTest, Testverifiercalledonack) {
   gpr_atm_rel_store(&verifier_called, gpr_atm{0});
   tb_list.AddNewEntry(213, 0, &verifier_called);
   tb_list.ProcessTimestamp(&serr, nullptr, &tss);
-  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), gpr_atm{1});
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), 1);
   tb_list.Shutdown(nullptr, absl::OkStatus());
 }
 
@@ -105,7 +105,7 @@ TEST(BufferListTest, Testrepeatedshutdown) {
   gpr_atm_rel_store(&verifier_called, gpr_atm{0});
   tb_list.AddNewEntry(213, 0, &verifier_called);
   tb_list.ProcessTimestamp(&serr, nullptr, &tss);
-  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), gpr_atm{1});
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), 1);
   tb_list.Shutdown(nullptr, absl::OkStatus());
   tb_list.Shutdown(nullptr, absl::OkStatus());
   tb_list.Shutdown(nullptr, absl::OkStatus());

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -33,7 +33,7 @@ static void TestShutdownFlushesListVerifier(void* arg,
   ASSERT_TRUE(error.ok());
   ASSERT_NE(arg, nullptr);
   gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
-  gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
+  gpr_atm_rel_store(done, gpr_atm{1});
 }
 
 /** Tests that all TracedBuffer elements in the list are flushed out on
@@ -47,12 +47,12 @@ TEST(BufferListTest, Testshutdownflusheslist) {
 #define NUM_ELEM 5
   gpr_atm verifier_called[NUM_ELEM];
   for (auto i = 0; i < NUM_ELEM; i++) {
-    gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
+    gpr_atm_rel_store(&verifier_called[i], gpr_atm{0});
     tb_list.AddNewEntry(i, 0, static_cast<void*>(&verifier_called[i]));
   }
   tb_list.Shutdown(nullptr, absl::OkStatus());
   for (auto i = 0; i < NUM_ELEM; i++) {
-    ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
+    ASSERT_EQ(gpr_atm_acq_load(&verifier_called[i]), gpr_atm{1});
   }
 }
 
@@ -66,7 +66,7 @@ static void TestVerifierCalledOnAckVerifier(void* arg,
   ASSERT_EQ(ts->acked_time.time.tv_nsec, 456);
   ASSERT_GT(ts->info.length, 0);
   gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
-  gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
+  gpr_atm_rel_store(done, gpr_atm{1});
 }
 
 /** Tests that the timestamp verifier is called on an ACK timestamp.
@@ -82,10 +82,10 @@ TEST(BufferListTest, Testverifiercalledonack) {
       TestVerifierCalledOnAckVerifier);
   grpc_core::TracedBufferList tb_list;
   gpr_atm verifier_called;
-  gpr_atm_rel_store(&verifier_called, static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&verifier_called, gpr_atm{0});
   tb_list.AddNewEntry(213, 0, &verifier_called);
   tb_list.ProcessTimestamp(&serr, nullptr, &tss);
-  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), static_cast<gpr_atm>(1));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), gpr_atm{1});
   tb_list.Shutdown(nullptr, absl::OkStatus());
 }
 
@@ -102,10 +102,10 @@ TEST(BufferListTest, Testrepeatedshutdown) {
       TestVerifierCalledOnAckVerifier);
   grpc_core::TracedBufferList tb_list;
   gpr_atm verifier_called;
-  gpr_atm_rel_store(&verifier_called, static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&verifier_called, gpr_atm{0});
   tb_list.AddNewEntry(213, 0, &verifier_called);
   tb_list.ProcessTimestamp(&serr, nullptr, &tss);
-  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), static_cast<gpr_atm>(1));
+  ASSERT_EQ(gpr_atm_acq_load(&verifier_called), gpr_atm{1});
   tb_list.Shutdown(nullptr, absl::OkStatus());
   tb_list.Shutdown(nullptr, absl::OkStatus());
   tb_list.Shutdown(nullptr, absl::OkStatus());

--- a/test/core/iomgr/stranded_event_test.cc
+++ b/test/core/iomgr/stranded_event_test.cc
@@ -397,7 +397,7 @@ TEST(Pollers, TestReadabilityNotificationsDontGetStrandedOnOneCq) {
         {
           grpc_core::MutexLock lock(&ping_pong_round_mu);
           ping_pong_round_cv.SignalAll();
-          while (int(ping_pong_round) != i) {
+          while (static_cast<int>(ping_pong_round) != i) {
             ping_pong_round_cv.Wait(&ping_pong_round_mu);
           }
         }

--- a/test/core/iomgr/tcp_posix_test.cc
+++ b/test/core/iomgr/tcp_posix_test.cc
@@ -429,7 +429,7 @@ void timestamps_verifier(void* arg, grpc_core::Timestamps* ts,
   GPR_ASSERT(ts->scheduled_time.time.clock_type == GPR_CLOCK_REALTIME);
   GPR_ASSERT(ts->acked_time.time.clock_type == GPR_CLOCK_REALTIME);
   gpr_atm* done_timestamps = static_cast<gpr_atm*>(arg);
-  gpr_atm_rel_store(done_timestamps, static_cast<gpr_atm>(1));
+  gpr_atm_rel_store(done_timestamps, gpr_atm{1});
 }
 
 /* Write to a socket using the grpc_tcp API, then drain it directly.
@@ -492,7 +492,7 @@ static void write_test(size_t num_bytes, size_t slice_size,
                     grpc_schedule_on_exec_ctx);
 
   gpr_atm done_timestamps;
-  gpr_atm_rel_store(&done_timestamps, static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&done_timestamps, gpr_atm{0});
   grpc_endpoint_write(ep, &outgoing, &write_done_closure,
                       grpc_event_engine_can_track_errors() && collect_timestamps
                           ? &done_timestamps
@@ -505,7 +505,7 @@ static void write_test(size_t num_bytes, size_t slice_size,
     grpc_pollset_worker* worker = nullptr;
     if (state.write_done &&
         (!(grpc_event_engine_can_track_errors() && collect_timestamps) ||
-         gpr_atm_acq_load(&done_timestamps) == static_cast<gpr_atm>(1))) {
+         gpr_atm_acq_load(&done_timestamps) == gpr_atm{1})) {
       break;
     }
     GPR_ASSERT(GRPC_LOG_IF_ERROR(

--- a/test/core/resource_quota/memory_quota_stress_test.cc
+++ b/test/core/resource_quota/memory_quota_stress_test.cc
@@ -113,7 +113,8 @@ class StressTest {
           quotas_distribution_(0, test_->quotas_.size() - 1),
           allocators_distribution_(0, test_->allocators_.size() - 1),
           size_distribution_(1, 4 * 1024 * 1024),
-          quota_size_distribution_(1024 * 1024, size_t(8) * 1024 * 1024 * 1024),
+          quota_size_distribution_(1024 * 1024,
+                                   static_cast<size_t>(8) * 1024 * 1024 * 1024),
           choose_variable_size_(1, 100) {}
 
     // Choose a random quota, and return an owned pointer to it.

--- a/test/core/resource_quota/memory_quota_stress_test.cc
+++ b/test/core/resource_quota/memory_quota_stress_test.cc
@@ -113,8 +113,7 @@ class StressTest {
           quotas_distribution_(0, test_->quotas_.size() - 1),
           allocators_distribution_(0, test_->allocators_.size() - 1),
           size_distribution_(1, 4 * 1024 * 1024),
-          quota_size_distribution_(1024 * 1024,
-                                   static_cast<size_t>(8) * 1024 * 1024 * 1024),
+          quota_size_distribution_(1024 * 1024, size_t{8} * 1024 * 1024 * 1024),
           choose_variable_size_(1, 100) {}
 
     // Choose a random quota, and return an owned pointer to it.

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -312,7 +312,7 @@ std::string RandomString(size_t length) {
   std::string str;
   std::random_device r;
   for (size_t i = 0; i < length; ++i) {
-    str.push_back(char(r()));
+    str.push_back(static_cast<char>(r()));
   }
   return str;
 }

--- a/test/core/transport/binder/binder_transport_test.cc
+++ b/test/core/transport/binder/binder_transport_test.cc
@@ -192,8 +192,8 @@ class MetadataEncoder {
   template <typename Which>
   void Encode(Which, const typename Which::ValueType& value) {
     metadata_.emplace_back(
-        std::string(Which::key()),
-        std::string(grpc_core::Slice(Which::Encode(value)).as_string_view()));
+        std::string{Which::key()},
+        std::string{grpc_core::Slice(Which::Encode(value)).as_string_view()});
   }
 
   const Metadata& metadata() const { return metadata_; }

--- a/test/core/transport/binder/binder_transport_test.cc
+++ b/test/core/transport/binder/binder_transport_test.cc
@@ -192,8 +192,9 @@ class MetadataEncoder {
   template <typename Which>
   void Encode(Which, const typename Which::ValueType& value) {
     metadata_.emplace_back(
-        std::string{Which::key()},
-        std::string{grpc_core::Slice(Which::Encode(value)).as_string_view()});
+        std::string(Which::key()),
+        // NOLINTNEXTLINE(google-readability-casting)
+        std::string(grpc_core::Slice(Which::Encode(value)).as_string_view()));
   }
 
   const Metadata& metadata() const { return metadata_; }

--- a/test/core/transport/chttp2/context_list_test.cc
+++ b/test/core/transport/chttp2/context_list_test.cc
@@ -58,7 +58,7 @@ void TestExecuteFlushesListVerifier(void* arg, Timestamps* ts,
     EXPECT_EQ(ts->byte_offset, kByteOffset);
   }
   gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
-  gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
+  gpr_atm_rel_store(done, gpr_atm{1});
 }
 
 void discard_write(grpc_slice /*slice*/) {}
@@ -97,13 +97,13 @@ TEST_F(ContextListTest, ExecuteFlushesList) {
                                nullptr, nullptr);
     s[i]->context = &verifier_called[i];
     s[i]->byte_counter = kByteOffset;
-    gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
+    gpr_atm_rel_store(&verifier_called[i], gpr_atm{0});
     ContextList::Append(&list, s[i]);
   }
   Timestamps ts;
   ContextList::Execute(list, &ts, absl::OkStatus());
   for (auto i = 0; i < kNumElems; i++) {
-    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
+    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), gpr_atm{1});
     grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
                                   reinterpret_cast<grpc_stream*>(s[i]),
                                   nullptr);
@@ -151,12 +151,12 @@ TEST_F(ContextListTest, NonEmptyListEmptyTimestamp) {
                                nullptr, nullptr);
     s[i]->context = &verifier_called[i];
     s[i]->byte_counter = kByteOffset;
-    gpr_atm_rel_store(&verifier_called[i], static_cast<gpr_atm>(0));
+    gpr_atm_rel_store(&verifier_called[i], gpr_atm{0});
     ContextList::Append(&list, s[i]);
   }
   ContextList::Execute(list, nullptr, absl::OkStatus());
   for (auto i = 0; i < kNumElems; i++) {
-    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), static_cast<gpr_atm>(1));
+    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), gpr_atm{1});
     grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
                                   reinterpret_cast<grpc_stream*>(s[i]),
                                   nullptr);

--- a/test/core/transport/chttp2/context_list_test.cc
+++ b/test/core/transport/chttp2/context_list_test.cc
@@ -103,7 +103,7 @@ TEST_F(ContextListTest, ExecuteFlushesList) {
   Timestamps ts;
   ContextList::Execute(list, &ts, absl::OkStatus());
   for (auto i = 0; i < kNumElems; i++) {
-    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), gpr_atm{1});
+    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), 1);
     grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
                                   reinterpret_cast<grpc_stream*>(s[i]),
                                   nullptr);
@@ -156,7 +156,7 @@ TEST_F(ContextListTest, NonEmptyListEmptyTimestamp) {
   }
   ContextList::Execute(list, nullptr, absl::OkStatus());
   for (auto i = 0; i < kNumElems; i++) {
-    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), gpr_atm{1});
+    EXPECT_EQ(gpr_atm_acq_load(&verifier_called[i]), 1);
     grpc_transport_destroy_stream(reinterpret_cast<grpc_transport*>(t),
                                   reinterpret_cast<grpc_stream*>(s[i]),
                                   nullptr);

--- a/test/core/transport/chttp2/flow_control_fuzzer.cc
+++ b/test/core/transport/chttp2/flow_control_fuzzer.cc
@@ -151,15 +151,14 @@ void FlowControlFuzzer::Perform(const flow_control_fuzzer::Action& action) {
       break;
     case flow_control_fuzzer::Action::kSetMemoryQuota: {
       memory_quota_->SetSize(
-          Clamp(action.set_memory_quota(), static_cast<uint64_t>(1),
+          Clamp(action.set_memory_quota(), uint64_t{1},
                 static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
     } break;
     case flow_control_fuzzer::Action::kStepTimeMs: {
       g_now = gpr_time_add(
-          g_now, gpr_time_from_millis(
-                     Clamp(action.step_time_ms(), static_cast<uint64_t>(1),
-                           kMaxAdvanceTimeMillis),
-                     GPR_TIMESPAN));
+          g_now, gpr_time_from_millis(Clamp(action.step_time_ms(), uint64_t{1},
+                                            kMaxAdvanceTimeMillis),
+                                      GPR_TIMESPAN));
       exec_ctx.InvalidateNow();
       if (Timestamp::Now() >= next_bdp_ping_) {
         scheduled_write_ = true;

--- a/test/core/transport/chttp2/flow_control_fuzzer.cc
+++ b/test/core/transport/chttp2/flow_control_fuzzer.cc
@@ -319,8 +319,7 @@ void FlowControlFuzzer::PerformAction(FlowControlAction action,
                                       Stream* stream) {
   if (!squelch) {
     fprintf(stderr, "[%" PRId64 "]: ACTION: %s\n",
-            stream == nullptr ? static_cast<int64_t>(-1)
-                              : static_cast<int64_t>(stream->id),
+            stream == nullptr ? int64_t{-1} : static_cast<int64_t>(stream->id),
             action.DebugString().c_str());
   }
 

--- a/test/core/transport/chttp2/flow_control_fuzzer.cc
+++ b/test/core/transport/chttp2/flow_control_fuzzer.cc
@@ -151,14 +151,15 @@ void FlowControlFuzzer::Perform(const flow_control_fuzzer::Action& action) {
       break;
     case flow_control_fuzzer::Action::kSetMemoryQuota: {
       memory_quota_->SetSize(
-          Clamp(action.set_memory_quota(), uint64_t(1),
-                uint64_t(std::numeric_limits<int64_t>::max())));
+          Clamp(action.set_memory_quota(), static_cast<uint64_t>(1),
+                static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
     } break;
     case flow_control_fuzzer::Action::kStepTimeMs: {
       g_now = gpr_time_add(
-          g_now, gpr_time_from_millis(Clamp(action.step_time_ms(), uint64_t(1),
-                                            kMaxAdvanceTimeMillis),
-                                      GPR_TIMESPAN));
+          g_now, gpr_time_from_millis(
+                     Clamp(action.step_time_ms(), static_cast<uint64_t>(1),
+                           kMaxAdvanceTimeMillis),
+                     GPR_TIMESPAN));
       exec_ctx.InvalidateNow();
       if (Timestamp::Now() >= next_bdp_ping_) {
         scheduled_write_ = true;
@@ -252,7 +253,8 @@ void FlowControlFuzzer::Perform(const flow_control_fuzzer::Action& action) {
             {id_stream.second.queued_writes, remote_transport_window_size_,
              remote_initial_window_size_ + id_stream.second.window_delta});
         if (send_amount <= 0) continue;
-        send.stream_writes.push_back({id_stream.first, uint64_t(send_amount)});
+        send.stream_writes.push_back(
+            {id_stream.first, static_cast<uint64_t>(send_amount)});
         id_stream.second.queued_writes -= send_amount;
         id_stream.second.window_delta -= send_amount;
         remote_transport_window_size_ -= send_amount;
@@ -267,14 +269,14 @@ void FlowControlFuzzer::Perform(const flow_control_fuzzer::Action& action) {
     } break;
     case flow_control_fuzzer::Action::kAllocateMemory: {
       auto allocate = std::min(
-          size_t(action.allocate_memory()),
+          static_cast<size_t>(action.allocate_memory()),
           grpc_event_engine::experimental::MemoryRequest::max_allowed_size());
       allocated_memory_ += allocate;
       memory_owner_.Reserve(allocate);
     } break;
     case flow_control_fuzzer::Action::kDeallocateMemory: {
-      auto deallocate =
-          std::min(uint64_t(action.deallocate_memory()), allocated_memory_);
+      auto deallocate = std::min(
+          static_cast<uint64_t>(action.deallocate_memory()), allocated_memory_);
       allocated_memory_ -= deallocate;
       memory_owner_.Release(deallocate);
     } break;
@@ -318,7 +320,8 @@ void FlowControlFuzzer::PerformAction(FlowControlAction action,
                                       Stream* stream) {
   if (!squelch) {
     fprintf(stderr, "[%" PRId64 "]: ACTION: %s\n",
-            stream == nullptr ? int64_t(-1) : int64_t(stream->id),
+            stream == nullptr ? static_cast<int64_t>(-1)
+                              : static_cast<int64_t>(stream->id),
             action.DebugString().c_str());
   }
 
@@ -394,7 +397,7 @@ void FlowControlFuzzer::AssertNoneStuck() const {
               id_stream.first, stream_window, reconciled_transport_window,
               reconciled_stream_deltas[id_stream.first],
               reconciled_initial_window,
-              int64_t(id_stream.second.fc.min_progress_size()));
+              (id_stream.second.fc.min_progress_size()));
       abort();
     }
   }

--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -57,7 +57,7 @@ void InitGlobals() {
 
 void AdvanceClockMillis(uint64_t millis) {
   ExecCtx exec_ctx;
-  g_now = gpr_time_add(g_now, gpr_time_from_millis(Clamp(millis, uint64_t(1),
+  g_now = gpr_time_add(g_now, gpr_time_from_millis(Clamp(millis, uint64_t{1},
                                                          kMaxAdvanceTimeMillis),
                                                    GPR_TIMESPAN));
   exec_ctx.InvalidateNow();

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -227,7 +227,7 @@ void FakeUdpAndTcpServer::FakeUdpAndTcpServerPeer::
       0x00,                   // flags
       0x00, 0x00, 0x00, 0x00  // stream identifier
   };
-  if (total_bytes_sent_ < int(kEmptyHttp2SettingsFrame.size())) {
+  if (total_bytes_sent_ < static_cast<int>(kEmptyHttp2SettingsFrame.size())) {
     int bytes_to_send = kEmptyHttp2SettingsFrame.size() - total_bytes_sent_;
     int bytes_sent =
         send(fd_, kEmptyHttp2SettingsFrame.data() + total_bytes_sent_,

--- a/test/cpp/common/channel_arguments_test.cc
+++ b/test/cpp/common/channel_arguments_test.cc
@@ -99,7 +99,7 @@ class ChannelArgumentsTest : public ::testing::Test {
   void VerifyDefaultChannelArgs() {
     grpc_channel_args args;
     SetChannelArgs(channel_args_, &args);
-    EXPECT_EQ(static_cast<size_t>(1), args.num_args);
+    EXPECT_EQ(size_t{1}, args.num_args);
     EXPECT_STREQ(GRPC_ARG_PRIMARY_USER_AGENT_STRING, args.args[0].key);
     EXPECT_EQ(GetDefaultUserAgentPrefix(),
               std::string(args.args[0].value.string));

--- a/test/cpp/common/channel_arguments_test.cc
+++ b/test/cpp/common/channel_arguments_test.cc
@@ -99,7 +99,7 @@ class ChannelArgumentsTest : public ::testing::Test {
   void VerifyDefaultChannelArgs() {
     grpc_channel_args args;
     SetChannelArgs(channel_args_, &args);
-    EXPECT_EQ(size_t{1}, args.num_args);
+    EXPECT_EQ(1, args.num_args);
     EXPECT_STREQ(GRPC_ARG_PRIMARY_USER_AGENT_STRING, args.args[0].key);
     EXPECT_EQ(GetDefaultUserAgentPrefix(),
               std::string(args.args[0].value.string));

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -979,7 +979,7 @@ TEST_P(AsyncEnd2endTest, ClientInitialMetadataRpc) {
             ToString(client_initial_metadata.find(meta2.first)->second));
   EXPECT_EQ(meta3.second,
             ToString(client_initial_metadata.find(meta3.first)->second));
-  EXPECT_GE(client_initial_metadata.size(), size_t{2});
+  EXPECT_GE(client_initial_metadata.size(), 2);
 
   send_response.set_message(recv_request.message());
   response_writer.Finish(send_response, Status::OK, tag(3));
@@ -1023,7 +1023,7 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataRpc) {
             ToString(server_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(size_t{2}, server_initial_metadata.size());
+  EXPECT_EQ(2, server_initial_metadata.size());
 
   send_response.set_message(recv_request.message());
   response_writer.Finish(send_response, Status::OK, tag(5));
@@ -1066,7 +1066,7 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataServerStreaming) {
             ToString(server_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(size_t{2}, server_initial_metadata.size());
+  EXPECT_EQ(2, server_initial_metadata.size());
 
   srv_stream.Write(send_response, tag(3));
 
@@ -1126,7 +1126,7 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataServerStreamingImplicit) {
             ToString(server_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(size_t{2}, server_initial_metadata.size());
+  EXPECT_EQ(2, server_initial_metadata.size());
 
   srv_stream.Write(send_response, tag(5));
   cli_stream->Read(&recv_response, tag(6));
@@ -1184,7 +1184,7 @@ TEST_P(AsyncEnd2endTest, ServerTrailingMetadataRpc) {
             ToString(server_trailing_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_trailing_metadata.find(meta2.first)->second));
-  EXPECT_EQ(size_t{2}, server_trailing_metadata.size());
+  EXPECT_EQ(2, server_trailing_metadata.size());
 }
 
 TEST_P(AsyncEnd2endTest, MetadataRpc) {
@@ -1232,7 +1232,7 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
             ToString(client_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(client_initial_metadata.find(meta2.first)->second));
-  EXPECT_GE(client_initial_metadata.size(), size_t{2});
+  EXPECT_GE(client_initial_metadata.size(), 2);
 
   srv_ctx.AddInitialMetadata(meta3.first, meta3.second);
   srv_ctx.AddInitialMetadata(meta4.first, meta4.second);
@@ -1243,7 +1243,7 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
             ToString(server_initial_metadata.find(meta3.first)->second));
   EXPECT_EQ(meta4.second,
             ToString(server_initial_metadata.find(meta4.first)->second));
-  EXPECT_GE(server_initial_metadata.size(), size_t{2});
+  EXPECT_GE(server_initial_metadata.size(), 2);
 
   send_response.set_message(recv_request.message());
   srv_ctx.AddTrailingMetadata(meta5.first, meta5.second);
@@ -1260,7 +1260,7 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
             ToString(server_trailing_metadata.find(meta5.first)->second));
   EXPECT_EQ(meta6.second,
             ToString(server_trailing_metadata.find(meta6.first)->second));
-  EXPECT_GE(server_trailing_metadata.size(), size_t{2});
+  EXPECT_GE(server_trailing_metadata.size(), 2);
 }
 
 // Server uses AsyncNotifyWhenDone API to check for cancellation

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -979,7 +979,7 @@ TEST_P(AsyncEnd2endTest, ClientInitialMetadataRpc) {
             ToString(client_initial_metadata.find(meta2.first)->second));
   EXPECT_EQ(meta3.second,
             ToString(client_initial_metadata.find(meta3.first)->second));
-  EXPECT_GE(client_initial_metadata.size(), static_cast<size_t>(2));
+  EXPECT_GE(client_initial_metadata.size(), size_t{2});
 
   send_response.set_message(recv_request.message());
   response_writer.Finish(send_response, Status::OK, tag(3));
@@ -1023,7 +1023,7 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataRpc) {
             ToString(server_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(static_cast<size_t>(2), server_initial_metadata.size());
+  EXPECT_EQ(size_t{2}, server_initial_metadata.size());
 
   send_response.set_message(recv_request.message());
   response_writer.Finish(send_response, Status::OK, tag(5));
@@ -1066,7 +1066,7 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataServerStreaming) {
             ToString(server_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(static_cast<size_t>(2), server_initial_metadata.size());
+  EXPECT_EQ(size_t{2}, server_initial_metadata.size());
 
   srv_stream.Write(send_response, tag(3));
 
@@ -1126,7 +1126,7 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataServerStreamingImplicit) {
             ToString(server_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(static_cast<size_t>(2), server_initial_metadata.size());
+  EXPECT_EQ(size_t{2}, server_initial_metadata.size());
 
   srv_stream.Write(send_response, tag(5));
   cli_stream->Read(&recv_response, tag(6));
@@ -1184,7 +1184,7 @@ TEST_P(AsyncEnd2endTest, ServerTrailingMetadataRpc) {
             ToString(server_trailing_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(server_trailing_metadata.find(meta2.first)->second));
-  EXPECT_EQ(static_cast<size_t>(2), server_trailing_metadata.size());
+  EXPECT_EQ(size_t{2}, server_trailing_metadata.size());
 }
 
 TEST_P(AsyncEnd2endTest, MetadataRpc) {
@@ -1232,7 +1232,7 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
             ToString(client_initial_metadata.find(meta1.first)->second));
   EXPECT_EQ(meta2.second,
             ToString(client_initial_metadata.find(meta2.first)->second));
-  EXPECT_GE(client_initial_metadata.size(), static_cast<size_t>(2));
+  EXPECT_GE(client_initial_metadata.size(), size_t{2});
 
   srv_ctx.AddInitialMetadata(meta3.first, meta3.second);
   srv_ctx.AddInitialMetadata(meta4.first, meta4.second);
@@ -1243,7 +1243,7 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
             ToString(server_initial_metadata.find(meta3.first)->second));
   EXPECT_EQ(meta4.second,
             ToString(server_initial_metadata.find(meta4.first)->second));
-  EXPECT_GE(server_initial_metadata.size(), static_cast<size_t>(2));
+  EXPECT_GE(server_initial_metadata.size(), size_t{2});
 
   send_response.set_message(recv_request.message());
   srv_ctx.AddTrailingMetadata(meta5.first, meta5.second);
@@ -1260,7 +1260,7 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
             ToString(server_trailing_metadata.find(meta5.first)->second));
   EXPECT_EQ(meta6.second,
             ToString(server_trailing_metadata.find(meta6.first)->second));
-  EXPECT_GE(server_trailing_metadata.size(), static_cast<size_t>(2));
+  EXPECT_GE(server_trailing_metadata.size(), size_t{2});
 }
 
 // Server uses AsyncNotifyWhenDone API to check for cancellation

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -423,7 +423,7 @@ TEST_P(ClientCallbackEnd2endTest, SimpleRpcUnderLockNested) {
                            rpc_state[index].done = true;
                            rpc_state[index].cv.notify_all();
                            // Call the next level of nesting if possible
-                           if (index + 1 < int(rpc_state.size())) {
+                           if (index + 1 < static_cast<int>(rpc_state.size())) {
                              nested_call(index + 1);
                            }
                          });

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -87,7 +87,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), static_cast<unsigned>(1));
+      ASSERT_EQ(map->size(), unsigned{1});
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -111,7 +111,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::POST_RECV_MESSAGE)) {
@@ -140,7 +140,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here at the moment
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)) {
@@ -153,7 +153,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -193,7 +193,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), static_cast<unsigned>(1));
+      ASSERT_EQ(map->size(), unsigned{1});
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -233,7 +233,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::POST_RECV_MESSAGE)) {
@@ -261,7 +261,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here at the moment
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)) {
@@ -274,7 +274,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -355,7 +355,7 @@ class BidiStreamingRpcHijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -447,7 +447,7 @@ class ServerStreamingRpcHijackingInterceptor
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), static_cast<unsigned>(1));
+      ASSERT_EQ(map->size(), unsigned{1});
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -500,7 +500,7 @@ class ServerStreamingRpcHijackingInterceptor
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -560,7 +560,7 @@ class LoggingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), static_cast<unsigned>(1));
+      ASSERT_EQ(map->size(), unsigned{1});
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -603,7 +603,7 @@ class LoggingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
       post_recv_initial_metadata_ = true;
     }
     if (methods->QueryInterceptionHookPoint(

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -87,7 +87,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), unsigned{1});
+      ASSERT_EQ(map->size(), 1);
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -111,7 +111,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::POST_RECV_MESSAGE)) {
@@ -140,7 +140,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here at the moment
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)) {
@@ -153,7 +153,7 @@ class HijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -193,7 +193,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), unsigned{1});
+      ASSERT_EQ(map->size(), 1);
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -233,7 +233,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::POST_RECV_MESSAGE)) {
@@ -261,7 +261,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here at the moment
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)) {
@@ -274,7 +274,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -355,7 +355,7 @@ class BidiStreamingRpcHijackingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -447,7 +447,7 @@ class ServerStreamingRpcHijackingInterceptor
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), unsigned{1});
+      ASSERT_EQ(map->size(), 1);
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -500,7 +500,7 @@ class ServerStreamingRpcHijackingInterceptor
             experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
       auto* map = methods->GetRecvTrailingMetadata();
       // insert the metadata that we want
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
       map->insert(std::make_pair("testkey", "testvalue"));
       auto* status = methods->GetRecvStatus();
       *status = Status(StatusCode::OK, "");
@@ -560,7 +560,7 @@ class LoggingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Check that we can see the test metadata
-      ASSERT_EQ(map->size(), unsigned{1});
+      ASSERT_EQ(map->size(), 1);
       auto iterator = map->begin();
       EXPECT_EQ("testkey", iterator->first);
       EXPECT_EQ("testvalue", iterator->second);
@@ -603,7 +603,7 @@ class LoggingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA)) {
       auto* map = methods->GetRecvInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
       post_recv_initial_metadata_ = true;
     }
     if (methods->QueryInterceptionHookPoint(

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -79,7 +79,7 @@ class LoggingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), static_cast<unsigned>(0));
+      EXPECT_EQ(map->size(), unsigned{0});
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_SEND_MESSAGE)) {

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -79,7 +79,7 @@ class LoggingInterceptor : public experimental::Interceptor {
             experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
       auto* map = methods->GetSendInitialMetadata();
       // Got nothing better to do here for now
-      EXPECT_EQ(map->size(), unsigned{0});
+      EXPECT_EQ(map->size(), 0);
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_SEND_MESSAGE)) {

--- a/test/cpp/end2end/streaming_throughput_test.cc
+++ b/test/cpp/end2end/streaming_throughput_test.cc
@@ -92,7 +92,7 @@ class TestServiceImpl : public grpc::testing::EchoTestService::Service {
       gpr_atm* should_exit) {
     EchoResponse response;
     response.set_message(kLargeString);
-    while (gpr_atm_acq_load(should_exit) == static_cast<gpr_atm>(0)) {
+    while (gpr_atm_acq_load(should_exit) == gpr_atm{0}) {
       struct timespec tv = {0, 1000000};  // 1 ms
       struct timespec rem;
       // TODO (vpai): Mark this blocking
@@ -110,7 +110,7 @@ class TestServiceImpl : public grpc::testing::EchoTestService::Service {
       ServerReaderWriter<EchoResponse, EchoRequest>* stream) override {
     EchoRequest request;
     gpr_atm should_exit;
-    gpr_atm_rel_store(&should_exit, static_cast<gpr_atm>(0));
+    gpr_atm_rel_store(&should_exit, gpr_atm{0});
 
     std::thread sender(
         std::bind(&TestServiceImpl::BidiStream_Sender, stream, &should_exit));
@@ -123,7 +123,7 @@ class TestServiceImpl : public grpc::testing::EchoTestService::Service {
         tv = rem;
       };
     }
-    gpr_atm_rel_store(&should_exit, static_cast<gpr_atm>(1));
+    gpr_atm_rel_store(&should_exit, gpr_atm{1});
     sender.join();
     return Status::OK;
   }

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -334,7 +334,7 @@ TYPED_TEST(End2endTest, ThreadStress) {
   }
   // If this test allows resource exhaustion, expect that it actually sees some
   if (this->common_.AllowExhaustion()) {
-    EXPECT_GT(error_cnt, uint64_t{0});
+    EXPECT_GT(error_cnt, 0);
   }
 }
 

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -294,7 +294,7 @@ static void SendRpc(grpc::testing::EchoTestService::Stub* stub, int num_rpcs,
         gpr_log(GPR_ERROR, "RPC error: %d: %s", s.error_code(),
                 s.error_message().c_str());
       }
-      gpr_atm_no_barrier_fetch_add(errors, static_cast<gpr_atm>(1));
+      gpr_atm_no_barrier_fetch_add(errors, gpr_atm{1});
     } else {
       EXPECT_EQ(response.message(), request.message());
     }
@@ -316,7 +316,7 @@ TYPED_TEST(End2endTest, ThreadStress) {
   this->common_.ResetStub();
   std::vector<std::thread> threads;
   gpr_atm errors;
-  gpr_atm_rel_store(&errors, static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&errors, gpr_atm{0});
   int num_threads = kNumThreads / grpc_test_slowdown_factor();
   // The number of threads should be > 10 to be able to catch errors
   ASSERT_GT(num_threads, 10);
@@ -334,7 +334,7 @@ TYPED_TEST(End2endTest, ThreadStress) {
   }
   // If this test allows resource exhaustion, expect that it actually sees some
   if (this->common_.AllowExhaustion()) {
-    EXPECT_GT(error_cnt, static_cast<uint64_t>(0));
+    EXPECT_GT(error_cnt, uint64_t{0});
   }
 }
 

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -96,7 +96,7 @@ namespace {
 // gpr_now() is called with invalid clock_type
 TEST(TimespecTest, GprNowInvalidClockType) {
   // initialize to some junk value
-  gpr_clock_type invalid_clock_type = gpr_clock_type{32641};
+  gpr_clock_type invalid_clock_type = static_cast<gpr_clock_type>(32641);
   EXPECT_DEATH(gpr_now(invalid_clock_type), ".*");
 }
 

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -96,7 +96,7 @@ namespace {
 // gpr_now() is called with invalid clock_type
 TEST(TimespecTest, GprNowInvalidClockType) {
   // initialize to some junk value
-  gpr_clock_type invalid_clock_type = static_cast<gpr_clock_type>(32641);
+  gpr_clock_type invalid_clock_type = gpr_clock_type{32641};
   EXPECT_DEATH(gpr_now(invalid_clock_type), ".*");
 }
 

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -860,7 +860,8 @@ void XdsEnd2endTest::CheckRpcSendOk(
     const RpcOptions& rpc_options) {
   SendRpcsUntil(
       debug_location,
-      [debug_location, times, n = size_t(0)](const RpcResult& result) mutable {
+      [debug_location, times,
+       n = static_cast<size_t>(0)](const RpcResult& result) mutable {
         EXPECT_TRUE(result.status.ok())
             << "code=" << result.status.error_code()
             << " message=" << result.status.error_message() << " at "
@@ -891,7 +892,7 @@ size_t XdsEnd2endTest::SendRpcsAndCountFailuresWithMessage(
   size_t num_failed = 0;
   SendRpcsUntil(
       debug_location,
-      [&, n = size_t(0)](const RpcResult& result) mutable {
+      [&, n = static_cast<size_t>(0)](const RpcResult& result) mutable {
         if (!result.status.ok()) {
           EXPECT_EQ(result.status.error_code(), expected_status)
               << debug_location.file() << ":" << debug_location.line();

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -860,8 +860,7 @@ void XdsEnd2endTest::CheckRpcSendOk(
     const RpcOptions& rpc_options) {
   SendRpcsUntil(
       debug_location,
-      [debug_location, times,
-       n = static_cast<size_t>(0)](const RpcResult& result) mutable {
+      [debug_location, times, n = size_t{0}](const RpcResult& result) mutable {
         EXPECT_TRUE(result.status.ok())
             << "code=" << result.status.error_code()
             << " message=" << result.status.error_message() << " at "
@@ -892,7 +891,7 @@ size_t XdsEnd2endTest::SendRpcsAndCountFailuresWithMessage(
   size_t num_failed = 0;
   SendRpcsUntil(
       debug_location,
-      [&, n = static_cast<size_t>(0)](const RpcResult& result) mutable {
+      [&, n = size_t{0}](const RpcResult& result) mutable {
         if (!result.status.ok()) {
           EXPECT_EQ(result.status.error_code(), expected_status)
               << debug_location.file() << ":" << debug_location.line();

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -87,7 +87,7 @@ static void BM_HpackEncoderEncodeDeadline(benchmark::State& state) {
             static_cast<uint32_t>(state.iterations()),
             true,
             false,
-            static_cast<size_t>(1024),
+            size_t{1024},
             &stats,
         },
         b, &outbuf);

--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -95,7 +95,7 @@ class SynchronousClient
           return true;
         } else {
           gpr_sleep_until(one_sec_delay);
-          if (gpr_atm_acq_load(&thread_pool_done_) != static_cast<gpr_atm>(0)) {
+          if (gpr_atm_acq_load(&thread_pool_done_) != gpr_atm{0}) {
             return false;
           }
         }

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -277,7 +277,7 @@ class WorkerServiceImpl final : public WorkerService::Service {
 QpsWorker::QpsWorker(int driver_port, int server_port,
                      const std::string& credential_type) {
   impl_ = std::make_unique<WorkerServiceImpl>(server_port, this);
-  gpr_atm_rel_store(&done_, static_cast<gpr_atm>(0));
+  gpr_atm_rel_store(&done_, gpr_atm{0});
 
   std::unique_ptr<ServerBuilder> builder = CreateQpsServerBuilder();
   builder->AddChannelArgument(GRPC_ARG_ALLOW_REUSEPORT, 0);
@@ -304,10 +304,8 @@ QpsWorker::QpsWorker(int driver_port, int server_port,
 QpsWorker::~QpsWorker() {}
 
 bool QpsWorker::Done() const {
-  return (gpr_atm_acq_load(&done_) != static_cast<gpr_atm>(0));
+  return (gpr_atm_acq_load(&done_) != gpr_atm{0});
 }
-void QpsWorker::MarkDone() {
-  gpr_atm_rel_store(&done_, static_cast<gpr_atm>(1));
-}
+void QpsWorker::MarkDone() { gpr_atm_rel_store(&done_, gpr_atm{1}); }
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/util/byte_buffer_test.cc
+++ b/test/cpp/util/byte_buffer_test.cc
@@ -70,7 +70,7 @@ TEST_F(ByteBufferTest, Clear) {
   Slice s(kContent1);
   ByteBuffer buffer(&s, 1);
   buffer.Clear();
-  EXPECT_EQ(size_t{0}, buffer.Length());
+  EXPECT_EQ(0, buffer.Length());
 }
 
 TEST_F(ByteBufferTest, Length) {

--- a/test/cpp/util/byte_buffer_test.cc
+++ b/test/cpp/util/byte_buffer_test.cc
@@ -70,7 +70,7 @@ TEST_F(ByteBufferTest, Clear) {
   Slice s(kContent1);
   ByteBuffer buffer(&s, 1);
   buffer.Clear();
-  EXPECT_EQ(static_cast<size_t>(0), buffer.Length());
+  EXPECT_EQ(size_t{0}, buffer.Length());
 }
 
 TEST_F(ByteBufferTest, Length) {

--- a/test/cpp/util/channelz_sampler.cc
+++ b/test/cpp/util/channelz_sampler.cc
@@ -329,7 +329,7 @@ class ChannelzSampler final {
           gpr_log(GPR_ERROR,
                   "GetServers RPC with GetServersRequest.server_start_id=%d, "
                   "failed: %s",
-                  int(server_start_id),
+                  static_cast<int>(server_start_id),
                   get_servers_context.debug_error_string().c_str());
         }
         GPR_ASSERT(0);
@@ -385,7 +385,7 @@ class ChannelzSampler final {
         gpr_log(GPR_ERROR,
                 "GetTopChannels RPC with "
                 "GetTopChannelsRequest.channel_start_id=%d failed: %s",
-                int(channel_start_id),
+                static_cast<int>(channel_start_id),
                 get_top_channels_context.debug_error_string().c_str());
         GPR_ASSERT(0);
       }


### PR DESCRIPTION
Revived `google-readability-casting` which was disabled temporarily by https://github.com/grpc/grpc/pull/31518. It's still acting up on some edge cases but it's easy to tame using brace initialization.