### PR TITLE
Add query delay flag to Prometheus query script.

### DIFF
--- a/tools/run_tests/performance/prometheus.py
+++ b/tools/run_tests/performance/prometheus.py
@@ -274,7 +274,8 @@ def main() -> None:
         '--delay_seconds',
         default=0,
         type=int,
-        help='Configure delay in seconds to perform Prometheus queries, default is 0',
+        help=
+        'Configure delay in seconds to perform Prometheus queries, default is 0',
     )
     args = argp.parse_args()
 
@@ -293,7 +294,7 @@ def main() -> None:
         )
 
     time.sleep(args.delay_seconds)
-    
+
     pod_dict = construct_pod_dict(args.node_info_file, args.pod_type)
     processed_data = p.fetch_cpu_and_memory_data(
         container_list=args.container_name, pod_dict=pod_dict)

--- a/tools/run_tests/performance/prometheus.py
+++ b/tools/run_tests/performance/prometheus.py
@@ -274,7 +274,7 @@ def main() -> None:
         '--delay_seconds',
         default=0,
         type=int,
-        help='Configure delay in seconds to perform Prometheus queries, default is 0s',
+        help='Configure delay in seconds to perform Prometheus queries, default is 0',
     )
     args = argp.parse_args()
 

--- a/tools/run_tests/performance/prometheus.py
+++ b/tools/run_tests/performance/prometheus.py
@@ -31,6 +31,7 @@ import argparse
 import json
 import logging
 import statistics
+import time
 from typing import Any, Dict, List
 
 from dateutil import parser
@@ -269,6 +270,12 @@ def main() -> None:
         default=False,
         help='Suppress informative output',
     )
+    argp.add_argument(
+        '--delay_seconds',
+        default=0,
+        type=int,
+        help='Configure delay in seconds to perform Prometheus queries, default is 0s',
+    )
     args = argp.parse_args()
 
     if not args.quiet:
@@ -285,6 +292,8 @@ def main() -> None:
             end=end_time,
         )
 
+    time.sleep(args.delay_seconds)
+    
     pod_dict = construct_pod_dict(args.node_info_file, args.pod_type)
     processed_data = p.fetch_cpu_and_memory_data(
         container_list=args.container_name, pod_dict=pod_dict)


### PR DESCRIPTION
This PR adds the flag allowing user to configure the delay before query
the Prometheus.


