### PR TITLE
Revert "Revert "Add BaseEvent""

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/event.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/event.pxd.pxi
@@ -12,15 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cdef class BaseEvent:
+  pass
 
-cdef class ConnectivityEvent:
+cdef class ConnectivityEvent(BaseEvent):
 
   cdef readonly grpc_completion_type completion_type
   cdef readonly bint success
   cdef readonly object tag
 
 
-cdef class RequestCallEvent:
+cdef class RequestCallEvent(BaseEvent):
 
   cdef readonly grpc_completion_type completion_type
   cdef readonly bint success
@@ -30,7 +32,7 @@ cdef class RequestCallEvent:
   cdef readonly tuple invocation_metadata
 
 
-cdef class BatchOperationEvent:
+cdef class BatchOperationEvent(BaseEvent):
 
   cdef readonly grpc_completion_type completion_type
   cdef readonly bint success
@@ -38,7 +40,7 @@ cdef class BatchOperationEvent:
   cdef readonly object batch_operations
 
 
-cdef class ServerShutdownEvent:
+cdef class ServerShutdownEvent(BaseEvent):
 
   cdef readonly grpc_completion_type completion_type
   cdef readonly bint success

--- a/src/python/grpcio/grpc/_cython/_cygrpc/event.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/event.pyx.pxi
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-cdef class ConnectivityEvent:
+cdef class ConnectivityEvent(BaseEvent):
 
   def __cinit__(
       self, grpc_completion_type completion_type, bint success, object tag):
@@ -22,7 +21,7 @@ cdef class ConnectivityEvent:
     self.tag = tag
 
 
-cdef class RequestCallEvent:
+cdef class RequestCallEvent(BaseEvent):
 
   def __cinit__(
       self, grpc_completion_type completion_type, bint success, object tag,
@@ -35,7 +34,7 @@ cdef class RequestCallEvent:
     self.invocation_metadata = invocation_metadata
 
 
-cdef class BatchOperationEvent:
+cdef class BatchOperationEvent(BaseEvent):
 
   def __cinit__(
       self, grpc_completion_type completion_type, bint success, object tag,
@@ -46,7 +45,7 @@ cdef class BatchOperationEvent:
     self.batch_operations = batch_operations
 
 
-cdef class ServerShutdownEvent:
+cdef class ServerShutdownEvent(BaseEvent):
 
   def __cinit__(
       self, grpc_completion_type completion_type, bint success, object tag):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
@@ -15,7 +15,7 @@
 
 cdef class _Tag:
 
-  cdef object event(self, grpc_event c_event)
+  cdef BaseEvent event(self, grpc_event c_event)
 
 
 cdef class _ConnectivityTag(_Tag):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
@@ -15,7 +15,7 @@
 
 cdef class _Tag:
 
-  cdef object event(self, grpc_event c_event):
+  cdef BaseEvent event(self, grpc_event c_event):
     raise NotImplementedError()
 
 


### PR DESCRIPTION
Reverts grpc/grpc#31623 to reapply `Add BaseEvent` changes.

Previous import was broken due to import orders in G3 `net/grpc/python/_cython/cygrpc.pxd`, already merged a CL to fix this and tested that presubmit passed, thus reapply those changes.