### PR TITLE
nit: update the documentation in error.h

### DIFF
--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -37,8 +37,6 @@
 #include "src/core/lib/slice/slice_internal.h"
 
 /// Opaque representation of an error.
-/// See https://github.com/grpc/grpc/blob/master/doc/core/grpc-error.md for a
-/// full write up of this object.
 
 typedef absl::Status grpc_error_handle;
 


### PR DESCRIPTION
https://github.com/grpc/grpc/blob/master/doc/core/grpc-error.md seems to be a dead link...
I didn't find any substitute from it. If there is one, please let me know :)