### PR TITLE
Dont install ruby macos artifact deps on v1.49.x

### DIFF
--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -23,7 +23,6 @@ cd $(dirname $0)/../../..
 
 export PREPARE_BUILD_INSTALL_DEPS_CSHARP=true
 export PREPARE_BUILD_INSTALL_DEPS_PYTHON=true
-export PREPARE_BUILD_INSTALL_DEPS_RUBY=true
 export PREPARE_BUILD_INSTALL_DEPS_PHP=true
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 


### PR DESCRIPTION
These dependencies are causing installation failures and preventing a successful package build on the 1.49.x branch.

Since we don't actually use macos for the ruby artifact build anymore (we haven't since 1.45.x), let's stop installing them on this branch (master already doesn't use them).

cc @jtattermusch 
