### PR TITLE
Add ability to control callback service threadpool with resource quota

### DIFF
--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -413,7 +413,8 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
     return true;
   }
 
-  static CompletionQueue* CallbackAlternativeCQ();
+  static CompletionQueue* CallbackAlternativeCQ(
+      grpc_resource_quota* server_rq = nullptr);
   static void ReleaseCallbackAlternativeCQ(CompletionQueue* cq);
 
   grpc_completion_queue* cq_;  // owned

--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -256,7 +256,11 @@ class Server : public ServerInterface, private internal::GrpcLibrary {
     return max_receive_message_size_;
   }
 
-  CompletionQueue* CallbackCQ() ABSL_LOCKS_EXCLUDED(mu_) override;
+  CompletionQueue* CallbackCQ() ABSL_LOCKS_EXCLUDED(mu_) override {
+    return CallbackCQ(nullptr);
+  };
+  CompletionQueue* CallbackCQ(grpc_resource_quota* server_rq)
+      ABSL_LOCKS_EXCLUDED(mu_);
 
   ServerInitializer* initializer();
 

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -219,8 +219,12 @@ class ServerBuilder {
   ServerBuilder& SetDefaultCompressionAlgorithm(
       grpc_compression_algorithm algorithm);
 
-  /// Set the attached buffer pool for this server
+  /// Set the attached buffer pool for synchronous calls on this server
   ServerBuilder& SetResourceQuota(const grpc::ResourceQuota& resource_quota);
+
+  /// Set the attached buffer pool for callbacks on this server
+  ServerBuilder& SetCallbackResourceQuota(
+      const grpc::ResourceQuota& resource_quota);
 
   ServerBuilder& SetOption(std::unique_ptr<grpc::ServerBuilderOption> option);
 
@@ -390,6 +394,7 @@ class ServerBuilder {
   std::shared_ptr<grpc::ServerCredentials> creds_;
   std::vector<std::unique_ptr<grpc::ServerBuilderPlugin>> plugins_;
   grpc_resource_quota* resource_quota_;
+  grpc_resource_quota* callback_resource_quota_;
   grpc::AsyncGenericService* generic_service_{nullptr};
   std::unique_ptr<ContextAllocator> context_allocator_;
   grpc::CallbackGenericService* callback_generic_service_{nullptr};

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1339,7 +1339,7 @@ grpc::ServerInitializer* Server::initializer() {
   return server_initializer_.get();
 }
 
-grpc::CompletionQueue* Server::CallbackCQ() {
+grpc::CompletionQueue* Server::CallbackCQ(grpc_resource_quota* server_rq) {
   // TODO(vjpai): Consider using a single global CQ for the default CQ
   // if there is no explicit per-server CQ registered
   CompletionQueue* callback_cq = callback_cq_.load(std::memory_order_acquire);
@@ -1364,7 +1364,7 @@ grpc::CompletionQueue* Server::CallbackCQ() {
     shutdown_callback->TakeCQ(callback_cq);
   } else {
     // Otherwise we need to use the alternative CQ variant
-    callback_cq = CompletionQueue::CallbackAlternativeCQ();
+    callback_cq = CompletionQueue::CallbackAlternativeCQ(server_rq);
   }
 
   callback_cq_.store(callback_cq, std::memory_order_release);


### PR DESCRIPTION
Right now there is a hard coded upper bound of 16 threads in the thread pool for Callback Services. #28642 requested a mechanism to control the number of threads. (It also requested controlling per thread stack size which wasn't addressed here).

AFAICT, the existing `SetResourceQuota` just controls the thread manager for synchronous servers. This exposes an additional `SetCallbackResourceQuota` to the server builder to provide plumbing to tune a CallbackService. For mixed servers with synchronous calls and callbacks two ResourceQuotas could be used to determine how to share the underlying hardware.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

