### PR TITLE
Fix Python AIO interop test

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -627,7 +627,7 @@ class PythonAsyncIOLanguage:
     def server_cmd(self, args):
         return [
             _PYTHON_BINARY, 'src/python/grpcio_tests/setup.py', 'run_interop',
-            '--server', '--args="{}"'.format(' '.join(args))
+            '--use-asyncio', '--server', '--args="{}"'.format(' '.join(args))
         ]
 
     def global_env(self):

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -626,9 +626,8 @@ class PythonAsyncIOLanguage:
 
     def server_cmd(self, args):
         return [
-            _PYTHON_BINARY, 'src/python/grpcio_tests/setup.py',
-            'py39/bin/python', 'src/python/grpcio_tests/setup.py',
-            '--args="{}"'.format(' '.join(args))
+            _PYTHON_BINARY, 'src/python/grpcio_tests/setup.py', 'run_interop',
+            '--server', '--args="{}"'.format(' '.join(args))
         ]
 
     def global_env(self):


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/31644.

We changed the wrong line in this commit( https://github.com/grpc/grpc/commit/179a7c7459d2fd9ae24cae6ea906bf2e8bac8300#) causing interop test fail with error `invalid command name 'py39/bin/python'`. This PR fixes that.