### PR TITLE
Use CMake variables for paths in pkg-config files

### DIFF
--- a/cmake/pkg-config-template.pc.in
+++ b/cmake/pkg-config-template.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+includedir=${prefix}/@gRPC_INSTALL_INCLUDEDIR@
+libdir=${exec_prefix}/@gRPC_INSTALL_LIBDIR@
 
 Name: @PC_NAME@
 Description: @PC_DESCRIPTION@


### PR DESCRIPTION
Use `@gRPC_INSTALL_LIBDIR@` for `libdir`; this fixes an incorrect `-L/usr/lib` on multilib Linux systems where that is the 32-bit library path and the correct path is `/usr/lib64`.

Use `@gRPC_INSTALL_INCLUDEDIR@` for consistency.