### PR TITLE
doc/PROTOCOL-HTTP2.md: Clarify Percent-Byte-Unencoded comment

### DIFF
--- a/doc/PROTOCOL-HTTP2.md
+++ b/doc/PROTOCOL-HTTP2.md
@@ -111,7 +111,7 @@ For requests, **EOS** (end-of-stream) is indicated by the presence of the END_ST
 * **Status** → "grpc-status" 1\*DIGIT ; 0-9
 * **Status-Message** → "grpc-message" Percent-Encoded
 * **Percent-Encoded** → 1\*(Percent-Byte-Unencoded / Percent-Byte-Encoded)
-* **Percent-Byte-Unencoded** → 1\*( %x20-%x24 / %x26-%x7E ) ; space and VCHAR, except %
+* **Percent-Byte-Unencoded** → 1\*( %x20-%x24 / %x26-%x7E ) ; SPACE through ~ inclusive, except %
 * **Percent-Byte-Encoded** → "%" 2HEXDIGIT ; 0-9 A-F
 
 **Response-Headers** & **Trailers-Only** are each delivered in a single HTTP2 HEADERS frame block. Most responses are expected to have both headers and trailers but **Trailers-Only** is permitted for calls that produce an immediate error. Status must be sent in **Trailers** even if the status code is OK.


### PR DESCRIPTION
The comment about Percent-Byte-Unencoded used to read: "space and VCHAR, except %". Attempt to clarify that the unencoded characters are SPACE (0x20) through TILDE (0x7E) inclusive, excluding % (0x25). This more directly represents how it is implemented.
