### PR TITLE
Backport "Fix python tests on kokoro macos monterey (#31126)" to 1.49.x

### DIFF
--- a/tools/internal_ci/macos/grpc_distribtests_python.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_python.sh
@@ -26,12 +26,11 @@ source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # TODO(jtattermusch): cleanup this prepare build step (needed for python artifact build)
 # install cython for all python versions
-python2.7 -m pip install -U cython setuptools==44.1.1 wheel --user
-python3.5 -m pip install -U cython setuptools==44.1.1 wheel --user
-python3.6 -m pip install -U cython setuptools==44.1.1 wheel --user
-python3.7 -m pip install -U cython setuptools==44.1.1 wheel --user
-python3.8 -m pip install -U cython setuptools==44.1.1 wheel --user
-python3.9 -m pip install -U cython setuptools==44.1.1 wheel --user
+python3.7 -m pip install -U cython setuptools==65.4.1 wheel --user
+python3.8 -m pip install -U cython setuptools==65.4.1 wheel --user
+python3.9 -m pip install -U cython setuptools==65.4.1 wheel --user
+python3.10 -m pip install -U cython setuptools==65.4.1 wheel --user
+python3.11 -m pip install -U cython setuptools==65.4.1 wheel --user
 
 # Build all python macos artifacts (this step actually builds all the binary wheels and source archives)
 tools/run_tests/task_runner.py -f artifact macos python ${TASK_RUNNER_EXTRA_FILTERS} -j 4 -x build_artifacts/sponge_log.xml || FAILED="true"

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -135,10 +135,11 @@ ${SETARCH_CMD} "${PYTHON}" tools/distrib/python/grpcio_tools/setup.py bdist_whee
 # the artifacts output dir.
 if [ "$GRPC_SKIP_TWINE_CHECK" == "" ]
 then
-  # Ensure the generated artifacts are valid.
-  # TODO(jtattermusch): avoid the need for always re-installing virtualenv and twine
+  # Install virtualenv if it isn't already available.
+  # TODO(jtattermusch): cleanup the virtualenv version fallback logic.
   "${PYTHON}" -m pip install virtualenv
-  "${PYTHON}" -m virtualenv venv || { "${PYTHON}" -m pip install virtualenv==16.7.9 && "${PYTHON}" -m virtualenv venv; }
+  "${PYTHON}" -m virtualenv venv || { "${PYTHON}" -m pip install virtualenv==20.0.23 && "${PYTHON}" -m virtualenv venv; }
+  # Ensure the generated artifacts are valid using "twine check"
   venv/bin/python -m pip install "twine<=2.0"
   venv/bin/python -m twine check dist/* tools/distrib/python/grpcio_tools/dist/*
   rm -rf venv/

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -86,20 +86,6 @@ function toolchain() {
   fi
 }
 
-# TODO(jtattermusch): this adds dependency on grealpath on mac
-# (brew install coreutils) for little reason.
-# Command to invoke the linux command `realpath` or equivalent.
-function script_realpath() {
-  # Find `realpath`
-  if [ -x "$(command -v realpath)" ]; then
-    realpath "$@"
-  elif [ -x "$(command -v grealpath)" ]; then
-    grealpath "$@"
-  else
-    exit 1
-  fi
-}
-
 ####################
 # Script Arguments #
 ####################
@@ -137,9 +123,9 @@ if [[ "$(inside_venv)" ]]; then
   VENV_PYTHON="$PYTHON"
 else
   # Instantiate the virtualenv from the Python version passed in.
-  $PYTHON -m pip install --user virtualenv==16.7.9
+  $PYTHON -m pip install --user virtualenv==20.0.23
   $PYTHON -m virtualenv "$VENV"
-  VENV_PYTHON=$(script_realpath "$VENV/$VENV_RELATIVE_PYTHON")
+  VENV_PYTHON="$(pwd)/$VENV/$VENV_RELATIVE_PYTHON"
 fi
 
 

--- a/tools/run_tests/helper_scripts/run_python.sh
+++ b/tools/run_tests/helper_scripts/run_python.sh
@@ -18,7 +18,8 @@ set -ex
 # change to grpc repo root
 cd "$(dirname "$0")/../../.."
 
-PYTHON=$(realpath "${1:-py37/bin/python}")
+# TODO(jtattermusch): is the $(pwd) prefix actually useful?
+PYTHON="$(pwd)/${1:-py37/bin/python}"
 
 ROOT=$(pwd)
 


### PR DESCRIPTION
As mentioned in https://github.com/grpc/grpc/pull/31664#issuecomment-1319732737, this should fix python package builds on 1.49.x
