### PR TITLE
Remove `include/grpc/impl/codegen/byte_buffer_reader.h`

### DIFF
--- a/include/grpc/byte_buffer_reader.h
+++ b/include/grpc/byte_buffer_reader.h
@@ -21,6 +21,24 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/byte_buffer_reader.h>  // IWYU pragma: export
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct grpc_byte_buffer;
+
+struct grpc_byte_buffer_reader {
+  struct grpc_byte_buffer* buffer_in;
+  struct grpc_byte_buffer* buffer_out;
+  /** Different current objects correspond to different types of byte buffers */
+  union grpc_byte_buffer_reader_current {
+    /** Index into a slice buffer's array of slices */
+    unsigned index;
+  } current;
+};
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* GRPC_BYTE_BUFFER_READER_H */

--- a/include/grpc/impl/codegen/byte_buffer_reader.h
+++ b/include/grpc/impl/codegen/byte_buffer_reader.h
@@ -19,26 +19,11 @@
 #ifndef GRPC_IMPL_CODEGEN_BYTE_BUFFER_READER_H
 #define GRPC_IMPL_CODEGEN_BYTE_BUFFER_READER_H
 
-// IWYU pragma: private, include <grpc/byte_buffer_reader.h>
+// IWYU pragma: private
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <grpc/support/port_platform.h>
 
-struct grpc_byte_buffer;
-
-struct grpc_byte_buffer_reader {
-  struct grpc_byte_buffer* buffer_in;
-  struct grpc_byte_buffer* buffer_out;
-  /** Different current objects correspond to different types of byte buffers */
-  union grpc_byte_buffer_reader_current {
-    /** Index into a slice buffer's array of slices */
-    unsigned index;
-  } current;
-};
-
-#ifdef __cplusplus
-}
-#endif
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/byte_buffer_reader.h>
 
 #endif /* GRPC_IMPL_CODEGEN_BYTE_BUFFER_READER_H */


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->


This PR is a part of [b/196639718](http://b/196639718). It tries to move the content of `include/grpc/impl/codegen/byte_buffer_reader.h` to `include/grpcpp/byte_buffer_reader.h`. We do not remove anything to achieve backward compatibility. The file `include/grpc/impl/codegen/byte_buffer_reader.h` should be removed in the future.