### PR TITLE
[tests] Restore grpc_interop_matrix_adhoc.cfg

### DIFF
--- a/tools/internal_ci/linux/pull_request/grpc_interop_matrix_adhoc.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_interop_matrix_adhoc.cfg
@@ -1,0 +1,30 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_interop_matrix.sh"
+timeout_mins: 600
+action {
+  define_artifacts {
+    regex: "**/sponge_log.xml"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "--language=all --release=all --allow_flakes --report_file=sponge_log.xml"
+}


### PR DESCRIPTION
Previously deleted in https://github.com/grpc/grpc/pull/31423.

We still need this build config to execute adhoc run of interop matrix tests per https://github.com/grpc/grpc/blob/master/tools/interop_matrix/README.md instructions.




