### PR TITLE
[PHP] A trivial performace improvement for the PHP extension

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -451,7 +451,8 @@ PHP_METHOD(Call, startBatch) {
     op_num++;
   PHP_GRPC_HASH_FOREACH_END()
 
-  error = grpc_call_start_batch(call->wrapped, ops, op_num, call->wrapped,
+  grpc_call *wrapped = call->wrapped;
+  error = grpc_call_start_batch(wrapped, ops, op_num, wrapped,
                                 NULL);
   if (error != GRPC_CALL_OK) {
     zend_throw_exception(spl_ce_LogicException,
@@ -459,7 +460,7 @@ PHP_METHOD(Call, startBatch) {
                          (long)error TSRMLS_CC);
     goto cleanup;
   }
-  grpc_completion_queue_pluck(completion_queue, call->wrapped,
+  grpc_completion_queue_pluck(completion_queue, wrapped,
                               gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
   zval *recv_md;
   for (int i = 0; i < op_num; i++) {


### PR DESCRIPTION
Perf shows that the memory are accessed twice for call->wrapped in startBatch. If we assign call->wrapped to a variable and then use it in startBatch, only one memory access is needed. Then, the second attempting to get the value of call->wrapped will be done via register.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

