### PR TITLE
Revert "Build with System OpenSSL on Mac OS arm64 (#31096)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,22 +133,11 @@ BUILD_OVERRIDE_BORING_SSL_ASM_PLATFORM = os.environ.get(
 # present, then it will still attempt to use Cython.
 BUILD_WITH_CYTHON = _env_bool_value('GRPC_PYTHON_BUILD_WITH_CYTHON', 'False')
 
-# Currently, boringssl does not support macOS arm64, so we try to use the system
-# installation of openssl to build gRPC locally by default.
-if "darwin" in sys.platform and "arm64" == platform.machine().lower():
-    sys.stderr.write(
-        "Boringssl currently does not support macOS arm64, so we'll try to use the system installation "
-        "of 'openssl' to build by default, make sure you have 'openssl' installed in this case\n"
-    )
-    BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV = "True"
-else:
-    BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV = "False"
-
 # Export this variable to use the system installation of openssl. You need to
 # have the header files installed (in /usr/include/openssl) and during
 # runtime, the shared library must be installed
-BUILD_WITH_SYSTEM_OPENSSL = _env_bool_value(
-    'GRPC_PYTHON_BUILD_SYSTEM_OPENSSL', BUILD_WITH_SYSTEM_OPENSSL_DEFAULT_ENV)
+BUILD_WITH_SYSTEM_OPENSSL = _env_bool_value('GRPC_PYTHON_BUILD_SYSTEM_OPENSSL',
+                                            'False')
 
 # Export this variable to use the system installation of zlib. You need to
 # have the header files installed (in /usr/include/) and during


### PR DESCRIPTION
This reverts #31096 due to https://github.com/grpc/grpc/issues/31737. It seems many people actually _were_ successfully using boringssl on M1 and they viewed the new default dependency on openssl as a regression.