### PR TITLE
Build native MacOS arm64 artifacts (universal2)

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -133,6 +133,7 @@ class PythonArtifact:
 
         if self.platform == "macos":
             environ['ARCHFLAGS'] = "-arch arm64 -arch x86_64"
+            environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
 
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -129,13 +129,10 @@ class PythonArtifact:
         if inner_jobs is not None:
             # set number of parallel jobs when building native extension
             # building the native extension is the most time-consuming part of the build
-            environ['ARCHFLAGS'] = "-arch arm64 -arch xd86_64"
+            environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'] = str(inner_jobs)
 
-        # This is necessary due to https://github.com/pypa/wheel/issues/406.
-        # distutils incorrectly generates a universal2 artifact that only contains
-        # x86_64 libraries.
-        if self.platform == "macos" and self.arch == "x64":
-            environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
+        if self.platform == "macos":
+            environ['ARCHFLAGS'] = "-arch arm64 -arch x86_64"
 
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -129,7 +129,7 @@ class PythonArtifact:
         if inner_jobs is not None:
             # set number of parallel jobs when building native extension
             # building the native extension is the most time-consuming part of the build
-            environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'] = str(inner_jobs)
+            environ['ARCHFLAGS'] = "-arch arm64 -arch xd86_64"
 
         # This is necessary due to https://github.com/pypa/wheel/issues/406.
         # distutils incorrectly generates a universal2 artifact that only contains

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -134,6 +134,7 @@ class PythonArtifact:
         if self.platform == "macos":
             environ['ARCHFLAGS'] = "-arch arm64 -arch x86_64"
             environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
+            environ['GRPC_BUILD_WITH_BORING_SSL_ASM'] = "true"
 
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -134,7 +134,7 @@ class PythonArtifact:
         if self.platform == "macos":
             environ['ARCHFLAGS'] = "-arch arm64 -arch x86_64"
             environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
-            environ['GRPC_BUILD_WITH_BORING_SSL_ASM'] = "true"
+            environ['GRPC_BUILD_WITH_BORING_SSL_ASM'] = "false"
 
         if self.platform == 'linux_extra':
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -145,10 +145,23 @@ then
   rm -rf venv/
 fi
 
+assert_is_universal_wheel()  {
+  WHL="$1"
+  TMPDIR=$(mktemp -d)
+  unzip "$WHL" -d "$TMPDIR"
+  SO=$(find "$TMPDIR" -name '*.so' | head -n1)
+  if ! file "$SO" | grep "Mach-O universal binary with 2 architectures"; then
+    echo "$WHL is not universal2. Found the following:" >/dev/stderr
+    file "$SO" >/dev/stderr
+    exit 1
+  fi
+}
+
 fix_faulty_universal2_wheel() {
   WHL="$1"
-  if echo "$WHL" | grep "universal2"; then
-    UPDATED_NAME="${WHL//universal2/x86_64}"
+  assert_is_universal_wheel "$WHL"
+  if echo "$WHL" | grep "x86_64"; then
+    UPDATED_NAME="${WHL//x86_64/universal2}"
     mv "$WHL" "$UPDATED_NAME"
   fi
 }


### PR DESCRIPTION
This PR builds all MacOS artifacts as [`universal2`](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) artifacts by default. This builds the `.whl` with a shared object library supporting both the `x86_64` and `arm64` platforms:

```
rbellevi-macbookpro:tmp.u9QVKZQH rbellevi$ file ./grpc/_cython/cygrpc.cpython-311-darwin.so
./grpc/_cython/cygrpc.cpython-311-darwin.so: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit bundle x86_64Mach-O 64-bit bundle x86_64] [arm64]
./grpc/_cython/cygrpc.cpython-311-darwin.so (for architecture x86_64):	Mach-O 64-bit bundle x86_64
./grpc/_cython/cygrpc.cpython-311-darwin.so (for architecture arm64):	Mach-O 64-bit bundle arm64
```

This also removes the hack introduced by https://github.com/grpc/grpc/pull/29857 since we are now truly building universal artifacts. Fixes #29262