### PR TITLE
Remove functions in `class CoreCodegen`

### DIFF
--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -34,6 +34,7 @@
 
 #include <list>
 
+#include <grpc/grpc.h>
 #include <grpc/support/atm.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/rpc_service_method.h>
@@ -251,9 +252,8 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
   /// Private constructor of CompletionQueue only visible to friend classes
   explicit CompletionQueue(const grpc_completion_queue_attributes& attributes) {
     cq_ = grpc::g_core_codegen_interface->grpc_completion_queue_create(
-        grpc::g_core_codegen_interface->grpc_completion_queue_factory_lookup(
-            &attributes),
-        &attributes, nullptr);
+        grpc_completion_queue_factory_lookup(&attributes), &attributes,
+        nullptr);
     InitialAvalanching();  // reserve this for the future shutdown
   }
 

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -322,8 +322,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
     auto deadline =
         grpc::g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_REALTIME);
     while (true) {
-      auto ev = grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
-          cq_, tag, deadline, nullptr);
+      auto ev = grpc_completion_queue_pluck(cq_, tag, deadline, nullptr);
       bool ok = ev.success != 0;
       void* ignored = tag;
       if (tag->FinalizeResult(&ignored, &ok)) {
@@ -344,8 +343,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
   void TryPluck(grpc::internal::CompletionQueueTag* tag) {
     auto deadline =
         grpc::g_core_codegen_interface->gpr_time_0(GPR_CLOCK_REALTIME);
-    auto ev = grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
-        cq_, tag, deadline, nullptr);
+    auto ev = grpc_completion_queue_pluck(cq_, tag, deadline, nullptr);
     if (ev.type == GRPC_QUEUE_TIMEOUT) return;
     bool ok = ev.success != 0;
     void* ignored = tag;
@@ -360,8 +358,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
   /// that the tag is internal not something that is returned to the user.
   void TryPluck(grpc::internal::CompletionQueueTag* tag,
                 gpr_timespec deadline) {
-    auto ev = grpc::g_core_codegen_interface->grpc_completion_queue_pluck(
-        cq_, tag, deadline, nullptr);
+    auto ev = grpc_completion_queue_pluck(cq_, tag, deadline, nullptr);
     if (ev.type == GRPC_QUEUE_TIMEOUT || ev.type == GRPC_QUEUE_SHUTDOWN) {
       return;
     }

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -116,9 +116,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
   explicit CompletionQueue(grpc_completion_queue* take);
 
   /// Destructor. Destroys the owned wrapped completion queue / instance.
-  ~CompletionQueue() override {
-    grpc::g_core_codegen_interface->grpc_completion_queue_destroy(cq_);
-  }
+  ~CompletionQueue() override { grpc_completion_queue_destroy(cq_); }
 
   /// Tri-state return for AsyncNext: SHUTDOWN, GOT_EVENT, TIMEOUT.
   enum NextStatus {

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -388,7 +388,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
   void CompleteAvalanching() {
     if (gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_, gpr_atm{-1}) ==
         1) {
-      grpc::g_core_codegen_interface->grpc_completion_queue_shutdown(cq_);
+      grpc_completion_queue_shutdown(cq_);
     }
   }
 

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -251,7 +251,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
  protected:
   /// Private constructor of CompletionQueue only visible to friend classes
   explicit CompletionQueue(const grpc_completion_queue_attributes& attributes) {
-    cq_ = grpc::g_core_codegen_interface->grpc_completion_queue_create(
+    cq_ = grpc_completion_queue_create(
         grpc_completion_queue_factory_lookup(&attributes), &attributes,
         nullptr);
     InitialAvalanching();  // reserve this for the future shutdown

--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -25,6 +25,7 @@
 
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/impl/compression_types.h>
+#include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/completion_queue.h>
@@ -58,9 +59,8 @@ inline grpc_metadata* FillMetadataArray(
   if (*metadata_count == 0) {
     return nullptr;
   }
-  grpc_metadata* metadata_array =
-      static_cast<grpc_metadata*>(g_core_codegen_interface->gpr_malloc(
-          (*metadata_count) * sizeof(grpc_metadata)));
+  grpc_metadata* metadata_array = static_cast<grpc_metadata*>(
+      gpr_malloc((*metadata_count) * sizeof(grpc_metadata)));
   size_t i = 0;
   for (auto iter = metadata.cbegin(); iter != metadata.cend(); ++iter, ++i) {
     metadata_array[i].key = SliceReferencingString(iter->first);

--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -254,7 +254,7 @@ class CallOpSendInitialMetadata {
   }
   void FinishOp(bool* /*status*/) {
     if (!send_ || hijacked_) return;
-    g_core_codegen_interface->gpr_free(initial_metadata_);
+    gpr_free(initial_metadata_);
     send_ = false;
   }
 
@@ -687,7 +687,7 @@ class CallOpServerSendStatus {
 
   void FinishOp(bool* /*status*/) {
     if (!send_status_available_ || hijacked_) return;
-    g_core_codegen_interface->gpr_free(trailing_metadata_);
+    gpr_free(trailing_metadata_);
     send_status_available_ = false;
   }
 
@@ -808,8 +808,7 @@ class CallOpClientRecvStatus {
                  metadata_map_->GetBinaryErrorDetails());
       if (debug_error_string_ != nullptr) {
         client_context_->set_debug_error_string(debug_error_string_);
-        g_core_codegen_interface->gpr_free(
-            const_cast<char*>(debug_error_string_));
+        gpr_free(const_cast<char*>(debug_error_string_));
       }
     }
     // TODO(soheil): Find callers that set debug string even for status OK,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_completion_queue* grpc_completion_queue_create_for_pluck(
-      void* reserved) override;
   void grpc_completion_queue_shutdown(grpc_completion_queue* cq) override;
   void grpc_completion_queue_destroy(grpc_completion_queue* cq) override;
   grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) override;
   void gpr_cv_signal(gpr_cv* cv) override;
   void gpr_cv_broadcast(gpr_cv* cv) override;
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void* gpr_malloc(size_t size) override;
   void gpr_free(void* p) override;
 
   void grpc_init() override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_completion_queue_destroy(grpc_completion_queue* cq) override;
   grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,
                                          gpr_timespec deadline,
                                          void* reserved) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_init() override;
   void grpc_shutdown() override;
 
   void gpr_mu_init(gpr_mu* mu) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_free(void* p) override;
-
   void grpc_init() override;
   void grpc_shutdown() override;
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_completion_queue_shutdown(grpc_completion_queue* cq) override;
   void grpc_completion_queue_destroy(grpc_completion_queue* cq) override;
   grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,
                                          gpr_timespec deadline,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,10 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_completion_queue* grpc_completion_queue_create(
-      const grpc_completion_queue_factory* factory,
-      const grpc_completion_queue_attributes* attributes,
-      void* reserved) override;
   grpc_completion_queue* grpc_completion_queue_create_for_next(
       void* reserved) override;
   grpc_completion_queue* grpc_completion_queue_create_for_pluck(

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_mu_destroy(gpr_mu* mu) override;
   void gpr_mu_lock(gpr_mu* mu) override;
   void gpr_mu_unlock(gpr_mu* mu) override;
   void gpr_cv_init(gpr_cv* cv) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_cv_signal(gpr_cv* cv) override;
   void gpr_cv_broadcast(gpr_cv* cv) override;
 
   grpc_call_error grpc_call_start_batch(grpc_call* call, const grpc_op* ops,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_cv_broadcast(gpr_cv* cv) override;
-
   grpc_call_error grpc_call_start_batch(grpc_call* call, const grpc_op* ops,
                                         size_t nops, void* tag,
                                         void* reserved) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_mu_init(gpr_mu* mu) override;
   void gpr_mu_destroy(gpr_mu* mu) override;
   void gpr_mu_lock(gpr_mu* mu) override;
   void gpr_mu_unlock(gpr_mu* mu) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,10 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,
-                                         gpr_timespec deadline,
-                                         void* reserved) override;
-
   void* gpr_malloc(size_t size) override;
   void gpr_free(void* p) override;
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_cv_destroy(gpr_cv* cv) override;
   int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) override;
   void gpr_cv_signal(gpr_cv* cv) override;
   void gpr_cv_broadcast(gpr_cv* cv) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_mu_lock(gpr_mu* mu) override;
   void gpr_mu_unlock(gpr_mu* mu) override;
   void gpr_cv_init(gpr_cv* cv) override;
   void gpr_cv_destroy(gpr_cv* cv) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  const grpc_completion_queue_factory* grpc_completion_queue_factory_lookup(
-      const grpc_completion_queue_attributes* attributes) override;
   grpc_completion_queue* grpc_completion_queue_create(
       const grpc_completion_queue_factory* factory,
       const grpc_completion_queue_attributes* attributes,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_shutdown() override;
-
   void gpr_mu_init(gpr_mu* mu) override;
   void gpr_mu_destroy(gpr_mu* mu) override;
   void gpr_mu_lock(gpr_mu* mu) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_cv_init(gpr_cv* cv) override;
   void gpr_cv_destroy(gpr_cv* cv) override;
   int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) override;
   void gpr_cv_signal(gpr_cv* cv) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_completion_queue* grpc_completion_queue_create_for_next(
-      void* reserved) override;
   grpc_completion_queue* grpc_completion_queue_create_for_pluck(
       void* reserved) override;
   void grpc_completion_queue_shutdown(grpc_completion_queue* cq) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void gpr_mu_unlock(gpr_mu* mu) override;
   void gpr_cv_init(gpr_cv* cv) override;
   void gpr_cv_destroy(gpr_cv* cv) override;
   int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) override;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_free(void* p) = 0;
-
   // These are only to be used to fix edge cases involving grpc_init and
   // grpc_shutdown. Calling grpc_init from the codegen interface before
   // the real grpc_init is called will cause a crash, so if you use this

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,12 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  // These are only to be used to fix edge cases involving grpc_init and
-  // grpc_shutdown. Calling grpc_init from the codegen interface before
-  // the real grpc_init is called will cause a crash, so if you use this
-  // function, ensure that it is not the first call to grpc_init.
-  virtual void grpc_shutdown() = 0;
-
   virtual void gpr_mu_init(gpr_mu* mu) = 0;
   virtual void gpr_mu_destroy(gpr_mu* mu) = 0;
   virtual void gpr_mu_lock(gpr_mu* mu) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_mu_destroy(gpr_mu* mu) = 0;
   virtual void gpr_mu_lock(gpr_mu* mu) = 0;
   virtual void gpr_mu_unlock(gpr_mu* mu) = 0;
   virtual void gpr_cv_init(gpr_cv* cv) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,9 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_completion_queue* grpc_completion_queue_create(
-      const grpc_completion_queue_factory* factory,
-      const grpc_completion_queue_attributes* attributes, void* reserved) = 0;
   virtual grpc_completion_queue* grpc_completion_queue_create_for_next(
       void* reserved) = 0;
   virtual grpc_completion_queue* grpc_completion_queue_create_for_pluck(

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_completion_queue* grpc_completion_queue_create_for_pluck(
-      void* reserved) = 0;
   virtual void grpc_completion_queue_shutdown(grpc_completion_queue* cq) = 0;
   virtual void grpc_completion_queue_destroy(grpc_completion_queue* cq) = 0;
   virtual grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -49,7 +49,6 @@ class CoreCodegenInterface {
   // grpc_shutdown. Calling grpc_init from the codegen interface before
   // the real grpc_init is called will cause a crash, so if you use this
   // function, ensure that it is not the first call to grpc_init.
-  virtual void grpc_init() = 0;
   virtual void grpc_shutdown() = 0;
 
   virtual void gpr_mu_init(gpr_mu* mu) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_mu_init(gpr_mu* mu) = 0;
   virtual void gpr_mu_destroy(gpr_mu* mu) = 0;
   virtual void gpr_mu_lock(gpr_mu* mu) = 0;
   virtual void gpr_mu_unlock(gpr_mu* mu) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,
-                          gpr_timespec abs_deadline) = 0;
   virtual void gpr_cv_signal(gpr_cv* cv) = 0;
   virtual void gpr_cv_broadcast(gpr_cv* cv) = 0;
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_cv_destroy(gpr_cv* cv) = 0;
   virtual int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,
                           gpr_timespec abs_deadline) = 0;
   virtual void gpr_cv_signal(gpr_cv* cv) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_completion_queue_destroy(grpc_completion_queue* cq) = 0;
   virtual grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq,
                                                  void* tag,
                                                  gpr_timespec deadline,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_cv_signal(gpr_cv* cv) = 0;
   virtual void gpr_cv_broadcast(gpr_cv* cv) = 0;
 
   virtual grpc_byte_buffer* grpc_byte_buffer_copy(grpc_byte_buffer* bb) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_cv_init(gpr_cv* cv) = 0;
   virtual void gpr_cv_destroy(gpr_cv* cv) = 0;
   virtual int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,
                           gpr_timespec abs_deadline) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_completion_queue_shutdown(grpc_completion_queue* cq) = 0;
   virtual void grpc_completion_queue_destroy(grpc_completion_queue* cq) = 0;
   virtual grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq,
                                                  void* tag,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,9 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual const grpc_completion_queue_factory*
-  grpc_completion_queue_factory_lookup(
-      const grpc_completion_queue_attributes* attributes) = 0;
   virtual grpc_completion_queue* grpc_completion_queue_create(
       const grpc_completion_queue_factory* factory,
       const grpc_completion_queue_attributes* attributes, void* reserved) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_mu_unlock(gpr_mu* mu) = 0;
   virtual void gpr_cv_init(gpr_cv* cv) = 0;
   virtual void gpr_cv_destroy(gpr_cv* cv) = 0;
   virtual int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void* gpr_malloc(size_t size) = 0;
   virtual void gpr_free(void* p) = 0;
 
   // These are only to be used to fix edge cases involving grpc_init and

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,11 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq,
-                                                 void* tag,
-                                                 gpr_timespec deadline,
-                                                 void* reserved) = 0;
-
   virtual void* gpr_malloc(size_t size) = 0;
   virtual void gpr_free(void* p) = 0;
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_cv_broadcast(gpr_cv* cv) = 0;
-
   virtual grpc_byte_buffer* grpc_byte_buffer_copy(grpc_byte_buffer* bb) = 0;
   virtual void grpc_byte_buffer_destroy(grpc_byte_buffer* bb) = 0;
   virtual size_t grpc_byte_buffer_length(grpc_byte_buffer* bb)

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void gpr_mu_lock(gpr_mu* mu) = 0;
   virtual void gpr_mu_unlock(gpr_mu* mu) = 0;
   virtual void gpr_cv_init(gpr_cv* cv) = 0;
   virtual void gpr_cv_destroy(gpr_cv* cv) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_completion_queue* grpc_completion_queue_create_for_next(
-      void* reserved) = 0;
   virtual grpc_completion_queue* grpc_completion_queue_create_for_pluck(
       void* reserved) = 0;
   virtual void grpc_completion_queue_shutdown(grpc_completion_queue* cq) = 0;

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -63,9 +63,7 @@ class ABSL_LOCKABLE Mutex {
   Mutex& operator=(const Mutex&) = delete;
 
   void Lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() { gpr_mu_lock(&mu_); }
-  void Unlock() ABSL_UNLOCK_FUNCTION() {
-    g_core_codegen_interface->gpr_mu_unlock(&mu_);
-  }
+  void Unlock() ABSL_UNLOCK_FUNCTION() { gpr_mu_unlock(&mu_); }
 
  private:
   union {

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -57,7 +57,7 @@ using CondVar = absl::CondVar;
 class ABSL_LOCKABLE Mutex {
  public:
   Mutex() { gpr_mu_init(&mu_); }
-  ~Mutex() { g_core_codegen_interface->gpr_mu_destroy(&mu_); }
+  ~Mutex() { gpr_mu_destroy(&mu_); }
 
   Mutex(const Mutex&) = delete;
   Mutex& operator=(const Mutex&) = delete;

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -56,7 +56,7 @@ using CondVar = absl::CondVar;
 
 class ABSL_LOCKABLE Mutex {
  public:
-  Mutex() { g_core_codegen_interface->gpr_mu_init(&mu_); }
+  Mutex() { gpr_mu_init(&mu_); }
   ~Mutex() { g_core_codegen_interface->gpr_mu_destroy(&mu_); }
 
   Mutex(const Mutex&) = delete;

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -118,7 +118,7 @@ class ABSL_SCOPED_LOCKABLE ReleasableMutexLock {
 class CondVar {
  public:
   CondVar() { gpr_cv_init(&cv_); }
-  ~CondVar() { g_core_codegen_interface->gpr_cv_destroy(&cv_); }
+  ~CondVar() { gpr_cv_destroy(&cv_); }
 
   CondVar(const CondVar&) = delete;
   CondVar& operator=(const CondVar&) = delete;

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -117,7 +117,7 @@ class ABSL_SCOPED_LOCKABLE ReleasableMutexLock {
 
 class CondVar {
  public:
-  CondVar() { g_core_codegen_interface->gpr_cv_init(&cv_); }
+  CondVar() { gpr_cv_init(&cv_); }
   ~CondVar() { g_core_codegen_interface->gpr_cv_destroy(&cv_); }
 
   CondVar(const CondVar&) = delete;

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -124,7 +124,7 @@ class CondVar {
   CondVar& operator=(const CondVar&) = delete;
 
   void Signal() { gpr_cv_signal(&cv_); }
-  void SignalAll() { g_core_codegen_interface->gpr_cv_broadcast(&cv_); }
+  void SignalAll() { gpr_cv_broadcast(&cv_); }
 
   void Wait(Mutex* mu) {
     gpr_cv_wait(&cv_, &mu->mu_,

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -62,9 +62,7 @@ class ABSL_LOCKABLE Mutex {
   Mutex(const Mutex&) = delete;
   Mutex& operator=(const Mutex&) = delete;
 
-  void Lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() {
-    g_core_codegen_interface->gpr_mu_lock(&mu_);
-  }
+  void Lock() ABSL_EXCLUSIVE_LOCK_FUNCTION() { gpr_mu_lock(&mu_); }
   void Unlock() ABSL_UNLOCK_FUNCTION() {
     g_core_codegen_interface->gpr_mu_unlock(&mu_);
   }

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -127,9 +127,8 @@ class CondVar {
   void SignalAll() { g_core_codegen_interface->gpr_cv_broadcast(&cv_); }
 
   void Wait(Mutex* mu) {
-    g_core_codegen_interface->gpr_cv_wait(
-        &cv_, &mu->mu_,
-        g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_REALTIME));
+    gpr_cv_wait(&cv_, &mu->mu_,
+                g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_REALTIME));
   }
 
  private:

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -123,7 +123,7 @@ class CondVar {
   CondVar(const CondVar&) = delete;
   CondVar& operator=(const CondVar&) = delete;
 
-  void Signal() { g_core_codegen_interface->gpr_cv_signal(&cv_); }
+  void Signal() { gpr_cv_signal(&cv_); }
   void SignalAll() { g_core_codegen_interface->gpr_cv_broadcast(&cv_); }
 
   void Wait(Mutex* mu) {

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,11 +36,6 @@
 
 namespace grpc {
 
-grpc_completion_queue* CoreCodegen::grpc_completion_queue_create_for_next(
-    void* reserved) {
-  return ::grpc_completion_queue_create_for_next(reserved);
-}
-
 grpc_completion_queue* CoreCodegen::grpc_completion_queue_create_for_pluck(
     void* reserved) {
   return ::grpc_completion_queue_create_for_pluck(reserved);

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_mu_init(gpr_mu* mu) { ::gpr_mu_init(mu); }
 void CoreCodegen::gpr_mu_destroy(gpr_mu* mu) { ::gpr_mu_destroy(mu); }
 void CoreCodegen::gpr_mu_lock(gpr_mu* mu) { ::gpr_mu_lock(mu); }
 void CoreCodegen::gpr_mu_unlock(gpr_mu* mu) { ::gpr_mu_unlock(mu); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,8 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_shutdown() { ::grpc_shutdown(); }
-
 void CoreCodegen::gpr_mu_init(gpr_mu* mu) { ::gpr_mu_init(mu); }
 void CoreCodegen::gpr_mu_destroy(gpr_mu* mu) { ::gpr_mu_destroy(mu); }
 void CoreCodegen::gpr_mu_lock(gpr_mu* mu) { ::gpr_mu_lock(mu); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_mu_unlock(gpr_mu* mu) { ::gpr_mu_unlock(mu); }
 void CoreCodegen::gpr_cv_init(gpr_cv* cv) { ::gpr_cv_init(cv); }
 void CoreCodegen::gpr_cv_destroy(gpr_cv* cv) { ::gpr_cv_destroy(cv); }
 int CoreCodegen::gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_completion_queue_shutdown(grpc_completion_queue* cq) {
-  ::grpc_completion_queue_shutdown(cq);
-}
-
 void CoreCodegen::grpc_completion_queue_destroy(grpc_completion_queue* cq) {
   ::grpc_completion_queue_destroy(cq);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,8 +36,6 @@
 
 namespace grpc {
 
-void* CoreCodegen::gpr_malloc(size_t size) { return ::gpr_malloc(size); }
-
 void CoreCodegen::gpr_free(void* p) { return ::gpr_free(p); }
 
 void CoreCodegen::grpc_init() { ::grpc_init(); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_cv_destroy(gpr_cv* cv) { ::gpr_cv_destroy(cv); }
 int CoreCodegen::gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,
                              gpr_timespec abs_deadline) {
   return ::gpr_cv_wait(cv, mu, abs_deadline);

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_cv_signal(gpr_cv* cv) { ::gpr_cv_signal(cv); }
 void CoreCodegen::gpr_cv_broadcast(gpr_cv* cv) { ::gpr_cv_broadcast(cv); }
 
 grpc_byte_buffer* CoreCodegen::grpc_byte_buffer_copy(grpc_byte_buffer* bb) {

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,11 +36,6 @@
 
 namespace grpc {
 
-grpc_completion_queue* CoreCodegen::grpc_completion_queue_create_for_pluck(
-    void* reserved) {
-  return ::grpc_completion_queue_create_for_pluck(reserved);
-}
-
 void CoreCodegen::grpc_completion_queue_shutdown(grpc_completion_queue* cq) {
   ::grpc_completion_queue_shutdown(cq);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-int CoreCodegen::gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,
-                             gpr_timespec abs_deadline) {
-  return ::gpr_cv_wait(cv, mu, abs_deadline);
-}
 void CoreCodegen::gpr_cv_signal(gpr_cv* cv) { ::gpr_cv_signal(cv); }
 void CoreCodegen::gpr_cv_broadcast(gpr_cv* cv) { ::gpr_cv_broadcast(cv); }
 

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_completion_queue_destroy(grpc_completion_queue* cq) {
-  ::grpc_completion_queue_destroy(cq);
-}
-
 grpc_event CoreCodegen::grpc_completion_queue_pluck(grpc_completion_queue* cq,
                                                     void* tag,
                                                     gpr_timespec deadline,

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_mu_destroy(gpr_mu* mu) { ::gpr_mu_destroy(mu); }
 void CoreCodegen::gpr_mu_lock(gpr_mu* mu) { ::gpr_mu_lock(mu); }
 void CoreCodegen::gpr_mu_unlock(gpr_mu* mu) { ::gpr_mu_unlock(mu); }
 void CoreCodegen::gpr_cv_init(gpr_cv* cv) { ::gpr_cv_init(cv); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,12 +36,6 @@
 
 namespace grpc {
 
-const grpc_completion_queue_factory*
-CoreCodegen::grpc_completion_queue_factory_lookup(
-    const grpc_completion_queue_attributes* attributes) {
-  return ::grpc_completion_queue_factory_lookup(attributes);
-}
-
 grpc_completion_queue* CoreCodegen::grpc_completion_queue_create(
     const grpc_completion_queue_factory* factory,
     const grpc_completion_queue_attributes* attributes, void* reserved) {

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,13 +36,6 @@
 
 namespace grpc {
 
-grpc_event CoreCodegen::grpc_completion_queue_pluck(grpc_completion_queue* cq,
-                                                    void* tag,
-                                                    gpr_timespec deadline,
-                                                    void* reserved) {
-  return ::grpc_completion_queue_pluck(cq, tag, deadline, reserved);
-}
-
 void* CoreCodegen::gpr_malloc(size_t size) { return ::gpr_malloc(size); }
 
 void CoreCodegen::gpr_free(void* p) { return ::gpr_free(p); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,8 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_free(void* p) { return ::gpr_free(p); }
-
 void CoreCodegen::grpc_init() { ::grpc_init(); }
 void CoreCodegen::grpc_shutdown() { ::grpc_shutdown(); }
 

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,12 +36,6 @@
 
 namespace grpc {
 
-grpc_completion_queue* CoreCodegen::grpc_completion_queue_create(
-    const grpc_completion_queue_factory* factory,
-    const grpc_completion_queue_attributes* attributes, void* reserved) {
-  return ::grpc_completion_queue_create(factory, attributes, reserved);
-}
-
 grpc_completion_queue* CoreCodegen::grpc_completion_queue_create_for_next(
     void* reserved) {
   return ::grpc_completion_queue_create_for_next(reserved);

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_init() { ::grpc_init(); }
 void CoreCodegen::grpc_shutdown() { ::grpc_shutdown(); }
 
 void CoreCodegen::gpr_mu_init(gpr_mu* mu) { ::gpr_mu_init(mu); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_cv_init(gpr_cv* cv) { ::gpr_cv_init(cv); }
 void CoreCodegen::gpr_cv_destroy(gpr_cv* cv) { ::gpr_cv_destroy(cv); }
 int CoreCodegen::gpr_cv_wait(gpr_cv* cv, gpr_mu* mu,
                              gpr_timespec abs_deadline) {

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,7 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_mu_lock(gpr_mu* mu) { ::gpr_mu_lock(mu); }
 void CoreCodegen::gpr_mu_unlock(gpr_mu* mu) { ::gpr_mu_unlock(mu); }
 void CoreCodegen::gpr_cv_init(gpr_cv* cv) { ::gpr_cv_init(cv); }
 void CoreCodegen::gpr_cv_destroy(gpr_cv* cv) { ::gpr_cv_destroy(cv); }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,8 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::gpr_cv_broadcast(gpr_cv* cv) { ::gpr_cv_broadcast(cv); }
-
 grpc_byte_buffer* CoreCodegen::grpc_byte_buffer_copy(grpc_byte_buffer* bb) {
   return ::grpc_byte_buffer_copy(bb);
 }


### PR DESCRIPTION

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR cleans up some functions in `class CoreCodegen`. Other functions should be cleaned up in a subsequent PR. The ultimate goal is to remove `class CoreCodegen` and its global pointer `g_core_codegen_interface` entirely.

This does not require any internal change, which has been verified through a test import CL.

