### PR TITLE
fix typo in src/python/grpcio/grpc/__init__.py::ServicerContext

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1084,7 +1084,7 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def invocation_metadata(self):
-        """Accesses the metadata from the sent by the client.
+        """Accesses the metadata sent by the client.
 
         Returns:
           The invocation :term:`metadata`.


### PR DESCRIPTION
Fixes a typo in `src/python/grpcio/grpc/__init__.py`
`Accesses the metadata from the sent by the client` => `Accesses the metadata sent by the client`

https://github.com/grpc/grpc/blob/7e201fbe42718d48226d1d795abe6796943601db/src/python/grpcio/grpc/__init__.py#L1085-L1092