### PR TITLE
Remove `include/grpc/impl/codegen/sync.h`

### DIFF
--- a/include/grpc/impl/codegen/sync.h
+++ b/include/grpc/impl/codegen/sync.h
@@ -21,48 +21,9 @@
 
 // IWYU pragma: private, include <grpc/support/sync.h>
 
-/** Synchronization primitives for GPR.
+#include <grpc/support/port_platform.h>
 
-   The type  gpr_mu              provides a non-reentrant mutex (lock).
-
-   The type  gpr_cv              provides a condition variable.
-
-   The type  gpr_once            provides for one-time initialization.
-
-   The type gpr_event            provides one-time-setting, reading, and
-                                 waiting of a void*, with memory barriers.
-
-   The type gpr_refcount         provides an object reference counter,
-                                 with memory barriers suitable to control
-                                 object lifetimes.
-
-   The type gpr_stats_counter    provides an atomic statistics counter. It
-                                 provides no memory barriers.
- */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/* Platform-specific type declarations of gpr_mu and gpr_cv.   */
-#include <grpc/impl/codegen/port_platform.h>
-
-#include <grpc/impl/codegen/sync_generic.h>  // IWYU pragma: export
-
-#if defined(GPR_CUSTOM_SYNC)
-#include <grpc/impl/codegen/sync_custom.h>  // IWYU pragma: export
-#elif defined(GPR_ABSEIL_SYNC)
-#include <grpc/impl/codegen/sync_abseil.h>  // IWYU pragma: export
-#elif defined(GPR_POSIX_SYNC)
-#include <grpc/impl/codegen/sync_posix.h>  // IWYU pragma: export
-#elif defined(GPR_WINDOWS)
-#include <grpc/impl/codegen/sync_windows.h>  // IWYU pragma: export
-#else
-#error Unable to determine platform for sync
-#endif
-
-#ifdef __cplusplus
-}
-#endif
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/support/sync.h>
 
 #endif /* GRPC_IMPL_CODEGEN_SYNC_H */

--- a/include/grpc/impl/codegen/sync_abseil.h
+++ b/include/grpc/impl/codegen/sync_abseil.h
@@ -21,18 +21,9 @@
 
 // IWYU pragma: private, include <grpc/support/sync.h>
 
-#include <grpc/impl/codegen/port_platform.h>
+#include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_generic.h>
-
-#ifdef GPR_ABSEIL_SYNC
-
-typedef intptr_t gpr_mu;
-typedef intptr_t gpr_cv;
-typedef int32_t gpr_once;
-
-#define GPR_ONCE_INIT 0
-
-#endif
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/support/sync_abseil.h>
 
 #endif /* GRPC_IMPL_CODEGEN_SYNC_ABSEIL_H */

--- a/include/grpc/impl/codegen/sync_custom.h
+++ b/include/grpc/impl/codegen/sync_custom.h
@@ -21,20 +21,9 @@
 
 // IWYU pragma: private, include <grpc/support/sync.h>
 
-#include <grpc/impl/codegen/port_platform.h>
+#include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_generic.h>
-
-/* Users defining GPR_CUSTOM_SYNC need to define the following macros. */
-
-#ifdef GPR_CUSTOM_SYNC
-
-typedef GPR_CUSTOM_MU_TYPE gpr_mu;
-typedef GPR_CUSTOM_CV_TYPE gpr_cv;
-typedef GPR_CUSTOM_ONCE_TYPE gpr_once;
-
-#define GPR_ONCE_INIT GPR_CUSTOM_ONCE_INIT
-
-#endif
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/support/sync_custom.h>
 
 #endif /* GRPC_IMPL_CODEGEN_SYNC_CUSTOM_H */

--- a/include/grpc/impl/codegen/sync_generic.h
+++ b/include/grpc/impl/codegen/sync_generic.h
@@ -21,31 +21,9 @@
 
 // IWYU pragma: private, include <grpc/support/sync.h>
 
-/* Generic type definitions for gpr_sync. */
+#include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/port_platform.h>
-
-#include <grpc/impl/codegen/atm.h>
-
-/* gpr_event */
-typedef struct {
-  gpr_atm state;
-} gpr_event;
-
-#define GPR_EVENT_INIT \
-  { 0 }
-
-/* gpr_refcount */
-typedef struct {
-  gpr_atm count;
-} gpr_refcount;
-
-/* gpr_stats_counter */
-typedef struct {
-  gpr_atm value;
-} gpr_stats_counter;
-
-#define GPR_STATS_INIT \
-  { 0 }
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/support/sync_generic.h>
 
 #endif /* GRPC_IMPL_CODEGEN_SYNC_GENERIC_H */

--- a/include/grpc/impl/codegen/sync_posix.h
+++ b/include/grpc/impl/codegen/sync_posix.h
@@ -21,34 +21,9 @@
 
 // IWYU pragma: private, include <grpc/support/sync.h>
 
-#include <grpc/impl/codegen/port_platform.h>
+#include <grpc/support/port_platform.h>
 
-#include <pthread.h>
-
-#include <grpc/impl/codegen/sync_generic.h>
-
-#ifdef GRPC_ASAN_ENABLED
-/* The member |leak_checker| is used to check whether there is a memory leak
- * caused by upper layer logic that's missing the |gpr_xx_destroy| call
- * to the object before freeing it.
- * This issue was reported at https://github.com/grpc/grpc/issues/17563
- * and discussed at https://github.com/grpc/grpc/pull/17586
- */
-typedef struct {
-  pthread_mutex_t mutex;
-  int* leak_checker;
-} gpr_mu;
-
-typedef struct {
-  pthread_cond_t cond_var;
-  int* leak_checker;
-} gpr_cv;
-#else
-typedef pthread_mutex_t gpr_mu;
-typedef pthread_cond_t gpr_cv;
-#endif
-typedef pthread_once_t gpr_once;
-
-#define GPR_ONCE_INIT PTHREAD_ONCE_INIT
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/support/sync_posix.h>
 
 #endif /* GRPC_IMPL_CODEGEN_SYNC_POSIX_H */

--- a/include/grpc/impl/codegen/sync_windows.h
+++ b/include/grpc/impl/codegen/sync_windows.h
@@ -21,22 +21,9 @@
 
 // IWYU pragma: private, include <grpc/support/sync.h>
 
-#include <grpc/impl/codegen/port_platform.h>
+#include <grpc/support/port_platform.h>
 
-#ifdef GPR_WINDOWS
-
-#include <grpc/impl/codegen/sync_generic.h>
-
-typedef struct {
-  CRITICAL_SECTION cs; /* Not an SRWLock until Vista is unsupported */
-  int locked;
-} gpr_mu;
-
-typedef CONDITION_VARIABLE gpr_cv;
-
-typedef INIT_ONCE gpr_once;
-#define GPR_ONCE_INIT INIT_ONCE_STATIC_INIT
-
-#endif /* GPR_WINDOWS */
+/// TODO(chengyuc): Remove this file after solving compatibility.
+#include <grpc/support/sync_windows.h>
 
 #endif /* GRPC_IMPL_CODEGEN_SYNC_WINDOWS_H */

--- a/include/grpc/support/sync.h
+++ b/include/grpc/support/sync.h
@@ -19,13 +19,46 @@
 #ifndef GRPC_SUPPORT_SYNC_H
 #define GRPC_SUPPORT_SYNC_H
 
+/* Platform-specific type declarations of gpr_mu and gpr_cv.   */
 #include <grpc/support/port_platform.h>
 
 #include <grpc/impl/codegen/gpr_types.h> /* for gpr_timespec */
-#include <grpc/impl/codegen/sync.h>      // IWYU pragma: export
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/** Synchronization primitives for GPR.
+
+   The type  gpr_mu              provides a non-reentrant mutex (lock).
+
+   The type  gpr_cv              provides a condition variable.
+
+   The type  gpr_once            provides for one-time initialization.
+
+   The type gpr_event            provides one-time-setting, reading, and
+                                 waiting of a void*, with memory barriers.
+
+   The type gpr_refcount         provides an object reference counter,
+                                 with memory barriers suitable to control
+                                 object lifetimes.
+
+   The type gpr_stats_counter    provides an atomic statistics counter. It
+                                 provides no memory barriers.
+ */
+
+#include <grpc/support/sync_generic.h>  // IWYU pragma: export
+
+#if defined(GPR_CUSTOM_SYNC)
+#include <grpc/support/sync_custom.h>  // IWYU pragma: export
+#elif defined(GPR_ABSEIL_SYNC)
+#include <grpc/support/sync_abseil.h>  // IWYU pragma: export
+#elif defined(GPR_POSIX_SYNC)
+#include <grpc/support/sync_posix.h>  // IWYU pragma: export
+#elif defined(GPR_WINDOWS)
+#include <grpc/support/sync_windows.h>  // IWYU pragma: export
+#else
+#error Unable to determine platform for sync
 #endif
 
 /** --- Mutex interface ---

--- a/include/grpc/support/sync_abseil.h
+++ b/include/grpc/support/sync_abseil.h
@@ -21,6 +21,16 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_abseil.h>  // IWYU pragma: export
+#include <grpc/support/sync_generic.h>
+
+#ifdef GPR_ABSEIL_SYNC
+
+typedef intptr_t gpr_mu;
+typedef intptr_t gpr_cv;
+typedef int32_t gpr_once;
+
+#define GPR_ONCE_INIT 0
+
+#endif
 
 #endif /* GRPC_SUPPORT_SYNC_ABSEIL_H */

--- a/include/grpc/support/sync_custom.h
+++ b/include/grpc/support/sync_custom.h
@@ -21,6 +21,18 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_custom.h>  // IWYU pragma: export
+#include <grpc/support/sync_generic.h>
+
+/* Users defining GPR_CUSTOM_SYNC need to define the following macros. */
+
+#ifdef GPR_CUSTOM_SYNC
+
+typedef GPR_CUSTOM_MU_TYPE gpr_mu;
+typedef GPR_CUSTOM_CV_TYPE gpr_cv;
+typedef GPR_CUSTOM_ONCE_TYPE gpr_once;
+
+#define GPR_ONCE_INIT GPR_CUSTOM_ONCE_INIT
+
+#endif
 
 #endif /* GRPC_SUPPORT_SYNC_CUSTOM_H */

--- a/include/grpc/support/sync_generic.h
+++ b/include/grpc/support/sync_generic.h
@@ -19,8 +19,31 @@
 #ifndef GRPC_SUPPORT_SYNC_GENERIC_H
 #define GRPC_SUPPORT_SYNC_GENERIC_H
 
+/* Generic type definitions for gpr_sync. */
+
 #include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_generic.h>  // IWYU pragma: export
+#include <grpc/support/atm.h>
+
+/* gpr_event */
+typedef struct {
+  gpr_atm state;
+} gpr_event;
+
+#define GPR_EVENT_INIT \
+  { 0 }
+
+/* gpr_refcount */
+typedef struct {
+  gpr_atm count;
+} gpr_refcount;
+
+/* gpr_stats_counter */
+typedef struct {
+  gpr_atm value;
+} gpr_stats_counter;
+
+#define GPR_STATS_INIT \
+  { 0 }
 
 #endif /* GRPC_SUPPORT_SYNC_GENERIC_H */

--- a/include/grpc/support/sync_posix.h
+++ b/include/grpc/support/sync_posix.h
@@ -21,6 +21,32 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_posix.h>  // IWYU pragma: export
+#include <pthread.h>
+
+#include <grpc/support/sync_generic.h>
+
+#ifdef GRPC_ASAN_ENABLED
+/* The member |leak_checker| is used to check whether there is a memory leak
+ * caused by upper layer logic that's missing the |gpr_xx_destroy| call
+ * to the object before freeing it.
+ * This issue was reported at https://github.com/grpc/grpc/issues/17563
+ * and discussed at https://github.com/grpc/grpc/pull/17586
+ */
+typedef struct {
+  pthread_mutex_t mutex;
+  int* leak_checker;
+} gpr_mu;
+
+typedef struct {
+  pthread_cond_t cond_var;
+  int* leak_checker;
+} gpr_cv;
+#else
+typedef pthread_mutex_t gpr_mu;
+typedef pthread_cond_t gpr_cv;
+#endif
+typedef pthread_once_t gpr_once;
+
+#define GPR_ONCE_INIT PTHREAD_ONCE_INIT
 
 #endif /* GRPC_SUPPORT_SYNC_POSIX_H */

--- a/include/grpc/support/sync_windows.h
+++ b/include/grpc/support/sync_windows.h
@@ -21,6 +21,20 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <grpc/impl/codegen/sync_windows.h>  // IWYU pragma: export
+#ifdef GPR_WINDOWS
+
+#include <grpc/support/sync_generic.h>
+
+typedef struct {
+  CRITICAL_SECTION cs; /* Not an SRWLock until Vista is unsupported */
+  int locked;
+} gpr_mu;
+
+typedef CONDITION_VARIABLE gpr_cv;
+
+typedef INIT_ONCE gpr_once;
+#define GPR_ONCE_INIT INIT_ONCE_STATIC_INIT
+
+#endif /* GPR_WINDOWS */
 
 #endif /* GRPC_SUPPORT_SYNC_WINDOWS_H */

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamClientTests.mm
@@ -25,7 +25,6 @@
 #include <netinet/in.h>
 
 #include <grpc/grpc.h>
-#include <grpc/impl/codegen/sync.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/address_utils/parse_address.h"

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -27,7 +27,6 @@
 #include <netinet/in.h>
 
 #include <grpc/grpc.h>
-#include <grpc/impl/codegen/sync.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/address_utils/parse_address.h"


### PR DESCRIPTION

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR is a part of [b/196639718](http://b/196639718). It tries to move the content of `include/grpc/impl/codegen/sync.h` to `include/grpc/support/sync.h`. We do not remove anything to achieve backward compatibility. The file `include/grpc/impl/codegen/sync.h` should be removed in the future.

This does not require any internal change, which has been verified through a test import CL.