### PR TITLE
Add empty constructor to workaround gcc/clang bug

### DIFF
--- a/src/core/ext/xds/xds_listener.h
+++ b/src/core/ext/xds/xds_listener.h
@@ -79,6 +79,8 @@ struct XdsListenerResource : public XdsResourceType::ResourceData {
   };
 
   struct DownstreamTlsContext {
+    DownstreamTlsContext() {}
+
     CommonTlsContext common_tls_context;
     bool require_client_certificate = false;
 


### PR DESCRIPTION
Some versions of gcc/clang have a bug that fail to compile with an error message without a constructor definition. Adding a no-op constructor to avoid this issue.

(issue is similar to https://github.com/grpc/grpc/issues/28147)

See also https://stackoverflow.com/questions/53408962/try-to-understand-compiler-error-message-default-member-initializer-required-be