### PR TITLE
[Ruby] Fixed the return value of `PLATFORM.architecture` when MacOS is Ventura ( #31782 ).

### DIFF
--- a/src/ruby/tools/platform_check.rb
+++ b/src/ruby/tools/platform_check.rb
@@ -32,7 +32,7 @@ module PLATFORM
     host_cpu = RbConfig::CONFIG['host_cpu']
 
     # When we're on arm in macOS, we can rely on Rosetta and use the x86_64 binary
-    return 'x86_64' if RbConfig::CONFIG['host_os'] =~ /darwin/ && host_cpu =~ /arm/
+    return 'x86_64' if RbConfig::CONFIG['host_os'] =~ /darwin/ && host_cpu =~ /arm|aarch/
 
     case host_cpu
       when /x86_64/


### PR DESCRIPTION
i apologize if my PR is wrong. I'm not used to sending PRs. 🙇 

i fixed the bug(#31782).
please read this issue for more information.