### PR TITLE
Remove posix_engine namespace

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -49,18 +49,10 @@
 #include "src/core/lib/gprpp/strerror.h"
 #include "src/core/lib/gprpp/sync.h"
 
-using ::grpc_event_engine::experimental::LockfreeEvent;
-using ::grpc_event_engine::experimental::WakeupFd;
-
 #define MAX_EPOLL_EVENTS_HANDLED_PER_ITERATION 1
 
 namespace grpc_event_engine {
 namespace experimental {
-
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::LockfreeEvent;
-using ::grpc_event_engine::experimental::Poller;
-using ::grpc_event_engine::experimental::WakeupFd;
 
 class Epoll1EventHandle : public EventHandle {
  public:

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -49,18 +49,18 @@
 #include "src/core/lib/gprpp/strerror.h"
 #include "src/core/lib/gprpp/sync.h"
 
-using ::grpc_event_engine::posix_engine::LockfreeEvent;
-using ::grpc_event_engine::posix_engine::WakeupFd;
+using ::grpc_event_engine::experimental::LockfreeEvent;
+using ::grpc_event_engine::experimental::WakeupFd;
 
 #define MAX_EPOLL_EVENTS_HANDLED_PER_ITERATION 1
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::Poller;
-using ::grpc_event_engine::posix_engine::LockfreeEvent;
-using ::grpc_event_engine::posix_engine::WakeupFd;
+using ::grpc_event_engine::experimental::LockfreeEvent;
+using ::grpc_event_engine::experimental::WakeupFd;
 
 class Epoll1EventHandle : public EventHandle {
  public:
@@ -268,7 +268,7 @@ void ResetEventManagerOnFork() {
 // It is possible that GLIBC has epoll but the underlying kernel doesn't.
 // Create epoll_fd to make sure epoll support is available
 bool InitEpoll1PollerLinux() {
-  if (!grpc_event_engine::posix_engine::SupportsWakeupFd()) {
+  if (!grpc_event_engine::experimental::SupportsWakeupFd()) {
     return false;
   }
   int fd = EpollCreateAndCloexec();
@@ -564,14 +564,14 @@ Epoll1Poller* MakeEpoll1Poller(Scheduler* scheduler) {
   return nullptr;
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #else /* defined(GRPC_LINUX_EPOLL) */
 #if defined(GRPC_POSIX_SOCKET_EV_EPOLL1)
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::Poller;
@@ -610,7 +610,7 @@ void Epoll1Poller::Kick() { GPR_ASSERT(false && "unimplemented"); }
 // nullptr.
 Epoll1Poller* MakeEpoll1Poller(Scheduler* /*scheduler*/) { return nullptr; }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* defined(GRPC_POSIX_SOCKET_EV_EPOLL1) */

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.h
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.h
@@ -41,7 +41,7 @@
 #define MAX_EPOLL_EVENTS 100
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class Epoll1EventHandle;
 
@@ -123,7 +123,7 @@ class Epoll1Poller : public PosixEventPoller {
 // engine.
 Epoll1Poller* MakeEpoll1Poller(Scheduler* scheduler);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_EV_EPOLL1_LINUX_H

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -69,12 +69,12 @@ static const int kPollinCheck = POLLIN | POLLHUP | POLLERR;
 static const int kPolloutCheck = POLLOUT | POLLHUP | POLLERR;
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::AnyInvocableClosure;
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::Poller;
-using ::grpc_event_engine::posix_engine::WakeupFd;
+using ::grpc_event_engine::experimental::WakeupFd;
 using Events = absl::InlinedVector<PollEventHandle*, 5>;
 
 class PollEventHandle : public EventHandle {
@@ -334,7 +334,7 @@ void ResetEventManagerOnFork() {
 // It is possible that GLIBC has epoll but the underlying kernel doesn't.
 // Create epoll_fd to make sure epoll support is available
 bool InitPollPollerPosix() {
-  if (!grpc_event_engine::posix_engine::SupportsWakeupFd()) {
+  if (!grpc_event_engine::experimental::SupportsWakeupFd()) {
     return false;
   }
   if (grpc_core::Fork::Enabled()) {
@@ -844,13 +844,13 @@ PollPoller* MakePollPoller(Scheduler* scheduler, bool use_phony_poll) {
   return nullptr;
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #else /* GRPC_POSIX_SOCKET_EV_POLL */
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::Poller;
@@ -895,7 +895,7 @@ void PollPoller::PollerHandlesListRemoveHandle(PollEventHandle* /*handle*/) {
   GPR_ASSERT(false && "unimplemented");
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_POSIX_SOCKET_EV_POLL */

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -71,10 +71,6 @@ static const int kPolloutCheck = POLLOUT | POLLHUP | POLLERR;
 namespace grpc_event_engine {
 namespace experimental {
 
-using ::grpc_event_engine::experimental::AnyInvocableClosure;
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::Poller;
-using ::grpc_event_engine::experimental::WakeupFd;
 using Events = absl::InlinedVector<PollEventHandle*, 5>;
 
 class PollEventHandle : public EventHandle {
@@ -851,9 +847,6 @@ PollPoller* MakePollPoller(Scheduler* scheduler, bool use_phony_poll) {
 
 namespace grpc_event_engine {
 namespace experimental {
-
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::Poller;
 
 PollPoller::PollPoller(Scheduler* /* engine */) {
   GPR_ASSERT(false && "unimplemented");

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.h
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.h
@@ -33,7 +33,7 @@
 #include "src/core/lib/gprpp/sync.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class PollEventHandle;
 
@@ -91,7 +91,7 @@ class PollPoller : public PosixEventPoller {
 // crash failure.
 PollPoller* MakePollPoller(Scheduler* scheduler, bool use_phony_poll);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_EV_POLL_POSIX_H

--- a/src/core/lib/event_engine/posix_engine/event_poller.h
+++ b/src/core/lib/event_engine/posix_engine/event_poller.h
@@ -28,7 +28,7 @@
 #include "src/core/lib/event_engine/posix_engine/posix_engine_closure.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class Scheduler {
  public:
@@ -105,7 +105,7 @@ class PosixEventPoller : public grpc_event_engine::experimental::Poller {
   ~PosixEventPoller() override = default;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_EVENT_POLLER_H

--- a/src/core/lib/event_engine/posix_engine/event_poller_posix_default.cc
+++ b/src/core/lib/event_engine/posix_engine/event_poller_posix_default.cc
@@ -29,7 +29,7 @@ GPR_GLOBAL_CONFIG_DECLARE_STRING(grpc_poll_strategy);
 #endif
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_POSIX_SOCKET_TCP
 namespace {
@@ -70,5 +70,5 @@ PosixEventPoller* MakeDefaultPoller(Scheduler* /*scheduler*/) {
 
 #endif  // GRPC_POSIX_SOCKET_TCP
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/event_poller_posix_default.h
+++ b/src/core/lib/event_engine/posix_engine/event_poller_posix_default.h
@@ -18,7 +18,7 @@
 #include <grpc/support/port_platform.h>
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class PosixEventPoller;
 class Scheduler;
@@ -27,7 +27,7 @@ class Scheduler;
 // scheduler.
 PosixEventPoller* MakeDefaultPoller(Scheduler* scheduler);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_EVENT_POLLER_POSIX_DEFAULT_H

--- a/src/core/lib/event_engine/posix_engine/internal_errqueue.cc
+++ b/src/core/lib/event_engine/posix_engine/internal_errqueue.cc
@@ -35,7 +35,7 @@
 #include "src/core/lib/gprpp/strerror.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_LINUX_ERRQUEUE
 int GetSocketTcpInfo(struct tcp_info* info, int fd) {
@@ -71,7 +71,7 @@ bool KernelSupportsErrqueue() {
   return errqueue_supported;
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_POSIX_SOCKET_TCP

--- a/src/core/lib/event_engine/posix_engine/internal_errqueue.h
+++ b/src/core/lib/event_engine/posix_engine/internal_errqueue.h
@@ -31,7 +31,7 @@
 #endif /* GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_LINUX_ERRQUEUE
 
@@ -171,7 +171,7 @@ int GetSocketTcpInfo(tcp_info* info, int fd);
 // Currently allowing only linux kernels above 4.0.0
 bool KernelSupportsErrqueue();
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_POSIX_SOCKET_TCP */

--- a/src/core/lib/event_engine/posix_engine/lockfree_event.cc
+++ b/src/core/lib/event_engine/posix_engine/lockfree_event.cc
@@ -61,7 +61,7 @@
 //     For 5,6,7: See SetShutdown() function
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 void LockfreeEvent::InitEvent() {
   // Perform an atomic store to start the state machine.
@@ -263,5 +263,5 @@ void LockfreeEvent::SetReady() {
   }
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/lockfree_event.h
+++ b/src/core/lib/event_engine/posix_engine/lockfree_event.h
@@ -24,7 +24,7 @@
 #include "src/core/lib/event_engine/posix_engine/posix_engine_closure.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class Scheduler;
 
@@ -67,7 +67,7 @@ class LockfreeEvent {
   Scheduler* scheduler_;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_LOCKFREE_EVENT_H

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -92,11 +92,6 @@ namespace experimental {
 
 namespace {
 
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::MemoryAllocator;
-using ::grpc_event_engine::experimental::Slice;
-using ::grpc_event_engine::experimental::SliceBuffer;
-
 // A wrapper around sendmsg. It sends \a msg over \a fd and returns the number
 // of bytes sent.
 ssize_t TcpSend(int fd, const struct msghdr* msg, int* saved_errno,
@@ -1253,9 +1248,6 @@ std::unique_ptr<PosixEndpoint> CreatePosixEndpoint(
 
 namespace grpc_event_engine {
 namespace experimental {
-
-using ::grpc_event_engine::experimental::EndpointConfig;
-using ::grpc_event_engine::experimental::EventEngine;
 
 std::unique_ptr<PosixEndpoint> CreatePosixEndpoint(
     EventHandle* /*handle*/, PosixEngineClosure* /*on_shutdown*/,

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -88,7 +88,7 @@
 #define MAX_READ_IOVEC 64
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 
@@ -1246,13 +1246,13 @@ std::unique_ptr<PosixEndpoint> CreatePosixEndpoint(
                                          std::move(allocator), options);
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #else  // GRPC_POSIX_SOCKET_TCP
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::EndpointConfig;
 using ::grpc_event_engine::experimental::EventEngine;
@@ -1264,7 +1264,7 @@ std::unique_ptr<PosixEndpoint> CreatePosixEndpoint(
   GPR_ASSERT(false && "Cannot create PosixEndpoint on this platform");
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_POSIX_SOCKET_TCP

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.h
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.h
@@ -61,7 +61,7 @@ typedef size_t msg_iovlen_type;
 #endif  //  GRPC_POSIX_SOCKET_TCP
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_POSIX_SOCKET_TCP
 
@@ -676,7 +676,7 @@ std::unique_ptr<PosixEndpoint> CreatePosixEndpoint(
     grpc_event_engine::experimental::MemoryAllocator&& allocator,
     const PosixTcpOptions& options);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENDPOINT_H

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -62,14 +62,6 @@ namespace grpc_event_engine {
 namespace experimental {
 
 #ifdef GRPC_POSIX_SOCKET_TCP
-using ::grpc_event_engine::experimental::EventHandle;
-using ::grpc_event_engine::experimental::PosixEngineClosure;
-using ::grpc_event_engine::experimental::PosixEngineListener;
-using ::grpc_event_engine::experimental::PosixEventPoller;
-using ::grpc_event_engine::experimental::PosixSocketWrapper;
-using ::grpc_event_engine::experimental::PosixTcpOptions;
-using ::grpc_event_engine::experimental::ResolvedAddressToNormalizedString;
-using ::grpc_event_engine::experimental::TcpOptionsFromEndpointConfig;
 
 void AsyncConnect::Start(EventEngine::Duration timeout) {
   on_writable_ = PosixEngineClosure::ToPermanentClosure(

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -63,13 +63,13 @@ namespace experimental {
 
 #ifdef GRPC_POSIX_SOCKET_TCP
 using ::grpc_event_engine::experimental::ResolvedAddressToNormalizedString;
-using ::grpc_event_engine::posix_engine::EventHandle;
-using ::grpc_event_engine::posix_engine::PosixEngineClosure;
-using ::grpc_event_engine::posix_engine::PosixEngineListener;
-using ::grpc_event_engine::posix_engine::PosixEventPoller;
-using ::grpc_event_engine::posix_engine::PosixSocketWrapper;
-using ::grpc_event_engine::posix_engine::PosixTcpOptions;
-using ::grpc_event_engine::posix_engine::TcpOptionsFromEndpointConfig;
+using ::grpc_event_engine::experimental::EventHandle;
+using ::grpc_event_engine::experimental::PosixEngineClosure;
+using ::grpc_event_engine::experimental::PosixEngineListener;
+using ::grpc_event_engine::experimental::PosixEventPoller;
+using ::grpc_event_engine::experimental::PosixSocketWrapper;
+using ::grpc_event_engine::experimental::PosixTcpOptions;
+using ::grpc_event_engine::experimental::TcpOptionsFromEndpointConfig;
 
 void AsyncConnect::Start(EventEngine::Duration timeout) {
   on_writable_ = PosixEngineClosure::ToPermanentClosure(
@@ -293,7 +293,7 @@ void PosixEventEngine::OnConnectFinishInternal(int connection_handle) {
 
 PosixEnginePollerManager::PosixEnginePollerManager(
     std::shared_ptr<ThreadPool> executor)
-    : poller_(grpc_event_engine::posix_engine::MakeDefaultPoller(this)),
+    : poller_(grpc_event_engine::experimental::MakeDefaultPoller(this)),
       executor_(std::move(executor)) {}
 
 PosixEnginePollerManager::PosixEnginePollerManager(PosixEventPoller* poller)
@@ -391,7 +391,7 @@ void PosixEventEngine::PollerWorkInternal(
 
 struct PosixEventEngine::ClosureData final : public EventEngine::Closure {
   absl::AnyInvocable<void()> cb;
-  posix_engine::Timer timer;
+  Timer timer;
   PosixEventEngine* engine;
   EventEngine::TaskHandle handle;
 

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -56,9 +56,9 @@ class AsyncConnect {
  public:
   AsyncConnect(EventEngine::OnConnectCallback on_connect,
                std::shared_ptr<EventEngine> engine, ThreadPool* executor,
-               grpc_event_engine::posix_engine::EventHandle* fd,
+               grpc_event_engine::experimental::EventHandle* fd,
                MemoryAllocator&& allocator,
-               const grpc_event_engine::posix_engine::PosixTcpOptions& options,
+               const grpc_event_engine::experimental::PosixTcpOptions& options,
                std::string resolved_addr_str, int64_t connection_handle)
       : on_connect_(std::move(on_connect)),
         engine_(engine),
@@ -80,15 +80,15 @@ class AsyncConnect {
   void OnWritable(absl::Status status) ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
   grpc_core::Mutex mu_;
-  grpc_event_engine::posix_engine::PosixEngineClosure* on_writable_ = nullptr;
+  grpc_event_engine::experimental::PosixEngineClosure* on_writable_ = nullptr;
   EventEngine::OnConnectCallback on_connect_;
   std::shared_ptr<EventEngine> engine_;
   ThreadPool* executor_;
   EventEngine::TaskHandle alarm_handle_;
   int refs_{2};
-  grpc_event_engine::posix_engine::EventHandle* fd_;
+  grpc_event_engine::experimental::EventHandle* fd_;
   MemoryAllocator allocator_;
-  grpc_event_engine::posix_engine::PosixTcpOptions options_;
+  grpc_event_engine::experimental::PosixTcpOptions options_;
   std::string resolved_addr_str_;
   int64_t connection_handle_;
   bool connect_cancelled_;
@@ -97,12 +97,12 @@ class AsyncConnect {
 // A helper class to manager lifetime of the poller associated with the
 // posix event engine.
 class PosixEnginePollerManager
-    : public grpc_event_engine::posix_engine::Scheduler {
+    : public grpc_event_engine::experimental::Scheduler {
  public:
   explicit PosixEnginePollerManager(std::shared_ptr<ThreadPool> executor);
   explicit PosixEnginePollerManager(
-      grpc_event_engine::posix_engine::PosixEventPoller* poller);
-  grpc_event_engine::posix_engine::PosixEventPoller* Poller() {
+      grpc_event_engine::experimental::PosixEventPoller* poller);
+  grpc_event_engine::experimental::PosixEventPoller* Poller() {
     return poller_;
   }
 
@@ -121,7 +121,7 @@ class PosixEnginePollerManager
 
  private:
   enum class PollerState { kExternal, kOk, kShuttingDown };
-  grpc_event_engine::posix_engine::PosixEventPoller* poller_ = nullptr;
+  grpc_event_engine::experimental::PosixEventPoller* poller_ = nullptr;
   std::atomic<PollerState> poller_state_{PollerState::kOk};
   std::shared_ptr<ThreadPool> executor_;
 };
@@ -155,7 +155,7 @@ class PosixEventEngine final : public EventEngine,
   // constructor directly. Instead use the MakeTestOnlyPosixEventEngine static
   // method. Its expected to be used only in tests.
   explicit PosixEventEngine(
-      grpc_event_engine::posix_engine::PosixEventPoller* poller);
+      grpc_event_engine::experimental::PosixEventPoller* poller);
   PosixEventEngine();
 #else   // GRPC_POSIX_SOCKET_TCP
   PosixEventEngine();
@@ -194,7 +194,7 @@ class PosixEventEngine final : public EventEngine,
   // event engine will also not attempt to shutdown the poller since it does not
   // own it.
   static std::shared_ptr<PosixEventEngine> MakeTestOnlyPosixEventEngine(
-      grpc_event_engine::posix_engine::PosixEventPoller* test_only_poller) {
+      grpc_event_engine::experimental::PosixEventPoller* test_only_poller) {
     return std::make_shared<PosixEventEngine>(test_only_poller);
   }
 #endif  // GRPC_POSIX_SOCKET_TCP
@@ -216,10 +216,10 @@ class PosixEventEngine final : public EventEngine,
       std::shared_ptr<PosixEnginePollerManager> poller_manager);
 
   ConnectionHandle ConnectInternal(
-      grpc_event_engine::posix_engine::PosixSocketWrapper sock,
+      grpc_event_engine::experimental::PosixSocketWrapper sock,
       OnConnectCallback on_connect, ResolvedAddress addr,
       MemoryAllocator&& allocator,
-      const grpc_event_engine::posix_engine::PosixTcpOptions& options,
+      const grpc_event_engine::experimental::PosixTcpOptions& options,
       Duration timeout);
 
   void OnConnectFinishInternal(int connection_handle);
@@ -233,7 +233,7 @@ class PosixEventEngine final : public EventEngine,
   TaskHandleSet known_handles_ ABSL_GUARDED_BY(mu_);
   std::atomic<intptr_t> aba_token_{0};
   std::shared_ptr<ThreadPool> executor_;
-  posix_engine::TimerManager timer_manager_;
+  TimerManager timer_manager_;
 #ifdef GRPC_POSIX_SOCKET_TCP
   std::shared_ptr<PosixEnginePollerManager> poller_manager_;
 #endif  // GRPC_POSIX_SOCKET_TCP

--- a/src/core/lib/event_engine/posix_engine/posix_engine_closure.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_closure.h
@@ -24,7 +24,7 @@
 #include <grpc/event_engine/event_engine.h>
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 // The callbacks for Endpoint read and write take an absl::Status as
 // argument - this is important for the tcp code to function correctly. We need
@@ -74,7 +74,7 @@ class PosixEngineClosure final
   absl::Status status_;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENGINE_CLOSURE_H

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
@@ -43,7 +43,7 @@
 #include "src/core/lib/iomgr/socket_mutator.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 using ::grpc_event_engine::experimental::ResolvedAddressGetPort;
@@ -238,7 +238,7 @@ PosixEngineListenerImpl::~PosixEngineListenerImpl() {
   }
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_POSIX_SOCKET_TCP

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
@@ -45,14 +45,6 @@
 namespace grpc_event_engine {
 namespace experimental {
 
-namespace {
-using ::grpc_event_engine::experimental::ResolvedAddressGetPort;
-using ::grpc_event_engine::experimental::ResolvedAddressIsWildcard;
-using ::grpc_event_engine::experimental::ResolvedAddressSetPort;
-using ::grpc_event_engine::experimental::ResolvedAddressToNormalizedString;
-using ::grpc_event_engine::experimental::ResolvedAddressToV4Mapped;
-}  // namespace
-
 PosixEngineListenerImpl::PosixEngineListenerImpl(
     EventEngine::Listener::AcceptCallback on_accept,
     absl::AnyInvocable<void(absl::Status)> on_shutdown,

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
@@ -45,7 +45,7 @@
 #endif
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_POSIX_SOCKET_TCP
 class PosixEngineListenerImpl
@@ -221,6 +221,6 @@ class PosixEngineListener
 
 #endif
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENGINE_LISTENER_H

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
@@ -47,7 +47,7 @@
 #endif
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_POSIX_SOCKET_UTILS_COMMON
 
@@ -382,5 +382,5 @@ absl::StatusOr<int> ListenerContainerAddAllLocalAddresses(
 
 #endif  // GRPC_POSIX_SOCKET_UTILS_COMMON
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
@@ -56,12 +56,6 @@ namespace {
 using ResolvedAddress =
     grpc_event_engine::experimental::EventEngine::ResolvedAddress;
 using ListenerSocket = ListenerSocketsContainer::ListenerSocket;
-using ::grpc_event_engine::experimental::ResolvedAddressGetPort;
-using ::grpc_event_engine::experimental::ResolvedAddressIsV4Mapped;
-using ::grpc_event_engine::experimental::ResolvedAddressMakeWild4;
-using ::grpc_event_engine::experimental::ResolvedAddressMakeWild6;
-using ::grpc_event_engine::experimental::ResolvedAddressSetPort;
-using ::grpc_event_engine::experimental::ResolvedAddressToString;
 
 #ifdef GRPC_HAVE_IFADDRS
 

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.h
@@ -23,7 +23,7 @@
 #include "src/core/lib/event_engine/posix_engine/tcp_socket_utils.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 // This interface exists to allow different Event Engines to implement different
 // custom interception operations while a socket is Appended. The
@@ -85,7 +85,7 @@ absl::StatusOr<int> ListenerContainerAddAllLocalAddresses(
     ListenerSocketsContainer& listener_sockets, const PosixTcpOptions& options,
     int requested_port);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENGINE_LISTENER_UTILS_H

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
@@ -66,12 +66,6 @@ namespace experimental {
 
 namespace {
 
-using ::grpc_event_engine::experimental::EndpointConfig;
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::ResolvedAddressIsV4Mapped;
-using ::grpc_event_engine::experimental::ResolvedAddressToNormalizedString;
-using ::grpc_event_engine::experimental::ResolvedAddressToV4Mapped;
-
 int AdjustValue(int default_value, int min_value, int max_value,
                 absl::optional<int> actual_value) {
   if (!actual_value.has_value() || *actual_value < min_value ||

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
@@ -62,7 +62,7 @@
 #endif
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 
@@ -844,5 +844,5 @@ PosixSocketWrapper::CreateAndPrepareTcpClientSocket(
 
 #endif /* GRPC_POSIX_SOCKET_UTILS_COMMON */
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
@@ -50,8 +50,6 @@
 namespace grpc_event_engine {
 namespace experimental {
 
-using ::grpc_event_engine::experimental::EventEngine;
-
 struct PosixTcpOptions {
   static constexpr int kDefaultReadChunkSize = 8192;
   static constexpr int kDefaultMinReadChunksize = 256;

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
@@ -48,7 +48,7 @@
 #endif /* ifdef GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::EventEngine;
 
@@ -312,7 +312,7 @@ struct PosixSocketWrapper::PosixSocketCreateResult {
   EventEngine::ResolvedAddress mapped_target_addr;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_TCP_SOCKET_UTILS_H

--- a/src/core/lib/event_engine/posix_engine/timer.cc
+++ b/src/core/lib/event_engine/posix_engine/timer.cc
@@ -32,7 +32,7 @@
 #include "src/core/lib/gprpp/time.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 static const size_t kInvalidHeapIndex = std::numeric_limits<size_t>::max();
 static const double kAddDeadlineScale = 0.33;
@@ -307,5 +307,5 @@ TimerList::TimerCheck(grpc_core::Timestamp* next) {
   return std::move(run);
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/timer.h
+++ b/src/core/lib/event_engine/posix_engine/timer.h
@@ -39,7 +39,7 @@
 #include "src/core/lib/gprpp/time_averaged_stats.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 struct Timer {
   int64_t deadline;
@@ -188,7 +188,7 @@ class TimerList {
   const std::unique_ptr<Shard*[]> shard_queue_ ABSL_GUARDED_BY(mu_);
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_TIMER_H */

--- a/src/core/lib/event_engine/posix_engine/timer_heap.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_heap.cc
@@ -27,7 +27,7 @@
 #include "src/core/lib/event_engine/posix_engine/timer.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 /* Adjusts a heap so as to move a hole at position i closer to the root,
    until a suitable position is found for element t. Then, copies t into that
@@ -103,5 +103,5 @@ Timer* TimerHeap::Top() { return timers_[0]; }
 
 void TimerHeap::Pop() { Remove(Top()); }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/timer_heap.h
+++ b/src/core/lib/event_engine/posix_engine/timer_heap.h
@@ -25,7 +25,7 @@
 #include <vector>
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 struct Timer;
 
@@ -50,7 +50,7 @@ class TimerHeap {
   std::vector<Timer*> timers_;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_TIMER_HEAP_H */

--- a/src/core/lib/event_engine/posix_engine/timer_manager.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.cc
@@ -36,7 +36,7 @@
 static thread_local bool g_timer_thread;
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 grpc_core::DebugOnlyTraceFlag grpc_event_engine_timer_trace(false, "timer");
 
@@ -170,5 +170,5 @@ void TimerManager::PrepareFork() { Shutdown(); }
 void TimerManager::PostforkParent() { RestartPostFork(); }
 void TimerManager::PostforkChild() { RestartPostFork(); }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/timer_manager.h
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.h
@@ -40,7 +40,7 @@
 #include "src/core/lib/gprpp/time.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 // Timer Manager tries to keep only one thread waiting for the next timeout at
 // all times, and thus effectively preventing the thundering herd problem.
@@ -108,7 +108,7 @@ class TimerManager final : public grpc_event_engine::experimental::Forkable {
   absl::optional<grpc_core::Notification> main_loop_exit_signal_;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_TIMER_MANAGER_H */

--- a/src/core/lib/event_engine/posix_engine/traced_buffer_list.cc
+++ b/src/core/lib/event_engine/posix_engine/traced_buffer_list.cc
@@ -37,7 +37,7 @@
 #include <sys/socket.h>  // IWYU pragma: keep
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 // Fills gpr_timespec gts based on values from timespec ts.
@@ -311,20 +311,20 @@ void TcpSetWriteTimestampsCallback(
   g_timestamps_callback = std::move(fn);
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #else /* GRPC_LINUX_ERRQUEUE */
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 void TcpSetWriteTimestampsCallback(
     absl::AnyInvocable<void(void*, Timestamps*, absl::Status)> /*fn*/) {
   GPR_ASSERT(false && "Timestamps callback is not enabled for this platform");
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_LINUX_ERRQUEUE */

--- a/src/core/lib/event_engine/posix_engine/traced_buffer_list.h
+++ b/src/core/lib/event_engine/posix_engine/traced_buffer_list.h
@@ -30,7 +30,7 @@
 #include "src/core/lib/iomgr/port.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 struct ConnectionMetrics { /* Delivery rate in Bytes/s. */
   absl::optional<uint64_t> delivery_rate;
@@ -179,7 +179,7 @@ class TracedBufferList {
 void TcpSetWriteTimestampsCallback(
     absl::AnyInvocable<void(void*, Timestamps*, absl::Status)>);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif /* GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_TRACED_BUFFER_LIST_H */

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_eventfd.cc
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_eventfd.cc
@@ -36,7 +36,7 @@
 #include "src/core/lib/gprpp/strerror.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_LINUX_EVENTFD
 
@@ -122,5 +122,5 @@ EventFdWakeupFd::CreateEventFdWakeupFd() {
 
 #endif  // GRPC_LINUX_EVENTFD
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_eventfd.h
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_eventfd.h
@@ -24,7 +24,7 @@
 #include "src/core/lib/event_engine/posix_engine/wakeup_fd_posix.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class EventFdWakeupFd : public WakeupFd {
  public:
@@ -39,7 +39,7 @@ class EventFdWakeupFd : public WakeupFd {
   absl::Status Init();
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_WAKEUP_FD_EVENTFD_H

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_pipe.cc
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_pipe.cc
@@ -36,7 +36,7 @@
 #include "src/core/lib/gprpp/strerror.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_POSIX_WAKEUP_FD
 
@@ -147,5 +147,5 @@ absl::StatusOr<std::unique_ptr<WakeupFd>> PipeWakeupFd::CreatePipeWakeupFd() {
 
 #endif  //  GRPC_POSIX_WAKEUP_FD
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_pipe.h
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_pipe.h
@@ -24,7 +24,7 @@
 #include "src/core/lib/event_engine/posix_engine/wakeup_fd_posix.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class PipeWakeupFd : public WakeupFd {
  public:
@@ -39,7 +39,7 @@ class PipeWakeupFd : public WakeupFd {
   absl::Status Init();
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_WAKEUP_FD_PIPE_H

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_posix.h
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_posix.h
@@ -47,7 +47,7 @@
 #include "absl/status/status.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class WakeupFd {
  public:
@@ -70,7 +70,7 @@ class WakeupFd {
   int write_fd_;
 };
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_WAKEUP_FD_POSIX_H

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_posix_default.cc
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_posix_default.cc
@@ -24,7 +24,7 @@
 #include "src/core/lib/iomgr/port.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 #ifdef GRPC_POSIX_WAKEUP_FD
 
@@ -63,5 +63,5 @@ absl::StatusOr<std::unique_ptr<WakeupFd>> CreateWakeupFd() {
 
 #endif /* GRPC_POSIX_WAKEUP_FD */
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/wakeup_fd_posix_default.h
+++ b/src/core/lib/event_engine/posix_engine/wakeup_fd_posix_default.h
@@ -21,7 +21,7 @@
 #include "absl/status/statusor.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class WakeupFd;
 
@@ -31,7 +31,7 @@ bool SupportsWakeupFd();
 // Create and return an initialized WakeupFd instance if supported.
 absl::StatusOr<std::unique_ptr<WakeupFd>> CreateWakeupFd();
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 #endif  // GRPC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_WAKEUP_FD_POSIX_DEFAULT_H

--- a/src/core/lib/event_engine/windows/windows_engine.cc
+++ b/src/core/lib/event_engine/windows/windows_engine.cc
@@ -44,7 +44,7 @@ namespace experimental {
 
 struct WindowsEventEngine::Closure final : public EventEngine::Closure {
   absl::AnyInvocable<void()> cb;
-  posix_engine::Timer timer;
+  Timer timer;
   WindowsEventEngine* engine;
   EventEngine::TaskHandle handle;
 

--- a/src/core/lib/event_engine/windows/windows_engine.h
+++ b/src/core/lib/event_engine/windows/windows_engine.h
@@ -113,7 +113,7 @@ class WindowsEventEngine : public EventEngine,
 
   std::shared_ptr<ThreadPool> executor_;
   IOCP iocp_;
-  posix_engine::TimerManager timer_manager_;
+  TimerManager timer_manager_;
 };
 
 }  // namespace experimental

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -182,7 +182,7 @@ void grpc_shutdown(void) {
     grpc_core::ApplicationCallbackExecCtx* acec =
         grpc_core::ApplicationCallbackExecCtx::Get();
     if (!grpc_iomgr_is_any_background_poller_thread() &&
-        !grpc_event_engine::posix_engine::TimerManager::
+        !grpc_event_engine::experimental::TimerManager::
             IsTimerManagerThread() &&
         (acec == nullptr ||
          (acec->Flags() & GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD) ==

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -73,7 +73,7 @@
 GPR_GLOBAL_CONFIG_DECLARE_STRING(grpc_poll_strategy);
 
 using ::grpc_event_engine::experimental::PosixEventEngine;
-using ::grpc_event_engine::posix_engine::PosixEventPoller;
+using ::grpc_event_engine::experimental::PosixEventPoller;
 
 static gpr_mu g_mu;
 static PosixEventPoller* g_event_poller = nullptr;
@@ -89,11 +89,11 @@ static PosixEventPoller* g_event_poller = nullptr;
 #define CLIENT_TOTAL_WRITE_CNT 3
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::Poller;
 using ::grpc_event_engine::experimental::SelfDeletingClosure;
-using ::grpc_event_engine::posix_engine::PosixEventPoller;
+using ::grpc_event_engine::experimental::PosixEventPoller;
 using namespace std::chrono_literals;
 
 namespace {
@@ -388,7 +388,7 @@ class EventPollerTest : public ::testing::Test {
         std::make_unique<grpc_event_engine::experimental::PosixEventEngine>();
     EXPECT_NE(engine_, nullptr);
     scheduler_ =
-        std::make_unique<grpc_event_engine::posix_engine::TestScheduler>(
+        std::make_unique<grpc_event_engine::experimental::TestScheduler>(
             engine_.get());
     EXPECT_NE(scheduler_, nullptr);
     g_event_poller = MakeDefaultPoller(scheduler_.get());
@@ -411,7 +411,7 @@ class EventPollerTest : public ::testing::Test {
 
  private:
   std::shared_ptr<grpc_event_engine::experimental::PosixEventEngine> engine_;
-  std::unique_ptr<grpc_event_engine::posix_engine::TestScheduler> scheduler_;
+  std::unique_ptr<grpc_event_engine::experimental::TestScheduler> scheduler_;
 };
 
 // Test grpc_fd. Start an upload server and client, upload a stream of bytes
@@ -709,7 +709,7 @@ TEST_F(EventPollerTest, TestMultipleHandles) {
 }
 
 }  // namespace
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -72,11 +72,9 @@
 
 GPR_GLOBAL_CONFIG_DECLARE_STRING(grpc_poll_strategy);
 
-using ::grpc_event_engine::experimental::PosixEventEngine;
-using ::grpc_event_engine::experimental::PosixEventPoller;
-
 static gpr_mu g_mu;
-static PosixEventPoller* g_event_poller = nullptr;
+static grpc_event_engine::experimental::PosixEventPoller* g_event_poller =
+    nullptr;
 
 // buffer size used to send and receive data.
 // 1024 is the minimal value to set TCP send and receive buffer.
@@ -91,9 +89,6 @@ static PosixEventPoller* g_event_poller = nullptr;
 namespace grpc_event_engine {
 namespace experimental {
 
-using ::grpc_event_engine::experimental::Poller;
-using ::grpc_event_engine::experimental::PosixEventPoller;
-using ::grpc_event_engine::experimental::SelfDeletingClosure;
 using namespace std::chrono_literals;
 
 namespace {

--- a/test/core/event_engine/posix/lock_free_event_test.cc
+++ b/test/core/event_engine/posix/lock_free_event_test.cc
@@ -33,7 +33,7 @@
 #include "src/core/lib/gprpp/sync.h"
 
 using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::posix_engine::Scheduler;
+using ::grpc_event_engine::experimental::Scheduler;
 
 namespace {
 class TestScheduler : public Scheduler {
@@ -58,7 +58,7 @@ TestScheduler* g_scheduler;
 }  // namespace
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 TEST(LockFreeEventTest, BasicTest) {
   LockfreeEvent event(g_scheduler);
@@ -151,7 +151,7 @@ TEST(LockFreeEventTest, MultiThreadedTest) {
   event.DestroyEvent();
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -54,7 +54,7 @@
 GPR_GLOBAL_CONFIG_DECLARE_STRING(grpc_poll_strategy);
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 
@@ -203,7 +203,7 @@ class PosixEndpointTest : public ::testing::TestWithParam<bool> {
   void SetUp() override {
     oracle_ee_ = std::make_shared<PosixOracleEventEngine>();
     scheduler_ =
-        std::make_unique<grpc_event_engine::posix_engine::TestScheduler>(
+        std::make_unique<grpc_event_engine::experimental::TestScheduler>(
             posix_ee_.get());
     EXPECT_NE(scheduler_, nullptr);
     poller_ = MakeDefaultPoller(scheduler_.get());
@@ -336,7 +336,7 @@ TEST_P(PosixEndpointTest, MultipleIPv6ConnectionsToOneOracleListenerTest) {
 INSTANTIATE_TEST_SUITE_P(PosixEndpoint, PosixEndpointTest,
                          ::testing::ValuesIn({false, true}), &TestScenarioName);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -58,14 +58,6 @@ namespace experimental {
 
 namespace {
 
-using ::grpc_event_engine::experimental::ChannelArgsEndpointConfig;
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::GetNextSendMessage;
-using ::grpc_event_engine::experimental::Poller;
-using ::grpc_event_engine::experimental::PosixEventEngine;
-using ::grpc_event_engine::experimental::PosixOracleEventEngine;
-using ::grpc_event_engine::experimental::URIToResolvedAddress;
-using ::grpc_event_engine::experimental::WaitForSingleOwner;
 using Endpoint = ::grpc_event_engine::experimental::EventEngine::Endpoint;
 using Listener = ::grpc_event_engine::experimental::EventEngine::Listener;
 using namespace std::chrono_literals;

--- a/test/core/event_engine/posix/posix_engine_listener_utils_test.cc
+++ b/test/core/event_engine/posix/posix_engine_listener_utils_test.cc
@@ -46,10 +46,6 @@ namespace experimental {
 
 namespace {
 
-using ::grpc_event_engine::experimental::ChannelArgsEndpointConfig;
-using ::grpc_event_engine::experimental::ResolvedAddressGetPort;
-using ::grpc_event_engine::experimental::ResolvedAddressToNormalizedString;
-
 class TestListenerSocketsContainer : public ListenerSocketsContainer {
  public:
   void Append(ListenerSocket socket) override { sockets_.push_back(socket); }

--- a/test/core/event_engine/posix/posix_engine_listener_utils_test.cc
+++ b/test/core/event_engine/posix/posix_engine_listener_utils_test.cc
@@ -42,7 +42,7 @@
 #include "test/core/util/port.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 
@@ -148,7 +148,7 @@ TEST(PosixEngineListenerUtils, ListenerContainerAddAllLocalAddressesTest) {
 }
 #endif  // GRPC_HAVE_IFADDRS
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/posix_engine_test_utils.cc
+++ b/test/core/event_engine/posix/posix_engine_test_utils.cc
@@ -23,7 +23,7 @@
 #include <grpc/support/log.h>
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ResolvedAddress =
     grpc_event_engine::experimental::EventEngine::ResolvedAddress;
@@ -60,5 +60,5 @@ int ConnectToServerOrDie(const ResolvedAddress& server_address) {
   return client_fd;
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/test/core/event_engine/posix/posix_engine_test_utils.h
+++ b/test/core/event_engine/posix/posix_engine_test_utils.h
@@ -21,7 +21,7 @@
 #include "src/core/lib/event_engine/posix_engine/event_poller.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 class TestScheduler : public Scheduler {
  public:
@@ -58,5 +58,5 @@ int ConnectToServerOrDie(
     const grpc_event_engine::experimental::EventEngine::ResolvedAddress&
         server_address);
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -51,7 +51,7 @@
 #include "test/core/util/test_config.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 using ::grpc_event_engine::experimental::ChannelArgsEndpointConfig;
 using ::grpc_event_engine::experimental::EventEngine;
@@ -208,7 +208,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectCancellationTest) {
   WaitForSingleOwner(std::move(posix_ee));
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -53,12 +53,6 @@
 namespace grpc_event_engine {
 namespace experimental {
 
-using ::grpc_event_engine::experimental::ChannelArgsEndpointConfig;
-using ::grpc_event_engine::experimental::EventEngine;
-using ::grpc_event_engine::experimental::PosixEventEngine;
-using ::grpc_event_engine::experimental::ResolvedAddressToNormalizedString;
-using ::grpc_event_engine::experimental::URIToResolvedAddress;
-using ::grpc_event_engine::experimental::WaitForSingleOwner;
 using namespace std::chrono_literals;
 
 namespace {

--- a/test/core/event_engine/posix/tcp_posix_socket_utils_test.cc
+++ b/test/core/event_engine/posix/tcp_posix_socket_utils_test.cc
@@ -45,7 +45,7 @@
 #include "src/core/lib/iomgr/socket_mutator.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 
@@ -178,7 +178,7 @@ TEST(TcpPosixSocketUtilsTest, SocketOptionsTest) {
   close(sock);
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/timer_heap_test.cc
+++ b/test/core/event_engine/posix/timer_heap_test.cc
@@ -36,7 +36,7 @@ using testing::Contains;
 using testing::Not;
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 int64_t RandomDeadline(void) { return rand(); }
@@ -197,7 +197,7 @@ TEST(TimerHeapTest, RandomMutations) {
 }
 
 }  // namespace
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/timer_list_test.cc
+++ b/test/core/event_engine/posix/timer_list_test.cc
@@ -35,7 +35,7 @@ using testing::Return;
 using testing::StrictMock;
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 namespace {
 const int64_t kHoursIn25Days = 25 * 24;
@@ -239,7 +239,7 @@ TEST(TimerListTest, LongRunningServiceCleanup) {
   EXPECT_TRUE(timer_list.TimerCancel(&timers[3]));
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/timer_manager_test.cc
+++ b/test/core/event_engine/posix/timer_manager_test.cc
@@ -33,7 +33,7 @@
 #include "test/core/util/test_config.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 TEST(TimerManagerTest, StressTest) {
   grpc_core::ExecCtx exec_ctx;
@@ -93,7 +93,7 @@ TEST(TimerManagerTest, ShutDownBeforeAllCallbacksAreExecuted) {
   pool->Quiesce();
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/traced_buffer_list_test.cc
+++ b/test/core/event_engine/posix/traced_buffer_list_test.cc
@@ -33,7 +33,7 @@
 extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 namespace {
 
 constexpr uint64_t kMaxAdvanceTimeMillis = 24ull * 365 * 3600 * 1000;
@@ -266,12 +266,12 @@ TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
   tb_list.Shutdown(nullptr, absl::OkStatus());
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_event_engine::posix_engine::InitGlobals();
+  grpc_event_engine::experimental::InitGlobals();
   return RUN_ALL_TESTS();
 }
 

--- a/test/core/event_engine/posix/wakeup_fd_posix_test.cc
+++ b/test/core/event_engine/posix/wakeup_fd_posix_test.cc
@@ -23,7 +23,7 @@
 #include "src/core/lib/event_engine/posix_engine/wakeup_fd_pipe.h"
 
 namespace grpc_event_engine {
-namespace posix_engine {
+namespace experimental {
 
 TEST(WakeupFdPosixTest, PipeWakeupFdTest) {
   if (!PipeWakeupFd::IsSupported()) {
@@ -49,7 +49,7 @@ TEST(WakeupFdPosixTest, EventFdWakeupFdTest) {
   EXPECT_TRUE((*eventfd_wakeup_fd)->ConsumeWakeup().ok());
 }
 
-}  // namespace posix_engine
+}  // namespace experimental
 }  // namespace grpc_event_engine
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/tcp_socket_utils_test.cc
+++ b/test/core/event_engine/tcp_socket_utils_test.cc
@@ -42,8 +42,6 @@ namespace grpc_event_engine {
 namespace experimental {
 
 namespace {
-using ::grpc_event_engine::experimental::EventEngine;
-
 const uint8_t kMapped[] = {0, 0, 0,    0,    0,   0, 0, 0,
                            0, 0, 0xff, 0xff, 192, 0, 2, 1};
 const uint8_t kNotQuiteMapped[] = {0, 0, 0,    0,    0,   0, 0, 0,


### PR DESCRIPTION
This is in the interest of:
* avoiding deep namespaces (suggested in the style guide, and https://abseil.io/tips/130)
* reducing namespace qualification noise for shared EventEngine code.

The experimental namespace will eventually be removed, leaving all EventEngine code in a top-level namespace.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

