### PR TITLE
Remove functions in `class CoreCodegen`

### DIFF
--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -340,8 +340,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
   /// timeout. i.e:
   ///      TryPluck(tag, gpr_time_0(GPR_CLOCK_REALTIME))
   void TryPluck(grpc::internal::CompletionQueueTag* tag) {
-    auto deadline =
-        grpc::g_core_codegen_interface->gpr_time_0(GPR_CLOCK_REALTIME);
+    auto deadline = gpr_time_0(GPR_CLOCK_REALTIME);
     auto ev = grpc_completion_queue_pluck(cq_, tag, deadline, nullptr);
     if (ev.type == GRPC_QUEUE_TIMEOUT) return;
     bool ok = ev.success != 0;

--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -69,9 +69,8 @@ inline grpc_metadata* FillMetadataArray(
     metadata_array[i].value = SliceReferencingString(iter->second);
   }
   if (!optional_error_details.empty()) {
-    metadata_array[i].key =
-        g_core_codegen_interface->grpc_slice_from_static_buffer(
-            kBinaryErrorDetailsKey, sizeof(kBinaryErrorDetailsKey) - 1);
+    metadata_array[i].key = grpc_slice_from_static_buffer(
+        kBinaryErrorDetailsKey, sizeof(kBinaryErrorDetailsKey) - 1);
     metadata_array[i].value = SliceReferencingString(optional_error_details);
   }
   return metadata_array;

--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -815,7 +815,7 @@ class CallOpClientRecvStatus {
     }
     // TODO(soheil): Find callers that set debug string even for status OK,
     //               and fix them.
-    g_core_codegen_interface->grpc_slice_unref(error_message_);
+    grpc_slice_unref(error_message_);
   }
 
   void SetInterceptionHookPoint(

--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -26,6 +26,7 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/impl/compression_types.h>
+#include <grpc/slice.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpcpp/client_context.h>
@@ -778,7 +779,7 @@ class CallOpClientRecvStatus {
     client_context_ = context;
     metadata_map_ = &client_context_->trailing_metadata_;
     recv_status_ = status;
-    error_message_ = g_core_codegen_interface->grpc_empty_slice();
+    error_message_ = grpc_empty_slice();
   }
 
  protected:

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_metadata_array_init(grpc_metadata_array* array) override;
   void grpc_metadata_array_destroy(grpc_metadata_array* array) override;
 
   gpr_timespec gpr_inf_future(gpr_clock_type type) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_empty_slice() override;
   grpc_slice grpc_slice_malloc(size_t length) override;
   void grpc_slice_unref(grpc_slice slice) override;
   grpc_slice grpc_slice_ref(grpc_slice slice) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_slice_buffer_pop(grpc_slice_buffer* sb) override;
   grpc_slice grpc_slice_from_static_buffer(const void* buffer,
                                            size_t length) override;
   grpc_slice grpc_slice_from_copied_buffer(const void* buffer,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) override;
   grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) override;
   grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) override;
   void grpc_slice_buffer_add(grpc_slice_buffer* sb, grpc_slice slice) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) override;
   grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) override;
   void grpc_slice_buffer_add(grpc_slice_buffer* sb, grpc_slice slice) override;
   void grpc_slice_buffer_pop(grpc_slice_buffer* sb) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_malloc(size_t length) override;
   void grpc_slice_unref(grpc_slice slice) override;
   grpc_slice grpc_slice_ref(grpc_slice slice) override;
   grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_slice_unref(grpc_slice slice) override;
   grpc_slice grpc_slice_ref(grpc_slice slice) override;
   grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) override;
   grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_metadata_array_destroy(grpc_metadata_array* array) override;
-
   gpr_timespec gpr_inf_future(gpr_clock_type type) override;
   gpr_timespec gpr_time_0(gpr_clock_type type) override;
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_ref(grpc_slice slice) override;
   grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) override;
   grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) override;
   grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  void grpc_slice_buffer_add(grpc_slice_buffer* sb, grpc_slice slice) override;
   void grpc_slice_buffer_pop(grpc_slice_buffer* sb) override;
   void grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,
                                      grpc_slice slice) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  gpr_timespec gpr_time_0(gpr_clock_type type) override;
-
   const Status& ok() override;
   const Status& cancelled() override;
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_from_copied_buffer(const void* buffer,
-                                           size_t length) override;
   void grpc_metadata_array_init(grpc_metadata_array* array) override;
   void grpc_metadata_array_destroy(grpc_metadata_array* array) override;
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,8 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_from_static_buffer(const void* buffer,
-                                           size_t length) override;
   grpc_slice grpc_slice_from_copied_buffer(const void* buffer,
                                            size_t length) override;
   void grpc_metadata_array_init(grpc_metadata_array* array) override;

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -34,8 +34,6 @@ namespace grpc {
 class CoreCodegen final : public CoreCodegenInterface {
  private:
   void grpc_slice_buffer_pop(grpc_slice_buffer* sb) override;
-  void grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,
-                                     grpc_slice slice) override;
   grpc_slice grpc_slice_from_static_buffer(const void* buffer,
                                            size_t length) override;
   grpc_slice grpc_slice_from_copied_buffer(const void* buffer,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) override;
   void grpc_slice_buffer_add(grpc_slice_buffer* sb, grpc_slice slice) override;
   void grpc_slice_buffer_pop(grpc_slice_buffer* sb) override;
   void grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -33,7 +33,6 @@ namespace grpc {
 /// Implementation of the core codegen interface.
 class CoreCodegen final : public CoreCodegenInterface {
  private:
-  gpr_timespec gpr_inf_future(gpr_clock_type type) override;
   gpr_timespec gpr_time_0(gpr_clock_type type) override;
 
   const Status& ok() override;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_slice_unref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_ref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) = 0;
   virtual grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_slice_buffer_pop(grpc_slice_buffer* sb) = 0;
   virtual grpc_slice grpc_slice_from_static_buffer(const void* buffer,
                                                    size_t length) = 0;
   virtual grpc_slice grpc_slice_from_copied_buffer(const void* buffer,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,
-                                             grpc_slice slice) = 0;
   virtual void grpc_slice_buffer_pop(grpc_slice_buffer* sb) = 0;
   virtual grpc_slice grpc_slice_from_static_buffer(const void* buffer,
                                                    size_t length) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_empty_slice() = 0;
   virtual grpc_slice grpc_slice_malloc(size_t length) = 0;
   virtual void grpc_slice_unref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_ref(grpc_slice slice) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,9 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_from_copied_buffer(const void* buffer,
-                                                   size_t length) = 0;
-
   virtual void grpc_metadata_array_init(grpc_metadata_array* array) = 0;
   virtual void grpc_metadata_array_destroy(grpc_metadata_array* array) = 0;
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -48,7 +48,6 @@ class CoreCodegenInterface {
   virtual const Status& ok() = 0;
   virtual const Status& cancelled() = 0;
 
-  virtual gpr_timespec gpr_inf_future(gpr_clock_type type) = 0;
   virtual gpr_timespec gpr_time_0(gpr_clock_type type) = 0;
 };
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_metadata_array_init(grpc_metadata_array* array) = 0;
   virtual void grpc_metadata_array_destroy(grpc_metadata_array* array) = 0;
 
   virtual const Status& ok() = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_slice_buffer_add(grpc_slice_buffer* sb,
-                                     grpc_slice slice) = 0;
   virtual void grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,
                                              grpc_slice slice) = 0;
   virtual void grpc_slice_buffer_pop(grpc_slice_buffer* sb) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -21,12 +21,12 @@
 
 // IWYU pragma: private
 
-#include <grpc/impl/codegen/byte_buffer.h>
-#include <grpc/impl/codegen/byte_buffer_reader.h>
+#include <grpc/byte_buffer.h>
+#include <grpc/byte_buffer_reader.h>
 #include <grpc/impl/codegen/grpc_types.h>
-#include <grpc/impl/codegen/sync.h>
-#include <grpcpp/impl/codegen/config.h>
-#include <grpcpp/impl/codegen/status.h>
+#include <grpc/support/sync.h>
+#include <grpcpp/support/config.h>
+#include <grpcpp/support/status.h>
 
 namespace grpc {
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_ref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) = 0;
   virtual grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) = 0;
   virtual grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) = 0;
   virtual grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) = 0;
   virtual void grpc_slice_buffer_add(grpc_slice_buffer* sb,
                                      grpc_slice slice) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_malloc(size_t length) = 0;
   virtual void grpc_slice_unref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_ref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) = 0;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) = 0;
   virtual grpc_slice grpc_slice_split_head(grpc_slice* s, size_t split) = 0;
   virtual grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) = 0;
   virtual void grpc_slice_buffer_add(grpc_slice_buffer* sb,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual void grpc_metadata_array_destroy(grpc_metadata_array* array) = 0;
-
   virtual const Status& ok() = 0;
   virtual const Status& cancelled() = 0;
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,8 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_from_static_buffer(const void* buffer,
-                                                   size_t length) = 0;
   virtual grpc_slice grpc_slice_from_copied_buffer(const void* buffer,
                                                    size_t length) = 0;
 

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -45,7 +45,6 @@ class CoreCodegenInterface {
   virtual void assert_fail(const char* failed_assertion, const char* file,
                            int line) = 0;
 
-  virtual grpc_slice grpc_slice_sub(grpc_slice s, size_t begin, size_t end) = 0;
   virtual void grpc_slice_buffer_add(grpc_slice_buffer* sb,
                                      grpc_slice slice) = 0;
   virtual void grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -47,8 +47,6 @@ class CoreCodegenInterface {
 
   virtual const Status& ok() = 0;
   virtual const Status& cancelled() = 0;
-
-  virtual gpr_timespec gpr_time_0(gpr_clock_type type) = 0;
 };
 
 extern CoreCodegenInterface* g_core_codegen_interface;

--- a/include/grpcpp/impl/metadata_map.h
+++ b/include/grpcpp/impl/metadata_map.h
@@ -21,6 +21,7 @@
 
 #include <map>
 
+#include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpcpp/support/slice.h>
 
@@ -81,9 +82,7 @@ class MetadataMap {
   grpc_metadata_array arr_;
   std::multimap<grpc::string_ref, grpc::string_ref> map_;
 
-  void Destroy() {
-    g_core_codegen_interface->grpc_metadata_array_destroy(&arr_);
-  }
+  void Destroy() { grpc_metadata_array_destroy(&arr_); }
 
   void Setup() { memset(&arr_, 0, sizeof(arr_)); }
 

--- a/include/grpcpp/impl/sync.h
+++ b/include/grpcpp/impl/sync.h
@@ -31,6 +31,7 @@
 
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
+#include <grpc/support/time.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 
 // The core library is not accessible in C++ codegen headers, and vice versa.
@@ -127,8 +128,7 @@ class CondVar {
   void SignalAll() { gpr_cv_broadcast(&cv_); }
 
   void Wait(Mutex* mu) {
-    gpr_cv_wait(&cv_, &mu->mu_,
-                g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_REALTIME));
+    gpr_cv_wait(&cv_, &mu->mu_, gpr_inf_future(GPR_CLOCK_REALTIME));
   }
 
  private:

--- a/include/grpcpp/server_interface.h
+++ b/include/grpcpp/server_interface.h
@@ -23,6 +23,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
+#include <grpc/support/time.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/call_hook.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
@@ -103,10 +104,7 @@ class ServerInterface : public internal::CallHook {
   /// All completion queue associated with the server (for example, for async
   /// serving) must be shutdown *after* this method has returned:
   /// See \a ServerBuilder::AddCompletionQueue for details.
-  void Shutdown() {
-    ShutdownInternal(
-        g_core_codegen_interface->gpr_inf_future(GPR_CLOCK_MONOTONIC));
-  }
+  void Shutdown() { ShutdownInternal(gpr_inf_future(GPR_CLOCK_MONOTONIC)); }
 
   /// Block waiting for all work to complete.
   ///

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -136,8 +136,8 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
     if (static_cast<size_t>(count) == GRPC_SLICE_LENGTH(slice_)) {
       backup_slice_ = slice_;
     } else {
-      backup_slice_ = g_core_codegen_interface->grpc_slice_split_tail(
-          &slice_, GRPC_SLICE_LENGTH(slice_) - count);
+      backup_slice_ =
+          grpc_slice_split_tail(&slice_, GRPC_SLICE_LENGTH(slice_) - count);
       g_core_codegen_interface->grpc_slice_buffer_add(slice_buffer_, slice_);
     }
     // It's dangerous to keep an inlined grpc_slice as the backup slice, since

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -72,7 +72,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
 
   ~ProtoBufferWriter() override {
     if (have_backup_) {
-      g_core_codegen_interface->grpc_slice_unref(backup_slice_);
+      grpc_slice_unref(backup_slice_);
     }
   }
 

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -99,10 +99,9 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
       // But make sure the allocated slice is not inlined.
       size_t allocate_length =
           remain > static_cast<size_t>(block_size_) ? block_size_ : remain;
-      slice_ = g_core_codegen_interface->grpc_slice_malloc(
-          allocate_length > GRPC_SLICE_INLINED_SIZE
-              ? allocate_length
-              : GRPC_SLICE_INLINED_SIZE + 1);
+      slice_ = grpc_slice_malloc(allocate_length > GRPC_SLICE_INLINED_SIZE
+                                     ? allocate_length
+                                     : GRPC_SLICE_INLINED_SIZE + 1);
     }
     *data = GRPC_SLICE_START_PTR(slice_);
     // On win x64, int is only 32bit

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -24,6 +24,7 @@
 #include <grpc/byte_buffer.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>
+#include <grpc/slice_buffer.h>
 #include <grpcpp/impl/codegen/config_protobuf.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/serialization_traits.h>
@@ -111,8 +112,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
     // previous slice. Therefore, use grpc_slice_buffer_add_indexed method to
     // ensure the slice gets added at a separate index. It can then be kept
     // around and popped later in the BackUp function.
-    g_core_codegen_interface->grpc_slice_buffer_add_indexed(slice_buffer_,
-                                                            slice_);
+    grpc_slice_buffer_add_indexed(slice_buffer_, slice_);
     return true;
   }
 
@@ -138,7 +138,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
     } else {
       backup_slice_ =
           grpc_slice_split_tail(&slice_, GRPC_SLICE_LENGTH(slice_) - count);
-      g_core_codegen_interface->grpc_slice_buffer_add(slice_buffer_, slice_);
+      grpc_slice_buffer_add(slice_buffer_, slice_);
     }
     // It's dangerous to keep an inlined grpc_slice as the backup slice, since
     // on a following Next() call, a reference will be returned to this slice

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -132,7 +132,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
     /// 3. Add the needed part back to the slice buffer
     /// 4. Mark that we still have the remaining part (for later use/unref)
     GPR_CODEGEN_ASSERT(count <= static_cast<int>(GRPC_SLICE_LENGTH(slice_)));
-    g_core_codegen_interface->grpc_slice_buffer_pop(slice_buffer_);
+    grpc_slice_buffer_pop(slice_buffer_);
     if (static_cast<size_t>(count) == GRPC_SLICE_LENGTH(slice_)) {
       backup_slice_ = slice_;
     } else {

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -48,8 +48,7 @@ class Slice final {
   Slice(grpc_slice slice, StealRef) : slice_(slice) {}
 
   /// Allocate a slice of specified size
-  explicit Slice(size_t len)
-      : slice_(g_core_codegen_interface->grpc_slice_malloc(len)) {}
+  explicit Slice(size_t len) : slice_(grpc_slice_malloc(len)) {}
 
   /// Construct a slice from a copied buffer
   Slice(const void* buf, size_t len)

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -40,8 +40,7 @@ class Slice final {
 
   enum AddRef { ADD_REF };
   /// Construct a slice from \a slice, adding a reference.
-  Slice(grpc_slice slice, AddRef)
-      : slice_(g_core_codegen_interface->grpc_slice_ref(slice)) {}
+  Slice(grpc_slice slice, AddRef) : slice_(grpc_slice_ref(slice)) {}
 
   enum StealRef { STEAL_REF };
   /// Construct a slice from \a slice, stealing a reference.
@@ -69,8 +68,7 @@ class Slice final {
             reinterpret_cast<const char*>(buf), len)) {}
 
   /// Copy constructor, adds a reference.
-  Slice(const Slice& other)
-      : slice_(g_core_codegen_interface->grpc_slice_ref(other.slice_)) {}
+  Slice(const Slice& other) : slice_(grpc_slice_ref(other.slice_)) {}
 
   /// Move constructor, steals a reference.
   Slice(Slice&& other) noexcept : slice_(other.slice_) {
@@ -115,9 +113,7 @@ class Slice final {
   }
 
   /// Raw C slice. Caller needs to call grpc_slice_unref when done.
-  grpc_slice c_slice() const {
-    return g_core_codegen_interface->grpc_slice_ref(slice_);
-  }
+  grpc_slice c_slice() const { return grpc_slice_ref(slice_); }
 
  private:
   friend class ByteBuffer;

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -51,14 +51,13 @@ class Slice final {
 
   /// Construct a slice from a copied buffer
   Slice(const void* buf, size_t len)
-      : slice_(g_core_codegen_interface->grpc_slice_from_copied_buffer(
-            reinterpret_cast<const char*>(buf), len)) {}
+      : slice_(grpc_slice_from_copied_buffer(reinterpret_cast<const char*>(buf),
+                                             len)) {}
 
   /// Construct a slice from a copied string
   /* NOLINTNEXTLINE(google-explicit-constructor) */
   Slice(const std::string& str)
-      : slice_(g_core_codegen_interface->grpc_slice_from_copied_buffer(
-            str.c_str(), str.length())) {}
+      : slice_(grpc_slice_from_copied_buffer(str.c_str(), str.length())) {}
 
   enum StaticSlice { STATIC_SLICE };
 
@@ -136,8 +135,7 @@ inline grpc_slice SliceReferencingString(const std::string& str) {
 }
 
 inline grpc_slice SliceFromCopiedString(const std::string& str) {
-  return g_core_codegen_interface->grpc_slice_from_copied_buffer(str.data(),
-                                                                 str.length());
+  return grpc_slice_from_copied_buffer(str.data(), str.length());
 }
 
 }  // namespace grpc

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -36,7 +36,7 @@ class Slice final {
   /// Construct an empty slice.
   Slice() : slice_(grpc_empty_slice()) {}
   /// Destructor - drops one reference.
-  ~Slice() { g_core_codegen_interface->grpc_slice_unref(slice_); }
+  ~Slice() { grpc_slice_unref(slice_); }
 
   enum AddRef { ADD_REF };
   /// Construct a slice from \a slice, adding a reference.

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -34,7 +34,7 @@ namespace grpc {
 class Slice final {
  public:
   /// Construct an empty slice.
-  Slice() : slice_(g_core_codegen_interface->grpc_empty_slice()) {}
+  Slice() : slice_(grpc_empty_slice()) {}
   /// Destructor - drops one reference.
   ~Slice() { g_core_codegen_interface->grpc_slice_unref(slice_); }
 
@@ -75,7 +75,7 @@ class Slice final {
 
   /// Move constructor, steals a reference.
   Slice(Slice&& other) noexcept : slice_(other.slice_) {
-    other.slice_ = g_core_codegen_interface->grpc_empty_slice();
+    other.slice_ = grpc_empty_slice();
   }
 
   /// Assignment, reference count is unchanged.

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -108,8 +108,7 @@ class Slice final {
 
   /// Returns a substring of the `slice` as another slice.
   Slice sub(size_t begin, size_t end) const {
-    return Slice(g_core_codegen_interface->grpc_slice_sub(slice_, begin, end),
-                 STEAL_REF);
+    return Slice(grpc_slice_sub(slice_, begin, end), STEAL_REF);
   }
 
   /// Raw C slice. Caller needs to call grpc_slice_unref when done.

--- a/include/grpcpp/support/slice.h
+++ b/include/grpcpp/support/slice.h
@@ -64,8 +64,8 @@ class Slice final {
 
   /// Construct a slice from a static buffer
   Slice(const void* buf, size_t len, StaticSlice)
-      : slice_(g_core_codegen_interface->grpc_slice_from_static_buffer(
-            reinterpret_cast<const char*>(buf), len)) {}
+      : slice_(grpc_slice_from_static_buffer(reinterpret_cast<const char*>(buf),
+                                             len)) {}
 
   /// Copy constructor, adds a reference.
   Slice(const Slice& other) : slice_(grpc_slice_ref(other.slice_)) {}
@@ -132,8 +132,7 @@ inline std::string StringFromCopiedSlice(grpc_slice slice) {
 }
 
 inline grpc_slice SliceReferencingString(const std::string& str) {
-  return g_core_codegen_interface->grpc_slice_from_static_buffer(str.data(),
-                                                                 str.length());
+  return grpc_slice_from_static_buffer(str.data(), str.length());
 }
 
 inline grpc_slice SliceFromCopiedString(const std::string& str) {

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -74,7 +74,7 @@ Channel::~Channel() {
 namespace {
 
 inline grpc_slice SliceFromArray(const char* arr, size_t len) {
-  return g_core_codegen_interface->grpc_slice_from_copied_buffer(arr, len);
+  return grpc_slice_from_copied_buffer(arr, len);
 }
 
 std::string GetChannelInfoField(grpc_channel* channel,

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_metadata_array_destroy(grpc_metadata_array* array) {
-  ::grpc_metadata_array_destroy(array);
-}
-
 const Status& CoreCodegen::ok() { return grpc::Status::OK; }
 
 const Status& CoreCodegen::cancelled() { return grpc::Status::CANCELLED; }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_split_tail(grpc_slice* s, size_t split) {
-  return ::grpc_slice_split_tail(s, split);
-}
-
 grpc_slice CoreCodegen::grpc_slice_split_head(grpc_slice* s, size_t split) {
   return ::grpc_slice_split_head(s, split);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -47,11 +47,6 @@ grpc_slice CoreCodegen::grpc_slice_from_copied_buffer(const void* buffer,
                                          length);
 }
 
-void CoreCodegen::grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,
-                                                grpc_slice slice) {
-  ::grpc_slice_buffer_add_indexed(sb, slice);
-}
-
 void CoreCodegen::grpc_slice_buffer_pop(grpc_slice_buffer* sb) {
   ::grpc_slice_buffer_pop(sb);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -47,11 +47,6 @@ grpc_slice CoreCodegen::grpc_slice_from_copied_buffer(const void* buffer,
                                          length);
 }
 
-void CoreCodegen::grpc_slice_buffer_add(grpc_slice_buffer* sb,
-                                        grpc_slice slice) {
-  ::grpc_slice_buffer_add(sb, slice);
-}
-
 void CoreCodegen::grpc_slice_buffer_add_indexed(grpc_slice_buffer* sb,
                                                 grpc_slice slice) {
   ::grpc_slice_buffer_add_indexed(sb, slice);

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_slice_unref(grpc_slice slice) {
-  ::grpc_slice_unref(slice);
-}
-
 grpc_slice CoreCodegen::grpc_slice_ref(grpc_slice slice) {
   return ::grpc_slice_ref(slice);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_malloc(size_t length) {
-  return ::grpc_slice_malloc(length);
-}
-
 void CoreCodegen::grpc_slice_unref(grpc_slice slice) {
   ::grpc_slice_unref(slice);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,11 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_from_static_buffer(const void* buffer,
-                                                      size_t length) {
-  return ::grpc_slice_from_static_buffer(buffer, length);
-}
-
 grpc_slice CoreCodegen::grpc_slice_from_copied_buffer(const void* buffer,
                                                       size_t length) {
   return ::grpc_slice_from_copied_buffer(static_cast<const char*>(buffer),

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_split_head(grpc_slice* s, size_t split) {
-  return ::grpc_slice_split_head(s, split);
-}
-
 grpc_slice CoreCodegen::grpc_slice_sub(grpc_slice s, size_t begin, size_t end) {
   return ::grpc_slice_sub(s, begin, end);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -47,10 +47,6 @@ grpc_slice CoreCodegen::grpc_slice_from_copied_buffer(const void* buffer,
                                          length);
 }
 
-void CoreCodegen::grpc_slice_buffer_pop(grpc_slice_buffer* sb) {
-  ::grpc_slice_buffer_pop(sb);
-}
-
 void CoreCodegen::grpc_metadata_array_init(grpc_metadata_array* array) {
   ::grpc_metadata_array_init(array);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-void CoreCodegen::grpc_metadata_array_init(grpc_metadata_array* array) {
-  ::grpc_metadata_array_init(array);
-}
-
 void CoreCodegen::grpc_metadata_array_destroy(grpc_metadata_array* array) {
   ::grpc_metadata_array_destroy(array);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_sub(grpc_slice s, size_t begin, size_t end) {
-  return ::grpc_slice_sub(s, begin, end);
-}
-
 grpc_slice CoreCodegen::grpc_slice_from_static_buffer(const void* buffer,
                                                       size_t length) {
   return ::grpc_slice_from_static_buffer(buffer, length);

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,10 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_ref(grpc_slice slice) {
-  return ::grpc_slice_ref(slice);
-}
-
 grpc_slice CoreCodegen::grpc_slice_split_tail(grpc_slice* s, size_t split) {
   return ::grpc_slice_split_tail(s, split);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,12 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_slice_from_copied_buffer(const void* buffer,
-                                                      size_t length) {
-  return ::grpc_slice_from_copied_buffer(static_cast<const char*>(buffer),
-                                         length);
-}
-
 void CoreCodegen::grpc_metadata_array_init(grpc_metadata_array* array) {
   ::grpc_metadata_array_init(array);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -36,8 +36,6 @@
 
 namespace grpc {
 
-grpc_slice CoreCodegen::grpc_empty_slice() { return ::grpc_empty_slice(); }
-
 grpc_slice CoreCodegen::grpc_slice_malloc(size_t length) {
   return ::grpc_slice_malloc(length);
 }

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -40,10 +40,6 @@ const Status& CoreCodegen::ok() { return grpc::Status::OK; }
 
 const Status& CoreCodegen::cancelled() { return grpc::Status::CANCELLED; }
 
-gpr_timespec CoreCodegen::gpr_time_0(gpr_clock_type type) {
-  return ::gpr_time_0(type);
-}
-
 void CoreCodegen::assert_fail(const char* failed_assertion, const char* file,
                               int line) {
   gpr_log(file, line, GPR_LOG_SEVERITY_ERROR, "assertion failed: %s",

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -40,10 +40,6 @@ const Status& CoreCodegen::ok() { return grpc::Status::OK; }
 
 const Status& CoreCodegen::cancelled() { return grpc::Status::CANCELLED; }
 
-gpr_timespec CoreCodegen::gpr_inf_future(gpr_clock_type type) {
-  return ::gpr_inf_future(type);
-}
-
 gpr_timespec CoreCodegen::gpr_time_0(gpr_clock_type type) {
   return ::gpr_time_0(type);
 }

--- a/test/cpp/microbenchmarks/bm_byte_buffer.cc
+++ b/test/cpp/microbenchmarks/bm_byte_buffer.cc
@@ -57,8 +57,7 @@ static void BM_ByteBufferReader_Next(benchmark::State& state) {
   std::vector<grpc_slice> slices;
   for (int i = 0; i < num_slices; ++i) {
     std::unique_ptr<char[]> buf(new char[kSliceSize]);
-    slices.emplace_back(g_core_codegen_interface->grpc_slice_from_copied_buffer(
-        buf.get(), kSliceSize));
+    slices.emplace_back(grpc_slice_from_copied_buffer(buf.get(), kSliceSize));
   }
   grpc_byte_buffer* bb = grpc_raw_byte_buffer_create(slices.data(), num_slices);
   grpc_byte_buffer_reader reader;
@@ -86,8 +85,7 @@ static void BM_ByteBufferReader_Peek(benchmark::State& state) {
   std::vector<grpc_slice> slices;
   for (int i = 0; i < num_slices; ++i) {
     std::unique_ptr<char[]> buf(new char[kSliceSize]);
-    slices.emplace_back(g_core_codegen_interface->grpc_slice_from_copied_buffer(
-        buf.get(), kSliceSize));
+    slices.emplace_back(grpc_slice_from_copied_buffer(buf.get(), kSliceSize));
   }
   grpc_byte_buffer* bb = grpc_raw_byte_buffer_create(slices.data(), num_slices);
   grpc_byte_buffer_reader reader;

--- a/test/cpp/microbenchmarks/bm_byte_buffer.cc
+++ b/test/cpp/microbenchmarks/bm_byte_buffer.cc
@@ -23,6 +23,7 @@
 #include <benchmark/benchmark.h>
 
 #include <grpc/byte_buffer.h>
+#include <grpc/slice.h>
 #include <grpcpp/impl/grpc_library.h>
 #include <grpcpp/support/byte_buffer.h>
 
@@ -74,7 +75,7 @@ static void BM_ByteBufferReader_Next(benchmark::State& state) {
   grpc_byte_buffer_reader_destroy(&reader);
   grpc_byte_buffer_destroy(bb);
   for (auto& slice : slices) {
-    g_core_codegen_interface->grpc_slice_unref(slice);
+    grpc_slice_unref(slice);
   }
 }
 BENCHMARK(BM_ByteBufferReader_Next)->Ranges({{64 * 1024, 1024 * 1024}});
@@ -103,7 +104,7 @@ static void BM_ByteBufferReader_Peek(benchmark::State& state) {
   grpc_byte_buffer_reader_destroy(&reader);
   grpc_byte_buffer_destroy(bb);
   for (auto& slice : slices) {
-    g_core_codegen_interface->grpc_slice_unref(slice);
+    grpc_slice_unref(slice);
   }
 }
 BENCHMARK(BM_ByteBufferReader_Peek)->Ranges({{64 * 1024, 1024 * 1024}});


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR cleans up some functions in `class CoreCodegen`. Other functions should be cleaned up in a subsequent PR. The ultimate goal is to remove `class CoreCodegen` and its global pointer `g_core_codegen_interface` entirely.

