### PR TITLE
Make http proxy fixture test more robust

### DIFF
--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -58,6 +58,7 @@ grpc_cc_library(
     srcs = ["fixtures/http_proxy_fixture.cc"],
     hdrs = ["fixtures/http_proxy_fixture.h"],
     external_deps = [
+        "absl/status",
         "absl/status:statusor",
         "absl/strings",
     ],

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -42,7 +42,6 @@
 #include "src/core/lib/channel/channel_args_preconditioning.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/event_engine/channel_args_endpoint_config.h"
-#include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/status_helper.h"
@@ -69,8 +68,7 @@ struct grpc_end2end_http_proxy {
   grpc_end2end_http_proxy()
       : server(nullptr), channel_args(nullptr), mu(nullptr), combiner(nullptr) {
     gpr_ref_init(&users, 1);
-    combiner = grpc_combiner_create(
-        grpc_event_engine::experimental::GetDefaultEventEngine());
+    combiner = grpc_combiner_create();
   }
   std::string proxy_name;
   grpc_core::Thread thd;


### PR DESCRIPTION

This fixes  bugs in the test. If the connection to the server (client) endpoint fails, we trigger shutdown of the corresponding other connection to client (server). This bug was unearthed during testing undertaken with event engine endpoints in https://github.com/grpc/grpc/pull/31661 and it caused some flakiness.

