### PR TITLE
Sends out-of-band close for streams from client side when destroying transport

### DIFF
--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -149,7 +149,26 @@ static void cancel_stream_locked(grpc_binder_transport* gbt,
                                  grpc_binder_stream* gbs,
                                  grpc_error_handle error) {
   gpr_log(GPR_INFO, "cancel_stream_locked");
+
   if (!gbs->is_closed) {
+    if (gbt->is_client) {
+      // Always do an out-of-band close to play it safe. Due the design of gRPC,
+      // a bidi-streaming call can be "closed" from the client side, but a
+      // server-streaming call can only be "cancelled". An out-of-band close
+      // effectively "cancels" both bidi-streaming and server-streaming call.
+      //
+      // TODO(littlecvr): Investigate how BinderTransport work in Java and align
+      // with their behavior.
+      auto cancel_tx = std::make_unique<grpc_binder::Transaction>(
+          gbs->GetTxCode(), gbt->is_client);
+      cancel_tx->SetOutOfBandClose();
+      cancel_tx->SetStatus(GRPC_STATUS_CANCELLED);
+      gpr_log(GPR_INFO,
+              "Sending out-of-band close, gbt = %p, gbs = %p, is_client = %d",
+              gbt, gbs, gbt->is_client);
+      gbt->wire_writer->RpcCall(std::move(cancel_tx)).IgnoreError();
+    }
+
     GPR_ASSERT(gbs->cancel_self_error.ok());
     gbs->is_closed = true;
     gbs->cancel_self_error = error;

--- a/src/core/ext/transport/binder/wire_format/transaction.cc
+++ b/src/core/ext/transport/binder/wire_format/transaction.cc
@@ -28,7 +28,6 @@ ABSL_CONST_INIT const int kFlagExpectSingleMessage = 0x10;
 ABSL_CONST_INIT const int kFlagStatusDescription = 0x20;
 ABSL_CONST_INIT const int kFlagMessageDataIsParcelable = 0x40;
 ABSL_CONST_INIT const int kFlagMessageDataIsPartial = 0x80;
-
 ABSL_CONST_INIT const int kStatusCodeShift = 16;
 
 }  // namespace grpc_binder

--- a/src/core/ext/transport/binder/wire_format/transaction.cc
+++ b/src/core/ext/transport/binder/wire_format/transaction.cc
@@ -29,5 +29,7 @@ ABSL_CONST_INIT const int kFlagStatusDescription = 0x20;
 ABSL_CONST_INIT const int kFlagMessageDataIsParcelable = 0x40;
 ABSL_CONST_INIT const int kFlagMessageDataIsPartial = 0x80;
 
+ABSL_CONST_INIT const int kStatusCodeShift = 16;
+
 }  // namespace grpc_binder
 #endif

--- a/src/core/ext/transport/binder/wire_format/transaction.h
+++ b/src/core/ext/transport/binder/wire_format/transaction.h
@@ -35,6 +35,8 @@ ABSL_CONST_INIT extern const int kFlagStatusDescription;
 ABSL_CONST_INIT extern const int kFlagMessageDataIsParcelable;
 ABSL_CONST_INIT extern const int kFlagMessageDataIsPartial;
 
+ABSL_CONST_INIT extern const int kStatusCodeShift;
+
 using Metadata = std::vector<std::pair<std::string, std::string>>;
 
 class Transaction {
@@ -67,11 +69,11 @@ class Transaction {
     GPR_ASSERT((flags_ & kFlagStatusDescription) == 0);
     status_desc_ = status_desc;
   }
+  void SetOutOfBandClose() { flags_ |= kFlagOutOfBandClose; }
   void SetStatus(int status) {
-    GPR_ASSERT(!is_client_);
-    GPR_ASSERT((flags_ >> 16) == 0);
-    GPR_ASSERT(status < (1 << 16));
-    flags_ |= (status << 16);
+    GPR_ASSERT((flags_ >> kStatusCodeShift) == 0);
+    GPR_ASSERT(status < (1 << kStatusCodeShift));
+    flags_ |= (status << kStatusCodeShift);
   }
 
   bool IsClient() const { return is_client_; }

--- a/src/core/ext/transport/binder/wire_format/transaction.h
+++ b/src/core/ext/transport/binder/wire_format/transaction.h
@@ -34,7 +34,6 @@ ABSL_CONST_INIT extern const int kFlagExpectSingleMessage;
 ABSL_CONST_INIT extern const int kFlagStatusDescription;
 ABSL_CONST_INIT extern const int kFlagMessageDataIsParcelable;
 ABSL_CONST_INIT extern const int kFlagMessageDataIsPartial;
-
 ABSL_CONST_INIT extern const int kStatusCodeShift;
 
 using Metadata = std::vector<std::pair<std::string, std::string>>;

--- a/test/core/transport/binder/binder_transport_test.cc
+++ b/test/core/transport/binder/binder_transport_test.cc
@@ -82,7 +82,12 @@ MATCHER_P4(TransactionMatches, flag, method_ref, initial_metadata, message_data,
     }
   }
   if (flag & kFlagMessageData) {
-    if (arg->GetMessageData() != message_data) return false;
+    if (arg->GetMessageData() != message_data) {
+      printf("MESSAGE NOT EQUIVALENT: %s %s\n",
+             std::string(arg->GetMessageData()).c_str(),
+             std::string(message_data).c_str());
+      return false;
+    }
   }
   return true;
 }


### PR DESCRIPTION
Due to its design, simply destroying a Binder object doesn't really tell the other end to close theirs, thus, streams won't be closed, either. We have to explicitly send a close message to each stream in order to close them.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

