### PR TITLE
[cleanups] Remove functions in `class CoreCodegen`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -260,7 +260,6 @@ GRPCXX_SRCS = [
     "src/cpp/server/server_posix.cc",
     "src/cpp/thread_manager/thread_manager.cc",
     "src/cpp/util/byte_buffer_cc.cc",
-    "src/cpp/util/status.cc",
     "src/cpp/util/string_ref.cc",
     "src/cpp/util/time_cc.cc",
     "src/cpp/codegen/codegen_init.cc",
@@ -1762,6 +1761,7 @@ grpc_cc_library(
         "grpc_service_config_impl",
         "grpc_trace",
         "grpcpp_call_metric_recorder",
+        "grpcpp_status",
         "iomgr_timer",
         "ref_counted_ptr",
         "//src/core:arena",
@@ -1827,6 +1827,7 @@ grpc_cc_library(
         "grpc_trace",
         "grpc_unsecure",
         "grpcpp_call_metric_recorder",
+        "grpcpp_status",
         "iomgr_timer",
         "ref_counted_ptr",
         "//src/core:arena",
@@ -1866,6 +1867,7 @@ grpc_cc_library(
     deps = [
         "grpc++_config_proto",
         "grpc++_public_hdrs",
+        "grpcpp_status",
     ],
 )
 
@@ -3557,6 +3559,25 @@ grpc_cc_library(
         "//src/core:time",
         "//src/core:transport_fwd",
         "//src/core:useful",
+    ],
+)
+
+grpc_cc_library(
+    name = "grpcpp_status",
+    srcs = [
+        "src/cpp/util/status.cc",
+    ],
+    public_hdrs = [
+        "include/grpc++/support/status.h",
+        "include/grpcpp/impl/status.h",
+        "include/grpcpp/support/status.h",
+        "include/grpc++/impl/codegen/status.h",
+        "include/grpcpp/impl/codegen/status.h",
+    ],
+    deps = [
+        "gpr_platform",
+        "grpc++_public_hdrs",
+        "grpc_public_hdrs",
     ],
 )
 

--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -24,6 +24,9 @@ EXPERIMENTS = {
         "hpack_test": [
             "new_hpack_huffman_decoder",
         ],
+        "resource_quota_test": [
+            "memory_pressure_controller",
+        ],
     },
     "off": {
         "core_end2end_test": [
@@ -45,7 +48,6 @@ EXPERIMENTS = {
             "promise_based_client_call",
         ],
         "resource_quota_test": [
-            "memory_pressure_controller",
             "unconstrained_max_quota_buffer_size",
         ],
     },

--- a/include/grpcpp/client_context.h
+++ b/include/grpcpp/client_context.h
@@ -40,6 +40,7 @@
 
 #include <grpc/impl/codegen/propagation_bits.h>
 #include <grpc/impl/compression_types.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/create_auth_context.h>
 #include <grpcpp/impl/metadata_map.h>
@@ -246,7 +247,7 @@ class ClientContext {
   /// \return A multimap of initial metadata key-value pairs from the server.
   const std::multimap<grpc::string_ref, grpc::string_ref>&
   GetServerInitialMetadata() const {
-    GPR_CODEGEN_ASSERT(initial_metadata_received_);
+    GPR_ASSERT(initial_metadata_received_);
     return *recv_initial_metadata_.map();
   }
 

--- a/include/grpcpp/completion_queue.h
+++ b/include/grpcpp/completion_queue.h
@@ -36,6 +36,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/support/atm.h>
+#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/rpc_service_method.h>
@@ -325,7 +326,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
       bool ok = ev.success != 0;
       void* ignored = tag;
       if (tag->FinalizeResult(&ignored, &ok)) {
-        GPR_CODEGEN_ASSERT(ignored == tag);
+        GPR_ASSERT(ignored == tag);
         return ok;
       }
     }
@@ -346,7 +347,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
     bool ok = ev.success != 0;
     void* ignored = tag;
     // the tag must be swallowed if using TryPluck
-    GPR_CODEGEN_ASSERT(!tag->FinalizeResult(&ignored, &ok));
+    GPR_ASSERT(!tag->FinalizeResult(&ignored, &ok));
   }
 
   /// Performs a single polling pluck on \a tag. Calls tag->FinalizeResult if
@@ -363,7 +364,7 @@ class CompletionQueue : private grpc::internal::GrpcLibrary {
 
     bool ok = ev.success != 0;
     void* ignored = tag;
-    GPR_CODEGEN_ASSERT(!tag->FinalizeResult(&ignored, &ok));
+    GPR_ASSERT(!tag->FinalizeResult(&ignored, &ok));
   }
 
   /// Manage state of avalanching operations : completion queue tags that

--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -319,7 +319,7 @@ class CallOpSendMessage {
       return;
     }
     if (msg_ != nullptr) {
-      GPR_CODEGEN_ASSERT(serializer_(msg_).ok());
+      GPR_ASSERT(serializer_(msg_).ok());
     }
     serializer_ = nullptr;
     grpc_op* op = &ops[(*nops)++];
@@ -798,7 +798,7 @@ class CallOpClientRecvStatus {
     if (recv_status_ == nullptr || hijacked_) return;
     if (static_cast<StatusCode>(status_code_) == StatusCode::OK) {
       *recv_status_ = Status();
-      GPR_CODEGEN_DEBUG_ASSERT(debug_error_string_ == nullptr);
+      GPR_DEBUG_ASSERT(debug_error_string_ == nullptr);
     } else {
       *recv_status_ =
           Status(static_cast<StatusCode>(status_code_),
@@ -977,7 +977,7 @@ class CallOpSet : public CallOpSetInterface,
       // WritesDone multiple times
       gpr_log(GPR_ERROR, "API misuse of type %s observed",
               grpc_call_error_to_string(err));
-      GPR_CODEGEN_ASSERT(false);
+      GPR_ASSERT(false);
     }
   }
 
@@ -987,9 +987,8 @@ class CallOpSet : public CallOpSetInterface,
     done_intercepting_ = true;
     // The following call_start_batch is internally-generated so no need for an
     // explanatory log on failure.
-    GPR_CODEGEN_ASSERT(grpc_call_start_batch(call_.call(), nullptr, 0,
-                                             core_cq_tag(),
-                                             nullptr) == GRPC_CALL_OK);
+    GPR_ASSERT(grpc_call_start_batch(call_.call(), nullptr, 0, core_cq_tag(),
+                                     nullptr) == GRPC_CALL_OK);
   }
 
  private:

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -31,11 +31,7 @@
 namespace grpc {
 
 /// Implementation of the core codegen interface.
-class CoreCodegen final : public CoreCodegenInterface {
- private:
-  const Status& ok() override;
-  const Status& cancelled() override;
-};
+class CoreCodegen final : public CoreCodegenInterface {};
 
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/core_codegen.h
+++ b/include/grpcpp/impl/codegen/core_codegen.h
@@ -35,9 +35,6 @@ class CoreCodegen final : public CoreCodegenInterface {
  private:
   const Status& ok() override;
   const Status& cancelled() override;
-
-  void assert_fail(const char* failed_assertion, const char* file,
-                   int line) override;
 };
 
 }  // namespace grpc

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -40,9 +40,6 @@ namespace grpc {
 class CoreCodegenInterface {
  public:
   virtual ~CoreCodegenInterface() = default;
-
-  virtual const Status& ok() = 0;
-  virtual const Status& cancelled() = 0;
 };
 
 extern CoreCodegenInterface* g_core_codegen_interface;

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -41,32 +41,11 @@ class CoreCodegenInterface {
  public:
   virtual ~CoreCodegenInterface() = default;
 
-  /// Upon a failed assertion, log the error.
-  virtual void assert_fail(const char* failed_assertion, const char* file,
-                           int line) = 0;
-
   virtual const Status& ok() = 0;
   virtual const Status& cancelled() = 0;
 };
 
 extern CoreCodegenInterface* g_core_codegen_interface;
-
-/// Codegen specific version of \a GPR_ASSERT.
-#define GPR_CODEGEN_ASSERT(x)                                              \
-  do {                                                                     \
-    if (GPR_UNLIKELY(!(x))) {                                              \
-      grpc::g_core_codegen_interface->assert_fail(#x, __FILE__, __LINE__); \
-    }                                                                      \
-  } while (0)
-
-/// Codegen specific version of \a GPR_DEBUG_ASSERT.
-#ifndef NDEBUG
-#define GPR_CODEGEN_DEBUG_ASSERT(x) GPR_CODEGEN_ASSERT(x)
-#else
-#define GPR_CODEGEN_DEBUG_ASSERT(x) \
-  do {                              \
-  } while (0)
-#endif
 
 }  // namespace grpc
 

--- a/include/grpcpp/impl/interceptor_common.h
+++ b/include/grpcpp/impl/interceptor_common.h
@@ -23,6 +23,7 @@
 #include <functional>
 
 #include <grpc/impl/codegen/grpc_types.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/call_op_set_interface.h>
 #include <grpcpp/impl/intercepted_channel.h>
@@ -55,16 +56,16 @@ class InterceptorBatchMethodsImpl
     if (call_->client_rpc_info() != nullptr) {
       return ProceedClient();
     }
-    GPR_CODEGEN_ASSERT(call_->server_rpc_info() != nullptr);
+    GPR_ASSERT(call_->server_rpc_info() != nullptr);
     ProceedServer();
   }
 
   void Hijack() override {
     // Only the client can hijack when sending down initial metadata
-    GPR_CODEGEN_ASSERT(!reverse_ && ops_ != nullptr &&
-                       call_->client_rpc_info() != nullptr);
+    GPR_ASSERT(!reverse_ && ops_ != nullptr &&
+               call_->client_rpc_info() != nullptr);
     // It is illegal to call Hijack twice
-    GPR_CODEGEN_ASSERT(!ran_hijacking_interceptor_);
+    GPR_ASSERT(!ran_hijacking_interceptor_);
     auto* rpc_info = call_->client_rpc_info();
     rpc_info->hijacked_ = true;
     rpc_info->hijacked_interceptor_ = current_interceptor_index_;
@@ -79,21 +80,21 @@ class InterceptorBatchMethodsImpl
   }
 
   ByteBuffer* GetSerializedSendMessage() override {
-    GPR_CODEGEN_ASSERT(orig_send_message_ != nullptr);
+    GPR_ASSERT(orig_send_message_ != nullptr);
     if (*orig_send_message_ != nullptr) {
-      GPR_CODEGEN_ASSERT(serializer_(*orig_send_message_).ok());
+      GPR_ASSERT(serializer_(*orig_send_message_).ok());
       *orig_send_message_ = nullptr;
     }
     return send_message_;
   }
 
   const void* GetSendMessage() override {
-    GPR_CODEGEN_ASSERT(orig_send_message_ != nullptr);
+    GPR_ASSERT(orig_send_message_ != nullptr);
     return *orig_send_message_;
   }
 
   void ModifySendMessage(const void* message) override {
-    GPR_CODEGEN_ASSERT(orig_send_message_ != nullptr);
+    GPR_ASSERT(orig_send_message_ != nullptr);
     *orig_send_message_ = message;
   }
 
@@ -128,7 +129,7 @@ class InterceptorBatchMethodsImpl
   Status* GetRecvStatus() override { return recv_status_; }
 
   void FailHijackedSendMessage() override {
-    GPR_CODEGEN_ASSERT(hooks_[static_cast<size_t>(
+    GPR_ASSERT(hooks_[static_cast<size_t>(
         experimental::InterceptionHookPoints::PRE_SEND_MESSAGE)]);
     *fail_send_message_ = true;
   }
@@ -191,7 +192,7 @@ class InterceptorBatchMethodsImpl
   }
 
   void FailHijackedRecvMessage() override {
-    GPR_CODEGEN_ASSERT(hooks_[static_cast<size_t>(
+    GPR_ASSERT(hooks_[static_cast<size_t>(
         experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)]);
     *hijacked_recv_message_failed_ = true;
   }
@@ -235,7 +236,7 @@ class InterceptorBatchMethodsImpl
   // ContinueFinalizeOpsAfterInterception will be called. Note that neither of
   // them is invoked if there were no interceptors registered.
   bool RunInterceptors() {
-    GPR_CODEGEN_ASSERT(ops_);
+    GPR_ASSERT(ops_);
     auto* client_rpc_info = call_->client_rpc_info();
     if (client_rpc_info != nullptr) {
       if (client_rpc_info->interceptors_.empty()) {
@@ -260,8 +261,8 @@ class InterceptorBatchMethodsImpl
   // SyncRequest.
   bool RunInterceptors(std::function<void(void)> f) {
     // This is used only by the server for initial call request
-    GPR_CODEGEN_ASSERT(reverse_ == true);
-    GPR_CODEGEN_ASSERT(call_->client_rpc_info() == nullptr);
+    GPR_ASSERT(reverse_ == true);
+    GPR_ASSERT(call_->client_rpc_info() == nullptr);
     auto* server_rpc_info = call_->server_rpc_info();
     if (server_rpc_info == nullptr || server_rpc_info->interceptors_.empty()) {
       return true;
@@ -355,7 +356,7 @@ class InterceptorBatchMethodsImpl
         return ops_->ContinueFinalizeResultAfterInterception();
       }
     }
-    GPR_CODEGEN_ASSERT(callback_);
+    GPR_ASSERT(callback_);
     callback_();
   }
 
@@ -421,115 +422,112 @@ class CancelInterceptorBatchMethods
 
   void Hijack() override {
     // Only the client can hijack when sending down initial metadata
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call Hijack on a method which has a "
-                       "Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call Hijack on a method which has a "
+               "Cancel notification");
   }
 
   ByteBuffer* GetSerializedSendMessage() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetSendMessage on a method which "
-                       "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetSendMessage on a method which "
+               "has a Cancel notification");
     return nullptr;
   }
 
   bool GetSendMessageStatus() override {
-    GPR_CODEGEN_ASSERT(
-        false &&
-        "It is illegal to call GetSendMessageStatus on a method which "
-        "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetSendMessageStatus on a method which "
+               "has a Cancel notification");
     return false;
   }
 
   const void* GetSendMessage() override {
-    GPR_CODEGEN_ASSERT(
-        false &&
-        "It is illegal to call GetOriginalSendMessage on a method which "
-        "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetOriginalSendMessage on a method which "
+               "has a Cancel notification");
     return nullptr;
   }
 
   void ModifySendMessage(const void* /*message*/) override {
-    GPR_CODEGEN_ASSERT(
-        false &&
-        "It is illegal to call ModifySendMessage on a method which "
-        "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call ModifySendMessage on a method which "
+               "has a Cancel notification");
   }
 
   std::multimap<std::string, std::string>* GetSendInitialMetadata() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetSendInitialMetadata on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetSendInitialMetadata on a "
+               "method which has a Cancel notification");
     return nullptr;
   }
 
   Status GetSendStatus() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetSendStatus on a method which "
-                       "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetSendStatus on a method which "
+               "has a Cancel notification");
     return Status();
   }
 
   void ModifySendStatus(const Status& /*status*/) override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call ModifySendStatus on a method "
-                       "which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call ModifySendStatus on a method "
+               "which has a Cancel notification");
   }
 
   std::multimap<std::string, std::string>* GetSendTrailingMetadata() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetSendTrailingMetadata on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetSendTrailingMetadata on a "
+               "method which has a Cancel notification");
     return nullptr;
   }
 
   void* GetRecvMessage() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetRecvMessage on a method which "
-                       "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetRecvMessage on a method which "
+               "has a Cancel notification");
     return nullptr;
   }
 
   std::multimap<grpc::string_ref, grpc::string_ref>* GetRecvInitialMetadata()
       override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetRecvInitialMetadata on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetRecvInitialMetadata on a "
+               "method which has a Cancel notification");
     return nullptr;
   }
 
   Status* GetRecvStatus() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetRecvStatus on a method which "
-                       "has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetRecvStatus on a method which "
+               "has a Cancel notification");
     return nullptr;
   }
 
   std::multimap<grpc::string_ref, grpc::string_ref>* GetRecvTrailingMetadata()
       override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetRecvTrailingMetadata on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetRecvTrailingMetadata on a "
+               "method which has a Cancel notification");
     return nullptr;
   }
 
   std::unique_ptr<ChannelInterface> GetInterceptedChannel() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call GetInterceptedChannel on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call GetInterceptedChannel on a "
+               "method which has a Cancel notification");
     return std::unique_ptr<ChannelInterface>(nullptr);
   }
 
   void FailHijackedRecvMessage() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call FailHijackedRecvMessage on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call FailHijackedRecvMessage on a "
+               "method which has a Cancel notification");
   }
 
   void FailHijackedSendMessage() override {
-    GPR_CODEGEN_ASSERT(false &&
-                       "It is illegal to call FailHijackedSendMessage on a "
-                       "method which has a Cancel notification");
+    GPR_ASSERT(false &&
+               "It is illegal to call FailHijackedSendMessage on a "
+               "method which has a Cancel notification");
   }
 };
 }  // namespace internal

--- a/include/grpcpp/impl/proto_utils.h
+++ b/include/grpcpp/impl/proto_utils.h
@@ -59,11 +59,11 @@ Status GenericSerialize(const grpc::protobuf::MessageLite& msg, ByteBuffer* bb,
     ByteBuffer tmp(&slice, 1);
     bb->Swap(&tmp);
 
-    return g_core_codegen_interface->ok();
+    return grpc::Status::OK;
   }
   ProtoBufferWriter writer(bb, kProtoBufferWriterMaxBufferLength, byte_size);
   return msg.SerializeToZeroCopyStream(&writer)
-             ? g_core_codegen_interface->ok()
+             ? grpc::Status::OK
              : Status(StatusCode::INTERNAL, "Failed to serialize message");
 }
 
@@ -78,7 +78,7 @@ Status GenericDeserialize(ByteBuffer* buffer,
   if (buffer == nullptr) {
     return Status(StatusCode::INTERNAL, "No payload");
   }
-  Status result = g_core_codegen_interface->ok();
+  Status result = grpc::Status::OK;
   {
     ProtoBufferReader reader(buffer);
     if (!reader.status().ok()) {

--- a/include/grpcpp/impl/proto_utils.h
+++ b/include/grpcpp/impl/proto_utils.h
@@ -24,6 +24,7 @@
 #include <grpc/byte_buffer_reader.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/config_protobuf.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/serialization_traits.h>
@@ -53,8 +54,8 @@ Status GenericSerialize(const grpc::protobuf::MessageLite& msg, ByteBuffer* bb,
   if (static_cast<size_t>(byte_size) <= GRPC_SLICE_INLINED_SIZE) {
     Slice slice(byte_size);
     // We serialize directly into the allocated slices memory
-    GPR_CODEGEN_ASSERT(slice.end() == msg.SerializeWithCachedSizesToArray(
-                                          const_cast<uint8_t*>(slice.begin())));
+    GPR_ASSERT(slice.end() == msg.SerializeWithCachedSizesToArray(
+                                  const_cast<uint8_t*>(slice.begin())));
     ByteBuffer tmp(&slice, 1);
     bb->Swap(&tmp);
 

--- a/include/grpcpp/impl/rpc_service_method.h
+++ b/include/grpcpp/impl/rpc_service_method.h
@@ -75,7 +75,7 @@ class MethodHandler {
      retained by the handler. Returns nullptr if deserialization failed. */
   virtual void* Deserialize(grpc_call* /*call*/, grpc_byte_buffer* req,
                             Status* /*status*/, void** /*handler_data*/) {
-    GPR_CODEGEN_ASSERT(req == nullptr);
+    GPR_ASSERT(req == nullptr);
     return nullptr;
   }
 };

--- a/include/grpcpp/impl/server_callback_handlers.h
+++ b/include/grpcpp/impl/server_callback_handlers.h
@@ -19,6 +19,7 @@
 #define GRPCPP_IMPL_SERVER_CALLBACK_HANDLERS_H
 
 #include <grpc/grpc.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/rpc_service_method.h>
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/message_allocator.h>
@@ -145,7 +146,7 @@ class CallbackUnaryHandler : public grpc::internal::MethodHandler {
     }
 
     void SendInitialMetadata() override {
-      GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+      GPR_ASSERT(!ctx_->sent_initial_metadata_);
       this->Ref();
       // The callback for this function should not be marked inline because it
       // is directly invoking a user-controlled reaction
@@ -331,7 +332,7 @@ class CallbackClientStreamingHandler : public grpc::internal::MethodHandler {
     }
 
     void SendInitialMetadata() override {
-      GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+      GPR_ASSERT(!ctx_->sent_initial_metadata_);
       this->Ref();
       // The callback for this function should not be inlined because it invokes
       // a user-controlled reaction, but any resulting OnDone can be inlined in
@@ -533,7 +534,7 @@ class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
     }
 
     void SendInitialMetadata() override {
-      GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+      GPR_ASSERT(!ctx_->sent_initial_metadata_);
       this->Ref();
       // The callback for this function should not be inlined because it invokes
       // a user-controlled reaction, but any resulting OnDone can be inlined in
@@ -571,7 +572,7 @@ class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
         ctx_->sent_initial_metadata_ = true;
       }
       // TODO(vjpai): don't assert
-      GPR_CODEGEN_ASSERT(write_ops_.SendMessagePtr(resp, options).ok());
+      GPR_ASSERT(write_ops_.SendMessagePtr(resp, options).ok());
       call_.PerformOps(&write_ops_);
     }
 
@@ -579,7 +580,7 @@ class CallbackServerStreamingHandler : public grpc::internal::MethodHandler {
                         grpc::Status s) override {
       // This combines the write into the finish callback
       // TODO(vjpai): don't assert
-      GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
+      GPR_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
       Finish(std::move(s));
     }
 
@@ -743,7 +744,7 @@ class CallbackBidiHandler : public grpc::internal::MethodHandler {
     }
 
     void SendInitialMetadata() override {
-      GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+      GPR_ASSERT(!ctx_->sent_initial_metadata_);
       this->Ref();
       // The callback for this function should not be inlined because it invokes
       // a user-controlled reaction, but any resulting OnDone can be inlined in
@@ -781,14 +782,14 @@ class CallbackBidiHandler : public grpc::internal::MethodHandler {
         ctx_->sent_initial_metadata_ = true;
       }
       // TODO(vjpai): don't assert
-      GPR_CODEGEN_ASSERT(write_ops_.SendMessagePtr(resp, options).ok());
+      GPR_ASSERT(write_ops_.SendMessagePtr(resp, options).ok());
       call_.PerformOps(&write_ops_);
     }
 
     void WriteAndFinish(const ResponseType* resp, grpc::WriteOptions options,
                         grpc::Status s) override {
       // TODO(vjpai): don't assert
-      GPR_CODEGEN_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
+      GPR_ASSERT(finish_ops_.SendMessagePtr(resp, options).ok());
       Finish(std::move(s));
     }
 

--- a/include/grpcpp/impl/service_type.h
+++ b/include/grpcpp/impl/service_type.h
@@ -19,6 +19,7 @@
 #ifndef GRPCPP_IMPL_SERVICE_TYPE_H
 #define GRPCPP_IMPL_SERVICE_TYPE_H
 
+#include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/rpc_service_method.h>
 #include <grpcpp/impl/serialization_traits.h>
@@ -52,7 +53,7 @@ class ServerAsyncStreamingInterface {
 };
 }  // namespace internal
 
-/// Desriptor of an RPC service and its various RPC methods
+/// Descriptor of an RPC service and its various RPC methods
 class Service {
  public:
   Service() : server_(nullptr) {}
@@ -150,10 +151,9 @@ class Service {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
-    GPR_CODEGEN_ASSERT(
-        methods_[idx].get() != nullptr &&
-        "Cannot mark the method as 'async' because it has already been "
-        "marked as 'generic'.");
+    GPR_ASSERT(methods_[idx].get() != nullptr &&
+               "Cannot mark the method as 'async' because it has already been "
+               "marked as 'generic'.");
     methods_[idx]->SetServerApiType(internal::RpcServiceMethod::ApiType::ASYNC);
   }
 
@@ -161,9 +161,9 @@ class Service {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
-    GPR_CODEGEN_ASSERT(methods_[idx].get() != nullptr &&
-                       "Cannot mark the method as 'raw' because it has already "
-                       "been marked as 'generic'.");
+    GPR_ASSERT(methods_[idx].get() != nullptr &&
+               "Cannot mark the method as 'raw' because it has already "
+               "been marked as 'generic'.");
     methods_[idx]->SetServerApiType(internal::RpcServiceMethod::ApiType::RAW);
   }
 
@@ -171,7 +171,7 @@ class Service {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
-    GPR_CODEGEN_ASSERT(
+    GPR_ASSERT(
         methods_[idx]->handler() != nullptr &&
         "Cannot mark the method as 'generic' because it has already been "
         "marked as 'async' or 'raw'.");
@@ -182,8 +182,8 @@ class Service {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
-    GPR_CODEGEN_ASSERT(methods_[idx] && methods_[idx]->handler() &&
-                       "Cannot mark an async or generic method Streamed");
+    GPR_ASSERT(methods_[idx] && methods_[idx]->handler() &&
+               "Cannot mark an async or generic method Streamed");
     methods_[idx]->SetHandler(streamed_method);
 
     // From the server's point of view, streamed unary is a special
@@ -197,7 +197,7 @@ class Service {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
-    GPR_CODEGEN_ASSERT(
+    GPR_ASSERT(
         methods_[idx].get() != nullptr &&
         "Cannot mark the method as 'callback' because it has already been "
         "marked as 'generic'.");
@@ -210,7 +210,7 @@ class Service {
     // This does not have to be a hard error, however no one has approached us
     // with a use case yet. Please file an issue if you believe you have one.
     size_t idx = static_cast<size_t>(index);
-    GPR_CODEGEN_ASSERT(
+    GPR_ASSERT(
         methods_[idx].get() != nullptr &&
         "Cannot mark the method as 'raw callback' because it has already "
         "been marked as 'generic'.");

--- a/include/grpcpp/server_interface.h
+++ b/include/grpcpp/server_interface.h
@@ -23,6 +23,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
+#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/call_hook.h>
@@ -315,7 +316,7 @@ class ServerInterface : public internal::CallHook {
                         grpc::CompletionQueue* call_cq,
                         grpc::ServerCompletionQueue* notification_cq, void* tag,
                         Message* message) {
-    GPR_CODEGEN_ASSERT(method);
+    GPR_ASSERT(method);
     new PayloadAsyncRequest<Message>(method, this, context, stream, call_cq,
                                      notification_cq, tag, message);
   }
@@ -326,7 +327,7 @@ class ServerInterface : public internal::CallHook {
                         grpc::CompletionQueue* call_cq,
                         grpc::ServerCompletionQueue* notification_cq,
                         void* tag) {
-    GPR_CODEGEN_ASSERT(method);
+    GPR_ASSERT(method);
     new NoPayloadAsyncRequest(method, this, context, stream, call_cq,
                               notification_cq, tag);
   }

--- a/include/grpcpp/support/async_stream.h
+++ b/include/grpcpp/support/async_stream.h
@@ -20,6 +20,7 @@
 #define GRPCPP_SUPPORT_ASYNC_STREAM_H
 
 #include <grpc/grpc.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/channel_interface.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
@@ -200,7 +201,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncReader));
+    GPR_ASSERT(size == sizeof(ClientAsyncReader));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -208,10 +209,10 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall(void* tag) override {
-    GPR_CODEGEN_ASSERT(!started_);
+    GPR_ASSERT(!started_);
     started_ = true;
     StartCallInternal(tag);
   }
@@ -225,8 +226,8 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   ///     calling code can access the received metadata through the
   ///     \a ClientContext.
   void ReadInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
-    GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
+    GPR_ASSERT(started_);
+    GPR_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
     meta_ops_.RecvInitialMetadata(context_);
@@ -234,7 +235,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   }
 
   void Read(R* msg, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     read_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       read_ops_.RecvInitialMetadata(context_);
@@ -249,7 +250,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata received from the server.
   void Finish(grpc::Status* status, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
@@ -265,12 +266,12 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
                     const W& request, bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(init_ops_.SendMessage(request).ok());
+    GPR_ASSERT(init_ops_.SendMessage(request).ok());
     init_ops_.ClientSendClose();
     if (start) {
       StartCallInternal(tag);
     } else {
-      GPR_CODEGEN_ASSERT(tag == nullptr);
+      GPR_ASSERT(tag == nullptr);
     }
   }
 
@@ -348,7 +349,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncWriter));
+    GPR_ASSERT(size == sizeof(ClientAsyncWriter));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -356,10 +357,10 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall(void* tag) override {
-    GPR_CODEGEN_ASSERT(!started_);
+    GPR_ASSERT(!started_);
     started_ = true;
     StartCallInternal(tag);
   }
@@ -372,8 +373,8 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   ///     associated with this call is updated, and the calling code can access
   ///     the received metadata through the \a ClientContext.
   void ReadInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
-    GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
+    GPR_ASSERT(started_);
+    GPR_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
     meta_ops_.RecvInitialMetadata(context_);
@@ -381,27 +382,27 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   }
 
   void Write(const W& msg, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg).ok());
     call_.PerformOps(&write_ops_);
   }
 
   void Write(const W& msg, grpc::WriteOptions options, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
       options.set_buffer_hint();
       write_ops_.ClientSendClose();
     }
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg, options).ok());
     call_.PerformOps(&write_ops_);
   }
 
   void WritesDone(void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     write_ops_.ClientSendClose();
     call_.PerformOps(&write_ops_);
@@ -415,7 +416,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   ///   - attempts to fill in the \a response parameter passed to this class's
   ///     constructor with the server's response message.
   void Finish(grpc::Status* status, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
@@ -435,7 +436,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
     if (start) {
       StartCallInternal(tag);
     } else {
-      GPR_CODEGEN_ASSERT(tag == nullptr);
+      GPR_ASSERT(tag == nullptr);
     }
   }
 
@@ -515,7 +516,7 @@ class ClientAsyncReaderWriter final
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncReaderWriter));
+    GPR_ASSERT(size == sizeof(ClientAsyncReaderWriter));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -523,10 +524,10 @@ class ClientAsyncReaderWriter final
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall(void* tag) override {
-    GPR_CODEGEN_ASSERT(!started_);
+    GPR_ASSERT(!started_);
     started_ = true;
     StartCallInternal(tag);
   }
@@ -539,8 +540,8 @@ class ClientAsyncReaderWriter final
   ///     is updated with it, and then the receiving initial metadata can
   ///     be accessed through this \a ClientContext.
   void ReadInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
-    GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
+    GPR_ASSERT(started_);
+    GPR_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
     meta_ops_.RecvInitialMetadata(context_);
@@ -548,7 +549,7 @@ class ClientAsyncReaderWriter final
   }
 
   void Read(R* msg, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     read_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       read_ops_.RecvInitialMetadata(context_);
@@ -558,27 +559,27 @@ class ClientAsyncReaderWriter final
   }
 
   void Write(const W& msg, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg).ok());
     call_.PerformOps(&write_ops_);
   }
 
   void Write(const W& msg, grpc::WriteOptions options, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
       options.set_buffer_hint();
       write_ops_.ClientSendClose();
     }
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg, options).ok());
     call_.PerformOps(&write_ops_);
   }
 
   void WritesDone(void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     write_ops_.ClientSendClose();
     call_.PerformOps(&write_ops_);
@@ -589,7 +590,7 @@ class ClientAsyncReaderWriter final
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
   void Finish(grpc::Status* status, void* tag) override {
-    GPR_CODEGEN_ASSERT(started_);
+    GPR_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
@@ -606,7 +607,7 @@ class ClientAsyncReaderWriter final
     if (start) {
       StartCallInternal(tag);
     } else {
-      GPR_CODEGEN_ASSERT(tag == nullptr);
+      GPR_ASSERT(tag == nullptr);
     }
   }
 
@@ -706,7 +707,7 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
   ///   - The initial metadata that will be sent to the client from this op will
   ///     be taken from the \a ServerContext associated with the call.
   void SendInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     meta_ops_.set_output_tag(tag);
     meta_ops_.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -765,7 +766,7 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
   /// gRPC doesn't take ownership or a reference to \a status, so it is safe to
   /// to deallocate once FinishWithError returns.
   void FinishWithError(const grpc::Status& status, void* tag) override {
-    GPR_CODEGEN_ASSERT(!status.ok());
+    GPR_ASSERT(!status.ok());
     finish_ops_.set_output_tag(tag);
     if (!ctx_->sent_initial_metadata_) {
       finish_ops_.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -855,7 +856,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
   ///
   /// \param[in] tag Tag identifying this request.
   void SendInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     meta_ops_.set_output_tag(tag);
     meta_ops_.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -871,7 +872,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
     write_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&write_ops_);
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg).ok());
     call_.PerformOps(&write_ops_);
   }
 
@@ -883,7 +884,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
 
     EnsureInitialMetadataSent(&write_ops_);
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg, options).ok());
     call_.PerformOps(&write_ops_);
   }
 
@@ -902,7 +903,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
     write_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&write_ops_);
     options.set_buffer_hint();
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg, options).ok());
     write_ops_.ServerSendStatus(&ctx_->trailing_metadata_, status);
     call_.PerformOps(&write_ops_);
   }
@@ -1021,7 +1022,7 @@ class ServerAsyncReaderWriter final
   ///
   /// \param[in] tag Tag identifying this request.
   void SendInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     meta_ops_.set_output_tag(tag);
     meta_ops_.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -1043,7 +1044,7 @@ class ServerAsyncReaderWriter final
     write_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&write_ops_);
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg).ok());
     call_.PerformOps(&write_ops_);
   }
 
@@ -1053,7 +1054,7 @@ class ServerAsyncReaderWriter final
       options.set_buffer_hint();
     }
     EnsureInitialMetadataSent(&write_ops_);
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg, options).ok());
     call_.PerformOps(&write_ops_);
   }
 
@@ -1073,7 +1074,7 @@ class ServerAsyncReaderWriter final
     write_ops_.set_output_tag(tag);
     EnsureInitialMetadataSent(&write_ops_);
     options.set_buffer_hint();
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessage(msg, options).ok());
     write_ops_.ServerSendStatus(&ctx_->trailing_metadata_, status);
     call_.PerformOps(&write_ops_);
   }

--- a/include/grpcpp/support/async_unary_call.h
+++ b/include/grpcpp/support/async_unary_call.h
@@ -20,6 +20,7 @@
 #define GRPCPP_SUPPORT_ASYNC_UNARY_CALL_H
 
 #include <grpc/grpc.h>
+#include <grpc/support/log.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/call_op_set.h>
@@ -130,7 +131,7 @@ class ClientAsyncResponseReaderHelper {
         new (grpc_call_arena_alloc(call, sizeof(SingleBufType))) SingleBufType;
     *single_buf_ptr = single_buf;
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(single_buf->SendMessage(request).ok());
+    GPR_ASSERT(single_buf->SendMessage(request).ok());
     single_buf->ClientSendClose();
 
     // The purpose of the following functions is to type-erase the actual
@@ -220,7 +221,7 @@ class ClientAsyncResponseReader final
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncResponseReader));
+    GPR_ASSERT(size == sizeof(ClientAsyncResponseReader));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -228,10 +229,10 @@ class ClientAsyncResponseReader final
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall() override {
-    GPR_CODEGEN_DEBUG_ASSERT(!started_);
+    GPR_DEBUG_ASSERT(!started_);
     started_ = true;
     internal::ClientAsyncResponseReaderHelper::StartCall(context_, single_buf_);
   }
@@ -243,8 +244,8 @@ class ClientAsyncResponseReader final
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
   void ReadInitialMetadata(void* tag) override {
-    GPR_CODEGEN_DEBUG_ASSERT(started_);
-    GPR_CODEGEN_DEBUG_ASSERT(!context_->initial_metadata_received_);
+    GPR_DEBUG_ASSERT(started_);
+    GPR_DEBUG_ASSERT(!context_->initial_metadata_received_);
     read_initial_metadata_(context_, &call_, single_buf_, tag);
     initial_metadata_read_ = true;
   }
@@ -255,7 +256,7 @@ class ClientAsyncResponseReader final
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
   void Finish(R* msg, grpc::Status* status, void* tag) override {
-    GPR_CODEGEN_DEBUG_ASSERT(started_);
+    GPR_DEBUG_ASSERT(started_);
     finish_(context_, &call_, initial_metadata_read_, single_buf_, &finish_buf_,
             static_cast<void*>(msg), status, tag);
   }
@@ -304,7 +305,7 @@ class ServerAsyncResponseWriter final
   ///
   /// \param[in] tag Tag identifying this request.
   void SendInitialMetadata(void* tag) override {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     meta_buf_.set_output_tag(tag);
     meta_buf_.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -373,7 +374,7 @@ class ServerAsyncResponseWriter final
   /// deallocate them once the Finish operation is complete (i.e. a result
   /// arrives in the completion queue).
   void FinishWithError(const grpc::Status& status, void* tag) {
-    GPR_CODEGEN_ASSERT(!status.ok());
+    GPR_ASSERT(!status.ok());
     finish_buf_.set_output_tag(tag);
     if (!ctx_->sent_initial_metadata_) {
       finish_buf_.SendInitialMetadata(&ctx_->initial_metadata_,

--- a/include/grpcpp/support/byte_buffer.h
+++ b/include/grpcpp/support/byte_buffer.h
@@ -226,7 +226,7 @@ class SerializationTraits<ByteBuffer, void> {
                           bool* own_buffer) {
     *buffer = source;
     *own_buffer = true;
-    return g_core_codegen_interface->ok();
+    return grpc::Status::OK;
   }
 };
 

--- a/include/grpcpp/support/callback_common.h
+++ b/include/grpcpp/support/callback_common.h
@@ -23,6 +23,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/grpc_types.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
@@ -71,7 +72,7 @@ class CallbackWithStatusTag : public grpc_completion_queue_functor {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(CallbackWithStatusTag));
+    GPR_ASSERT(size == sizeof(CallbackWithStatusTag));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -79,7 +80,7 @@ class CallbackWithStatusTag : public grpc_completion_queue_functor {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   CallbackWithStatusTag(grpc_call* call, std::function<void(Status)> f,
                         CompletionQueueTag* ops)
@@ -118,7 +119,7 @@ class CallbackWithStatusTag : public grpc_completion_queue_functor {
       // The tag was swallowed
       return;
     }
-    GPR_CODEGEN_ASSERT(ignored == ops_);
+    GPR_ASSERT(ignored == ops_);
 
     // Last use of func_ or status_, so ok to move them out
     auto func = std::move(func_);
@@ -137,7 +138,7 @@ class CallbackWithSuccessTag : public grpc_completion_queue_functor {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(CallbackWithSuccessTag));
+    GPR_ASSERT(size == sizeof(CallbackWithSuccessTag));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -145,7 +146,7 @@ class CallbackWithSuccessTag : public grpc_completion_queue_functor {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   CallbackWithSuccessTag() : call_(nullptr) {}
 
@@ -162,7 +163,7 @@ class CallbackWithSuccessTag : public grpc_completion_queue_functor {
   // callbacks.
   void Set(grpc_call* call, std::function<void(bool)> f,
            CompletionQueueTag* ops, bool can_inline) {
-    GPR_CODEGEN_ASSERT(call_ == nullptr);
+    GPR_ASSERT(call_ == nullptr);
     grpc_call_ref(call);
     call_ = call;
     func_ = std::move(f);
@@ -207,7 +208,7 @@ class CallbackWithSuccessTag : public grpc_completion_queue_functor {
     auto* ops = ops_;
 #endif
     bool do_callback = ops_->FinalizeResult(&ignored, &ok);
-    GPR_CODEGEN_DEBUG_ASSERT(ignored == ops);
+    GPR_DEBUG_ASSERT(ignored == ops);
 
     if (do_callback) {
       CatchingCallback(func_, ok);

--- a/include/grpcpp/support/client_callback.h
+++ b/include/grpcpp/support/client_callback.h
@@ -23,6 +23,7 @@
 #include <functional>
 
 #include <grpc/grpc.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/call_op_set.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
@@ -69,7 +70,7 @@ class CallbackUnaryCallImpl {
                         const InputMessage* request, OutputMessage* result,
                         std::function<void(grpc::Status)> on_completion) {
     grpc::CompletionQueue* cq = channel->CallbackCQ();
-    GPR_CODEGEN_ASSERT(cq != nullptr);
+    GPR_ASSERT(cq != nullptr);
     grpc::internal::Call call(channel->CreateCall(method, context, cq));
 
     using FullCallOpSet = grpc::internal::CallOpSet<
@@ -312,7 +313,7 @@ class ClientBidiReactor : public internal::ClientReactor {
   /// The argument to AddMultipleHolds must be positive.
   void AddHold() { AddMultipleHolds(1); }
   void AddMultipleHolds(int holds) {
-    GPR_CODEGEN_DEBUG_ASSERT(holds > 0);
+    GPR_DEBUG_ASSERT(holds > 0);
     stream_->AddHold(holds);
   }
   void RemoveHold() { stream_->RemoveHold(); }
@@ -376,7 +377,7 @@ class ClientReadReactor : public internal::ClientReactor {
 
   void AddHold() { AddMultipleHolds(1); }
   void AddMultipleHolds(int holds) {
-    GPR_CODEGEN_DEBUG_ASSERT(holds > 0);
+    GPR_DEBUG_ASSERT(holds > 0);
     reader_->AddHold(holds);
   }
   void RemoveHold() { reader_->RemoveHold(); }
@@ -408,7 +409,7 @@ class ClientWriteReactor : public internal::ClientReactor {
 
   void AddHold() { AddMultipleHolds(1); }
   void AddMultipleHolds(int holds) {
-    GPR_CODEGEN_DEBUG_ASSERT(holds > 0);
+    GPR_DEBUG_ASSERT(holds > 0);
     writer_->AddHold(holds);
   }
   void RemoveHold() { writer_->RemoveHold(); }
@@ -469,7 +470,7 @@ class ClientCallbackReaderWriterImpl
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackReaderWriterImpl));
+    GPR_ASSERT(size == sizeof(ClientCallbackReaderWriterImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -477,7 +478,7 @@ class ClientCallbackReaderWriterImpl
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall() ABSL_LOCKS_EXCLUDED(start_mu_) override {
     // This call initiates two batches, plus any backlog, each with a callback
@@ -535,7 +536,7 @@ class ClientCallbackReaderWriterImpl
       write_ops_.ClientSendClose();
     }
     // TODO(vjpai): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessagePtr(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessagePtr(msg, options).ok());
     callbacks_outstanding_.fetch_add(1, std::memory_order_relaxed);
     if (GPR_UNLIKELY(corked_write_needed_)) {
       write_ops_.SendInitialMetadata(&context_->send_initial_metadata_,
@@ -725,7 +726,7 @@ class ClientCallbackReaderImpl : public ClientCallbackReader<Response> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackReaderImpl));
+    GPR_ASSERT(size == sizeof(ClientCallbackReaderImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -733,7 +734,7 @@ class ClientCallbackReaderImpl : public ClientCallbackReader<Response> {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall() override {
     // This call initiates two batches, plus any backlog, each with a callback
@@ -810,7 +811,7 @@ class ClientCallbackReaderImpl : public ClientCallbackReader<Response> {
       : context_(context), call_(call), reactor_(reactor) {
     this->BindReactor(reactor);
     // TODO(vjpai): don't assert
-    GPR_CODEGEN_ASSERT(start_ops_.SendMessagePtr(request).ok());
+    GPR_ASSERT(start_ops_.SendMessagePtr(request).ok());
     start_ops_.ClientSendClose();
   }
 
@@ -884,7 +885,7 @@ class ClientCallbackWriterImpl : public ClientCallbackWriter<Request> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackWriterImpl));
+    GPR_ASSERT(size == sizeof(ClientCallbackWriterImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -892,7 +893,7 @@ class ClientCallbackWriterImpl : public ClientCallbackWriter<Request> {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall() ABSL_LOCKS_EXCLUDED(start_mu_) override {
     // This call initiates two batches, plus any backlog, each with a callback
@@ -933,7 +934,7 @@ class ClientCallbackWriterImpl : public ClientCallbackWriter<Request> {
       write_ops_.ClientSendClose();
     }
     // TODO(vjpai): don't assert
-    GPR_CODEGEN_ASSERT(write_ops_.SendMessagePtr(msg, options).ok());
+    GPR_ASSERT(write_ops_.SendMessagePtr(msg, options).ok());
     callbacks_outstanding_.fetch_add(1, std::memory_order_relaxed);
 
     if (GPR_UNLIKELY(corked_write_needed_)) {
@@ -1112,7 +1113,7 @@ class ClientCallbackUnaryImpl final : public ClientCallbackUnary {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackUnaryImpl));
+    GPR_ASSERT(size == sizeof(ClientCallbackUnaryImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -1120,7 +1121,7 @@ class ClientCallbackUnaryImpl final : public ClientCallbackUnary {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
+  static void operator delete(void*, void*) { GPR_ASSERT(false); }
 
   void StartCall() override {
     // This call initiates two batches, each with a callback
@@ -1159,7 +1160,7 @@ class ClientCallbackUnaryImpl final : public ClientCallbackUnary {
       : context_(context), call_(call), reactor_(reactor) {
     this->BindReactor(reactor);
     // TODO(vjpai): don't assert
-    GPR_CODEGEN_ASSERT(start_ops_.SendMessagePtr(request).ok());
+    GPR_ASSERT(start_ops_.SendMessagePtr(request).ok());
     start_ops_.ClientSendClose();
     finish_ops_.RecvMessage(response);
     finish_ops_.AllowNoMessage();

--- a/include/grpcpp/support/client_interceptor.h
+++ b/include/grpcpp/support/client_interceptor.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <vector>
 
+#include <grpc/support/log.h>
 #include <grpcpp/impl/rpc_method.h>
 #include <grpcpp/support/interceptor.h>
 #include <grpcpp/support/string_ref.h>
@@ -135,7 +136,7 @@ class ClientRpcInfo {
   // Runs interceptor at pos \a pos.
   void RunInterceptor(
       experimental::InterceptorBatchMethods* interceptor_methods, size_t pos) {
-    GPR_CODEGEN_ASSERT(pos < interceptors_.size());
+    GPR_ASSERT(pos < interceptors_.size());
     interceptors_[pos]->Intercept(interceptor_methods);
   }
 

--- a/include/grpcpp/support/method_handler.h
+++ b/include/grpcpp/support/method_handler.h
@@ -20,6 +20,7 @@
 #define GRPCPP_SUPPORT_METHOD_HANDLER_H
 
 #include <grpc/byte_buffer.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/rpc_service_method.h>
 #include <grpcpp/support/byte_buffer.h>
@@ -57,7 +58,7 @@ template <class Callable>
 template <class ResponseType>
 void UnaryRunHandlerHelper(const MethodHandler::HandlerParameter& param,
                            ResponseType* rsp, grpc::Status& status) {
-  GPR_CODEGEN_ASSERT(!param.server_context->sent_initial_metadata_);
+  GPR_ASSERT(!param.server_context->sent_initial_metadata_);
   grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata,
                             grpc::internal::CallOpSendMessage,
                             grpc::internal::CallOpServerSendStatus>

--- a/include/grpcpp/support/proto_buffer_reader.h
+++ b/include/grpcpp/support/proto_buffer_reader.h
@@ -25,6 +25,7 @@
 #include <grpc/byte_buffer_reader.h>
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/config_protobuf.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/serialization_traits.h>
@@ -75,7 +76,7 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
     if (backup_count_ > 0) {
       *data = GRPC_SLICE_START_PTR(*slice_) + GRPC_SLICE_LENGTH(*slice_) -
               backup_count_;
-      GPR_CODEGEN_ASSERT(backup_count_ <= INT_MAX);
+      GPR_ASSERT(backup_count_ <= INT_MAX);
       *size = static_cast<int>(backup_count_);
       backup_count_ = 0;
       return true;
@@ -86,7 +87,7 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
     }
     *data = GRPC_SLICE_START_PTR(*slice_);
     // On win x64, int is only 32bit
-    GPR_CODEGEN_ASSERT(GRPC_SLICE_LENGTH(*slice_) <= INT_MAX);
+    GPR_ASSERT(GRPC_SLICE_LENGTH(*slice_) <= INT_MAX);
     byte_count_ += * size = static_cast<int>(GRPC_SLICE_LENGTH(*slice_));
     return true;
   }
@@ -98,7 +99,7 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
   /// bytes that have already been returned by the last call of Next.
   /// So do the backup and have that ready for a later Next.
   void BackUp(int count) override {
-    GPR_CODEGEN_ASSERT(count <= static_cast<int>(GRPC_SLICE_LENGTH(*slice_)));
+    GPR_ASSERT(count <= static_cast<int>(GRPC_SLICE_LENGTH(*slice_)));
     backup_count_ = count;
   }
 

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -25,6 +25,7 @@
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/slice.h>
 #include <grpc/slice_buffer.h>
+#include <grpc/support/log.h>
 #include <grpcpp/impl/codegen/config_protobuf.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/serialization_traits.h>
@@ -64,7 +65,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
         total_size_(total_size),
         byte_count_(0),
         have_backup_(false) {
-    GPR_CODEGEN_ASSERT(!byte_buffer->Valid());
+    GPR_ASSERT(!byte_buffer->Valid());
     /// Create an empty raw byte buffer and look at its underlying slice buffer
     grpc_byte_buffer* bp = grpc_raw_byte_buffer_create(nullptr, 0);
     byte_buffer->set_buffer(bp);
@@ -81,7 +82,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
   /// safe for the caller to write from data[0, size - 1].
   bool Next(void** data, int* size) override {
     // Protobuf should not ask for more memory than total_size_.
-    GPR_CODEGEN_ASSERT(byte_count_ < total_size_);
+    GPR_ASSERT(byte_count_ < total_size_);
     // 1. Use the remaining backup slice if we have one
     // 2. Otherwise allocate a slice, up to the remaining length needed
     //    or our maximum allocation size
@@ -106,7 +107,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
     }
     *data = GRPC_SLICE_START_PTR(slice_);
     // On win x64, int is only 32bit
-    GPR_CODEGEN_ASSERT(GRPC_SLICE_LENGTH(slice_) <= INT_MAX);
+    GPR_ASSERT(GRPC_SLICE_LENGTH(slice_) <= INT_MAX);
     byte_count_ += * size = static_cast<int>(GRPC_SLICE_LENGTH(slice_));
     // Using grpc_slice_buffer_add could modify slice_ and merge it with the
     // previous slice. Therefore, use grpc_slice_buffer_add_indexed method to
@@ -131,7 +132,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
     /// 2. Split it into the needed (if any) and unneeded part
     /// 3. Add the needed part back to the slice buffer
     /// 4. Mark that we still have the remaining part (for later use/unref)
-    GPR_CODEGEN_ASSERT(count <= static_cast<int>(GRPC_SLICE_LENGTH(slice_)));
+    GPR_ASSERT(count <= static_cast<int>(GRPC_SLICE_LENGTH(slice_)));
     grpc_slice_buffer_pop(slice_buffer_);
     if (static_cast<size_t>(count) == GRPC_SLICE_LENGTH(slice_)) {
       backup_slice_ = slice_;

--- a/include/grpcpp/support/server_interceptor.h
+++ b/include/grpcpp/support/server_interceptor.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <vector>
 
+#include <grpc/support/log.h>
 #include <grpcpp/impl/rpc_method.h>
 #include <grpcpp/support/interceptor.h>
 #include <grpcpp/support/string_ref.h>
@@ -99,7 +100,7 @@ class ServerRpcInfo {
   // Runs interceptor at pos \a pos.
   void RunInterceptor(
       experimental::InterceptorBatchMethods* interceptor_methods, size_t pos) {
-    GPR_CODEGEN_ASSERT(pos < interceptors_.size());
+    GPR_ASSERT(pos < interceptors_.size());
     interceptors_[pos]->Intercept(interceptor_methods);
   }
 

--- a/include/grpcpp/support/sync_stream.h
+++ b/include/grpcpp/support/sync_stream.h
@@ -19,6 +19,7 @@
 #ifndef GRPCPP_SUPPORT_SYNC_STREAM_H
 #define GRPCPP_SUPPORT_SYNC_STREAM_H
 
+#include <grpc/support/log.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/completion_queue.h>
 #include <grpcpp/impl/call.h>
@@ -184,7 +185,7 @@ class ClientReader final : public ClientReaderInterface<R> {
   ///   the server will be accessible through the \a ClientContext used to
   ///   construct this object.
   void WaitForInitialMetadata() override {
-    GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
+    GPR_ASSERT(!context_->initial_metadata_received_);
 
     grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
@@ -230,7 +231,7 @@ class ClientReader final : public ClientReaderInterface<R> {
     grpc::Status status;
     ops.ClientRecvStatus(context_, &status);
     call_.PerformOps(&ops);
-    GPR_CODEGEN_ASSERT(cq_.Pluck(&ops));
+    GPR_ASSERT(cq_.Pluck(&ops));
     return status;
   }
 
@@ -259,7 +260,7 @@ class ClientReader final : public ClientReaderInterface<R> {
     ops.SendInitialMetadata(&context->send_initial_metadata_,
                             context->initial_metadata_flags());
     // TODO(ctiller): don't assert
-    GPR_CODEGEN_ASSERT(ops.SendMessagePtr(&request).ok());
+    GPR_ASSERT(ops.SendMessagePtr(&request).ok());
     ops.ClientSendClose();
     call_.PerformOps(&ops);
     cq_.Pluck(&ops);
@@ -306,7 +307,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   ///   Once complete, the initial metadata read from the server will be
   ///   accessible through the \a ClientContext used to construct this object.
   void WaitForInitialMetadata() {
-    GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
+    GPR_ASSERT(!context_->initial_metadata_received_);
 
     grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
@@ -364,7 +365,7 @@ class ClientWriter : public ClientWriterInterface<W> {
     }
     finish_ops_.ClientRecvStatus(context_, &status);
     call_.PerformOps(&finish_ops_);
-    GPR_CODEGEN_ASSERT(cq_.Pluck(&finish_ops_));
+    GPR_ASSERT(cq_.Pluck(&finish_ops_));
     return status;
   }
 
@@ -455,7 +456,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   /// Once complete, the initial metadata read from the server will be
   /// accessible through the \a ClientContext used to construct this object.
   void WaitForInitialMetadata() override {
-    GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
+    GPR_ASSERT(!context_->initial_metadata_received_);
 
     grpc::internal::CallOpSet<grpc::internal::CallOpRecvInitialMetadata> ops;
     ops.RecvInitialMetadata(context_);
@@ -536,7 +537,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
     grpc::Status status;
     ops.ClientRecvStatus(context_, &status);
     call_.PerformOps(&ops);
-    GPR_CODEGEN_ASSERT(cq_.Pluck(&ops));
+    GPR_ASSERT(cq_.Pluck(&ops));
     return status;
   }
 
@@ -583,7 +584,7 @@ class ServerReader final : public ServerReaderInterface<R> {
   /// for semantics. Note that initial metadata will be affected by the
   /// \a ServerContext associated with this call.
   void SendInitialMetadata() override {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -640,7 +641,7 @@ class ServerWriter final : public ServerWriterInterface<W> {
   /// Note that initial metadata will be affected by the
   /// \a ServerContext associated with this call.
   void SendInitialMetadata() override {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,
@@ -713,7 +714,7 @@ class ServerReaderWriterBody final {
       : call_(call), ctx_(ctx) {}
 
   void SendInitialMetadata() {
-    GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
+    GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata> ops;
     ops.SendInitialMetadata(&ctx_->initial_metadata_,

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -67,7 +67,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"peer_state_based_framing", description_peer_state_based_framing, false},
     {"flow_control_fixes", description_flow_control_fixes, true},
     {"memory_pressure_controller", description_memory_pressure_controller,
-     false},
+     kDefaultForDebugOnly},
     {"unconstrained_max_quota_buffer_size",
      description_unconstrained_max_quota_buffer_size, false},
     {"new_hpack_huffman_decoder", description_new_hpack_huffman_decoder,

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -80,7 +80,7 @@
 - name: memory_pressure_controller
   description:
     New memory pressure controller
-  default: false
+  default: debug
   expiry: 2023/01/01
   owner: ctiller@google.com
   test_tags: [resource_quota_test]

--- a/src/core/lib/resource_quota/memory_quota.h
+++ b/src/core/lib/resource_quota/memory_quota.h
@@ -280,12 +280,12 @@ class BasicMemoryQuota final
   // Data about current memory pressure.
   struct PressureInfo {
     // The current instantaneously measured memory pressure.
-    double instantaneous_pressure;
+    double instantaneous_pressure = 0.0;
     // A control value that can be used to scale buffer sizes up or down to
     // adjust memory pressure to our target set point.
-    double pressure_control_value;
+    double pressure_control_value = 0.0;
     // Maximum recommended individual allocation size.
-    size_t max_recommended_allocation_size;
+    size_t max_recommended_allocation_size = 0;
   };
 
   explicit BasicMemoryQuota(std::string name) : name_(std::move(name)) {}
@@ -460,6 +460,7 @@ class MemoryOwner final : public MemoryAllocator {
 
   // Instantaneous memory pressure in the underlying quota.
   BasicMemoryQuota::PressureInfo GetPressureInfo() const {
+    if (!is_valid()) return BasicMemoryQuota::PressureInfo{};
     return impl()->GetPressureInfo();
   }
 

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -32,10 +32,4 @@
 #include <grpcpp/impl/codegen/core_codegen.h>
 #include <grpcpp/support/status.h>
 
-namespace grpc {
-
-const Status& CoreCodegen::ok() { return grpc::Status::OK; }
-
-const Status& CoreCodegen::cancelled() { return grpc::Status::CANCELLED; }
-
-}  // namespace grpc
+namespace grpc {}  // namespace grpc

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -38,11 +38,4 @@ const Status& CoreCodegen::ok() { return grpc::Status::OK; }
 
 const Status& CoreCodegen::cancelled() { return grpc::Status::CANCELLED; }
 
-void CoreCodegen::assert_fail(const char* failed_assertion, const char* file,
-                              int line) {
-  gpr_log(file, line, GPR_LOG_SEVERITY_ERROR, "assertion failed: %s",
-          failed_assertion);
-  abort();
-}
-
 }  // namespace grpc


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

This PR cleans up some functions in `class CoreCodegen`. Other functions should be cleaned up in a subsequent PR. The ultimate goal is to remove `class CoreCodegen` and its global pointer `g_core_codegen_interface` entirely.

