### PR TITLE
fake_handshaker_server: Allow specifying a different peer identity.

### DIFF
--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.cc
@@ -55,8 +55,10 @@ namespace gcp {
 // It is thread-safe.
 class FakeHandshakerService : public HandshakerService::Service {
  public:
-  explicit FakeHandshakerService(int expected_max_concurrent_rpcs)
-      : expected_max_concurrent_rpcs_(expected_max_concurrent_rpcs) {}
+  FakeHandshakerService(int expected_max_concurrent_rpcs,
+                        const std::string& peer_identity)
+      : expected_max_concurrent_rpcs_(expected_max_concurrent_rpcs),
+        peer_identity_(peer_identity) {}
 
   Status DoHandshake(
       ServerContext* /*server_context*/,
@@ -232,7 +234,7 @@ class FakeHandshakerService : public HandshakerService::Service {
     HandshakerResult result;
     result.set_application_protocol("grpc");
     result.set_record_protocol("ALTSRP_GCM_AES128_REKEY");
-    result.mutable_peer_identity()->set_service_account("peer_identity");
+    result.mutable_peer_identity()->set_service_account(peer_identity_);
     result.mutable_local_identity()->set_service_account("local_identity");
     string key(1024, '\0');
     result.set_key_data(key);
@@ -278,12 +280,13 @@ class FakeHandshakerService : public HandshakerService::Service {
   grpc::internal::Mutex expected_max_concurrent_rpcs_mu_;
   int concurrent_rpcs_ = 0;
   const int expected_max_concurrent_rpcs_;
+  const std::string peer_identity_;
 };
 
 std::unique_ptr<grpc::Service> CreateFakeHandshakerService(
-    int expected_max_concurrent_rpcs) {
-  return std::unique_ptr<grpc::Service>{
-      new grpc::gcp::FakeHandshakerService(expected_max_concurrent_rpcs)};
+    int expected_max_concurrent_rpcs, const std::string& peer_identity) {
+  return std::unique_ptr<grpc::Service>{new grpc::gcp::FakeHandshakerService(
+      expected_max_concurrent_rpcs, peer_identity)};
 }
 
 }  // namespace gcp

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server.h
@@ -31,7 +31,7 @@ namespace gcp {
 // will track the number of concurrent RPCs that it handles and abort
 // if if ever exceeds that number.
 std::unique_ptr<grpc::Service> CreateFakeHandshakerService(
-    int expected_max_concurrent_rpcs);
+    int expected_max_concurrent_rpcs, const std::string& peer_identity);
 
 }  // namespace gcp
 }  // namespace grpc

--- a/test/core/tsi/alts/fake_handshaker/fake_handshaker_server_main.cc
+++ b/test/core/tsi/alts/fake_handshaker/fake_handshaker_server_main.cc
@@ -29,11 +29,13 @@
 
 ABSL_FLAG(int32_t, handshaker_port, 55056,
           "TCP port on which the fake handshaker server listens to.");
+ABSL_FLAG(std::string, peer_identity, "peer_identity", "The peer identity.");
 
-static void RunFakeHandshakerServer(const std::string& server_address) {
+static void RunFakeHandshakerServer(const std::string& server_address,
+                                    const std::string& peer_identity) {
   std::unique_ptr<grpc::Service> service =
       grpc::gcp::CreateFakeHandshakerService(
-          0 /* expected max concurrent rpcs unset */);
+          /*expected_max_concurrent_rpcs=*/0, peer_identity);
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(service.get());
@@ -51,6 +53,7 @@ int main(int argc, char** argv) {
   std::ostringstream server_address;
   server_address << "[::1]:" << absl::GetFlag(FLAGS_handshaker_port);
 
-  RunFakeHandshakerServer(server_address.str());
+  RunFakeHandshakerServer(server_address.str(),
+                          absl::GetFlag(FLAGS_peer_identity));
   return 0;
 }

--- a/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
@@ -107,11 +107,12 @@ class FakeHandshakeServer {
     int port = grpc_pick_unused_port_or_die();
     address_ = grpc_core::JoinHostPort("localhost", port);
     if (check_num_concurrent_rpcs) {
-      service_ = grpc::gcp::
-          CreateFakeHandshakerService(kFakeHandshakeServerMaxConcurrentStreams /* expected max concurrent rpcs */);
+      service_ = grpc::gcp::CreateFakeHandshakerService(
+          /*expected_max_concurrent_rpcs=*/
+          kFakeHandshakeServerMaxConcurrentStreams, "peer_identity");
     } else {
       service_ = grpc::gcp::CreateFakeHandshakerService(
-          0 /* expected max concurrent rpcs unset */);
+          /*expected_max_concurrent_rpcs=*/0, "peer_identity");
     }
     grpc::ServerBuilder builder;
     builder.AddListeningPort(address_, grpc::InsecureServerCredentials());


### PR DESCRIPTION
This is helpful when writing integration tests with systems that expect a specific value for the peer.
