### PR TITLE
[time] Fix multiple second stall at startup of mac/ios apps

### DIFF
--- a/src/core/lib/gpr/time_posix.cc
+++ b/src/core/lib/gpr/time_posix.cc
@@ -113,10 +113,11 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
       now.tv_nsec = now_tv.tv_usec * 1000;
       break;
     case GPR_CLOCK_MONOTONIC:
-      now_dbl = ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
       // Add 5 seconds arbitrarily: avoids weird conditions in gprpp/time.cc
       // when there's a small number of seconds returned.
-      now.tv_sec = 5 + (int64_t)(now_dbl * 1e-9);
+      now_dbl =
+          5.0 + ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
+      now.tv_sec = (int64_t)(now_dbl * 1e-9);
       now.tv_nsec = (int32_t)(now_dbl - ((double)now.tv_sec) * 1e9);
       break;
     case GPR_CLOCK_PRECISE:

--- a/src/core/lib/gpr/time_posix.cc
+++ b/src/core/lib/gpr/time_posix.cc
@@ -114,7 +114,9 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
       break;
     case GPR_CLOCK_MONOTONIC:
       now_dbl = ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
-      now.tv_sec = (int64_t)(now_dbl * 1e-9);
+      // Add 5 seconds arbitrarily: avoids weird conditions in gprpp/time.cc
+      // when there's a small number of seconds returned.
+      now.tv_sec = (int64_t)(now_dbl * 1e-9 + 5.0);
       now.tv_nsec = (int32_t)(now_dbl - ((double)now.tv_sec) * 1e9);
       break;
     case GPR_CLOCK_PRECISE:

--- a/src/core/lib/gpr/time_posix.cc
+++ b/src/core/lib/gpr/time_posix.cc
@@ -116,7 +116,7 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
       now_dbl = ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
       // Add 5 seconds arbitrarily: avoids weird conditions in gprpp/time.cc
       // when there's a small number of seconds returned.
-      now.tv_sec = (int64_t)(now_dbl * 1e-9 + 5.0);
+      now.tv_sec = 5 + (int64_t)(now_dbl * 1e-9);
       now.tv_nsec = (int32_t)(now_dbl - ((double)now.tv_sec) * 1e9);
       break;
     case GPR_CLOCK_PRECISE:

--- a/src/core/lib/gpr/time_posix.cc
+++ b/src/core/lib/gpr/time_posix.cc
@@ -115,8 +115,8 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
     case GPR_CLOCK_MONOTONIC:
       // Add 5 seconds arbitrarily: avoids weird conditions in gprpp/time.cc
       // when there's a small number of seconds returned.
-      now_dbl =
-          5.0 + ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
+      now_dbl = 5.0e9 +
+                ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
       now.tv_sec = (int64_t)(now_dbl * 1e-9);
       now.tv_nsec = (int32_t)(now_dbl - ((double)now.tv_sec) * 1e9);
       break;

--- a/src/core/lib/gpr/time_windows.cc
+++ b/src/core/lib/gpr/time_windows.cc
@@ -61,10 +61,10 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
     case GPR_CLOCK_PRECISE:
       QueryPerformanceCounter(&timestamp);
       diff = timestamp.QuadPart - g_start_time.QuadPart;
-      now_dbl = (double)diff * g_time_scale;
       // Add an arbitrary 5 seconds to the monotonic clock so we don't
       // immediately return close to zero.
-      now_tv.tv_sec = 5 + (int64_t)now_dbl;
+      now_dbl = 5.0 + (double)diff * g_time_scale;
+      now_tv.tv_sec = (int64_t)now_dbl;
       now_tv.tv_nsec = (int32_t)((now_dbl - (double)now_tv.tv_sec) * 1e9);
       break;
     case GPR_TIMESPAN:

--- a/src/core/lib/gpr/time_windows.cc
+++ b/src/core/lib/gpr/time_windows.cc
@@ -62,7 +62,9 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
       QueryPerformanceCounter(&timestamp);
       diff = timestamp.QuadPart - g_start_time.QuadPart;
       now_dbl = (double)diff * g_time_scale;
-      now_tv.tv_sec = (int64_t)now_dbl;
+      // Add an arbitrary 5 seconds to the monotonic clock so we don't
+      // immediately return close to zero.
+      now_tv.tv_sec = 5 + (int64_t)now_dbl;
       now_tv.tv_nsec = (int32_t)((now_dbl - (double)now_tv.tv_sec) * 1e9);
       break;
     case GPR_TIMESPAN:

--- a/src/core/lib/gprpp/time.cc
+++ b/src/core/lib/gprpp/time.cc
@@ -65,7 +65,7 @@ GPR_ATTRIBUTE_NOINLINE std::pair<int64_t, gpr_cycle_counter> InitTime() {
     gpr_sleep_until(gpr_time_add(now, gpr_time_from_millis(100, GPR_TIMESPAN)));
   }
 
-  // Time does not seem to be increasing from zero...
+  // Check time has increased past 1 second.
   GPR_ASSERT(process_epoch_seconds > 1);
   // Fake the epoch to always return >=1 second from our monotonic clock (to
   // avoid bugs elsewhere)


### PR DESCRIPTION
Fixes b/261747192

Quick explainer (this is gross):
- `grpc_core::Timestamp` measures millis since an arbitrary epoch, and on 32-bit platforms is 32-bit precise
- `gpr_now(GPR_CLOCK_MONOTONIC)` measures nanos since a different arbitrary epoch
- since Timestamp has limited range, we choose its epoch to roughly correlate with process startup to avoid overflow
- since we have static initialization problems on some platforms we choose 0 as an uninitialized designator for that epoch
- since we have bugs elsewhere, we insist that time values are >1 second from Timestamp
- to deal with all that, if we get `gpr_now(GPR_CLOCK_MONOTONIC)` values that are close to 0 or 1 seconds we wait for a little while to get values that will work better later
- on mac and windows gpr_now(GPR_CLOCK_MONOTONIC) was setting its epoch to be process startup exactly, and so we hit this all the time

This PR fixes some bugs in initialization of the Timestamp epoch and clarifies the code somewhat, and (more importantly) shifts the Windows and Mac epochs five seconds prior to process startup, guaranteeing that the logic in `grpc_core::Timestamp`'s epoch sees values that it can immediately use in all cases and eliminating the need for the pause.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

