### PR TITLE
[BinderTransport] Make `CreateBinderChannel` parameter names consistent

### DIFF
--- a/include/grpcpp/create_channel_binder.h
+++ b/include/grpcpp/create_channel_binder.h
@@ -36,7 +36,7 @@ namespace experimental {
 /// name and class name will be used identify the specific application component
 /// to connect to.
 ///
-/// \param jni_env Pointer to a JNIEnv structure
+/// \param jni_env_void Pointer to a JNIEnv structure
 /// \param context The context that we will use to invoke \a bindService See
 /// https://developer.android.com/reference/android/content/Context#bindService(android.content.Intent,%20android.content.ServiceConnection,%20int)
 /// for detail.
@@ -45,7 +45,7 @@ namespace experimental {
 /// \param security_policy Used for checking if remote component is allowed to
 /// connect
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
-    void* jni_env, jobject context, absl::string_view package_name,
+    void* jni_env_void, jobject context, absl::string_view package_name,
     absl::string_view class_name,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy>
         security_policy);
@@ -54,7 +54,7 @@ std::shared_ptr<grpc::Channel> CreateBinderChannel(
 /// name and class name will be used identify the specific application component
 /// to connect to.
 ///
-/// \param jni_env Pointer to a JNIEnv structure
+/// \param jni_env_void Pointer to a JNIEnv structure
 /// \param context The context that we will use to invoke \a bindService See
 /// https://developer.android.com/reference/android/content/Context#bindService(android.content.Intent,%20android.content.ServiceConnection,%20int)
 /// for detail.
@@ -64,14 +64,14 @@ std::shared_ptr<grpc::Channel> CreateBinderChannel(
 /// connect
 /// \param args Options for channel creation.
 std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
-    void* jni_env_void, jobject application, absl::string_view package_name,
+    void* jni_env_void, jobject context, absl::string_view package_name,
     absl::string_view class_name,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
     const ChannelArguments& args);
 
 /// EXPERIMENTAL Create a new \a Channel based on binder transport.
 ///
-/// \param jni_env Pointer to a JNIEnv structure
+/// \param jni_env_void Pointer to a JNIEnv structure
 /// \param context The context that we will use to invoke \a bindService See
 /// https://developer.android.com/reference/android/content/Context#bindService(android.content.Intent,%20android.content.ServiceConnection,%20int)
 /// for detail.
@@ -80,13 +80,13 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
 /// \param security_policy Used for checking if remote component is allowed to
 /// connect
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
-    void* jni_env, jobject context, absl::string_view uri,
+    void* jni_env_void, jobject context, absl::string_view uri,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy>
         security_policy);
 
 /// EXPERIMENTAL Create a new \a Channel based on binder transport.
 ///
-/// \param jni_env Pointer to a JNIEnv structure
+/// \param jni_env_void Pointer to a JNIEnv structure
 /// \param context The context that we will use to invoke \a bindService See
 /// https://developer.android.com/reference/android/content/Context#bindService(android.content.Intent,%20android.content.ServiceConnection,%20int)
 /// for detail.
@@ -96,7 +96,7 @@ std::shared_ptr<grpc::Channel> CreateBinderChannel(
 /// connect
 /// \param args Options for channel creation.
 std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
-    void* jni_env, jobject context, absl::string_view uri,
+    void* jni_env_void, jobject context, absl::string_view uri,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
     const ChannelArguments& args);
 

--- a/src/core/ext/transport/binder/client/channel_create.cc
+++ b/src/core/ext/transport/binder/client/channel_create.cc
@@ -66,37 +66,37 @@ namespace grpc {
 namespace experimental {
 
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
-    void* jni_env_void, jobject application, absl::string_view package_name,
+    void* jni_env_void, jobject context, absl::string_view package_name,
     absl::string_view class_name,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy>
         security_policy) {
-  return CreateCustomBinderChannel(jni_env_void, application, package_name,
+  return CreateCustomBinderChannel(jni_env_void, context, package_name,
                                    class_name, security_policy,
                                    ChannelArguments());
 }
 
 std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
-    void* jni_env_void, jobject application, absl::string_view package_name,
+    void* jni_env_void, jobject context, absl::string_view package_name,
     absl::string_view class_name,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
     const ChannelArguments& args) {
   return CreateCustomBinderChannel(
-      jni_env_void, application,
+      jni_env_void, context,
       absl::Substitute("android-app://$0#Intent;action=$1;component=$0/$2;end",
                        package_name, kStandardActionName, class_name),
       security_policy, args);
 }
 
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
-    void* jni_env_void, jobject application, absl::string_view uri,
+    void* jni_env_void, jobject context, absl::string_view uri,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy>
         security_policy) {
-  return CreateCustomBinderChannel(jni_env_void, application, uri,
-                                   security_policy, ChannelArguments());
+  return CreateCustomBinderChannel(jni_env_void, context, uri, security_policy,
+                                   ChannelArguments());
 }
 
 std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
-    void* jni_env_void, jobject application, absl::string_view uri,
+    void* jni_env_void, jobject context, absl::string_view uri,
     std::shared_ptr<grpc::experimental::binder::SecurityPolicy> security_policy,
     const ChannelArguments& args) {
   grpc_init();
@@ -117,7 +117,7 @@ std::shared_ptr<grpc::Channel> CreateCustomBinderChannel(
   // until SubchannelConnector start establishing connection. For now we don't
   // see any benifits doing that.
   grpc_binder::TryEstablishConnectionWithUri(static_cast<JNIEnv*>(jni_env_void),
-                                             application, uri, connection_id);
+                                             context, uri, connection_id);
 
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);


### PR DESCRIPTION
* Rename `jni_env` to `jni_env_void`
* Rename `application` to `context`




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

