### PR TITLE
Work around UnaryCall hang with corrupt status detail string #29854

### DIFF
--- a/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
@@ -137,7 +137,7 @@ namespace Grpc.Core.Internal
             return true;
         }
 
-        // This method decodes the status details string "safely" and returns and empty
+        // This method decodes the status details string "safely" and returns an empty
         // string in case it seems corrupt.
         // This is to stop UnaryCall from hanging if there is an issue with decoding
         // the UTF8 status details string (likely due to an unexplained corruption).


### PR DESCRIPTION
An improved and more targeted version of https://github.com/grpc/grpc/pull/31450.

Fixes the unary call hang #29854 by eating the exception when attempting to parse a corrupt status details string (and returning an empty status string instead).

