### PR TITLE
Change ProtoReflectionDescriptorDatabase to take grpc::ChannelInterface.

### DIFF
--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -35,7 +35,7 @@ ProtoReflectionDescriptorDatabase::ProtoReflectionDescriptorDatabase(
     : stub_(std::move(stub)) {}
 
 ProtoReflectionDescriptorDatabase::ProtoReflectionDescriptorDatabase(
-    const std::shared_ptr<grpc::Channel>& channel)
+    const std::shared_ptr<grpc::ChannelInterface>& channel)
     : stub_(ServerReflection::NewStub(channel)) {}
 
 ProtoReflectionDescriptorDatabase::~ProtoReflectionDescriptorDatabase() {

--- a/test/cpp/util/proto_reflection_descriptor_database.h
+++ b/test/cpp/util/proto_reflection_descriptor_database.h
@@ -39,7 +39,7 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
       std::unique_ptr<reflection::v1alpha::ServerReflection::Stub> stub);
 
   explicit ProtoReflectionDescriptorDatabase(
-      const std::shared_ptr<grpc::Channel>& channel);
+      const std::shared_ptr<grpc::ChannelInterface>& channel);
 
   ~ProtoReflectionDescriptorDatabase() override;
 


### PR DESCRIPTION
Updates the `ProtoReflectionDescriptorDatabase` ctor to take a reference to `std::shared_ptr<grpc::ChannelInterface>` rather than `std::shared_ptr<grpc::Channel>`. This helps code that is making use of `grpc::ChannelInterface` from having to perform a cast from the Base to the Derived when creating the refelction db.

I was not able to discern a reason why `grpc::Channel` is currently used since it is passed on to the stub ctor which takes a `grpc::ChannelInterface`.