### PR TITLE
[o11y] Rough transport latency metric

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2090,6 +2090,8 @@ void grpc_chttp2_mark_stream_closed(grpc_chttp2_transport* t,
     grpc_chttp2_maybe_complete_recv_message(t, s);
   }
   if (became_closed) {
+    s->stats.latency =
+        gpr_time_sub(gpr_now(GPR_CLOCK_MONOTONIC), s->creation_time);
     grpc_chttp2_maybe_complete_recv_trailing_metadata(t, s);
     GRPC_CHTTP2_STREAM_UNREF(s, "chttp2");
   }

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -585,6 +585,9 @@ struct grpc_chttp2_stream {
   bool traced = false;
   /** Byte counter for number of bytes written */
   size_t byte_counter = 0;
+
+  // time this stream was created
+  gpr_timespec creation_time = gpr_now(GPR_CLOCK_MONOTONIC);
 };
 
 /** Transport writing call flow:

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -97,6 +97,7 @@ void grpc_transport_move_stats(grpc_transport_stream_stats* from,
                                grpc_transport_stream_stats* to) {
   grpc_transport_move_one_way_stats(&from->incoming, &to->incoming);
   grpc_transport_move_one_way_stats(&from->outgoing, &to->outgoing);
+  to->latency = std::exchange(from->latency, gpr_inf_future(GPR_TIMESPAN));
 }
 
 size_t grpc_transport_stream_size(grpc_transport* transport) {

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -239,6 +239,7 @@ struct grpc_transport_one_way_stats {
 struct grpc_transport_stream_stats {
   grpc_transport_one_way_stats incoming;
   grpc_transport_one_way_stats outgoing;
+  gpr_timespec latency = gpr_inf_future(GPR_TIMESPAN);
 };
 
 void grpc_transport_move_one_way_stats(grpc_transport_one_way_stats* from,


### PR DESCRIPTION
This is a terrible approximation of the transport latency we've been talking about including - a correct measure should be measured from actually sending initial metadata, not the creation of the stream (though the termination part is probably close to the right place!)

Nevertheless, I think this will help some folks now and we can tune later.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

