### PR TITLE
fix generate_projects.sh fails in M1 Mac

### DIFF
--- a/tools/distrib/buildozer.sh
+++ b/tools/distrib/buildozer.sh
@@ -33,6 +33,7 @@ function download_buildozer() {
     platform="$(uname -sm)"
     case "${platform}" in
         "Linux x86_64")     download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-linux-amd64";;
+        "Linux aarch64")    download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-linux-arm64";;
         "Darwin x86_64")    download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-darwin-amd64";;
         "Darwin arm64")     download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-darwin-arm64";;
         *)                  error_handling "Unsupported platform: ${platform}";;

--- a/tools/distrib/buildozer.sh
+++ b/tools/distrib/buildozer.sh
@@ -30,11 +30,12 @@ function error_handling() {
 }
 
 function download_buildozer() {
-    platform="$(uname -s)"
+    platform="$(uname -sm)"
     case "${platform}" in
-        Linux*)     download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-linux-amd64";;
-        Darwin*)    download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-darwin-amd64";;
-        *)          error_handling "Unsupported platform: ${platform}";;
+        "Linux x86_64")     download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-linux-amd64";;
+        "Darwin x86_64")    download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-darwin-amd64";;
+        "Darwin arm64")     download_link="https://github.com/bazelbuild/buildtools/releases/download/${BUILDOZER_VERSION}/buildozer-darwin-arm64";;
+        *)                  error_handling "Unsupported platform: ${platform}";;
     esac
 
     download_success=0

--- a/tools/distrib/fix_build_deps.py
+++ b/tools/distrib/fix_build_deps.py
@@ -631,25 +631,26 @@ def make_library(library):
     return (library, error, deps, external_deps)
 
 
-update_libraries = []
-for library in sorted(consumes.keys()):
-    if library in no_update:
-        continue
-    if args.targets and library not in args.targets:
-        continue
-    update_libraries.append(library)
-with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as p:
-    updated_libraries = p.map(make_library, update_libraries, 1)
+if __name__ == "__main__":
+    update_libraries = []
+    for library in sorted(consumes.keys()):
+        if library in no_update:
+            continue
+        if args.targets and library not in args.targets:
+            continue
+        update_libraries.append(library)
+    with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as p:
+        updated_libraries = p.map(make_library, update_libraries, 1)
 
-error = False
-for library, lib_error, deps, external_deps in updated_libraries:
-    if lib_error:
-        error = True
-        continue
-    buildozer_set_list('external_deps', external_deps, library, via='deps')
-    buildozer_set_list('deps', deps, library)
+    error = False
+    for library, lib_error, deps, external_deps in updated_libraries:
+        if lib_error:
+            error = True
+            continue
+        buildozer_set_list('external_deps', external_deps, library, via='deps')
+        buildozer_set_list('deps', deps, library)
 
-run_buildozer.run_buildozer(buildozer_commands)
+    run_buildozer.run_buildozer(buildozer_commands)
 
-if error:
-    sys.exit(1)
+    if error:
+        sys.exit(1)


### PR DESCRIPTION
use `buildozer-darwin-arm64` package with ARM Mac

add `if __name__ == "__main__":` test which is required on Mac after Python 3.8 because `spawn` is used in `multiprocessing`



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

