### PR TITLE
[promises] Move Empty to be first class

### DIFF
--- a/src/core/lib/promise/poll.h
+++ b/src/core/lib/promise/poll.h
@@ -32,6 +32,12 @@ struct Pending {
   constexpr bool operator==(Pending) const { return true; }
 };
 
+// A type that contains no value. Useful for simulating 'void' in promises that
+// always need to return some kind of value.
+struct Empty {
+  constexpr bool operator==(Empty) const { return true; }
+};
+
 // The result of polling a Promise once.
 //
 // Can be either pending - the Promise has not yet completed, or ready -

--- a/src/core/lib/promise/try_join.h
+++ b/src/core/lib/promise/try_join.h
@@ -40,7 +40,6 @@ T IntoResult(absl::StatusOr<T>* status) {
 // TryJoin returns a StatusOr<tuple<A,B,C>> for f()->Poll<StatusOr<A>>,
 // g()->Poll<StatusOr<B>>, h()->Poll<StatusOr<C>>. If one of those should be a
 // Status instead, we need a placeholder type to return, and this is it.
-struct Empty {};
 inline Empty IntoResult(absl::Status*) { return Empty{}; }
 
 // Traits object to pass to BasicJoin

--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -301,7 +301,6 @@ class BasicMemoryQuota::WaitForSweepPromise {
                       uint64_t token)
       : memory_quota_(std::move(memory_quota)), token_(token) {}
 
-  struct Empty {};
   Poll<Empty> operator()() {
     if (memory_quota_->reclamation_counter_.load(std::memory_order_relaxed) !=
         token_) {


### PR DESCRIPTION
Promises cannot return void, and it's really problematic to do so.
I've been using `Empty` in that place occasionally, time to promote it to be the solution.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

