### PR TITLE
[c++20] Demonstrate coroutines being used as promises

### DIFF
--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -186,6 +186,11 @@ class CensusContext {
     span_.AddAttribute(key, attribute);
   }
 
+  void AddSpanAnnotation(absl::string_view description,
+                         opencensus::trace::AttributesRef attributes) {
+    span_.AddAnnotation(description, attributes);
+  }
+
   const ::opencensus::trace::Span& Span() const { return span_; }
   const ::opencensus::tags::TagMap& tags() const { return tags_; }
 

--- a/src/core/lib/channel/call_tracer.h
+++ b/src/core/lib/channel/call_tracer.h
@@ -75,6 +75,10 @@ class CallTracer {
     // Should be the last API call to the object. Once invoked, the tracer
     // library is free to destroy the object.
     virtual void RecordEnd(const gpr_timespec& latency) = 0;
+    // Records an annotation on the call attempt.
+    // TODO(yashykt): If needed, extend this to attach attributes with
+    // annotations.
+    virtual void RecordAnnotation(absl::string_view annotation) = 0;
   };
 
   virtual ~CallTracer() {}
@@ -87,6 +91,10 @@ class CallTracer {
   // serves as an indication that the call stack is done with all API calls, and
   // the tracer library is free to destroy it after that.
   virtual CallAttemptTracer* StartNewAttempt(bool is_transparent_retry) = 0;
+  // Records an annotation on the call attempt.
+  // TODO(yashykt): If needed, extend this to attach attributes with
+  // annotations.
+  virtual void RecordAnnotation(absl::string_view annotation) = 0;
 };
 
 }  // namespace grpc_core

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -246,6 +246,11 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordEnd(
   }
 }
 
+void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordAnnotation(
+    absl::string_view annotation) {
+  context_.AddSpanAnnotation(annotation, {});
+}
+
 //
 // OpenCensusCallTracer
 //
@@ -310,6 +315,10 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
   }
   return new OpenCensusCallAttemptTracer(
       this, attempt_num, is_transparent_retry, false /* arena_allocated */);
+}
+
+void OpenCensusCallTracer::RecordAnnotation(absl::string_view annotation) {
+  context_.AddSpanAnnotation(annotation, {});
 }
 
 CensusContext OpenCensusCallTracer::CreateCensusContextForCallAttempt() {

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -81,6 +81,7 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
         const grpc_transport_stream_stats* transport_stream_stats) override;
     void RecordCancel(grpc_error_handle cancel_error) override;
     void RecordEnd(const gpr_timespec& /*latency*/) override;
+    void RecordAnnotation(absl::string_view annotation) override;
 
     experimental::CensusContext* context() { return &context_; }
 
@@ -108,6 +109,7 @@ class OpenCensusCallTracer : public grpc_core::CallTracer {
   void GenerateContext();
   OpenCensusCallAttemptTracer* StartNewAttempt(
       bool is_transparent_retry) override;
+  void RecordAnnotation(absl::string_view annotation) override;
 
  private:
   experimental::CensusContext CreateCensusContextForCallAttempt();

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -36,6 +36,21 @@ grpc_cc_library(
 )
 
 grpc_cc_test(
+    name = "cpp20_test",
+    srcs = ["cpp20_test.cc"],
+    copts = ["-std=c++20"],
+    external_deps = ["gtest"],
+    language = "c++",
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//src/core:construct_destruct",
+        "//src/core:poll",
+        "//src/core:promise_like",
+    ],
+)
+
+grpc_cc_test(
     name = "poll_test",
     srcs = ["poll_test.cc"],
     external_deps = ["gtest"],

--- a/test/core/promise/cpp20_test.cc
+++ b/test/core/promise/cpp20_test.cc
@@ -1,0 +1,94 @@
+// Copyright 2022 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <coroutine>
+#include <optional>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "src/core/lib/gprpp/construct_destruct.h"
+#include "src/core/lib/promise/detail/promise_like.h"
+#include "src/core/lib/promise/poll.h"
+
+namespace grpc_core {
+namespace {
+
+// A wrapper around a coroutine that can be used as a promise.
+template <typename T>
+class Async {
+ public:
+  struct promise_type {
+    using Handle = std::coroutine_handle<promise_type>;
+    std::optional<T> value;
+    Async<T> get_return_object() {
+      return Async<T>{Handle::from_promise(*this)};
+    }
+    std::suspend_always initial_suspend() noexcept { return {}; }
+    std::suspend_always final_suspend() noexcept { return {}; }
+    void unhandled_exception() {}
+    void return_value(T value) { value = std::move(value); }
+  };
+
+  explicit Async(typename promise_type::Handle coroutine)
+      : coroutine_(coroutine) {}
+
+  Async(const Async&) = delete;
+  Async& operator=(const Async&) = delete;
+  Async(Async&& t) noexcept : coroutine_(std::move(t.coroutine_)) {}
+  Async& operator=(Async&& t) noexcept {
+    std::swap(coroutine_, t.coroutine_);
+    return *this;
+  }
+  ~Async() {
+    if (coroutine_) {
+      coroutine_.destroy();
+    }
+  }
+
+  Poll<T> operator()() {
+    coroutine_.resume();
+    if (coroutine_.done()) {
+      return std::move(*coroutine_.promise().value);
+    } else {
+      return Pending{};
+    }
+  }
+
+ private:
+  typename promise_type::Handle coroutine_;
+};
+
+Async<int> TestFunction() {
+  printf("TestFunction.0\n");
+  co_await std::suspend_always{};
+  printf("TestFunction.1\n");
+  co_return 42;
+}
+
+TEST(Cpp20Test, CoroutinesArePromises) {
+  auto f = TestFunction();
+  printf("initial poll\n");
+  EXPECT_EQ(f(), Poll<int>(Pending{}));
+  printf("final poll\n");
+  EXPECT_EQ(f(), Poll<int>(42));
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
A 'proof of implementability' test: demonstrate a C++ coroutine being used as a promise with zero overhead.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

