### PR TITLE
Update tcp server interface to move on_accept_cb to the create method

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -680,7 +680,7 @@ grpc_error_handle Chttp2ServerListener::Create(
     error = grpc_tcp_server_create(
         &listener->tcp_server_shutdown_complete_,
         grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-        &listener->tcp_server_);
+        OnAccept, listener, &listener->tcp_server_);
     if (!error.ok()) return error;
     if (server->config_fetcher() != nullptr) {
       listener->resolved_address_ = *addr;
@@ -727,7 +727,7 @@ grpc_error_handle Chttp2ServerListener::CreateWithAcceptor(
   grpc_error_handle error = grpc_tcp_server_create(
       &listener->tcp_server_shutdown_complete_,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-      &listener->tcp_server_);
+      OnAccept, listener, &listener->tcp_server_);
   if (!error.ok()) {
     delete listener;
     return error;
@@ -780,7 +780,7 @@ void Chttp2ServerListener::Start(
 }
 
 void Chttp2ServerListener::StartListening() {
-  grpc_tcp_server_start(tcp_server_, &server_->pollsets(), OnAccept, this);
+  grpc_tcp_server_start(tcp_server_, &server_->pollsets());
 }
 
 void Chttp2ServerListener::SetOnDestroyDone(grpc_closure* on_destroy_done) {

--- a/src/core/lib/iomgr/tcp_server.cc
+++ b/src/core/lib/iomgr/tcp_server.cc
@@ -25,14 +25,14 @@ grpc_tcp_server_vtable* grpc_tcp_server_impl;
 grpc_error_handle grpc_tcp_server_create(
     grpc_closure* shutdown_complete,
     const grpc_event_engine::experimental::EndpointConfig& config,
-    grpc_tcp_server** server) {
-  return grpc_tcp_server_impl->create(shutdown_complete, config, server);
+    grpc_tcp_server_cb on_accept_cb, void* cb_arg, grpc_tcp_server** server) {
+  return grpc_tcp_server_impl->create(shutdown_complete, config, on_accept_cb,
+                                      cb_arg, server);
 }
 
 void grpc_tcp_server_start(grpc_tcp_server* server,
-                           const std::vector<grpc_pollset*>* pollsets,
-                           grpc_tcp_server_cb on_accept_cb, void* cb_arg) {
-  grpc_tcp_server_impl->start(server, pollsets, on_accept_cb, cb_arg);
+                           const std::vector<grpc_pollset*>* pollsets) {
+  grpc_tcp_server_impl->start(server, pollsets);
 }
 
 grpc_error_handle grpc_tcp_server_add_port(grpc_tcp_server* s,

--- a/src/core/lib/iomgr/tcp_server.h
+++ b/src/core/lib/iomgr/tcp_server.h
@@ -67,10 +67,9 @@ typedef struct grpc_tcp_server_vtable {
   grpc_error_handle (*create)(
       grpc_closure* shutdown_complete,
       const grpc_event_engine::experimental::EndpointConfig& config,
-      grpc_tcp_server** server);
+      grpc_tcp_server_cb on_accept_cb, void* cb_arg, grpc_tcp_server** server);
   void (*start)(grpc_tcp_server* server,
-                const std::vector<grpc_pollset*>* pollsets,
-                grpc_tcp_server_cb on_accept_cb, void* cb_arg);
+                const std::vector<grpc_pollset*>* pollsets);
   grpc_error_handle (*add_port)(grpc_tcp_server* s,
                                 const grpc_resolved_address* addr,
                                 int* out_port);
@@ -91,12 +90,11 @@ typedef struct grpc_tcp_server_vtable {
 grpc_error_handle grpc_tcp_server_create(
     grpc_closure* shutdown_complete,
     const grpc_event_engine::experimental::EndpointConfig& config,
-    grpc_tcp_server** server);
+    grpc_tcp_server_cb on_accept_cb, void* cb_arg, grpc_tcp_server** server);
 
 /* Start listening to bound ports */
 void grpc_tcp_server_start(grpc_tcp_server* server,
-                           const std::vector<grpc_pollset*>* pollsets,
-                           grpc_tcp_server_cb on_accept_cb, void* cb_arg);
+                           const std::vector<grpc_pollset*>* pollsets);
 
 /* Add a port to the server, returning the newly allocated port on success, or
    -1 on failure.

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -99,7 +99,6 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, int fd,
   std::string name = absl::StrCat("tcp-server-listener:", addr_str.value());
   gpr_mu_lock(&s->mu);
   s->nports++;
-  GPR_ASSERT(!s->on_accept_cb && "must add ports before starting server");
   grpc_tcp_listener* sp =
       static_cast<grpc_tcp_listener*>(gpr_malloc(sizeof(grpc_tcp_listener)));
   sp->next = nullptr;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -425,7 +425,6 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
 
   GPR_ASSERT(port >= 0);
   gpr_mu_lock(&s->mu);
-  GPR_ASSERT(!s->on_accept_cb && "must add ports before starting server");
   sp = (grpc_tcp_listener*)gpr_malloc(sizeof(grpc_tcp_listener));
   sp->next = NULL;
   if (s->head == NULL) {
@@ -526,7 +525,6 @@ done:
 static void tcp_server_start(grpc_tcp_server* s,
                              const std::vector<grpc_pollset*>* /*pollsets*/) {
   grpc_tcp_listener* sp;
-  GPR_ASSERT(on_accept_cb);
   gpr_mu_lock(&s->mu);
   GPR_ASSERT(s->on_accept_cb);
   GPR_ASSERT(s->active_ports == 0);

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -526,7 +526,6 @@ static void tcp_server_start(grpc_tcp_server* s,
                              const std::vector<grpc_pollset*>* /*pollsets*/) {
   grpc_tcp_listener* sp;
   gpr_mu_lock(&s->mu);
-  GPR_ASSERT(s->on_accept_cb);
   GPR_ASSERT(s->active_ports == 0);
   for (sp = s->head; sp; sp = sp->next) {
     GPR_ASSERT(GRPC_LOG_IF_ERROR("start_accept", start_accept_locked(sp)));

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -629,7 +629,7 @@ grpc_end2end_http_proxy* grpc_end2end_http_proxy_create(
   grpc_error_handle error = grpc_tcp_server_create(
       nullptr,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(channel_args),
-      &proxy->server);
+      on_accept, proxy, &proxy->server);
   GPR_ASSERT(error.ok());
   // Bind to port.
   grpc_resolved_address resolved_addr;
@@ -646,7 +646,7 @@ grpc_end2end_http_proxy* grpc_end2end_http_proxy_create(
   auto* pollset = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
   grpc_pollset_init(pollset, &proxy->mu);
   proxy->pollset.push_back(pollset);
-  grpc_tcp_server_start(proxy->server, &proxy->pollset, on_accept, proxy);
+  grpc_tcp_server_start(proxy->server, &proxy->pollset);
 
   // Start proxy thread.
   proxy->thd = grpc_core::Thread("grpc_http_proxy", thread_main, proxy);

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -176,7 +176,7 @@ static void test_no_op(void) {
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+          on_connect, nullptr, &s));
   grpc_tcp_server_unref(s);
 }
 
@@ -191,10 +191,10 @@ static void test_no_op_with_start(void) {
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+          on_connect, nullptr, &s));
   LOG_TEST("test_no_op_with_start");
   std::vector<grpc_pollset*> empty_pollset;
-  grpc_tcp_server_start(s, &empty_pollset, on_connect, nullptr);
+  grpc_tcp_server_start(s, &empty_pollset);
   grpc_tcp_server_unref(s);
 }
 
@@ -212,7 +212,7 @@ static void test_no_op_with_port(void) {
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+          on_connect, nullptr, &s));
   LOG_TEST("test_no_op_with_port");
 
   memset(&resolved_addr, 0, sizeof(resolved_addr));
@@ -240,7 +240,7 @@ static void test_no_op_with_port_and_start(void) {
       grpc_tcp_server_create(
           nullptr,
           grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-          &s));
+          on_connect, nullptr, &s));
   LOG_TEST("test_no_op_with_port_and_start");
   int port = -1;
 
@@ -252,7 +252,7 @@ static void test_no_op_with_port_and_start(void) {
   ASSERT_GT(port, 0);
 
   std::vector<grpc_pollset*> empty_pollset;
-  grpc_tcp_server_start(s, &empty_pollset, on_connect, nullptr);
+  grpc_tcp_server_start(s, &empty_pollset);
 
   grpc_tcp_server_unref(s);
 }
@@ -344,7 +344,7 @@ static void test_connect(size_t num_connects,
                 nullptr,
                 grpc_event_engine::experimental::ChannelArgsEndpointConfig(
                     new_channel_args),
-                &s));
+                on_connect, nullptr, &s));
   unsigned port_num;
   server_weak_ref weak_ref;
   server_weak_ref_init(&weak_ref);
@@ -392,7 +392,7 @@ static void test_connect(size_t num_connects,
 
   std::vector<grpc_pollset*> test_pollset;
   test_pollset.push_back(g_pollset);
-  grpc_tcp_server_start(s, &test_pollset, on_connect, nullptr);
+  grpc_tcp_server_start(s, &test_pollset);
 
   if (dst_addrs != nullptr) {
     int ports[] = {svr_port, svr1_port};

--- a/test/core/surface/concurrent_connectivity_test.cc
+++ b/test/core/surface/concurrent_connectivity_test.cc
@@ -150,7 +150,7 @@ void bad_server_thread(void* vargs) {
   grpc_error_handle error = grpc_tcp_server_create(
       nullptr,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(channel_args),
-      &s);
+      on_connect, args, &s);
   ASSERT_TRUE(error.ok());
   memset(&resolved_addr, 0, sizeof(resolved_addr));
   addr->sa_family = GRPC_AF_INET;
@@ -159,7 +159,7 @@ void bad_server_thread(void* vargs) {
   ASSERT_GT(port, 0);
   args->addr = absl::StrCat("localhost:", port);
 
-  grpc_tcp_server_start(s, &args->pollset, on_connect, args);
+  grpc_tcp_server_start(s, &args->pollset);
   gpr_event_set(&args->ready, reinterpret_cast<void*>(1));
 
   gpr_mu_lock(args->mu);

--- a/test/core/util/test_tcp_server.cc
+++ b/test/core/util/test_tcp_server.cc
@@ -79,15 +79,14 @@ void test_tcp_server_start(test_tcp_server* server, int port) {
   grpc_error_handle error = grpc_tcp_server_create(
       &server->shutdown_complete,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(args),
-      &server->tcp_server);
+      server->on_connect, server->cb_data, &server->tcp_server);
   GPR_ASSERT(error.ok());
   error =
       grpc_tcp_server_add_port(server->tcp_server, &resolved_addr, &port_added);
   GPR_ASSERT(error.ok());
   GPR_ASSERT(port_added == port);
 
-  grpc_tcp_server_start(server->tcp_server, &server->pollset,
-                        server->on_connect, server->cb_data);
+  grpc_tcp_server_start(server->tcp_server, &server->pollset);
   gpr_log(GPR_INFO, "test tcp server listening on 0.0.0.0:%d", port);
 }
 


### PR DESCRIPTION
This is required for event engine-iomgr shim layer integration.

EventEngine listeners require an on_accept callback when they are created. But the grpc_tcp_server_create method does not take the on_accept callback. The on_accept callback is instead only provided to the grpc_tcp_server_start method. This change moves the on_accept callback and its argument to the create method.

It would allow creating EventEngine listeners in the create method implementation directly. Otherwise they cannot be created here since the on_accept_cb callback is not provided at this point.

