### PR TITLE
Tracing: Add annotations for when call is removed from resolver result queue and lb pick queue

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2148,8 +2148,7 @@ void ClientChannel::CallData::MaybeRemoveCallFromResolverQueuedCallsLocked(
   auto* call_tracer =
       static_cast<CallTracer*>(call_context_[GRPC_CONTEXT_CALL_TRACER].value);
   if (call_tracer != nullptr) {
-    call_tracer->RecordAnnotation(
-        "Removed call from channel's pending resolver result queue.");
+    call_tracer->RecordAnnotation("Delayed name resolution complete.");
   }
 }
 
@@ -3040,8 +3039,7 @@ void ClientChannel::LoadBalancedCall::MaybeRemoveCallFromLbQueuedCallsLocked() {
   lb_call_canceller_ = nullptr;
   // Add trace annotation
   if (call_attempt_tracer_ != nullptr) {
-    call_attempt_tracer_->RecordAnnotation(
-        "Removed call attempt from channel's pending LB pick queue.");
+    call_attempt_tracer_->RecordAnnotation("Delayed LB pick complete.");
   }
 }
 

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2144,6 +2144,13 @@ void ClientChannel::CallData::MaybeRemoveCallFromResolverQueuedCallsLocked(
   queued_pending_resolver_result_ = false;
   // Lame the call combiner canceller.
   resolver_call_canceller_ = nullptr;
+  // Add trace annotation
+  auto* call_tracer =
+      static_cast<CallTracer*>(call_context_[GRPC_CONTEXT_CALL_TRACER].value);
+  if (call_tracer != nullptr) {
+    call_tracer->RecordAnnotation(
+        "Removed call from channel's pending resolver result queue.");
+  }
 }
 
 void ClientChannel::CallData::MaybeAddCallToResolverQueuedCallsLocked(
@@ -3031,6 +3038,11 @@ void ClientChannel::LoadBalancedCall::MaybeRemoveCallFromLbQueuedCallsLocked() {
   queued_pending_lb_pick_ = false;
   // Lame the call combiner canceller.
   lb_call_canceller_ = nullptr;
+  // Add trace annotation
+  if (call_attempt_tracer_ != nullptr) {
+    call_attempt_tracer_->RecordAnnotation(
+        "Removed call attempt from channel's pending LB pick queue.");
+  }
 }
 
 void ClientChannel::LoadBalancedCall::MaybeAddCallToLbQueuedCallsLocked() {

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -248,6 +248,7 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordEnd(
 
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordAnnotation(
     absl::string_view annotation) {
+  // If tracing is disabled, the following will be a no-op.
   context_.AddSpanAnnotation(annotation, {});
 }
 

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -319,6 +319,7 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
 }
 
 void OpenCensusCallTracer::RecordAnnotation(absl::string_view annotation) {
+  // If tracing is disabled, the following will be a no-op.
   context_.AddSpanAnnotation(annotation, {});
 }
 

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -792,17 +792,15 @@ TEST_F(StatsPluginEnd2EndTest,
   auto sent_span_data =
       GetSpanByName(recorded_spans, absl::StrCat("Sent.", client_method_name_));
   ASSERT_NE(sent_span_data, recorded_spans.end());
-  EXPECT_TRUE(IsAnnotationPresent(
-      sent_span_data,
-      "Removed call from channel's pending resolver result queue."));
+  EXPECT_TRUE(
+      IsAnnotationPresent(sent_span_data, "Delayed name resolution complete."));
   // Check presence of trace annotation for removal from channel's pending
   // lb pick queue.
   auto attempt_span_data = GetSpanByName(
       recorded_spans, absl::StrCat("Attempt.", client_method_name_));
   ASSERT_NE(attempt_span_data, recorded_spans.end());
-  EXPECT_TRUE(IsAnnotationPresent(
-      attempt_span_data,
-      "Removed call attempt from channel's pending LB pick queue."));
+  EXPECT_TRUE(
+      IsAnnotationPresent(attempt_span_data, "Delayed LB pick complete."));
 }
 
 // Test the working of GRPC_ARG_DISABLE_OBSERVABILITY.

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -685,6 +685,15 @@ TEST_F(StatsPluginEnd2EndTest, TestApplicationCensusContextFlows) {
   EXPECT_TRUE(status.ok());
 }
 
+std::vector<opencensus::trace::exporter::SpanData>::const_iterator
+GetSpanByName(
+    const std::vector<::opencensus::trace::exporter::SpanData>& recorded_spans,
+    absl::string_view name) {
+  return std::find_if(
+      recorded_spans.begin(), recorded_spans.end(),
+      [name](auto const& span_data) { return span_data.name() == name; });
+}
+
 TEST_F(StatsPluginEnd2EndTest, TestAllSpansAreExported) {
   {
     // Client spans are ended when the ClientContext's destructor is invoked.
@@ -715,27 +724,65 @@ TEST_F(StatsPluginEnd2EndTest, TestAllSpansAreExported) {
   ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
   traces_recorder_->StopRecording();
   auto recorded_spans = traces_recorder_->GetAndClearSpans();
-  auto GetSpanByName = [&recorded_spans](absl::string_view name) {
-    return std::find_if(
-        recorded_spans.begin(), recorded_spans.end(),
-        [name](auto const& span_data) { return span_data.name() == name; });
-  };
   // We never ended the two spans created in the scope above, so we don't
   // expect them to be exported.
   ASSERT_EQ(3, recorded_spans.size());
   auto sent_span_data =
-      GetSpanByName(absl::StrCat("Sent.", client_method_name_));
+      GetSpanByName(recorded_spans, absl::StrCat("Sent.", client_method_name_));
   ASSERT_NE(sent_span_data, recorded_spans.end());
-  auto attempt_span_data =
-      GetSpanByName(absl::StrCat("Attempt.", client_method_name_));
+  auto attempt_span_data = GetSpanByName(
+      recorded_spans, absl::StrCat("Attempt.", client_method_name_));
   ASSERT_NE(attempt_span_data, recorded_spans.end());
   EXPECT_EQ(sent_span_data->context().span_id(),
             attempt_span_data->parent_span_id());
   auto recv_span_data =
-      GetSpanByName(absl::StrCat("Recv.", server_method_name_));
+      GetSpanByName(recorded_spans, absl::StrCat("Recv.", server_method_name_));
   ASSERT_NE(recv_span_data, recorded_spans.end());
   EXPECT_EQ(attempt_span_data->context().span_id(),
             recv_span_data->parent_span_id());
+}
+
+TEST_F(StatsPluginEnd2EndTest, TestRemovePendingLbPickQueueAnnotation) {
+  {
+    // Client spans are ended when the ClientContext's destructor is invoked.
+    auto channel = CreateChannel(server_address_, InsecureChannelCredentials());
+    ResetStub(channel);
+    EchoRequest request;
+    request.set_message("foo");
+    EchoResponse response;
+
+    grpc::ClientContext context;
+    ::opencensus::trace::AlwaysSampler always_sampler;
+    ::opencensus::trace::StartSpanOptions options;
+    options.sampler = &always_sampler;
+    auto sampling_span =
+        ::opencensus::trace::Span::StartSpan("sampling", nullptr, options);
+    grpc::CensusContext app_census_context("root", &sampling_span,
+                                           ::opencensus::tags::TagMap{});
+    context.set_census_context(
+        reinterpret_cast<census_context*>(&app_census_context));
+    context.AddMetadata(kExpectedTraceIdKey,
+                        app_census_context.Span().context().trace_id().ToHex());
+    traces_recorder_->StartRecording();
+    grpc::Status status = stub_->Echo(&context, request, &response);
+    EXPECT_TRUE(status.ok());
+  }
+  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
+  TestUtils::Flush();
+  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  traces_recorder_->StopRecording();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans();
+  auto attempt_span_data = GetSpanByName(
+      recorded_spans, absl::StrCat("Attempt.", client_method_name_));
+  ASSERT_NE(attempt_span_data, recorded_spans.end());
+  bool found_annotation = false;
+  for (const auto& event : attempt_span_data->annotations().events()) {
+    if (event.event().description() ==
+        "Removed call attempt from channel's pending LB pick queue.") {
+      found_annotation = true;
+    }
+  }
+  EXPECT_TRUE(found_annotation);
 }
 
 // Test the working of GRPC_ARG_DISABLE_OBSERVABILITY.
@@ -770,21 +817,15 @@ TEST_F(StatsPluginEnd2EndTest, TestObservabilityDisabledChannelArg) {
   ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
   traces_recorder_->StopRecording();
   auto recorded_spans = traces_recorder_->GetAndClearSpans();
-  auto GetSpanByName = [&recorded_spans](absl::string_view name) {
-    return std::find_if(
-        recorded_spans.begin(), recorded_spans.end(),
-        [name](auto const& span_data) { return span_data.name() == name; });
-  };
-
   // The size might be 0 or 1, depending on whether the server-side ends up
   // getting sampled or not.
   ASSERT_LE(recorded_spans.size(), 1);
   // Make sure that the client-side traces are not collected.
   auto sent_span_data =
-      GetSpanByName(absl::StrCat("Sent.", client_method_name_));
+      GetSpanByName(recorded_spans, absl::StrCat("Sent.", client_method_name_));
   ASSERT_EQ(sent_span_data, recorded_spans.end());
-  auto attempt_span_data =
-      GetSpanByName(absl::StrCat("Attempt.", client_method_name_));
+  auto attempt_span_data = GetSpanByName(
+      recorded_spans, absl::StrCat("Attempt.", client_method_name_));
   ASSERT_EQ(attempt_span_data, recorded_spans.end());
 }
 


### PR DESCRIPTION
Written as per suggestions in https://b.corp.google.com/issues/251881969#comment2


