### PR TITLE
CMake's better handling c++14 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 set(PACKAGE_NAME          "grpc")
 set(PACKAGE_VERSION       "1.53.0-dev")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,26 +222,6 @@ if(WIN32)
   set(_gRPC_PLATFORM_WINDOWS ON)
 endif()
 
- # Use C11 standard
-if (NOT DEFINED CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 11)
-endif()
-
-# Add c++14 flags
-if (NOT DEFINED CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-else()
-  if (CMAKE_CXX_STANDARD LESS 14)
-    message(FATAL_ERROR "CMAKE_CXX_STANDARD is less than 14, please specify at least SET(CMAKE_CXX_STANDARD 14)")
-  endif()
-endif()
-if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
 if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()
@@ -1350,6 +1330,8 @@ add_library(address_sorting
   third_party/address_sorting/address_sorting_windows.c
 )
 
+target_compile_features(address_sorting PUBLIC cxx_std_14)
+
 set_target_properties(address_sorting PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
   SOVERSION ${gRPC_CORE_SOVERSION}
@@ -1505,6 +1487,8 @@ add_library(end2end_tests
   test/core/util/test_lb_policies.cc
 )
 
+target_compile_features(end2end_tests PUBLIC cxx_std_14)
+
 set_target_properties(end2end_tests PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
   SOVERSION ${gRPC_CORE_SOVERSION}
@@ -1594,6 +1578,8 @@ add_library(gpr
   src/core/lib/gprpp/thd_windows.cc
   src/core/lib/gprpp/time_util.cc
 )
+
+target_compile_features(gpr PUBLIC cxx_std_14)
 
 set_target_properties(gpr PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
@@ -2445,6 +2431,8 @@ add_library(grpc
   src/core/tsi/transport_security_grpc.cc
 )
 
+target_compile_features(grpc PUBLIC cxx_std_14)
+
 set_target_properties(grpc PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
   SOVERSION ${gRPC_CORE_SOVERSION}
@@ -2604,6 +2592,8 @@ add_library(grpc_test_util
   test/core/util/tls_utils.cc
 )
 
+target_compile_features(grpc_test_util PUBLIC cxx_std_14)
+
 set_target_properties(grpc_test_util PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
   SOVERSION ${gRPC_CORE_SOVERSION}
@@ -2661,6 +2651,8 @@ add_library(grpc_test_util_unsecure
   test/core/util/test_config.cc
   test/core/util/test_tcp_server.cc
 )
+
+target_compile_features(grpc_test_util_unsecure PUBLIC cxx_std_14)
 
 set_target_properties(grpc_test_util_unsecure PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
@@ -3063,6 +3055,8 @@ add_library(grpc_unsecure
   src/core/tsi/transport_security_grpc.cc
 )
 
+target_compile_features(grpc_unsecure PUBLIC cxx_std_14)
+
 set_target_properties(grpc_unsecure PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
   SOVERSION ${gRPC_CORE_SOVERSION}
@@ -3242,6 +3236,8 @@ add_library(benchmark_helpers
   test/cpp/microbenchmarks/helpers.cc
 )
 
+target_compile_features(benchmark_helpers PUBLIC cxx_std_14)
+
 set_target_properties(benchmark_helpers PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
   SOVERSION ${gRPC_CPP_SOVERSION}
@@ -3357,6 +3353,8 @@ add_library(grpc++
   src/cpp/util/string_ref.cc
   src/cpp/util/time_cc.cc
 )
+
+target_compile_features(grpc++ PUBLIC cxx_std_14)
 
 set_target_properties(grpc++ PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
@@ -3623,6 +3621,8 @@ add_library(grpc++_alts
   src/cpp/common/alts_util.cc
 )
 
+target_compile_features(grpc++_alts PUBLIC cxx_std_14)
+
 set_target_properties(grpc++_alts PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
   SOVERSION ${gRPC_CPP_SOVERSION}
@@ -3686,6 +3686,8 @@ endif()
 add_library(grpc++_error_details
   src/cpp/util/error_details.cc
 )
+
+target_compile_features(grpc++_error_details PUBLIC cxx_std_14)
 
 set_target_properties(grpc++_error_details PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
@@ -3757,6 +3759,8 @@ add_library(grpc++_reflection
   src/cpp/ext/proto_server_reflection_plugin.cc
 )
 
+target_compile_features(grpc++_reflection PUBLIC cxx_std_14)
+
 set_target_properties(grpc++_reflection PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
   SOVERSION ${gRPC_CPP_SOVERSION}
@@ -3825,6 +3829,8 @@ add_library(grpc++_test
   src/cpp/client/channel_test_peer.cc
 )
 
+target_compile_features(grpc++_test PUBLIC cxx_std_14)
+
 set_target_properties(grpc++_test PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
   SOVERSION ${gRPC_CPP_SOVERSION}
@@ -3889,6 +3895,8 @@ if(gRPC_BUILD_TESTS)
 add_library(grpc++_test_config
   test/cpp/util/test_config_cc.cc
 )
+
+target_compile_features(grpc++_test_config PUBLIC cxx_std_14)
 
 set_target_properties(grpc++_test_config PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
@@ -3960,6 +3968,8 @@ add_library(grpc++_test_util
   test/cpp/util/subprocess.cc
   test/cpp/util/test_credentials_provider.cc
 )
+
+target_compile_features(grpc++_test_util PUBLIC cxx_std_14)
 
 set_target_properties(grpc++_test_util PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
@@ -4046,6 +4056,8 @@ add_library(grpc++_unsecure
   src/cpp/util/string_ref.cc
   src/cpp/util/time_cc.cc
 )
+
+target_compile_features(grpc++_unsecure PUBLIC cxx_std_14)
 
 set_target_properties(grpc++_unsecure PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
@@ -4541,6 +4553,8 @@ add_library(grpc_authorization_provider
   src/core/tsi/transport_security_grpc.cc
 )
 
+target_compile_features(grpc_authorization_provider PUBLIC cxx_std_14)
+
 set_target_properties(grpc_authorization_provider PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
   SOVERSION ${gRPC_CPP_SOVERSION}
@@ -4688,6 +4702,8 @@ add_library(grpc_plugin_support
   src/compiler/ruby_generator.cc
 )
 
+target_compile_features(grpc_plugin_support PUBLIC cxx_std_14)
+
 set_target_properties(grpc_plugin_support PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
   SOVERSION ${gRPC_CPP_SOVERSION}
@@ -4759,6 +4775,8 @@ add_library(grpcpp_channelz
   src/cpp/server/channelz/channelz_service.cc
   src/cpp/server/channelz/channelz_service_plugin.cc
 )
+
+target_compile_features(grpcpp_channelz PUBLIC cxx_std_14)
 
 set_target_properties(grpcpp_channelz PROPERTIES
   VERSION ${gRPC_CPP_VERSION}
@@ -4849,6 +4867,8 @@ add_library(upb
   src/core/ext/upbdefs-generated/google/protobuf/descriptor.upbdefs.c
 )
 
+target_compile_features(upb PUBLIC cxx_std_14)
+
 set_target_properties(upb PROPERTIES
   VERSION ${gRPC_CORE_VERSION}
   SOVERSION ${gRPC_CORE_SOVERSION}
@@ -4902,7 +4922,7 @@ add_executable(bad_server_response_test
   test/core/end2end/bad_server_response_test.cc
   test/core/end2end/cq_verifier.cc
 )
-
+target_compile_features(bad_server_response_test PUBLIC cxx_std_14)
 target_include_directories(bad_server_response_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -4945,7 +4965,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/subprocess_windows.cc
     test/core/util/tracer_util.cc
   )
-
+  target_compile_features(bad_ssl_alpn_test PUBLIC cxx_std_14)
   target_include_directories(bad_ssl_alpn_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -4989,7 +5009,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/subprocess_windows.cc
     test/core/util/tracer_util.cc
   )
-
+  target_compile_features(bad_ssl_cert_test PUBLIC cxx_std_14)
   target_include_directories(bad_ssl_cert_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5020,7 +5040,7 @@ add_executable(connection_refused_test
   test/core/end2end/connection_refused_test.cc
   test/core/end2end/cq_verifier.cc
 )
-
+target_compile_features(connection_refused_test PUBLIC cxx_std_14)
 target_include_directories(connection_refused_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5051,7 +5071,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/end2end/cq_verifier.cc
     test/core/end2end/dualstack_socket_test.cc
   )
-
+  target_compile_features(dualstack_socket_test PUBLIC cxx_std_14)
   target_include_directories(dualstack_socket_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5094,7 +5114,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/subprocess_windows.cc
     test/core/util/tracer_util.cc
   )
-
+  target_compile_features(fd_conservation_posix_test PUBLIC cxx_std_14)
   target_include_directories(fd_conservation_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5125,7 +5145,7 @@ add_executable(goaway_server_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/goaway_server_test.cc
 )
-
+target_compile_features(goaway_server_test PUBLIC cxx_std_14)
 target_include_directories(goaway_server_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5155,7 +5175,7 @@ add_executable(inproc_callback_test
   test/core/end2end/fixtures/local_util.cc
   test/core/end2end/inproc_callback_test.cc
 )
-
+target_compile_features(inproc_callback_test PUBLIC cxx_std_14)
 target_include_directories(inproc_callback_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5185,7 +5205,7 @@ add_executable(invalid_call_argument_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/invalid_call_argument_test.cc
 )
-
+target_compile_features(invalid_call_argument_test PUBLIC cxx_std_14)
 target_include_directories(invalid_call_argument_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5214,7 +5234,7 @@ if(gRPC_BUILD_TESTS)
 add_executable(multiple_server_queues_test
   test/core/end2end/multiple_server_queues_test.cc
 )
-
+target_compile_features(multiple_server_queues_test PUBLIC cxx_std_14)
 target_include_directories(multiple_server_queues_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5244,7 +5264,7 @@ add_executable(no_server_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/no_server_test.cc
 )
-
+target_compile_features(no_server_test PUBLIC cxx_std_14)
 target_include_directories(no_server_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5274,7 +5294,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   add_executable(pollset_windows_starvation_test
     test/core/iomgr/pollset_windows_starvation_test.cc
   )
-
+  target_compile_features(pollset_windows_starvation_test PUBLIC cxx_std_14)
   target_include_directories(pollset_windows_starvation_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5304,7 +5324,7 @@ if(gRPC_BUILD_TESTS)
 add_executable(public_headers_must_be_c89
   test/core/surface/public_headers_must_be_c89.c
 )
-
+target_compile_features(public_headers_must_be_c89 PUBLIC cxx_std_14)
 target_include_directories(public_headers_must_be_c89
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5336,7 +5356,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     src/core/ext/filters/client_channel/lb_policy/weighted_round_robin/static_stride_scheduler.cc
     test/core/client_channel/lb_policy/static_stride_scheduler_benchmark.cc
   )
-
+  target_compile_features(static_stride_scheduler_benchmark PUBLIC cxx_std_14)
   target_include_directories(static_stride_scheduler_benchmark
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5384,7 +5404,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/core/util/subprocess_windows.cc
     test/core/util/tracer_util.cc
   )
-
+  target_compile_features(tcp_posix_test PUBLIC cxx_std_14)
   target_include_directories(tcp_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5426,7 +5446,7 @@ add_executable(test_core_iomgr_timer_list_test
   test/core/util/subprocess_windows.cc
   test/core/util/tracer_util.cc
 )
-
+target_compile_features(test_core_iomgr_timer_list_test PUBLIC cxx_std_14)
 target_include_directories(test_core_iomgr_timer_list_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5458,7 +5478,7 @@ add_executable(activity_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(activity_test PUBLIC cxx_std_14)
 target_include_directories(activity_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5501,7 +5521,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(address_sorting_test PUBLIC cxx_std_14)
   target_include_directories(address_sorting_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5556,7 +5576,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(address_sorting_test_unsecure PUBLIC cxx_std_14)
   target_include_directories(address_sorting_test_unsecure
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5614,7 +5634,7 @@ add_executable(admin_services_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(admin_services_end2end_test PUBLIC cxx_std_14)
 target_include_directories(admin_services_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5666,7 +5686,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(alarm_test PUBLIC cxx_std_14)
   target_include_directories(alarm_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5705,7 +5725,7 @@ add_executable(alloc_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alloc_test PUBLIC cxx_std_14)
 target_include_directories(alloc_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5742,7 +5762,7 @@ add_executable(alpn_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alpn_test PUBLIC cxx_std_14)
 target_include_directories(alpn_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5791,7 +5811,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(alts_concurrent_connectivity_test PUBLIC cxx_std_14)
   target_include_directories(alts_concurrent_connectivity_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5831,7 +5851,7 @@ add_executable(alts_counter_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_counter_test PUBLIC cxx_std_14)
 target_include_directories(alts_counter_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5869,7 +5889,7 @@ add_executable(alts_crypt_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_crypt_test PUBLIC cxx_std_14)
 target_include_directories(alts_crypt_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5907,7 +5927,7 @@ add_executable(alts_crypter_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_crypter_test PUBLIC cxx_std_14)
 target_include_directories(alts_crypter_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5946,7 +5966,7 @@ add_executable(alts_frame_protector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_frame_protector_test PUBLIC cxx_std_14)
 target_include_directories(alts_frame_protector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -5984,7 +6004,7 @@ add_executable(alts_grpc_record_protocol_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_grpc_record_protocol_test PUBLIC cxx_std_14)
 target_include_directories(alts_grpc_record_protocol_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6022,7 +6042,7 @@ add_executable(alts_handshaker_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_handshaker_client_test PUBLIC cxx_std_14)
 target_include_directories(alts_handshaker_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6060,7 +6080,7 @@ add_executable(alts_iovec_record_protocol_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_iovec_record_protocol_test PUBLIC cxx_std_14)
 target_include_directories(alts_iovec_record_protocol_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6109,7 +6129,7 @@ add_executable(alts_security_connector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_security_connector_test PUBLIC cxx_std_14)
 target_include_directories(alts_security_connector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6147,7 +6167,7 @@ add_executable(alts_tsi_handshaker_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_tsi_handshaker_test PUBLIC cxx_std_14)
 target_include_directories(alts_tsi_handshaker_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6185,7 +6205,7 @@ add_executable(alts_tsi_utils_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_tsi_utils_test PUBLIC cxx_std_14)
 target_include_directories(alts_tsi_utils_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6222,7 +6242,7 @@ add_executable(alts_util_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_util_test PUBLIC cxx_std_14)
 target_include_directories(alts_util_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6261,7 +6281,7 @@ add_executable(alts_zero_copy_grpc_protector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(alts_zero_copy_grpc_protector_test PUBLIC cxx_std_14)
 target_include_directories(alts_zero_copy_grpc_protector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6298,7 +6318,7 @@ add_executable(arena_promise_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(arena_promise_test PUBLIC cxx_std_14)
 target_include_directories(arena_promise_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6335,7 +6355,7 @@ add_executable(arena_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(arena_test PUBLIC cxx_std_14)
 target_include_directories(arena_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6396,7 +6416,7 @@ add_executable(async_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(async_end2end_test PUBLIC cxx_std_14)
 target_include_directories(async_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6445,7 +6465,7 @@ add_executable(auth_context_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(auth_context_test PUBLIC cxx_std_14)
 target_include_directories(auth_context_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6482,7 +6502,7 @@ add_executable(auth_property_iterator_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(auth_property_iterator_test PUBLIC cxx_std_14)
 target_include_directories(auth_property_iterator_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6531,7 +6551,7 @@ add_executable(authorization_matchers_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(authorization_matchers_test PUBLIC cxx_std_14)
 target_include_directories(authorization_matchers_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6569,7 +6589,7 @@ add_executable(authorization_policy_provider_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(authorization_policy_provider_test PUBLIC cxx_std_14)
 target_include_directories(authorization_policy_provider_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6608,7 +6628,7 @@ add_executable(avl_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(avl_test PUBLIC cxx_std_14)
 target_include_directories(avl_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6658,7 +6678,7 @@ add_executable(aws_request_signer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(aws_request_signer_test PUBLIC cxx_std_14)
 target_include_directories(aws_request_signer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6695,7 +6715,7 @@ add_executable(b64_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(b64_test PUBLIC cxx_std_14)
 target_include_directories(b64_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6732,7 +6752,7 @@ add_executable(backoff_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(backoff_test PUBLIC cxx_std_14)
 target_include_directories(backoff_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6771,7 +6791,7 @@ add_executable(bad_streaming_id_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(bad_streaming_id_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(bad_streaming_id_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6810,7 +6830,7 @@ add_executable(badreq_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(badreq_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(badreq_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6848,7 +6868,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(bdp_estimator_test PUBLIC cxx_std_14)
   target_include_directories(bdp_estimator_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6886,7 +6906,7 @@ add_executable(bin_decoder_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(bin_decoder_test PUBLIC cxx_std_14)
 target_include_directories(bin_decoder_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6923,7 +6943,7 @@ add_executable(bin_encoder_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(bin_encoder_test PUBLIC cxx_std_14)
 target_include_directories(bin_encoder_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -6960,7 +6980,7 @@ add_executable(binder_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(binder_resolver_test PUBLIC cxx_std_14)
 target_include_directories(binder_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7015,7 +7035,7 @@ add_executable(binder_server_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(binder_server_test PUBLIC cxx_std_14)
 target_include_directories(binder_server_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7115,7 +7135,7 @@ add_executable(binder_transport_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(binder_transport_test PUBLIC cxx_std_14)
 target_include_directories(binder_transport_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7152,7 +7172,7 @@ add_executable(bitset_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(bitset_test PUBLIC cxx_std_14)
 target_include_directories(bitset_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7202,7 +7222,7 @@ add_executable(buffer_list_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(buffer_list_test PUBLIC cxx_std_14)
 target_include_directories(buffer_list_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7239,7 +7259,7 @@ add_executable(byte_buffer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(byte_buffer_test PUBLIC cxx_std_14)
 target_include_directories(byte_buffer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7276,7 +7296,7 @@ add_executable(c_slice_buffer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(c_slice_buffer_test PUBLIC cxx_std_14)
 target_include_directories(c_slice_buffer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7313,7 +7333,7 @@ add_executable(call_finalization_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(call_finalization_test PUBLIC cxx_std_14)
 target_include_directories(call_finalization_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7352,7 +7372,7 @@ add_executable(cancel_ares_query_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cancel_ares_query_test PUBLIC cxx_std_14)
 target_include_directories(cancel_ares_query_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7390,7 +7410,7 @@ add_executable(cancel_callback_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cancel_callback_test PUBLIC cxx_std_14)
 target_include_directories(cancel_callback_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7529,7 +7549,7 @@ add_executable(cel_authorization_engine_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cel_authorization_engine_test PUBLIC cxx_std_14)
 target_include_directories(cel_authorization_engine_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7566,7 +7586,7 @@ add_executable(certificate_provider_registry_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(certificate_provider_registry_test PUBLIC cxx_std_14)
 target_include_directories(certificate_provider_registry_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7603,7 +7623,7 @@ add_executable(certificate_provider_store_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(certificate_provider_store_test PUBLIC cxx_std_14)
 target_include_directories(certificate_provider_store_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7645,7 +7665,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(cf_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(cf_event_engine_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7701,7 +7721,7 @@ add_executable(cfstream_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cfstream_test PUBLIC cxx_std_14)
 target_include_directories(cfstream_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7738,7 +7758,7 @@ add_executable(channel_args_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_args_test PUBLIC cxx_std_14)
 target_include_directories(channel_args_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7775,7 +7795,7 @@ add_executable(channel_arguments_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_arguments_test PUBLIC cxx_std_14)
 target_include_directories(channel_arguments_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7825,7 +7845,7 @@ add_executable(channel_creds_registry_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_creds_registry_test PUBLIC cxx_std_14)
 target_include_directories(channel_creds_registry_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7862,7 +7882,7 @@ add_executable(channel_filter_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_filter_test PUBLIC cxx_std_14)
 target_include_directories(channel_filter_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7900,7 +7920,7 @@ add_executable(channel_stack_builder_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_stack_builder_test PUBLIC cxx_std_14)
 target_include_directories(channel_stack_builder_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7937,7 +7957,7 @@ add_executable(channel_stack_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_stack_test PUBLIC cxx_std_14)
 target_include_directories(channel_stack_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -7979,7 +7999,7 @@ add_executable(channel_trace_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channel_trace_test PUBLIC cxx_std_14)
 target_include_directories(channel_trace_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8017,7 +8037,7 @@ add_executable(channelz_registry_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channelz_registry_test PUBLIC cxx_std_14)
 target_include_directories(channelz_registry_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8072,7 +8092,7 @@ add_executable(channelz_service_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channelz_service_test PUBLIC cxx_std_14)
 target_include_directories(channelz_service_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8115,7 +8135,7 @@ add_executable(channelz_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(channelz_test PUBLIC cxx_std_14)
 target_include_directories(channelz_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8165,7 +8185,7 @@ add_executable(check_gcp_environment_linux_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(check_gcp_environment_linux_test PUBLIC cxx_std_14)
 target_include_directories(check_gcp_environment_linux_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8214,7 +8234,7 @@ add_executable(check_gcp_environment_windows_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(check_gcp_environment_windows_test PUBLIC cxx_std_14)
 target_include_directories(check_gcp_environment_windows_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8274,7 +8294,7 @@ add_executable(chunked_vector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(chunked_vector_test PUBLIC cxx_std_14)
 target_include_directories(chunked_vector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8345,7 +8365,7 @@ add_executable(cli_call_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cli_call_test PUBLIC cxx_std_14)
 target_include_directories(cli_call_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8382,7 +8402,7 @@ add_executable(client_auth_filter_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_auth_filter_test PUBLIC cxx_std_14)
 target_include_directories(client_auth_filter_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8419,7 +8439,7 @@ add_executable(client_authority_filter_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_authority_filter_test PUBLIC cxx_std_14)
 target_include_directories(client_authority_filter_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8474,7 +8494,7 @@ add_executable(client_callback_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_callback_end2end_test PUBLIC cxx_std_14)
 target_include_directories(client_callback_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8511,7 +8531,7 @@ add_executable(client_channel_service_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_channel_service_config_test PUBLIC cxx_std_14)
 target_include_directories(client_channel_service_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8574,7 +8594,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(client_channel_stress_test PUBLIC cxx_std_14)
   target_include_directories(client_channel_stress_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8612,7 +8632,7 @@ add_executable(client_channel_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_channel_test PUBLIC cxx_std_14)
 target_include_directories(client_channel_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8649,7 +8669,7 @@ add_executable(client_context_test_peer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_context_test_peer_test PUBLIC cxx_std_14)
 target_include_directories(client_context_test_peer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8705,7 +8725,7 @@ add_executable(client_interceptors_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(client_interceptors_end2end_test PUBLIC cxx_std_14)
 target_include_directories(client_interceptors_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8768,7 +8788,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(client_lb_end2end_test PUBLIC cxx_std_14)
   target_include_directories(client_lb_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8807,7 +8827,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(client_ssl_test PUBLIC cxx_std_14)
   target_include_directories(client_ssl_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8857,7 +8877,7 @@ add_executable(cmdline_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cmdline_test PUBLIC cxx_std_14)
 target_include_directories(cmdline_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8894,7 +8914,7 @@ add_executable(codegen_test_full
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(codegen_test_full PUBLIC cxx_std_14)
 target_include_directories(codegen_test_full
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8932,7 +8952,7 @@ add_executable(codegen_test_minimal
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(codegen_test_minimal PUBLIC cxx_std_14)
 target_include_directories(codegen_test_minimal
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -8983,7 +9003,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(combiner_test PUBLIC cxx_std_14)
   target_include_directories(combiner_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9021,7 +9041,7 @@ add_executable(common_closures_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(common_closures_test PUBLIC cxx_std_14)
 target_include_directories(common_closures_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9060,7 +9080,7 @@ add_executable(completion_queue_threading_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(completion_queue_threading_test PUBLIC cxx_std_14)
 target_include_directories(completion_queue_threading_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9097,7 +9117,7 @@ add_executable(compression_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(compression_test PUBLIC cxx_std_14)
 target_include_directories(compression_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9134,7 +9154,7 @@ add_executable(concurrent_connectivity_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(concurrent_connectivity_test PUBLIC cxx_std_14)
 target_include_directories(concurrent_connectivity_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9173,7 +9193,7 @@ add_executable(connection_prefix_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(connection_prefix_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(connection_prefix_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9222,7 +9242,7 @@ add_executable(connectivity_state_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(connectivity_state_test PUBLIC cxx_std_14)
 target_include_directories(connectivity_state_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9276,7 +9296,7 @@ add_executable(context_allocator_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(context_allocator_end2end_test PUBLIC cxx_std_14)
 target_include_directories(context_allocator_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9325,7 +9345,7 @@ add_executable(context_list_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(context_list_test PUBLIC cxx_std_14)
 target_include_directories(context_list_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9362,7 +9382,7 @@ add_executable(context_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(context_test PUBLIC cxx_std_14)
 target_include_directories(context_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9399,7 +9419,7 @@ add_executable(core_configuration_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(core_configuration_test PUBLIC cxx_std_14)
 target_include_directories(core_configuration_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9436,7 +9456,7 @@ add_executable(cpp_impl_of_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cpp_impl_of_test PUBLIC cxx_std_14)
 target_include_directories(cpp_impl_of_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9472,7 +9492,7 @@ add_executable(cpu_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(cpu_test PUBLIC cxx_std_14)
 target_include_directories(cpu_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9511,7 +9531,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(crl_ssl_transport_security_test PUBLIC cxx_std_14)
   target_include_directories(crl_ssl_transport_security_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9549,7 +9569,7 @@ add_executable(default_engine_methods_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(default_engine_methods_test PUBLIC cxx_std_14)
 target_include_directories(default_engine_methods_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9603,7 +9623,7 @@ add_executable(delegating_channel_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(delegating_channel_test PUBLIC cxx_std_14)
 target_include_directories(delegating_channel_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9640,7 +9660,7 @@ add_executable(destroy_grpclb_channel_with_active_connect_stress_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(destroy_grpclb_channel_with_active_connect_stress_test PUBLIC cxx_std_14)
 target_include_directories(destroy_grpclb_channel_with_active_connect_stress_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9677,7 +9697,7 @@ add_executable(dns_resolver_cooldown_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(dns_resolver_cooldown_test PUBLIC cxx_std_14)
 target_include_directories(dns_resolver_cooldown_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9714,7 +9734,7 @@ add_executable(dns_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(dns_resolver_test PUBLIC cxx_std_14)
 target_include_directories(dns_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9751,7 +9771,7 @@ add_executable(dual_ref_counted_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(dual_ref_counted_test PUBLIC cxx_std_14)
 target_include_directories(dual_ref_counted_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9790,7 +9810,7 @@ add_executable(duplicate_header_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(duplicate_header_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(duplicate_header_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9847,7 +9867,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(end2end_binder_transport_test PUBLIC cxx_std_14)
   target_include_directories(end2end_binder_transport_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -9907,7 +9927,7 @@ add_executable(end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(end2end_test PUBLIC cxx_std_14)
 target_include_directories(end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10008,7 +10028,7 @@ add_executable(endpoint_binder_pool_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(endpoint_binder_pool_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_binder_pool_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10049,7 +10069,7 @@ add_executable(endpoint_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(endpoint_config_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10102,7 +10122,7 @@ add_executable(endpoint_pair_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(endpoint_pair_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_pair_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10139,7 +10159,7 @@ add_executable(env_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(env_test PUBLIC cxx_std_14)
 target_include_directories(env_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10188,7 +10208,7 @@ add_executable(error_details_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(error_details_test PUBLIC cxx_std_14)
 target_include_directories(error_details_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10239,7 +10259,7 @@ add_executable(error_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(error_test PUBLIC cxx_std_14)
 target_include_directories(error_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10288,7 +10308,7 @@ add_executable(error_utils_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(error_utils_test PUBLIC cxx_std_14)
 target_include_directories(error_utils_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10337,7 +10357,7 @@ add_executable(evaluate_args_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(evaluate_args_test PUBLIC cxx_std_14)
 target_include_directories(evaluate_args_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10374,7 +10394,7 @@ add_executable(event_engine_wakeup_scheduler_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(event_engine_wakeup_scheduler_test PUBLIC cxx_std_14)
 target_include_directories(event_engine_wakeup_scheduler_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10413,7 +10433,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(event_poller_posix_test PUBLIC cxx_std_14)
   target_include_directories(event_poller_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10452,7 +10472,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(examine_stack_test PUBLIC cxx_std_14)
   target_include_directories(examine_stack_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10506,7 +10526,7 @@ add_executable(exception_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(exception_test PUBLIC cxx_std_14)
 target_include_directories(exception_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10557,7 +10577,7 @@ add_executable(exec_ctx_wakeup_scheduler_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(exec_ctx_wakeup_scheduler_test PUBLIC cxx_std_14)
 target_include_directories(exec_ctx_wakeup_scheduler_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10600,7 +10620,7 @@ add_executable(factory_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(factory_test PUBLIC cxx_std_14)
 target_include_directories(factory_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10700,7 +10720,7 @@ add_executable(fake_binder_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(fake_binder_test PUBLIC cxx_std_14)
 target_include_directories(fake_binder_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10737,7 +10757,7 @@ add_executable(fake_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(fake_resolver_test PUBLIC cxx_std_14)
 target_include_directories(fake_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10775,7 +10795,7 @@ add_executable(fake_transport_security_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(fake_transport_security_test PUBLIC cxx_std_14)
 target_include_directories(fake_transport_security_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10825,7 +10845,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(fd_posix_test PUBLIC cxx_std_14)
   target_include_directories(fd_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10863,7 +10883,7 @@ add_executable(file_watcher_certificate_provider_factory_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(file_watcher_certificate_provider_factory_test PUBLIC cxx_std_14)
 target_include_directories(file_watcher_certificate_provider_factory_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10920,7 +10940,7 @@ add_executable(filter_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(filter_end2end_test PUBLIC cxx_std_14)
 target_include_directories(filter_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -10974,7 +10994,7 @@ add_executable(flaky_network_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(flaky_network_test PUBLIC cxx_std_14)
 target_include_directories(flaky_network_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11037,7 +11057,7 @@ add_executable(flow_control_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(flow_control_test PUBLIC cxx_std_14)
 target_include_directories(flow_control_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11106,7 +11126,7 @@ add_executable(for_each_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(for_each_test PUBLIC cxx_std_14)
 target_include_directories(for_each_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11152,7 +11172,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(fork_test PUBLIC cxx_std_14)
   target_include_directories(fork_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11191,7 +11211,7 @@ add_executable(forkable_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(forkable_test PUBLIC cxx_std_14)
 target_include_directories(forkable_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11247,7 +11267,7 @@ add_executable(format_request_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(format_request_test PUBLIC cxx_std_14)
 target_include_directories(format_request_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11285,7 +11305,7 @@ add_executable(frame_handler_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(frame_handler_test PUBLIC cxx_std_14)
 target_include_directories(frame_handler_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11323,7 +11343,7 @@ add_executable(frame_header_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(frame_header_test PUBLIC cxx_std_14)
 target_include_directories(frame_header_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11582,7 +11602,7 @@ add_executable(frame_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(frame_test PUBLIC cxx_std_14)
 target_include_directories(frame_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11640,7 +11660,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(fuzzing_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(fuzzing_event_engine_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11699,7 +11719,7 @@ add_executable(generic_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(generic_end2end_test PUBLIC cxx_std_14)
 target_include_directories(generic_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11737,7 +11757,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(global_config_env_test PUBLIC cxx_std_14)
   target_include_directories(global_config_env_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11775,7 +11795,7 @@ add_executable(global_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(global_config_test PUBLIC cxx_std_14)
 target_include_directories(global_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11813,7 +11833,7 @@ add_executable(google_c2p_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(google_c2p_resolver_test PUBLIC cxx_std_14)
 target_include_directories(google_c2p_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11851,7 +11871,7 @@ add_executable(google_mesh_ca_certificate_provider_factory_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(google_mesh_ca_certificate_provider_factory_test PUBLIC cxx_std_14)
 target_include_directories(google_mesh_ca_certificate_provider_factory_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11889,7 +11909,7 @@ add_executable(graceful_shutdown_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(graceful_shutdown_test PUBLIC cxx_std_14)
 target_include_directories(graceful_shutdown_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11938,7 +11958,7 @@ add_executable(grpc_alts_credentials_options_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_alts_credentials_options_test PUBLIC cxx_std_14)
 target_include_directories(grpc_alts_credentials_options_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -11987,7 +12007,7 @@ add_executable(grpc_authorization_engine_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_authorization_engine_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authorization_engine_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12036,7 +12056,7 @@ add_executable(grpc_authorization_policy_provider_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_authorization_policy_provider_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authorization_policy_provider_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12092,7 +12112,7 @@ add_executable(grpc_authz_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_authz_end2end_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authz_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12130,7 +12150,7 @@ add_executable(grpc_byte_buffer_reader_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_byte_buffer_reader_test PUBLIC cxx_std_14)
 target_include_directories(grpc_byte_buffer_reader_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12177,7 +12197,7 @@ add_executable(grpc_cli
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_cli PUBLIC cxx_std_14)
 target_include_directories(grpc_cli
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12216,7 +12236,7 @@ add_executable(grpc_completion_queue_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_completion_queue_test PUBLIC cxx_std_14)
 target_include_directories(grpc_completion_queue_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12251,7 +12271,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_CPP_PLUGIN)
 add_executable(grpc_cpp_plugin
   src/compiler/cpp_plugin.cc
 )
-
+target_compile_features(grpc_cpp_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_cpp_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12293,7 +12313,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_CSHARP_PLUGIN)
 add_executable(grpc_csharp_plugin
   src/compiler/csharp_plugin.cc
 )
-
+target_compile_features(grpc_csharp_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_csharp_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12349,7 +12369,7 @@ add_executable(grpc_ipv6_loopback_available_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_ipv6_loopback_available_test PUBLIC cxx_std_14)
 target_include_directories(grpc_ipv6_loopback_available_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12384,7 +12404,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_NODE_PLUGIN)
 add_executable(grpc_node_plugin
   src/compiler/node_plugin.cc
 )
-
+target_compile_features(grpc_node_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_node_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12426,7 +12446,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN)
 add_executable(grpc_objective_c_plugin
   src/compiler/objective_c_plugin.cc
 )
-
+target_compile_features(grpc_objective_c_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_objective_c_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12468,7 +12488,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_PHP_PLUGIN)
 add_executable(grpc_php_plugin
   src/compiler/php_plugin.cc
 )
-
+target_compile_features(grpc_php_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_php_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12510,7 +12530,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_PYTHON_PLUGIN)
 add_executable(grpc_python_plugin
   src/compiler/python_plugin.cc
 )
-
+target_compile_features(grpc_python_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_python_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12552,7 +12572,7 @@ if(gRPC_BUILD_CODEGEN AND gRPC_BUILD_GRPC_RUBY_PLUGIN)
 add_executable(grpc_ruby_plugin
   src/compiler/ruby_plugin.cc
 )
-
+target_compile_features(grpc_ruby_plugin PUBLIC cxx_std_14)
 target_include_directories(grpc_ruby_plugin
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12608,7 +12628,7 @@ add_executable(grpc_tls_certificate_distributor_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_tls_certificate_distributor_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_certificate_distributor_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12657,7 +12677,7 @@ add_executable(grpc_tls_certificate_provider_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_tls_certificate_provider_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_certificate_provider_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12706,7 +12726,7 @@ add_executable(grpc_tls_certificate_verifier_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_tls_certificate_verifier_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_certificate_verifier_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12755,7 +12775,7 @@ add_executable(grpc_tls_credentials_options_comparator_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_tls_credentials_options_comparator_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_credentials_options_comparator_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12804,7 +12824,7 @@ add_executable(grpc_tls_credentials_options_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpc_tls_credentials_options_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_credentials_options_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12864,7 +12884,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(grpc_tool_test PUBLIC cxx_std_14)
   target_include_directories(grpc_tool_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12908,7 +12928,7 @@ add_executable(grpclb_api_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(grpclb_api_test PUBLIC cxx_std_14)
 target_include_directories(grpclb_api_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -12971,7 +12991,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(grpclb_end2end_test PUBLIC cxx_std_14)
   target_include_directories(grpclb_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13011,7 +13031,7 @@ add_executable(h2_ssl_session_reuse_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(h2_ssl_session_reuse_test PUBLIC cxx_std_14)
 target_include_directories(h2_ssl_session_reuse_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13050,7 +13070,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(handshake_server_with_readahead_handshaker_test PUBLIC cxx_std_14)
   target_include_directories(handshake_server_with_readahead_handshaker_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13090,7 +13110,7 @@ add_executable(head_of_line_blocking_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(head_of_line_blocking_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(head_of_line_blocking_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13129,7 +13149,7 @@ add_executable(headers_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(headers_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(headers_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13192,7 +13212,7 @@ add_executable(health_service_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(health_service_end2end_test PUBLIC cxx_std_14)
 target_include_directories(health_service_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13241,7 +13261,7 @@ add_executable(histogram_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(histogram_test PUBLIC cxx_std_14)
 target_include_directories(histogram_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13278,7 +13298,7 @@ add_executable(host_port_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(host_port_test PUBLIC cxx_std_14)
 target_include_directories(host_port_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13327,7 +13347,7 @@ add_executable(hpack_encoder_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(hpack_encoder_test PUBLIC cxx_std_14)
 target_include_directories(hpack_encoder_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13376,7 +13396,7 @@ add_executable(hpack_parser_table_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(hpack_parser_table_test PUBLIC cxx_std_14)
 target_include_directories(hpack_parser_table_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13425,7 +13445,7 @@ add_executable(hpack_parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(hpack_parser_test PUBLIC cxx_std_14)
 target_include_directories(hpack_parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13474,7 +13494,7 @@ add_executable(http2_client
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(http2_client PUBLIC cxx_std_14)
 target_include_directories(http2_client
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13512,7 +13532,7 @@ add_executable(http_proxy_mapper_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(http_proxy_mapper_test PUBLIC cxx_std_14)
 target_include_directories(http_proxy_mapper_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13552,7 +13572,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(httpcli_test PUBLIC cxx_std_14)
   target_include_directories(httpcli_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13593,7 +13613,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(httpscli_test PUBLIC cxx_std_14)
   target_include_directories(httpscli_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13652,7 +13672,7 @@ add_executable(hybrid_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(hybrid_end2end_test PUBLIC cxx_std_14)
 target_include_directories(hybrid_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13690,7 +13710,7 @@ add_executable(idle_filter_state_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(idle_filter_state_test PUBLIC cxx_std_14)
 target_include_directories(idle_filter_state_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13726,7 +13746,7 @@ add_executable(if_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(if_test PUBLIC cxx_std_14)
 target_include_directories(if_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13765,7 +13785,7 @@ add_executable(init_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(init_test PUBLIC cxx_std_14)
 target_include_directories(init_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13804,7 +13824,7 @@ add_executable(initial_settings_frame_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(initial_settings_frame_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(initial_settings_frame_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13853,7 +13873,7 @@ add_executable(insecure_security_connector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(insecure_security_connector_test PUBLIC cxx_std_14)
 target_include_directories(insecure_security_connector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13905,7 +13925,7 @@ add_executable(interop_client
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(interop_client PUBLIC cxx_std_14)
 target_include_directories(interop_client
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13957,7 +13977,7 @@ add_executable(interop_server
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(interop_server PUBLIC cxx_std_14)
 target_include_directories(interop_server
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -13997,7 +14017,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(iocp_test PUBLIC cxx_std_14)
   target_include_directories(iocp_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14040,7 +14060,7 @@ add_executable(istio_echo_server_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(istio_echo_server_test PUBLIC cxx_std_14)
 target_include_directories(istio_echo_server_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14079,7 +14099,7 @@ add_executable(join_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(join_test PUBLIC cxx_std_14)
 target_include_directories(join_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14119,7 +14139,7 @@ add_executable(json_object_loader_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(json_object_loader_test PUBLIC cxx_std_14)
 target_include_directories(json_object_loader_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14156,7 +14176,7 @@ add_executable(json_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(json_test PUBLIC cxx_std_14)
 target_include_directories(json_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14205,7 +14225,7 @@ add_executable(json_token_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(json_token_test PUBLIC cxx_std_14)
 target_include_directories(json_token_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14254,7 +14274,7 @@ add_executable(jwt_verifier_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(jwt_verifier_test PUBLIC cxx_std_14)
 target_include_directories(jwt_verifier_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14292,7 +14312,7 @@ add_executable(lame_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(lame_client_test PUBLIC cxx_std_14)
 target_include_directories(lame_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14331,7 +14351,7 @@ add_executable(large_metadata_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(large_metadata_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(large_metadata_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14369,7 +14389,7 @@ add_executable(latch_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(latch_test PUBLIC cxx_std_14)
 target_include_directories(latch_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14413,7 +14433,7 @@ add_executable(lb_get_cpu_stats_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(lb_get_cpu_stats_test PUBLIC cxx_std_14)
 target_include_directories(lb_get_cpu_stats_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14451,7 +14471,7 @@ add_executable(lb_load_data_store_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(lb_load_data_store_test PUBLIC cxx_std_14)
 target_include_directories(lb_load_data_store_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14490,7 +14510,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(lock_free_event_test PUBLIC cxx_std_14)
   target_include_directories(lock_free_event_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14529,7 +14549,7 @@ add_executable(log_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(log_test PUBLIC cxx_std_14)
 target_include_directories(log_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14566,7 +14586,7 @@ add_executable(loop_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(loop_test PUBLIC cxx_std_14)
 target_include_directories(loop_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14631,7 +14651,7 @@ add_executable(map_pipe_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(map_pipe_test PUBLIC cxx_std_14)
 target_include_directories(map_pipe_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14676,7 +14696,7 @@ add_executable(match_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(match_test PUBLIC cxx_std_14)
 target_include_directories(match_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14725,7 +14745,7 @@ add_executable(matchers_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(matchers_test PUBLIC cxx_std_14)
 target_include_directories(matchers_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14763,7 +14783,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(memory_quota_stress_test PUBLIC cxx_std_14)
   target_include_directories(memory_quota_stress_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14801,7 +14821,7 @@ add_executable(memory_quota_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(memory_quota_test PUBLIC cxx_std_14)
 target_include_directories(memory_quota_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14855,7 +14875,7 @@ add_executable(message_allocator_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(message_allocator_end2end_test PUBLIC cxx_std_14)
 target_include_directories(message_allocator_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14904,7 +14924,7 @@ add_executable(message_compress_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(message_compress_test PUBLIC cxx_std_14)
 target_include_directories(message_compress_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14941,7 +14961,7 @@ add_executable(message_size_service_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(message_size_service_config_test PUBLIC cxx_std_14)
 target_include_directories(message_size_service_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14990,7 +15010,7 @@ add_executable(metadata_map_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(metadata_map_test PUBLIC cxx_std_14)
 target_include_directories(metadata_map_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15027,7 +15047,7 @@ add_executable(minimal_stack_is_minimal_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(minimal_stack_is_minimal_test PUBLIC cxx_std_14)
 target_include_directories(minimal_stack_is_minimal_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15064,7 +15084,7 @@ add_executable(miscompile_with_no_unique_address_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(miscompile_with_no_unique_address_test PUBLIC cxx_std_14)
 target_include_directories(miscompile_with_no_unique_address_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15116,7 +15136,7 @@ add_executable(mock_stream_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(mock_stream_test PUBLIC cxx_std_14)
 target_include_directories(mock_stream_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15174,7 +15194,7 @@ add_executable(mock_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(mock_test PUBLIC cxx_std_14)
 target_include_directories(mock_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15213,7 +15233,7 @@ add_executable(mpsc_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(mpsc_test PUBLIC cxx_std_14)
 target_include_directories(mpsc_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15256,7 +15276,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(mpscq_test PUBLIC cxx_std_14)
   target_include_directories(mpscq_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15294,7 +15314,7 @@ add_executable(no_destruct_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(no_destruct_test PUBLIC cxx_std_14)
 target_include_directories(no_destruct_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15346,7 +15366,7 @@ add_executable(nonblocking_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(nonblocking_test PUBLIC cxx_std_14)
 target_include_directories(nonblocking_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15383,7 +15403,7 @@ add_executable(notification_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(notification_test PUBLIC cxx_std_14)
 target_include_directories(notification_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15420,7 +15440,7 @@ add_executable(num_external_connectivity_watchers_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(num_external_connectivity_watchers_test PUBLIC cxx_std_14)
 target_include_directories(num_external_connectivity_watchers_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15458,7 +15478,7 @@ add_executable(observable_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(observable_test PUBLIC cxx_std_14)
 target_include_directories(observable_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15506,7 +15526,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(oracle_event_engine_posix_test PUBLIC cxx_std_14)
   target_include_directories(oracle_event_engine_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15554,7 +15574,7 @@ add_executable(orca_service_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(orca_service_end2end_test PUBLIC cxx_std_14)
 target_include_directories(orca_service_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15591,7 +15611,7 @@ add_executable(orphanable_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(orphanable_test PUBLIC cxx_std_14)
 target_include_directories(orphanable_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15630,7 +15650,7 @@ add_executable(out_of_bounds_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(out_of_bounds_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(out_of_bounds_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15667,7 +15687,7 @@ add_executable(outlier_detection_lb_config_parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(outlier_detection_lb_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(outlier_detection_lb_config_parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15704,7 +15724,7 @@ add_executable(outlier_detection_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(outlier_detection_test PUBLIC cxx_std_14)
 target_include_directories(outlier_detection_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15741,7 +15761,7 @@ add_executable(overload_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(overload_test PUBLIC cxx_std_14)
 target_include_directories(overload_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15777,7 +15797,7 @@ add_executable(parse_address_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(parse_address_test PUBLIC cxx_std_14)
 target_include_directories(parse_address_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15815,7 +15835,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(parse_address_with_named_scope_id_test PUBLIC cxx_std_14)
   target_include_directories(parse_address_with_named_scope_id_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15853,7 +15873,7 @@ add_executable(parsed_metadata_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(parsed_metadata_test PUBLIC cxx_std_14)
 target_include_directories(parsed_metadata_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15906,7 +15926,7 @@ add_executable(parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(parser_test PUBLIC cxx_std_14)
 target_include_directories(parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15943,7 +15963,7 @@ add_executable(percent_encoding_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(percent_encoding_test PUBLIC cxx_std_14)
 target_include_directories(percent_encoding_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -15994,7 +16014,7 @@ add_executable(periodic_update_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(periodic_update_test PUBLIC cxx_std_14)
 target_include_directories(periodic_update_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16036,7 +16056,7 @@ add_executable(pick_first_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(pick_first_test PUBLIC cxx_std_14)
 target_include_directories(pick_first_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16085,7 +16105,7 @@ add_executable(pid_controller_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(pid_controller_test PUBLIC cxx_std_14)
 target_include_directories(pid_controller_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16146,7 +16166,7 @@ add_executable(pipe_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(pipe_test PUBLIC cxx_std_14)
 target_include_directories(pipe_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16191,7 +16211,7 @@ add_executable(poll_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(poll_test PUBLIC cxx_std_14)
 target_include_directories(poll_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16245,7 +16265,7 @@ add_executable(port_sharing_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(port_sharing_end2end_test PUBLIC cxx_std_14)
 target_include_directories(port_sharing_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16287,7 +16307,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(posix_endpoint_test PUBLIC cxx_std_14)
   target_include_directories(posix_endpoint_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16327,7 +16347,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(posix_engine_listener_utils_test PUBLIC cxx_std_14)
   target_include_directories(posix_engine_listener_utils_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16369,7 +16389,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(posix_event_engine_connect_test PUBLIC cxx_std_14)
   target_include_directories(posix_event_engine_connect_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16415,7 +16435,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(posix_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(posix_event_engine_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16454,7 +16474,7 @@ add_executable(promise_factory_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(promise_factory_test PUBLIC cxx_std_14)
 target_include_directories(promise_factory_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16495,7 +16515,7 @@ add_executable(promise_map_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(promise_map_test PUBLIC cxx_std_14)
 target_include_directories(promise_map_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16535,7 +16555,7 @@ add_executable(promise_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(promise_test PUBLIC cxx_std_14)
 target_include_directories(promise_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16597,7 +16617,7 @@ add_executable(proto_server_reflection_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(proto_server_reflection_test PUBLIC cxx_std_14)
 target_include_directories(proto_server_reflection_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16635,7 +16655,7 @@ add_executable(proto_utils_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(proto_utils_test PUBLIC cxx_std_14)
 target_include_directories(proto_utils_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16714,7 +16734,7 @@ add_executable(qps_json_driver
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(qps_json_driver PUBLIC cxx_std_14)
 target_include_directories(qps_json_driver
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16785,7 +16805,7 @@ add_executable(qps_worker
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(qps_worker PUBLIC cxx_std_14)
 target_include_directories(qps_worker
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16823,7 +16843,7 @@ add_executable(race_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(race_test PUBLIC cxx_std_14)
 target_include_directories(race_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16881,7 +16901,7 @@ add_executable(raw_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(raw_end2end_test PUBLIC cxx_std_14)
 target_include_directories(raw_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16918,7 +16938,7 @@ add_executable(rbac_service_config_parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(rbac_service_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(rbac_service_config_parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -16967,7 +16987,7 @@ add_executable(rbac_translator_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(rbac_translator_test PUBLIC cxx_std_14)
 target_include_directories(rbac_translator_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17005,7 +17025,7 @@ add_executable(ref_counted_ptr_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(ref_counted_ptr_test PUBLIC cxx_std_14)
 target_include_directories(ref_counted_ptr_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17042,7 +17062,7 @@ add_executable(ref_counted_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(ref_counted_test PUBLIC cxx_std_14)
 target_include_directories(ref_counted_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17080,7 +17100,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(remove_stream_from_stalled_lists_test PUBLIC cxx_std_14)
   target_include_directories(remove_stream_from_stalled_lists_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17131,7 +17151,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(resolve_address_using_ares_resolver_posix_test PUBLIC cxx_std_14)
   target_include_directories(resolve_address_using_ares_resolver_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17184,7 +17204,7 @@ add_executable(resolve_address_using_ares_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(resolve_address_using_ares_resolver_test PUBLIC cxx_std_14)
 target_include_directories(resolve_address_using_ares_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17235,7 +17255,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(resolve_address_using_native_resolver_posix_test PUBLIC cxx_std_14)
   target_include_directories(resolve_address_using_native_resolver_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17288,7 +17308,7 @@ add_executable(resolve_address_using_native_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(resolve_address_using_native_resolver_test PUBLIC cxx_std_14)
 target_include_directories(resolve_address_using_native_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17326,7 +17346,7 @@ add_executable(resource_quota_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(resource_quota_test PUBLIC cxx_std_14)
 target_include_directories(resource_quota_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17363,7 +17383,7 @@ add_executable(retry_service_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(retry_service_config_test PUBLIC cxx_std_14)
 target_include_directories(retry_service_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17400,7 +17420,7 @@ add_executable(retry_throttle_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(retry_throttle_test PUBLIC cxx_std_14)
 target_include_directories(retry_throttle_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17464,7 +17484,7 @@ add_executable(rls_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(rls_end2end_test PUBLIC cxx_std_14)
 target_include_directories(rls_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17502,7 +17522,7 @@ add_executable(rls_lb_config_parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(rls_lb_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(rls_lb_config_parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17539,7 +17559,7 @@ add_executable(round_robin_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(round_robin_test PUBLIC cxx_std_14)
 target_include_directories(round_robin_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17576,7 +17596,7 @@ add_executable(secure_auth_context_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(secure_auth_context_test PUBLIC cxx_std_14)
 target_include_directories(secure_auth_context_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17613,7 +17633,7 @@ add_executable(secure_channel_create_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(secure_channel_create_test PUBLIC cxx_std_14)
 target_include_directories(secure_channel_create_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17663,7 +17683,7 @@ add_executable(secure_endpoint_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(secure_endpoint_test PUBLIC cxx_std_14)
 target_include_directories(secure_endpoint_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17712,7 +17732,7 @@ add_executable(security_connector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(security_connector_test PUBLIC cxx_std_14)
 target_include_directories(security_connector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17749,7 +17769,7 @@ add_executable(seq_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(seq_test PUBLIC cxx_std_14)
 target_include_directories(seq_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17788,7 +17808,7 @@ add_executable(sequential_connectivity_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(sequential_connectivity_test PUBLIC cxx_std_14)
 target_include_directories(sequential_connectivity_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17846,7 +17866,7 @@ add_executable(server_builder_plugin_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_builder_plugin_test PUBLIC cxx_std_14)
 target_include_directories(server_builder_plugin_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17912,7 +17932,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(server_builder_test PUBLIC cxx_std_14)
   target_include_directories(server_builder_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -17980,7 +18000,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(server_builder_with_socket_mutator_test PUBLIC cxx_std_14)
   target_include_directories(server_builder_with_socket_mutator_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18019,7 +18039,7 @@ add_executable(server_chttp2_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_chttp2_test PUBLIC cxx_std_14)
 target_include_directories(server_chttp2_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18056,7 +18076,7 @@ add_executable(server_config_selector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_config_selector_test PUBLIC cxx_std_14)
 target_include_directories(server_config_selector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18093,7 +18113,7 @@ add_executable(server_context_test_spouse_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_context_test_spouse_test PUBLIC cxx_std_14)
 target_include_directories(server_context_test_spouse_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18147,7 +18167,7 @@ add_executable(server_early_return_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_early_return_test PUBLIC cxx_std_14)
 target_include_directories(server_early_return_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18202,7 +18222,7 @@ add_executable(server_interceptors_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_interceptors_end2end_test PUBLIC cxx_std_14)
 target_include_directories(server_interceptors_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18241,7 +18261,7 @@ add_executable(server_registered_method_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_registered_method_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(server_registered_method_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18307,7 +18327,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(server_request_call_test PUBLIC cxx_std_14)
   target_include_directories(server_request_call_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18348,7 +18368,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(server_ssl_test PUBLIC cxx_std_14)
   target_include_directories(server_ssl_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18386,7 +18406,7 @@ add_executable(server_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(server_test PUBLIC cxx_std_14)
 target_include_directories(server_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18444,7 +18464,7 @@ add_executable(service_config_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(service_config_end2end_test PUBLIC cxx_std_14)
 target_include_directories(service_config_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18481,7 +18501,7 @@ add_executable(service_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(service_config_test PUBLIC cxx_std_14)
 target_include_directories(service_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18530,7 +18550,7 @@ add_executable(settings_timeout_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(settings_timeout_test PUBLIC cxx_std_14)
 target_include_directories(settings_timeout_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18587,7 +18607,7 @@ add_executable(shutdown_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(shutdown_test PUBLIC cxx_std_14)
 target_include_directories(shutdown_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18626,7 +18646,7 @@ add_executable(simple_request_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(simple_request_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(simple_request_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18663,7 +18683,7 @@ add_executable(single_set_ptr_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(single_set_ptr_test PUBLIC cxx_std_14)
 target_include_directories(single_set_ptr_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18700,7 +18720,7 @@ add_executable(sleep_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(sleep_test PUBLIC cxx_std_14)
 target_include_directories(sleep_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18739,7 +18759,7 @@ add_executable(slice_string_helpers_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(slice_string_helpers_test PUBLIC cxx_std_14)
 target_include_directories(slice_string_helpers_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18779,7 +18799,7 @@ add_executable(smoke_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(smoke_test PUBLIC cxx_std_14)
 target_include_directories(smoke_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18816,7 +18836,7 @@ add_executable(sockaddr_resolver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(sockaddr_resolver_test PUBLIC cxx_std_14)
 target_include_directories(sockaddr_resolver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18853,7 +18873,7 @@ add_executable(sockaddr_utils_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(sockaddr_utils_test PUBLIC cxx_std_14)
 target_include_directories(sockaddr_utils_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18903,7 +18923,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(socket_utils_test PUBLIC cxx_std_14)
   target_include_directories(socket_utils_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18941,7 +18961,7 @@ add_executable(sorted_pack_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(sorted_pack_test PUBLIC cxx_std_14)
 target_include_directories(sorted_pack_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -18977,7 +18997,7 @@ add_executable(spinlock_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(spinlock_test PUBLIC cxx_std_14)
 target_include_directories(spinlock_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19026,7 +19046,7 @@ add_executable(ssl_credentials_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(ssl_credentials_test PUBLIC cxx_std_14)
 target_include_directories(ssl_credentials_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19065,7 +19085,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(ssl_transport_security_test PUBLIC cxx_std_14)
   target_include_directories(ssl_transport_security_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19104,7 +19124,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(ssl_transport_security_utils_test PUBLIC cxx_std_14)
   target_include_directories(ssl_transport_security_utils_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19143,7 +19163,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(stack_tracer_test PUBLIC cxx_std_14)
   target_include_directories(stack_tracer_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19181,7 +19201,7 @@ add_executable(stat_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(stat_test PUBLIC cxx_std_14)
 target_include_directories(stat_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19219,7 +19239,7 @@ add_executable(static_stride_scheduler_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(static_stride_scheduler_test PUBLIC cxx_std_14)
 target_include_directories(static_stride_scheduler_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19258,7 +19278,7 @@ add_executable(stats_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(stats_test PUBLIC cxx_std_14)
 target_include_directories(stats_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19307,7 +19327,7 @@ add_executable(status_conversion_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(status_conversion_test PUBLIC cxx_std_14)
 target_include_directories(status_conversion_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19344,7 +19364,7 @@ add_executable(status_helper_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(status_helper_test PUBLIC cxx_std_14)
 target_include_directories(status_helper_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19381,7 +19401,7 @@ add_executable(status_util_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(status_util_test PUBLIC cxx_std_14)
 target_include_directories(status_util_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19432,7 +19452,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(stranded_event_test PUBLIC cxx_std_14)
   target_include_directories(stranded_event_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19470,7 +19490,7 @@ add_executable(stream_leak_with_queued_flow_control_update_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(stream_leak_with_queued_flow_control_update_test PUBLIC cxx_std_14)
 target_include_directories(stream_leak_with_queued_flow_control_update_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19519,7 +19539,7 @@ add_executable(stream_map_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(stream_map_test PUBLIC cxx_std_14)
 target_include_directories(stream_map_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19577,7 +19597,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(streaming_throughput_test PUBLIC cxx_std_14)
   target_include_directories(streaming_throughput_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19628,7 +19648,7 @@ add_executable(streams_not_seen_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(streams_not_seen_test PUBLIC cxx_std_14)
 target_include_directories(streams_not_seen_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19665,7 +19685,7 @@ add_executable(string_ref_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(string_ref_test PUBLIC cxx_std_14)
 target_include_directories(string_ref_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19703,7 +19723,7 @@ add_executable(string_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(string_test PUBLIC cxx_std_14)
 target_include_directories(string_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19740,7 +19760,7 @@ add_executable(sync_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(sync_test PUBLIC cxx_std_14)
 target_include_directories(sync_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19789,7 +19809,7 @@ add_executable(system_roots_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(system_roots_test PUBLIC cxx_std_14)
 target_include_directories(system_roots_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19826,7 +19846,7 @@ add_executable(table_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(table_test PUBLIC cxx_std_14)
 target_include_directories(table_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19880,7 +19900,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(tcp_client_posix_test PUBLIC cxx_std_14)
   target_include_directories(tcp_client_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19919,7 +19939,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(tcp_posix_socket_utils_test PUBLIC cxx_std_14)
   target_include_directories(tcp_posix_socket_utils_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -19970,7 +19990,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(tcp_server_posix_test PUBLIC cxx_std_14)
   target_include_directories(tcp_server_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20008,7 +20028,7 @@ add_executable(tcp_socket_utils_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(tcp_socket_utils_test PUBLIC cxx_std_14)
 target_include_directories(tcp_socket_utils_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20049,7 +20069,7 @@ add_executable(test_core_event_engine_posix_timer_heap_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_event_engine_posix_timer_heap_test PUBLIC cxx_std_14)
 target_include_directories(test_core_event_engine_posix_timer_heap_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20092,7 +20112,7 @@ add_executable(test_core_event_engine_posix_timer_list_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_event_engine_posix_timer_list_test PUBLIC cxx_std_14)
 target_include_directories(test_core_event_engine_posix_timer_list_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20137,7 +20157,7 @@ add_executable(test_core_event_engine_slice_buffer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_event_engine_slice_buffer_test PUBLIC cxx_std_14)
 target_include_directories(test_core_event_engine_slice_buffer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20179,7 +20199,7 @@ add_executable(test_core_gpr_time_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_gpr_time_test PUBLIC cxx_std_14)
 target_include_directories(test_core_gpr_time_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20216,7 +20236,7 @@ add_executable(test_core_gprpp_load_file_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_gprpp_load_file_test PUBLIC cxx_std_14)
 target_include_directories(test_core_gprpp_load_file_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20254,7 +20274,7 @@ add_executable(test_core_gprpp_time_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_gprpp_time_test PUBLIC cxx_std_14)
 target_include_directories(test_core_gprpp_time_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20305,7 +20325,7 @@ add_executable(test_core_iomgr_load_file_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_iomgr_load_file_test PUBLIC cxx_std_14)
 target_include_directories(test_core_iomgr_load_file_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20354,7 +20374,7 @@ add_executable(test_core_iomgr_timer_heap_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_iomgr_timer_heap_test PUBLIC cxx_std_14)
 target_include_directories(test_core_iomgr_timer_heap_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20403,7 +20423,7 @@ add_executable(test_core_security_credentials_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_security_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_core_security_credentials_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20440,7 +20460,7 @@ add_executable(test_core_slice_slice_buffer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_slice_slice_buffer_test PUBLIC cxx_std_14)
 target_include_directories(test_core_slice_slice_buffer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20478,7 +20498,7 @@ add_executable(test_core_slice_slice_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_core_slice_slice_test PUBLIC cxx_std_14)
 target_include_directories(test_core_slice_slice_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20516,7 +20536,7 @@ add_executable(test_cpp_client_credentials_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_cpp_client_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_client_credentials_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20555,7 +20575,7 @@ add_executable(test_cpp_server_credentials_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_cpp_server_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_server_credentials_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20593,7 +20613,7 @@ add_executable(test_cpp_util_slice_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_cpp_util_slice_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_util_slice_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20630,7 +20650,7 @@ add_executable(test_cpp_util_time_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(test_cpp_util_time_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_util_time_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20667,7 +20687,7 @@ add_executable(thd_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(thd_test PUBLIC cxx_std_14)
 target_include_directories(thd_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20704,7 +20724,7 @@ add_executable(thread_manager_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(thread_manager_test PUBLIC cxx_std_14)
 target_include_directories(thread_manager_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20745,7 +20765,7 @@ add_executable(thread_pool_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(thread_pool_test PUBLIC cxx_std_14)
 target_include_directories(thread_pool_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20786,7 +20806,7 @@ add_executable(thread_quota_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(thread_quota_test PUBLIC cxx_std_14)
 target_include_directories(thread_quota_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20844,7 +20864,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(thread_stress_test PUBLIC cxx_std_14)
   target_include_directories(thread_stress_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20883,7 +20903,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(time_jump_test PUBLIC cxx_std_14)
   target_include_directories(time_jump_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20922,7 +20942,7 @@ add_executable(time_util_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(time_util_test PUBLIC cxx_std_14)
 target_include_directories(time_util_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -20971,7 +20991,7 @@ add_executable(timeout_encoding_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(timeout_encoding_test PUBLIC cxx_std_14)
 target_include_directories(timeout_encoding_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21008,7 +21028,7 @@ add_executable(timer_manager_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(timer_manager_test PUBLIC cxx_std_14)
 target_include_directories(timer_manager_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21045,7 +21065,7 @@ add_executable(timer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(timer_test PUBLIC cxx_std_14)
 target_include_directories(timer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21084,7 +21104,7 @@ add_executable(tls_certificate_verifier_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(tls_certificate_verifier_test PUBLIC cxx_std_14)
 target_include_directories(tls_certificate_verifier_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21138,7 +21158,7 @@ add_executable(tls_key_export_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(tls_key_export_test PUBLIC cxx_std_14)
 target_include_directories(tls_key_export_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21187,7 +21207,7 @@ add_executable(tls_security_connector_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(tls_security_connector_test PUBLIC cxx_std_14)
 target_include_directories(tls_security_connector_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21225,7 +21245,7 @@ add_executable(too_many_pings_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(too_many_pings_test PUBLIC cxx_std_14)
 target_include_directories(too_many_pings_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21264,7 +21284,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(traced_buffer_list_test PUBLIC cxx_std_14)
   target_include_directories(traced_buffer_list_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21302,7 +21322,7 @@ add_executable(transport_security_common_api_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(transport_security_common_api_test PUBLIC cxx_std_14)
 target_include_directories(transport_security_common_api_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21339,7 +21359,7 @@ add_executable(transport_security_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(transport_security_test PUBLIC cxx_std_14)
 target_include_directories(transport_security_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21438,7 +21458,7 @@ add_executable(transport_stream_receiver_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(transport_stream_receiver_test PUBLIC cxx_std_14)
 target_include_directories(transport_stream_receiver_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21497,7 +21517,7 @@ add_executable(try_concurrently_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(try_concurrently_test PUBLIC cxx_std_14)
 target_include_directories(try_concurrently_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21542,7 +21562,7 @@ add_executable(try_join_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(try_join_test PUBLIC cxx_std_14)
 target_include_directories(try_join_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21584,7 +21604,7 @@ add_executable(try_seq_metadata_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(try_seq_metadata_test PUBLIC cxx_std_14)
 target_include_directories(try_seq_metadata_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21621,7 +21641,7 @@ add_executable(try_seq_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(try_seq_test PUBLIC cxx_std_14)
 target_include_directories(try_seq_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21662,7 +21682,7 @@ add_executable(unique_type_name_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(unique_type_name_test PUBLIC cxx_std_14)
 target_include_directories(unique_type_name_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21703,7 +21723,7 @@ add_executable(unknown_frame_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(unknown_frame_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(unknown_frame_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21740,7 +21760,7 @@ add_executable(uri_parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(uri_parser_test PUBLIC cxx_std_14)
 target_include_directories(uri_parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21777,7 +21797,7 @@ add_executable(useful_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(useful_test PUBLIC cxx_std_14)
 target_include_directories(useful_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21815,7 +21835,7 @@ add_executable(validation_errors_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(validation_errors_test PUBLIC cxx_std_14)
 target_include_directories(validation_errors_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21852,7 +21872,7 @@ add_executable(varint_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(varint_test PUBLIC cxx_std_14)
 target_include_directories(varint_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21890,7 +21910,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(wakeup_fd_posix_test PUBLIC cxx_std_14)
   target_include_directories(wakeup_fd_posix_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21928,7 +21948,7 @@ add_executable(weighted_round_robin_config_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(weighted_round_robin_config_test PUBLIC cxx_std_14)
 target_include_directories(weighted_round_robin_config_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -21965,7 +21985,7 @@ add_executable(weighted_round_robin_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(weighted_round_robin_test PUBLIC cxx_std_14)
 target_include_directories(weighted_round_robin_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22004,7 +22024,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(win_socket_test PUBLIC cxx_std_14)
   target_include_directories(win_socket_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22044,7 +22064,7 @@ add_executable(window_overflow_bad_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(window_overflow_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(window_overflow_bad_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22083,7 +22103,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(windows_endpoint_test PUBLIC cxx_std_14)
   target_include_directories(windows_endpoint_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22184,7 +22204,7 @@ add_executable(wire_reader_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(wire_reader_test PUBLIC cxx_std_14)
 target_include_directories(wire_reader_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22284,7 +22304,7 @@ add_executable(wire_writer_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(wire_writer_test PUBLIC cxx_std_14)
 target_include_directories(wire_writer_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22322,7 +22342,7 @@ add_executable(work_queue_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(work_queue_test PUBLIC cxx_std_14)
 target_include_directories(work_queue_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22360,7 +22380,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(work_serializer_test PUBLIC cxx_std_14)
   target_include_directories(work_serializer_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22427,7 +22447,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(writes_per_rpc_test PUBLIC cxx_std_14)
   target_include_directories(writes_per_rpc_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22466,7 +22486,7 @@ add_executable(xds_bootstrap_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_bootstrap_test PUBLIC cxx_std_14)
 target_include_directories(xds_bootstrap_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22503,7 +22523,7 @@ add_executable(xds_certificate_provider_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_certificate_provider_test PUBLIC cxx_std_14)
 target_include_directories(xds_certificate_provider_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22554,7 +22574,7 @@ add_executable(xds_client_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_client_test PUBLIC cxx_std_14)
 target_include_directories(xds_client_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22722,7 +22742,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_cluster_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_cluster_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22825,7 +22845,7 @@ add_executable(xds_cluster_resource_type_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_cluster_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_cluster_resource_type_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -22997,7 +23017,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_cluster_type_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_cluster_type_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23076,7 +23096,7 @@ add_executable(xds_common_types_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_common_types_test PUBLIC cxx_std_14)
 target_include_directories(xds_common_types_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23245,7 +23265,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_core_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_core_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23300,7 +23320,7 @@ add_executable(xds_credentials_end2end_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_credentials_end2end_test PUBLIC cxx_std_14)
 target_include_directories(xds_credentials_end2end_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23349,7 +23369,7 @@ add_executable(xds_credentials_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_credentials_test PUBLIC cxx_std_14)
 target_include_directories(xds_credentials_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23525,7 +23545,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_csds_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_csds_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23709,7 +23729,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23769,7 +23789,7 @@ add_executable(xds_endpoint_resource_type_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_endpoint_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_endpoint_resource_type_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -23944,7 +23964,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_fault_injection_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_fault_injection_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24071,7 +24091,7 @@ add_executable(xds_http_filters_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_http_filters_test PUBLIC cxx_std_14)
 target_include_directories(xds_http_filters_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24140,7 +24160,7 @@ add_executable(xds_interop_client
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_interop_client PUBLIC cxx_std_14)
 target_include_directories(xds_interop_client
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24216,7 +24236,7 @@ add_executable(xds_interop_server
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_interop_server PUBLIC cxx_std_14)
 target_include_directories(xds_interop_server
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24326,7 +24346,7 @@ add_executable(xds_lb_policy_registry_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_lb_policy_registry_test PUBLIC cxx_std_14)
 target_include_directories(xds_lb_policy_registry_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24462,7 +24482,7 @@ add_executable(xds_listener_resource_type_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_listener_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_listener_resource_type_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24639,7 +24659,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_outlier_detection_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_outlier_detection_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24677,7 +24697,7 @@ add_executable(xds_override_host_lb_config_parser_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_override_host_lb_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(xds_override_host_lb_config_parser_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24714,7 +24734,7 @@ add_executable(xds_override_host_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_override_host_test PUBLIC cxx_std_14)
 target_include_directories(xds_override_host_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -24886,7 +24906,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_ring_hash_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_ring_hash_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -25063,7 +25083,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_rls_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_rls_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}
@@ -25178,7 +25198,7 @@ add_executable(xds_route_config_resource_type_test
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
-
+target_compile_features(xds_route_config_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_route_config_resource_type_test
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -25355,7 +25375,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_routing_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_routing_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25551,7 +25551,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     third_party/googletest/googletest/src/gtest-all.cc
     third_party/googletest/googlemock/src/gmock-all.cc
   )
-
+  target_compile_features(xds_wrr_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_wrr_end2end_test
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}

--- a/examples/android/helloworld/app/CMakeLists.txt
+++ b/examples/android/helloworld/app/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-
-# https://github.com/abseil/abseil-cpp/issues/626
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DABSL_NO_XRAY_ATTRIBUTES=1")
-
 set(helloworld_PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(helloworld_GRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")
 

--- a/examples/android/helloworld/app/CMakeLists.txt
+++ b/examples/android/helloworld/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.8)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 

--- a/examples/cpp/cmake/common.cmake
+++ b/examples/cpp/cmake/common.cmake
@@ -19,10 +19,6 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-if (NOT DEFINED CMAKE_CXX_STANDARD)
-  set (CMAKE_CXX_STANDARD 14)
-endif()
-
 if(MSVC)
   add_definitions(-D_WIN32_WINNT=0x600)
 endif()

--- a/examples/cpp/cmake/common.cmake
+++ b/examples/cpp/cmake/common.cmake
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building route_guide.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   set (CMAKE_CXX_STANDARD 14)

--- a/examples/cpp/compression/CMakeLists.txt
+++ b/examples/cpp/compression/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(Compression C CXX)
 

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -20,7 +20,7 @@
 # including the "helloworld" project itself.
 # See https://blog.kitware.com/cmake-superbuilds-git-submodules/
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 # Project
 project(HelloWorld-SuperBuild C CXX)

--- a/examples/cpp/keyvaluestore/CMakeLists.txt
+++ b/examples/cpp/keyvaluestore/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(KeyValueStore C CXX)
 

--- a/examples/cpp/load_balancing/CMakeLists.txt
+++ b/examples/cpp/load_balancing/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(LoadBalancing C CXX)
 

--- a/examples/cpp/metadata/CMakeLists.txt
+++ b/examples/cpp/metadata/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(Metadata C CXX)
 

--- a/examples/cpp/route_guide/CMakeLists.txt
+++ b/examples/cpp/route_guide/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building route_guide.
 
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.8)
 
 project(RouteGuide C CXX)
 

--- a/src/android/test/interop/app/CMakeLists.txt
+++ b/src/android/test/interop/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.8)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 

--- a/src/android/test/interop/app/CMakeLists.txt
+++ b/src/android/test/interop/app/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-
-# https://github.com/abseil/abseil-cpp/issues/626
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DABSL_NO_XRAY_ATTRIBUTES=1")
-
 set(PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(gRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -264,26 +264,6 @@
     set(_gRPC_PLATFORM_WINDOWS ON)
   endif()
 
-   # Use C11 standard
-  if (NOT DEFINED CMAKE_C_STANDARD)
-    set(CMAKE_C_STANDARD 11)
-  endif()
-
-  # Add c++14 flags
-  if (NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
-  else()
-    if (CMAKE_CXX_STANDARD LESS 14)
-      message(FATAL_ERROR "CMAKE_CXX_STANDARD is less than 14, please specify at least SET(CMAKE_CXX_STANDARD 14)")
-    endif()
-  endif()
-  if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  endif()
-  if (NOT DEFINED CMAKE_CXX_EXTENSIONS)
-    set(CMAKE_CXX_EXTENSIONS OFF)
-  endif()
-
   ## Some libraries are shared even with BUILD_SHARED_LIBRARIES=OFF
   if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
     set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
@@ -660,6 +640,8 @@
   % endfor
   )
 
+  target_compile_features(${lib.name} PUBLIC cxx_std_14)
+
   set_target_properties(${lib.name} PROPERTIES
   % if lib.language == 'c++':
     VERSION <%text>${gRPC_CPP_VERSION}</%text>
@@ -764,7 +746,7 @@
     third_party/googletest/googlemock/src/gmock-all.cc
   % endif
   )
-
+  target_compile_features(${tgt.name} PUBLIC cxx_std_14)
   target_include_directories(${tgt.name}
     PRIVATE
       <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -154,7 +154,7 @@
         protobuf_gen_files.add(src)
   %>
 
-  cmake_minimum_required(VERSION 3.5.1)
+  cmake_minimum_required(VERSION 3.8)
 
   set(PACKAGE_NAME          "grpc")
   set(PACKAGE_VERSION       "${settings.cpp_version}")

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -477,7 +477,7 @@ class CLanguage(object):
             _check_compiler(compiler, ['default', 'cmake'])
 
         if compiler == 'default' or compiler == 'cmake':
-            return ('debian11', [])
+            return ('debian11', ["-DCMAKE_CXX_STANDARD=14"])
         elif compiler == 'gcc7':
             return ('gcc_7', [])
         elif compiler == 'gcc10.2':


### PR DESCRIPTION
As Cmake got a better way to specify that C++14 or above is required with [target_compile_features](https://cmake.org/cmake/help/latest/manual/cmake-compile-features.7.html#id5), gRPC needs to use this instead of using `CMAKE_CXX_STANDARD` which should be done by the application. This is also aligned with [how Cloud C++ does](https://github.com/googleapis/google-cloud-cpp/blob/5a32dd780d87a2af5b5df6f014c37ba600f8a8fb/cmake/FindgRPC.cmake#L260).

In order for gRPC to get this change, the minium version of cmake should be bumped to 3.8, which is acceptable as OSS C++ policy needs 3.10 as the oldest version of cmake to support.