### PR TITLE
[resource_quota] Fix allocator experiment bug

### DIFF
--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -411,18 +411,15 @@ void BasicMemoryQuota::Take(GrpcMemoryAllocatorImpl* allocator, size_t amount) {
     auto& shard = big_allocators_.shards[allocator->IncrementShardIndex() %
                                          big_allocators_.shards.size()];
 
-    size_t ret = 0;
     if (shard.shard_mu.TryLock()) {
       if (!shard.allocators.empty()) {
         chosen_allocator = *shard.allocators.begin();
-        ret = chosen_allocator->ReturnFree();
       }
       shard.shard_mu.Unlock();
     }
 
     if (chosen_allocator != nullptr) {
-      MaybeMoveAllocator(chosen_allocator, /*old_free_bytes=*/ret,
-                         /*new_free_bytes=*/0);
+      chosen_allocator->ReturnFree();
     }
   }
 }

--- a/src/core/lib/resource_quota/memory_quota.h
+++ b/src/core/lib/resource_quota/memory_quota.h
@@ -415,16 +415,19 @@ class GrpcMemoryAllocatorImpl final : public EventEngineMemoryAllocatorImpl {
   }
 
   // Return all free bytes to quota.
-  void ReturnFree() {
+  size_t ReturnFree() {
     size_t ret = free_bytes_.exchange(0, std::memory_order_acq_rel);
-    if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-      gpr_log(GPR_INFO, "Allocator %p returning %zu bytes to quota", this, ret);
+
+    if (ret > 0) {
+      if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
+        gpr_log(GPR_INFO, "Allocator %p returning %zu bytes to quota", this,
+                ret);
+      }
+      taken_bytes_.fetch_sub(ret, std::memory_order_relaxed);
+      memory_quota_->Return(ret);
     }
-    if (ret == 0) return;
-    memory_quota_->MaybeMoveAllocator(this, /*old_free_bytes=*/ret,
-                                      /*new_free_bytes=*/0);
-    taken_bytes_.fetch_sub(ret, std::memory_order_relaxed);
-    memory_quota_->Return(ret);
+
+    return ret;
   }
 
   // Post a reclamation function.

--- a/src/core/lib/resource_quota/memory_quota.h
+++ b/src/core/lib/resource_quota/memory_quota.h
@@ -415,19 +415,16 @@ class GrpcMemoryAllocatorImpl final : public EventEngineMemoryAllocatorImpl {
   }
 
   // Return all free bytes to quota.
-  size_t ReturnFree() {
+  void ReturnFree() {
     size_t ret = free_bytes_.exchange(0, std::memory_order_acq_rel);
-
-    if (ret > 0) {
-      if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
-        gpr_log(GPR_INFO, "Allocator %p returning %zu bytes to quota", this,
-                ret);
-      }
-      taken_bytes_.fetch_sub(ret, std::memory_order_relaxed);
-      memory_quota_->Return(ret);
+    if (ret == 0) return;
+    if (GRPC_TRACE_FLAG_ENABLED(grpc_resource_quota_trace)) {
+      gpr_log(GPR_INFO, "Allocator %p returning %zu bytes to quota", this, ret);
     }
-
-    return ret;
+    taken_bytes_.fetch_sub(ret, std::memory_order_relaxed);
+    memory_quota_->Return(ret);
+    memory_quota_->MaybeMoveAllocator(this, /*old_free_bytes=*/ret,
+                                      /*new_free_bytes=*/0);
   }
 
   // Post a reclamation function.


### PR DESCRIPTION
Server would crash if allocator was being accessed after it was destroyed. This moves removal of allocator from global list to Shutdown instead of destructor.

