### PR TITLE
[autofix] Get iwyu, clang-tidy working with the pr-autofixer again

### DIFF
--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -84,9 +84,9 @@ jobs:
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 upstream master
       # Run the things!
       - name: clang-tidy fixes
-        run: ${{ github.workspace }}/tools/distrib/clang_tidy_code.sh --fix --only-changed || true
+        run: ANDROID_NDK_HOME= ${{ github.workspace }}/tools/distrib/clang_tidy_code.sh --fix --only-changed || true
       - name: Run sanitize
-        run: ${{ github.workspace }}/tools/distrib/sanitize.sh
+        run: ANDROID_NDK_HOME= ${{ github.workspace }}/tools/distrib/sanitize.sh
       # Report back with a PR if things are broken
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -125,8 +125,6 @@ def fixCompilationDatabase(args, db):
 
 
 if __name__ == "__main__":
-    for k, v in os.environ.items():
-        print("ENV: %s=%s" % (k, v))
     parser = argparse.ArgumentParser(
         description='Generate JSON compilation database')
     parser.add_argument('--include_external', action='store_true')

--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -125,6 +125,8 @@ def fixCompilationDatabase(args, db):
 
 
 if __name__ == "__main__":
+    for k, v in os.environ.items():
+        print("ENV: %s=%s" % (k, v))
     parser = argparse.ArgumentParser(
         description='Generate JSON compilation database')
     parser.add_argument('--include_external', action='store_true')


### PR DESCRIPTION
Somehow `ANDROID_NDK_VERSION` is creeping into the environment for this stuff, I don't know why, but I can remove it where it matters!

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

