### PR TITLE
[event_engine+promises] EventEngine based wakeup scheduler for activities

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -721,6 +721,19 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "event_engine_wakeup_scheduler",
+    hdrs = [
+        "lib/promise/event_engine_wakeup_scheduler.h",
+    ],
+    external_deps = ["absl/status"],
+    language = "c++",
+    deps = [
+        "//:event_engine_base_hdrs",
+        "//:gpr_platform",
+    ],
+)
+
+grpc_cc_library(
     name = "wait_set",
     external_deps = [
         "absl/container:flat_hash_set",

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -387,23 +387,32 @@ class FreestandingActivity : public Activity, private Wakeable {
 };
 
 // Implementation details for an Activity of an arbitrary type of promise.
-// There should exist a static function:
+// There should exist an inner template class `BoundScheduler` that provides
+// the following interface:
 // struct WakeupScheduler {
 //   template <typename ActivityType>
-//   void ScheduleWakeup(ActivityType* activity);
+//   class BoundScheduler {
+//    public:
+//     BoundScheduler(ActivityType);
+//     void ScheduleWakeup();
+//   };
 // };
-// This function should arrange that activity->RunScheduledWakeup() be invoked
-// at the earliest opportunity.
+// The ScheduleWakeup function should arrange that
+// static_cast<ActivityType*>(this)->RunScheduledWakeup() be invoked at the
+// earliest opportunity.
 // It can assume that activity will remain live until RunScheduledWakeup() is
 // invoked, and that a given activity will not be concurrently scheduled again
 // until its RunScheduledWakeup() has been invoked.
-// We use private inheritance here as a way of getting private members for
-// each of the contexts.
+// We use private inheritance here as a way of getting private members for each
+// of the contexts.
 // TODO(ctiller): We can probably reconsider the private inheritance here
 // when we move away from C++11 and have more powerful template features.
 template <class F, class WakeupScheduler, class OnDone, typename... Contexts>
-class PromiseActivity final : public FreestandingActivity,
-                              private ActivityContexts<Contexts...> {
+class PromiseActivity final
+    : public FreestandingActivity,
+      public WakeupScheduler::template BoundScheduler<
+          PromiseActivity<F, WakeupScheduler, OnDone, Contexts...>>,
+      private ActivityContexts<Contexts...> {
  public:
   using Factory = OncePromiseFactory<void, F>;
   using ResultType = typename Factory::Promise::Result;
@@ -411,8 +420,9 @@ class PromiseActivity final : public FreestandingActivity,
   PromiseActivity(F promise_factory, WakeupScheduler wakeup_scheduler,
                   OnDone on_done, Contexts&&... contexts)
       : FreestandingActivity(),
+        WakeupScheduler::template BoundScheduler<PromiseActivity>(
+            std::move(wakeup_scheduler)),
         ActivityContexts<Contexts...>(std::forward<Contexts>(contexts)...),
-        wakeup_scheduler_(std::move(wakeup_scheduler)),
         on_done_(std::move(on_done)) {
     // Lock, construct an initial promise from the factory, and step it.
     // This may hit a waiter, which could expose our this pointer to other
@@ -482,7 +492,7 @@ class PromiseActivity final : public FreestandingActivity,
     }
     if (!wakeup_scheduled_.exchange(true, std::memory_order_acq_rel)) {
       // Can't safely run, so ask to run later.
-      wakeup_scheduler_.ScheduleWakeup(this);
+      this->ScheduleWakeup();
     } else {
       // Already a wakeup scheduled for later, drop ref.
       WakeupComplete();
@@ -564,8 +574,6 @@ class PromiseActivity final : public FreestandingActivity,
   }
 
   using Promise = typename Factory::Promise;
-  // Scheduler for wakeups
-  GPR_NO_UNIQUE_ADDRESS WakeupScheduler wakeup_scheduler_;
   // Callback on completion of the promise.
   GPR_NO_UNIQUE_ADDRESS OnDone on_done_;
   // Has execution completed?

--- a/src/core/lib/promise/event_engine_wakeup_scheduler.h
+++ b/src/core/lib/promise/event_engine_wakeup_scheduler.h
@@ -1,0 +1,56 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_CORE_LIB_PROMISE_EXEC_CTX_WAKEUP_SCHEDULER_H
+#define GRPC_CORE_LIB_PROMISE_EXEC_CTX_WAKEUP_SCHEDULER_H
+
+#include <grpc/support/port_platform.h>
+
+#include "absl/status/status.h"
+
+#include <grpc/event_engine/event_engine.h>
+
+namespace grpc_core {
+
+// A callback scheduler for activities that works by scheduling callbacks on the
+// exec ctx.
+class EventEngineWakeupScheduler {
+ public:
+  explicit EventEngineWakeupScheduler(
+      std::shared_ptr<grpc_event_engine::experimental::EventEngine>
+          event_engine)
+      : event_engine_(std::move(event_engine)) {}
+
+  template <typename ActivityType>
+  class BoundScheduler
+      : public grpc_event_engine::experimental::EventEngine::Closure {
+   protected:
+    explicit BoundScheduler(EventEngineWakeupScheduler scheduler)
+        : event_engine_(std::move(scheduler.event_engine_)) {}
+    BoundScheduler(const BoundScheduler&) = delete;
+    BoundScheduler& operator=(const BoundScheduler&) = delete;
+    void ScheduleWakeup() { event_engine_->Run(this); }
+    void Run() final { static_cast<ActivityType*>(this)->RunScheduledWakeup(); }
+
+   private:
+    std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine_;
+  };
+
+ private:
+  std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine_;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_CORE_LIB_PROMISE_EXEC_CTX_WAKEUP_SCHEDULER_H

--- a/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
+++ b/src/core/lib/promise/exec_ctx_wakeup_scheduler.h
@@ -31,18 +31,24 @@ namespace grpc_core {
 class ExecCtxWakeupScheduler {
  public:
   template <typename ActivityType>
-  void ScheduleWakeup(ActivityType* activity) {
-    GRPC_CLOSURE_INIT(
-        &closure_,
-        [](void* arg, grpc_error_handle) {
-          static_cast<ActivityType*>(arg)->RunScheduledWakeup();
-        },
-        activity, grpc_schedule_on_exec_ctx);
-    ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
-  }
+  class BoundScheduler {
+   protected:
+    explicit BoundScheduler(ExecCtxWakeupScheduler) {}
+    BoundScheduler(const BoundScheduler&) = delete;
+    BoundScheduler& operator=(const BoundScheduler&) = delete;
+    void ScheduleWakeup() {
+      GRPC_CLOSURE_INIT(
+          &closure_,
+          [](void* arg, grpc_error_handle) {
+            static_cast<ActivityType*>(arg)->RunScheduledWakeup();
+          },
+          static_cast<ActivityType*>(this), nullptr);
+      ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
+    }
 
- private:
-  grpc_closure closure_;
+   private:
+    grpc_closure closure_;
+  };
 };
 
 }  // namespace grpc_core

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -437,6 +437,26 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "event_engine_wakeup_scheduler_test",
+    srcs = ["event_engine_wakeup_scheduler_test.cc"],
+    external_deps = [
+        "absl/status",
+        "gtest",
+    ],
+    language = "c++",
+    tags = ["promise_test"],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//:grpc",
+        "//src/core:activity",
+        "//src/core:event_engine_wakeup_scheduler",
+        "//src/core:notification",
+        "//src/core:poll",
+    ],
+)
+
+grpc_cc_test(
     name = "sleep_test",
     srcs = ["sleep_test.cc"],
     external_deps = ["gtest"],

--- a/test/core/promise/event_engine_wakeup_scheduler_test.cc
+++ b/test/core/promise/event_engine_wakeup_scheduler_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2021 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/lib/promise/event_engine_wakeup_scheduler.h"
+
+#include <stdlib.h>
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/grpc.h>
+
+#include "src/core/lib/gprpp/notification.h"
+#include "src/core/lib/promise/activity.h"
+#include "src/core/lib/promise/poll.h"
+
+namespace grpc_core {
+
+TEST(EventEngineWakeupSchedulerTest, Works) {
+  int state = 0;
+  Notification done;
+  auto activity = MakeActivity(
+      [&state]() mutable -> Poll<absl::Status> {
+        ++state;
+        switch (state) {
+          case 1:
+            return Pending();
+          case 2:
+            return absl::OkStatus();
+          default:
+            abort();
+        }
+      },
+      EventEngineWakeupScheduler(
+          grpc_event_engine::experimental::CreateEventEngine()),
+      [&done](absl::Status status) {
+        EXPECT_EQ(status, absl::OkStatus());
+        done.Notify();
+      });
+
+  EXPECT_EQ(state, 1);
+  EXPECT_FALSE(done.HasBeenNotified());
+  activity->ForceWakeup();
+  done.WaitForNotification();
+  EXPECT_EQ(state, 2);
+}
+
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc_init();
+  auto r = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return r;
+}

--- a/test/core/promise/promise_fuzzer.cc
+++ b/test/core/promise/promise_fuzzer.cc
@@ -121,13 +121,23 @@ class Fuzzer {
   // Schedule wakeups against the fuzzer
   struct Scheduler {
     Fuzzer* fuzzer;
-    // Schedule a wakeup
     template <typename ActivityType>
-    void ScheduleWakeup(ActivityType* activity) {
-      GPR_ASSERT(activity == fuzzer->activity_.get());
-      GPR_ASSERT(fuzzer->wakeup_ == nullptr);
-      fuzzer->wakeup_ = [activity]() { activity->RunScheduledWakeup(); };
-    }
+    class BoundScheduler {
+     public:
+      explicit BoundScheduler(Scheduler scheduler)
+          : fuzzer_(scheduler.fuzzer) {}
+      void ScheduleWakeup() {
+        GPR_ASSERT(static_cast<ActivityType*>(this) ==
+                   fuzzer_->activity_.get());
+        GPR_ASSERT(fuzzer_->wakeup_ == nullptr);
+        fuzzer_->wakeup_ = [this]() {
+          static_cast<ActivityType*>(this)->RunScheduledWakeup();
+        };
+      }
+
+     private:
+      Fuzzer* fuzzer_;
+    };
   };
 
   // We know that if not already finished, the status when finished will be

--- a/test/core/promise/test_wakeup_schedulers.h
+++ b/test/core/promise/test_wakeup_schedulers.h
@@ -27,9 +27,11 @@ namespace grpc_core {
 // Useful for very limited tests.
 struct NoWakeupScheduler {
   template <typename ActivityType>
-  void ScheduleWakeup(ActivityType*) {
-    abort();
-  }
+  class BoundScheduler {
+   public:
+    explicit BoundScheduler(NoWakeupScheduler) {}
+    void ScheduleWakeup() { abort(); }
+  };
 };
 
 // A wakeup scheduler that simply runs the callback immediately.
@@ -37,9 +39,13 @@ struct NoWakeupScheduler {
 // ordering problems.
 struct InlineWakeupScheduler {
   template <typename ActivityType>
-  void ScheduleWakeup(ActivityType* activity) {
-    activity->RunScheduledWakeup();
-  }
+  class BoundScheduler {
+   public:
+    explicit BoundScheduler(InlineWakeupScheduler) {}
+    void ScheduleWakeup() {
+      static_cast<ActivityType*>(this)->RunScheduledWakeup();
+    }
+  };
 };
 
 // Mock for something that can schedule callbacks.
@@ -58,9 +64,18 @@ class MockCallbackScheduler {
 struct UseMockCallbackScheduler {
   MockCallbackScheduler* scheduler;
   template <typename ActivityType>
-  void ScheduleWakeup(ActivityType* activity) {
-    scheduler->Schedule([activity] { activity->RunScheduledWakeup(); });
-  }
+  class BoundScheduler {
+   public:
+    explicit BoundScheduler(UseMockCallbackScheduler use_scheduler)
+        : scheduler(use_scheduler.scheduler) {}
+    void ScheduleWakeup() {
+      scheduler->Schedule(
+          [this] { static_cast<ActivityType*>(this)->RunScheduledWakeup(); });
+    }
+
+   private:
+    MockCallbackScheduler* scheduler;
+  };
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
This change cleans up a few details on the `WakeupScheduler` interface used by `MakeActivity`, and then leverages that to provide an implementation that does wakeups by calling into `EventEngine::Run`.

Cleanup: Instead of passing the activity pointer into the wakeup scheduler every wakeup, leverage the fact that it's constant and use CRTP to access it. This involves moving the `ScheduleWakeup` function into a child templated class and is probably a little shenanigan heavy - please note where additional commentary would be useful during the review.

What it gets us: all this allows us to do wakeups from an `Activity` without any memory allocations: common `EventEngine` implementations provide fast paths for `Closure*` callbacks, and by having the `BoundScheduler` child templated class *know* which `Activity` to wakeup (via a single free `static_cast`) we hit beneficial fast paths.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

