### PR TITLE
Run multi arch ios unit test for M1 mac

### DIFF
--- a/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.dependency "!ProtoCompiler-gRPCPlugin"
 
   repo_root = '../../../..'
-  bazel_exec_root = "#{repo_root}/bazel-out/darwin-fastbuild/bin"
+  bazel_exec_root = "#{repo_root}/bazel-bin"
 
   protoc = "#{bazel_exec_root}/external/com_google_protobuf/protoc"
   well_known_types_dir = "#{repo_root}/third_party/protobuf/src"

--- a/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.dependency "!ProtoCompiler-gRPCPlugin"
 
   repo_root = '../../../..'
-  bazel_exec_root = "#{repo_root}/bazel-out/darwin-fastbuild/bin"
+  bazel_exec_root = "#{repo_root}/bazel-bin"
 
   protoc = "#{bazel_exec_root}/external/com_google_protobuf/protoc"
   well_known_types_dir = "#{repo_root}/third_party/protobuf/src"

--- a/src/objective-c/tests/run_one_test.sh
+++ b/src/objective-c/tests/run_one_test.sh
@@ -22,7 +22,7 @@ cd $(dirname $0)
 
 BAZEL=../../../tools/bazel
 
-INTEROP=../../../bazel-out/darwin-fastbuild/bin/test/cpp/interop/interop_server
+INTEROP=../../../bazel-bin/test/cpp/interop/interop_server
 
 [ -d Tests.xcworkspace ] || {
     ./build_tests.sh

--- a/src/objective-c/tests/run_one_test_bazel.sh
+++ b/src/objective-c/tests/run_one_test_bazel.sh
@@ -25,11 +25,12 @@ cd $(dirname $0)
 
 BAZEL=../../../tools/bazel
 
-INTEROP=../../../bazel-out/darwin-fastbuild/bin/test/cpp/interop/interop_server
+INTEROP=../../../bazel-bin/test/cpp/interop/interop_server
 
 [ -f $INTEROP ] || {
     $BAZEL build //test/cpp/interop:interop_server
 }
+[ -f $INTEROP ] || exit 1
 
 [ -z "$(ps aux |egrep 'port_server\.py.*-p\s32766')" ] && {
     echo >&2 "Can't find the port server. Start port server with tools/run_tests/start_port_server.py."
@@ -44,7 +45,7 @@ $INTEROP --port=$TLS_PORT --max_send_message_size=8388608 --use_tls &
 
 trap 'kill -9 `jobs -p` ; echo "EXIT TIME:  $(date)"' EXIT
 
-time $BAZEL run \
+time $BAZEL test --ios_multi_cpus=x86_64,sim_arm64 \
     --test_env HOST_PORT_LOCALSSL=localhost:$TLS_PORT \
     --test_env HOST_PORT_LOCAL=localhost:$PLAIN_PORT \
     $SCHEME

--- a/test/cpp/ios/RemoteTestClientCpp/RemoteTestCpp.podspec
+++ b/test/cpp/ios/RemoteTestClientCpp/RemoteTestCpp.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc = false
 
   repo_root = '../../../..'
-  bazel_exec_root = "#{repo_root}/bazel-out/darwin-fastbuild/bin"
+  bazel_exec_root = "#{repo_root}/bazel-bin"
 
   protoc = "#{bazel_exec_root}/external/com_google_protobuf/protoc"
   well_known_types_dir = "#{repo_root}/third_party/protobuf/src"

--- a/test/distrib/bazel/python/namespaced/upper/example/BUILD
+++ b/test/distrib/bazel/python/namespaced/upper/example/BUILD
@@ -112,16 +112,16 @@ py_grpc_library(
 # in the following directory layout for python, which needs to properly be added to the imports.
 #
 # No Import or Strip (Can't compile if there are any proto dependencies)
-# bazel-out/darwin-fastbuild/bin/namespaced/upper/example/namespaced_example_pb2.py
+# bazel-bin/namespaced/upper/example/namespaced_example_pb2.py
 #
 # No import Prefix (Can't compile if there are any proto dependencies)
-# bazel-out/darwin-fastbuild/bin/namespaced/upper/example/_virtual_imports/namespaced_example_proto/namespaced_example_pb2.py
+# bazel-bin/namespaced/upper/example/_virtual_imports/namespaced_example_proto/namespaced_example_pb2.py
 #
 # No strip prefix (Can't compile if there are any proto dependencies)
-# bazel-out/darwin-fastbuild/bin/namespaced/upper/example/_virtual_imports/namespaced_example_proto/upper/example/namespaced/upper/example/namespaced_example_pb2.py
+# bazel-bin/namespaced/upper/example/_virtual_imports/namespaced_example_proto/upper/example/namespaced/upper/example/namespaced_example_pb2.py
 #
 # Both Import and Strip
-# bazel-out/darwin-fastbuild/bin/namespaced/upper/example/_virtual_imports/namespaced_example_proto/upper/example/namespaced_example_pb2.py
+# bazel-bin/namespaced/upper/example/_virtual_imports/namespaced_example_proto/upper/example/namespaced_example_pb2.py
 
 py_test(
     name = "import_no_strip_test",

--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -56,6 +56,11 @@ config_setting(
     values = {"cpu": "ios_arm64"},
 )
 
+config_setting(
+    name = "ios_sim_arm64",
+    values = {"cpu": "ios_sim_arm64"},
+)
+
 # The following architectures are found in 
 # https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/rules/apple/ApplePlatform.java
 config_setting(
@@ -106,6 +111,7 @@ copy_file(
         ":ios_armv7": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
         ":ios_armv7s": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
         ":ios_arm64": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
+        ":ios_sim_arm64": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
         ":tvos_x86_64": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
         ":tvos_arm64": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",
         ":watchos_i386": "@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h",


### PR DESCRIPTION
1. pass `--ios_multi_cpus=x86_64,sim_arm64` to bazel to build multi-arch binary
2. add `ios_sim_arm64` config for `third_party/cares`
3. update `bazel-out/darwin-fastbuild/bin` to `bazel-bin` which points to `bazel-out/darwin_arm64-fastbuild/bin` on M1 macs.



tested with `SCHEME=InteropTestsLocalSSL src/objective-c/tests/run_one_test_bazel.sh`


---
Example failure:
```
2022-12-18 12:29:08.229 xctest[86573:242977] The bundle “InteropTestsLocalCleartext” couldn’t be loaded because it doesn’t contain a version for the current architecture. Try installing a universal version of the bundle.
```


@sampajano 