### PR TITLE
Remove stack trace from Status.ToString

### DIFF
--- a/src/csharp/Grpc.Core.Api/Status.cs
+++ b/src/csharp/Grpc.Core.Api/Status.cs
@@ -87,7 +87,8 @@ namespace Grpc.Core
         {
             if (DebugException != null)
             {
-                return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\", DebugException=\"{DebugException}\")";
+                return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\"," +
+                    $" DebugException=\"{DebugException.GetType().Name}: {DebugException.Message}\")";
             }
             return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\")";
         }

--- a/src/csharp/Grpc.Core.Api/Status.cs
+++ b/src/csharp/Grpc.Core.Api/Status.cs
@@ -88,7 +88,7 @@ namespace Grpc.Core
             if (DebugException != null)
             {
                 return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\"," +
-                    $" DebugException=\"{DebugException.GetType().Name}: {DebugException.Message}\")";
+                    $" DebugException=\"{DebugException.GetType().FullName}: {DebugException.Message}\")";
             }
             return $"Status(StatusCode=\"{StatusCode}\", Detail=\"{Detail}\")";
         }


### PR DESCRIPTION
Fix for https://github.com/grpc/grpc/issues/27066 - remove the stack trace from `Status.ToString()` when getting the info from the `DebugException`

However I've not been able to reproduce the original reported problem with "100 lines of stack trace" since the only `DebugException` that I can see added is that in
https://github.com/grpc/grpc/blob/af855eb64eea02d2f7b68d49c3d4d7a263649104/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs#L97

which doesn't contain a stack trace since it wasn't thrown.

