### PR TITLE
testing: bump timeout of grpc/abseil-head build job from 4 to 5 hours

### DIFF
--- a/tools/internal_ci/linux/grpc_build_abseil-cpp_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_abseil-cpp_at_head.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
-timeout_mins: 240
+timeout_mins: 300
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
This test has recently timed out 4 times in a row