### PR TITLE
[BinderTransport] remove unnecessary grpc_init() in binder_server_test

### DIFF
--- a/test/core/transport/binder/end2end/binder_server_test.cc
+++ b/test/core/transport/binder/end2end/binder_server_test.cc
@@ -67,7 +67,6 @@ std::shared_ptr<ServerCredentials> BinderServerCredentials() {
 
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
     std::unique_ptr<grpc_binder::Binder> endpoint_binder) {
-
   return grpc::CreateChannelInternal(
       "",
       grpc::internal::CreateDirectBinderChannelImplForTesting(

--- a/test/core/transport/binder/end2end/binder_server_test.cc
+++ b/test/core/transport/binder/end2end/binder_server_test.cc
@@ -67,7 +67,6 @@ std::shared_ptr<ServerCredentials> BinderServerCredentials() {
 
 std::shared_ptr<grpc::Channel> CreateBinderChannel(
     std::unique_ptr<grpc_binder::Binder> endpoint_binder) {
-  grpc_init();
 
   return grpc::CreateChannelInternal(
       "",


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

