### PR TITLE
xds_override_host LB: add basic support for overriding host

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -1390,6 +1390,7 @@ grpc_cc_library(
     external_deps = [
         "absl/functional:any_invocable",
         "absl/status",
+        "absl/status:statusor",
     ],
     deps = [
         "//:event_engine_base_hdrs",
@@ -4448,14 +4449,17 @@ grpc_cc_library(
         "ext/filters/client_channel/lb_policy/xds/xds_override_host.cc",
     ],
     external_deps = [
+        "absl/base:core_headers",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
+        "absl/synchronization",
+        "absl/types:optional",
+        "absl/types:variant",
     ],
     language = "c++",
     deps = [
         "channel_args",
-        "grpc_lb_subchannel_list",
         "grpc_stateful_session_filter",
         "json",
         "json_args",

--- a/src/core/ext/filters/client_channel/lb_call_state_internal.h
+++ b/src/core/ext/filters/client_channel/lb_call_state_internal.h
@@ -19,6 +19,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "absl/strings/string_view.h"
+
 #include "src/core/lib/gprpp/unique_type_name.h"
 #include "src/core/lib/load_balancing/lb_policy.h"
 

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -16,14 +16,21 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
+#include "absl/base/thread_annotations.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "absl/types/optional.h"
+#include "absl/types/variant.h"
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/impl/connectivity_state.h>
@@ -31,7 +38,6 @@
 
 #include "src/core/ext/filters/client_channel/lb_call_state_internal.h"
 #include "src/core/ext/filters/client_channel/lb_policy/child_policy_handler.h"
-#include "src/core/ext/filters/client_channel/lb_policy/subchannel_list.h"
 #include "src/core/ext/filters/stateful_session/stateful_session_filter.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/channel/channel_args.h"

--- a/src/core/lib/event_engine/posix.h
+++ b/src/core/lib/event_engine/posix.h
@@ -16,16 +16,15 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <functional>
-#include <vector>
+#include <memory>
 
 #include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
 
 #include <grpc/event_engine/endpoint_config.h>
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/event_engine/memory_allocator.h>
-#include <grpc/event_engine/port.h>
 #include <grpc/event_engine/slice_buffer.h>
 
 namespace grpc_event_engine {

--- a/test/core/client_channel/lb_policy/lb_policy_test_lib.h
+++ b/test/core/client_channel/lb_policy/lb_policy_test_lib.h
@@ -60,6 +60,7 @@
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/gprpp/sync.h"
+#include "src/core/lib/gprpp/unique_type_name.h"
 #include "src/core/lib/gprpp/work_serializer.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/resolved_address.h"

--- a/test/core/client_channel/lb_policy/round_robin_test.cc
+++ b/test/core/client_channel/lb_policy/round_robin_test.cc
@@ -16,13 +16,15 @@
 
 #include <stddef.h>
 
+#include <array>
+
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
 #include "gtest/gtest.h"
 
 #include <grpc/grpc.h>
 
-#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/load_balancing/lb_policy.h"

--- a/test/core/client_channel/lb_policy/xds_override_host_test.cc
+++ b/test/core/client_channel/lb_policy/xds_override_host_test.cc
@@ -14,11 +14,27 @@
 // limitations under the License.
 //
 
-#include <unordered_set>
+#include <stddef.h>
 
-#include "gmock/gmock.h"
+#include <array>
+#include <map>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "gtest/gtest.h"
+
+#include <grpc/grpc.h>
 
 #include "src/core/ext/filters/stateful_session/stateful_session_filter.h"
+#include "src/core/lib/gprpp/orphanable.h"
+#include "src/core/lib/gprpp/ref_counted_ptr.h"
+#include "src/core/lib/gprpp/unique_type_name.h"
+#include "src/core/lib/json/json.h"
+#include "src/core/lib/load_balancing/lb_policy.h"
 #include "test/core/client_channel/lb_policy/lb_policy_test_lib.h"
 #include "test/core/util/test_config.h"
 


### PR DESCRIPTION
This is same as #31819 but with fixed compilation issues.
