### PR TITLE
[windows] explicitly ignore set_int() status in iomgr

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -746,7 +746,12 @@ class SockToPolledFdMap {
           protocol);
       return s;
     }
-    std::ignore = grpc_tcp_set_non_block(s);
+    grpc_error_handle error = grpc_tcp_set_non_block(s);
+    if (!error.ok()) {
+      GRPC_CARES_TRACE_LOG("WSAIoctl failed with error: %s",
+                           StatusToString(error).c_str());
+      return INVALID_SOCKET;
+    }
     GrpcPolledFdWindows* polled_fd =
         new GrpcPolledFdWindows(s, map->mu_, af, type);
     GRPC_CARES_TRACE_LOG(

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -746,7 +746,7 @@ class SockToPolledFdMap {
           protocol);
       return s;
     }
-    grpc_tcp_set_non_block(s);
+    std::ignore = grpc_tcp_set_non_block(s);
     GrpcPolledFdWindows* polled_fd =
         new GrpcPolledFdWindows(s, map->mu_, af, type);
     GRPC_CARES_TRACE_LOG(

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -63,8 +63,8 @@ static void create_sockets(SOCKET sv[2]) {
   GPR_ASSERT(svr_sock != INVALID_SOCKET);
 
   closesocket(lst_sock);
-  grpc_tcp_prepare_socket(cli_sock);
-  grpc_tcp_prepare_socket(svr_sock);
+  std::ignore = grpc_tcp_prepare_socket(cli_sock);
+  std::ignore = grpc_tcp_prepare_socket(svr_sock);
 
   sv[1] = cli_sock;
   sv[0] = svr_sock;

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -63,8 +63,8 @@ static void create_sockets(SOCKET sv[2]) {
   GPR_ASSERT(svr_sock != INVALID_SOCKET);
 
   closesocket(lst_sock);
-  std::ignore = grpc_tcp_prepare_socket(cli_sock);
-  std::ignore = grpc_tcp_prepare_socket(svr_sock);
+  GPR_ASSERT(grpc_tcp_prepare_socket(cli_sock).ok());
+  GPR_ASSERT(grpc_tcp_prepare_socket(svr_sock).ok());
 
   sv[1] = cli_sock;
   sv[0] = svr_sock;

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -65,12 +65,12 @@ static void create_sockets(SOCKET sv[2]) {
   closesocket(lst_sock);
   grpc_error_handle error = grpc_tcp_prepare_socket(cli_sock);
   if (!error.ok()) {
-    gpr_log(GPR_WARN, "Prepare cli_sock failed with error: %s",
+    gpr_log(GPR_INFO, "Prepare cli_sock failed with error: %s",
             grpc_core::StatusToString(error).c_str());
   }
   error = grpc_tcp_prepare_socket(svr_sock);
   if (!error.ok()) {
-    gpr_log(GPR_ERROR, "Prepare svr_sock failed with error: %s",
+    gpr_log(GPR_INFO, "Prepare svr_sock failed with error: %s",
             grpc_core::StatusToString(error).c_str());
   }
 

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -63,8 +63,16 @@ static void create_sockets(SOCKET sv[2]) {
   GPR_ASSERT(svr_sock != INVALID_SOCKET);
 
   closesocket(lst_sock);
-  GPR_ASSERT(grpc_tcp_prepare_socket(cli_sock).ok());
-  GPR_ASSERT(grpc_tcp_prepare_socket(svr_sock).ok());
+  grpc_error_handle error = grpc_tcp_prepare_socket(cli_sock);
+  if (!error.ok()) {
+    gpr_log(GPR_ERROR, "Prepare cli_sock failed with error: %s",
+            grpc_core::StatusToString(error).c_str());
+  }
+  error = grpc_tcp_prepare_socket(svr_sock);
+  if (!error.ok()) {
+    gpr_log(GPR_ERROR, "Prepare svr_sock failed with error: %s",
+            grpc_core::StatusToString(error).c_str());
+  }
 
   sv[1] = cli_sock;
   sv[0] = svr_sock;

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -65,7 +65,7 @@ static void create_sockets(SOCKET sv[2]) {
   closesocket(lst_sock);
   grpc_error_handle error = grpc_tcp_prepare_socket(cli_sock);
   if (!error.ok()) {
-    gpr_log(GPR_ERROR, "Prepare cli_sock failed with error: %s",
+    gpr_log(GPR_WARN, "Prepare cli_sock failed with error: %s",
             grpc_core::StatusToString(error).c_str());
   }
   error = grpc_tcp_prepare_socket(svr_sock);

--- a/src/core/lib/iomgr/pollset_windows.cc
+++ b/src/core/lib/iomgr/pollset_windows.cc
@@ -96,7 +96,7 @@ static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
 
 static void pollset_shutdown(grpc_pollset* pollset, grpc_closure* closure) {
   pollset->shutting_down = 1;
-  grpc_pollset_kick(pollset, GRPC_POLLSET_KICK_BROADCAST);
+  std::ignore = grpc_pollset_kick(pollset, GRPC_POLLSET_KICK_BROADCAST);
   if (!pollset->is_iocp_worker) {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, closure, absl::OkStatus());
   } else {
@@ -215,7 +215,7 @@ static grpc_error_handle pollset_kick(grpc_pollset* p,
     specific_worker =
         pop_front_worker(&p->root_worker, GRPC_POLLSET_WORKER_LINK_POLLSET);
     if (specific_worker != NULL) {
-      grpc_pollset_kick(p, specific_worker);
+      std::ignore = grpc_pollset_kick(p, specific_worker);
     } else if (p->is_iocp_worker) {
       grpc_iocp_kick();
     } else {

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -225,7 +225,7 @@ static grpc_error_handle prepare_socket(SOCKET sock,
 failure:
   GPR_ASSERT(!error.ok());
   auto addr_uri = grpc_sockaddr_to_uri(addr);
-  grpc_error_set_int(
+  std::ignore = grpc_error_set_int(
       grpc_error_set_str(
           GRPC_ERROR_CREATE_REFERENCING("Failed to prepare server socket",
                                         &error, 1),

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -225,7 +225,7 @@ static grpc_error_handle prepare_socket(SOCKET sock,
 failure:
   GPR_ASSERT(!error.ok());
   auto addr_uri = grpc_sockaddr_to_uri(addr);
-  std::ignore = grpc_error_set_int(
+  error = grpc_error_set_int(
       grpc_error_set_str(
           GRPC_ERROR_CREATE_REFERENCING("Failed to prepare server socket",
                                         &error, 1),


### PR DESCRIPTION
Found due to compiling grpc for windows with `-Werror=unused-result`.