### PR TITLE
Backport #31503 to v1.46.x

### DIFF
--- a/tools/internal_ci/linux/grpc_microbenchmark_diff.sh
+++ b/tools/internal_ci/linux/grpc_microbenchmark_diff.sh
@@ -16,15 +16,11 @@
 # This script is invoked by Kokoro and runs a diff on the microbenchmarks
 set -ex
 
-# List of benchmarks that provide good signal for analyzing performance changes in pull requests
-BENCHMARKS_TO_RUN="bm_fullstack_unary_ping_pong bm_fullstack_streaming_ping_pong bm_fullstack_streaming_pump bm_closure bm_cq bm_call_create bm_chttp2_hpack bm_chttp2_transport bm_pollset"
-
 # Enter the gRPC repo root
 cd $(dirname $0)/../../..
 
-source tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/start_port_server.py
-tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/microbenchmarks/bm_diff/bm_main.py \
-  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" \
-  -b $BENCHMARKS_TO_RUN
+export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64
+export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_microbenchmark_diff_in_docker.sh
+exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/internal_ci/linux/grpc_microbenchmark_diff_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_microbenchmark_diff_in_docker.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Enter the gRPC repo root
+cd $(dirname $0)/../../..
+
+# some extra pip packages are needed for the check_on_pr.py script to work
+# TODO(jtattermusch): avoid needing to install these pip packages each time
+time python3 -m pip install --user -r tools/internal_ci/helper_scripts/requirements.linux_perf.txt
+
+# List of benchmarks that provide good signal for analyzing performance changes in pull requests
+BENCHMARKS_TO_RUN="bm_fullstack_unary_ping_pong bm_fullstack_streaming_ping_pong bm_fullstack_streaming_pump bm_closure bm_cq bm_call_create bm_chttp2_hpack bm_chttp2_transport bm_pollset"
+
+tools/run_tests/start_port_server.py
+
+tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/microbenchmarks/bm_diff/bm_main.py \
+  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" \
+  -b $BENCHMARKS_TO_RUN


### PR DESCRIPTION
Backports #31503 to make the microbenchmark_diff pass on 1.46.x branch.