### PR TITLE
Fix hang on fork when the security context is destroyed in the Executor

### DIFF
--- a/src/core/lib/security/context/security_context.cc
+++ b/src/core/lib/security/context/security_context.cc
@@ -112,7 +112,6 @@ grpc_client_security_context* grpc_client_security_context_create(
 }
 
 void grpc_client_security_context_destroy(void* ctx) {
-  grpc_core::ExecCtx exec_ctx;
   grpc_client_security_context* c =
       static_cast<grpc_client_security_context*>(ctx);
   c->~grpc_client_security_context();


### PR DESCRIPTION
Attempting to create an ExecCtx while forking will hang forever. In the apparently rare case that the transport is destroyed in an Executor thread, this blocks indefinitely in the Executor pre-fork handler

I don't believe this ExecCtx is needed regardless, see `grpc_server_security_context_destroy` for comparison.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

