### PR TITLE
[Ruby] build: make exported symbol files platform-specific

### DIFF
--- a/src/ruby/ext/grpc/ext-export-truffleruby-with-ruby-abi-version.clang
+++ b/src/ruby/ext/grpc/ext-export-truffleruby-with-ruby-abi-version.clang
@@ -1,0 +1,2 @@
+_Init_grpc_c
+_rb_tr_abi_version

--- a/src/ruby/ext/grpc/ext-export-truffleruby-with-ruby-abi-version.gcc
+++ b/src/ruby/ext/grpc/ext-export-truffleruby-with-ruby-abi-version.gcc
@@ -1,6 +1,7 @@
 grpc_1.0 { 
   global: 
     Init_grpc_c;
+    rb_tr_abi_version;
   local: 
     *;
 };

--- a/src/ruby/ext/grpc/ext-export-truffleruby.clang
+++ b/src/ruby/ext/grpc/ext-export-truffleruby.clang
@@ -1,2 +1,1 @@
 _Init_grpc_c
-_rb_tr_abi_version

--- a/src/ruby/ext/grpc/ext-export-with-ruby-abi-version.clang
+++ b/src/ruby/ext/grpc/ext-export-with-ruby-abi-version.clang
@@ -1,0 +1,2 @@
+_Init_grpc_c
+_ruby_abi_version

--- a/src/ruby/ext/grpc/ext-export-with-ruby-abi-version.gcc
+++ b/src/ruby/ext/grpc/ext-export-with-ruby-abi-version.gcc
@@ -1,6 +1,7 @@
 grpc_1.0 { 
   global: 
     Init_grpc_c;
+    ruby_abi_version;
   local: 
     *;
 };

--- a/src/ruby/ext/grpc/ext-export.clang
+++ b/src/ruby/ext/grpc/ext-export.clang
@@ -1,2 +1,1 @@
 _Init_grpc_c
-_ruby_abi_version

--- a/src/ruby/ext/grpc/ext-export.gcc
+++ b/src/ruby/ext/grpc/ext-export.gcc
@@ -1,7 +1,6 @@
 grpc_1.0 { 
   global: 
     Init_grpc_c;
-    ruby_abi_version;
   local: 
     *;
 };

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -113,8 +113,30 @@ end
 $CFLAGS << ' -DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 $CFLAGS << ' -I' + File.join(grpc_root, 'include')
 
-ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', 'ext-export')
-ext_export_file += '-truffleruby' if RUBY_ENGINE == 'truffleruby'
+def have_ruby_abi_version()
+  m = /(\d+)\.(\d+)/.match(RUBY_VERSION)
+  if m.nil?
+    puts "Failed to parse ruby version: #{RUBY_VERSION}. Assuming ruby_abi_version symbol is NOT present."
+    return false
+  end
+  major = m[1].to_i
+  minor = m[2].to_i
+  if major >= 3 and minor >= 2
+    puts "Ruby version #{RUBY_VERSION} >= 3.2. Assuming ruby_abi_version symbol is present."
+    return true
+  end
+  puts "Ruby version #{RUBY_VERSION} < 3.2. Assuming ruby_abi_version symbol is NOT present."
+  false
+end
+
+def ext_export_filename()
+  name = 'ext-export'
+  name += '-truffleruby' if RUBY_ENGINE == 'truffleruby'
+  name += '-with-ruby-abi-version' if have_ruby_abi_version()
+  name
+end
+
+ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', ext_export_filename())
 $LDFLAGS << ' -Wl,--version-script="' + ext_export_file + '.gcc"' if linux
 $LDFLAGS << ' -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"' if apple_toolchain
 


### PR DESCRIPTION
This is an alternative to https://github.com/grpc/grpc/pull/31151, and should fix https://github.com/grpc/grpc/issues/30976.

The idea of this PR is to use separate export files depending on whether or not we expect `ruby_abi_version` to be defined (i.e. depending on whether or not we're using ruby 3.2+).

I lean towards this PR over https://github.com/grpc/grpc/pull/31151 because it maintains the current symbol-stripping behavior:

Mainly, it looks like https://github.com/grpc/grpc/pull/31151 will cause a size increase of an uncompressed `grpc_c.so` file on linux from ~8MB to ~11MB due to the extra symbols. Compressed size correspondingly increases from ~3MB to ~4MB.

The latest pre-compiled linux gem, `grpc-1.50.0-x86_64-linux.gem`, is ~21MB. So the size increase might be noticeable.

cc @peterzhu2118 

