### PR TITLE
Fix str vs. bytes error in Python bindings for ALTS.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -400,7 +400,8 @@ cdef class ALTSChannelCredentials(ChannelCredentials):
     self.c_options = grpc_alts_credentials_client_options_create()
     cdef str account
     for account in service_accounts:
-      grpc_alts_credentials_client_options_add_target_service_account(self.c_options, account)
+      grpc_alts_credentials_client_options_add_target_service_account(
+          self.c_options, str_to_bytes(account))
  
   def __dealloc__(self):
     if self.c_options != NULL:


### PR DESCRIPTION
It looks like nobody ever created ALTS redentials from Python with a list of accepted service accounts before.

Simple reproduction:

```
import grpc
grpc.alts_channel_credentials(None)  # works
grpc.alts_channel_credentials(['foo'])  # fails
```

Without this change, generates this error:

```
[...]
  File "src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi", line 414, in _cython.cygrpc.channel_credentials_alts
  File "src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi", line 403, in _cython.cygrpc.ALTSChannelCredentials.__cinit__
TypeError: expected bytes, str found
```

(And the error cannot be worked around by the caller by passing a bytes
object from the Python side: you still get the same error.)