### PR TITLE
Change Aio abort() function return type to NoReturn

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -14,7 +14,7 @@
 """Abstract base classes for server-side classes."""
 
 import abc
-from typing import Generic, Iterable, Mapping, Optional, Sequence
+from typing import Generic, Iterable, Mapping, NoReturn, Optional, Sequence
 
 import grpc
 
@@ -178,7 +178,7 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         self,
         code: grpc.StatusCode,
         details: str = '',
-        trailing_metadata: MetadataType = tuple()) -> None:
+        trailing_metadata: MetadataType = tuple()) -> NoReturn:
         """Raises an exception to terminate the RPC with a non-OK status.
 
         The code and details passed as arguments will supercede any existing


### PR DESCRIPTION
`abort()` function always raises an exception thus return type should be `NoReturn`.

Fix: https://github.com/grpc/grpc/issues/31880