### PR TITLE
[EventEngine] ThreadPool: pause closure execution on fork events

### DIFF
--- a/src/core/lib/event_engine/thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool.cc
@@ -128,8 +128,9 @@ bool ThreadPool::Queue::Step() {
   switch (state_) {
     case State::kRunning:
       break;
-    case State::kShutdown:
     case State::kForking:
+      return false;
+    case State::kShutdown:
       if (!callbacks_.empty()) break;
       return false;
   }


### PR DESCRIPTION
See #31885 and #31772 for context.

I'm not sure this is the right solution, but if it resolves Python's issues, we should try it.

Why this may be the wrong solution: in a post-fork child process for example, any pre-existing closures will likely (but not necessarily) want to do things it shouldn't, the post-fork child should essentially be a clean slate with respect to timers, polling, in-flight RPCs, etc.. 

Better potential solutions are much more complicated:

* ensuring no callback can possibly instantiate an ExecCtx during a fork event
* removing ExecCtx's special handling of fork events altogether
* removing ExecCtxs altogether

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

