### PR TITLE
[ruby] TruffleRuby support: Always export _rb_tr_abi_version on truffle ruby

### DIFF
--- a/src/ruby/ext/grpc/ext-export-truffleruby.clang
+++ b/src/ruby/ext/grpc/ext-export-truffleruby.clang
@@ -1,1 +1,0 @@
-_Init_grpc_c

--- a/src/ruby/ext/grpc/ext-export-truffleruby.gcc
+++ b/src/ruby/ext/grpc/ext-export-truffleruby.gcc
@@ -1,6 +1,0 @@
-grpc_1.0 { 
-  global: 
-    Init_grpc_c;
-  local: 
-    *;
-};

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -114,6 +114,7 @@ $CFLAGS << ' -DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
 $CFLAGS << ' -I' + File.join(grpc_root, 'include')
 
 def have_ruby_abi_version()
+  return true if RUBY_ENGINE == 'truffleruby'
   m = /(\d+)\.(\d+)/.match(RUBY_VERSION)
   if m.nil?
     puts "Failed to parse ruby version: #{RUBY_VERSION}. Assuming ruby_abi_version symbol is NOT present."


### PR DESCRIPTION
Followup from https://github.com/grpc/grpc/pull/31970, specifically [this comment](https://github.com/grpc/grpc/pull/31970#pullrequestreview-1228356119) from @eregon:

"""
This doesn't seem correct as it will break the gem on TruffleRuby if I read the PR correctly. TruffleRuby has rb_tr_abi_version before RUBY_VERSION 3.2, specifically it's 3.0 in the 22.3 release currently for TruffleRuby and it already had it before that. We can consider TruffleRuby always had this symbol, versions before are not supported anymore.
"""

