### PR TITLE
Fix Ruby build errors in 3.2.0 on Apple M1

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -115,6 +115,9 @@ $CFLAGS << ' -I' + File.join(grpc_root, 'include')
 
 def have_ruby_abi_version()
   return true if RUBY_ENGINE == 'truffleruby'
+  # ruby_abi_version is only available in development versions: https://github.com/ruby/ruby/pull/6231
+  return false if RUBY_PATCHLEVEL >= 0
+
   m = /(\d+)\.(\d+)/.match(RUBY_VERSION)
   if m.nil?
     puts "Failed to parse ruby version: #{RUBY_VERSION}. Assuming ruby_abi_version symbol is NOT present."


### PR DESCRIPTION
Previously attempting to build the Ruby C extension would result in undefined symbol:

```
Undefined symbols for architecture arm64:
  "_ruby_abi_version", referenced from:
     -exported_symbol[s_list] command line option
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

As noted in https://github.com/ruby/ruby/pull/6231, `_ruby_abi_version` is only available for development versions. `RUBY_PATCHLEVEL` < 0 denotes a development version, while >= 0 denotes a released version.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

