### PR TITLE
[EventEngine] Use overloading to get a mutable slice buffer

### DIFF
--- a/include/grpc/event_engine/slice_buffer.h
+++ b/include/grpc/event_engine/slice_buffer.h
@@ -126,7 +126,7 @@ class SliceBuffer {
   }
 
   /// Return mutable reference to the slice at the specified index
-  Slice& MutableSliceAt(size_t index) const {
+  Slice& operator[](size_t index) {
     return internal::SliceCast<Slice>(slice_buffer_.slices[index]);
   }
 


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

I think the PR https://github.com/grpc/grpc/pull/31996 has some problems. The member function returning a mutable slice buffer reference should not be a const function. On the other hand, we can use overloading to do the same thing making it consistent.