### PR TITLE
[iwyu] Add missing #include <type_traits> to fix build breakage with LLVM after https://github.com/llvm/llvm-project/commit/e0a66116fcccd59d12485810f5311efafa134ea5

### DIFF
--- a/src/core/lib/gprpp/manual_constructor.h
+++ b/src/core/lib/gprpp/manual_constructor.h
@@ -25,6 +25,7 @@
 
 #include <stddef.h>
 
+#include <type_traits>
 #include <utility>
 
 #include "src/core/lib/gprpp/construct_destruct.h"

--- a/src/core/lib/gprpp/no_destruct.h
+++ b/src/core/lib/gprpp/no_destruct.h
@@ -17,6 +17,7 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <type_traits>
 #include <utility>
 
 #include "src/core/lib/gprpp/construct_destruct.h"

--- a/src/core/lib/gprpp/ref_counted_ptr.h
+++ b/src/core/lib/gprpp/ref_counted_ptr.h
@@ -22,6 +22,7 @@
 #include <grpc/support/port_platform.h>
 
 #include <iosfwd>
+#include <type_traits>
 #include <utility>
 
 #include "src/core/lib/gprpp/debug_location.h"

--- a/tools/distrib/iwyu_mappings.imp
+++ b/tools/distrib/iwyu_mappings.imp
@@ -4,7 +4,6 @@
     { include: ["<sys/socket.h>", "public", "\"src/core/lib/iomgr/sockaddr.h\"", "public"]},
     { include: ["<openssl/base.h>", "private", "<openssl/crypto.h>", "public"] },
     { include: ["<openssl/digest.h>", "private", "<openssl/evp.h>", "public"] },
-    { include: ["<type_traits>", "public", "<utility>", "public" ] },
     # workaround: https://github.com/include-what-you-use/include-what-you-use/issues/908
     { symbol: ["std::max", "private", "<algorithm>", "public" ] },
 ] 


### PR DESCRIPTION



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

