### PR TITLE
ring_hash: fix cast in WorkSerializerRunner

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -288,7 +288,7 @@ class RingHash : public LoadBalancingPolicy {
 
      private:
       static void RunInExecCtx(void* arg, grpc_error_handle /*error*/) {
-        auto* self = static_cast<SubchannelConnectionAttempter*>(arg);
+        auto* self = static_cast<WorkSerializerRunner*>(arg);
         self->ring_hash_lb()->work_serializer()->Run(
             [self]() {
               self->Run();


### PR DESCRIPTION
This fixes a bug accidentally introduced in #30714.  This may address #31766.