### PR TITLE
Grpc.Tools: Use x86 protoc binaries on arm64 Windows

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
@@ -79,6 +79,11 @@ namespace Grpc.Tools.Tests
                 {
                     Assert.AreEqual("x64", _task.Cpu);
                 }
+                // On windows arm64, x86 is used until a native protoc is shipped
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Assert.AreEqual("x86", _task.Cpu);
+                }
                 else
                 {
                     Assert.AreEqual("arm64", _task.Cpu);

--- a/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
+++ b/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
@@ -65,6 +65,11 @@ namespace Grpc.Tools
             {
                 Cpu = "x64";
             }
+            // Use x86 on Windows arm64 until a native protoc is shipped
+            else if (Os == "windows" && Cpu == "arm64")
+            {
+                Cpu = "x86";
+            }
 
             return true;
         }


### PR DESCRIPTION
A workaround for https://github.com/grpc/grpc/issues/31975 - use x86 protoc binaries on Windows arm64.

Unable to test as I don't have access to Windows-arm64.

Also not sure how NUnit PlatformAttribute handles arm64 (could not find any information).  It is possible that tests will fail if run on Windows-arm64 with full .NET framework if NUnit doesn't distinguish between x64 and arm64 (just identifies a 64 bit platform). Not sure that we run tests on Windows-arm64.