### PR TITLE
[bazel 7.0.0] migrate --incompatible_disable_starlark_host_transitions

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -175,7 +175,7 @@ _generate_cc = rule(
         "plugin": attr.label(
             executable = True,
             providers = ["files_to_run"],
-            cfg = "host",
+            cfg = "exec",
         ),
         "flags": attr.string_list(
             mandatory = False,
@@ -189,7 +189,7 @@ _generate_cc = rule(
         "_protoc": attr.label(
             default = Label("//external:protocol_compiler"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     # We generate .h files, so we need to output to genfiles.


### PR DESCRIPTION
The grpc bazel rules will not be compatible with future versions of bazel due to  
 [--incompatible_disable_starlark_host_transitions](https://github.com/bazelbuild/bazel/issues/17032)

This PR follows the recommended migration.