### PR TITLE
Fix order issue in setting grpc_tcp_client_impl in api_fuzzer

### DIFF
--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -815,7 +815,6 @@ DEFINE_PROTO_FUZZER(const api_fuzzer::Msg& msg) {
   if (squelch && !grpc_core::GetEnv("GRPC_TRACE_FUZZER").has_value()) {
     gpr_set_log_function(dont_log);
   }
-  grpc_set_tcp_client_impl(&fuzz_tcp_client_vtable);
   grpc_event_engine::experimental::SetEventEngineFactory(
       [actions = msg.event_engine_actions()]() {
         return std::make_unique<FuzzingEventEngine>(
@@ -825,6 +824,7 @@ DEFINE_PROTO_FUZZER(const api_fuzzer::Msg& msg) {
       std::dynamic_pointer_cast<FuzzingEventEngine>(GetDefaultEventEngine());
   FuzzingEventEngine::SetGlobalNowImplEngine(engine.get());
   grpc_init();
+  grpc_set_tcp_client_impl(&fuzz_tcp_client_vtable);
   grpc_timer_manager_set_threading(false);
   {
     grpc_core::ExecCtx exec_ctx;


### PR DESCRIPTION
`iomgr` sets the `grpc_tcp_client_impl` vtable [here](https://github.com/grpc/grpc/blob/f99b8b5bc4a89d37f86bf063999ec22e44312663/src/core/lib/iomgr/iomgr_posix.cc#L78) as part of the first `grpc_init` which overwrites the `fuzz_tcp_client_vtable` set by api_fuzzer. This caused inconsistent behavior between whether api_fuzzer is used to run one test case or multiple test cases (since later test case run will overwrite the vtable again and use the intended one).

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

