### PR TITLE
add back grpc_artifact_android_ndk image to unbreak C# artifact build

### DIFF
--- a/templates/tools/dockerfile/grpc_artifact_android_ndk/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_artifact_android_ndk/Dockerfile.template
@@ -1,0 +1,44 @@
+%YAML 1.2
+--- |
+  # Copyright 2021 The gRPC Authors
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM debian:stretch
+  
+  <%include file="../apt_get_basic.include"/>
+  <%include file="../run_tests_python_deps.include"/>
+  <%include file="../cmake.include"/>
+  <%include file="../run_tests_addons.include"/>
+
+  # Java required by Android SDK
+  RUN apt-get update && apt-get -y install openjdk-8-jdk && apt-get clean
+
+  # Install Android SDK
+  ENV ANDROID_SDK_VERSION 4333796
+  RUN mkdir -p /opt/android-sdk && cd /opt/android-sdk && \
+      wget -q https://dl.google.com/android/repository/sdk-tools-linux-$ANDROID_SDK_VERSION.zip && \
+      unzip -q sdk-tools-linux-$ANDROID_SDK_VERSION.zip && \
+      rm sdk-tools-linux-$ANDROID_SDK_VERSION.zip
+  ENV ANDROID_SDK_PATH /opt/android-sdk
+
+  # Install Android NDK and cmake using sdkmanager
+  RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
+  RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licenses
+  RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager ndk-bundle 'cmake;3.6.4111459'
+  ENV ANDROID_NDK_PATH $ANDROID_SDK_PATH/ndk-bundle
+  ENV ANDROID_SDK_CMAKE $ANDROID_SDK_PATH/cmake/3.6.4111459/bin/cmake
+
+  # Define the default command.
+  CMD ["bash"]
+

--- a/tools/dockerfile/grpc_artifact_android_ndk/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_android_ndk/Dockerfile
@@ -1,0 +1,107 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+#=================
+# Basic C core dependencies
+
+# C/C++ dependencies according to https://github.com/grpc/grpc/blob/master/BUILDING.md
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  autoconf \
+  libtool \
+  pkg-config \
+  && apt-get clean
+
+# GCC
+RUN apt-get update && apt-get install -y \
+  gcc \
+  g++ \
+  && apt-get clean
+
+# libc6
+RUN apt-get update && apt-get install -y \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  && apt-get clean
+
+# Tools
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  curl \
+  dnsutils \
+  git \
+  lcov \
+  make \
+  strace \
+  time \
+  unzip \
+  wget \
+  zip \
+  && apt-get clean
+
+#====================
+# run_tests.py python dependencies
+
+# Basic python dependencies to be able to run tools/run_tests python scripts
+# These dependencies are not sufficient to build gRPC Python, gRPC Python
+# deps are defined elsewhere (e.g. python_deps.include)
+RUN apt-get update && apt-get install -y \
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  python3-yaml \
+  && apt-get clean
+
+# use pinned version of pip to avoid sudden breakages
+RUN python3 -m pip install --upgrade pip==19.3.1
+
+# TODO(jtattermusch): currently six is needed for tools/run_tests scripts
+# but since our python2 usage is deprecated, we should get rid of it.
+RUN python3 -m pip install six==1.16.0
+
+# Google Cloud Platform API libraries
+# These are needed for uploading test results to BigQuery (e.g. by tools/run_tests scripts)
+RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-client==1.12.8 oauth2client==4.1.0
+
+
+#=================
+# Install cmake
+# Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
+
+RUN apt-get update && apt-get install -y cmake && apt-get clean
+
+
+RUN mkdir /var/local/jenkins
+
+
+# Java required by Android SDK
+RUN apt-get update && apt-get -y install openjdk-8-jdk && apt-get clean
+
+# Install Android SDK
+ENV ANDROID_SDK_VERSION 4333796
+RUN mkdir -p /opt/android-sdk && cd /opt/android-sdk &&     wget -q https://dl.google.com/android/repository/sdk-tools-linux-$ANDROID_SDK_VERSION.zip &&     unzip -q sdk-tools-linux-$ANDROID_SDK_VERSION.zip &&     rm sdk-tools-linux-$ANDROID_SDK_VERSION.zip
+ENV ANDROID_SDK_PATH /opt/android-sdk
+
+# Install Android NDK and cmake using sdkmanager
+RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
+RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licenses
+RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager ndk-bundle 'cmake;3.6.4111459'
+ENV ANDROID_NDK_PATH $ANDROID_SDK_PATH/ndk-bundle
+ENV ANDROID_SDK_CMAKE $ANDROID_SDK_PATH/cmake/3.6.4111459/bin/cmake
+
+# Define the default command.
+CMD ["bash"]


### PR DESCRIPTION
Fixup https://github.com/grpc/grpc/pull/31961/files in v1.46.x branch.
The backport PR has by mistake removed the docker image that's needed for building Grpc C# android artifacts.

Example failed build:
https://source.cloud.google.com/results/invocations/1a51e8f9-1595-4fc6-a118-cdff4dfdd2d6/targets/github%2Fgrpc/tests
