### PR TITLE
Pin version of rubygems-update (on v1.46.x)

### DIFF
--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -34,7 +34,7 @@ python3.8 -m pip install -U cython setuptools==65.4.1 wheel --user
 python3.9 -m pip install -U cython setuptools==65.4.1 wheel --user
 python3.10 -m pip install -U cython setuptools==65.4.1 wheel --user
 
-gem install rubygems-update
+gem install rubygems-update -v 3.3.26
 update_rubygems
 
 tools/run_tests/task_runner.py -f artifact macos ${TASK_RUNNER_EXTRA_FILTERS} || FAILED="true"


### PR DESCRIPTION
To unbreak macos artifact build on v1.46.x branch.

```
+ gem install rubygems-update
+ typeset result
+ typeset rvmrc
+ rvm_rvmrc_files=("/etc/rvmrc" "$HOME/.rvmrc")
+ [[ -n /Users/kbuilder ]]
+ [[ /Users/kbuilder/.rvmrc -ef /Users/kbuilder/.rvmrc ]]
+ rvm_rvmrc_files+=("${rvm_prefix}/.rvmrc")
+ for rvmrc in '"${rvm_rvmrc_files[@]}"'
+ [[ -s /etc/rvmrc ]]
+ true
+ for rvmrc in '"${rvm_rvmrc_files[@]}"'
+ [[ -s /Users/kbuilder/.rvmrc ]]
+ true
+ for rvmrc in '"${rvm_rvmrc_files[@]}"'
+ [[ -s /Users/kbuilder/.rvmrc ]]
+ true
+ unset rvm_rvmrc_files
+ command gem install rubygems-update
+ gem install rubygems-update
ERROR:  Error installing rubygems-update:
	The last version of rubygems-update (>= 0) to support your Ruby & RubyGems was 3.3.26. Try installing it with `gem install rubygems-update -v 3.3.26`
	rubygems-update requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.0.
```

https://source.cloud.google.com/results/invocations/14d23e11-f883-4b69-8fd3-da20acfe0591

