### PR TITLE
Fix flakiness in xds_cluster_end2end_test: XdsTest/CdsTest.CircuitBreaking/V3

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -218,6 +218,10 @@ TEST_P(CdsTest, CircuitBreaking) {
                       "circuit breaker drop");
   // Cancel one RPC to allow another one through.
   rpcs[0].CancelRpc();
+  // Add a sleep here to ensure the RPC cancellation has completed correctly
+  // before trying the next RPC.
+  gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                               gpr_time_from_millis(1000, GPR_TIMESPAN)));
   CheckRpcSendOk(DEBUG_LOCATION);
   // Clean up.
   for (size_t i = 1; i < kMaxConcurrentRequests; ++i) {

--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -219,7 +219,9 @@ TEST_P(CdsTest, CircuitBreaking) {
   // Cancel one RPC to allow another one through.
   rpcs[0].CancelRpc();
   // Add a sleep here to ensure the RPC cancellation has completed correctly
-  // before trying the next RPC.
+  // before trying the next RPC. There maybe a slight delay between return of
+  // CANCELLED RPC status and update of internal state tracking the number of
+  // concurrent active requests.
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
                                gpr_time_from_millis(1000, GPR_TIMESPAN)));
   CheckRpcSendOk(DEBUG_LOCATION);
@@ -262,6 +264,12 @@ TEST_P(CdsTest, CircuitBreakingMultipleChannelsShareCallCounter) {
                       "circuit breaker drop");
   // Cancel one RPC to allow another one through
   rpcs[0].CancelRpc();
+  // Add a sleep here to ensure the RPC cancellation has completed correctly
+  // before trying the next RPC. There maybe a slight delay between return of
+  // CANCELLED RPC status and update of internal state tracking the number of
+  // concurrent active requests.
+  gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                               gpr_time_from_millis(1000, GPR_TIMESPAN)));
   CheckRpcSendOk(DEBUG_LOCATION);
   // Clean up.
   for (size_t i = 1; i < kMaxConcurrentRequests; ++i) {


### PR DESCRIPTION
Flakiness appears to be caused by immediately trying a new RPC after cancelling a previous one.

Link:https://source.cloud.google.com/results/invocations/1e9f67e9-7888-41c8-9a20-cf0475272e13/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_end2end_test@poller%3Dpoll/tests

