### PR TITLE
Disable ruby artifact builds on v1.46.x

### DIFF
--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -23,7 +23,9 @@ cd $(dirname $0)/../../..
 
 export PREPARE_BUILD_INSTALL_DEPS_CSHARP=true
 export PREPARE_BUILD_INSTALL_DEPS_PYTHON=true
-export PREPARE_BUILD_INSTALL_DEPS_RUBY=true
+# Ruby builds are disabled on this branch because they're broken.
+# TODO(apolcyn): re-enable and fix if a ruby patch release on 1.46.x is needed
+export PREPARE_BUILD_INSTALL_DEPS_RUBY=false
 export PREPARE_BUILD_INSTALL_DEPS_PHP=true
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
@@ -35,9 +37,6 @@ python3.6 -m pip install -U cython setuptools==44.1.1 wheel --user
 python3.7 -m pip install -U cython setuptools==44.1.1 wheel --user
 python3.8 -m pip install -U cython setuptools==44.1.1 wheel --user
 python3.9 -m pip install -U cython setuptools==44.1.1 wheel --user
-
-gem install rubygems-update
-update_rubygems
 
 tools/run_tests/task_runner.py -f artifact macos ${TASK_RUNNER_EXTRA_FILTERS} || FAILED="true"
 

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -486,12 +486,8 @@ def targets():
         PythonArtifact('windows', 'x64', 'Python38'),
         PythonArtifact('windows', 'x64', 'Python39'),
         PythonArtifact('windows', 'x64', 'Python310', presubmit=True),
-        RubyArtifact('linux', 'x86-mingw32', presubmit=True),
-        RubyArtifact('linux', 'x64-mingw32', presubmit=True),
-        RubyArtifact('linux', 'x86_64-linux', presubmit=True),
-        RubyArtifact('linux', 'x86-linux', presubmit=True),
-        RubyArtifact('linux', 'x86_64-darwin', presubmit=True),
-        RubyArtifact('linux', 'arm64-darwin', presubmit=True),
+        # Ruby artifacts disabled because they're broken.
+        # TODO(apolcyn): fix and re-enable if a ruby patch release is needed
         PHPArtifact('linux', 'x64', presubmit=True),
         PHPArtifact('macos', 'x64', presubmit=True),
     ])


### PR DESCRIPTION
**Note this PR should not be up-merged to master**

Ruby artifact builds are broken on this branch which is preventing patch releases for other languages e.g. C#

Since we don't actually plan to do any patch releases on v1.46.x for ruby, let's just disable ruby builds on this branch

