### PR TITLE
Print exception trace for functions submitted to thread_pool

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -19,10 +19,10 @@ import collections
 from concurrent import futures
 import enum
 import logging
+import sys
 import threading
 import time
 import traceback
-import sys
 from typing import (Any, Callable, Iterable, Iterator, List, Mapping, Optional,
                     Sequence, Set, Tuple, Union)
 
@@ -626,7 +626,7 @@ def _unary_response_in_pool(
                     rpc_event, state, response, response_serializer)
                 if serialized_response is not None:
                     _status(rpc_event, state, serialized_response)
-    except Exception as exp:  # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         traceback.print_exception(*sys.exc_info())
     finally:
         cygrpc.uninstall_context()
@@ -666,7 +666,7 @@ def _stream_response_in_pool(
                 if proceed:
                     _send_message_callback_to_blocking_iterator_adapter(
                         rpc_event, state, send_response, response_iterator)
-    except Exception as exp:  # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         traceback.print_exception(*sys.exc_info())
     finally:
         cygrpc.uninstall_context()

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -20,8 +20,9 @@ from concurrent import futures
 import enum
 import logging
 import threading
-import traceback
 import time
+import traceback
+import sys
 from typing import (Any, Callable, Iterable, Iterator, List, Mapping, Optional,
                     Sequence, Set, Tuple, Union)
 
@@ -626,7 +627,7 @@ def _unary_response_in_pool(
                 if serialized_response is not None:
                     _status(rpc_event, state, serialized_response)
     except Exception as exp:  # pylint: disable=broad-except
-        traceback.print_exception(exp)
+        traceback.print_exception(*sys.exc_info())
     finally:
         cygrpc.uninstall_context()
 
@@ -666,7 +667,7 @@ def _stream_response_in_pool(
                     _send_message_callback_to_blocking_iterator_adapter(
                         rpc_event, state, send_response, response_iterator)
     except Exception as exp:  # pylint: disable=broad-except
-        traceback.print_exception(exp)
+        traceback.print_exception(*sys.exc_info())
     finally:
         cygrpc.uninstall_context()
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -20,6 +20,7 @@ from concurrent import futures
 import enum
 import logging
 import threading
+import traceback
 import time
 from typing import (Any, Callable, Iterable, Iterator, List, Mapping, Optional,
                     Sequence, Set, Tuple, Union)
@@ -624,6 +625,8 @@ def _unary_response_in_pool(
                     rpc_event, state, response, response_serializer)
                 if serialized_response is not None:
                     _status(rpc_event, state, serialized_response)
+    except Exception as exp:  # pylint: disable=broad-except
+        traceback.print_exception(exp)
     finally:
         cygrpc.uninstall_context()
 
@@ -662,6 +665,8 @@ def _stream_response_in_pool(
                 if proceed:
                     _send_message_callback_to_blocking_iterator_adapter(
                         rpc_event, state, send_response, response_iterator)
+    except Exception as exp:  # pylint: disable=broad-except
+        traceback.print_exception(exp)
     finally:
         cygrpc.uninstall_context()
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -19,7 +19,6 @@ import collections
 from concurrent import futures
 import enum
 import logging
-import sys
 import threading
 import time
 import traceback
@@ -627,7 +626,7 @@ def _unary_response_in_pool(
                 if serialized_response is not None:
                     _status(rpc_event, state, serialized_response)
     except Exception:  # pylint: disable=broad-except
-        traceback.print_exception(*sys.exc_info())
+        traceback.print_exc()
     finally:
         cygrpc.uninstall_context()
 
@@ -667,7 +666,7 @@ def _stream_response_in_pool(
                     _send_message_callback_to_blocking_iterator_adapter(
                         rpc_event, state, send_response, response_iterator)
     except Exception:  # pylint: disable=broad-except
-        traceback.print_exception(*sys.exc_info())
+        traceback.print_exc()
     finally:
         cygrpc.uninstall_context()
 


### PR DESCRIPTION
Currently we don't have any error log for functions submitted to thread_pool by `thread_pool.submit`, this PR is to print those error traces.

* Log before change:
```
TIMEOUT: //src/python/grpcio_tests/tests/unit:_abort_test.native (Summary)
      /usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/testlogs/src/python/grpcio_tests/tests/unit/_abort_test.native/test.log
INFO: From Testing //src/python/grpcio_tests/tests/unit:_abort_test.native:
==================== Test output for //src/python/grpcio_tests/tests/unit:_abort_test.native:
test_abort (__main__.AbortTest) ... -- Test timed out at 2023-01-11 01:03:36 UTC --
================================================================================
```

* Log After change:
```
TIMEOUT: //src/python/grpcio_tests/tests/unit:_abort_test.native (Summary)
      /usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/testlogs/src/python/grpcio_tests/tests/unit/_abort_test.native/test.log
INFO: From Testing //src/python/grpcio_tests/tests/unit:_abort_test.native:
==================== Test output for //src/python/grpcio_tests/tests/unit:_abort_test.native:
test_abort (__main__.AbortTest) ... Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/sandbox/linux-sandbox/1624/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_abort_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 495, in _
call_behavior
    response_or_iterator = behavior(argument, context)
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/sandbox/linux-sandbox/1624/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_abort_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio_tests/tests/unit/_abort_test.py"
, line 54, in abort_unary_unary
    servicer_context.abort(
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/sandbox/linux-sandbox/1624/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_abort_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 364, in a
bort
    raise Exception()
Exception

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/sandbox/linux-sandbox/1624/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_abort_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 622, in _
unary_response_in_pool
    response, proceed = _call_behavior(rpc_event, state, behavior,
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/sandbox/linux-sandbox/1624/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_abort_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 500, in _
call_behavior
    _abort(state, rpc_event.call, cygrpc.StatusCode.unknown,
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/36b8ff3f6248f9f6b372e5787162cc70/sandbox/linux-sandbox/1624/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_abort_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 188, in _
abort
    raise Exception('test exception')
Exception: test exception
-- Test timed out at 2023-01-11 01:02:53 UTC --
================================================================================
```

