### PR TITLE
doc: npm package migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ please refer to these documents
   Repository
 - [Kotlin](https://github.com/grpc/grpc-kotlin): Use JARs from Maven Central
   Repository
-- [Node](https://github.com/grpc/grpc-node): `npm install grpc`
+- [Node](https://github.com/grpc/grpc-node): `npm install @grpc/grpc-js`
 - [Objective-C](src/objective-c): Add `gRPC-ProtoRPC` dependency to podspec
 - [PHP](src/php): `pecl install grpc`
 - [Python](src/python/grpcio): `pip install grpcio`

--- a/tools/package_hosting/home.xsl
+++ b/tools/package_hosting/home.xsl
@@ -47,7 +47,7 @@
     <li><a href="https://github.com/grpc/grpc-go">Go</a>: <code>go get google.golang.org/grpc</code></li>
     <li><a href="https://github.com/grpc/grpc-java">Java</a>: Use JARs from <a href="https://search.maven.org/search?q=g:io.grpc">gRPC Maven Central Repository</a></li>
     <li><a href="https://github.com/grpc/grpc-kotlin">Kotlin</a>: Use JARs from <a href="https://mvnrepository.com/artifact/io.grpc">gRPC Maven Central Repository</a></li>
-    <li><a href="https://github.com/grpc/grpc-node">Node</a>: <code>npm install grpc</code></li>
+    <li><a href="https://github.com/grpc/grpc-node">Node</a>: <code>npm install @grpc/grpc-js</code></li>
     <li><a href="https://github.com/grpc/grpc/blob/master/src/objective-c">Objective-C</a>: Add <code>gRPC-ProtoRPC</code> dependency to podspec</li>
     <li><a href="https://github.com/grpc/grpc/blob/master/src/php">PHP</a>: <code>pecl install grpc</code></li>
     <li><a href="https://github.com/grpc/grpc/blob/master/src/python/grpcio">Python</a>: <code>pip install grpcio</code></li>


### PR DESCRIPTION
docs change, as [grpc](https://www.npmjs.com/package/grpc) package of node.js is no longer maintained and migrated to another package [@grpc/grpc-js](https://www.npmjs.com/package/@grpc/grpc-js).

