### PR TITLE
Make grpc++_test target publicly visible

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -97,7 +97,7 @@ def _update_visibility(visibility):
         "grpc_opencensus_plugin": PUBLIC,
         "grpcpp_gcp_observability": PUBLIC,
         "grpc_resolver_fake": PRIVATE,
-        "grpc++_test": PRIVATE,
+        "grpc++_test": PUBLIC,
         "http": PRIVATE,
         "httpcli": PRIVATE,
         "iomgr_timer": PRIVATE,


### PR DESCRIPTION
Fix #31296

I think Craig's concern here was the stability of the APIs. We could potentially add a disclaimer at the very top of all these files that we do not guarantee the stability of these files or this build target. What do y'all think?

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

