### PR TITLE
xDS interop: resume circuit_breaking test (v1.43.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -68,7 +68,7 @@ export PYTHONUNBUFFERED=true
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
   tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
-    --test_case="ping_pong" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -70,7 +70,7 @@ bazel build test/cpp/interop:xds_interop_client
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
   tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
-    --test_case="ping_pong" \
+    --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \


### PR DESCRIPTION
Backport of #32038 to v1.43.x.
---
This is a test running on legacy (GCE) framework.
It was disabled in https://github.com/grpc/grpc/pull/27355, however it has never been ported to the new framework. Unless there were reasons I'm not aware of, disabling it is a mistake. Other languages still run it:

- Java: https://github.com/grpc/grpc-java/blob/cc5378453fcdb8d4fdc18a1a369184210ce9ece0/buildscripts/kokoro/xds_v3.sh#L21
- Go: https://github.com/grpc/grpc-go/blob/f2fbb0e07ebf3dd46aa641ee89c9f17e8083eaf6/test/kokoro/xds.sh#L30
- Node: https://github.com/grpc/grpc-node/blob/81083bd22912bd3272d193dcc14077d0c4f50399/packages/grpc-js-xds/scripts/xds.sh#L57