### PR TITLE
Improve logging while calling core API

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -15,7 +15,6 @@
 
 cdef class CallbackFailureHandler:
     cdef str _core_function_name
-    cdef const char* _core_error_string
     cdef object _error_details
     cdef object _exception_type
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -15,6 +15,7 @@
 
 cdef class CallbackFailureHandler:
     cdef str _core_function_name
+    cdef const char* _core_error_string
     cdef object _error_details
     cdef object _exception_type
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import enum
 
 cdef class CallbackFailureHandler:
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -24,17 +24,19 @@ cdef class CallbackFailureHandler:
         self._core_function_name = core_function_name
         self._error_details = error_details
         self._exception_type = exception_type
-        self._core_error_string = grpc_call_error_to_string(grpc_call_error.GRPC_CALL_ERROR)
+        self._core_error_string = NULL
         if isinstance(exception_type, enum.IntEnum):
             self._core_error_string = grpc_call_error_to_string(exception_type)
 
     cdef handle(self, object future):
-        future.set_exception(self._exception_type(
-            'Failed "%s" with core error %s: %s' % (
+        if self._core_error_string == NULL:
+            error_string = 'Failed "%s": %s' % (self._core_function_name, self._error_details)
+        else:
+            error_string = 'Failed "%s" with core error %s: %s' % (
                 self._core_function_name,
                 self._core_error_string,
                 self._error_details)
-        ))
+        future.set_exception(self._exception_type(error_string))
 
 
 cdef class CallbackWrapper:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -24,19 +24,11 @@ cdef class CallbackFailureHandler:
         self._core_function_name = core_function_name
         self._error_details = error_details
         self._exception_type = exception_type
-        self._core_error_string = NULL
-        if isinstance(exception_type, enum.IntEnum):
-            self._core_error_string = grpc_call_error_to_string(exception_type)
 
     cdef handle(self, object future):
-        if self._core_error_string == NULL:
-            error_string = 'Failed "%s": %s' % (self._core_function_name, self._error_details)
-        else:
-            error_string = 'Failed "%s" with core error %s: %s' % (
-                self._core_function_name,
-                self._core_error_string,
-                self._error_details)
-        future.set_exception(self._exception_type(error_string))
+        future.set_exception(self._exception_type(
+            'Failed "%s": %s' % (self._core_function_name, self._error_details)
+        ))
 
 
 cdef class CallbackWrapper:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -93,8 +93,8 @@ async def execute_batch(GrpcCallWrapper grpc_call_wrapper,
         wrapper.c_functor(), NULL)
 
     if error != GRPC_CALL_OK:
-        grpc_call_error_string = grpc_call_error_to_string(error)
-        raise ExecuteBatchError("Failed grpc_call_start_batch: {} with grpc_call_error value: {}".format(error, grpc_call_error_string))
+        grpc_call_error_string = grpc_call_error_to_string(error).decode()
+        raise ExecuteBatchError("Failed grpc_call_start_batch: {} with grpc_call_error value: '{}'".format(error, grpc_call_error_string))
 
     await future
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -716,14 +716,18 @@ async def _handle_exceptions(RPCState rpc_state, object rpc_coro, object loop):
                 status_code = rpc_state.status_code
 
             rpc_state.status_sent = True
-            await _send_error_status_from_server(
-                rpc_state,
-                status_code,
-                'Unexpected %s: %s' % (type(e), e),
-                rpc_state.trailing_metadata,
-                rpc_state.create_send_initial_metadata_op_if_not_sent(),
-                loop
-            )
+            try:
+                await _send_error_status_from_server(
+                    rpc_state,
+                    status_code,
+                    'Unexpected %s: %s' % (type(e), e),
+                    rpc_state.trailing_metadata,
+                    rpc_state.create_send_initial_metadata_op_if_not_sent(),
+                    loop
+                )
+            except ExecuteBatchError:
+                _LOGGER.exception('Failed sending error status from server')
+                raise
 
 
 cdef _add_callback_handler(object rpc_task, RPCState rpc_state):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -727,6 +727,7 @@ async def _handle_exceptions(RPCState rpc_state, object rpc_coro, object loop):
                 )
             except ExecuteBatchError:
                 _LOGGER.exception('Failed sending error status from server')
+                traceback.print_exc()
 
 
 cdef _add_callback_handler(object rpc_task, RPCState rpc_state):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -727,7 +727,6 @@ async def _handle_exceptions(RPCState rpc_state, object rpc_coro, object loop):
                 )
             except ExecuteBatchError:
                 _LOGGER.exception('Failed sending error status from server')
-                raise
 
 
 cdef _add_callback_handler(object rpc_task, RPCState rpc_state):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -396,6 +396,7 @@ cdef extern from "grpc/grpc.h":
   grpc_call_error grpc_call_start_batch(
       grpc_call *call, const grpc_op *ops, size_t nops, void *tag,
       void *reserved) nogil
+  const char* grpc_call_error_to_string(grpc_call_error error) nogil
   grpc_call_error grpc_call_cancel(grpc_call *call, void *reserved) nogil
   grpc_call_error grpc_call_cancel_with_status(grpc_call *call,
                                                grpc_status_code status,


### PR DESCRIPTION
### Description

We have multiple cases that users are seeing `grpc._cython.cygrpc.ExecuteBatchError: Failed "execute_batch"` in their logs, while the root causes are different, they're all raised while executing batch operations in core, this PR is to improve logging so we can have more context on what types of error is raised in core.

### Changes included
- Use core API `grpc_call_error_to_string` to get more details from errors.
- Add additional log while handling exception and calling `_send_error_status_from_server`.

### Testing
* Error in core while starting batch:
  * Before change:
```
_cython.cygrpc.ExecuteBatchError: Failed grpc_call_start_batch: 2
```

  * After change:
```
_cython.cygrpc.ExecuteBatchError: Failed grpc_call_start_batch: 2 with grpc_call_error value: b'GRPC_CALL_ERROR_NOT_ON_SERVER'
```

* Error in RPC handler with additional exception calling `_send_error_status_from_server`:
  * Before change:
```
RROR:grpc._cython.cygrpc:Unexpected [Exception] raised by servicer method [/grpc.testing.TestService/UnaryCall]
Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 683, in _cython.cygrpc._handle_exceptions
Exception: test Exception in rpc_coro
ERROR:grpc._cython.cygrpc:calling _send_error_status_from_server
Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 683, in _cython.cygrpc._handle_exceptions
Exception: test Exception in rpc_coro
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-6' coro=<<coroutine without __name__>()> exception=ExecuteBatchError('test ExecuteBatchError') created at /usr/lib/python3.10/asyncio/events.py:80>
source_traceback: Object created at (most recent call last):
....<Skipped>
```

  * After change:
```
RROR:grpc._cython.cygrpc:Unexpected [Exception] raised by servicer method [/grpc.testing.TestService/UnaryCall]
Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 683, in _cython.cygrpc._handle_exceptions
Exception: test Exception in rpc_coro
ERROR:grpc._cython.cygrpc:calling _send_error_status_from_server
Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 683, in _cython.cygrpc._handle_exceptions
Exception: test Exception in rpc_coro
ERROR:grpc._cython.cygrpc:Failed sending error status from server
Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 683, in _cython.cygrpc._handle_exceptions
Exception: test Exception in rpc_coro

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 722, in _cython.cygrpc._handle_exceptions
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi", line 176, in _send_error_status_from_server
_cython.cygrpc.ExecuteBatchError: test ExecuteBatchError
Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 683, in _cython.cygrpc._handle_exceptions
Exception: test Exception in rpc_coro

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi", line 722, in _cython.cygrpc._handle_exceptions
  File "src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi", line 176, in _send_error_status_from_server
_cython.cygrpc.ExecuteBatchError: test ExecuteBatchError
```