### PR TITLE
xDS: don't NACK RouteConfig with a VirtualHost containing no valid routes

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -101,8 +101,6 @@ class XdsClusterManagerLbConfig : public LoadBalancingPolicy::Config {
   }
 
   static const JsonLoaderInterface* JsonLoader(const JsonArgs&);
-  void JsonPostLoad(const Json& json, const JsonArgs&,
-                    ValidationErrors* errors);
 
  private:
   std::map<std::string, Child> cluster_map_;
@@ -664,16 +662,6 @@ const JsonLoaderInterface* XdsClusterManagerLbConfig::JsonLoader(
           .Field("children", &XdsClusterManagerLbConfig::cluster_map_)
           .Finish();
   return loader;
-}
-
-void XdsClusterManagerLbConfig::JsonPostLoad(const Json&, const JsonArgs&,
-                                             ValidationErrors* errors) {
-  if (cluster_map_.empty()) {
-    ValidationErrors::ScopedField field(errors, ".children");
-    if (!errors->FieldHasErrors()) {
-      errors->AddError("no valid children configured");
-    }
-  }
 }
 
 class XdsClusterManagerLbFactory : public LoadBalancingPolicyFactory {

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -1056,7 +1056,6 @@ XdsRouteConfigResource XdsRouteConfigResource::Parse(
     }
     // Parse routes.
     ValidationErrors::ScopedField field2(errors, ".routes");
-    const size_t original_error_size = errors->size();
     size_t num_routes;
     const envoy_config_route_v3_Route* const* routes =
         envoy_config_route_v3_VirtualHost_routes(virtual_hosts[i], &num_routes);
@@ -1066,9 +1065,6 @@ XdsRouteConfigResource XdsRouteConfigResource::Parse(
                               rds_update.cluster_specifier_plugin_map,
                               &cluster_specifier_plugins_not_seen, errors);
       if (route.has_value()) vhost.routes.emplace_back(std::move(*route));
-    }
-    if (errors->size() == original_error_size && vhost.routes.empty()) {
-      errors->AddError("no valid routes in VirtualHost");
     }
   }
   // For cluster specifier plugins that were not used in any route action,

--- a/test/core/xds/xds_route_config_resource_type_test.cc
+++ b/test/core/xds/xds_route_config_resource_type_test.cc
@@ -274,25 +274,6 @@ TEST_F(VirtualHostTest, NoDomainsSpecified) {
       << decode_result.resource.status();
 }
 
-TEST_F(VirtualHostTest, NoRoutesInVirtualHost) {
-  RouteConfiguration route_config;
-  route_config.set_name("foo");
-  auto* vhost = route_config.add_virtual_hosts();
-  vhost->add_domains("*");
-  std::string serialized_resource;
-  ASSERT_TRUE(route_config.SerializeToString(&serialized_resource));
-  auto* resource_type = XdsRouteConfigResourceType::Get();
-  auto decode_result =
-      resource_type->Decode(decode_context_, serialized_resource);
-  EXPECT_EQ(decode_result.resource.status().code(),
-            absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(decode_result.resource.status().message(),
-            "errors validating RouteConfiguration resource: ["
-            "field:virtual_hosts[0].routes "
-            "error:no valid routes in VirtualHost]")
-      << decode_result.resource.status();
-}
-
 //
 // typed_per_filter_config tests
 //


### PR DESCRIPTION
Instead, we will catch this problem at L7, just like we would if none of the routes matches a particular RPC.

Fixes #32023.