### PR TITLE
Fix flakiness of `End2EndBinderTransportTest/UnaryCallServerTimeout`

### DIFF
--- a/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
+++ b/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
@@ -121,9 +121,8 @@ TEST_P(End2EndBinderTransportTest, UnaryCallWithNonOkStatus) {
 TEST_P(End2EndBinderTransportTest, UnaryCallServerTimeout) {
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub = NewStub();
   grpc::ClientContext context;
-  constexpr auto timeout_ms = absl::Milliseconds(1 * 1000);  /// 1 second
   context.set_deadline(absl::ToChronoTime(
-      absl::Now() + (timeout_ms * grpc_test_slowdown_factor())));
+      absl::Now() + (absl::Seconds(1) * grpc_test_slowdown_factor())));
   grpc::testing::EchoRequest request;
   grpc::testing::EchoResponse response;
   request.set_message("UnaryCallServerTimeout");

--- a/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
+++ b/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
@@ -121,7 +121,9 @@ TEST_P(End2EndBinderTransportTest, UnaryCallWithNonOkStatus) {
 TEST_P(End2EndBinderTransportTest, UnaryCallServerTimeout) {
   std::unique_ptr<grpc::testing::EchoTestService::Stub> stub = NewStub();
   grpc::ClientContext context;
-  context.set_deadline(absl::ToChronoTime(absl::Now() + absl::Seconds(1)));
+  constexpr auto timeout_ms = absl::Milliseconds(1 * 1000);  /// 1 second
+  context.set_deadline(absl::ToChronoTime(
+      absl::Now() + (timeout_ms * grpc_test_slowdown_factor())));
   grpc::testing::EchoRequest request;
   grpc::testing::EchoResponse response;
   request.set_message("UnaryCallServerTimeout");


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

Add `grpc_test_slowdown_factor()` for the deadline in `End2EndBinderTransportTest/UnaryCallServerTimeout` to reduce flakiness. The echo server takes the timeout value and multiplies it with `grpc_test_slowdown_factor()` while the test case itself does not take `grpc_test_slowdown_factor()` into consideration when setting up the deadline value.

The recent error report is https://source.cloud.google.com/results/invocations/50f05f83-9ad6-4ea7-a383-166ae1291e7a/targets.