### PR TITLE
Update boringssl-with-bazel readme

### DIFF
--- a/third_party/README.md
+++ b/third_party/README.md
@@ -58,26 +58,26 @@ Updating some dependencies requires extra care.
 
 ### Updating third_party/boringssl-with-bazel
 
-- Update the `third_party/boringssl-with-bazel` submodule to the latest [`main-with-bazel`](https://github.com/google/boringssl/tree/main-with-bazel) branch
+- Update the `third_party/boringssl-with-bazel` submodule to the latest [`master-with-bazel`](https://github.com/google/boringssl/tree/master-with-bazel) branch
 ```
 git submodule update --init      # just to start in a clean state
 cd third_party/boringssl-with-bazel
 git fetch origin   # fetch what's new in the boringssl repository
-git checkout origin/main-with-bazel  # checkout the current state of main-with-bazel branch in the boringssl repo
-# Note the latest commit SHA on main-with-bazel branch
+git checkout origin/master-with-bazel  # checkout the current state of master-with-bazel branch in the boringssl repo
+# Note the latest commit SHA on master-with-bazel branch
 cd ../..   # go back to grpc repo root
 git status   #  will show that there are new commits in third_party/boringssl-with-bazel
 git add  third_party/boringssl-with-bazel     # we actually want to update the changes to the submodule
-git commit -m "update submodule boringssl-with-bazel with origin/main-with-bazel"   # commit
+git commit -m "update submodule boringssl-with-bazel with origin/master-with-bazel"   # commit
 ```
 
-- Update boringssl dependency in `bazel/grpc_deps.bzl` to the same commit SHA as main-with-bazel branch
+- Update boringssl dependency in `bazel/grpc_deps.bzl` to the same commit SHA as master-with-bazel branch
     - Update `http_archive(name = "boringssl",` section by updating the sha in `strip_prefix` and `urls` fields.
     - Also, set `sha256` field to "" as the existing value is not valid. This will be added later once we know what that value is.
 
 - Update `tools/run_tests/sanity/check_submodules.sh` with the same commit
 
-- Commit these changes `git commit -m "update boringssl dependency to main-with-bazel commit SHA"`
+- Commit these changes `git commit -m "update boringssl dependency to master-with-bazel commit SHA"`
 
 - Run `tools/buildgen/generate_projects.sh` to regenerate the generated files
     - Because `sha256` in `bazel/grpc_deps.bzl` was left empty, you will get a DEBUG msg like this one:


### PR DESCRIPTION
The docs change is extracted from https://github.com/grpc/grpc/pull/31869 and https://github.com/grpc/grpc/pull/31938.
The actual upgrade of boringssl is in progress, but in the meantime we can at least make sure the instructions are up-to-date.
I'll also update the internal counterpart (cl/501499368)