### PR TITLE
[EventEngine] Update EventEngine client experiment

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -1877,6 +1877,7 @@ grpc_cc_library(
         "event_engine_thread_pool",
         "event_engine_trace",
         "event_engine_utils",
+        "experiments",
         "init_internally",
         "iomgr_port",
         "posix_event_engine_base_hdrs",

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -331,18 +331,22 @@ PosixEventEngine::PosixEventEngine(PosixEventPoller* poller)
     : connection_shards_(std::max(2 * gpr_cpu_num_cores(), 1u)),
       executor_(std::make_shared<ThreadPool>()),
       timer_manager_(executor_) {
-  poller_manager_ = std::make_shared<PosixEnginePollerManager>(poller);
+  if (grpc_core::IsEventEngineClientEnabled()) {
+    poller_manager_ = std::make_shared<PosixEnginePollerManager>(poller);
+  }
 }
 
 PosixEventEngine::PosixEventEngine()
     : connection_shards_(std::max(2 * gpr_cpu_num_cores(), 1u)),
       executor_(std::make_shared<ThreadPool>()),
       timer_manager_(executor_) {
-  poller_manager_ = std::make_shared<PosixEnginePollerManager>(executor_);
-  if (poller_manager_->Poller() != nullptr) {
-    executor_->Run([poller_manager = poller_manager_]() {
-      PollerWorkInternal(poller_manager);
-    });
+  if (grpc_core::IsEventEngineClientEnabled()) {
+    poller_manager_ = std::make_shared<PosixEnginePollerManager>(executor_);
+    if (poller_manager_->Poller() != nullptr) {
+      executor_->Run([poller_manager = poller_manager_]() {
+        PollerWorkInternal(poller_manager);
+      });
+    }
   }
 }
 
@@ -534,6 +538,9 @@ EventEngine::ConnectionHandle PosixEventEngine::Connect(
     OnConnectCallback on_connect, const ResolvedAddress& addr,
     const EndpointConfig& args, MemoryAllocator memory_allocator,
     Duration timeout) {
+  if (!grpc_core::IsEventEngineClientEnabled()) {
+    grpc_core::Crash("unimplemented");
+  }
 #ifdef GRPC_POSIX_SOCKET_TCP
   GPR_ASSERT(poller_manager_ != nullptr);
   PosixTcpOptions options = TcpOptionsFromEndpointConfig(args);
@@ -556,6 +563,9 @@ std::unique_ptr<PosixEndpointWithFdSupport>
 PosixEventEngine::CreatePosixEndpointFromFd(int fd,
                                             const EndpointConfig& config,
                                             MemoryAllocator memory_allocator) {
+  if (!grpc_core::IsEventEngineClientEnabled()) {
+    grpc_core::Crash("unimplemented");
+  }
 #ifdef GRPC_POSIX_SOCKET_TCP
   GPR_DEBUG_ASSERT(fd > 0);
   PosixEventPoller* poller = poller_manager_->Poller();
@@ -602,6 +612,9 @@ PosixEventEngine::CreatePosixListener(
     absl::AnyInvocable<void(absl::Status)> on_shutdown,
     const EndpointConfig& config,
     std::unique_ptr<MemoryAllocatorFactory> memory_allocator_factory) {
+  if (!grpc_core::IsEventEngineClientEnabled()) {
+    grpc_core::Crash("unimplemented");
+  }
 #ifdef GRPC_POSIX_SOCKET_TCP
   return std::make_unique<PosixEngineListener>(
       std::move(on_accept), std::move(on_shutdown), config,

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -44,6 +44,7 @@
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
 #include "src/core/lib/event_engine/trace.h"
 #include "src/core/lib/event_engine/utils.h"
+#include "src/core/lib/experiments/experiments.h"
 #include "src/core/lib/gprpp/crash.h"
 #include "src/core/lib/gprpp/sync.h"
 

--- a/src/core/lib/experiments/config.cc
+++ b/src/core/lib/experiments/config.cc
@@ -58,7 +58,11 @@ GPR_ATTRIBUTE_NOINLINE Experiments LoadExperimentsFromConfigVariable() {
   // Set defaults from metadata.
   Experiments experiments;
   for (size_t i = 0; i < kNumExperiments; i++) {
-    experiments.enabled[i] = g_experiment_metadata[i].default_value;
+    if (!g_forced_experiments[i].forced) {
+      experiments.enabled[i] = g_experiment_metadata[i].default_value;
+    } else {
+      experiments.enabled[i] = g_forced_experiments[i].value;
+    }
   }
   // Get the global config.
   auto experiments_str = GPR_GLOBAL_CONFIG_GET(grpc_experiments);

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -102,7 +102,7 @@
   description:
     Use EventEngine clients instead of iomgr's grpc_tcp_client
   default: false
-  expiry: 2023/01/13
+  expiry: 2023/04/13
   owner: hork@google.com
   test_tags: ["event_engine_client_test"]
 - name: monitoring_experiment

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -43,6 +43,7 @@
 #include "src/core/lib/event_engine/channel_args_endpoint_config.h"
 #include "src/core/lib/event_engine/posix_engine/posix_engine.h"
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
+#include "src/core/lib/experiments/config.h"
 #include "src/core/lib/gprpp/crash.h"
 #include "src/core/lib/gprpp/notification.h"
 #include "src/core/lib/resource_quota/memory_quota.h"
@@ -205,6 +206,8 @@ TEST(PosixEventEngineTest, IndefiniteConnectCancellationTest) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  // TODO(vigneshbabu): remove when the experiment is over
+  grpc_core::ForceEnableExperiment("event_engine_client", true);
   grpc_init();
   int ret = RUN_ALL_TESTS();
   grpc_shutdown();

--- a/test/core/event_engine/test_suite/posix_event_engine_test.cc
+++ b/test/core/event_engine/test_suite/posix_event_engine_test.cc
@@ -19,6 +19,7 @@
 #include <grpc/grpc.h>
 
 #include "src/core/lib/event_engine/posix_engine/posix_engine.h"
+#include "src/core/lib/experiments/config.h"
 #include "test/core/event_engine/test_suite/event_engine_test.h"
 #include "test/core/event_engine/test_suite/oracle_event_engine_posix.h"
 #include "test/core/util/test_config.h"
@@ -35,6 +36,8 @@ int main(int argc, char** argv) {
         return std::make_unique<
             grpc_event_engine::experimental::PosixOracleEventEngine>();
       });
+  // TODO(vigneshbabu): remove when the experiment is over
+  grpc_core::ForceEnableExperiment("event_engine_client", true);
   // TODO(ctiller): EventEngine temporarily needs grpc to be initialized first
   // until we clear out the iomgr shutdown code.
   grpc_init();


### PR DESCRIPTION
This bumps the expiry timeline, and guards certain poller behavior behind the flag. The Epoll1 poller has been shown to not support fork events, which is a problem for Python. Fixes for that are incoming, but for now, the poller instantiation is guarded behind the flag as well.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

