### PR TITLE
Add a test case for infinite past or unix epoch expiry in alarm_test.cc

### DIFF
--- a/test/cpp/common/alarm_test.cc
+++ b/test/cpp/common/alarm_test.cc
@@ -266,6 +266,30 @@ TEST(AlarmTest, NegativeExpiry) {
   EXPECT_EQ(junk, output_tag);
 }
 
+// Infinite past or unix epoch should fire immediately.
+TEST(AlarmTest, InfPastExpiry) {
+  CompletionQueue cq;
+  void* junk = reinterpret_cast<void*>(1618033);
+  Alarm alarm;
+  alarm.Set(&cq, gpr_inf_past(GPR_CLOCK_REALTIME), junk);
+
+  void* output_tag;
+  bool ok;
+  CompletionQueue::NextStatus status =
+      cq.AsyncNext(&output_tag, &ok, grpc_timeout_seconds_to_deadline(1));
+
+  EXPECT_EQ(status, CompletionQueue::GOT_EVENT);
+  EXPECT_TRUE(ok);
+  EXPECT_EQ(junk, output_tag);
+
+  alarm.Set(&cq, std::chrono::system_clock::time_point(), junk);
+  status = cq.AsyncNext(&output_tag, &ok, grpc_timeout_seconds_to_deadline(1));
+
+  EXPECT_EQ(status, CompletionQueue::GOT_EVENT);
+  EXPECT_TRUE(ok);
+  EXPECT_EQ(junk, output_tag);
+}
+
 TEST(AlarmTest, Cancellation) {
   CompletionQueue cq;
   void* junk = reinterpret_cast<void*>(1618033);


### PR DESCRIPTION
We have seen users using infinite past timespec or unix epoch time_point to set an alarm to be fired immediately. See https://github.com/grpc/grpc/issues/31738#issuecomment-1382087585.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

