### PR TITLE
[slice] Remove mutable slice casts

### DIFF
--- a/src/core/lib/slice/slice.h
+++ b/src/core/lib/slice/slice.h
@@ -418,16 +418,6 @@ template <>
 struct SliceCastable<grpc_core::Slice, Slice> {};
 template <>
 struct SliceCastable<Slice, grpc_core::Slice> {};
-
-template <>
-struct SliceCastable<grpc_core::MutableSlice, grpc_slice> {};
-template <>
-struct SliceCastable<grpc_slice, grpc_core::MutableSlice> {};
-
-template <>
-struct SliceCastable<grpc_core::MutableSlice, grpc_core::Slice> {};
-template <>
-struct SliceCastable<grpc_core::Slice, grpc_core::MutableSlice> {};
 }  // namespace internal
 }  // namespace experimental
 }  // namespace grpc_event_engine

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -441,28 +441,6 @@ TEST(SliceTest, SliceCastWorks) {
   EXPECT_EQ(&other, &test);
 }
 
-TEST(SliceTest, MutableSliceCastWorks) {
-  using ::grpc_event_engine::experimental::internal::SliceCast;
-  Slice test = Slice::FromCopiedString("hello world!");
-  grpc_slice& slice = SliceCast<grpc_slice>(test);
-  EXPECT_EQ(&slice, &test.c_slice());
-  slice = grpc_slice_from_static_string("goodbye world!");
-  EXPECT_EQ(test.as_string_view(), "goodbye world!");
-
-  MutableSlice& m_cpp_slice = SliceCast<MutableSlice>(test);
-  EXPECT_EQ(&m_cpp_slice.c_slice(), &test.c_slice());
-  m_cpp_slice = MutableSlice::FromCopiedString("hello world again!");
-  // Change the first byte.
-  m_cpp_slice[0] = 'e';
-  EXPECT_EQ(test.as_string_view(), "eello world again!");
-
-  MutableSlice& m_c_slice = SliceCast<MutableSlice>(slice);
-  EXPECT_EQ(&m_c_slice.c_slice(), &slice);
-  // Restore the first byte.
-  GRPC_SLICE_START_PTR(slice)[0] = 'h';
-  EXPECT_EQ(m_c_slice.as_string_view(), "hello world again!");
-}
-
 }  // namespace
 }  // namespace grpc_core
 


### PR DESCRIPTION
Any use of these are buggy - MutableSlice needs to do checks to ensure that there's at most one writer to slice memory in order to be safe, otherwise we could silently corrupt a reference held elsewhere in the system.

The right way to use this would probably be
SliceCast<Slice>(whatever).TakeMutable().




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

