### PR TITLE
Add an additional < marker in comment blocks after the documented functions

### DIFF
--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -55,9 +55,9 @@ typedef struct gpr_timespec {
 
 /** Time constants. */
 GPRAPI gpr_timespec
-gpr_time_0(gpr_clock_type type); /** The zero time interval. */
-GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type); /** The far future */
-GPRAPI gpr_timespec gpr_inf_past(gpr_clock_type type);   /** The far past. */
+gpr_time_0(gpr_clock_type type); /**< The zero time interval. */
+GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type); /**< The far future */
+GPRAPI gpr_timespec gpr_inf_past(gpr_clock_type type);   /**< The far past. */
 
 #define GPR_MS_PER_SEC 1000
 #define GPR_US_PER_SEC 1000000

--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -54,10 +54,13 @@ typedef struct gpr_timespec {
 } gpr_timespec;
 
 /** Time constants. */
+/** The zero time interval. */
 GPRAPI gpr_timespec
-gpr_time_0(gpr_clock_type type); /**< The zero time interval. */
-GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type); /**< The far future */
-GPRAPI gpr_timespec gpr_inf_past(gpr_clock_type type);   /**< The far past. */
+gpr_time_0(gpr_clock_type type);
+/** The far future */
+GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type);
+/** The far past. */
+GPRAPI gpr_timespec gpr_inf_past(gpr_clock_type type);
 
 #define GPR_MS_PER_SEC 1000
 #define GPR_US_PER_SEC 1000000

--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -55,8 +55,7 @@ typedef struct gpr_timespec {
 
 /** Time constants. */
 /** The zero time interval. */
-GPRAPI gpr_timespec
-gpr_time_0(gpr_clock_type type);
+GPRAPI gpr_timespec gpr_time_0(gpr_clock_type type);
 /** The far future */
 GPRAPI gpr_timespec gpr_inf_future(gpr_clock_type type);
 /** The far past. */


### PR DESCRIPTION
A user is seeing out-of-order documentation for these functions in https://github.com/grpc/grpc/issues/31738#issuecomment-1383861800. This seems to fix that.



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

