### PR TITLE
xDS: fix WeightedClusters total weight handling

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/xds/xds_resolver.cc
@@ -688,11 +688,8 @@ XdsResolver::XdsConfigSelector::GetCallConfig(GetCallConfigArgs args) {
       [&](const std::vector<
           XdsRouteConfigResource::Route::RouteAction::ClusterWeight>&
           /*weighted_clusters*/) {
-        const uint32_t key =
-            rand() %
-            entry
-                .weighted_cluster_state[entry.weighted_cluster_state.size() - 1]
-                .range_end;
+        const uint32_t key = absl::Uniform<uint32_t>(
+            absl::BitGen(), 0, entry.weighted_cluster_state.back().range_end);
         // Find the index in weighted clusters corresponding to key.
         size_t mid = 0;
         size_t start_index = 0;

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -835,6 +835,7 @@ absl::optional<XdsRouteConfigResource::Route::RouteAction> RouteActionParse(
     GPR_ASSERT(weighted_clusters_proto != nullptr);
     std::vector<XdsRouteConfigResource::Route::RouteAction::ClusterWeight>
         action_weighted_clusters;
+    uint64_t total_weight = 0;
     size_t clusters_size;
     const envoy_config_route_v3_WeightedCluster_ClusterWeight* const* clusters =
         envoy_config_route_v3_WeightedCluster_clusters(weighted_clusters_proto,
@@ -874,12 +875,15 @@ absl::optional<XdsRouteConfigResource::Route::RouteAction> RouteActionParse(
       } else {
         cluster.weight = google_protobuf_UInt32Value_value(weight_proto);
         if (cluster.weight == 0) continue;
+        total_weight += cluster.weight;
       }
       // Add entry to WeightedClusters.
       action_weighted_clusters.emplace_back(std::move(cluster));
     }
     if (action_weighted_clusters.empty()) {
       errors->AddError("no valid clusters specified");
+    } else if (total_weight > std::numeric_limits<uint32_t>::max()) {
+      errors->AddError("sum of cluster weights exceeds uint32 max");
     }
     route_action.action = std::move(action_weighted_clusters);
   } else if (XdsRlsEnabled() &&

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -21,6 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>

--- a/test/core/xds/xds_route_config_resource_type_test.cc
+++ b/test/core/xds/xds_route_config_resource_type_test.cc
@@ -1627,6 +1627,36 @@ TEST_F(WeightedClusterTest, Invalid) {
       << decode_result.resource.status();
 }
 
+TEST_F(WeightedClusterTest, TotalWeightExceedsUint32Max) {
+  RouteConfiguration route_config;
+  route_config.set_name("foo");
+  auto* vhost = route_config.add_virtual_hosts();
+  vhost->add_domains("*");
+  auto* route_proto = vhost->add_routes();
+  route_proto->mutable_match()->set_prefix("");
+  auto* weighted_clusters_proto =
+      route_proto->mutable_route()->mutable_weighted_clusters();
+  auto* cluster_weight_proto = weighted_clusters_proto->add_clusters();
+  cluster_weight_proto->set_name("cluster1");
+  cluster_weight_proto->mutable_weight()->set_value(
+      std::numeric_limits<uint32_t>::max());
+  cluster_weight_proto = weighted_clusters_proto->add_clusters();
+  cluster_weight_proto->set_name("cluster2");
+  cluster_weight_proto->mutable_weight()->set_value(1);
+  std::string serialized_resource;
+  ASSERT_TRUE(route_config.SerializeToString(&serialized_resource));
+  auto* resource_type = XdsRouteConfigResourceType::Get();
+  auto decode_result =
+      resource_type->Decode(decode_context_, serialized_resource);
+  EXPECT_EQ(decode_result.resource.status().code(),
+            absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(decode_result.resource.status().message(),
+            "errors validating RouteConfiguration resource: ["
+            "field:virtual_hosts[0].routes[0].route.weighted_clusters "
+            "error:sum of cluster weights exceeds uint32 max]")
+      << decode_result.resource.status();
+}
+
 //
 // RLS tests
 //

--- a/test/core/xds/xds_route_config_resource_type_test.cc
+++ b/test/core/xds/xds_route_config_resource_type_test.cc
@@ -14,7 +14,10 @@
 // limitations under the License.
 //
 
+#include <stdint.h>
+
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>


### PR DESCRIPTION
- Make sure we properly handle total weights up to uint32_max.
- NACK if the total weight exceeds uint32_max.