### PR TITLE
De-experimentalize compression

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -418,7 +418,7 @@ class ClientCallDetails(abc.ABC):
       wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
       compression: An element of grpc.compression, e.g.
-        grpc.compression.Gzip. This is an EXPERIMENTAL option.
+        grpc.compression.Gzip.
     """
 
 
@@ -683,7 +683,7 @@ class UnaryUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           The response value for the RPC.
@@ -716,7 +716,7 @@ class UnaryUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           The response value for the RPC and a Call value for the RPC.
@@ -749,7 +749,7 @@ class UnaryUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
             An object that is both a Call for the RPC and a Future.
@@ -785,7 +785,7 @@ class UnaryStreamMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
             An object that is a Call for the RPC, an iterator of response
@@ -821,7 +821,7 @@ class StreamUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           The response value for the RPC.
@@ -855,7 +855,7 @@ class StreamUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           The response value for the RPC and a Call object for the RPC.
@@ -888,7 +888,7 @@ class StreamUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
             An object that is both a Call for the RPC and a Future.
@@ -924,7 +924,7 @@ class StreamStreamMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
             An object that is a Call for the RPC, an iterator of response
@@ -1139,8 +1139,6 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
     def set_compression(self, compression):
         """Set the compression algorithm to be used for the entire call.
 
-        This is an EXPERIMENTAL method.
-
         Args:
           compression: An element of grpc.compression, e.g.
             grpc.compression.Gzip.
@@ -1272,8 +1270,6 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
 
     def disable_next_message_compression(self):
         """Disables compression for the next response message.
-
-        This is an EXPERIMENTAL method.
 
         This method will override any compression configuration set during
         server creation or set on the call.
@@ -1968,7 +1964,7 @@ def insecure_channel(target, options=None, compression=None):
       options: An optional list of key-value pairs (:term:`channel_arguments`
         in gRPC Core runtime) to configure the channel.
       compression: An optional value indicating the compression method to be
-        used over the lifetime of the channel. This is an EXPERIMENTAL option.
+        used over the lifetime of the channel.
 
     Returns:
       A Channel.
@@ -1989,7 +1985,7 @@ def secure_channel(target, credentials, options=None, compression=None):
       options: An optional list of key-value pairs (:term:`channel_arguments`
         in gRPC Core runtime) to configure the channel.
       compression: An optional value indicating the compression method to be
-        used over the lifetime of the channel. This is an EXPERIMENTAL option.
+        used over the lifetime of the channel.
 
     Returns:
       A Channel.
@@ -2056,7 +2052,7 @@ def server(thread_pool,
         indicate no limit.
       compression: An element of grpc.compression, e.g.
         grpc.compression.Gzip. This compression algorithm will be used for the
-        lifetime of the server unless overridden. This is an EXPERIMENTAL option.
+        lifetime of the server unless overridden.
       xds: If set to true, retrieves server configuration via xDS. This is an
         EXPERIMENTAL option.
 
@@ -2082,8 +2078,6 @@ def _create_servicer_context(rpc_event, state, request_deserializer):
 @enum.unique
 class Compression(enum.IntEnum):
     """Indicates the compression method to be used for an RPC.
-
-       This enumeration is part of an EXPERIMENTAL API.
 
        Attributes:
         NoCompression: Do not use compression algorithm.

--- a/src/python/grpcio/grpc/aio/_base_channel.py
+++ b/src/python/grpcio/grpc/aio/_base_channel.py
@@ -52,7 +52,7 @@ class UnaryUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           A UnaryUnaryCall object.
@@ -91,7 +91,7 @@ class UnaryStreamMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           A UnaryStreamCall object.
@@ -130,7 +130,7 @@ class StreamUnaryMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           A StreamUnaryCall object.
@@ -169,7 +169,7 @@ class StreamStreamMultiCallable(abc.ABC):
           wait_for_ready: This is an EXPERIMENTAL argument. An optional
             flag to enable :term:`wait_for_ready` mechanism.
           compression: An element of grpc.compression, e.g.
-            grpc.compression.Gzip. This is an EXPERIMENTAL option.
+            grpc.compression.Gzip.
 
         Returns:
           A StreamStreamCall object.

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -243,8 +243,6 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
     def set_compression(self, compression: grpc.Compression) -> None:
         """Set the compression algorithm to be used for the entire call.
 
-        This is an EXPERIMENTAL method.
-
         Args:
           compression: An element of grpc.compression, e.g.
             grpc.compression.Gzip.
@@ -253,8 +251,6 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
     @abc.abstractmethod
     def disable_next_message_compression(self) -> None:
         """Disables compression for the next response message.
-
-        This is an EXPERIMENTAL method.
 
         This method will override any compression configuration set during
         server creation or set on the call.

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -457,7 +457,7 @@ def insecure_channel(
       options: An optional list of key-value pairs (:term:`channel_arguments`
         in gRPC Core runtime) to configure the channel.
       compression: An optional value indicating the compression method to be
-        used over the lifetime of the channel. This is an EXPERIMENTAL option.
+        used over the lifetime of the channel.
       interceptors: An optional sequence of interceptors that will be executed for
         any call executed with this channel.
 
@@ -481,7 +481,7 @@ def secure_channel(target: str,
       options: An optional list of key-value pairs (:term:`channel_arguments`
         in gRPC Core runtime) to configure the channel.
       compression: An optional value indicating the compression method to be
-        used over the lifetime of the channel. This is an EXPERIMENTAL option.
+        used over the lifetime of the channel.
       interceptors: An optional sequence of interceptors that will be executed for
         any call executed with this channel.
 

--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -198,8 +198,7 @@ def server(migration_thread_pool: Optional[Executor] = None,
         indicate no limit.
       compression: An element of grpc.compression, e.g.
         grpc.compression.Gzip. This compression algorithm will be used for the
-        lifetime of the server unless overridden by set_compression. This is an
-        EXPERIMENTAL option.
+        lifetime of the server unless overridden by set_compression.
 
     Returns:
       A Server object.


### PR DESCRIPTION
Removes all docstrings referencing compression as an experimental API.