### PR TITLE
Fix test race condition on port binding

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -48,20 +48,20 @@ class ReconnectTest(unittest.TestCase):
             server = grpc.server(server_pool, (handler,), options=options)
             server.add_insecure_port(addr)
             server.start()
-        channel = grpc.insecure_channel(addr)
-        multi_callable = channel.unary_unary(_UNARY_UNARY)
-        self.assertEqual(_RESPONSE, multi_callable(_REQUEST))
-        server.stop(None)
-        # By default, the channel connectivity is checked every 5s
-        # GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS can be set to change
-        # this.
-        time.sleep(5.1)
-        server = grpc.server(server_pool, (handler,), options=options)
-        server.add_insecure_port(addr)
-        server.start()
-        self.assertEqual(_RESPONSE, multi_callable(_REQUEST))
-        server.stop(None)
-        channel.close()
+            channel = grpc.insecure_channel(addr)
+            multi_callable = channel.unary_unary(_UNARY_UNARY)
+            self.assertEqual(_RESPONSE, multi_callable(_REQUEST))
+            server.stop(None)
+            # By default, the channel connectivity is checked every 5s
+            # GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS can be set to change
+            # this.
+            time.sleep(5.1)
+            server = grpc.server(server_pool, (handler,), options=options)
+            server.add_insecure_port(addr)
+            server.start()
+            self.assertEqual(_RESPONSE, multi_callable(_REQUEST))
+            server.stop(None)
+            channel.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Spotted [here](https://source.cloud.google.com/results/invocations/eb046c1f-2328-45fd-8f8a-8c68c07183dd/details). It was previously possible for another process on the machine to take the server's port between when it went down and when it came back up. This change ensures that the port remains occupied throughout the duration of the test.