### PR TITLE
[http] Fix metadata size stat

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1300,6 +1300,7 @@ grpc_error_handle HPackParser::Parse(const grpc_slice& slice, bool is_last) {
 }
 
 grpc_error_handle HPackParser::ParseInput(Input input, bool is_last) {
+  global_stats().IncrementHttp2MetadataSize(frame_length_);
   if (ParseInputInner(&input)) {
     return absl::OkStatus();
   }
@@ -1311,7 +1312,6 @@ grpc_error_handle HPackParser::ParseInput(Input input, bool is_last) {
     unparsed_bytes_ = std::vector<uint8_t>(input.frontier(), input.end_ptr());
     return absl::OkStatus();
   }
-  global_stats().IncrementHttp2MetadataSize(frame_length_);
   return input.TakeError();
 }
 


### PR DESCRIPTION
This was inadvertently only counting failed HPACK parses (there are zero in real systems) - fix to count always.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

