### PR TITLE
Update Grpc.Tools integration tests to test for allowing duplicate proto file name

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/IntegrationTests/TestMultipleProtos/expected.json
+++ b/src/csharp/Grpc.Tools.Tests/IntegrationTests/TestMultipleProtos/expected.json
@@ -48,6 +48,30 @@
                 "protos/another.proto"
             ]
         },
+        "protos/file.proto": {
+            "--csharp_out": [
+                "${TEST_OUT_DIR}/obj/Debug/netstandard2.0/protos"
+            ],
+            "--plugin": [
+                "protoc-gen-grpc=dummy-plugin-not-used"
+            ],
+            "--grpc_out": [
+                "${TEST_OUT_DIR}/obj/Debug/netstandard2.0/protos"
+            ],
+            "--proto_path": [
+                "../../../Grpc.Tools/build/native/include",
+                "."
+            ],
+            "--dependency_out": [
+                "REGEX:${TEST_OUT_DIR}/obj/Debug/netstandard2.0/.*_file.protodep"
+            ],
+            "--error_format": [
+                "msvs"
+            ],
+            "protofile": [
+                "protos/file.proto"
+            ]
+        },
         "second.proto": {
             "--csharp_out": [
                 "${TEST_OUT_DIR}/obj/Debug/netstandard2.0"

--- a/src/csharp/Grpc.Tools.Tests/IntegrationTests/TestMultipleProtos/protos/file.proto
+++ b/src/csharp/Grpc.Tools.Tests/IntegrationTests/TestMultipleProtos/protos/file.proto
@@ -1,0 +1,38 @@
+// Copyright 2022 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+// This file has the same name as another proto file but
+// in a different directory
+
+package grpc_tools_tests.integration_tests.test_multiple_protos.duplicate_name;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc SayHelloSlowly (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+  int32 delay = 2;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/src/csharp/Grpc.Tools.Tests/MsBuildIntegrationTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/MsBuildIntegrationTest.cs
@@ -94,11 +94,12 @@ namespace Grpc.Tools.Tests
             SetUpForTest(nameof(TestMultipleProtos));
 
             var expectedFiles = new ExpectedFilesBuilder();
-            // TODO(jtattermusch): add test that "duplicate" .proto file
-            // name (under different directories) is allowed. See https://github.com/grpc/grpc/issues/17672
             expectedFiles.Add("file.proto", "File.cs", "FileGrpc.cs")
                 .Add("protos/another.proto", "Another.cs", "AnotherGrpc.cs")
-                .Add("second.proto", "Second.cs", "SecondGrpc.cs");
+                .Add("second.proto", "Second.cs", "SecondGrpc.cs")
+                // Test duplicate name under different directories is allowed.
+                // See https://github.com/grpc/grpc/issues/17672
+                .Add("protos/file.proto", "File.cs", "FileGrpc.cs"); 
 
             TryRunMsBuild("TestMultipleProtos", expectedFiles.ToString());
         }


### PR DESCRIPTION
Update to Grpc.Tools integration test TestMultipleProtos to test for duplicate proto file name but in a different directory.
See https://github.com/grpc/grpc/issues/17672

