### PR TITLE
CI: Move kokoro bazel output root to /tmpfs/bazel

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe.sh
+++ b/tools/internal_ci/linux/grpc_bazel_rbe.sh
@@ -30,6 +30,7 @@ python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_
 
 bazel_rbe/bazel_wrapper \
   --bazelrc=tools/remote_build/linux_kokoro.bazelrc \
+  --output_user_root=/tmpfs/bazel \
   test \
   $BAZEL_FLAGS \
   "$@" \


### PR DESCRIPTION
More information on the options available here - https://bazel.build/remote/output-directories
Earlier, the output directory was going in /home/... which has limited space ~49GB as opposed to /tmpfs which has ~246GB.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

