### PR TITLE
[Build] tests: fix compilation on older macOS: add port_platform.h (to pull in __STDC_FORMAT_MACROS define)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,24 @@ if(UNIX AND NOT HAIKU)
   endif()
 endif()
 
+include(CheckCXXSourceCompiles)
+
+if(UNIX OR APPLE)
+  # Some systems require the __STDC_FORMAT_MACROS macro to be defined
+  # to get the fixed-width integer type formatter macros.
+  check_cxx_source_compiles("#include <inttypes.h>
+  #include <cstdio>
+  int main()
+  {
+    int64_t i64{};
+    std::printf(\"%\" PRId64, i64);
+  }"
+  HAVE_STDC_FORMAT_MACROS)
+  if(NOT HAVE_STDC_FORMAT_MACROS)
+    add_definitions(-D__STDC_FORMAT_MACROS)
+  endif()
+endif()
+
 # configure ccache if requested
 include(cmake/ccache.cmake)
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -338,6 +338,24 @@
     endif()
   endif()
 
+  include(CheckCXXSourceCompiles)
+
+  if(UNIX OR APPLE)
+    # Some systems require the __STDC_FORMAT_MACROS macro to be defined
+    # to get the fixed-width integer type formatter macros.
+    check_cxx_source_compiles("#include <inttypes.h>
+    #include <cstdio>
+    int main()
+    {
+      int64_t i64{};
+      std::printf(\"%\" PRId64, i64);
+    }"
+    HAVE_STDC_FORMAT_MACROS)
+    if(NOT HAVE_STDC_FORMAT_MACROS)
+      add_definitions(-D__STDC_FORMAT_MACROS)
+    endif()
+  endif()
+
   # configure ccache if requested
   include(cmake/ccache.cmake)
 


### PR DESCRIPTION
Some versions of MacOS (as well as some `glibc`-based platforms) require `__STDC_FORMAT_MACROS` to be defined prior to including `<cinttypes>` or `<inttypes.h>`, otherwise build fails with undeclared `PRIdMAX`, `PRIdPTR` etc. 

See note here: https://en.cppreference.com/w/cpp/types/integer

label: (release notes: no)