### PR TITLE
Enforce POSIX-Sync on Linux

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -41,6 +41,11 @@
 #if defined(__APPLE__)
 // This is disabled on Apple platforms because macos/grpc_basictests_c_cpp
 // fails with this. https://github.com/grpc/grpc/issues/23661
+#elif defined(__linux__)
+// This is disabled on Linux as Abseil's time is exclusively based on the system time
+// which leads to gRPC being completely blocked in case the system clock is set back.
+// On linux we need to use SYNC_POSIX which uses the monotonic clock.
+// https://github.com/grpc/grpc/issues/32176
 #else
 #define GPR_ABSEIL_SYNC 1
 #endif


### PR DESCRIPTION
This is needed in order to handle system time changes properly. As SYNC-Abseil and Abseil in general (see https://github.com/abseil/abseil-cpp/issues/172) is exclusively based on system-time, we need to use POSIX-Sync which uses the monotonic clock for timeouts

Fixes #32176

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

