### PR TITLE
Add wait_for_ready with client timeout example

### DIFF
--- a/examples/protos/helloworld.proto
+++ b/examples/protos/helloworld.proto
@@ -25,6 +25,8 @@ package helloworld;
 service Greeter {
   // Sends a greeting
   rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  rpc SayHelloStreamReply (HelloRequest) returns (stream HelloReply) {}
 }
 
 // The request message containing the user's name.

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
@@ -43,28 +43,26 @@ def check_status(response_future, wait_success):
 
 def main():
     # Create gRPC channel
-    channel = grpc.insecure_channel('localhost:50051')
-    stub = helloworld_pb2_grpc.GreeterStub(channel)
+    with grpc.insecure_channel('localhost:50051') as channel:
+        stub = helloworld_pb2_grpc.GreeterStub(channel)
 
-    event_for_delay = threading.Event()
+        event_for_delay = threading.Event()
 
-    # Server will delay send initial metadata back for this RPC
-    response_future_delay = stub.SayHelloStreamReply(
-        helloworld_pb2.HelloRequest(name='you'), wait_for_ready=True)
+        # Server will delay send initial metadata back for this RPC
+        response_future_delay = stub.SayHelloStreamReply(
+            helloworld_pb2.HelloRequest(name='you'), wait_for_ready=True)
 
-    # Fire RPC and wait for metadata
-    thread_with_delay = threading.Thread(target=wait_for_metadata,
-        args=(response_future_delay, event_for_delay))
-    thread_with_delay.start()
+        # Fire RPC and wait for metadata
+        thread_with_delay = threading.Thread(target=wait_for_metadata,
+            args=(response_future_delay, event_for_delay))
+        thread_with_delay.start()
 
-    # Wait on client side with timeout
-    timeout = 3
-    check_status(response_future_delay, event_for_delay.wait(timeout))
+        # Wait on client side with timeout
+        timeout = 3
+        check_status(response_future_delay, event_for_delay.wait(timeout))
 
-    # Expected to timeout.
-    thread_with_delay.join()
-
-    channel.close()
+        # Expected to timeout.
+        thread_with_delay.join()
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
@@ -1,0 +1,71 @@
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python client of utilizing wait-for-ready flag with client time out."""
+
+import logging
+import threading
+
+import grpc
+
+helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
+    "helloworld.proto")
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+
+def wait_for_metadata(response_future, event):
+    for key, value in response_future.initial_metadata():
+        print('Greeter client received initial metadata: key=%s value=%s' %
+            (key, value))
+    event.set()
+
+def check_status(response_future, wait_success):
+    if wait_success:
+        print("received initial metadata before time out!")
+        for response in response_future:
+            message = response.message
+        print("Greeter client received: " + message)
+    else:
+        print("Timed out before receiving any initial metadata!")
+        response_future.cancel()
+
+
+def main():
+    # Create gRPC channel
+    channel = grpc.insecure_channel('localhost:50051')
+    stub = helloworld_pb2_grpc.GreeterStub(channel)
+
+    event_for_delay = threading.Event()
+
+    # Server will delay send initial metadata back for this RPC
+    response_future_delay = stub.SayHelloStreamReply(
+        helloworld_pb2.HelloRequest(name='you'), wait_for_ready=True)
+
+    # Fire RPC and wait for metadata
+    thread_with_delay = threading.Thread(target=wait_for_metadata,
+        args=(response_future_delay, event_for_delay))
+    thread_with_delay.start()
+
+    # Wait on client side with timeout
+    timeout = 3
+    check_status(response_future_delay, event_for_delay.wait(timeout))
+
+    # Expected to timeout.
+    thread_with_delay.join()
+
+    channel.close()
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
@@ -66,15 +66,13 @@ def main():
         # Fire RPC and wait for metadata
         thread_with_delay = threading.Thread(target=wait_for_metadata,
                                              args=(response_future_delay,
-                                                   event_for_delay))
+                                                   event_for_delay),
+                                             daemon=True)
         thread_with_delay.start()
 
         # Wait on client side with timeout
         timeout = 7
         check_status(response_future_delay, event_for_delay.wait(timeout))
-
-        # Expected to timeout.
-        thread_with_delay.join()
 
 
 if __name__ == '__main__':

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
@@ -24,11 +24,13 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 _LOGGER = logging.getLogger(__name__)
 _LOGGER.setLevel(logging.INFO)
 
+
 def wait_for_metadata(response_future, event):
     for key, value in response_future.initial_metadata():
         print('Greeter client received initial metadata: key=%s value=%s' %
-            (key, value))
+              (key, value))
     event.set()
+
 
 def check_status(response_future, wait_success):
     if wait_success:
@@ -54,7 +56,8 @@ def main():
 
         # Fire RPC and wait for metadata
         thread_with_delay = threading.Thread(target=wait_for_metadata,
-            args=(response_future_delay, event_for_delay))
+                                             args=(response_future_delay,
+                                                   event_for_delay))
         thread_with_delay.start()
 
         # Wait on client side with timeout
@@ -63,6 +66,7 @@ def main():
 
         # Expected to timeout.
         thread_with_delay.join()
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_client.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The Python client of utilizing wait-for-ready flag with client time out.
+"""An example of setting a server connection timeout independent from the
+overall RPC timeout.
 
 For stream server, if client set wait_for_ready but server never actually starts,
 client will wait indefinitely, this example will do the following steps to set a
@@ -70,7 +71,7 @@ def main():
                                              daemon=True)
         thread_with_delay.start()
 
-        # Wait on client side with timeout
+        # Wait on client side with 7 seconds timeout
         timeout = 7
         check_status(response_future_delay, event_for_delay.wait(timeout))
 

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The Python serer of utilizing wait-for-ready flag with client time out.
+"""An example of setting a server connection timeout independent from the
+overall RPC timeout.
 
 For stream server, if client set wait_for_ready but server never actually starts,
 client will wait indefinitely, this example will do the following steps to set a

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
@@ -14,8 +14,8 @@
 """The Python serer of utilizing wait-for-ready flag with client time out."""
 
 from concurrent import futures
-from time import sleep
 import logging
+from time import sleep
 
 import grpc
 
@@ -24,7 +24,9 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 
 _INITIAL_METADATA = ((b'initial-md', 'initial-md-value'),)
 
+
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
+
     def SayHelloStreamReply(self, request, servicer_context):
         # Send initial metadata back to indicate server is ready and running.
         print("sleeping 5s before sending metadata back")
@@ -36,6 +38,7 @@ class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
         # Server can do whatever it wants here before send actual response.
         yield helloworld_pb2.HelloReply(message='Hello, %s!' % (request.name))
+
 
 def serve():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
@@ -32,13 +32,16 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 
 _INITIAL_METADATA = ((b'initial-md', 'initial-md-value'),)
 
+
 def starting_up_server():
     print("sleeping 5s before sending metadata back")
     sleep(5)
 
+
 def do_work():
     print("server is processing the request")
     sleep(5)
+
 
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
@@ -56,7 +59,8 @@ class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
         # Sending actual response.
         for i in range(3):
-            yield helloworld_pb2.HelloReply(message='Hello %s times %s' % (request.name, i))
+            yield helloworld_pb2.HelloReply(message='Hello %s times %s' %
+                                            (request.name, i))
 
 
 def serve():

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
@@ -11,7 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The Python serer of utilizing wait-for-ready flag with client time out."""
+"""The Python serer of utilizing wait-for-ready flag with client time out.
+
+For stream server, if client set wait_for_ready but server never actually starts,
+client will wait indefinitely, this example will do the following steps to set a
+timeout on client side:
+1. Set server to return initial_metadata once it receives request.
+2. Client will set a timer (customized client timeout) waiting for initial_metadata.
+3. Client will timeout if it didn't receive initial_metadata.
+"""
 
 from concurrent import futures
 import logging
@@ -24,20 +32,31 @@ helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
 
 _INITIAL_METADATA = ((b'initial-md', 'initial-md-value'),)
 
+def starting_up_server():
+    print("sleeping 5s before sending metadata back")
+    sleep(5)
+
+def do_work():
+    print("server is processing the request")
+    sleep(5)
 
 class Greeter(helloworld_pb2_grpc.GreeterServicer):
 
     def SayHelloStreamReply(self, request, servicer_context):
-        # Send initial metadata back to indicate server is ready and running.
-        print("sleeping 5s before sending metadata back")
-        sleep(5)
+        # Suppose server will take some time to setup, client can set the time it willing to wait
+        # for server to up and running.
+        starting_up_server()
 
         # Initial metadata will be send back immediately after calling send_initial_metadata.
         print("sending inital metadata back")
         servicer_context.send_initial_metadata(_INITIAL_METADATA)
 
-        # Server can do whatever it wants here before send actual response.
-        yield helloworld_pb2.HelloReply(message='Hello, %s!' % (request.name))
+        # Time for server to process the request.
+        do_work()
+
+        # Sending actual response.
+        for i in range(3):
+            yield helloworld_pb2.HelloReply(message='Hello %s times %s' % (request.name, i))
 
 
 def serve():

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
@@ -1,0 +1,51 @@
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python serer of utilizing wait-for-ready flag with client time out."""
+
+from concurrent import futures
+from time import sleep
+import logging
+
+import grpc
+
+helloworld_pb2, helloworld_pb2_grpc = grpc.protos_and_services(
+    "helloworld.proto")
+
+_INITIAL_METADATA = ((b'initial-md', 'initial-md-value'),)
+
+class Greeter(helloworld_pb2_grpc.GreeterServicer):
+    def SayHelloStreamReply(self, request, servicer_context):
+        # Send initial metadata back to indicate server is ready and running.
+        print("sleeping 5s before sending metadata back")
+        sleep(5)
+
+        # Initial metadata will be send back immediately after calling send_initial_metadata.
+        print("sending inital metadata back")
+        servicer_context.send_initial_metadata(_INITIAL_METADATA)
+
+        # Server can do whatever it wants here before send actual response.
+        yield helloworld_pb2.HelloReply(message='Hello, %s!' % (request.name))
+
+def serve():
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
+    server.add_insecure_port('[::]:50051')
+    print("starting server")
+    server.start()
+    server.wait_for_termination()
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    serve()


### PR DESCRIPTION
### Description
Adding an example for `wait_for_ready` with client side timeout. (Requested from this issue: https://github.com/grpc/grpc/issues/31483)

### Details
For stream server, if client set `wait_for_ready` but server never actually starts, client will wait indefinitely, this example will do the following steps to set a timeout on client side:
 1. Set server to return `initial_metadata` once it receives request.
 2. Client will set a timer (customized client timeout) waiting for `initial_metadata`.
 3. Client will timeout if it didn't receive `initial_metadata`.