### PR TITLE
[codegen] Escape variable delimiters in raw comment printing

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -54,6 +54,16 @@ std::string FilenameIdentifier(const std::string& filename) {
   }
   return result;
 }
+
+std::string EscapeVariableDelimiters(std::string&& mut_str) {
+  size_t index = 0;
+  while ((index = mut_str.find('$', index)) != std::string::npos) {
+    mut_str.replace(index, 1, "$$");
+    index += 2;
+  }
+  return mut_str;
+}
+
 }  // namespace
 
 template <class T, size_t N>
@@ -1331,7 +1341,8 @@ void PrintHeaderService(grpc_generator::Printer* printer,
                         std::map<std::string, std::string>* vars) {
   (*vars)["Service"] = service->name();
 
-  printer->Print(service->GetLeadingComments("//").c_str());
+  printer->Print(
+      EscapeVariableDelimiters(service->GetLeadingComments("//")).c_str());
   printer->Print(*vars,
                  "class $Service$ final {\n"
                  " public:\n");

--- a/src/proto/grpc/testing/compiler_test.proto
+++ b/src/proto/grpc/testing/compiler_test.proto
@@ -22,7 +22,7 @@ syntax = "proto3";
 // Ignored detached comment
 // The comments in this file are not meant for readability
 // but rather to test to make sure that the code generator
-// properly preserves comments on files, services, and RPCs
+// properly preserves comments on files, services, and RPCs.
 
 // Ignored package leading comment
 package grpc.testing;
@@ -35,6 +35,8 @@ message Response {
 // ServiceA detached comment 1
 
 // ServiceA detached comment 2
+
+// Comments may contain special characters like "^[a-z0-9-]{1,63}$" and $$
 
 // ServiceA leading comment 1
 service ServiceA {

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -52,6 +52,8 @@ namespace testing {
 //
 // ServiceA detached comment 2
 //
+// Comments may contain special characters like "^[a-z0-9-]{1,63}$" and $$
+//
 // ServiceA leading comment 1
 class ServiceA final {
  public:


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/32171

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

