### PR TITLE
Add v1.52.1-1.52.3 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -211,6 +211,9 @@ LANG_RELEASE_MATRIX = {
             ('v1.50.1', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.51.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.52.0', ReleaseInfo(runtimes=['go1.19'])),
+            ('v1.52.1', ReleaseInfo(runtimes=['go1.19'])),
+            ('v1.52.2', ReleaseInfo(runtimes=['go1.19'])),
+            ('v1.52.3', ReleaseInfo(runtimes=['go1.19'])),
         ]),
     'java':
         OrderedDict([

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -211,8 +211,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.50.1', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.51.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.52.0', ReleaseInfo(runtimes=['go1.19'])),
-            ('v1.52.1', ReleaseInfo(runtimes=['go1.19'])),
-            ('v1.52.2', ReleaseInfo(runtimes=['go1.19'])),
             ('v1.52.3', ReleaseInfo(runtimes=['go1.19'])),
         ]),
     'java':


### PR DESCRIPTION
Adding gRPC-go v1.52.3 to the interop matrix