### PR TITLE
Upgrading to protobuf 22.x: Adapt make_grpcio_tools.py to changes in protobuf bazel build

### DIFF
--- a/tools/distrib/python/make_grpcio_tools.py
+++ b/tools/distrib/python/make_grpcio_tools.py
@@ -58,8 +58,8 @@ COMMIT_HASH_PREFIX = 'PROTOBUF_SUBMODULE_VERSION="'
 COMMIT_HASH_SUFFIX = '"'
 
 # Bazel query result prefix for expected source files in protobuf.
-PROTOBUF_CC_PREFIX = '//:src/'
-PROTOBUF_PROTO_PREFIX = '//:src/'
+PROTOBUF_CC_PREFIX = '//src/'
+PROTOBUF_PROTO_PREFIX = '//src/'
 
 GRPC_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..'))
@@ -88,7 +88,8 @@ BAZEL_DEPS = os.path.join(GRPC_ROOT, 'tools', 'distrib', 'python',
 BAZEL_DEPS_PROTOC_LIB_QUERY = '//:protoc_lib'
 BAZEL_DEPS_COMMON_PROTOS_QUERIES = [
     '//:well_known_type_protos',
-    '//:built_in_runtime_protos',
+    # has both plugin.proto and descriptor.proto
+    '//:compiler_plugin_proto',
 ]
 
 
@@ -125,7 +126,7 @@ def get_deps():
      `out_file`."""
     cc_files_output = bazel_query(BAZEL_DEPS_PROTOC_LIB_QUERY)
     cc_files = [
-        name[len(PROTOBUF_CC_PREFIX):]
+        name[len(PROTOBUF_CC_PREFIX):].replace(':', '/')
         for name in cc_files_output
         if name.endswith('.cc') and name.startswith(PROTOBUF_CC_PREFIX)
     ]
@@ -133,7 +134,7 @@ def get_deps():
     for target in BAZEL_DEPS_COMMON_PROTOS_QUERIES:
         raw_proto_files += bazel_query(target)
     proto_files = [
-        name[len(PROTOBUF_PROTO_PREFIX):]
+        name[len(PROTOBUF_PROTO_PREFIX):].replace(':', '/')
         for name in raw_proto_files
         if name.endswith('.proto') and name.startswith(PROTOBUF_PROTO_PREFIX)
     ]

--- a/tools/distrib/python/make_grpcio_tools.py
+++ b/tools/distrib/python/make_grpcio_tools.py
@@ -58,8 +58,8 @@ COMMIT_HASH_PREFIX = 'PROTOBUF_SUBMODULE_VERSION="'
 COMMIT_HASH_SUFFIX = '"'
 
 # Bazel query result prefix for expected source files in protobuf.
-PROTOBUF_CC_PREFIX = '//src/'
-PROTOBUF_PROTO_PREFIX = '//src/'
+PROTOBUF_CC_PREFIX = '//:src/'
+PROTOBUF_PROTO_PREFIX = '//:src/'
 
 GRPC_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..'))
@@ -88,8 +88,7 @@ BAZEL_DEPS = os.path.join(GRPC_ROOT, 'tools', 'distrib', 'python',
 BAZEL_DEPS_PROTOC_LIB_QUERY = '//:protoc_lib'
 BAZEL_DEPS_COMMON_PROTOS_QUERIES = [
     '//:well_known_type_protos',
-    # has both plugin.proto and descriptor.proto
-    '//:compiler_plugin_proto',
+    '//:built_in_runtime_protos',
 ]
 
 
@@ -126,7 +125,7 @@ def get_deps():
      `out_file`."""
     cc_files_output = bazel_query(BAZEL_DEPS_PROTOC_LIB_QUERY)
     cc_files = [
-        name[len(PROTOBUF_CC_PREFIX):].replace(':', '/')
+        name[len(PROTOBUF_CC_PREFIX):]
         for name in cc_files_output
         if name.endswith('.cc') and name.startswith(PROTOBUF_CC_PREFIX)
     ]
@@ -134,7 +133,7 @@ def get_deps():
     for target in BAZEL_DEPS_COMMON_PROTOS_QUERIES:
         raw_proto_files += bazel_query(target)
     proto_files = [
-        name[len(PROTOBUF_PROTO_PREFIX):].replace(':', '/')
+        name[len(PROTOBUF_PROTO_PREFIX):]
         for name in raw_proto_files
         if name.endswith('.proto') and name.startswith(PROTOBUF_PROTO_PREFIX)
     ]


### PR DESCRIPTION
Protobuf's HEAD has changed the layout of bazel targets we use for getting the list of source files for our python grpcio.tools build.

With this patch, make_grpcio_tools.py finishes successfully and gives reasonable results.

