### PR TITLE
Upgrading to protobuf 22.x: react to changes in C++ code

### DIFF
--- a/include/grpcpp/impl/codegen/config_protobuf.h
+++ b/include/grpcpp/impl/codegen/config_protobuf.h
@@ -68,8 +68,9 @@
 #ifndef GRPC_CUSTOM_JSONUTIL
 #include <google/protobuf/util/json_util.h>
 #include <google/protobuf/util/type_resolver_util.h>
+#include "absl/status/status.h"
 #define GRPC_CUSTOM_JSONUTIL ::google::protobuf::util
-#define GRPC_CUSTOM_UTIL_STATUS ::google::protobuf::util::Status
+#define GRPC_CUSTOM_UTIL_STATUS ::absl::Status
 #endif
 
 namespace grpc {

--- a/src/compiler/config_protobuf.h
+++ b/src/compiler/config_protobuf.h
@@ -50,7 +50,7 @@
 #endif
 
 #ifndef GRPC_CUSTOM_CSHARP_GETCLASSNAME
-#include <google/protobuf/compiler/csharp/csharp_names.h>
+#include <google/protobuf/compiler/csharp/names.h>
 #define GRPC_CUSTOM_CSHARP_GETCLASSNAME \
   ::google::protobuf::compiler::csharp::GetClassName
 #define GRPC_CUSTOM_CSHARP_GETFILENAMESPACE \

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -22,7 +22,7 @@
 #include <set>
 #include <sstream>
 
-#include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
+#include <google/protobuf/compiler/objectivec/names.h>
 
 #include "src/compiler/config.h"
 #include "src/compiler/objective_c_generator_helpers.h"

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -21,7 +21,7 @@
 
 #include <map>
 
-#include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
+#include <google/protobuf/compiler/objectivec/names.h>
 
 #include "src/compiler/config.h"
 #include "src/compiler/generator_helpers.h"

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -20,7 +20,7 @@
 
 #include <memory>
 
-#include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
+#include <google/protobuf/compiler/objectivec/names.h>
 
 #include "src/compiler/config.h"
 #include "src/compiler/objective_c_generator.h"


### PR DESCRIPTION
- `::google::protobuf::util::Status` was removed, so trying to replace it with `::absl::Status` (hopefully that makes sense)
- some public protobuf headers were removed, adapting code of grpc codegen plugins to the new names.

TODO: As is, this change would need to get merged atomically with the actual protobuf upgrade.
Potentially we could condition the changes being made on protobuf version, so that grpc plugins can still compile against an older version of protobuf:
(e.g. sth like this).
```
#include <google/protobuf/port_def.inc>
#if PROTOBUF_VERSION ...
#define IS_OLD
#endif
#include <google/protobuf/port_undef.inc>
#ifdef IS_OLD
#include <google/protobuf/old/path>
#else
#include <google/protobuf/new/path>
#endif
```

Ideally, protobuf would add forwarding headers for the headers that were removed, (e.g. like here: https://github.com/protocolbuffers/protobuf/pull/11613/files, but more adjustments would be needed to the protobuf bazel build).
