### PR TITLE
[backport][1.48.x] Fix ruby builds on kokoro macos monterey images (#31125)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -73,6 +73,8 @@ then
     sleep 3
   done
   [[ "$gpg_recv_keys_success" == 1 ]] || exit 1
+  # fix .rvm directory ownership on kokoro monterey image
+  sudo chown -R "${USER}" ~/.rvm
   rvm get stable # Per https://stackoverflow.com/questions/65477613/rvm-where-is-ruby-3-0-0
   # stop echoing bash commands temporarily to prevent rvm from polluting the logs
   set +x
@@ -84,8 +86,6 @@ then
   done;
   echo "Setting default ruby version."
   rvm use 2.5.0 --default
-  echo "Installing cocoapods."
-  time gem install cocoapods --version 1.3.1 --no-document
   echo "Updating osx-ssl-certs."
   rvm osx-ssl-certs status all
   rvm osx-ssl-certs update all


### PR DESCRIPTION


* cocoapods is not a ruby dependency

* fix rvm update on macos monterey images




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

