### PR TITLE
rls_e2e_test: increase RPC timeout

### DIFF
--- a/test/cpp/end2end/rls_end2end_test.cc
+++ b/test/cpp/end2end/rls_end2end_test.cc
@@ -230,7 +230,7 @@ class RlsEnd2endTest : public ::testing::Test {
   }
 
   struct RpcOptions {
-    int timeout_ms = 1000;
+    int timeout_ms = 2000;
     bool wait_for_ready = false;
     std::vector<std::pair<std::string, std::string>> metadata;
 


### PR DESCRIPTION
This should fix a DEADLINE_EXCEEDED flake seen under MSAN.