### PR TITLE
xds_override_host LB: make subchannel keys compatible with the filter

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -519,7 +519,7 @@ absl::StatusOr<ServerAddressList> XdsOverrideHostLb::UpdateAddressMap(
       // Skip draining hosts if not in the override status set.
       continue;
     }
-    auto key = grpc_sockaddr_to_string(&address.address(), false);
+    auto key = grpc_sockaddr_to_uri(&address.address());
     if (key.ok()) {
       addresses_for_map.emplace(std::move(*key), status);
     }
@@ -550,7 +550,7 @@ absl::StatusOr<ServerAddressList> XdsOverrideHostLb::UpdateAddressMap(
 RefCountedPtr<XdsOverrideHostLb::SubchannelWrapper>
 XdsOverrideHostLb::AdoptSubchannel(
     ServerAddress address, RefCountedPtr<SubchannelInterface> subchannel) {
-  auto key = grpc_sockaddr_to_string(&address.address(), false);
+  auto key = grpc_sockaddr_to_uri(&address.address());
   if (!key.ok()) {
     return subchannel;
   }

--- a/test/core/client_channel/lb_policy/lb_policy_test_lib.h
+++ b/test/core/client_channel/lb_policy/lb_policy_test_lib.h
@@ -465,8 +465,8 @@ class LoadBalancingPolicyTest : public ::testing::Test {
    public:
     explicit FakeCallState(
         const std::map<UniqueTypeName, absl::string_view>& attributes) {
-      for (const auto& it : attributes) {
-        attributes_.emplace(it.first, std::string(it.second));
+      for (const auto& p : attributes) {
+        attributes_.emplace(p.first, std::string(p.second));
       }
     }
 


### PR DESCRIPTION
Fixes an issue when keys used by override host policy to be consistent with the ones used by stateful session filter.