### PR TITLE
Generate record instead of class

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -436,14 +436,14 @@ void GenerateServiceDescriptorProperty(Printer* out,
 
 void GenerateServerClass(Printer* out, const ServiceDescriptor* service) {
   out->Print(
-      "/// <summary>Base class for server-side implementations of "
+      "/// <summary>Base record for server-side implementations of "
       "$servicename$</summary>\n",
       "servicename", GetServiceClassName(service));
   out->Print(
       "[grpc::BindServiceMethod(typeof($classname$), "
       "\"BindService\")]\n",
       "classname", GetServiceClassName(service));
-  out->Print("public abstract partial class $name$\n", "name",
+  out->Print("public abstract partial record $name$\n", "name",
              GetServerClassName(service));
   out->Print("{\n");
   out->Indent();


### PR DESCRIPTION
The motivation for this PR is that I'd like to make an adapter that's a record instead of a class.
But since gRPC generates a class instead of a record, it forces my hand to use a class as well, since a record can't inherit from a class.

I want to use a record in my adapter because it turns this:
```
public class XyzAdapter : XyzService.XyzServiceBase
{
	private readonly IAbc _abc;
        // x 10

	public XyzAdapter(
		IAbc abc,
                // x 10
	)
	{
		_abc = abc;
                // x 10
	}
```

into this

```
public record XyzAdapter(
	IAbc Abc,
        // x 10
) : XyzService.XyzServiceBase {
```
