### PR TITLE
GCP Observability header: Add missing port_platform include

### DIFF
--- a/src/cpp/ext/gcp/observability_config.h
+++ b/src/cpp/ext/gcp/observability_config.h
@@ -17,6 +17,8 @@
 #ifndef GRPC_SRC_CPP_EXT_GCP_OBSERVABILITY_CONFIG_H
 #define GRPC_SRC_CPP_EXT_GCP_OBSERVABILITY_CONFIG_H
 
+#include <grpc/support/port_platform.h>
+
 #include <stdint.h>
 
 #include <map>


### PR DESCRIPTION
It is most likely not needed, but erring on the side of safety in case this ends up using Core stuff in the future.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

