### PR TITLE
Fix cmake on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,12 @@ if(WIN32)
   set(_gRPC_PLATFORM_WINDOWS ON)
 endif()
 
+if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
+  # AppleClang defaults to C++98, so we bump it to C++14.
+  message("CMAKE_CXX_STANDARD was undefined, defaulting to C++14.")
+  set(CMAKE_CXX_STANDARD 14)
+endif ()
+
 if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 endif()

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -264,6 +264,12 @@
     set(_gRPC_PLATFORM_WINDOWS ON)
   endif()
 
+  if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
+    # AppleClang defaults to C++98, so we bump it to C++14.
+    message("CMAKE_CXX_STANDARD was undefined, defaulting to C++14.")
+    set(CMAKE_CXX_STANDARD 14)
+  endif ()
+
   ## Some libraries are shared even with BUILD_SHARED_LIBRARIES=OFF
   if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
     set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -477,7 +477,7 @@ class CLanguage(object):
             _check_compiler(compiler, ['default', 'cmake'])
 
         if compiler == 'default' or compiler == 'cmake':
-            return ('debian11', ["-DCMAKE_CXX_STANDARD=14"])
+            return ('debian11', [])
         elif compiler == 'gcc7':
             return ('gcc_7', [])
         elif compiler == 'gcc10.2':


### PR DESCRIPTION
AppleClang's default C++ version is C++98 so it always needs `CMAKE_CXX_STANDARD` option but it might be too much for existing use-cases that rely on the old gRPC cmake behavior setting `CMAKE_CXX_STANDARD` by itself. So I revived this behavior only for MacOS with a warning.