### PR TITLE
Changing parallelism of linux/grpc_portability_build_only

### DIFF
--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux c++ --inner_jobs 8 -j 4 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 16 -j 1 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux c++ --inner_jobs 16 -j 1 --internal_ci --build_only"
+  value: "-f portability linux c++ --inner_jobs 32 -j 1 --internal_ci --build_only"
 }


### PR DESCRIPTION
Currently `linux/grpc_portability_build_only` became flaky because of out of space (300GB). This is because one docker run can use up to 80GB and 4 docker jobs can work in parallel. Sometimes 4 jobs end up consuming all available 300GB resulting in out of space error. So I reduced this parallelism to 1 docker run at a time but increased the inner parallelism so that total elapsed time won't suffer much from this change.