### PR TITLE
Updating bazel deps when running submodule_at_head tests

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -39,6 +39,30 @@ echo "2) some change that was just merged in the submodule head has caused the f
 
 echo ""
 echo "submodule '${SUBMODULE_NAME}' is at commit: $(cd third_party/${SUBMODULE_NAME}; git rev-parse --verify HEAD)"
+echo ""
+
+# Update bazel for generate_projects
+case "$SUBMODULE_NAME" in
+  abseil-cpp)
+    BAZEL_DEP_NAME="com_google_absl"
+    ;;
+  boringssl)
+    BAZEL_DEP_NAME="boringssl"
+    ;;
+  protobuf)
+    BAZEL_DEP_NAME="com_google_protobuf"
+    ;;
+esac
+if [ -z "$BAZEL_DEP_NAME" ]
+then
+   echo "No bazel dependency is specified so skipping bazel reconfiguration."
+else
+   BAZEL_DEP_PATH="$(pwd)/third_party/${SUBMODULE_NAME}"
+   echo "bazel override_repository is set for ${BAZEL_DEP_NAME} to ${BAZEL_DEP_PATH}"
+   echo "build --override_repository=${BAZEL_DEP_NAME}=${BAZEL_DEP_PATH}" >> "tools/bazel.rc"
+   echo "query --override_repository=${BAZEL_DEP_NAME}=${BAZEL_DEP_PATH}" >> "tools/bazel.rc"
+fi
+echo ""
 
 if [ "${SUBMODULE_NAME}" == "abseil-cpp" ]
 then
@@ -55,4 +79,4 @@ fi
 # commit so that changes are passed to Docker
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 --inner_jobs 8 -j 4 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 --inner_jobs 16 -j 2 --internal_ci --build_only


### PR DESCRIPTION
Current `build_at_head` has a fundamental problem to miss some build changes from updated dependencies. gRPC build system relies on bazel BUILD to get all necessary build configuration when building CMakeLists.txt (what `tools/buildgen/generate_projects.sh` does) but current script doesn't update dependencies of bazel BUILD resulting in an incomplete information.

This change makes it update bazel BUILD dependencies along with the corresponding third_party submodule directory to complete this update. 