### PR TITLE
remove go version v1.52.0 and keep only v1.52.3

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -210,7 +210,6 @@ LANG_RELEASE_MATRIX = {
             ('v1.49.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.50.1', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.51.0', ReleaseInfo(runtimes=['go1.16'])),
-            ('v1.52.0', ReleaseInfo(runtimes=['go1.19'])),
             ('v1.52.3', ReleaseInfo(runtimes=['go1.19'])),
         ]),
     'java':


### PR DESCRIPTION
As a reactive from #32205, we need to remove the 52.0 release and only keep v1.52.3 which is the latest patch version for that minor release