### PR TITLE
fix TLS key logging file entry corruption on non-Windows

### DIFF
--- a/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
+++ b/src/core/tsi/ssl/key_logging/ssl_key_logging.cc
@@ -83,7 +83,7 @@ void TlsSessionKeyLoggerCache::TlsSessionKeyLogger::LogSessionKeys(
   if (fd_ == nullptr || session_keys_info.empty()) return;
   // Append to key log file under lock
   bool err =
-      fwrite((session_keys_info + "\r\n").c_str(), sizeof(char),
+      fwrite((session_keys_info + "\n").c_str(), sizeof(char),
              session_keys_info.length() + 1, fd_) < session_keys_info.length();
 
   if (err) {


### PR DESCRIPTION
On Windows I see properly formatted key logging files that include CRLF, e.g.

    CLIENT_RANDOM 1acfa70620279d4e2b2895fc510897db6b164be7c97b5e8ee2d3180a551d52ec 4214c5de0498316cedea48c767b97dcbc3cf8121c21b1c441026297796a8b96f502d06de280442b8232221f6be1fbf3a

However, on macOS and Linux see first 10 characters missing. Also there is no CR at the end of the line, e.g.

      DOM 0d462bc4dd7884a8ef0d6f493de9a3d9622e88cd22e117f41eff6a833317cb99 aeac8859bdffc000d385b23a9dbec5a6397a7e27097399c23e838617d3a22da00bcf3722d543c93015bd117b11c8a413

This fix changes "\r\n" to "\n" which Wireshark appears to accept on both Windows and macOS.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

