### PR TITLE
PSM Interop: Switch to the new GKE clusters (except the URL map)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -42,11 +42,11 @@ readonly GKE_CLUSTER_PSM_BASIC="psm-basic"
 activate_gke_cluster() {
   case $1 in
     GKE_CLUSTER_PSM_LB)
-      GKE_CLUSTER_NAME="interop-test-psm-lb-v1-us-central1-a"
+      GKE_CLUSTER_NAME="psm-interop-lb-primary"
       GKE_CLUSTER_ZONE="us-central1-a"
       ;;
     GKE_CLUSTER_PSM_SECURITY)
-      GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-central1-a"
+      GKE_CLUSTER_NAME="psm-interop-security"
       GKE_CLUSTER_ZONE="us-central1-a"
       ;;
     GKE_CLUSTER_PSM_BASIC)
@@ -75,11 +75,7 @@ activate_gke_cluster() {
 activate_secondary_gke_cluster() {
   case $1 in
     GKE_CLUSTER_PSM_LB)
-      SECONDARY_GKE_CLUSTER_NAME="interop-test-psm-lb-v1-us-west1-b"
-      SECONDARY_GKE_CLUSTER_ZONE="us-west1-b"
-      ;;
-    GKE_CLUSTER_PSM_SECURITY)
-      SECONDARY_GKE_CLUSTER_NAME="interop-test-psm-sec-v2-us-west1-b"
+      SECONDARY_GKE_CLUSTER_NAME="psm-interop-lb-secondary"
       SECONDARY_GKE_CLUSTER_ZONE="us-west1-b"
       ;;
     *)

--- a/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py
@@ -20,7 +20,7 @@ Typical usage examples:
 python3 tools/run_tests/xds_k8s_test_driver/bin/cleanup/cleanup.py\
     --project=grpc-testing\
     --network=default-vpc\
-    --kube_context=gke_grpc-testing_us-central1-a_interop-test-psm-sec-v2-us-central1-a\
+    --kube_context=gke_grpc-testing_us-central1-a_psm-interop-security
     --resource_prefix='required-but-does-not-matter'\
     --td_bootstrap_image='required-but-does-not-matter' --server_image='required-but-does-not-matter' --client_image='required-but-does-not-matter'
 """


### PR DESCRIPTION
Our test clusters are in the broken/dirty state (except the URL map's "basic" cluster, which isn't affected).  
This PR switches to the newly created clusters to:
1. Get a data point on whether newly created clusters are affected by the same issues.
2. Allow for descriptive work on the old clusters.
3. Hopefully, bring our tests back to green.

Bonus: more sensible cluster names.
