### PR TITLE
[flake] Remove inproc thread stress tests

### DIFF
--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -297,13 +297,8 @@ static void SendRpc(grpc::testing::EchoTestService::Stub* stub, int num_rpcs,
 
 typedef ::testing::Types<
     CommonStressTestSyncServer<CommonStressTestInsecure<TestServiceImpl>>,
-    CommonStressTestSyncServer<CommonStressTestInproc<TestServiceImpl, false>>,
-    CommonStressTestSyncServerLowThreadCount<
-        CommonStressTestInproc<TestServiceImpl, true>>,
     CommonStressTestAsyncServer<
-        CommonStressTestInsecure<grpc::testing::EchoTestService::AsyncService>>,
-    CommonStressTestAsyncServer<CommonStressTestInproc<
-        grpc::testing::EchoTestService::AsyncService, false>>>
+        CommonStressTestInsecure<grpc::testing::EchoTestService::AsyncService>>>
     CommonTypes;
 TYPED_TEST_SUITE(End2endTest, CommonTypes);
 TYPED_TEST(End2endTest, ThreadStress) {


### PR DESCRIPTION
These tests are failing because they're running with too few threads, however if we give them sufficient threads to catch bugs they're flaky.

Remove them and get the team some bandwidth back.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

