### PR TITLE
[flake] Reduce test size for too_many_pings_test

### DIFF
--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -197,7 +197,7 @@ TEST(TooManyPings, TestLotsOfServerCancelledRpcsDoesntGiveTooManyPings) {
                                               nullptr /* channel args */);
   grpc_channel_credentials_release(creds);
   std::map<grpc_status_code, int> statuses_and_counts;
-  const int kNumTotalRpcs = 1e5;
+  const int kNumTotalRpcs = 100;
   // perform an RPC
   gpr_log(GPR_INFO,
           "Performing %d total RPCs and expecting them all to receive status "


### PR DESCRIPTION
It was timing out in some sanitizer builds, likely because we've got more debug code in the path now.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

