### PR TITLE
DRAFT: Grpc.Tools detect alpine linux

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/LinuxDistroDetectionTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/LinuxDistroDetectionTest.cs
@@ -1,0 +1,35 @@
+#region Copyright notice and license
+
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.IO;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Grpc.Tools.Tests
+{
+    public class LinuxDistroDetectionTest
+    {
+        [Test]
+        public void ReadLinuxDistroFile()
+        {
+            var filesDir = Path.GetFullPath(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)+"../../../..");
+            var osReleasePath = Path.GetFullPath($"{filesDir}/os-release-test.txt");
+            Assert.AreEqual("alpine", LinuxDistroDetection.ReadLinuxDistroId(osReleasePath));
+        }
+    }
+}

--- a/src/csharp/Grpc.Tools.Tests/os-release-test.txt
+++ b/src/csharp/Grpc.Tools.Tests/os-release-test.txt
@@ -1,0 +1,7 @@
+# test file for /etc/os-release
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.17.1
+PRETTY_NAME="Alpine Linux v3.17"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"

--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>Protobuf.MSBuild</AssemblyName>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
@@ -65,6 +65,8 @@
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_ProtoCompiler)linux_x64/protoc" />
     <_Asset PackagePath="tools/linux_arm64/" Include="$(Assets_ProtoCompiler)linux_aarch64/protoc" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_ProtoCompiler)macos_x64/protoc" /> <!-- GPB: macosx-->
+    <_Asset PackagePath="tools/linux_alpine_x86/" Include="$(Assets_ProtoCompiler)linux_alpine_x86/protoc" />
+    <_Asset PackagePath="tools/linux_alpine_x64/" Include="$(Assets_ProtoCompiler)linux_alpine_x64/protoc" />
 
     <!-- gRPC assets (for Grpc.Tools) -->
     <_Asset PackagePath="tools/windows_x86/" Include="$(Assets_GrpcPlugins)protoc_windows_x86/grpc_csharp_plugin.exe" />
@@ -73,6 +75,8 @@
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_GrpcPlugins)protoc_linux_x64/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/linux_arm64/" Include="$(Assets_GrpcPlugins)protoc_linux_aarch64/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_GrpcPlugins)protoc_macos_x64/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/linux_alpine_x86/" Include="$(Assets_GrpcPlugins)protoc_linux_alpine_x86/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/linux_alpine_x64/" Include="$(Assets_GrpcPlugins)protoc_linux_alpine_x64/grpc_csharp_plugin" />
 
     <None Include="@(_Asset)" Pack="true" Visible="false" />
   </ItemGroup>

--- a/src/csharp/Grpc.Tools/LinuxDistroDetection.cs
+++ b/src/csharp/Grpc.Tools/LinuxDistroDetection.cs
@@ -1,0 +1,86 @@
+#region Copyright notice and license
+
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.IO;
+using Grpc.Core.Internal;
+
+namespace Grpc.Tools
+{
+    /// <summary>
+    /// Detect the ID of the Linux distribution.
+    /// If running on a Linux system the we try and detect the name of the distribution
+    /// by reading the file /etc/os-release if it exists. Most commonly used Linux
+    /// distributions have adopted the use of this file.
+    /// <para> As we are only really interested in detecting Alpine linux to provide different
+    /// binaries, and Alpine linux does use this file, then this is all we need to do.</para>
+    ///
+    /// </summary>
+    internal static class LinuxDistroDetection
+    {
+        /// <summary>
+        /// Get the Linux distribution ID (e.g. alpine, ubuntu, etc) or an empty
+        /// string if it cannot be determined or is not Linux.
+        /// </summary>
+        /// <returns></returns>
+        public static string GetLinuxDistroId()
+        {
+            if (Platform.Os == CommonPlatformDetection.OSKind.Linux)
+            {
+                return ReadLinuxDistroId("/etc/os-release");
+            }
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Read a file to get the Linux distribution ID.
+        /// This method is public to allow for testing.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        public static string ReadLinuxDistroId(string path)
+        {
+            const string IdPrefix = "ID=";
+
+            string id = string.Empty;
+            if (File.Exists(path))
+            {
+                try
+                {
+                    string[] lines = System.IO.File.ReadAllLines(path);
+                    foreach (string line in lines)
+                    {
+                        if (line.StartsWith(IdPrefix) && line.Length > IdPrefix.Length)
+                        {
+                            id = line.Substring(IdPrefix.Length).ToLowerInvariant();
+                            break;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    // log the error and continue
+                    Console.Error.WriteLine($"ReadDistroId: Unable to read {path}: Exception: {e}");
+                }
+            }
+
+            return id;
+        }
+
+    }
+}

--- a/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
+++ b/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
@@ -41,6 +41,12 @@ namespace Grpc.Tools
         [Output]
         public string Cpu { get; set; }
 
+        /// <summary>
+        /// Return the linux distribution id (if known), e.g. 'alpine', 'ubuntu'
+        /// If the it is unknown, the property is not set.
+        /// </summary>
+        [Output]
+        public string LinuxDistroId { get; set; }
 
         public override bool Execute()
         {
@@ -60,6 +66,8 @@ namespace Grpc.Tools
                 default: Cpu = ""; break;
             }
 
+            LinuxDistroId = LinuxDistroDetection.GetLinuxDistroId();
+
             // Use x64 on macosx arm64 until a native protoc is shipped
             if (Os == "macosx" && Cpu == "arm64")
             {
@@ -73,5 +81,7 @@ namespace Grpc.Tools
 
             return true;
         }
+
+
     };
 }

--- a/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
@@ -28,6 +28,8 @@
 
       <gRPC_PluginFullPath Condition=" '$(gRPC_PluginFullPath)' == '' and '$(Protobuf_ToolsOs)' == 'windows' "
            >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)\$(gRPC_PluginFileName).exe</gRPC_PluginFullPath>
+      <gRPC_PluginFullPath Condition=" '$(gRPC_PluginFullPath)' == '' and '$(_Protobuf_ToolsLinuxDistroId)' == 'alpine' "
+           >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_alpine_$(Protobuf_ToolsCpu)\$(gRPC_PluginFileName)</gRPC_PluginFullPath>
       <gRPC_PluginFullPath Condition=" '$(gRPC_PluginFullPath)' == '' "
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/$(gRPC_PluginFileName)</gRPC_PluginFullPath>
     </PropertyGroup>

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -65,6 +65,7 @@
     <ProtoToolsPlatform>
       <Output TaskParameter="Os" PropertyName="_Protobuf_ToolsOs"/>
       <Output TaskParameter="Cpu" PropertyName="_Protobuf_ToolsCpu"/>
+      <Output TaskParameter="LinuxDistroId" PropertyName="_Protobuf_ToolsLinuxDistroId"/>
     </ProtoToolsPlatform>
 
     <PropertyGroup>
@@ -78,6 +79,8 @@
       <Protobuf_ToolsCpu Condition=" '$(Protobuf_ToolsCpu)' == '' ">$(_Protobuf_ToolsCpu)</Protobuf_ToolsCpu>
       <Protobuf_ProtocFullPath Condition=" '$(Protobuf_ProtocFullPath)' == '' and '$(Protobuf_ToolsOs)' == 'windows' "
            >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)\protoc.exe</Protobuf_ProtocFullPath>
+      <Protobuf_ProtocFullPath Condition=" '$(Protobuf_ProtocFullPath)' == '' and '$(_Protobuf_ToolsLinuxDistroId)' == 'alpine' "
+           >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_alpine_$(Protobuf_ToolsCpu)/protoc</Protobuf_ProtocFullPath>
       <Protobuf_ProtocFullPath Condition=" '$(Protobuf_ProtocFullPath)' == '' "
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/protoc</Protobuf_ProtocFullPath>
     </PropertyGroup>


### PR DESCRIPTION
This contains changes to the Grpc.Tools package to detect running on alpine linux and adds placeholders for using x86 and x64 alpine linux protoc and grpc_csharp_plugin binaries in MSBuild.

NOTE: **It does not build or provide the alpine linux tools binaries**. It assumes the alpine artifacts are already built and are available in `${EXTERNAL_GIT_ROOT}"/input_artifacts/`

Thus there are the changes that would need to be made to Grpc.Tools if we built the alpine linux tools - so is marked as a draft PR until we do so.

The detection of alpine linux is done by reading the file `/etc/os-release` if it exists. This is done in a new class `LinuxDistroDetection` rather than adding to the existing `CommonPlatformDetection` class to separate it out (as the latter class is a copy from elsewhere) and make it easier to test. The code can be moved into  `CommonPlatformDetection` if that was felt to be a more appropriate place.