### PR TITLE
Reversing order of execution

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -169,7 +169,7 @@ module GRPC
     def intercept!(type, args = {})
       return yield if @interceptors.none?
 
-      i = @interceptors.pop
+      i = @interceptors.shift
       return yield unless i
 
       i.send(type, **args) do

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -190,18 +190,30 @@ describe 'Server Interceptors' do
       ]
     end
 
-    it 'each should be called', server: true do
+    it 'each should be called in order', server: true do
+      call_order = []
       expect(interceptor).to receive(:request_response)
-        .once.and_call_original
+        .once.and_wrap_original do |m, *args| 
+          m.call(*args)
+          call_order << interceptor
+        end
       expect(interceptor2).to receive(:request_response)
-        .once.and_call_original
+        .once.and_wrap_original do |m, *args| 
+          m.call(*args)
+          call_order << interceptor2
+        end
       expect(interceptor3).to receive(:request_response)
-        .once.and_call_original
+        .once.and_wrap_original do |m, *args| 
+          m.call(*args)
+          call_order << interceptor3
+        end
 
       run_services_on_server(@server, services: [service]) do
         stub = build_insecure_stub(EchoStub)
         expect(stub.an_rpc(request)).to be_a(EchoMsg)
       end
+
+      expect(call_order).to eq interceptors
     end
   end
 


### PR DESCRIPTION
Fixes #32286 by reversing the order of execution.

Alternative options would be to reverse the array on Context init since pop is cheaper than shift.

