### PR TITLE
Increased timeout for sanity test variants

### DIFF
--- a/tools/internal_ci/linux/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/grpc_clang_tidy.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 40
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_iwyu.cfg
+++ b/tools/internal_ci/linux/grpc_iwyu.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 40
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_sanity.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 40
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 40
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/pull_request/grpc_iwyu.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_iwyu.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 40
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 40
+timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1069,7 +1069,7 @@ class Sanity(object):
                 environ['DISABLE_BAZEL_WRAPPER'] = 'true'
             return [
                 self.config.job_spec(cmd['script'].split(),
-                                     timeout_seconds=30 * 60,
+                                     timeout_seconds=45 * 60,
                                      environ=environ,
                                      cpu_cost=cmd.get('cpu_cost', 1))
                 for cmd in yaml.safe_load(f)


### PR DESCRIPTION
Usually clang-tidy spends ~20 minutes to complete but there was a case of having a little more than 30 minutes resulting in timeout so let's give these sanity-test variants 45 minutes to have enough buffer. 