### PR TITLE
Excluding more tests from build_submodule_at_head

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -55,4 +55,4 @@ fi
 # commit so that changes are passed to Docker
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude basictests_arm64 --inner_jobs 8 -j 4 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 --inner_jobs 8 -j 4 --internal_ci --build_only

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -185,7 +185,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
     test_jobs += _generate_jobs(languages=['sanity', 'clang-tidy', 'iwyu'],
                                 configs=['dbg'],
                                 platforms=['linux'],
-                                labels=['basictests'],
+                                labels=['basictests', 'sanity'],
                                 extra_args=extra_args +
                                 ['--report_multi_target'],
                                 inner_jobs=inner_jobs)


### PR DESCRIPTION
As build_submodule_at_head variants hit time-out more often, unnecessary tests are removed from them. 
- C tests (considered redundant as C++ will build C anyway)
- Sanity tests (...)