### PR TITLE
Make non-local static variables const

### DIFF
--- a/src/core/lib/gprpp/global_config_env.h
+++ b/src/core/lib/gprpp/global_config_env.h
@@ -106,21 +106,21 @@ class GlobalConfigEnvString : public GlobalConfigEnv {
 // `help` argument is ignored for this implementation.
 
 #define GPR_GLOBAL_CONFIG_DEFINE_BOOL(name, default_value, help)         \
-  static char g_env_str_##name[] = #name;                                \
+  static const char g_env_str_##name[] = #name;                                \
   static ::grpc_core::GlobalConfigEnvBool g_env_##name(g_env_str_##name, \
                                                        default_value);   \
   bool gpr_global_config_get_##name() { return g_env_##name.Get(); }     \
   void gpr_global_config_set_##name(bool value) { g_env_##name.Set(value); }
 
 #define GPR_GLOBAL_CONFIG_DEFINE_INT32(name, default_value, help)         \
-  static char g_env_str_##name[] = #name;                                 \
+  static const char g_env_str_##name[] = #name;                                 \
   static ::grpc_core::GlobalConfigEnvInt32 g_env_##name(g_env_str_##name, \
                                                         default_value);   \
   int32_t gpr_global_config_get_##name() { return g_env_##name.Get(); }   \
   void gpr_global_config_set_##name(int32_t value) { g_env_##name.Set(value); }
 
 #define GPR_GLOBAL_CONFIG_DEFINE_STRING(name, default_value, help)         \
-  static char g_env_str_##name[] = #name;                                  \
+  static const char g_env_str_##name[] = #name;                                  \
   static ::grpc_core::GlobalConfigEnvString g_env_##name(g_env_str_##name, \
                                                          default_value);   \
   ::grpc_core::UniquePtr<char> gpr_global_config_get_##name() {            \


### PR DESCRIPTION
Non-const non-local static variables are not guaranteed to be initialized before they are used.

This is hard to reproduce. I encounter this bug undeterministically in a CI task.

Reference: Embracing Modern C++ Safely

Despite C++11’s guarantee that each individual function-scope static initialization will occur at most once and before control can reach a point where the variable can be referenced, no analogous guarantees are made of nonlocal objects of static storage duration. Absence of this guarantee makes any interdependency in the initialization of such objects, especially across translation units (TUs), an abundant source of insidious errors.

Objects that undergo constant initialization have no such issue: Such objects will never be accessible at run time before having their initial values. Objects that are not constant initialized5 will instead be zero initialized until their constructors run, which itself might lead to undefined behavior that is not necessarily conspicuous.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

