### PR TITLE
[channel_args] Use c++ channel args during channel init

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -46,7 +46,6 @@
 
 #include "src/core/ext/filters/client_channel/backend_metric.h"
 #include "src/core/ext/filters/client_channel/backup_poller.h"
-#include "src/core/ext/filters/client_channel/client_channel.h"
 #include "src/core/ext/filters/client_channel/client_channel_channelz.h"
 #include "src/core/ext/filters/client_channel/client_channel_service_config.h"
 #include "src/core/ext/filters/client_channel/config_selector.h"

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -36,6 +36,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
+#include "client_channel.h"
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/slice.h>
@@ -285,9 +286,8 @@ class DynamicTerminationFilter {
                              const grpc_channel_info* /*info*/) {}
 
  private:
-  explicit DynamicTerminationFilter(const grpc_channel_args* args)
-      : chand_(grpc_channel_args_find_pointer<ClientChannel>(
-            args, GRPC_ARG_CLIENT_CHANNEL)) {}
+  explicit DynamicTerminationFilter(const ChannelArgs& args)
+      : chand_(args.GetObject<ClientChannel>()) {}
 
   ClientChannel* chand_;
 };
@@ -975,7 +975,7 @@ RefCountedPtr<SubchannelPoolInterface> GetSubchannelPool(
 
 ClientChannel::ClientChannel(grpc_channel_element_args* args,
                              grpc_error_handle* error)
-    : channel_args_(ChannelArgs::FromC(args->channel_args)),
+    : channel_args_(args->channel_args),
       deadline_checking_enabled_(grpc_deadline_checking_enabled(channel_args_)),
       owning_stack_(args->channel_stack),
       client_channel_factory_(channel_args_.GetObject<ClientChannelFactory>()),

--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -34,6 +34,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 #include "absl/types/optional.h"
+#include "client_channel.h"
 
 #include <grpc/grpc.h>
 #include <grpc/slice.h>
@@ -168,36 +169,33 @@ class RetryFilter {
                              const grpc_channel_info* /*info*/) {}
 
  private:
-  static size_t GetMaxPerRpcRetryBufferSize(const grpc_channel_args* args) {
-    return static_cast<size_t>(grpc_channel_args_find_integer(
-        args, GRPC_ARG_PER_RPC_RETRY_BUFFER_SIZE,
-        {DEFAULT_PER_RPC_RETRY_BUFFER_SIZE, 0, INT_MAX}));
+  static size_t GetMaxPerRpcRetryBufferSize(const ChannelArgs& args) {
+    return Clamp(args.GetInt(GRPC_ARG_PER_RPC_RETRY_BUFFER_SIZE)
+                     .value_or(DEFAULT_PER_RPC_RETRY_BUFFER_SIZE),
+                 0, INT_MAX);
   }
 
-  RetryFilter(const grpc_channel_args* args, grpc_error_handle* error)
-      : client_channel_(grpc_channel_args_find_pointer<ClientChannel>(
-            args, GRPC_ARG_CLIENT_CHANNEL)),
+  RetryFilter(const ChannelArgs& args, grpc_error_handle* error)
+      : client_channel_(args.GetObject<ClientChannel>()),
         per_rpc_retry_buffer_size_(GetMaxPerRpcRetryBufferSize(args)),
         service_config_parser_index_(
             internal::RetryServiceConfigParser::ParserIndex()) {
     // Get retry throttling parameters from service config.
-    auto* service_config = grpc_channel_args_find_pointer<ServiceConfig>(
-        args, GRPC_ARG_SERVICE_CONFIG_OBJ);
+    auto* service_config = args.GetObject<ServiceConfig>();
     if (service_config == nullptr) return;
     const auto* config = static_cast<const RetryGlobalConfig*>(
         service_config->GetGlobalParsedConfig(
             RetryServiceConfigParser::ParserIndex()));
     if (config == nullptr) return;
     // Get server name from target URI.
-    const char* server_uri =
-        grpc_channel_args_find_string(args, GRPC_ARG_SERVER_URI);
-    if (server_uri == nullptr) {
+    auto server_uri = args.GetString(GRPC_ARG_SERVER_URI);
+    if (!server_uri.has_value()) {
       *error = GRPC_ERROR_CREATE(
           "server URI channel arg missing or wrong type in client channel "
           "filter");
       return;
     }
-    absl::StatusOr<URI> uri = URI::Parse(server_uri);
+    absl::StatusOr<URI> uri = URI::Parse(*server_uri);
     if (!uri.ok() || uri->path().empty()) {
       *error =
           GRPC_ERROR_CREATE("could not extract server name from target URI");

--- a/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
+++ b/src/core/ext/filters/client_channel/service_config_channel_arg_filter.cc
@@ -54,11 +54,11 @@ class ServiceConfigChannelArgChannelData {
  public:
   explicit ServiceConfigChannelArgChannelData(
       const grpc_channel_element_args* args) {
-    const char* service_config_str = grpc_channel_args_find_string(
-        args->channel_args, GRPC_ARG_SERVICE_CONFIG);
-    if (service_config_str != nullptr) {
+    auto service_config_str =
+        args->channel_args.GetOwnedString(GRPC_ARG_SERVICE_CONFIG);
+    if (service_config_str.has_value()) {
       auto service_config = ServiceConfigImpl::Create(
-          ChannelArgs::FromC(args->channel_args), service_config_str);
+          args->channel_args, service_config_str->c_str());
       if (!service_config.ok()) {
         gpr_log(GPR_ERROR, "%s", service_config.status().ToString().c_str());
       } else {

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -305,7 +305,7 @@ static grpc_error_handle message_size_init_channel_elem(
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   new (chand) channel_data();
   chand->limits = grpc_core::MessageSizeParsedConfig::GetFromChannelArgs(
-      grpc_core::ChannelArgs::FromC(args->channel_args));
+      args->channel_args);
   return absl::OkStatus();
 }
 

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -36,6 +36,7 @@
 #include "src/core/lib/security/context/security_context.h"
 #include "src/core/lib/service_config/service_config_call_data.h"
 #include "src/core/lib/transport/transport_fwd.h"
+#include "src/core/lib/transport/transport_impl.h"
 
 namespace grpc_core {
 
@@ -144,12 +145,11 @@ RbacFilter::RbacFilter(size_t index,
 grpc_error_handle RbacFilter::Init(grpc_channel_element* elem,
                                    grpc_channel_element_args* args) {
   GPR_ASSERT(elem->filter == &kFilterVtable);
-  auto* auth_context = grpc_find_auth_context_in_args(args->channel_args);
+  auto* auth_context = args->channel_args.GetObject<grpc_auth_context>();
   if (auth_context == nullptr) {
     return GRPC_ERROR_CREATE("No auth context found");
   }
-  auto* transport = grpc_channel_args_find_pointer<grpc_transport>(
-      args->channel_args, GRPC_ARG_TRANSPORT);
+  auto* transport = args->channel_args.GetObject<grpc_transport>();
   if (transport == nullptr) {
     // This should never happen since the transport is always set on the server
     // side.

--- a/src/core/lib/channel/channel_stack.cc
+++ b/src/core/lib/channel/channel_stack.cc
@@ -139,10 +139,9 @@ grpc_error_handle grpc_channel_stack_init(
 
   // init per-filter data
   grpc_error_handle first_error;
-  auto c_channel_args = channel_args.ToC();
   for (i = 0; i < filter_count; i++) {
     args.channel_stack = stack;
-    args.channel_args = c_channel_args.get();
+    args.channel_args = channel_args;
     args.is_first = i == 0;
     args.is_last = i == (filter_count - 1);
     elems[i].filter = filters[i];

--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -76,7 +76,7 @@
 
 struct grpc_channel_element_args {
   grpc_channel_stack* channel_stack;
-  const grpc_channel_args* channel_args;
+  grpc_core::ChannelArgs channel_args;
   int is_first;
   int is_last;
 };

--- a/src/core/lib/channel/connected_channel.cc
+++ b/src/core/lib/channel/connected_channel.cc
@@ -228,8 +228,7 @@ static grpc_error_handle connected_channel_init_channel_elem(
     grpc_channel_element* elem, grpc_channel_element_args* args) {
   channel_data* cd = static_cast<channel_data*>(elem->channel_data);
   GPR_ASSERT(args->is_last);
-  cd->transport = grpc_channel_args_find_pointer<grpc_transport>(
-      args->channel_args, GRPC_ARG_TRANSPORT);
+  cd->transport = args->channel_args.GetObject<grpc_transport>();
   return absl::OkStatus();
 }
 

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -873,7 +873,7 @@ struct ChannelFilterWithFlagsMethods {
   static absl::Status InitChannelElem(grpc_channel_element* elem,
                                       grpc_channel_element_args* args) {
     GPR_ASSERT(args->is_last == ((kFlags & kFilterIsLast) != 0));
-    auto status = F::Create(ChannelArgs::FromC(args->channel_args),
+    auto status = F::Create(args->channel_args,
                             ChannelFilter::Args(args->channel_stack, elem));
     if (!status.ok()) {
       static_assert(

--- a/src/cpp/common/channel_filter.cc
+++ b/src/cpp/common/channel_filter.cc
@@ -73,12 +73,12 @@ namespace internal {
 
 void RegisterChannelFilter(
     grpc_channel_stack_type stack_type, int priority,
-    std::function<bool(const grpc_channel_args&)> include_filter,
+    std::function<bool(const grpc_core::ChannelArgs&)> include_filter,
     const grpc_channel_filter* filter) {
   auto maybe_add_filter = [include_filter,
                            filter](grpc_core::ChannelStackBuilder* builder) {
     if (include_filter != nullptr) {
-      if (!include_filter(*builder->channel_args().ToC())) {
+      if (!include_filter(builder->channel_args())) {
         return true;
       }
     }

--- a/src/cpp/common/channel_filter.cc
+++ b/src/cpp/common/channel_filter.cc
@@ -18,8 +18,6 @@
 
 #include "src/cpp/common/channel_filter.h"
 
-#include <memory>
-
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 

--- a/src/cpp/common/channel_filter.h
+++ b/src/cpp/common/channel_filter.h
@@ -313,7 +313,7 @@ class ChannelFilter final {
 
 void RegisterChannelFilter(
     grpc_channel_stack_type stack_type, int priority,
-    std::function<bool(const grpc_channel_args&)> include_filter,
+    std::function<bool(const grpc_core::ChannelArgs&)> include_filter,
     const grpc_channel_filter* filter);
 
 }  // namespace internal
@@ -331,7 +331,7 @@ void RegisterChannelFilter(
 template <typename ChannelDataType, typename CallDataType>
 void RegisterChannelFilter(
     const char* name, grpc_channel_stack_type stack_type, int priority,
-    std::function<bool(const grpc_channel_args&)> include_filter) {
+    std::function<bool(const grpc_core::ChannelArgs&)> include_filter) {
   using FilterType = internal::ChannelFilter<ChannelDataType, CallDataType>;
   static const grpc_channel_filter filter = {
       FilterType::StartTransportStreamOpBatch,

--- a/src/cpp/common/channel_filter.h
+++ b/src/cpp/common/channel_filter.h
@@ -33,6 +33,7 @@
 #include <grpc/support/atm.h>
 #include <grpcpp/support/config.h>
 
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/context.h"

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -73,9 +73,8 @@ constexpr uint32_t
 
 grpc_error_handle OpenCensusClientChannelData::Init(
     grpc_channel_element* /*elem*/, grpc_channel_element_args* args) {
-  bool observability_enabled = grpc_core::ChannelArgs::FromC(args->channel_args)
-                                   .GetInt(GRPC_ARG_ENABLE_OBSERVABILITY)
-                                   .value_or(true);
+  bool observability_enabled =
+      args->channel_args.GetInt(GRPC_ARG_ENABLE_OBSERVABILITY).value_or(true);
   // Only run the Post-Init Registry if observability is enabled to avoid
   // running into a cyclic loop for exporter channels.
   if (observability_enabled) {

--- a/test/core/channel/channel_stack_test.cc
+++ b/test/core/channel/channel_stack_test.cc
@@ -36,12 +36,10 @@
 
 static grpc_error_handle channel_init_func(grpc_channel_element* elem,
                                            grpc_channel_element_args* args) {
-  int test_value = grpc_channel_args_find_integer(args->channel_args,
-                                                  "test_key", {-1, 0, INT_MAX});
+  int test_value = args->channel_args.GetInt("test_key").value_or(-1);
   EXPECT_EQ(test_value, 42);
-  auto* ee = grpc_channel_args_find_pointer<
-      grpc_event_engine::experimental::EventEngine>(
-      args->channel_args, GRPC_INTERNAL_ARG_EVENT_ENGINE);
+  auto* ee = args->channel_args
+                 .GetObject<grpc_event_engine::experimental::EventEngine>();
   EXPECT_NE(ee, nullptr);
   EXPECT_TRUE(args->is_first);
   EXPECT_TRUE(args->is_last);


### PR DESCRIPTION
Previously we were converting to C and then back to C++ for each filter... this ought to save some CPU time during connection establishment.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

