### PR TITLE
[ruby testing]: simplify grpc_class_init_test.rb

### DIFF
--- a/src/ruby/end2end/grpc_class_init_client.rb
+++ b/src/ruby/end2end/grpc_class_init_client.rb
@@ -46,15 +46,14 @@ def run_gc_stress_test(test_proc)
 end
 
 def run_concurrency_stress_test(test_proc)
+  thds = []
   100.times do
-    Thread.new do
+    thds << Thread.new do
       test_proc.call
     end
   end
-
   test_proc.call
-
-  fail '(expected) exception thrown while child thread initing class'
+  thds.each(&:join)
 end
 
 # default (no gc_stress and no concurrency_stress)
@@ -139,13 +138,13 @@ def main
   # clean shutdown in a different way
   case stress_test
   when 'gc'
-    p 'run gc stress'
+    p "run gc stress: #{grpc_class}"
     run_gc_stress_test(test_proc)
   when 'concurrency'
-    p 'run concurrency stress'
+    p "run concurrency stress: #{grpc_class}"
     run_concurrency_stress_test(test_proc)
   when ''
-    p 'run default'
+    p "run default: #{grpc_class}"
     run_default_test(test_proc)
   else
     fail "bad --stress_test=#{stress_test} param"


### PR DESCRIPTION
A potential mitigation for b/266212253, which has not been reproducible.

One thing this test happens to exercise right now is the case where a thread lingers on process exit. The stack traces of failures have been in the ruby runtime's `require` method, e.g.:

```
c:0012 p:-11741830283234 s:0078 e:000077 TOP    [FINISH]
c:0011 p:---- s:0075 e:000074 CFUNC  :require
c:0010 p:0111 s:0070 e:000069 METHOD /usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72
c:0009 p:0101 s:0054 e:000053 TOP    /var/local/git/grpc/src/ruby/lib/grpc/grpc.rb:22 [FINISH]
c:0008 p:---- s:0049 e:000048 CFUNC  :require_relative
c:0007 p:0034 s:0044 e:000043 TOP    /var/local/git/grpc/src/ruby/lib/grpc.rb:19 [FINISH]
c:0006 p:---- s:0038 e:000037 CFUNC  :require
c:0005 p:0111 s:0033 e:000032 METHOD /usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72
c:0004 p:0121 s:0017 e:000016 TOP    /var/local/git/grpc/src/ruby/end2end/end2end_common.rb:24 [FINISH]
c:0003 p:---- s:0011 e:000010 CFUNC  :require_relative
c:0002 p:0005 s:0006 e:000005 EVAL   /var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:20 [FINISH]
```

As I've not been able to repro, let's stop exercising this case within the test (it's possible this bug is not within gRPC and is specific to the ruby 2.7 runtime).