### PR TITLE
Updated clang 15 images

### DIFF
--- a/templates/tools/dockerfile/git-jenkins.include
+++ b/templates/tools/dockerfile/git-jenkins.include
@@ -1,0 +1,5 @@
+#=================
+# Setup git to access working directory across docker boundary
+
+RUN git config --global --add safe.directory /var/local/jenkins/grpc
+RUN git config --global protocol.file.allow always

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -16,10 +16,9 @@
   
   <%include file="../../oss_fuzz_base.include"/>
   <%include file="../../bazel.include"/>
+  <%include file="../../git-jenkins.include"/>
   
   RUN mkdir -p /var/local/jenkins
 
-  RUN git config --global --add safe.directory /var/local/jenkins/grpc
-  
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile.template
@@ -18,10 +18,10 @@
   
   RUN apt-get update && apt-get install -y build-essential curl git time wget zip && apt-get clean
   <%include file="../../run_tests_python_deps.include"/>
-  <%include file="../../cxx_deps.include"/>
   <%include file="../../cmake.include"/>
   <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
-  
+  <%include file="../../git-jenkins.include"/>
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -17,7 +17,6 @@
   FROM silkeh/clang:15-bullseye
 
   <%include file="../../apt_get_basic.include"/>
-  <%include file="../../cxx_deps.include"/>
 
   # Install Python 3.7 from source (and installed as a default python3)
   # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
@@ -60,6 +59,7 @@
 
   <%include file="../../bazel.include"/>
   <%include file="../../buildifier.include"/>
+  <%include file="../../git-jenkins.include"/>
 
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/bazel.current_version
+++ b/tools/dockerfile/test/bazel.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:b3e48464a04576cc42dd4f946feaf4fec1eca447@sha256:cbbb5081c04f1a6eb485ca52faa727f525b1666838f528ae3059dce17f50b650
+us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:b3e48464a04576cc42dd4f946feaf4fec1eca447@sha256:1faf10ff176c391507a5a4ed7b0c513d95bcd9f5a71877796d00a48039a67f55

--- a/tools/dockerfile/test/bazel.current_version
+++ b/tools/dockerfile/test/bazel.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:2345e87c22697f699d33a64d305a0177ce77e5f5@sha256:b42f10625321296c7f646e1e82023d0b46e4f9b6d2205cff2b49352c5dc1ce9f
+us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:b3e48464a04576cc42dd4f946feaf4fec1eca447@sha256:cbbb5081c04f1a6eb485ca52faa727f525b1666838f528ae3059dce17f50b650

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -57,10 +57,14 @@ RUN BAZEL_ARCH_SUFFIX="$(uname -m | sed s/aarch64/arm64/)" \
 # The binary will work correctly when run on real arm64
 # hardware, when qemu-user-static isn't getting into the way.
 
-
-RUN mkdir -p /var/local/jenkins
+#=================
+# Setup git to access working directory across docker boundary
 
 RUN git config --global --add safe.directory /var/local/jenkins/grpc
+RUN git config --global protocol.file.allow always
+
+
+RUN mkdir -p /var/local/jenkins
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_clang_15_x64.current_version
+++ b/tools/dockerfile/test/cxx_clang_15_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:890005619b89999b0bb3256a3f13d8bda9a1560a@sha256:cb24820cb9c660220495317c519d93c34374f7d6dd152e89723734b298dbd0ea
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:890005619b89999b0bb3256a3f13d8bda9a1560a@sha256:e543c7ba117708d114ffa1c821f0ee329795cd808b8efd426683e2b355ac4834

--- a/tools/dockerfile/test/cxx_clang_15_x64.current_version
+++ b/tools/dockerfile/test/cxx_clang_15_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:99325d14f5121515b2454bfab9b59c155e182c18@sha256:fdb96ba3018ab82247f31c225502c4dfb37c131e4b155fc196dc696ea0e6208f
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:99325d14f5121515b2454bfab9b59c155e182c18@sha256:906c0ca1edcab595fce313636528e6244d8fc914a6e72a22764e96208f465936

--- a/tools/dockerfile/test/cxx_clang_15_x64.current_version
+++ b/tools/dockerfile/test/cxx_clang_15_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:890005619b89999b0bb3256a3f13d8bda9a1560a@sha256:e543c7ba117708d114ffa1c821f0ee329795cd808b8efd426683e2b355ac4834
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_15_x64:99325d14f5121515b2454bfab9b59c155e182c18@sha256:fdb96ba3018ab82247f31c225502c4dfb37c131e4b155fc196dc696ea0e6208f

--- a/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_clang_15_x64/Dockerfile
@@ -41,10 +41,6 @@ RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-clien
 
 
 #=================
-# C++ dependencies
-RUN apt-get update && apt-get -y install libc++-dev clang && apt-get clean
-
-#=================
 # Install cmake
 # Note that this step should be only used for distributions that have new enough cmake to satisfy gRPC's cmake version requirement.
 
@@ -66,6 +62,12 @@ RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/downloa
 
 
 RUN mkdir /var/local/jenkins
+
+#=================
+# Setup git to access working directory across docker boundary
+
+RUN git config --global --add safe.directory /var/local/jenkins/grpc
+RUN git config --global protocol.file.allow always
 
 
 # Define the default command.

--- a/tools/dockerfile/test/sanity.current_version
+++ b/tools/dockerfile/test/sanity.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:48ab42c150a5f94cfbdfa339c14c2f0c8f174e12@sha256:08856cbe711e1817b3ca0caead550020a97ef68b0b9ff48637d44ef24a205964
+us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:48ab42c150a5f94cfbdfa339c14c2f0c8f174e12@sha256:e6c1c137ddb702568aeba089c7fe842c38cd281078cf907d5caa95d992902155

--- a/tools/dockerfile/test/sanity.current_version
+++ b/tools/dockerfile/test/sanity.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:48ab42c150a5f94cfbdfa339c14c2f0c8f174e12@sha256:e6c1c137ddb702568aeba089c7fe842c38cd281078cf907d5caa95d992902155
+us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:66c9d7a730029cfb6fb74cc8fa722927fd70bc79@sha256:4119ad12d242f4bfad4a2cdb2dfc789732c254af2a499b455c000c59b18a6180

--- a/tools/dockerfile/test/sanity.current_version
+++ b/tools/dockerfile/test/sanity.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:66c9d7a730029cfb6fb74cc8fa722927fd70bc79@sha256:4119ad12d242f4bfad4a2cdb2dfc789732c254af2a499b455c000c59b18a6180
+us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:66c9d7a730029cfb6fb74cc8fa722927fd70bc79@sha256:d3bfac6827ec0e9e0103e8dabc8ba535e09af5e1a1305943f1464975de38d848

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -53,10 +53,6 @@ RUN apt-get update && apt-get install -y \
   zip \
   && apt-get clean
 
-#=================
-# C++ dependencies
-RUN apt-get update && apt-get -y install libc++-dev clang && apt-get clean
-
 
 # Install Python 3.7 from source (and installed as a default python3)
 # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
@@ -129,6 +125,12 @@ RUN BAZEL_ARCH_SUFFIX="$(uname -m | sed s/aarch64/arm64/)" \
 RUN wget https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier
 RUN chmod +x buildifier
 RUN mv buildifier /usr/local/bin
+
+#=================
+# Setup git to access working directory across docker boundary
+
+RUN git config --global --add safe.directory /var/local/jenkins/grpc
+RUN git config --global protocol.file.allow always
 
 
 # Define the default command.


### PR DESCRIPTION
This is to get the latest version of clang 15 (15.0.7) for our docker images based on that. By doing so, I had to address this new git  security enforcement so I added a new file to tame it. In a nutshell, this PR is about polishing docker images based on clang 15.