### PR TITLE
Revert "client channel: don't hold mutexes while calling the ConfigSelector or the LB picker"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2768,7 +2768,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/base:core_headers",
-        "absl/container:flat_hash_set",
         "absl/container:inlined_vector",
         "absl/status",
         "absl/status:statusor",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2470,7 +2470,6 @@ grpc_cc_library(
     srcs = ["lib/load_balancing/lb_policy.cc"],
     hdrs = ["lib/load_balancing/lb_policy.h"],
     external_deps = [
-        "absl/base:core_headers",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -2490,7 +2489,6 @@ grpc_cc_library(
         "//:debug_location",
         "//:event_engine_base_hdrs",
         "//:exec_ctx",
-        "//:gpr",
         "//:gpr_platform",
         "//:grpc_trace",
         "//:orphanable",
@@ -3814,7 +3812,6 @@ grpc_cc_library(
         "absl/base:core_headers",
         "absl/functional:bind_front",
         "absl/memory",
-        "absl/random",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -4412,7 +4409,6 @@ grpc_cc_library(
         "ext/filters/client_channel/lb_policy/round_robin/round_robin.cc",
     ],
     external_deps = [
-        "absl/random",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -4599,7 +4595,6 @@ grpc_cc_library(
         "ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc",
     ],
     external_deps = [
-        "absl/base:core_headers",
         "absl/random",
         "absl/status",
         "absl/status:statusor",

--- a/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/ring_hash/ring_hash.cc
@@ -254,14 +254,19 @@ class RingHash : public LoadBalancingPolicy {
     explicit Picker(RefCountedPtr<RingHashSubchannelList> subchannel_list)
         : subchannel_list_(std::move(subchannel_list)) {}
 
+    ~Picker() override {
+      // Hop into WorkSerializer to unref the subchannel list, since that may
+      // trigger the unreffing of the underlying subchannels.
+      MakeOrphanable<WorkSerializerRunner>(std::move(subchannel_list_));
+    }
+
     PickResult Pick(PickArgs args) override;
 
    private:
-    // A fire-and-forget class that schedules subchannel connection attempts
-    // on the control plane WorkSerializer.
-    class SubchannelConnectionAttempter : public Orphanable {
+    // An interface for running a callback in the control plane WorkSerializer.
+    class WorkSerializerRunner : public Orphanable {
      public:
-      explicit SubchannelConnectionAttempter(
+      explicit WorkSerializerRunner(
           RefCountedPtr<RingHashSubchannelList> subchannel_list)
           : subchannel_list_(std::move(subchannel_list)) {
         GRPC_CLOSURE_INIT(&closure_, RunInExecCtx, this, nullptr);
@@ -273,26 +278,17 @@ class RingHash : public LoadBalancingPolicy {
         ExecCtx::Run(DEBUG_LOCATION, &closure_, absl::OkStatus());
       }
 
-      void AddSubchannel(RefCountedPtr<SubchannelInterface> subchannel) {
-        subchannels_.push_back(std::move(subchannel));
-      }
-
       // Will be invoked inside of the WorkSerializer.
-      void Run() {
-        if (!ring_hash_lb()->shutdown_) {
-          for (auto& subchannel : subchannels_) {
-            subchannel->RequestConnection();
-          }
-        }
-      }
+      virtual void Run() {}
 
-     private:
+     protected:
       RingHash* ring_hash_lb() const {
         return static_cast<RingHash*>(subchannel_list_->policy());
       }
 
+     private:
       static void RunInExecCtx(void* arg, grpc_error_handle /*error*/) {
-        auto* self = static_cast<SubchannelConnectionAttempter*>(arg);
+        auto* self = static_cast<WorkSerializerRunner*>(arg);
         self->ring_hash_lb()->work_serializer()->Run(
             [self]() {
               self->Run();
@@ -302,8 +298,31 @@ class RingHash : public LoadBalancingPolicy {
       }
 
       RefCountedPtr<RingHashSubchannelList> subchannel_list_;
-      std::vector<RefCountedPtr<SubchannelInterface>> subchannels_;
       grpc_closure closure_;
+    };
+
+    // A fire-and-forget class that schedules subchannel connection attempts
+    // on the control plane WorkSerializer.
+    class SubchannelConnectionAttempter : public WorkSerializerRunner {
+     public:
+      explicit SubchannelConnectionAttempter(
+          RefCountedPtr<RingHashSubchannelList> subchannel_list)
+          : WorkSerializerRunner(std::move(subchannel_list)) {}
+
+      void AddSubchannel(RefCountedPtr<SubchannelInterface> subchannel) {
+        subchannels_.push_back(std::move(subchannel));
+      }
+
+      void Run() override {
+        if (!ring_hash_lb()->shutdown_) {
+          for (auto& subchannel : subchannels_) {
+            subchannel->RequestConnection();
+          }
+        }
+      }
+
+     private:
+      std::vector<RefCountedPtr<SubchannelInterface>> subchannels_;
     };
 
     RefCountedPtr<RingHashSubchannelList> subchannel_list_;

--- a/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/weighted_target/weighted_target.cc
@@ -26,7 +26,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/base/thread_annotations.h"
 #include "absl/random/random.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -47,7 +46,6 @@
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/gprpp/validation_errors.h"
 #include "src/core/lib/gprpp/work_serializer.h"
@@ -140,11 +138,7 @@ class WeightedTargetLb : public LoadBalancingPolicy {
 
    private:
     PickerList pickers_;
-
-    // TODO(roth): Consider using a separate thread-local BitGen for each CPU
-    // to avoid the need for this mutex.
-    Mutex mu_;
-    absl::BitGen bit_gen_ ABSL_GUARDED_BY(&mu_);
+    absl::BitGen bit_gen_;
   };
 
   // Each WeightedChild holds a ref to its parent WeightedTargetLb.
@@ -253,10 +247,8 @@ class WeightedTargetLb : public LoadBalancingPolicy {
 WeightedTargetLb::PickResult WeightedTargetLb::WeightedPicker::Pick(
     PickArgs args) {
   // Generate a random number in [0, total weight).
-  const uint64_t key = [&]() {
-    MutexLock lock(&mu_);
-    return absl::Uniform<uint64_t>(bit_gen_, 0, pickers_.back().first);
-  }();
+  const uint64_t key =
+      absl::Uniform<uint64_t>(bit_gen_, 0, pickers_.back().first);
   // Find the index in pickers_ corresponding to key.
   size_t mid = 0;
   size_t start_index = 0;

--- a/src/core/ext/filters/client_channel/retry_filter.cc
+++ b/src/core/ext/filters/client_channel/retry_filter.cc
@@ -1351,9 +1351,8 @@ RetryFilter::CallData::CallAttempt::BatchData::~BatchData() {
             this);
   }
   CallAttempt* call_attempt = std::exchange(call_attempt_, nullptr);
-  grpc_call_stack* owning_call = call_attempt->calld_->owning_call_;
+  GRPC_CALL_STACK_UNREF(call_attempt->calld_->owning_call_, "Retry BatchData");
   call_attempt->Unref(DEBUG_LOCATION, "~BatchData");
-  GRPC_CALL_STACK_UNREF(owning_call, "Retry BatchData");
 }
 
 void RetryFilter::CallData::CallAttempt::BatchData::

--- a/src/core/ext/xds/xds_endpoint.cc
+++ b/src/core/ext/xds/xds_endpoint.cc
@@ -93,14 +93,11 @@ std::string XdsEndpointResource::Priority::ToString() const {
 }
 
 bool XdsEndpointResource::DropConfig::ShouldDrop(
-    const std::string** category_name) {
+    const std::string** category_name) const {
   for (size_t i = 0; i < drop_category_list_.size(); ++i) {
     const auto& drop_category = drop_category_list_[i];
     // Generate a random number in [0, 1000000).
-    const uint32_t random = [&]() {
-      MutexLock lock(&mu_);
-      return absl::Uniform<uint32_t>(bit_gen_, 0, 1000000);
-    }();
+    const uint32_t random = static_cast<uint32_t>(rand()) % 1000000;
     if (random < drop_category.parts_per_million) {
       *category_name = &drop_category.name;
       return true;

--- a/src/core/ext/xds/xds_endpoint.h
+++ b/src/core/ext/xds/xds_endpoint.h
@@ -28,8 +28,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/base/thread_annotations.h"
-#include "absl/random/random.h"
 #include "absl/strings/string_view.h"
 #include "envoy/config/endpoint/v3/endpoint.upbdefs.h"
 #include "upb/def.h"
@@ -40,7 +38,6 @@
 #include "src/core/ext/xds/xds_resource_type_impl.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/resolver/server_address.h"
 
 namespace grpc_core {
@@ -93,7 +90,7 @@ struct XdsEndpointResource : public XdsResourceType::ResourceData {
 
     // The only method invoked from outside the WorkSerializer (used in
     // the data plane).
-    bool ShouldDrop(const std::string** category_name);
+    bool ShouldDrop(const std::string** category_name) const;
 
     const DropCategoryList& drop_category_list() const {
       return drop_category_list_;
@@ -111,11 +108,6 @@ struct XdsEndpointResource : public XdsResourceType::ResourceData {
    private:
     DropCategoryList drop_category_list_;
     bool drop_all_ = false;
-
-    // TODO(roth): Consider using a separate thread-local BitGen for each CPU
-    // to avoid the need for this mutex.
-    Mutex mu_;
-    absl::BitGen bit_gen_ ABSL_GUARDED_BY(&mu_);
   };
 
   PriorityList priorities;

--- a/src/core/lib/load_balancing/lb_policy.cc
+++ b/src/core/lib/load_balancing/lb_policy.cc
@@ -69,15 +69,19 @@ LoadBalancingPolicy::SubchannelPicker::SubchannelPicker()
 LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
     PickArgs /*args*/) {
   // We invoke the parent's ExitIdleLocked() via a closure instead
-  // of doing it directly here because ExitIdleLocked() may cause the
-  // policy's state to change and a new picker to be delivered to the
-  // channel.  If that new picker is delivered before ExitIdleLocked()
-  // returns, then by the time this function returns, the pick will already
-  // have been processed, and we'll be trying to re-process the same pick
-  // again, leading to a crash.
-  MutexLock lock(&mu_);
-  if (parent_ != nullptr) {
-    auto* parent = parent_.release();  // ref held by lambda.
+  // of doing it directly here, for two reasons:
+  // 1. ExitIdleLocked() may cause the policy's state to change and
+  //    a new picker to be delivered to the channel.  If that new
+  //    picker is delivered before ExitIdleLocked() returns, then by
+  //    the time this function returns, the pick will already have
+  //    been processed, and we'll be trying to re-process the same
+  //    pick again, leading to a crash.
+  // 2. We are currently running in the data plane mutex, but we
+  //    need to bounce into the control plane work_serializer to call
+  //    ExitIdleLocked().
+  if (!exit_idle_called_ && parent_ != nullptr) {
+    exit_idle_called_ = true;
+    auto* parent = parent_->Ref().release();  // ref held by lambda.
     ExecCtx::Run(DEBUG_LOCATION,
                  GRPC_CLOSURE_CREATE(
                      [](void* arg, grpc_error_handle /*error*/) {

--- a/src/core/lib/load_balancing/lb_policy.h
+++ b/src/core/lib/load_balancing/lb_policy.h
@@ -27,7 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/base/thread_annotations.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
@@ -45,7 +44,6 @@
 #include "src/core/lib/gprpp/orphanable.h"
 #include "src/core/lib/gprpp/ref_counted.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/gprpp/work_serializer.h"
 #include "src/core/lib/iomgr/iomgr_fwd.h"
 #include "src/core/lib/load_balancing/subchannel_interface.h"
@@ -394,8 +392,8 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     PickResult Pick(PickArgs args) override;
 
    private:
-    Mutex mu_;
-    RefCountedPtr<LoadBalancingPolicy> parent_ ABSL_GUARDED_BY(&mu_);
+    RefCountedPtr<LoadBalancingPolicy> parent_;
+    bool exit_idle_called_ = false;
   };
 
   // A picker that returns PickResult::Fail for all picks.


### PR DESCRIPTION
Reverts grpc/grpc#31973 due to test flakiness