### PR TITLE
e2e tests: update regex used for connection failure messages

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -568,14 +568,12 @@ class ClientLbEnd2endTest : public ::testing::Test {
   }
 
   static std::string MakeConnectionFailureRegex(absl::string_view prefix) {
-    return absl::StrCat(
-        prefix,
-        "; last error: (UNKNOWN: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-        "Failed to connect to remote host: Connection refused|"
-        "UNAVAILABLE: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-        "Failed to connect to remote host: FD shutdown|"
-        "UNAVAILABLE: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-        "(Socket closed|Connection reset by peer))");
+    return absl::StrCat(prefix,
+                        "; last error: (UNKNOWN|UNAVAILABLE): "
+                        "(ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
+                        "(Failed to connect to remote host: |)"
+                        "(Connection refused|Connection reset by peer|"
+                        "Socket closed|FD shutdown)");
   }
 
   const std::string server_host_;

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -571,7 +571,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
     return absl::StrCat(prefix,
                         "; last error: (UNKNOWN|UNAVAILABLE): "
                         "(ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-                        "(Failed to connect to remote host: |)"
+                        "(Failed to connect to remote host: )?"
                         "(Connection refused|Connection reset by peer|"
                         "Socket closed|FD shutdown)");
   }

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -1043,7 +1043,7 @@ std::string XdsEnd2endTest::MakeConnectionFailureRegex(
   return absl::StrCat(
       prefix,
       "(UNKNOWN|UNAVAILABLE): (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "(Failed to connect to remote host: |)"
+      "(Failed to connect to remote host: )?"
       "(Connection refused|Connection reset by peer|"
       "Socket closed|FD shutdown)");
 }

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -1038,6 +1038,16 @@ void XdsEnd2endTest::SetProtoDuration(
   duration_proto->set_nanos(ts.tv_nsec);
 }
 
+std::string XdsEnd2endTest::MakeConnectionFailureRegex(
+    absl::string_view prefix) {
+  return absl::StrCat(
+      prefix,
+      "(UNKNOWN|UNAVAILABLE): (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
+      "(Failed to connect to remote host: |)"
+      "(Connection refused|Connection reset by peer|"
+      "Socket closed|FD shutdown)");
+}
+
 std::string XdsEnd2endTest::ReadFile(const char* file_path) {
   grpc_slice slice;
   GPR_ASSERT(

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -1046,6 +1046,10 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType> {
     return num_rpcs;
   }
 
+  // Returns a regex that can be matched against an RPC failure status
+  // message for a connection failure.
+  static std::string MakeConnectionFailureRegex(absl::string_view prefix);
+
   // Returns the contents of the specified file.
   static std::string ReadFile(const char* file_path);
 

--- a/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
@@ -994,11 +994,8 @@ TEST_P(RingHashTest, ReattemptWhenAllEndpointsUnreachable) {
   ShutdownBackend(0);
   CheckRpcSendFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "ring hash cannot find a connected subchannel; first failure: "
-      "(UNKNOWN: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "Failed to connect to remote host: Connection refused|"
-      "UNAVAILABLE: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "Failed to connect to remote host: FD shutdown)",
+      MakeConnectionFailureRegex(
+          "ring hash cannot find a connected subchannel; first failure: "),
       RpcOptions().set_metadata(std::move(metadata)));
   StartBackend(0);
   // Ensure we are actively connecting without any traffic.
@@ -1036,11 +1033,8 @@ TEST_P(RingHashTest, TransientFailureSkipToAvailableReady) {
   gpr_log(GPR_INFO, "=== SENDING FIRST RPC ===");
   CheckRpcSendFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "ring hash cannot find a connected subchannel; first failure: "
-      "(UNKNOWN: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "Failed to connect to remote host: Connection refused|"
-      "UNAVAILABLE: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "Failed to connect to remote host: FD shutdown)",
+      MakeConnectionFailureRegex(
+          "ring hash cannot find a connected subchannel; first failure: "),
       rpc_options);
   gpr_log(GPR_INFO, "=== DONE WITH FIRST RPC ===");
   EXPECT_EQ(GRPC_CHANNEL_TRANSIENT_FAILURE, channel_->GetState(false));
@@ -1075,11 +1069,8 @@ TEST_P(RingHashTest, TransientFailureSkipToAvailableReady) {
   gpr_log(GPR_INFO, "=== SENDING SECOND RPC ===");
   CheckRpcSendFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "ring hash cannot find a connected subchannel; first failure: "
-      "(UNKNOWN: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "Failed to connect to remote host: Connection refused|"
-      "UNAVAILABLE: (ipv6:%5B::1%5D|ipv4:127.0.0.1):[0-9]+: "
-      "Failed to connect to remote host: FD shutdown)",
+      MakeConnectionFailureRegex(
+          "ring hash cannot find a connected subchannel; first failure: "),
       rpc_options);
   gpr_log(GPR_INFO, "=== STARTING BACKEND 1 ===");
   StartBackend(1);


### PR DESCRIPTION
This fixes a flake seen in client_lb_end2end_test.

We also use the same regex in many of the xDS e2e tests, so I updated it there as well, even though I don't actually know that we were seeing this flake in any of those tests.