### PR TITLE
[EventEngine] Fix IOCP test under load

### DIFF
--- a/test/core/event_engine/windows/iocp_test.cc
+++ b/test/core/event_engine/windows/iocp_test.cc
@@ -341,9 +341,12 @@ TEST_F(IOCPTest, StressTestThousandsOfSockets) {
           memset(pserver->write_info()->overlapped(), 0, sizeof(OVERLAPPED));
           int status = WSASend(pserver->socket(), &write_wsabuf, 1, &bytes_sent,
                                0, pserver->write_info()->overlapped(), NULL);
-          EXPECT_EQ(status, 0);
           if (status != 0) {
-            LogErrorMessage(WSAGetLastError(), "WSASend");
+            int wsa_error = WSAGetLastError();
+            if (wsa_error != WSA_IO_PENDING) {
+              LogErrorMessage(wsa_error, "WSASend");
+              FAIL() << "Error in WSASend. See logs";
+            }
           }
         }
       }


### PR DESCRIPTION
The test was not correctly handling a scenario where `WSASend` returned `WSA_IO_PENDING`, which could happen fairly infrequently on this stress test.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

