### PR TITLE
grpc_build_system: add compile options "-std=c++14" to library definitions

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -163,6 +163,8 @@ def grpc_cc_library(
     copts = []
     if language.upper() == "C":
         copts = copts + if_not_windows(["-std=c11"])
+    if language.upper() == "C++":
+        copts = copts + ["-std=c++14"]
     linkopts = linkopts + if_not_windows(["-pthread"]) + if_windows(["-defaultlib:ws2_32.lib"])
     if select_deps:
         for select_deps_entry in select_deps:


### PR DESCRIPTION
When importing com_github_grpc_grpc as an external dependency in a WORKSPACE which does not have "-std=c++14" as a setting in the bazelrc this leads to compiler errors as the default bazel toolchain uses c++0x.

Using c++14 for a complete project is not always desirable and with this change it's possible to import and use grpc++ libraries in such projects.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

