### PR TITLE
Add missing dependency for tsi_alts_credentials.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3130,6 +3130,7 @@ grpc_cc_library(
         "alts_util",
         "gpr",
         "grpc_base",
+        "grpc_security_base",
         "tsi_alts_frame_protector",
         "tsi_base",
         "//src/core:channel_args",


### PR DESCRIPTION
While creating an internal CL that depends directly on tsi_alts_credentials, I was getting linker errors saying ` error: backward reference detected: grpc_channel_credentials_release`, because `alts_tsi_handshaker.cc` uses the `grpc_channel_credentials_release` API, which is defined in the `grpc_security_base` target. 