### PR TITLE
[codehealth] Teach core_banned_functions.py to check headers as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10641,7 +10641,6 @@ target_link_libraries(exec_ctx_wakeup_scheduler_test
   absl::hash
   absl::type_traits
   absl::statusor
-  absl::utility
   gpr
   upb
 )
@@ -15341,7 +15340,6 @@ target_link_libraries(mpsc_test
   absl::hash
   absl::type_traits
   absl::statusor
-  absl::utility
   gpr
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -6839,7 +6839,6 @@ targets:
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
-  - absl/utility:utility
   - gpr
   - upb
   uses_polling: false
@@ -9538,7 +9537,6 @@ targets:
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
-  - absl/utility:utility
   - gpr
   uses_polling: false
 - name: mpscq_test

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -683,7 +683,6 @@ grpc_cc_library(
         "absl/strings:str_format",
         "absl/types:optional",
         "absl/types:variant",
-        "absl/utility",
     ],
     language = "c++",
     public_hdrs = [
@@ -829,7 +828,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/base:core_headers",
-        "absl/memory",
         "absl/strings",
         "absl/types:optional",
         "absl/types:variant",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -1210,7 +1210,6 @@ grpc_cc_library(
         "lib/slice/slice_buffer.h",
         "//:include/grpc/slice_buffer.h",
     ],
-    external_deps = ["absl/memory"],
     deps = [
         "slice",
         "slice_refcount",

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -29,7 +29,6 @@
 #include "absl/status/status.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
-#include "absl/utility/utility.h"
 
 #include <grpc/support/log.h>
 

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -509,7 +509,7 @@ class PromiseActivity final
   // Notification that we're no longer executing - it's ok to destruct the
   // promise.
   void MarkDone() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu()) {
-    GPR_ASSERT(!absl::exchange(done_, true));
+    GPR_ASSERT(!std::exchange(done_, true));
     ScopedContext contexts(this);
     Destruct(&promise_holder_.promise);
   }

--- a/src/core/lib/promise/pipe.h
+++ b/src/core/lib/promise/pipe.h
@@ -353,7 +353,7 @@ class Center : public InterceptorList<T> {
 
   // Make failure to destruct show up in ASAN builds.
 #ifndef NDEBUG
-  std::unique_ptr<int> asan_canary_ = absl::make_unique<int>(0);
+  std::unique_ptr<int> asan_canary_ = std::make_unique<int>(0);
 #endif
 };
 
@@ -406,7 +406,7 @@ class PipeSender {
 
   // Make failure to destruct show up in ASAN builds.
 #ifndef NDEBUG
-  std::unique_ptr<int> asan_canary_ = absl::make_unique<int>(0);
+  std::unique_ptr<int> asan_canary_ = std::make_unique<int>(0);
 #endif
 };
 
@@ -449,7 +449,7 @@ class PipeReceiver {
 
   // Make failure to destruct show up in ASAN builds.
 #ifndef NDEBUG
-  std::unique_ptr<int> asan_canary_ = absl::make_unique<int>(0);
+  std::unique_ptr<int> asan_canary_ = std::make_unique<int>(0);
 #endif
 };
 

--- a/src/core/lib/promise/pipe.h
+++ b/src/core/lib/promise/pipe.h
@@ -26,7 +26,6 @@
 #include <utility>
 
 #include "absl/base/attributes.h"
-#include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"

--- a/src/core/lib/slice/slice_buffer.h
+++ b/src/core/lib/slice/slice_buffer.h
@@ -23,8 +23,6 @@
 #include <memory>
 #include <string>
 
-#include "absl/memory/memory.h"
-
 #include <grpc/slice.h>
 #include <grpc/slice_buffer.h>
 

--- a/src/core/lib/slice/slice_buffer.h
+++ b/src/core/lib/slice/slice_buffer.h
@@ -157,7 +157,7 @@ class SliceBuffer {
 
 // Make failure to destruct show up in ASAN builds.
 #ifndef NDEBUG
-  std::unique_ptr<int> asan_canary_ = absl::make_unique<int>(0);
+  std::unique_ptr<int> asan_canary_ = std::make_unique<int>(0);
 #endif
 };
 

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -34,13 +34,13 @@ BANNED_EXCEPT = {
     ],
     'grpc_error_ref(': ['src/core/lib/iomgr/error.cc'],
     'grpc_error_unref(': ['src/core/lib/iomgr/error.cc'],
-    'grpc_os_error(': ['src/core/lib/iomgr/error.cc'],
-    'grpc_wsa_error(': ['src/core/lib/iomgr/error.cc'],
-    'grpc_log_if_error(': ['src/core/lib/iomgr/error.cc'],
-    'grpc_slice_malloc(': ['src/core/lib/slice/slice.cc'],
+    'grpc_os_error(': ['src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'],
+    'grpc_wsa_error(': ['src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'],
+    'grpc_log_if_error(': ['src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'],
+    'grpc_slice_malloc(': ['src/core/lib/slice/slice.cc', 'src/core/lib/slice/slice.h'],
     'grpc_call_cancel(': ['src/core/lib/surface/call.cc'],
-    'grpc_closure_create(': ['src/core/lib/iomgr/closure.cc'],
-    'grpc_closure_init(': ['src/core/lib/iomgr/closure.cc'],
+    'grpc_closure_create(': ['src/core/lib/iomgr/closure.cc', 'src/core/lib/iomgr/closure.h'],
+    'grpc_closure_init(': ['src/core/lib/iomgr/closure.cc', 'src/core/lib/iomgr/closure.h'],
     'grpc_closure_sched(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_run(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_list_sched(': ['src/core/lib/iomgr/closure.cc'],
@@ -73,7 +73,7 @@ for root, dirs, files in os.walk('src/core'):
     for filename in files:
         num_files += 1
         path = os.path.join(root, filename)
-        if os.path.splitext(path)[1] != '.cc':
+        if os.path.splitext(path)[1] not in ('.h', '.cc'):
             continue
         with open(path) as f:
             text = f.read()

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -34,13 +34,25 @@ BANNED_EXCEPT = {
     ],
     'grpc_error_ref(': ['src/core/lib/iomgr/error.cc'],
     'grpc_error_unref(': ['src/core/lib/iomgr/error.cc'],
-    'grpc_os_error(': ['src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'],
-    'grpc_wsa_error(': ['src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'],
-    'grpc_log_if_error(': ['src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'],
-    'grpc_slice_malloc(': ['src/core/lib/slice/slice.cc', 'src/core/lib/slice/slice.h'],
+    'grpc_os_error(': [
+        'src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'
+    ],
+    'grpc_wsa_error(': [
+        'src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'
+    ],
+    'grpc_log_if_error(': [
+        'src/core/lib/iomgr/error.cc', 'src/core/lib/iomgr/error.h'
+    ],
+    'grpc_slice_malloc(': [
+        'src/core/lib/slice/slice.cc', 'src/core/lib/slice/slice.h'
+    ],
     'grpc_call_cancel(': ['src/core/lib/surface/call.cc'],
-    'grpc_closure_create(': ['src/core/lib/iomgr/closure.cc', 'src/core/lib/iomgr/closure.h'],
-    'grpc_closure_init(': ['src/core/lib/iomgr/closure.cc', 'src/core/lib/iomgr/closure.h'],
+    'grpc_closure_create(': [
+        'src/core/lib/iomgr/closure.cc', 'src/core/lib/iomgr/closure.h'
+    ],
+    'grpc_closure_init(': [
+        'src/core/lib/iomgr/closure.cc', 'src/core/lib/iomgr/closure.h'
+    ],
     'grpc_closure_sched(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_run(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_list_sched(': ['src/core/lib/iomgr/closure.cc'],


### PR DESCRIPTION
Fixes the banned function checker to include header files. Some things had slipped through, such as `absl::make_unique` https://github.com/grpc/grpc/blob/033d55ffd33a75e3781ac0d48d315cf1c7257314/tools/run_tests/sanity/core_banned_functions.py#L64-L65




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

