### PR TITLE
resolver registry: require URI schemes to be lower-case

### DIFF
--- a/src/core/lib/resolver/resolver_factory.h
+++ b/src/core/lib/resolver/resolver_factory.h
@@ -55,7 +55,7 @@ class ResolverFactory {
   virtual ~ResolverFactory() {}
 
   /// Returns the URI scheme that this factory implements.
-  /// Caller does NOT take ownership of result.
+  /// Must not include any upper-case characters.
   virtual absl::string_view scheme() const = 0;
 
   /// Returns a bool indicating whether the input uri is valid to create a

--- a/src/core/lib/resolver/resolver_registry.cc
+++ b/src/core/lib/resolver/resolver_registry.cc
@@ -22,6 +22,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -39,8 +40,20 @@ void ResolverRegistry::Builder::SetDefaultPrefix(std::string default_prefix) {
   state_.default_prefix = std::move(default_prefix);
 }
 
+namespace {
+
+bool IsLowerCase(absl::string_view str) {
+  for (unsigned char c : str) {
+    if (absl::ascii_isalpha(c) && !absl::ascii_islower(c)) return false;
+  }
+  return true;
+}
+
+}  // namespace
+
 void ResolverRegistry::Builder::RegisterResolverFactory(
     std::unique_ptr<ResolverFactory> factory) {
+  GPR_ASSERT(IsLowerCase(factory->scheme()));
   auto p = state_.factories.emplace(factory->scheme(), std::move(factory));
   GPR_ASSERT(p.second);
 }


### PR DESCRIPTION
As per https://www.rfc-editor.org/rfc/rfc3986#section-3.1.