### PR TITLE
Disable testKeepaliveWithV2API test case for objc interop test

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1603,7 +1603,11 @@ static dispatch_once_t initGlobalInterceptorFactory;
   GRPCTestRunWithFlakeRepeats(self, ^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     // The test is highly flaky when ran as part of InteropTestsRemote
     // TODO(jtattermusch): fix and re-enable the test.
-    if ([[self class] isRemoteTest]) {
+    // if ([[self class] isRemoteTest]) {
+    //   return;
+    // }
+    // This test has a race and is flaky in any configurations. See b/268379869.
+    if (YES) {
       return;
     }
 

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1599,20 +1599,13 @@ static dispatch_once_t initGlobalInterceptorFactory;
   });
 }
 
+// TODO(b/268379869): This test has a race and is flaky in any configurations. One possible way to
+// deflake this test is to find a way to disable ping ack on the interop server for this test case.
 - (void)testKeepaliveWithV2API {
+  if (/* DISABLES CODE */ (YES)) {
+    return;
+  }
   GRPCTestRunWithFlakeRepeats(self, ^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
-    // The test is highly flaky when ran as part of InteropTestsRemote
-    // TODO(jtattermusch): fix and re-enable the test.
-    // if ([[self class] isRemoteTest]) {
-    //   return;
-    // }
-    // This test has a race and is flaky in any configurations. See b/268379869.
-    // One possible way to deflake this test is to find a way to disable ping ack on the interop
-    // server for this test case.
-    if (/* DISABLES CODE */ (YES)) {
-      return;
-    }
-
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     if ([[self class] transport] == gGRPCCoreCronetID) {
       // Cronet does not support keepalive

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1614,8 +1614,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
     /* DISABLES CODE */ (
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     if ([[self class] transport] == gGRPCCoreCronetID) {
-    // Cronet does not support keepalive
-    return;
+      // Cronet does not support keepalive
+      return;
     }
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Keepalive"];
 
@@ -1624,7 +1624,7 @@ static dispatch_once_t initGlobalInterceptorFactory;
     NSNumber *kResponseSize = @31415;
 
     id request = [RMTStreamingOutputCallRequest messageWithPayloadSize:kRequestSize
-                                                requestedResponseSize:kResponseSize];
+                                                 requestedResponseSize:kResponseSize];
     GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
     options.transportType = [[self class] transportType];
     options.transport = [[self class] transport];
@@ -1640,13 +1640,15 @@ static dispatch_once_t initGlobalInterceptorFactory;
                 initWithInitialMetadataCallback:nil
                                 messageCallback:nil
                                   closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
-    if (weakService == nil) {
-      return;
-    }
-    XCTAssertNotNil(error);
-    XCTAssertEqual(error.code, GRPC_STATUS_UNAVAILABLE,
-                    @"Received status %@ instead of UNAVAILABLE (14).", @(error.code));
-    [expectation fulfill];
+                                    if (weakService == nil) {
+                                      return;
+                                    }
+                                    XCTAssertNotNil(error);
+                                    XCTAssertEqual(
+                                        error.code, GRPC_STATUS_UNAVAILABLE,
+                                        @"Received status %@ instead of UNAVAILABLE (14).",
+                                        @(error.code));
+                                    [expectation fulfill];
                                   }]
                               callOptions:options];
     [call writeMessage:request];

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1611,50 +1611,50 @@ static dispatch_once_t initGlobalInterceptorFactory;
       return;
     }
 
-    RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
-    if ([[self class] transport] == gGRPCCoreCronetID) {
+    /* DISABLES CODE */ (
+      RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
+      if ([[self class] transport] == gGRPCCoreCronetID) {
       // Cronet does not support keepalive
       return;
-    }
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Keepalive"];
+      }
+      __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Keepalive"];
 
-    const NSTimeInterval kTestTimeout = 5;
-    NSNumber *kRequestSize = @27182;
-    NSNumber *kResponseSize = @31415;
+      const NSTimeInterval kTestTimeout = 5;
+      NSNumber *kRequestSize = @27182;
+      NSNumber *kResponseSize = @31415;
 
-    id request = [RMTStreamingOutputCallRequest messageWithPayloadSize:kRequestSize
-                                                 requestedResponseSize:kResponseSize];
-    GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
-    options.transportType = [[self class] transportType];
-    options.transport = [[self class] transport];
-    options.PEMRootCertificates = [[self class] PEMRootCertificates];
-    options.hostNameOverride = [[self class] hostNameOverride];
-    options.keepaliveInterval = 1.5;
-    options.keepaliveTimeout = 0;
+      id request = [RMTStreamingOutputCallRequest messageWithPayloadSize:kRequestSize
+                                                  requestedResponseSize:kResponseSize];
+      GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
+      options.transportType = [[self class] transportType];
+      options.transport = [[self class] transport];
+      options.PEMRootCertificates = [[self class] PEMRootCertificates];
+      options.hostNameOverride = [[self class] hostNameOverride];
+      options.keepaliveInterval = 1.5;
+      options.keepaliveTimeout = 0;
 
-    __weak RMTTestService *weakService = service;
-    GRPCStreamingProtoCall *call = [service
-        fullDuplexCallWithResponseHandler:
-            [[InteropTestsBlockCallbacks alloc]
-                initWithInitialMetadataCallback:nil
-                                messageCallback:nil
-                                  closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
-                                    if (weakService == nil) {
-                                      return;
-                                    }
-                                    XCTAssertNotNil(error);
-                                    XCTAssertEqual(
-                                        error.code, GRPC_STATUS_UNAVAILABLE,
-                                        @"Received status %@ instead of UNAVAILABLE (14).",
-                                        @(error.code));
-                                    [expectation fulfill];
-                                  }]
-                              callOptions:options];
-    [call writeMessage:request];
-    [call start];
+      __weak RMTTestService *weakService = service;
+      GRPCStreamingProtoCall *call = [service
+          fullDuplexCallWithResponseHandler:
+              [[InteropTestsBlockCallbacks alloc]
+                  initWithInitialMetadataCallback:nil
+                                  messageCallback:nil
+                                    closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
+      if (weakService == nil) {
+        return;
+      }
+      XCTAssertNotNil(error);
+      XCTAssertEqual(error.code, GRPC_STATUS_UNAVAILABLE,
+                     @"Received status %@ instead of UNAVAILABLE (14).", @(error.code));
+      [expectation fulfill];
+                                    }]
+                                callOptions:options];
+      [call writeMessage:request];
+      [call start];
 
-    waiterBlock(@[ expectation ], kTestTimeout);
-    [call finish];
+      waiterBlock(@[ expectation ], kTestTimeout);
+      [call finish];
+    )
   });
 }
 

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1607,6 +1607,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
     //   return;
     // }
     // This test has a race and is flaky in any configurations. See b/268379869.
+    // One possible way to deflake this test is to find a way to disable ping ack on the interop
+    // server for this test case.
     if (/* DISABLES CODE */ (YES)) {
       return;
     }

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1602,9 +1602,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
 // TODO(b/268379869): This test has a race and is flaky in any configurations. One possible way to
 // deflake this test is to find a way to disable ping ack on the interop server for this test case.
 - (void)testKeepaliveWithV2API {
-  if (/* DISABLES CODE */ (YES)) {
-    return;
-  }
+  return;
+
   GRPCTestRunWithFlakeRepeats(self, ^(GRPCTestWaiter waiterBlock, GRPCTestAssert assertBlock) {
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     if ([[self class] transport] == gGRPCCoreCronetID) {

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -1607,11 +1607,10 @@ static dispatch_once_t initGlobalInterceptorFactory;
     //   return;
     // }
     // This test has a race and is flaky in any configurations. See b/268379869.
-    if (YES) {
+    if (/* DISABLES CODE */ (YES)) {
       return;
     }
 
-    /* DISABLES CODE */ (
     RMTTestService *service = [RMTTestService serviceWithHost:[[self class] host]];
     if ([[self class] transport] == gGRPCCoreCronetID) {
       // Cronet does not support keepalive
@@ -1656,7 +1655,6 @@ static dispatch_once_t initGlobalInterceptorFactory;
 
     waiterBlock(@[ expectation ], kTestTimeout);
     [call finish];
-    )
   });
 }
 


### PR DESCRIPTION
This test has a race and is flaky, see [b/268379869](https://b.corp.google.com/issues/268379869). It sends an RPC to the interop server with 0s `keepaliveTimeout` and expects the keepalive watchdog timer to fire immediately before the server acks the ping.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

