### PR TITLE
[EventEngine] Fix the shims for iOS

### DIFF
--- a/src/core/lib/event_engine/shim.cc
+++ b/src/core/lib/event_engine/shim.cc
@@ -25,7 +25,7 @@ namespace experimental {
 bool UseEventEngineClient() {
 // TODO(hork, eryu): Adjust the ifdefs accordingly when event engines become
 // available for other platforms.
-#ifdef GRPC_POSIX_SOCKET_TCP
+#if defined(GRPC_POSIX_SOCKET_TCP) and !defined(GRPC_CFSTREAM)
   return grpc_core::IsEventEngineClientEnabled();
 #else
   return false;
@@ -35,8 +35,16 @@ bool UseEventEngineClient() {
 bool UseEventEngineListener() {
 // TODO(hork, eryu): Adjust the ifdefs accordingly when event engines become
 // available for other platforms.
-#ifdef GRPC_POSIX_SOCKET_TCP
+#if defined(GRPC_POSIX_SOCKET_TCP) and !defined(GRPC_CFSTREAM)
   return grpc_core::IsEventEngineListenerEnabled();
+#else
+  return false;
+#endif
+}
+
+bool EventEngineSupportsFd() {
+#if defined(GRPC_POSIX_SOCKET_TCP) and !defined(GRPC_CFSTREAM)
+  return true;
 #else
   return false;
 #endif

--- a/src/core/lib/event_engine/shim.h
+++ b/src/core/lib/event_engine/shim.h
@@ -14,6 +14,8 @@
 #ifndef GRPC_SRC_CORE_LIB_EVENT_ENGINE_SHIM_H
 #define GRPC_SRC_CORE_LIB_EVENT_ENGINE_SHIM_H
 
+// Platform-specific configuration for use of the EventEngine shims.
+
 #include <grpc/support/port_platform.h>
 
 namespace grpc_event_engine {
@@ -22,6 +24,8 @@ namespace experimental {
 bool UseEventEngineClient();
 
 bool UseEventEngineListener();
+
+bool EventEngineSupportsFd();
 
 }  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/transport/tcp_connect_handshaker.cc
+++ b/src/core/lib/transport/tcp_connect_handshaker.cc
@@ -152,7 +152,6 @@ void TCPConnectHandshaker::DoHandshake(grpc_tcp_server_acceptor* /*acceptor*/,
   // we don't want to pass args->endpoint directly.
   // Instead pass endpoint_ and swap this endpoint to
   // args endpoint on success.
-  // TODO(hork): use EventEngine::Connect if(IsEventEngineClientEnabled())
   grpc_tcp_client_connect(
       &connected_, &endpoint_to_destroy_, interested_parties_,
       grpc_event_engine::experimental::ChannelArgsEndpointConfig(args->args),


### PR DESCRIPTION
The shims assumed that all platforms with Posix socket support would use the PosixEventEngine. This is not the case for iOS.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

