### PR TITLE
Minimum time file watcher

### DIFF
--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -32,7 +32,6 @@
 #include <openssl/x509.h>
 
 #include "absl/status/status.h"
-#include "absl/strings/str_format.h"
 
 #include <grpc/slice.h>
 #include <grpc/support/log.h>

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -392,7 +392,7 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
   return absl::nullopt;
 }
 
-const int64_t FileWatcherCertificateProvider::TestOnlyGetRefreshIntervalSecond()
+int64_t FileWatcherCertificateProvider::TestOnlyGetRefreshIntervalSecond()
     const {
   return refresh_interval_sec_;
 }

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -117,7 +117,7 @@ gpr_timespec TimeoutSecondsToDeadline(int64_t seconds) {
 
 }  // namespace
 
-static const int64_t MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS = 1;
+static constexpr int64_t kMinimumFileWatcherRefreshIntervalSeconds = 1;
 
 FileWatcherCertificateProvider::FileWatcherCertificateProvider(
     std::string private_key_path, std::string identity_certificate_path,
@@ -127,15 +127,14 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
       identity_certificate_path_(std::move(identity_certificate_path)),
       root_cert_path_(std::move(root_cert_path)),
       distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
-  if (refresh_interval_sec_ < MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS) {
+  if (refresh_interval_sec_ < kMinimumFileWatcherRefreshIntervalSeconds) {
     gpr_log(GPR_INFO,
             "FileWatcherCertificateProvider refresh_interval_sec_ set to %ld "
             "seconds which is less "
             "than %ld second, the minimum allowed value. Overriding "
             "configured value.",
-            refresh_interval_sec_,
-            MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS);
-    refresh_interval_sec_ = MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS;
+            refresh_interval_sec_, kMinimumFileWatcherRefreshIntervalSeconds);
+    refresh_interval_sec_ = kMinimumFileWatcherRefreshIntervalSeconds;
   }
   // Private key and identity cert files must be both set or both unset.
   GPR_ASSERT(private_key_path_.empty() == identity_certificate_path_.empty());

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -122,10 +122,10 @@ static constexpr int64_t kMinimumFileWatcherRefreshIntervalSeconds = 1;
 FileWatcherCertificateProvider::FileWatcherCertificateProvider(
     std::string private_key_path, std::string identity_certificate_path,
     std::string root_cert_path, int64_t refresh_interval_sec)
-    : refresh_interval_sec_(refresh_interval_sec),
-      private_key_path_(std::move(private_key_path)),
+    : private_key_path_(std::move(private_key_path)),
       identity_certificate_path_(std::move(identity_certificate_path)),
       root_cert_path_(std::move(root_cert_path)),
+      refresh_interval_sec_(refresh_interval_sec),
       distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
   if (refresh_interval_sec_ < kMinimumFileWatcherRefreshIntervalSeconds) {
     gpr_log(GPR_INFO,
@@ -390,6 +390,11 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
   gpr_log(GPR_ERROR,
           "All retry attempts failed. Will try again after the next interval.");
   return absl::nullopt;
+}
+
+const int64_t FileWatcherCertificateProvider::TestOnlyGetRefreshIntervalSecond()
+    const {
+  return refresh_interval_sec_;
 }
 
 absl::StatusOr<bool> PrivateKeyAndCertificateMatch(

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -125,6 +125,15 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
       root_cert_path_(std::move(root_cert_path)),
       refresh_interval_sec_(refresh_interval_sec),
       distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
+  if (refresh_interval_sec_ < 1) {
+    gpr_log(GPR_INFO,
+            "FileWatcherCertificateProvider refresh_interval_sec_ set to %ld "
+            "seconds which is less "
+            "than 1 second. 1 second is the minimum allowed value. Overriding "
+            "configured value to 1 second.",
+            refresh_interval_sec_);
+    refresh_interval_sec_ = 1;
+  }
   // Private key and identity cert files must be both set or both unset.
   GPR_ASSERT(private_key_path_.empty() == identity_certificate_path_.empty());
   // Must be watching either root or identity certs.

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -117,6 +117,8 @@ gpr_timespec TimeoutSecondsToDeadline(int64_t seconds) {
 
 }  // namespace
 
+static const int64_t MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS = 1;
+
 FileWatcherCertificateProvider::FileWatcherCertificateProvider(
     std::string private_key_path, std::string identity_certificate_path,
     std::string root_cert_path, int64_t refresh_interval_sec)
@@ -125,14 +127,15 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
       identity_certificate_path_(std::move(identity_certificate_path)),
       root_cert_path_(std::move(root_cert_path)),
       distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
-  if (refresh_interval_sec_ < 1) {
+  if (refresh_interval_sec_ < MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS) {
     gpr_log(GPR_INFO,
             "FileWatcherCertificateProvider refresh_interval_sec_ set to %ld "
             "seconds which is less "
-            "than 1 second. 1 second is the minimum allowed value. Overriding "
-            "configured value to 1 second.",
-            refresh_interval_sec_);
-    refresh_interval_sec_ = 1;
+            "than %ld second, the minimum allowed value. Overriding "
+            "configured value.",
+            refresh_interval_sec_,
+            MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS);
+    refresh_interval_sec_ = MINIMUM_FILE_WATCHER_REFRESH_INTERVAL_SECONDS;
   }
   // Private key and identity cert files must be both set or both unset.
   GPR_ASSERT(private_key_path_.empty() == identity_certificate_path_.empty());

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -32,6 +32,7 @@
 #include <openssl/x509.h>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_format.h"
 
 #include <grpc/slice.h>
 #include <grpc/support/log.h>
@@ -129,11 +130,8 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
       distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
   if (refresh_interval_sec_ < kMinimumFileWatcherRefreshIntervalSeconds) {
     gpr_log(GPR_INFO,
-            "FileWatcherCertificateProvider refresh_interval_sec_ set to %ld "
-            "seconds which is less "
-            "than %ld second, the minimum allowed value. Overriding "
-            "configured value.",
-            refresh_interval_sec_, kMinimumFileWatcherRefreshIntervalSeconds);
+            "FileWatcherCertificateProvider refresh_interval_sec_ set to value "
+            "less than minimum. Overriding configured value to minimum.");
     refresh_interval_sec_ = kMinimumFileWatcherRefreshIntervalSeconds;
   }
   // Private key and identity cert files must be both set or both unset.

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -120,10 +120,10 @@ gpr_timespec TimeoutSecondsToDeadline(int64_t seconds) {
 FileWatcherCertificateProvider::FileWatcherCertificateProvider(
     std::string private_key_path, std::string identity_certificate_path,
     std::string root_cert_path, int64_t refresh_interval_sec)
-    : private_key_path_(std::move(private_key_path)),
+    : refresh_interval_sec_(refresh_interval_sec),
+      private_key_path_(std::move(private_key_path)),
       identity_certificate_path_(std::move(identity_certificate_path)),
       root_cert_path_(std::move(root_cert_path)),
-      refresh_interval_sec_(refresh_interval_sec),
       distributor_(MakeRefCounted<grpc_tls_certificate_distributor>()) {
   if (refresh_interval_sec_ < 1) {
     gpr_log(GPR_INFO,

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -150,6 +150,7 @@ class FileWatcherCertificateProvider final
   }
 
   UniqueTypeName type() const override;
+  int64_t refresh_interval_sec_ = 0;
 
  private:
   struct WatcherInfo {
@@ -178,7 +179,6 @@ class FileWatcherCertificateProvider final
   std::string private_key_path_;
   std::string identity_certificate_path_;
   std::string root_cert_path_;
-  int64_t refresh_interval_sec_ = 0;
 
   RefCountedPtr<grpc_tls_certificate_distributor> distributor_;
   Thread refresh_thread_;

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -150,7 +150,8 @@ class FileWatcherCertificateProvider final
   }
 
   UniqueTypeName type() const override;
-  int64_t refresh_interval_sec_ = 0;
+
+  const int64_t TestOnlyGetRefreshIntervalSecond() const;
 
  private:
   struct WatcherInfo {
@@ -179,6 +180,7 @@ class FileWatcherCertificateProvider final
   std::string private_key_path_;
   std::string identity_certificate_path_;
   std::string root_cert_path_;
+  int64_t refresh_interval_sec_ = 0;
 
   RefCountedPtr<grpc_tls_certificate_distributor> distributor_;
   Thread refresh_thread_;

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h
@@ -151,7 +151,7 @@ class FileWatcherCertificateProvider final
 
   UniqueTypeName type() const override;
 
-  const int64_t TestOnlyGetRefreshIntervalSecond() const;
+  int64_t TestOnlyGetRefreshIntervalSecond() const;
 
  private:
   struct WatcherInfo {

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -493,28 +493,6 @@ TEST_F(GrpcTlsCertificateProviderTest,
   FileWatcherCertificateProvider provider(SERVER_KEY_PATH, SERVER_CERT_PATH,
                                           CA_CERT_PATH, 0);
   ASSERT_THAT(provider.refresh_interval_sec_, 1);
-  // Watcher watching both root and identity certs.
-  WatcherState* watcher_state_1 =
-      MakeWatcher(provider.distributor(), kCertName, kCertName);
-  EXPECT_THAT(watcher_state_1->GetCredentialQueue(),
-              ::testing::ElementsAre(CredentialInfo(
-                  root_cert_, MakeCertKeyPairs(private_key_.c_str(),
-                                               cert_chain_.c_str()))));
-  CancelWatch(watcher_state_1);
-  // Watcher watching only root certs.
-  WatcherState* watcher_state_2 =
-      MakeWatcher(provider.distributor(), kCertName, absl::nullopt);
-  EXPECT_THAT(watcher_state_2->GetCredentialQueue(),
-              ::testing::ElementsAre(CredentialInfo(root_cert_, {})));
-  CancelWatch(watcher_state_2);
-  // Watcher watching only identity certs.
-  WatcherState* watcher_state_3 =
-      MakeWatcher(provider.distributor(), absl::nullopt, kCertName);
-  EXPECT_THAT(
-      watcher_state_3->GetCredentialQueue(),
-      ::testing::ElementsAre(CredentialInfo(
-          "", MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()))));
-  CancelWatch(watcher_state_3);
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -492,7 +492,7 @@ TEST_F(GrpcTlsCertificateProviderTest,
        FileWatcherCertificateProviderTooShortRefreshIntervalIsOverwritten) {
   FileWatcherCertificateProvider provider(SERVER_KEY_PATH, SERVER_CERT_PATH,
                                           CA_CERT_PATH, 0);
-  ASSERT_THAT(provider.refresh_interval_sec_, 1);
+  ASSERT_THAT(provider.TestOnlyGetRefreshIntervalSecond(), 1);
 }
 
 TEST_F(GrpcTlsCertificateProviderTest, FailedKeyCertMatchOnEmptyPrivateKey) {


### PR DESCRIPTION
Enforce a minimum value for the `refresh_interval_sec_` for the `FileWatcherCertificateProvider`. There have been issues found when this is set to 0, and the security team discussed and agreed that 0 should not be a valid value for this use-case.

I made the `refresh_interval_sec_` public to make it easy to test - I didn't immediately see an easy way around this. I found `FRIEND_TEST` exists for accessing private members, but I didn't see that used anywhere in grpc. If there is a better solution to this, please let me know.