### PR TITLE
[EventEngine] Add more granular trace flags

### DIFF
--- a/src/core/lib/event_engine/trace.cc
+++ b/src/core/lib/event_engine/trace.cc
@@ -16,3 +16,9 @@
 #include "src/core/lib/debug/trace.h"
 
 grpc_core::TraceFlag grpc_event_engine_trace(false, "event_engine");
+grpc_core::TraceFlag grpc_event_engine_endpoint_trace(false,
+                                                      "event_engine_endpoint");
+grpc_core::TraceFlag grpc_event_engine_endpoint_data_trace(
+    false, "event_engine_endpoint_data");
+grpc_core::TraceFlag grpc_event_engine_poller_trace(false,
+                                                    "event_engine_poller");

--- a/src/core/lib/event_engine/trace.h
+++ b/src/core/lib/event_engine/trace.h
@@ -21,10 +21,23 @@
 #include "src/core/lib/debug/trace.h"
 
 extern grpc_core::TraceFlag grpc_event_engine_trace;
+extern grpc_core::TraceFlag grpc_event_engine_endpoint_data_trace;
+extern grpc_core::TraceFlag grpc_event_engine_poller_trace;
+extern grpc_core::TraceFlag grpc_event_engine_endpoint_trace;
 
 #define GRPC_EVENT_ENGINE_TRACE(format, ...)                   \
   if (GRPC_TRACE_FLAG_ENABLED(grpc_event_engine_trace)) {      \
     gpr_log(GPR_DEBUG, "(event_engine) " format, __VA_ARGS__); \
+  }
+
+#define GRPC_EVENT_ENGINE_ENDPOINT_TRACE(format, ...)                   \
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_event_engine_endpoint_trace)) {      \
+    gpr_log(GPR_DEBUG, "(event_engine endpoint) " format, __VA_ARGS__); \
+  }
+
+#define GRPC_EVENT_ENGINE_POLLER_TRACE(format, ...)                   \
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_event_engine_poller_trace)) {      \
+    gpr_log(GPR_DEBUG, "(event_engine poller) " format, __VA_ARGS__); \
   }
 
 #endif  // GRPC_SRC_CORE_LIB_EVENT_ENGINE_TRACE_H

--- a/src/core/lib/event_engine/windows/windows_engine.cc
+++ b/src/core/lib/event_engine/windows/windows_engine.cc
@@ -128,6 +128,9 @@ WindowsEventEngine::~WindowsEventEngine() {
 bool WindowsEventEngine::Cancel(EventEngine::TaskHandle handle) {
   grpc_core::MutexLock lock(&task_mu_);
   if (!known_handles_.contains(handle)) return false;
+  GRPC_EVENT_ENGINE_TRACE(
+      "WindowsEventEngine::%p cancelling %s", this,
+      HandleToString<EventEngine::TaskHandle>(handle).c_str());
   auto* cd = reinterpret_cast<TimerClosure*>(handle.keys[0]);
   bool r = timer_manager_.TimerCancel(&cd->timer);
   known_handles_.erase(handle);

--- a/src/core/lib/event_engine/windows/windows_engine.h
+++ b/src/core/lib/event_engine/windows/windows_engine.h
@@ -45,12 +45,6 @@ namespace experimental {
 class WindowsEventEngine : public EventEngine,
                            public grpc_core::KeepsGrpcInitialized {
  public:
-  class WindowsListener : public EventEngine::Listener {
-   public:
-    ~WindowsListener() override;
-    absl::StatusOr<int> Bind(const ResolvedAddress& addr) override;
-    absl::Status Start() override;
-  };
   class WindowsDNSResolver : public EventEngine::DNSResolver {
    public:
     ~WindowsDNSResolver() override;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -456,7 +456,6 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
   grpc_resolved_address addr6_v4mapped;
   grpc_resolved_address wildcard;
   grpc_resolved_address* allocated_addr = NULL;
-  grpc_resolved_address sockname_temp;
   unsigned port_index = 0;
   grpc_error_handle error;
 
@@ -468,6 +467,7 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
   // as some previously created listener.
   if (grpc_sockaddr_get_port(addr) == 0) {
     for (sp = s->head; sp; sp = sp->next) {
+      grpc_resolved_address sockname_temp;
       int sockname_temp_len = sizeof(struct sockaddr_storage);
       if (0 == getsockname(sp->socket->socket,
                            (grpc_sockaddr*)sockname_temp.addr,


### PR DESCRIPTION
The set of trace flags is now:
* event_engine
* event_engine_endpoint
* event_engine_endpoint_data: additionally log all sent/received data, similar to what the shims do.
* event_engine_poller

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

