### PR TITLE
grpc: replace has_ methods for upb map fields with _size methods

### DIFF
--- a/src/core/ext/xds/xds_http_rbac_filter.cc
+++ b/src/core/ext/xds/xds_http_rbac_filter.cc
@@ -396,7 +396,7 @@ Json ParseHttpRbacToJson(const envoy_extensions_filters_http_rbac_v3_RBAC* rbac,
     }
     Json::Object inner_rbac_json;
     inner_rbac_json.emplace("action", envoy_config_rbac_v3_RBAC_action(rules));
-    if (envoy_config_rbac_v3_RBAC_has_policies(rules)) {
+    if (envoy_config_rbac_v3_RBAC_policies_size(rules) != 0) {
       Json::Object policies_object;
       size_t iter = kUpb_Map_Begin;
       while (true) {

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -351,7 +351,7 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
     gpr_log(GPR_ERROR, "Null peer identity in ALTS context.");
     return TSI_FAILED_PRECONDITION;
   }
-  if (grpc_gcp_Identity_has_attributes(identity)) {
+  if (grpc_gcp_Identity_attributes_size(identity) != 0) {
     size_t iter = kUpb_Map_Begin;
     grpc_gcp_Identity_AttributesEntry* peer_attributes_entry =
         grpc_gcp_Identity_attributes_nextmutable(peer_identity, &iter);

--- a/src/cpp/common/alts_context.cc
+++ b/src/cpp/common/alts_context.cc
@@ -87,7 +87,7 @@ AltsContext::AltsContext(const grpc_gcp_AltsContext* ctx) {
     security_level_ = static_cast<grpc_security_level>(
         grpc_gcp_AltsContext_security_level(ctx));
   }
-  if (grpc_gcp_AltsContext_has_peer_attributes(ctx)) {
+  if (grpc_gcp_AltsContext_peer_attributes_size(ctx) != 0) {
     size_t iter = kUpb_Map_Begin;
     const grpc_gcp_AltsContext_PeerAttributesEntry* peer_attributes_entry =
         grpc_gcp_AltsContext_peer_attributes_next(ctx, &iter);


### PR DESCRIPTION
The upb team wants to remove this particular bit of syntactic sugar from the generated code. So instead of calling has_foo() when foo is a map field, we call foo_size() and test the result against zero.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

