### PR TITLE
[codegen] Escape '$' delimiter in proto comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4731,6 +4731,7 @@ add_library(grpc_plugin_support
   src/compiler/node_generator.cc
   src/compiler/objective_c_generator.cc
   src/compiler/php_generator.cc
+  src/compiler/proto_parser_helper.cc
   src/compiler/python_generator.cc
   src/compiler/ruby_generator.cc
 )

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4098,6 +4098,7 @@ libs:
   - src/compiler/objective_c_generator_helpers.h
   - src/compiler/php_generator.h
   - src/compiler/php_generator_helpers.h
+  - src/compiler/proto_parser_helper.h
   - src/compiler/protobuf_plugin.h
   - src/compiler/python_generator.h
   - src/compiler/python_generator_helpers.h
@@ -4113,6 +4114,7 @@ libs:
   - src/compiler/node_generator.cc
   - src/compiler/objective_c_generator.cc
   - src/compiler/php_generator.cc
+  - src/compiler/proto_parser_helper.cc
   - src/compiler/python_generator.cc
   - src/compiler/ruby_generator.cc
   deps: []

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -2049,6 +2049,7 @@
         'src/compiler/node_generator.cc',
         'src/compiler/objective_c_generator.cc',
         'src/compiler/php_generator.cc',
+        'src/compiler/proto_parser_helper.cc',
         'src/compiler/python_generator.cc',
         'src/compiler/ruby_generator.cc',
       ],

--- a/src/compiler/BUILD
+++ b/src/compiler/BUILD
@@ -33,6 +33,13 @@ licenses(["notice"])
 exports_files(["LICENSE"])
 
 grpc_cc_library(
+    name = "proto_parser_helper",
+    srcs = ["proto_parser_helper.cc"],
+    hdrs = ["proto_parser_helper.h"],
+    language = "c++",
+)
+
+grpc_cc_library(
     name = "grpc_plugin_support",
     srcs = [
         "cpp_generator.cc",
@@ -73,6 +80,7 @@ grpc_cc_library(
     ],
     language = "c++",
     deps = [
+        "proto_parser_helper",
         "//:grpc++_config_proto",
     ],
 )

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -55,15 +55,6 @@ std::string FilenameIdentifier(const std::string& filename) {
   return result;
 }
 
-std::string EscapeVariableDelimiters(std::string&& mut_str) {
-  size_t index = 0;
-  while ((index = mut_str.find('$', index)) != std::string::npos) {
-    mut_str.replace(index, 1, "$$");
-    index += 2;
-  }
-  return mut_str;
-}
-
 }  // namespace
 
 template <class T, size_t N>
@@ -1341,8 +1332,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
                         std::map<std::string, std::string>* vars) {
   (*vars)["Service"] = service->name();
 
-  printer->Print(
-      EscapeVariableDelimiters(service->GetLeadingComments("//")).c_str());
+  printer->Print(service->GetLeadingComments("//").c_str());
   printer->Print(*vars,
                  "class $Service$ final {\n"
                  " public:\n");

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "src/compiler/config.h"
+#include "src/compiler/proto_parser_helper.h"
 
 namespace grpc_generator {
 
@@ -245,9 +246,9 @@ inline std::string GenerateCommentsWithPrefix(
     if (elem.empty()) {
       oss << prefix << "\n";
     } else if (elem[0] == ' ') {
-      oss << prefix << elem << "\n";
+      oss << prefix << EscapeVariableDelimiters(elem) << "\n";
     } else {
-      oss << prefix << " " << elem << "\n";
+      oss << prefix << " " << EscapeVariableDelimiters(elem) << "\n";
     }
   }
   return oss.str();

--- a/src/compiler/proto_parser_helper.cc
+++ b/src/compiler/proto_parser_helper.cc
@@ -1,0 +1,29 @@
+// Copyright 2023 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+namespace grpc_generator {
+
+std::string EscapeVariableDelimiters(const std::string& original) {
+  std::string mut_str = original;
+  size_t index = 0;
+  while ((index = mut_str.find('$', index)) != std::string::npos) {
+    mut_str.replace(index, 1, "$$");
+    index += 2;
+  }
+  return mut_str;
+}
+
+}  // namespace grpc_generator

--- a/src/compiler/proto_parser_helper.h
+++ b/src/compiler/proto_parser_helper.h
@@ -1,0 +1,22 @@
+// Copyright 2023 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+namespace grpc_generator {
+
+// Replaces '$' with "$$", useful in proto comments.
+std::string EscapeVariableDelimiters(const std::string& original);
+
+}  // namespace grpc_generator

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -252,7 +252,8 @@ def extension_modules():
 
     plugin_sources += [
         os.path.join('grpc_tools', 'main.cc'),
-        os.path.join('grpc_root', 'src', 'compiler', 'python_generator.cc')
+        os.path.join('grpc_root', 'src', 'compiler', 'python_generator.cc'),
+        os.path.join('grpc_root', 'src', 'compiler', 'proto_parser_helper.cc')
     ] + [os.path.join(CC_INCLUDE, cc_file) for cc_file in CC_FILES]
 
     plugin_ext = extension.Extension(


### PR DESCRIPTION
This applies to all wrapped languages.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

