### PR TITLE
[build] Enable -Wunused-but-set-variable

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -45,6 +45,7 @@ GRPC_LLVM_WARNING_FLAGS = [
     "-Wtautological-overlap-compare",
     "-Wthread-safety-analysis",
     "-Wthread-safety-beta",
+    "-Wunused-but-set-variable",
     "-Wunused-comparison",
     "-Wvla",
     # -Wextra compatibility between gcc and clang

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -328,7 +328,6 @@ void XdsClusterManagerLb::UpdateStateLocked() {
   size_t num_ready = 0;
   size_t num_connecting = 0;
   size_t num_idle = 0;
-  size_t num_transient_failures = 0;
   for (const auto& p : children_) {
     const auto& child_name = p.first;
     const ClusterChild* child = p.second.get();
@@ -351,7 +350,6 @@ void XdsClusterManagerLb::UpdateStateLocked() {
         break;
       }
       case GRPC_CHANNEL_TRANSIENT_FAILURE: {
-        ++num_transient_failures;
         break;
       }
       default:
@@ -367,7 +365,6 @@ void XdsClusterManagerLb::UpdateStateLocked() {
   } else if (num_idle > 0) {
     connectivity_state = GRPC_CHANNEL_IDLE;
   } else {
-    GPR_ASSERT(num_transient_failures > 0);
     connectivity_state = GRPC_CHANNEL_TRANSIENT_FAILURE;
   }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_cluster_manager_lb_trace)) {

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_cluster_manager.cc
@@ -367,6 +367,7 @@ void XdsClusterManagerLb::UpdateStateLocked() {
   } else if (num_idle > 0) {
     connectivity_state = GRPC_CHANNEL_IDLE;
   } else {
+    GPR_ASSERT(num_transient_failures > 0);
     connectivity_state = GRPC_CHANNEL_TRANSIENT_FAILURE;
   }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_cluster_manager_lb_trace)) {


### PR DESCRIPTION
This is a step towards enabling `--define=use_strict_warning=true` for Windows clang-cl.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

