### PR TITLE
Remove the if() to save some cpu cycles.

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -3645,13 +3645,9 @@ grpc_call_error grpc_call_start_batch(grpc_call* call, const grpc_op* ops,
       "reserved=%p)",
       5, (call, ops, (unsigned long)nops, tag, reserved));
 
-  if (reserved != nullptr) {
-    return GRPC_CALL_ERROR;
-  } else {
-    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
-    grpc_core::ExecCtx exec_ctx;
-    return grpc_core::Call::FromC(call)->StartBatch(ops, nops, tag, false);
-  }
+  grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
+  grpc_core::ExecCtx exec_ctx;
+  return grpc_core::Call::FromC(call)->StartBatch(ops, nops, tag, false);
 }
 
 grpc_call_error grpc_call_start_batch_and_execute(grpc_call* call,


### PR DESCRIPTION
The "reserved" var was not used in the function. So the if() can be removed. It saves some cpu cycles.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

