### PR TITLE
GCP Observability testing for C++

### DIFF
--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -356,3 +356,66 @@ grpc_cc_binary(
         "//test/cpp/util:test_config",
     ],
 )
+
+grpc_cc_binary(
+    name = "observability_interop_server",
+    srcs = [
+        "observability_interop_server_bootstrap.cc",
+    ],
+    external_deps = [
+        "absl/flags:flag",
+    ],
+    language = "C++",
+    deps = [
+        ":interop_server_lib",
+        "//:grpc++",
+        "//:grpcpp_gcp_observability",
+        "//test/cpp/util:test_util",
+    ],
+)
+
+grpc_cc_library(
+    name = "observability_interop_client_main",
+    srcs = [
+        "observability_client.cc",
+    ],
+    external_deps = [
+        "absl/flags:flag",
+    ],
+    language = "C++",
+    deps = [
+        ":client_helper_lib",
+        "//:grpcpp_gcp_observability",
+    ],
+)
+
+grpc_cc_binary(
+    name = "observability_interop_client",
+    language = "C++",
+    deps = [
+        ":observability_interop_client_main",
+        "//:grpc++",
+        "//test/cpp/util:test_util",
+    ],
+)
+
+grpc_cc_binary(
+    name = "observability_interop_test",
+    srcs = ["interop_test.cc"],
+    data = [
+        ":observability_interop_client",
+        ":observability_interop_server",
+    ],
+    external_deps = [
+        "absl/flags:flag",
+    ],
+    tags = ["no_windows"],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//:grpc++",
+        "//test/core/util:grpc_test_util",
+        "//test/cpp/util:test_config",
+        "//test/cpp/util:test_util",
+    ],
+)

--- a/test/cpp/interop/observability_client.cc
+++ b/test/cpp/interop/observability_client.cc
@@ -1,0 +1,74 @@
+//
+//
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <memory>
+#include <unordered_map>
+
+#include "absl/flags/flag.h"
+
+#include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/ext/gcp_observability.h>
+
+#include "src/core/lib/gpr/string.h"
+#include "src/core/lib/gprpp/crash.h"
+#include "test/core/util/test_config.h"
+#include "test/cpp/interop/client_helper.h"
+#include "test/cpp/interop/interop_client.h"
+#include "test/cpp/util/test_config.h"
+
+ABSL_FLAG(bool, enable_observability, false,
+          "Whether to enable GCP Observability");
+
+using grpc::testing::RunClient;
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  grpc::testing::InitTest(&argc, &argv, true);
+  gpr_log(GPR_INFO, "Testing these cases: %s",
+          absl::GetFlag(FLAGS_test_case).c_str());
+
+  if (absl::GetFlag(FLAGS_enable_observability)) {
+    auto status = grpc::experimental::GcpObservabilityInit();
+    gpr_log(GPR_DEBUG, "GcpObservabilityInit() status_code: %d", status.code());
+    if (!status.ok()) {
+      return 1;
+    }
+  }
+
+  int ret = RunClient();
+
+  if (absl::GetFlag(FLAGS_enable_observability)) {
+    grpc::experimental::GcpObservabilityClose();
+    // TODO(stanleycheung): remove this once the observability exporter plugin
+    //                      is able to gracefully flush observability data to
+    //                      cloud at shutdown
+    const int observability_exporter_sleep_seconds = 65;
+    gpr_log(GPR_DEBUG, "Sleeping %ds before shutdown.",
+            observability_exporter_sleep_seconds);
+    gpr_sleep_until(
+        gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                     gpr_time_from_seconds(observability_exporter_sleep_seconds,
+                                           GPR_TIMESPAN)));
+  }
+
+  return ret;
+}

--- a/test/cpp/interop/observability_interop_server_bootstrap.cc
+++ b/test/cpp/interop/observability_interop_server_bootstrap.cc
@@ -1,0 +1,55 @@
+//
+//
+// Copyright 2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <signal.h>
+
+#include "absl/flags/flag.h"
+
+#include <grpcpp/ext/gcp_observability.h>
+
+#include "test/core/util/test_config.h"
+#include "test/cpp/interop/server_helper.h"
+#include "test/cpp/util/test_config.h"
+
+gpr_atm grpc::testing::interop::g_got_sigint;
+
+ABSL_FLAG(bool, enable_observability, false,
+          "Whether to enable GCP Observability");
+
+static void sigint_handler(int /*x*/) {
+  gpr_atm_no_barrier_store(&grpc::testing::interop::g_got_sigint, true);
+}
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  grpc::testing::InitTest(&argc, &argv, true);
+  signal(SIGINT, sigint_handler);
+
+  if (absl::GetFlag(FLAGS_enable_observability)) {
+    auto status = grpc::experimental::GcpObservabilityInit();
+    gpr_log(GPR_DEBUG, "GcpObservabilityInit() status_code: %d", status.code());
+    if (!status.ok()) {
+      return 1;
+    }
+  }
+
+  grpc::testing::interop::RunServer(
+      grpc::testing::CreateInteropServerCredentials());
+
+  return 0;
+}

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -657,7 +657,8 @@ def _exclude_unwanted_cc_tests(tests: List[str]) -> List[str]:
         if not test.startswith('test/cpp/ext/filters/census:') and
         not test.startswith('test/core/xds:xds_channel_stack_modifier_test') and
         not test.startswith('test/cpp/ext/gcp:') and
-        not test.startswith('test/cpp/ext/filters/logging:')
+        not test.startswith('test/cpp/ext/filters/logging:') and
+        not test.startswith('test/cpp/interop:observability_interop')
     ]
 
     # missing opencensus/stats/stats.h

--- a/tools/dockerfile/observability-test/cpp/Dockerfile
+++ b/tools/dockerfile/observability-test/cpp/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#
+# Stage 1: Build the interop test client and server
+#
+
+FROM debian:bullseye as build
+
+RUN apt-get update && apt-get install -y clang curl git
+
+WORKDIR /grpc
+COPY . .
+
+RUN git submodule update --init --recursive && \
+  /grpc/tools/bazel build test/cpp/interop:observability_interop_test
+
+
+
+#
+# Stage 2:
+#
+# - Copy only the necessary files to reduce Docker image size.
+# - Have an ENTRYPOINT script which will launch the interop test client or server
+#   with the given parameters.
+#
+
+FROM debian:bullseye
+
+ENV GRPC_TRACE environment_autodetect
+ENV GRPC_VERBOSITY debug
+
+
+WORKDIR /usr/share/grpc
+COPY --from=build /grpc/etc/roots.pem .
+
+
+WORKDIR /grpc/bazel-bin/test/cpp/interop
+COPY --from=build /grpc/bazel-bin/test/cpp/interop/observability_interop_server .
+COPY --from=build /grpc/bazel-bin/test/cpp/interop/observability_interop_client .
+
+WORKDIR /grpc/tools/dockerfile/observability-test/cpp
+COPY --from=build /grpc/tools/dockerfile/observability-test/cpp/run.sh .
+
+ENTRYPOINT ["/grpc/tools/dockerfile/observability-test/cpp/run.sh"]

--- a/tools/dockerfile/observability-test/cpp/build_docker.sh
+++ b/tools/dockerfile/observability-test/cpp/build_docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+cd "$(dirname "$0")"/../../../..
+
+# Environment Variables:
+#
+# TAG_NAME: the docker image tag name
+#
+
+echo Building ${TAG_NAME}
+
+docker build --no-cache -t ${TAG_NAME} -f ./tools/dockerfile/observability-test/cpp/Dockerfile .

--- a/tools/dockerfile/observability-test/cpp/run.sh
+++ b/tools/dockerfile/observability-test/cpp/run.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2022 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+cd "$(dirname "$0")"/../..
+
+# TODO(stanleycheung): replace positional parameters with explicit parameters
+#
+#             $1: server | client
+#
+# For server: $2: server_port
+#
+# For client: $2: server_host
+#             $3: server_port
+#             $4: test_case
+#             $5: num_times
+
+if [ "$1" = "server" ] ; then
+  /grpc/bazel-bin/test/cpp/interop/observability_interop_server \
+    --enable_observability=true --port $2
+
+elif [ "$1" = "client" ] ; then
+  /grpc/bazel-bin/test/cpp/interop/observability_interop_client \
+    --enable_observability=true \
+    --server_host=$2 --server_port=$3 \
+    --test_case=$4 --num_times=$5
+
+else
+  echo "Invalid action: $1"
+  exit 1
+fi


### PR DESCRIPTION
This PR enables GCP Observability testing for C++.

This re-uses the existing interop test client and server and adds an `--enable_observability=true` flag.

This also adds a `Dockerfile` and `run.sh` script to allow the test framework to execute the test. 


Framework PR: https://github.com/GoogleCloudPlatform/grpc-gcp-tools/pull/18
Java PR: https://github.com/grpc/grpc-java/pull/9858
Golang PR: https://github.com/grpc/grpc-go/pull/5979