### PR TITLE
Make remaining objc test jobs to pass on MacOS monterey

### DIFF
--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -103,11 +103,6 @@ Pod::Spec.new do |s|
   # following lets users write `#include <openssl/ssl.h>`.
   s.header_dir = name
 
-  # The module map and umbrella header created automatically by Cocoapods don't work for C libraries
-  # like this one. The following file, and a correct umbrella header, are created on the fly by the
-  # `prepare_command` of this pod.
-  s.module_map = 'src/include/openssl/BoringSSL.modulemap'
-
   # We don't need to inhibit all warnings; only -Wno-shorten-64-to-32. But Cocoapods' linter doesn't
   # want that for some reason.
   s.compiler_flags = '-DOPENSSL_NO_ASM', '-GCC_WARN_INHIBIT_ALL_WARNINGS', '-w', '-DBORINGSSL_PREFIX=GRPC'
@@ -153,56 +148,6 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-END_OF_COMMAND
     set -e
-    # Add a module map and an umbrella header
-    mkdir -p src/include/openssl
-    cat > src/include/openssl/umbrella.h <<EOF
-      #include "ssl.h"
-      #include "crypto.h"
-      #include "aes.h"
-      /* The following macros are defined by base.h. The latter is the first file included by the
-         other headers. */
-      #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
-      #  include "arm_arch.h"
-      #endif
-      #include "asn1.h"
-      #include "asn1_mac.h"
-      #include "asn1t.h"
-      #include "blowfish.h"
-      #include "cast.h"
-      #include "chacha.h"
-      #include "cmac.h"
-      #include "conf.h"
-      #include "cpu.h"
-      #include "curve25519.h"
-      #include "des.h"
-      #include "dtls1.h"
-      #include "hkdf.h"
-      #include "md4.h"
-      #include "md5.h"
-      #include "obj_mac.h"
-      #include "objects.h"
-      #include "opensslv.h"
-      #include "ossl_typ.h"
-      #include "pkcs12.h"
-      #include "pkcs7.h"
-      #include "pkcs8.h"
-      #include "poly1305.h"
-      #include "rand.h"
-      #include "rc4.h"
-      #include "ripemd.h"
-      #include "safestack.h"
-      #include "srtp.h"
-      #include "x509.h"
-      #include "x509v3.h"
-    EOF
-    cat > src/include/openssl/BoringSSL.modulemap <<EOF
-      framework module openssl {
-        umbrella header "umbrella.h"
-        textual header "arm_arch.h"
-        export *
-        module * { export * }
-      }
-    EOF
 
     # To avoid symbol conflict with OpenSSL, gRPC needs to rename all the BoringSSL symbols with a
     # prefix. This is done with BoringSSL's BORINGSSL_PREFIX mechanism

--- a/src/objective-c/examples/InterceptorSample/Podfile
+++ b/src/objective-c/examples/InterceptorSample/Podfile
@@ -2,11 +2,6 @@ platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-# Default to use framework, so that providing no 'FRAMEWORK' env parameter works consistently
-# for all Samples, specifically because Swift only supports framework.
-# Only effective for examples/
-use_frameworks! if ENV['FRAMEWORKS'] != 'NO'
-
 ROOT_DIR = '../../../..'
 
 target 'InterceptorSample' do

--- a/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
@@ -24,30 +24,15 @@ Pod::Spec.new do |s|
 
   # Since we switched to importing full path, -I needs to be set to the directory
   # from which the imported file can be found, which is the grpc's root here
-  if ENV['FRAMEWORKS'] != 'NO' then
-    s.user_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'USE_FRAMEWORKS=1' }
-    s.prepare_command = <<-CMD
-    # Cannot find file if using *.proto. Maybe files' paths must match the -I flags
-      #{protoc} \
-          --plugin=protoc-gen-grpc=#{plugin} \
-          --objc_out=. \
-          --grpc_out=generate_for_named_framework=#{s.name}:. \
-          --objc_opt=generate_for_named_framework=#{s.name} \
-          -I #{repo_root} \
-          -I #{well_known_types_dir} \
-          #{repo_root}/src/objective-c/examples/RemoteTestClient/*.proto
-    CMD
-  else
-    s.prepare_command = <<-CMD
-      #{protoc} \
-          --plugin=protoc-gen-grpc=#{plugin} \
-          --objc_out=. \
-          --grpc_out=. \
-          -I #{repo_root} \
-          -I #{well_known_types_dir} \
-          #{repo_root}/src/objective-c/examples/RemoteTestClient/*.proto
-    CMD
-  end
+  s.prepare_command = <<-CMD
+    #{protoc} \
+        --plugin=protoc-gen-grpc=#{plugin} \
+        --objc_out=. \
+        --grpc_out=. \
+        -I #{repo_root} \
+        -I #{well_known_types_dir} \
+        #{repo_root}/src/objective-c/examples/RemoteTestClient/*.proto
+  CMD
 
   s.subspec 'Messages' do |ms|
     ms.source_files = 'src/objective-c/examples/RemoteTestClient/*.pbobjc.{h,m}'

--- a/src/objective-c/examples/Sample/Podfile
+++ b/src/objective-c/examples/Sample/Podfile
@@ -3,11 +3,6 @@ platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-# Default to use framework, so that providing no 'FRAMEWORK' env parameter works consistently
-# for all Samples, specifically because Swift only supports framework.
-# Only effective for examples/
-use_frameworks! if ENV['FRAMEWORKS'] != 'NO'
-
 # Location of gRPC's repo root relative to this file.
 GRPC_LOCAL_SRC = '../../../..'
 

--- a/src/objective-c/examples/SwiftSample/Podfile
+++ b/src/objective-c/examples/SwiftSample/Podfile
@@ -3,7 +3,7 @@ platform :ios, '9.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-use_frameworks!
+use_modular_headers!
 
 # Location of gRPC's repo root relative to this file.
 GRPC_LOCAL_SRC = '../../../..'

--- a/src/objective-c/examples/SwiftSample/ViewController.swift
+++ b/src/objective-c/examples/SwiftSample/ViewController.swift
@@ -19,6 +19,7 @@
 import UIKit
 
 import RemoteTest
+import RxLibrary
 
 class ViewController: UIViewController {
 

--- a/src/objective-c/examples/tvOS-sample/Podfile
+++ b/src/objective-c/examples/tvOS-sample/Podfile
@@ -2,8 +2,6 @@ platform :tvos, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 
-use_frameworks! if ENV['FRAMEWORKS'] != 'NO'
-
 ROOT_DIR = '../../../..'
 
 target 'tvOS-sample' do

--- a/src/objective-c/examples/watchOS-sample/Podfile
+++ b/src/objective-c/examples/watchOS-sample/Podfile
@@ -1,7 +1,5 @@
 install! 'cocoapods', :deterministic_uuids => false
 
-use_frameworks! if ENV['FRAMEWORKS'] != 'NO'
-
 ROOT_DIR = '../../../..'
 
 def grpc_deps

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -133,11 +133,6 @@
     # following lets users write `#include <openssl/ssl.h>`.
     s.header_dir = name
 
-    # The module map and umbrella header created automatically by Cocoapods don't work for C libraries
-    # like this one. The following file, and a correct umbrella header, are created on the fly by the
-    # `prepare_command` of this pod.
-    s.module_map = 'src/include/openssl/BoringSSL.modulemap'
-
     # We don't need to inhibit all warnings; only -Wno-shorten-64-to-32. But Cocoapods' linter doesn't
     # want that for some reason.
     s.compiler_flags = '-DOPENSSL_NO_ASM', '-GCC_WARN_INHIBIT_ALL_WARNINGS', '-w', '-DBORINGSSL_PREFIX=GRPC'
@@ -183,56 +178,6 @@
 
     s.prepare_command = <<-END_OF_COMMAND
       set -e
-      # Add a module map and an umbrella header
-      mkdir -p src/include/openssl
-      cat > src/include/openssl/umbrella.h <<EOF
-        #include "ssl.h"
-        #include "crypto.h"
-        #include "aes.h"
-        /* The following macros are defined by base.h. The latter is the first file included by the
-           other headers. */
-        #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
-        #  include "arm_arch.h"
-        #endif
-        #include "asn1.h"
-        #include "asn1_mac.h"
-        #include "asn1t.h"
-        #include "blowfish.h"
-        #include "cast.h"
-        #include "chacha.h"
-        #include "cmac.h"
-        #include "conf.h"
-        #include "cpu.h"
-        #include "curve25519.h"
-        #include "des.h"
-        #include "dtls1.h"
-        #include "hkdf.h"
-        #include "md4.h"
-        #include "md5.h"
-        #include "obj_mac.h"
-        #include "objects.h"
-        #include "opensslv.h"
-        #include "ossl_typ.h"
-        #include "pkcs12.h"
-        #include "pkcs7.h"
-        #include "pkcs8.h"
-        #include "poly1305.h"
-        #include "rand.h"
-        #include "rc4.h"
-        #include "ripemd.h"
-        #include "safestack.h"
-        #include "srtp.h"
-        #include "x509.h"
-        #include "x509v3.h"
-      EOF
-      cat > src/include/openssl/BoringSSL.modulemap <<EOF
-        framework module openssl {
-          umbrella header "umbrella.h"
-          textual header "arm_arch.h"
-          export *
-          module * { export * }
-        }
-      EOF
 
       # To avoid symbol conflict with OpenSSL, gRPC needs to rename all the BoringSSL symbols with a
       # prefix. This is done with BoringSSL's BORINGSSL_PREFIX mechanism

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -99,7 +99,7 @@ then
   # cocoapods
   export LANG=en_US.UTF-8
   # use "sudo" to avoid permission error on kokoro monterey image
-  time sudo gem install cocoapods --version 1.7.2 --no-document --user-install
+  time sudo gem install cocoapods --version 1.11.3 --no-document --user-install
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -978,7 +978,6 @@ class ObjCLanguage(object):
                 environ={
                     'SCHEME': 'Sample',
                     'EXAMPLE_PATH': 'src/objective-c/examples/Sample',
-                    'FRAMEWORKS': 'YES'
                 }))
         # TODO(jtattermusch): Create bazel target for the sample and remove the test task from here.
         out.append(

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -967,13 +967,11 @@ class ObjCLanguage(object):
 
     def test_specs(self):
         out = []
-        # Currently not supporting compiling as frameworks in Bazel
-        # TODO(jtattermusch): verify the above claim is still accurate.
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
                 timeout_seconds=20 * 60,
-                shortname='ios-buildtest-example-sample-frameworks',
+                shortname='ios-buildtest-example-sample',
                 cpu_cost=1e6,
                 environ={
                     'SCHEME': 'Sample',


### PR DESCRIPTION
Make remaining objC jobs compatible with kokoro monterey workers and prepare for boringssl upgrade.

The changes here are taken from https://github.com/grpc/grpc/pull/32357, but they should be merged in a separate PR
(we need the changes to be able to upgrade to monterey anyway and there's no reason to make the boringssl upgrade PR more complicated by bundling more fixes into it).

I've checked that the grpc_basictests_objc_examples and grpc_ios_binary_size are green if switched to monterey.
Unfortunately it's hard to make grpc_basictests_objc_examples pass on both monterey and mojave, so I suggest merging this PR at the same time as CL to upgrade the kokoro jobs to monterey.
- that way both PR and continuous runs will remain green
- older branches would need a backport anyway

