### PR TITLE
MetadataQuery: make metadata server hostname overrideable

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -150,7 +150,8 @@ void GoogleCloud2ProdResolver::StartLocked() {
   }
   // Using xDS.  Start metadata server queries.
   zone_query_ = MakeOrphanable<MetadataQuery>(
-      std::string(MetadataQuery::kZoneAttribute), &pollent_,
+      metadata_server_name_, std::string(MetadataQuery::kZoneAttribute),
+      &pollent_,
       [resolver = static_cast<RefCountedPtr<GoogleCloud2ProdResolver>>(Ref())](
           std::string /* attribute */,
           absl::StatusOr<std::string> result) mutable {
@@ -163,7 +164,8 @@ void GoogleCloud2ProdResolver::StartLocked() {
       },
       Duration::Seconds(10));
   ipv6_query_ = MakeOrphanable<MetadataQuery>(
-      std::string(MetadataQuery::kIPv6Attribute), &pollent_,
+      metadata_server_name_, std::string(MetadataQuery::kIPv6Attribute),
+      &pollent_,
       [resolver = static_cast<RefCountedPtr<GoogleCloud2ProdResolver>>(Ref())](
           std::string /* attribute */,
           absl::StatusOr<std::string> result) mutable {

--- a/src/core/ext/gcp/metadata_query.cc
+++ b/src/core/ext/gcp/metadata_query.cc
@@ -64,7 +64,7 @@ MetadataQuery::MetadataQuery(
         callback,
     Duration timeout)
     : MetadataQuery("metadata.google.internal.", std::move(attribute), pollent,
-                    std::move(callback), std::move(timeout)) {}
+                    std::move(callback), timeout) {}
 
 MetadataQuery::MetadataQuery(
     std::string metadata_server_name, std::string attribute,

--- a/src/core/ext/gcp/metadata_query.cc
+++ b/src/core/ext/gcp/metadata_query.cc
@@ -63,11 +63,21 @@ MetadataQuery::MetadataQuery(
                             absl::StatusOr<std::string> /* result */)>
         callback,
     Duration timeout)
+    : MetadataQuery("metadata.google.internal.", std::move(attribute), pollent,
+                    std::move(callback), std::move(timeout)) {}
+
+MetadataQuery::MetadataQuery(
+    std::string metadata_server_name, std::string attribute,
+    grpc_polling_entity* pollent,
+    absl::AnyInvocable<void(std::string /* attribute */,
+                            absl::StatusOr<std::string> /* result */)>
+        callback,
+    Duration timeout)
     : InternallyRefCounted<MetadataQuery>(nullptr, 2),
       attribute_(std::move(attribute)),
       callback_(std::move(callback)) {
   GRPC_CLOSURE_INIT(&on_done_, OnDone, this, nullptr);
-  auto uri = URI::Create("http", "metadata.google.internal.", attribute_,
+  auto uri = URI::Create("http", std::move(metadata_server_name), attribute_,
                          {} /* query params */, "" /* fragment */);
   GPR_ASSERT(uri.ok());  // params are hardcoded
   grpc_http_request request;

--- a/src/core/ext/gcp/metadata_query.h
+++ b/src/core/ext/gcp/metadata_query.h
@@ -51,6 +51,16 @@ class MetadataQuery : public InternallyRefCounted<MetadataQuery> {
           callback,
       Duration timeout);
 
+  // Alternative ctor allows overriding the metadata server address, mainly
+  // to inject fakes in tests
+  MetadataQuery(
+      std::string metadata_server_name, std::string attribute,
+      grpc_polling_entity* pollent,
+      absl::AnyInvocable<void(std::string /* attribute */,
+                              absl::StatusOr<std::string> /* result */)>
+          callback,
+      Duration timeout);
+
   ~MetadataQuery() override;
 
   void Orphan() override;


### PR DESCRIPTION
In https://github.com/grpc/grpc/pull/32294 , we accidentally stopped plumbing `grpc.testing.google_c2p_resolver_metadata_server_override` to the metadata server http queries. So, we stopped actually using the fake metadata servers injected in https://github.com/grpc/grpc/blob/b3d68001f7420ccb47615ed88ac79b4c0456f897/test/core/client_channel/resolvers/google_c2p_resolver_test.cc#L48.

The brings that back.

