### PR TITLE
Remove references to deprecated syntax field

### DIFF
--- a/src/python/grpcio_tests/tests/reflection/_reflection_client_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_client_test.py
@@ -69,14 +69,12 @@ class ReflectionClientTest(unittest.TestCase):
         file_desc = self.desc_pool.FindFileByName(file_name)
         self.assertEqual(file_name, file_desc.name)
         self.assertEqual(_PROTO_PACKAGE_NAME, file_desc.package)
-        self.assertEqual("proto3", file_desc.syntax)
         self.assertIn("TestService", file_desc.services_by_name)
 
         file_name = _EMPTY_PROTO_FILE_NAME
         file_desc = self.desc_pool.FindFileByName(file_name)
         self.assertEqual(file_name, file_desc.name)
         self.assertEqual(_PROTO_PACKAGE_NAME, file_desc.package)
-        self.assertEqual("proto3", file_desc.syntax)
         self.assertIn("Empty", file_desc.message_types_by_name)
 
     def testFindFileError(self):


### PR DESCRIPTION
This will be replaced by editions in an upcoming release, but for now these uses are blocking migration
