### PR TITLE
c2p resolver test: override the XDS server address, point it to a fake server that immediatley closes the connection

### DIFF
--- a/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
+++ b/test/core/client_channel/resolvers/google_c2p_resolver_test.cc
@@ -101,10 +101,19 @@ TEST(DestroyGoogleC2pChannelWithActiveConnectStressTest,
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
-  grpc_core::SetEnv("GRPC_EXPERIMENTAL_GOOGLE_C2P_RESOLVER", "true");
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
-  auto result = RUN_ALL_TESTS();
+  int result;
+  {
+    grpc_core::testing::FakeUdpAndTcpServer fake_xds_server(
+        grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
+            kWaitForClientToSendFirstBytes,
+        grpc_core::testing::FakeUdpAndTcpServer::
+            CloseSocketUponReceivingBytesFromPeer);
+    grpc_core::SetEnv("GRPC_TEST_ONLY_GOOGLE_C2P_RESOLVER_TRAFFIC_DIRECTOR_URI",
+                      fake_xds_server.address());
+    result = RUN_ALL_TESTS();
+  }
   grpc_shutdown();
   return result;
 }


### PR DESCRIPTION
Alongside https://github.com/grpc/grpc/pull/32496, this makes this test behave the same on all platforms.

FWIW, I verified this causes us to see the previous lock cycle problem in https://github.com/grpc/grpc/pull/32491 on linux - originally that lock cycle was only on mac, because of environmental differences between mac and linux in CI.

