### PR TITLE
Propose a fix for GRP_DEBUG_ASSERT failures seen in Google-internal l…

### DIFF
--- a/include/grpcpp/support/callback_common.h
+++ b/include/grpcpp/support/callback_common.h
@@ -203,11 +203,10 @@ class CallbackWithSuccessTag : public grpc_completion_queue_functor {
     void* ignored = ops_;
     // Allow a "false" return value from FinalizeResult to silence the
     // callback, just as it silences a CQ tag in the async cases
-#ifndef NDEBUG
-    auto* ops = ops_;
-#endif
+    auto* ops_tag = ops_;
+
     bool do_callback = ops_->FinalizeResult(&ignored, &ok);
-    GPR_DEBUG_ASSERT(ignored == ops);
+    GPR_DEBUG_ASSERT(ignored == ops_tag);
 
     if (do_callback) {
       CatchingCallback(func_, ok);


### PR DESCRIPTION
…ibrary

Context: A Google-internal change to the Scaffolding framework included a third party grpc header file (`grpc/include/grcpp/security/server_credentials.h`) into some google3 code, and an internal library's build started to break with the following error:
```
third_party/grpc/include/grpcpp/support/callback_common.h:210:33: error: reference to non-static member function must be called; did you mean to call it with no arguments?
    GPR_DEBUG_ASSERT(ignored == ops);
                                ^~~
third_party/grpc/include/grpc/support/log.h:103:40: note: expanded from macro 'GPR_DEBUG_ASSERT'
#define GPR_DEBUG_ASSERT(x) GPR_ASSERT(x)
                                       ^
third_party/grpc/include/grpc/support/log.h:97:24: note: expanded from macro 'GPR_ASSERT'
    if (GPR_UNLIKELY(!(x))) {                       \
                       ^
./third_party/grpc/include/grpc/support/port_platform.h:754:43: note: expanded from macro 'GPR_UNLIKELY'
#define GPR_UNLIKELY(x) __builtin_expect((x), 0)
```
It seems that when compiling, NDEBUG is defined, so the line `auto* ops = ops_;` is removed by the preprocessor. However, the GPR_DEBUG_ASSERT macro still expands to something like the following:
```
#ifndef NDEBUG
  do { ... } while (0);
#endif
```
When compiled in "non-optimized mode" with blaze (i.e. without -c opt), it seems like the contents of the loop are evaluated, so the symbol will need to be declared.

This proposed fix unblocks the original internal Scaffolding change (which had to be rolled back) and has been confirmed to fix the internal build error mentioned above.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

