### PR TITLE
[ruby]: skip grpc_class_init_test.rb

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -816,12 +816,16 @@ class RubyLanguage(object):
         # after dropping support for ruby 2.5:
         #   - src/ruby/end2end/channel_state_test.rb
         #   - src/ruby/end2end/sig_int_during_channel_watch_test.rb
+        # TODO(apolcyn): the following test is skipped because it sometimes
+        # hits "Bus Error" crashes while requiring the grpc/ruby C-extension.
+        # This crashes have been unreproducible outside of CI. Also see
+        # b/266212253.
+        #   - src/ruby/end2end/grpc_class_init_test.rb
         for test in [
                 'src/ruby/end2end/sig_handling_test.rb',
                 'src/ruby/end2end/channel_closing_test.rb',
                 'src/ruby/end2end/killed_client_thread_test.rb',
                 'src/ruby/end2end/forking_client_test.rb',
-                'src/ruby/end2end/grpc_class_init_test.rb',
                 'src/ruby/end2end/multiple_killed_watching_threads_test.rb',
                 'src/ruby/end2end/load_grpc_with_gc_stress_test.rb',
                 'src/ruby/end2end/client_memory_usage_test.rb',


### PR DESCRIPTION
This test has been occasionally failing on CI with "Bus Error" crashes while requiring the grpc shared library.

These crashes have been unreproducible locally. Let's continue debugging (b/266212253) but skip this on CI.

FTR an example crash looks like:

```
"run default: server"
start client
/home/apolcyn/grpc/src/ruby/lib/grpc/grpc_c.so: [BUG] Bus Error at 0x00007f49997bc6a0
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0010 p:-11818823242592 s:0046 e:000045 TOP    [FINISH]
c:0009 p:---- s:0043 e:000042 CFUNC  :require
c:0008 p:0101 s:0038 e:000037 TOP    /home/apolcyn/grpc/src/ruby/lib/grpc/grpc.rb:22 [FINISH]
c:0007 p:---- s:0033 e:000032 CFUNC  :require_relative
c:0006 p:0034 s:0028 e:000027 TOP    /home/apolcyn/grpc/src/ruby/lib/grpc.rb:19 [FINISH]
c:0005 p:---- s:0022 e:000021 CFUNC  :require
c:0004 p:0121 s:0017 e:000016 TOP    /home/apolcyn/grpc/src/ruby/end2end/end2end_common.rb:24 [FINISH]
c:0003 p:---- s:0011 e:000010 CFUNC  :require_relative
c:0002 p:0005 s:0006 e:000005 EVAL   /home/apolcyn/grpc/src/ruby/end2end/grpc_class_init_client.rb:20 [FINISH]
c:0001 p:0000 s:0003 E:001dd0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
/home/apolcyn/grpc/src/ruby/end2end/grpc_class_init_client.rb:20:in `<main>'
/home/apolcyn/grpc/src/ruby/end2end/grpc_class_init_client.rb:20:in `require_relative'
/home/apolcyn/grpc/src/ruby/end2end/end2end_common.rb:24:in `<top (required)>'
/home/apolcyn/grpc/src/ruby/end2end/end2end_common.rb:24:in `require'
/home/apolcyn/grpc/src/ruby/lib/grpc.rb:19:in `<top (required)>'
/home/apolcyn/grpc/src/ruby/lib/grpc.rb:19:in `require_relative'
/home/apolcyn/grpc/src/ruby/lib/grpc/grpc.rb:22:in `<top (required)>'
/home/apolcyn/grpc/src/ruby/lib/grpc/grpc.rb:22:in `require'

-- Machine register context ------------------------------------------------
 RIP: 0x00007f499da5b5d3 RBP: 0x00007ffd9a3892b0 RSP: 0x00007ffd9a388f18
 RAX: 0x00007f49997bc6a0 RBX: 0x00007ffd9a388fb0 RCX: 0x00007f49997bc6e0
 RDX: 0x0000000000000960 RDI: 0x00007f49997bc6a0 RSI: 0x0000000000000000
  R8: 0x00007f49997bc6a0  R9: 0x0000000000f36000 R10: 0x00007f49997bd000
 R11: 0x0000000000000206 R12: 0x000055fe46169340 R13: 0x0000000000000003
 R14: 0x00007ffd9a389388 R15: 0x0000000000000004 EFL: 0x0000000000010202

-- C level backtrace information -------------------------------------------
/home/apolcyn/.rvm/rubies/ruby-2.7.2/bin/../lib/libruby.so.2.7(rb_vm_bugreport+0x573) [0x7f499d90eb33] vm_dump.c:755
[0x7f499d731a1b]
/home/apolcyn/.rvm/rubies/ruby-2.7.2/bin/../lib/libruby.so.2.7(sigbus+0x4d) [0x7f499d86b47d] signal.c:932
/lib/x86_64-linux-gnu/libc.so.6(0x7f499d4ac090) [0x7f499d4ac090]
/lib64/ld-linux-x86-64.so.2(0x7f499da5b5d3) [0x7f499da5b5d3]
/lib64/ld-linux-x86-64.so.2(0x7f499da3f429) [0x7f499da3f429]
/lib64/ld-linux-x86-64.so.2(0x7f499da4261b) [0x7f499da4261b]
/lib64/ld-linux-x86-64.so.2(0x7f499da4dd47) [0x7f499da4dd47]
/lib/x86_64-linux-gnu/libc.so.6(_dl_catch_exception+0x88) [0x7f499d5c9928]
/lib64/ld-linux-x86-64.so.2(0x7f499da4d60a) [0x7f499da4d60a]
/lib/x86_64-linux-gnu/libdl.so.2(0x7f499d39534c) [0x7f499d39534c]
/lib/x86_64-linux-gnu/libc.so.6(_dl_catch_exception+0x88) [0x7f499d5c9928]
/lib/x86_64-linux-gnu/libc.so.6(_dl_catch_error+0x33) [0x7f499d5c99f3]
/lib/x86_64-linux-gnu/libdl.so.2(0x7f499d395b59) [0x7f499d395b59]
/lib/x86_64-linux-gnu/libdl.so.2(dlopen+0x4a) [0x7f499d3953da]
/home/apolcyn/.rvm/rubies/ruby-2.7.2/bin/../lib/libruby.so.2.7(dln_load+0xf5) [0x7f499d699755] dln.c:1341
/home/apolcyn/.rvm/rubies/ruby-2.7.2/bin/../lib/libruby.so.2.7(rb_vm_call_cfunc+0xb2) [0x7f499d8f2332] vm.c:2225
[0x7f499d793464]
/home/apolcyn/.rvm/rubies/ruby-2.7.2/bin/../lib/libruby.so.2.7(rb_require_string+0x27) [0x7f499d794257] load.c:1104
[0x7f499d8e6900]
[0x7f499d8fc15b]
[0x7f499d8f434b]
[0x7f499d8fa4d4]
[0x7f499d793b51]
/home/apolcyn/.rvm/rubies/ruby-2.7.2/bin/../lib/libruby.so.2.7(rb_require_string+0x27) [0x7f499d794257] load.c:1104
:
```

or

```
start client
"run default"
start client
"run gc stress"
start client
"run concurrency stress"
/var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:57:in `run_concurrency_stress_test': (expected) exception thrown while child thread initing class (RuntimeError)
	from /var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:146:in `main'
	from /var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:155:in `<main>'
start client
"run default"
start client
/var/local/git/grpc/src/ruby/lib/grpc/grpc_c.so: [BUG] Bus Error at 0x00007fe1044cd500
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0012 p:-11741830283234 s:0078 e:000077 TOP    [FINISH]
c:0011 p:---- s:0075 e:000074 CFUNC  :require
c:0010 p:0111 s:0070 e:000069 METHOD /usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72
c:0009 p:0101 s:0054 e:000053 TOP    /var/local/git/grpc/src/ruby/lib/grpc/grpc.rb:22 [FINISH]
c:0008 p:---- s:0049 e:000048 CFUNC  :require_relative
c:0007 p:0034 s:0044 e:000043 TOP    /var/local/git/grpc/src/ruby/lib/grpc.rb:19 [FINISH]
c:0006 p:---- s:0038 e:000037 CFUNC  :require
c:0005 p:0111 s:0033 e:000032 METHOD /usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72
c:0004 p:0121 s:0017 e:000016 TOP    /var/local/git/grpc/src/ruby/end2end/end2end_common.rb:24 [FINISH]
c:0003 p:---- s:0011 e:000010 CFUNC  :require_relative
c:0002 p:0005 s:0006 e:000005 EVAL   /var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:20 [FINISH]
c:0001 p:0000 s:0003 E:001340 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
/var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:20:in `<main>'
/var/local/git/grpc/src/ruby/end2end/grpc_class_init_client.rb:20:in `require_relative'
/var/local/git/grpc/src/ruby/end2end/end2end_common.rb:24:in `<top (required)>'
/usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
/usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
/var/local/git/grpc/src/ruby/lib/grpc.rb:19:in `<top (required)>'
/var/local/git/grpc/src/ruby/lib/grpc.rb:19:in `require_relative'
/var/local/git/grpc/src/ruby/lib/grpc/grpc.rb:22:in `<top (required)>'
/usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
/usr/local/rvm/rubies/ruby-2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:72:in `require'
```

