### PR TITLE
[fork] Log when pthread_create fails

### DIFF
--- a/src/core/lib/gprpp/posix/thd.cc
+++ b/src/core/lib/gprpp/posix/thd.cc
@@ -19,10 +19,8 @@
 // Posix implementation for gpr threads.
 
 #include <grpc/support/port_platform.h>
-
-#include <string.h>
-
 #include <grpc/support/time.h>
+#include <string>
 
 #ifdef GPR_POSIX_SYNC
 
@@ -30,7 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/thd_id.h>

--- a/src/core/lib/gprpp/posix/thd.cc
+++ b/src/core/lib/gprpp/posix/thd.cc
@@ -106,49 +106,52 @@ class ThreadInternalsPosix : public internal::ThreadInternalsInterface {
       GPR_ASSERT(pthread_attr_setstacksize(&attr, stack_size) == 0);
     }
 
-    *success = (pthread_create(
-                    &pthread_id_, &attr,
-                    [](void* v) -> void* {
-                      thd_arg arg = *static_cast<thd_arg*>(v);
-                      free(v);
-                      if (arg.name != nullptr) {
+    int pthread_create_err = pthread_create(
+        &pthread_id_, &attr,
+        [](void* v) -> void* {
+          thd_arg arg = *static_cast<thd_arg*>(v);
+          free(v);
+          if (arg.name != nullptr) {
 #if GPR_APPLE_PTHREAD_NAME
-                        // Apple supports 64 characters, and will
-                        // truncate if it's longer.
-                        pthread_setname_np(arg.name);
+            // Apple supports 64 characters, and will
+            // truncate if it's longer.
+            pthread_setname_np(arg.name);
 #elif GPR_LINUX_PTHREAD_NAME
-                        // Linux supports 16 characters max, and will
-                        // error if it's longer.
-                        char buf[16];
-                        size_t buf_len = GPR_ARRAY_SIZE(buf) - 1;
-                        strncpy(buf, arg.name, buf_len);
-                        buf[buf_len] = '\0';
-                        pthread_setname_np(pthread_self(), buf);
+            // Linux supports 16 characters max, and will
+            // error if it's longer.
+            char buf[16];
+            size_t buf_len = GPR_ARRAY_SIZE(buf) - 1;
+            strncpy(buf, arg.name, buf_len);
+            buf[buf_len] = '\0';
+            pthread_setname_np(pthread_self(), buf);
 #endif  // GPR_APPLE_PTHREAD_NAME
-                      }
+          }
 
-                      gpr_mu_lock(&arg.thread->mu_);
-                      while (!arg.thread->started_) {
-                        gpr_cv_wait(&arg.thread->ready_, &arg.thread->mu_,
-                                    gpr_inf_future(GPR_CLOCK_MONOTONIC));
-                      }
-                      gpr_mu_unlock(&arg.thread->mu_);
+          gpr_mu_lock(&arg.thread->mu_);
+          while (!arg.thread->started_) {
+            gpr_cv_wait(&arg.thread->ready_, &arg.thread->mu_,
+                        gpr_inf_future(GPR_CLOCK_MONOTONIC));
+          }
+          gpr_mu_unlock(&arg.thread->mu_);
 
-                      if (!arg.joinable) {
-                        delete arg.thread;
-                      }
+          if (!arg.joinable) {
+            delete arg.thread;
+          }
 
-                      (*arg.body)(arg.arg);
-                      if (arg.tracked) {
-                        Fork::DecThreadCount();
-                      }
-                      return nullptr;
-                    },
-                    info) == 0);
+          (*arg.body)(arg.arg);
+          if (arg.tracked) {
+            Fork::DecThreadCount();
+          }
+          return nullptr;
+        },
+        info);
+    *success = (pthread_create_err == 0);
 
     GPR_ASSERT(pthread_attr_destroy(&attr) == 0);
 
     if (!(*success)) {
+      gpr_log(GPR_ERROR, "pthread_create failed: %s",
+              strerror(pthread_create_err));
       // don't use gpr_free, as this was allocated using malloc (see above)
       free(info);
       if (options.tracked()) {

--- a/src/core/lib/gprpp/posix/thd.cc
+++ b/src/core/lib/gprpp/posix/thd.cc
@@ -20,6 +20,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <string.h>
+
 #include <grpc/support/time.h>
 
 #ifdef GPR_POSIX_SYNC

--- a/src/core/lib/gprpp/posix/thd.cc
+++ b/src/core/lib/gprpp/posix/thd.cc
@@ -19,8 +19,10 @@
 // Posix implementation for gpr threads.
 
 #include <grpc/support/port_platform.h>
-#include <grpc/support/time.h>
+
 #include <string>
+
+#include <grpc/support/time.h>
 
 #ifdef GPR_POSIX_SYNC
 
@@ -28,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/thd_id.h>

--- a/src/core/lib/gprpp/posix/thd.cc
+++ b/src/core/lib/gprpp/posix/thd.cc
@@ -35,6 +35,7 @@
 
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/fork.h"
+#include "src/core/lib/gprpp/strerror.h"
 #include "src/core/lib/gprpp/thd.h"
 
 namespace grpc_core {
@@ -151,7 +152,7 @@ class ThreadInternalsPosix : public internal::ThreadInternalsInterface {
 
     if (!(*success)) {
       gpr_log(GPR_ERROR, "pthread_create failed: %s",
-              strerror(pthread_create_err));
+              StrError(pthread_create_err).c_str());
       // don't use gpr_free, as this was allocated using malloc (see above)
       free(info);
       if (options.tracked()) {


### PR DESCRIPTION
There was evidence that a `pthread_create` failed in [this comment](https://github.com/grpc/grpc/issues/31885#issuecomment-1433917201), but without logging, we couldn't diagnose any further. This PR logs in this case.