### PR TITLE
Fix DeprecationWarning when calling asyncio.get_event_loop()

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -181,7 +181,7 @@ if PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
         try:
             return asyncio.get_running_loop()
         except RuntimeError:
-            return asyncio.get_event_loop()
+            return asyncio.get_event_loop_policy().get_event_loop()
 else:
     def get_working_loop():
         """Returns a running event loop."""


### PR DESCRIPTION
Fix: https://github.com/grpc/grpc/issues/32526#event-8652983465

### Context:
Calling `asyncio.get_event_loop()` [without an running loop will emitted a DeprecationWarning](https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop), in this case, we should call `asyncio.get_event_loop_policy().get_event_loop()` to get the loop.