### PR TITLE
[codehealth] Prevent the labeler workflow from removing labels

### DIFF
--- a/.github/workflows/pr-auto-tag.yaml
+++ b/.github/workflows/pr-auto-tag.yaml
@@ -16,4 +16,5 @@ jobs:
     - uses: actions/labeler@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: ""
 


### PR DESCRIPTION
It seems as if we ran into this bug https://github.com/actions/labeler/issues/442 on at least one PR https://github.com/grpc/grpc/pull/32515. This PR utilizes the suggested workaround until we can upgrade to a new major version release of actions/labeler.