### PR TITLE
Fixed memory leak in Alarm's move assignment

### DIFF
--- a/include/grpcpp/alarm.h
+++ b/include/grpcpp/alarm.h
@@ -72,8 +72,7 @@ class Alarm : private grpc::internal::GrpcLibrary {
   /// Alarms are movable.
   Alarm(Alarm&& rhs) noexcept : alarm_(rhs.alarm_) { rhs.alarm_ = nullptr; }
   Alarm& operator=(Alarm&& rhs) noexcept {
-    alarm_ = rhs.alarm_;
-    rhs.alarm_ = nullptr;
+    std::swap(alarm_, rhs.alarm_);
     return *this;
   }
 


### PR DESCRIPTION
Running the following example:

```
#include <grpcpp/alarm.h>
#include <grpcpp/grpcpp.h>
#include <vector>

int main() {
  grpc::CompletionQueue cq;
  std::vector<grpc::Alarm> alarms;
  alarms.resize(10);
  for (auto& alarm : alarms) {
    alarm = grpc::Alarm();
  }

  cq.Shutdown();
  void* tag;
  bool ok;
  while (cq.Next(&tag, &ok))
    ;
}
```

Gives the following output with address sanitizer on:
```
==2748==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2400 byte(s) in 10 object(s) allocated from:
    #0 0x7fa9d136333d in operator new(unsigned long) (/mnt/c/Users/Julien/Documents/source/repos/async_sandbox/out/build/linux-debug/async_grpc/server/server+0x17733d) (BuildId: 83ea7e985cde98d58613ccb1501821d9f67b5664)
    #1 0x7fa9d1442621 in grpc::Alarm::Alarm() /mnt/c/Users/Julien/Documents/source/repos/async_sandbox/out/build/linux-debug/_deps/grpc-src/src/cpp/common/alarm.cc:135:25
    #2 0x7fa9d1368414 in void std::_Construct<grpc::Alarm>(grpc::Alarm*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:119:38
    #3 0x7fa9d136835b in grpc::Alarm* std::__uninitialized_default_n_1<false>::__uninit_default_n<grpc::Alarm*, unsigned long>(grpc::Alarm*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:579:3
    #4 0x7fa9d1368320 in grpc::Alarm* std::__uninitialized_default_n<grpc::Alarm*, unsigned long>(grpc::Alarm*, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:638:14
    #5 0x7fa9d1367c90 in grpc::Alarm* std::__uninitialized_default_n_a<grpc::Alarm*, unsigned long, grpc::Alarm>(grpc::Alarm*, unsigned long, std::allocator<grpc::Alarm>&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:704:14
    #6 0x7fa9d1367887 in std::vector<grpc::Alarm, std::allocator<grpc::Alarm>>::_M_default_append(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/vector.tcc:640:9
    #7 0x7fa9d1366105 in std::vector<grpc::Alarm, std::allocator<grpc::Alarm>>::resize(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:940:4
    #8 0x7fa9d1365ab4 in main /mnt/c/Users/Julien/Documents/source/repos/async_sandbox/async_grpc/server/main.cpp:8:10
    #9 0x7fa9d0c39d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
```

This was cased by the `alarm_` pointer being lost during move assignment. This fix swaps the pointer with rhs so that it gets properly destroyed with rhs.