### PR TITLE
[EventEngine] Skip pathological iomgr test on Windows experiments

### DIFF
--- a/test/core/iomgr/endpoint_pair_test.cc
+++ b/test/core/iomgr/endpoint_pair_test.cc
@@ -142,6 +142,12 @@ static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
 }
 
 TEST(EndpointPairTest, MainTest) {
+#ifdef GPR_WINDOWS
+  if (grpc_event_engine::experimental::UseEventEngineClient()) {
+    gpr_log(GPR_INFO, "Skipping pathological EventEngine test on Windows");
+    return;
+  }
+#endif
   grpc_closure destroyed;
   grpc_init();
   {


### PR DESCRIPTION
With iomgr, this test is effectively rate limited by ExecCtx and the single thread running pollset_work, which results in thousands of tiny writes happening before every read. A small set of _synchronous_ 8k reads then dominate the read-side of the test. This is an efficient balance.

With the Windows EventEngine, the fully asynchronous, multi-threaded reads and writes end up alternating roughly 1:1, meaning that a read callback is executed for every tiny handful of bytes, tens of thousands of times. Compared to the Posix EventEngine, without things like TCP_INQ and/or recvmsg's timeout, I don't know of any great signal for how much data can safely be received in a batch (e.g., we don't want to wait for data that will never come, and we don't want to run callbacks for 2 bytes over and over again if we have KB in the pipe).

I believe the Windows EventEngine is WAI. I can significantly improve this test performance by artificially slowing the reader down (adding a >= 1ms sleep), but I believe that improves this use case to the detriment of all others.