### PR TITLE
[EventEngine] Fix PosixEventEngine IPv4 support

### DIFF
--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
@@ -149,6 +149,10 @@ void UnlinkIfUnixDomainSocket(
 
 class PosixSocketWrapper {
  public:
+  // Tries to set the socket to dualstack. Returns true on success.
+  // This is typically checked before creating a PosixSocketWrapper
+  static bool SetSocketDualStack(int fd);
+
   explicit PosixSocketWrapper(int fd) : fd_(fd) { GPR_ASSERT(fd_ > 0); }
 
   PosixSocketWrapper() : fd_(-1){};
@@ -237,9 +241,6 @@ class PosixSocketWrapper {
     // AF_INET6, which also supports ::ffff-mapped IPv4 addresses.
     DSMODE_DUALSTACK
   };
-
-  // Tries to set the socket to dualstack. Returns true on success.
-  bool SetSocketDualStack();
 
   // Returns the underlying file-descriptor.
   int Fd() const { return fd_; }


### PR DESCRIPTION
Connections cannot be made in IPv4-only environments. To test, hard-code `IsIpv6LoopbackAvailable` to return false.

Example Error:
`
D0309 00:29:49.514359445     235 tcp_client.cc:67]  (event_engine) EventEngine::Connect Status: INTERNAL: socket: Address family not supported by protocol
`

This can also be reproduced in gRPC's benchmark environment, which does not have IPv6 enabled.