### PR TITLE
Observability Testing: Pass interop parameters to each lang's run.sh script as-is

### DIFF
--- a/tools/dockerfile/observability-test/cpp/run.sh
+++ b/tools/dockerfile/observability-test/cpp/run.sh
@@ -16,28 +16,16 @@
 set -ex
 cd "$(dirname "$0")"/../..
 
-# TODO(stanleycheung): replace positional parameters with explicit parameters
-#
-#             $1: server | client
-#
-# For server: $2: server_port
-#
-# For client: $2: server_host
-#             $3: server_port
-#             $4: test_case
-#             $5: num_times
-
 if [ "$1" = "server" ] ; then
   /grpc/bazel-bin/test/cpp/interop/observability_interop_server \
-    --enable_observability=true --port $2
+    --enable_observability=true "${@:2}"
 
 elif [ "$1" = "client" ] ; then
   /grpc/bazel-bin/test/cpp/interop/observability_interop_client \
-    --enable_observability=true \
-    --server_host=$2 --server_port=$3 \
-    --test_case=$4 --num_times=$5
+    --enable_observability=true "${@:2}"
 
 else
-  echo "Invalid action: $1"
+  echo "Invalid action: $1. Usage:"
+  echo "  $ .../run.sh [server|client] --server_host=<hostname> --server_port=<port> ..."
   exit 1
 fi


### PR DESCRIPTION
Each `run.sh` should just pass those parameters through to the interop client/server binaries as-is.

Corresponding framework PR: https://github.com/GoogleCloudPlatform/grpc-gcp-tools/pull/28