### PR TITLE
Simplify tools/buildgen/extract_metadata_from_bazel_xml.py to prepare for protobuf upgrade.

### DIFF
--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -1086,7 +1086,6 @@ _BAZEL_DEPS_QUERIES = [
     'deps("//test/...")',
     'deps("//:all")',
     'deps("//src/compiler/...")',
-    'deps("//src/proto/...")',
     # The ^ is needed to differentiate proto_library from go_proto_library
     'deps(kind("^proto_library", @envoy_api//envoy/...))',
 ]


### PR DESCRIPTION
`bazel query deps(//src/proto/...)` seems unnecessary (regenerated projects are identical) and causes trouble with protobuf 22.x (since it basically breaks `tools/buildgen/generate_projects.sh` run and that makes upgrade experiments painful).

