### PR TITLE
[testing] make error check in log_too_many_open_files_test portable

### DIFF
--- a/test/core/event_engine/posix/log_too_many_open_files_test.cc
+++ b/test/core/event_engine/posix/log_too_many_open_files_test.cc
@@ -22,6 +22,7 @@
 
 #include "src/core/lib/event_engine/posix_engine/tcp_socket_utils.h"
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
+#include "src/core/lib/gprpp/strerror.h"
 #include "test/core/util/test_config.h"
 
 using ::grpc_event_engine::experimental::PosixSocketWrapper;
@@ -42,8 +43,8 @@ TEST(LogTooManyOpenFilesTest, MainTest) {
       PosixSocketWrapper::CreateDualStackSocket(mock_socket_factory, *addr,
                                                 SOCK_STREAM, AF_INET, dsmode);
   EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(),
-              ::testing::HasSubstr("Too many open files"));
+  std::string emfile_message = grpc_core::StrError(EMFILE);
+  EXPECT_THAT(result.status().message(), ::testing::HasSubstr(emfile_message));
 }
 
 int main(int argc, char** argv) {

--- a/test/core/event_engine/posix/log_too_many_open_files_test.cc
+++ b/test/core/event_engine/posix/log_too_many_open_files_test.cc
@@ -14,12 +14,14 @@
 
 #include <errno.h>
 #include <sys/socket.h>
+
 #include <string>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
 #include "src/core/lib/event_engine/posix_engine/tcp_socket_utils.h"
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
 #include "src/core/lib/gprpp/strerror.h"

--- a/test/core/event_engine/posix/log_too_many_open_files_test.cc
+++ b/test/core/event_engine/posix/log_too_many_open_files_test.cc
@@ -14,12 +14,12 @@
 
 #include <errno.h>
 #include <sys/socket.h>
+#include <string>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
 #include "src/core/lib/event_engine/posix_engine/tcp_socket_utils.h"
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
 #include "src/core/lib/gprpp/strerror.h"


### PR DESCRIPTION
The error message for EMFILE is different on Musl, so this test is currently broken portability tests on Musl: https://source.cloud.google.com/results/invocations/d742bd83-bd28-49a3-b64a-442d0667231e/targets/github%2Fgrpc%2Frun_tests%2Fcpp_linux_dbg_native_x64_gcc_musl/tests 

