### PR TITLE
[Ruby] rubify type names start with lower case or non-alpha characters

### DIFF
--- a/src/compiler/ruby_generator_string-inl.h
+++ b/src/compiler/ruby_generator_string-inl.h
@@ -30,6 +30,8 @@ using std::transform;
 
 namespace grpc_ruby_generator {
 
+std::string RubifyConstant(const std::string& name);
+
 // Split splits a string using char into elems.
 inline std::vector<std::string>& Split(const std::string& s, char delim,
                                        std::vector<std::string>* elems) {
@@ -137,7 +139,7 @@ inline std::string RubyTypeOf(const grpc::protobuf::Descriptor* descriptor) {
       if (i < prefixes_and_type.size() - 1) {
         res += Modularize(prefixes_and_type[i]);  // capitalize pkgs
       } else {
-        res += prefixes_and_type[i];
+        res += RubifyConstant(prefixes_and_type[i]);
       }
     }
     return res;


### PR DESCRIPTION
Copy `RubifyConstant` from [protobuf's ruby_generator.cc](
https://github.com/protocolbuffers/protobuf/blob/63895855d7b1298bee97591cbafced49f23902da/src/google/protobuf/compiler/ruby/ruby_generator.cc#L312)
and apply it to ruby type string.


Fixes [#3155](https://github.com/grpc/grpc/issues/31551)
`ruby -I. -e "require 'test_services_pb'"` succeeded with this PR.