### PR TITLE
[time] Fix startup stall in Linux, using the same approach as #31844.

### DIFF
--- a/src/core/lib/gpr/posix/time.cc
+++ b/src/core/lib/gpr/posix/time.cc
@@ -80,6 +80,11 @@ static gpr_timespec now_impl(gpr_clock_type clock_type) {
 #else
     clock_gettime(clockid_for_gpr_clock[clock_type], &now);
 #endif
+    if (clock_type == GPR_CLOCK_MONOTONIC) {
+      // Add 5 seconds arbitrarily: avoids weird conditions in gprpp/time.cc
+      // when there's a small number of seconds returned.
+      now.tv_sec += 5;
+    }
     return gpr_from_timespec(now, clock_type);
   }
 }


### PR DESCRIPTION
With this change, gpr_now(GPR_CLOCK_MONOTONIC) adds 5 seconds of padding to the returned timestamp on Linux as well as iOS. This makes gRPC start quickly on recently started machines (e.g. freshly booted micro-VMs).




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

