### PR TITLE
HttpFilters: Disable disabling of compression filters

### DIFF
--- a/src/core/ext/filters/http/http_filters_plugin.cc
+++ b/src/core/ext/filters/http/http_filters_plugin.cc
@@ -20,14 +20,9 @@
 
 #include <string.h>
 
-#include "absl/types/optional.h"
-
-#include <grpc/grpc.h>
-
 #include "src/core/ext/filters/http/client/http_client_filter.h"
 #include "src/core/ext/filters/http/message_compress/compression_filter.h"
 #include "src/core/ext/filters/http/server/http_server_filter.h"
-#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/channel/channel_stack_builder.h"
 #include "src/core/lib/config/core_configuration.h"
@@ -50,13 +45,7 @@ void RegisterHttpFilters(CoreConfiguration::Builder* builder) {
         channel_type, GRPC_CHANNEL_INIT_BUILTIN_PRIORITY,
         [filter](ChannelStackBuilder* builder) {
           if (!is_building_http_like_transport(builder)) return true;
-          auto args = builder->channel_args();
-          const bool enable =
-              args.GetBool(GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION)
-                  .value_or(true) ||
-              args.GetBool(GRPC_ARG_ENABLE_PER_MESSAGE_COMPRESSION)
-                  .value_or(true);
-          if (enable) builder->PrependFilter(filter);
+          builder->PrependFilter(filter);
           return true;
         });
   };


### PR DESCRIPTION
Note that there is no behavior change associated with this PR. In other words, folks that use `GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION` and `GRPC_ARG_ENABLE_PER_MESSAGE_COMPRESSION` will still see the same behavior as before.

The actual change - The compression filter will always be added to the filter stack for HTTP transports even if it is a no-op due to the above channel args.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

