### PR TITLE
Backport 1.53: Update minimum MSVC version to 2019

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,7 +55,7 @@ installed by `brew` is being used:
 ## Windows
 
 To prepare for cmake + Microsoft Visual C++ compiler build
-- Install Visual Studio 2017 or later (Visual C++ compiler will be used).
+- Install Visual Studio 2019 or later (Visual C++ compiler will be used).
 - Install [Git](https://git-scm.com/).
 - Install [CMake](https://cmake.org/download/).
 - Install [nasm](https://www.nasm.us/) and add it to `PATH` (`choco install nasm`) - *required by boringssl*
@@ -129,7 +129,7 @@ $ make
 
 If you want to build shared libraries (`.so` files), run `cmake` with `-DBUILD_SHARED_LIBS=ON`.
 
-### Windows, Using Visual Studio 2015 or 2017
+### Windows, Using Visual Studio 2019 or later
 
 When using the "Visual Studio" generator,
 cmake will generate a solution (`grpc.sln`) that contains a VS project for
@@ -140,7 +140,7 @@ you will be able to browse and build the code.
 > @rem Run from grpc directory after cloning the repo with --recursive or updating submodules.
 > md .build
 > cd .build
-> cmake .. -G "Visual Studio 14 2015"
+> cmake .. -G "Visual Studio 16 2019"
 > cmake --build . --config Release
 ```
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -31,7 +31,7 @@ Therefore, gRPC supports several major build systems, which should satisfy most 
 | Operating System | Architectures | Versions | Support Level |
 |------------------|---------------|----------|---------------|
 | Linux - Debian, Ubuntu, CentOS | x86, x64      | clang 6+, GCC 7.3+     | Officially Supported |
-| Windows 10+                    | x86, x64      | Visual Studio 2017+    | Officially Supported |
+| Windows 10+                    | x86, x64      | Visual Studio 2019+    | Officially Supported |
 | MacOS                          | x86, x64      | XCode 12+              | Officially Supported |
 | Linux - Others                 | x86, x64      | clang 6+, GCC 7.3+     | Best Effort          |
 | Linux                          | ARM           |                        | Best Effort          |


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc/pull/32614