### PR TITLE
PSM Interop: add orca proto to the new test driver dependencies

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -267,6 +267,7 @@ test_driver_pip_install() {
 test_driver_compile_protos() {
   declare -a protos
   protos=(
+    "${TEST_DRIVER_PROTOS_PATH}/xds/v3/orca_load_report.proto"
     "${TEST_DRIVER_PROTOS_PATH}/test.proto"
     "${TEST_DRIVER_PROTOS_PATH}/messages.proto"
     "${TEST_DRIVER_PROTOS_PATH}/empty.proto"

--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -185,6 +185,7 @@ pip install -r requirements.lock
 # Generate protos
 python -m grpc_tools.protoc --proto_path=../../../ \
     --python_out=. --grpc_python_out=. \
+    src/proto/grpc/testing/xds/v3/orca_load_report.proto \
     src/proto/grpc/testing/empty.proto \
     src/proto/grpc/testing/messages.proto \
     src/proto/grpc/testing/test.proto


### PR DESCRIPTION
Now `messages.proto` requires `xds/v3/orca_load_report.proto`.
The dependency introduced in https://github.com/grpc/grpc/pull/32524.

ref b/273575071
