### PR TITLE
Fix race conditions with windows endpoint shutdown.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -247,21 +247,7 @@ typedef enum {
   GRPC_CHTTP2_KEEPALIVE_STATE_DISABLED,
 } grpc_chttp2_keepalive_state;
 
-struct grpc_chttp2_transport
-// TODO(ctiller): #31319 fixed a crash on Linux & Mac whereby iomgr was
-// accessed after shutdown by chttp2. We've not seen similar behavior on
-// Windows afaik, but this fix has exposed another refcounting bug whereby
-// transports leak on Windows and prevent test shutdown.
-// This hack attempts to compromise between two things that are blocking our CI
-// from giving us a good quality signal, but are unlikely to be problems for
-// most customers. We should continue tracking down what's causing the failure,
-// but this gives us some runway to do so - and given that we're actively
-// working on removing the problematic code paths, it may be that effort brings
-// the result we need.
-#ifndef GPR_WINDOWS
-    : public grpc_core::KeepsGrpcInitialized
-#endif
-{
+struct grpc_chttp2_transport: public grpc_core::KeepsGrpcInitialized {
   grpc_chttp2_transport(const grpc_core::ChannelArgs& channel_args,
                         grpc_endpoint* ep, bool is_client);
   ~grpc_chttp2_transport();

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -247,7 +247,7 @@ typedef enum {
   GRPC_CHTTP2_KEEPALIVE_STATE_DISABLED,
 } grpc_chttp2_keepalive_state;
 
-struct grpc_chttp2_transport: public grpc_core::KeepsGrpcInitialized {
+struct grpc_chttp2_transport : public grpc_core::KeepsGrpcInitialized {
   grpc_chttp2_transport(const grpc_core::ChannelArgs& channel_args,
                         grpc_endpoint* ep, bool is_client);
   ~grpc_chttp2_transport();

--- a/src/core/lib/iomgr/iocp_windows.cc
+++ b/src/core/lib/iomgr/iocp_windows.cc
@@ -43,6 +43,7 @@ static ULONG g_iocp_kick_token;
 static OVERLAPPED g_iocp_custom_overlap;
 
 static gpr_atm g_custom_events = 0;
+static gpr_atm g_pending_socket_shutdowns = 0;
 
 static HANDLE g_iocp;
 
@@ -90,6 +91,7 @@ grpc_iocp_work_status grpc_iocp_work(grpc_core::Timestamp deadline) {
   } else {
     abort();
   }
+  gpr_mu_lock(&socket->state_mu);
   if (socket->shutdown_called) {
     info->bytes_transferred = 0;
     info->wsa_error = WSA_OPERATION_ABORTED;
@@ -100,7 +102,11 @@ grpc_iocp_work_status grpc_iocp_work(grpc_core::Timestamp deadline) {
     info->wsa_error = success ? 0 : WSAGetLastError();
   }
   GPR_ASSERT(overlapped == &info->overlapped);
-  grpc_socket_become_ready(socket, info);
+  bool should_destroy = grpc_socket_become_ready(socket, info);
+  gpr_mu_unlock(&socket->state_mu);
+  if (should_destroy) {
+    grpc_winsocket_finish(socket);
+  }
   return GRPC_IOCP_WORK_WORK;
 }
 
@@ -122,11 +128,13 @@ void grpc_iocp_kick(void) {
 void grpc_iocp_flush(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_iocp_work_status work_status;
-
+  // This method is called during grpc_shutdown. We make the loop
+  // spin until any pending socket shutdowns are complete.
   do {
     work_status = grpc_iocp_work(grpc_core::Timestamp::InfPast());
   } while (work_status == GRPC_IOCP_WORK_KICK ||
-           grpc_core::ExecCtx::Get()->Flush());
+           grpc_core::ExecCtx::Get()->Flush() ||
+           gpr_atm_acq_load(&g_pending_socket_shutdowns) != 0);
 }
 
 void grpc_iocp_shutdown(void) {
@@ -153,6 +161,22 @@ void grpc_iocp_add_socket(grpc_winsocket* socket) {
   }
   socket->added_to_iocp = 1;
   GPR_ASSERT(ret == g_iocp);
+}
+
+void grpc_iocp_register_socket_shutdown(grpc_winsocket* socket) {
+  if (!socket->shutdown_registered) {
+    socket->shutdown_registered = true;
+    // Register beginning of this socket shutdown. This implies that gRPC
+    // will not complete its shutdown until this socket's shutdown is finished.
+    gpr_atm_full_fetch_add(&g_pending_socket_shutdowns, 1);
+  }
+}
+
+void grpc_iocp_finish_socket_shutdown(grpc_winsocket* socket) {
+  if (socket->shutdown_registered) {
+    // Mark the completion of this socket shutdown.
+    gpr_atm_full_fetch_add(&g_pending_socket_shutdowns, -1);
+  }
 }
 
 #endif  // GRPC_WINSOCK_SOCKET

--- a/src/core/lib/iomgr/iocp_windows.h
+++ b/src/core/lib/iomgr/iocp_windows.h
@@ -42,6 +42,8 @@ void grpc_iocp_kick(void);
 void grpc_iocp_flush(void);
 void grpc_iocp_shutdown(void);
 void grpc_iocp_add_socket(grpc_winsocket*);
+void grpc_iocp_register_socket_shutdown(grpc_winsocket*);
+void grpc_iocp_finish_socket_shutdown(grpc_winsocket*);
 
 #endif
 

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -76,6 +76,49 @@ void grpc_winsocket_shutdown(grpc_winsocket* winsocket) {
     return;
   }
   winsocket->shutdown_called = true;
+  bool register_shutdown = false;
+  // If there is already a scheduled read closure, run it immediately. This
+  // follows the same semantics applied to posix endpoint which also runs any
+  // already registered closure immediately in the event of a shutdown.
+  if (winsocket->read_info.closure && !winsocket->read_info.has_pending_iocp) {
+    winsocket->read_info.bytes_transferred = 0;
+    winsocket->read_info.wsa_error = WSA_OPERATION_ABORTED;
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, winsocket->read_info.closure,
+                            absl::OkStatus());
+    // Note that while the read_info.closure closure is run, it is not set to
+    // NULL here. This ensures that the socket cannot get deleted yet until any
+    // pending I/O operations are flushed by the thread executing
+    // grpc_iocp_work. We set read_info.skip to true so that when the pending
+    // read I/O operations are flushed, the associated closure is not executed
+    // in the grpc_socket_became_ready function.
+    winsocket->read_info.skip = true;
+    register_shutdown = true;
+  }
+
+  // If there is already a scheduled write closure, run it immediately. This
+  // follows the same semantics applied to posix endpoint which also runs any
+  // already registered closure immediately in the event of a shutdown.
+  if (winsocket->write_info.closure &&
+      !winsocket->write_info.has_pending_iocp) {
+    winsocket->write_info.bytes_transferred = 0;
+    winsocket->write_info.wsa_error = WSA_OPERATION_ABORTED;
+    grpc_core::ExecCtx::Run(DEBUG_LOCATION, winsocket->write_info.closure,
+                            absl::OkStatus());
+    // Note that while the write_info.closure closure is run, it is not set to
+    // NULL here. This ensures that the socket cannot get deleted yet until any
+    // pending I/O operations are flushed by the thread executing
+    // grpc_iocp_work. We set write_info.closure.skip to true so that when the
+    // pending write I/O operations are flushed, the associated closure is not
+    // executed in the grpc_socket_became_ready function.
+    winsocket->write_info.skip = true;
+    register_shutdown = true;
+  }
+
+  if (register_shutdown) {
+    // Instruct gRPC to avoid completing any shutdowns until this socket is
+    // cleaned up.
+    grpc_iocp_register_socket_shutdown(winsocket);
+  }
   gpr_mu_unlock(&winsocket->state_mu);
 
   status = WSAIoctl(winsocket->socket, SIO_GET_EXTENSION_FUNCTION_POINTER,
@@ -90,7 +133,14 @@ void grpc_winsocket_shutdown(grpc_winsocket* winsocket) {
             utf8_message);
     gpr_free(utf8_message);
   }
-  closesocket(winsocket->socket);
+  int ret = 0;
+  // Calling closesocket triggers invocation of any pending I/O operations with
+  // ABORTED status. The pending I/O operations will not re-run any associated
+  // closures twice because the read_info.skip or write_info.skip variables have
+  // been set.
+  do {
+    ret = closesocket(winsocket->socket);
+  } while (ret != 0 && (ret == WSAEINPROGRESS || ret == WSAEINTR));
 }
 
 static void destroy(grpc_winsocket* winsocket) {
@@ -100,9 +150,14 @@ static void destroy(grpc_winsocket* winsocket) {
 }
 
 static bool check_destroyable(grpc_winsocket* winsocket) {
-  return winsocket->destroy_called == true &&
-         winsocket->write_info.closure == NULL &&
-         winsocket->read_info.closure == NULL;
+  return (winsocket->destroy_called == true &&
+          winsocket->write_info.closure == NULL &&
+          winsocket->read_info.closure == NULL);
+}
+
+void grpc_winsocket_finish(grpc_winsocket* winsocket) {
+  grpc_iocp_finish_socket_shutdown(winsocket);
+  destroy(winsocket);
 }
 
 void grpc_winsocket_destroy(grpc_winsocket* winsocket) {
@@ -111,7 +166,9 @@ void grpc_winsocket_destroy(grpc_winsocket* winsocket) {
   winsocket->destroy_called = true;
   bool should_destroy = check_destroyable(winsocket);
   gpr_mu_unlock(&winsocket->state_mu);
-  if (should_destroy) destroy(winsocket);
+  if (should_destroy) {
+    grpc_winsocket_finish(winsocket);
+  }
 }
 
 // Calling notify_on_read or write means either of two things:
@@ -140,19 +197,19 @@ void grpc_socket_notify_on_read(grpc_winsocket* socket, grpc_closure* closure) {
   socket_notify_on_iocp(socket, closure, &socket->read_info);
 }
 
-void grpc_socket_become_ready(grpc_winsocket* socket,
+bool grpc_socket_become_ready(grpc_winsocket* socket,
                               grpc_winsocket_callback_info* info) {
-  GPR_ASSERT(!info->has_pending_iocp);
-  gpr_mu_lock(&socket->state_mu);
   if (info->closure) {
-    grpc_core::ExecCtx::Run(DEBUG_LOCATION, info->closure, absl::OkStatus());
+    // If skip is set, it imples the closure has already run. Don't run it
+    // again.
+    if (!info->skip) {
+      grpc_core::ExecCtx::Run(DEBUG_LOCATION, info->closure, absl::OkStatus());
+    }
     info->closure = NULL;
   } else {
     info->has_pending_iocp = 1;
   }
-  bool should_destroy = check_destroyable(socket);
-  gpr_mu_unlock(&socket->state_mu);
-  if (should_destroy) destroy(socket);
+  return check_destroyable(socket);
 }
 
 static gpr_once g_probe_ipv6_once = GPR_ONCE_INIT;

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -61,6 +61,7 @@ typedef struct grpc_winsocket_callback_info {
   // The results of the overlapped operation.
   DWORD bytes_transferred;
   int wsa_error;
+  bool skip;
 } grpc_winsocket_callback_info;
 
 // This is a wrapper to a Windows socket. A socket can have one outstanding
@@ -81,6 +82,7 @@ typedef struct grpc_winsocket {
 
   gpr_mu state_mu;
   bool shutdown_called;
+  bool shutdown_registered;
 
   // You can't add the same socket twice to the same IO Completion Port.
   // This prevents that.
@@ -109,8 +111,8 @@ void grpc_socket_notify_on_write(grpc_winsocket* winsocket,
 void grpc_socket_notify_on_read(grpc_winsocket* winsocket,
                                 grpc_closure* closure);
 
-void grpc_socket_become_ready(grpc_winsocket* winsocket,
-                              grpc_winsocket_callback_info* ci);
+bool grpc_socket_become_ready(grpc_winsocket* socket,
+                              grpc_winsocket_callback_info* info);
 
 // Returns true if this system can create AF_INET6 sockets bound to ::1.
 // The value is probed once, and cached for the life of the process.
@@ -119,6 +121,9 @@ int grpc_ipv6_loopback_available(void);
 void grpc_wsa_socket_flags_init();
 
 DWORD grpc_get_default_wsa_socket_flags();
+
+// Final cleanup operations on the socket prior to deletion.
+void grpc_winsocket_finish(grpc_winsocket*);
 
 #endif
 

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -119,9 +119,13 @@ typedef struct grpc_tcp {
   grpc_slice_buffer* read_slices;
 
   // The IO Completion Port runs from another thread. We need some mechanism
-  // to protect ourselves when requesting a shutdown.
-  gpr_mu mu;
-  int shutting_down;
+  // to protect ourselves when requesting a shutdown. read_mu and write_mu are
+  // mutexes to protect races between shutdown and read/write operations
+  // respectively.
+  gpr_mu read_mu;
+  gpr_mu write_mu;
+  int read_shutting_down;
+  int write_shutting_down;
   grpc_error_handle shutdown_error;
 
   std::string peer_string;
@@ -130,7 +134,8 @@ typedef struct grpc_tcp {
 
 static void tcp_free(grpc_tcp* tcp) {
   grpc_winsocket_destroy(tcp->socket);
-  gpr_mu_destroy(&tcp->mu);
+  gpr_mu_destroy(&tcp->read_mu);
+  gpr_mu_destroy(&tcp->write_mu);
   grpc_slice_buffer_destroy(&tcp->last_read_buffer);
   delete tcp;
 }
@@ -184,14 +189,15 @@ static void on_read(void* tcpp, grpc_error_handle error) {
     gpr_log(GPR_INFO, "TCP:%p on_read", tcp);
   }
 
+  gpr_mu_lock(&tcp->read_mu);
   if (error.ok()) {
-    if (info->wsa_error != 0 && !tcp->shutting_down) {
+    if (info->wsa_error != 0 && !tcp->read_shutting_down) {
       char* utf8_message = gpr_format_message(info->wsa_error);
       error = GRPC_ERROR_CREATE(utf8_message);
       gpr_free(utf8_message);
       grpc_slice_buffer_reset_and_unref(tcp->read_slices);
     } else {
-      if (info->bytes_transferred != 0 && !tcp->shutting_down) {
+      if (info->bytes_transferred != 0 && !tcp->read_shutting_down) {
         GPR_ASSERT((size_t)info->bytes_transferred <= tcp->read_slices->length);
         if (static_cast<size_t>(info->bytes_transferred) !=
             tcp->read_slices->length) {
@@ -220,7 +226,7 @@ static void on_read(void* tcpp, grpc_error_handle error) {
         }
         grpc_slice_buffer_reset_and_unref(tcp->read_slices);
         error = grpc_error_set_int(
-            tcp->shutting_down
+            tcp->read_shutting_down
                 ? GRPC_ERROR_CREATE_REFERENCING("TCP stream shutting down",
                                                 &tcp->shutdown_error, 1)
                 : GRPC_ERROR_CREATE("End of TCP stream"),
@@ -230,6 +236,7 @@ static void on_read(void* tcpp, grpc_error_handle error) {
   }
 
   tcp->read_cb = NULL;
+  gpr_mu_unlock(&tcp->read_mu);
   TCP_UNREF(tcp, "read");
   grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, error);
 }
@@ -252,13 +259,15 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
     gpr_log(GPR_INFO, "TCP:%p win_read", tcp);
   }
 
-  if (tcp->shutting_down) {
+  gpr_mu_lock(&tcp->read_mu);
+  if (tcp->read_shutting_down) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
         grpc_error_set_int(
             GRPC_ERROR_CREATE_REFERENCING("TCP socket is shutting down",
                                           &tcp->shutdown_error, 1),
             grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE));
+    gpr_mu_unlock(&tcp->read_mu);
     return;
   }
 
@@ -292,6 +301,7 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
   if (info->wsa_error != WSAEWOULDBLOCK) {
     info->bytes_transferred = bytes_read;
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, &tcp->on_read, absl::OkStatus());
+    gpr_mu_unlock(&tcp->read_mu);
     return;
   }
 
@@ -306,10 +316,11 @@ static void win_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
       info->wsa_error = wsa_error;
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, &tcp->on_read,
                               GRPC_WSA_ERROR(info->wsa_error, "WSARecv"));
+      gpr_mu_unlock(&tcp->read_mu);
       return;
     }
   }
-
+  gpr_mu_unlock(&tcp->read_mu);
   grpc_socket_notify_on_read(tcp->socket, &tcp->on_read);
 }
 
@@ -324,10 +335,10 @@ static void on_write(void* tcpp, grpc_error_handle error) {
     gpr_log(GPR_INFO, "TCP:%p on_write", tcp);
   }
 
-  gpr_mu_lock(&tcp->mu);
+  gpr_mu_lock(&tcp->write_mu);
   cb = tcp->write_cb;
   tcp->write_cb = NULL;
-  gpr_mu_unlock(&tcp->mu);
+  gpr_mu_unlock(&tcp->write_mu);
 
   if (error.ok()) {
     if (info->wsa_error != 0) {
@@ -368,13 +379,15 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
     }
   }
 
-  if (tcp->shutting_down) {
+  gpr_mu_lock(&tcp->write_mu);
+  if (tcp->write_shutting_down) {
     grpc_core::ExecCtx::Run(
         DEBUG_LOCATION, cb,
         grpc_error_set_int(
             GRPC_ERROR_CREATE_REFERENCING("TCP socket is shutting down",
                                           &tcp->shutdown_error, 1),
             grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE));
+    gpr_mu_unlock(&tcp->write_mu);
     return;
   }
 
@@ -403,6 +416,7 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
       grpc_error_handle error = absl::OkStatus();
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, error);
       if (allocated) gpr_free(allocated);
+      gpr_mu_unlock(&tcp->write_mu);
       return;
     }
 
@@ -427,6 +441,7 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
       grpc_error_handle error = GRPC_WSA_ERROR(info->wsa_error, "WSASend");
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, error);
       if (allocated) gpr_free(allocated);
+      gpr_mu_unlock(&tcp->write_mu);
       return;
     }
   }
@@ -447,10 +462,11 @@ static void win_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
       TCP_UNREF(tcp, "write");
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb,
                               GRPC_WSA_ERROR(wsa_error, "WSASend"));
+      gpr_mu_unlock(&tcp->write_mu);
       return;
     }
   }
-
+  gpr_mu_unlock(&tcp->write_mu);
   // As all is now setup, we can now ask for the IOCP notification. It may
   // trigger the callback immediately however, but no matter.
   grpc_socket_notify_on_write(socket, &tcp->on_write);
@@ -481,15 +497,27 @@ static void win_delete_from_pollset_set(grpc_endpoint* /* ep */,
 // concurrent access of the data structure in that regard.
 static void win_shutdown(grpc_endpoint* ep, grpc_error_handle why) {
   grpc_tcp* tcp = (grpc_tcp*)ep;
-  gpr_mu_lock(&tcp->mu);
+  gpr_mu_lock(&tcp->read_mu);
   // At that point, what may happen is that we're already inside the IOCP
   // callback. See the comments in on_read and on_write.
-  if (!tcp->shutting_down) {
-    tcp->shutting_down = 1;
+  if (!tcp->read_shutting_down) {
+    tcp->read_shutting_down = 1;
     tcp->shutdown_error = why;
   }
-  grpc_winsocket_shutdown(tcp->socket);
-  gpr_mu_unlock(&tcp->mu);
+  gpr_mu_unlock(&tcp->read_mu);
+
+  gpr_mu_lock(&tcp->write_mu);
+  // At that point, what may happen is that we're already inside the IOCP
+  // callback. See the comments in on_read and on_write.
+  tcp->write_shutting_down = 1;
+  gpr_mu_unlock(&tcp->write_mu);
+  if (grpc_core::ExecCtx::Get() != nullptr) {
+    grpc_winsocket_shutdown(tcp->socket);
+  } else {
+    grpc_core::ApplicationCallbackExecCtx app_ctx;
+    grpc_core::ExecCtx exec_ctx;
+    grpc_winsocket_shutdown(tcp->socket);
+  }
 }
 
 static void win_destroy(grpc_endpoint* ep) {
@@ -531,7 +559,8 @@ grpc_endpoint* grpc_tcp_create(grpc_winsocket* socket,
   grpc_tcp* tcp = new grpc_tcp{};
   tcp->base.vtable = &vtable;
   tcp->socket = socket;
-  gpr_mu_init(&tcp->mu);
+  gpr_mu_init(&tcp->read_mu);
+  gpr_mu_init(&tcp->write_mu);
   gpr_ref_init(&tcp->refcount, 1);
   GRPC_CLOSURE_INIT(&tcp->on_read, on_read, tcp, grpc_schedule_on_exec_ctx);
   GRPC_CLOSURE_INIT(&tcp->on_write, on_write, tcp, grpc_schedule_on_exec_ctx);


### PR DESCRIPTION
The current endpoint semantics is as follows:
- On endpoint shutdown, the socket is immediately closed regardless and any pending registered read/write closures are not immediately executed. 
- The pending read/write closures get executed with aborted error whenever the next grpc_iocp_work method runs.

However the grpc_iocp_work may run only during grpc_shutdown and grpc_shutdown may only get scheduled after the pending registered read/write closures execute.

This PR changes the shutdown semantics to match shutdown semantics used in posix - i.e On endpoint shutdown, the socket is immediately closed and any pending registered read/write closures are executed immediately. Additional care is taken to ensure that the socket is not immediately deleted because the pending I/O ops still need to be flushed later during grpc_shutdown.

