### PR TITLE
Exclude generate core dependencies file from lang/python label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,6 +41,7 @@ lang/python:
 - requirements.bazel.txt
 - src/compiler/python*
 - src/python/**
+- "!src/python/grpcio/grpc_core_dependencies.py"
 
 lang/ruby:
 - examples/ruby/**


### PR DESCRIPTION
This file changes every time the set of core files changes. This PR leaves the `lang/python` label off of these PRs and therefore leaves them out of our attention set.