### PR TITLE
[testing] Update orca-* tests for better compatibility

### DIFF
--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -84,22 +84,6 @@ void UnaryCompressionChecks(const InteropClientContextInspector& inspector,
   }
 }
 
-void InitializeCustomLbPolicyIfNeeded() {
-  // Load balancing policy builder is global. For now, all instances of the
-  // LB policy will store data in the same collection. All interop_clients in
-  // the same process will also share the collection
-  // Realistically, we do not yet need synchronization as only a single test is
-  // running at a time.
-  static bool initialized = false;
-  if (!initialized) {
-    grpc_core::CoreConfiguration::RegisterBuilder(
-        [](grpc_core::CoreConfiguration::Builder* builder) {
-          RegisterBackendMetricsLbPolicy(builder);
-        });
-    initialized = true;
-  }
-}
-
 absl::optional<std::string> ValuesDiff(absl::string_view field, double expected,
                                        double actual) {
   if (expected != actual) {
@@ -161,44 +145,40 @@ absl::optional<std::string> OrcaLoadReportsDiff(
 InteropClient::ServiceStub::ServiceStub(
     ChannelCreationFunc channel_creation_func, bool new_stub_every_call)
     : channel_creation_func_(std::move(channel_creation_func)),
-      channel_(channel_creation_func_()),
-      new_stub_every_call_(new_stub_every_call) {
-  // If new_stub_every_call is false, then this is our chance to initialize
-  // stub_. (see Get())
-  if (!new_stub_every_call) {
-    stub_ = TestService::NewStub(channel_);
-  }
-}
+      new_stub_every_call_(new_stub_every_call) {}
 
 TestService::Stub* InteropClient::ServiceStub::Get() {
-  if (new_stub_every_call_) {
-    stub_ = TestService::NewStub(channel_);
+  if (new_stub_every_call_ || !stub_.has_value()) {
+    if (!channel_.has_value()) {
+      channel_ = channel_creation_func_();
+    }
+    stub_ = TestService::NewStub(*channel_);
   }
 
-  return stub_.get();
+  return stub_->get();
 }
 
 UnimplementedService::Stub*
 InteropClient::ServiceStub::GetUnimplementedServiceStub() {
   if (unimplemented_service_stub_ == nullptr) {
-    unimplemented_service_stub_ = UnimplementedService::NewStub(channel_);
+    if (!channel_.has_value()) {
+      channel_ = channel_creation_func_();
+    }
+    unimplemented_service_stub_ = UnimplementedService::NewStub(*channel_);
   }
   return unimplemented_service_stub_.get();
 }
 
 void InteropClient::ServiceStub::ResetChannel() {
-  channel_ = channel_creation_func_();
-  if (!new_stub_every_call_) {
-    stub_ = TestService::NewStub(channel_);
-  }
+  channel_ = absl::nullopt;
+  stub_ = absl::nullopt;
 }
 
 InteropClient::InteropClient(ChannelCreationFunc channel_creation_func,
                              bool new_stub_every_test_case,
                              bool do_not_abort_on_transient_failures)
     : serviceStub_(
-          [&]() {
-            InitializeCustomLbPolicyIfNeeded();
+          [channel_creation_func = std::move(channel_creation_func), this]() {
             return channel_creation_func(
                 load_report_tracker_.GetChannelArguments());
           },
@@ -1015,6 +995,7 @@ bool InteropClient::DoPickFirstUnary() {
 
 bool InteropClient::DoOrcaPerRpc() {
   load_report_tracker_.ResetCollectedLoadReports();
+  grpc_core::CoreConfiguration::RegisterBuilder(RegisterBackendMetricsLbPolicy);
   gpr_log(GPR_DEBUG, "testing orca per rpc");
   SimpleRequest request;
   SimpleResponse response;
@@ -1042,6 +1023,8 @@ bool InteropClient::DoOrcaPerRpc() {
 
 bool InteropClient::DoOrcaOob() {
   gpr_log(GPR_DEBUG, "testing orca oob");
+  load_report_tracker_.ResetCollectedLoadReports();
+  grpc_core::CoreConfiguration::RegisterBuilder(RegisterBackendMetricsLbPolicy);
   ClientContext context;
   std::unique_ptr<ClientReaderWriter<StreamingOutputCallRequest,
                                      StreamingOutputCallResponse>>

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -127,9 +127,9 @@ class InteropClient {
 
    private:
     ChannelCreationFunc channel_creation_func_;
-    std::unique_ptr<TestService::Stub> stub_;
+    absl::optional<std::unique_ptr<TestService::Stub>> stub_;
     std::unique_ptr<UnimplementedService::Stub> unimplemented_service_stub_;
-    std::shared_ptr<Channel> channel_;
+    absl::optional<std::shared_ptr<Channel>> channel_;
     bool new_stub_every_call_;  // If true, a new stub is returned by every
                                 // Get() call
   };

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -21,8 +21,6 @@
 
 #include <memory>
 
-#include "absl/types/optional.h"
-
 #include <grpc/grpc.h>
 #include <grpcpp/channel.h>
 
@@ -127,9 +125,9 @@ class InteropClient {
 
    private:
     ChannelCreationFunc channel_creation_func_;
-    absl::optional<std::unique_ptr<TestService::Stub>> stub_;
+    std::unique_ptr<TestService::Stub> stub_;
     std::unique_ptr<UnimplementedService::Stub> unimplemented_service_stub_;
-    absl::optional<std::shared_ptr<Channel>> channel_;
+    std::shared_ptr<Channel> channel_;
     bool new_stub_every_call_;  // If true, a new stub is returned by every
                                 // Get() call
   };


### PR DESCRIPTION
1. Make channel creation lazy. This allows test cases to update the configuration before the connection is made.
2. Pass load reports tracker when creating the policy. This way other test cases do not see any changes to ChannelArguments.

Using grpc_core::CoreConfiguration::RunWithSpecialConfiguration was considered but did not work as it removes other builders setup prior to starting the test cases.