### PR TITLE
Merge per-request and per-server named metrics field-wise

### DIFF
--- a/src/cpp/server/backend_metric_recorder.cc
+++ b/src/cpp/server/backend_metric_recorder.cc
@@ -295,8 +295,12 @@ BackendMetricData BackendMetricState::GetBackendMetricData() {
   }
   {
     internal::MutexLock lock(&mu_);
-    data.utilization = std::move(utilization_);
-    data.request_cost = std::move(request_cost_);
+    for (const auto& u : utilization_) {
+      data.utilization[u.first] = u.second;
+    }
+    for (const auto& r : request_cost_) {
+      data.request_cost[r.first] = r.second;
+    }
   }
   if (GRPC_TRACE_FLAG_ENABLED(grpc_backend_metric_trace)) {
     gpr_log(GPR_INFO,


### PR DESCRIPTION
We currently take named metrics recorded per-request only. Instead we should merge field-wise.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

