### PR TITLE
PSM Interop: revert adding XDS protos to protoc args

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -48,7 +48,6 @@ touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
     --grpc_python_out="$TOOLS_DIR" \
     "$PROTO_SOURCE_DIR"/test.proto \
     "$PROTO_SOURCE_DIR"/messages.proto \
-    "$PROTO_SOURCE_DIR"/xds/v3/orca_load_report.proto \
     "$PROTO_SOURCE_DIR"/empty.proto
 
 HEALTH_PROTO_SOURCE_DIR=src/proto/grpc/health/v1

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -48,7 +48,6 @@ touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
     --grpc_python_out="$TOOLS_DIR" \
     "$PROTO_SOURCE_DIR"/test.proto \
     "$PROTO_SOURCE_DIR"/messages.proto \
-    "$PROTO_SOURCE_DIR"/xds/v3/orca_load_report.proto \
     "$PROTO_SOURCE_DIR"/empty.proto
 
 HEALTH_PROTO_SOURCE_DIR=src/proto/grpc/health/v1

--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -267,7 +267,6 @@ test_driver_pip_install() {
 test_driver_compile_protos() {
   declare -a protos
   protos=(
-    "${TEST_DRIVER_PROTOS_PATH}/xds/v3/orca_load_report.proto"
     "${TEST_DRIVER_PROTOS_PATH}/test.proto"
     "${TEST_DRIVER_PROTOS_PATH}/messages.proto"
     "${TEST_DRIVER_PROTOS_PATH}/empty.proto"

--- a/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_php_test_in_docker.sh
@@ -46,7 +46,6 @@ touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
     --grpc_python_out="$TOOLS_DIR" \
     "$PROTO_SOURCE_DIR"/test.proto \
     "$PROTO_SOURCE_DIR"/messages.proto \
-    "$PROTO_SOURCE_DIR"/xds/v3/orca_load_report.proto \
     "$PROTO_SOURCE_DIR"/empty.proto
 
 HEALTH_PROTO_SOURCE_DIR=src/proto/grpc/health/v1

--- a/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_ruby_test_in_docker.sh
@@ -46,7 +46,6 @@ touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
     --grpc_python_out="$TOOLS_DIR" \
     "$PROTO_SOURCE_DIR"/test.proto \
     "$PROTO_SOURCE_DIR"/messages.proto \
-    "$PROTO_SOURCE_DIR"/xds/v3/orca_load_report.proto \
     "$PROTO_SOURCE_DIR"/empty.proto
 
 HEALTH_PROTO_SOURCE_DIR=src/proto/grpc/health/v1

--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -185,7 +185,6 @@ pip install -r requirements.lock
 # Generate protos
 python -m grpc_tools.protoc --proto_path=../../../ \
     --python_out=. --grpc_python_out=. \
-    src/proto/grpc/testing/xds/v3/orca_load_report.proto \
     src/proto/grpc/testing/empty.proto \
     src/proto/grpc/testing/messages.proto \
     src/proto/grpc/testing/test.proto


### PR DESCRIPTION
This dependency is no longer needed after #32631