### PR TITLE
[PHP] Add @deprecated tag in PHP generated methods and services

### DIFF
--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -77,6 +77,9 @@ void PrintMethod(const MethodDescriptor* method, Printer* out) {
       GeneratedClassName(output_type), output_type->file());
 
   out->Print("/**\n");
+  if (method->options().deprecated()) {
+    out->Print(" * @deprecated\n");
+  }
   out->Print(GetPHPComments(method, " *").c_str());
   if (method->client_streaming()) {
     if (method->server_streaming()) {
@@ -144,6 +147,9 @@ void PrintServerMethod(const MethodDescriptor* method, Printer* out) {
       GeneratedClassName(output_type), output_type->file());
 
   out->Print("/**\n");
+  if (method->options().deprecated()) {
+    out->Print(" * @deprecated\n");
+  }
   out->Print(GetPHPComments(method, " *").c_str());
 
   const char* method_template;
@@ -222,8 +228,11 @@ void PrintServerMethodDescriptors(const ServiceDescriptor* service,
   map<std::string, std::string> vars;
   vars["service_name"] = service->full_name();
 
+  out->Print("/**\n");
+  if (service->options().deprecated()) {
+    out->Print(" * @deprecated\n");
+  }
   out->Print(
-      "/**\n"
       " * Get the method descriptors of the service for server registration\n"
       " *\n"
       " * @return array of \\Grpc\\MethodDescriptor for the service methods\n"
@@ -272,6 +281,9 @@ void PrintService(const ServiceDescriptor* service,
                   Printer* out) {
   map<std::string, std::string> vars;
   out->Print("/**\n");
+  if (service->options().deprecated()) {
+    out->Print(" * @deprecated\n");
+  }
   out->Print(GetPHPComments(service, " *").c_str());
   out->Print(" */\n");
   vars["name"] = GetPHPServiceClassname(service, class_suffix, is_server);


### PR DESCRIPTION
When we deprecate services in proto-file:
```proto
syntax = "proto3";

option php_namespace = "Test";

service MyService {
  option deprecated = true;
  rpc Call(Test) returns (Test) {
    option deprecated = true;
  };
}

message Test {
}
```

It might be a good idea to propagate this flat in the generated classes so that the final users will be aware of the changes coming soon.

Example of the generated code:
```php
<?php
// GENERATED CODE -- DO NOT EDIT!

namespace Test;

/**
 * @deprecated
 */
class MyServiceClient extends \Grpc\BaseStub {

    /**
     * @param string $hostname hostname
     * @param array $opts channel options
     * @param \Grpc\Channel $channel (optional) re-use channel object
     */
    public function __construct($hostname, $opts, $channel = null) {
        parent::__construct($hostname, $opts, $channel);
    }

    /**
     * @deprecated
     * @param \Test\Test $argument input argument
     * @param array $metadata metadata
     * @param array $options call options
     * @return \Grpc\UnaryCall
     */
    public function Call(\Test\Test $argument,
      $metadata = [], $options = []) {
        return $this->_simpleRequest('/MyService/Call',
        $argument,
        ['\Test\Test', 'decode'],
        $metadata, $options);
    }

}
```

These tags will cause IDE to highlight the class/method to bring the developer's attention.

This is consistent with how "protoc" handles the "deprecated" option for PHP

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

