### PR TITLE
[test-infra] Re-enable skipped windows tests

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -336,15 +336,9 @@ class CLanguage(object):
                 if self.args.iomgr_platform in target.get('exclude_iomgrs', []):
                     continue
 
-                if self.platform == 'windows' and target['name'] in (
-                        'invalid_call_argument_test',
-                        'bad_server_response_test', 'goaway_server_test'):
-                    # A few tests fail on the win2019 workers, but since they pass on Windows bazel RBE,
-                    # it seems ok to skip them in run_tests.py temporarily.
-                    # TODO(jtattermusch): Reenable the tests.
-                    continue
-
                 if self.platform == 'windows':
+                    # TODO(jtattermusch): Ninja puts binaries directly under cmake/build so currently
+                    # test tests are being skipped when built with Ninja on windows.
                     binary = 'cmake/build/%s/%s.exe' % (_MSBUILD_CONFIG[
                         self.config.build_config], target['name'])
                 else:

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -337,10 +337,11 @@ class CLanguage(object):
                     continue
 
                 if self.platform == 'windows':
-                    # TODO(jtattermusch): Ninja puts binaries directly under cmake/build so currently
-                    # test tests are being skipped when built with Ninja on windows.
-                    binary = 'cmake/build/%s/%s.exe' % (_MSBUILD_CONFIG[
-                        self.config.build_config], target['name'])
+                    if self._cmake_generator_windows == 'Ninja':
+                        binary = 'cmake/build/%s.exe' % target['name']
+                    else:
+                        binary = 'cmake/build/%s/%s.exe' % (_MSBUILD_CONFIG[
+                            self.config.build_config], target['name'])
                 else:
                     binary = 'cmake/build/%s' % target['name']
 


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/32649 (which disabled the tests mentioned below).
Also sets correct path for tests build by ninja on windows, so that they don't get skipped.

Once merged, I'll backport to 1.54.x and 1.53.x

The original issue with tests being skipped.
```
+ python3 workspace_c_windows_dbg_native/tools/run_tests/run_tests.py -t -j 8 -x run_tests/c_windows_dbg_native/sponge_log.xml --report_suite_name c_windows_dbg_native -l c -c dbg --iomgr_platform native --bq_result_table aggregate_results --measure_cpu_costs
2023-03-20 07:56:53,523 START: tools\run_tests\helper_scripts\build_cxx.bat

2023-03-20 08:04:51,388 PASSED: tools\run_tests\helper_scripts\build_cxx.bat [time=477.9sec, retries=0:0; cpu_cost=0.0; estimated=1.0]

2023-03-20 08:04:52,434 detected port server running version 21

2023-03-20 08:04:52,672 my port server is version 21

2023-03-20 08:04:52,703 SUCCESS: All tests passed



WARNING: binary not found, skipping cmake/build/Debug/bad_server_response_test.exe



WARNING: binary not found, skipping cmake/build/Debug/connection_refused_test.exe



WARNING: binary not found, skipping cmake/build/Debug/goaway_server_test.exe



WARNING: binary not found, skipping cmake/build/Debug/invalid_call_argument_test.exe



WARNING: binary not found, skipping cmake/build/Debug/multiple_server_queues_test.exe



WARNING: binary not found, skipping cmake/build/Debug/no_server_test.exe



WARNING: binary not found, skipping cmake/build/Debug/pollset_windows_starvation_test.exe



WARNING: binary not found, skipping cmake/build/Debug/public_headers_must_be_c89.exe



```