### PR TITLE
Switch all VS2017 builds to VS2019

### DIFF
--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -32,39 +32,41 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
 set VS_GENERATOR="Visual Studio 16 2019"
+@rem TODO(jtattermusch): switch to x64 build (will require pulling a x64 build of openssl)
+set VS_ARCHITECTURE="Win32"
 
 @rem Install absl
 mkdir third_party\abseil-cpp\cmake\build
 pushd third_party\abseil-cpp\cmake\build
-cmake -G %VS_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
 cmake --build . --config Release --target install || goto :error
 popd
 
 @rem Install c-ares
 mkdir third_party\cares\cares\cmake\build
 pushd third_party\cares\cares\cmake\build
-cmake -G %VS_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
 cmake --build . --config Release --target install || goto :error
 popd
 
 @rem Install protobuf
 mkdir third_party\protobuf\cmake\build
 pushd third_party\protobuf\cmake\build
-cmake -G %VS_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DZLIB_ROOT=%INSTALL_DIR% -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF ..\..
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DZLIB_ROOT=%INSTALL_DIR% -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF ..\..
 cmake --build . --config Release --target install || goto :error
 popd
 
 @rem Install re2
 mkdir third_party\re2\cmake\build
 pushd third_party\re2\cmake\build
-cmake -G %VS_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
 cmake --build . --config Release --target install || goto :error
 popd
 
 @rem Install zlib
 mkdir third_party\zlib\cmake\build
 pushd third_party\zlib\cmake\build
-cmake -G %VS_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
 cmake --build . --config Release --target install || goto :error
 popd
 
@@ -87,6 +89,7 @@ mkdir cmake\build
 pushd cmake\build
 cmake ^
   -G %VS_GENERATOR% ^
+  -A %VS_ARCHITECTURE% ^
   -DCMAKE_BUILD_TYPE=Release ^
   -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ^
   -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% ^
@@ -108,7 +111,7 @@ popd
 @rem Build helloworld example using cmake
 mkdir examples\cpp\helloworld\cmake\build
 pushd examples\cpp\helloworld\cmake\build
-cmake -G %VS_GENERATOR% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% -DZLIB_ROOT=%INSTALL_DIR% ../.. || goto :error
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% -DZLIB_ROOT=%INSTALL_DIR% ../.. || goto :error
 cmake --build . --config Release || goto :error
 popd
 

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -31,7 +31,7 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
-set VS_GENERATOR="Visual Studio 15 2017"
+set VS_GENERATOR="Visual Studio 16 2019"
 
 @rem Install absl
 mkdir third_party\abseil-cpp\cmake\build

--- a/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
@@ -28,7 +28,7 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
-set VS_GENERATOR="Visual Studio 15 2017"
+set VS_GENERATOR="Visual Studio 16 2019"
 
 @rem Build helloworld example using cmake
 @rem Use non-standard build directory to avoid too long filenames

--- a/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
@@ -29,12 +29,14 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
 set VS_GENERATOR="Visual Studio 16 2019"
+@rem TODO(jtattermusch): switch to x64 build (will require pulling a x64 build of openssl)
+set VS_ARCHITECTURE="Win32"
 
 @rem Build helloworld example using cmake
 @rem Use non-standard build directory to avoid too long filenames
 mkdir example_build
 cd example_build
-cmake -G %VS_GENERATOR% -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% ../examples/cpp/helloworld/cmake_externalproject || goto :error
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% ../examples/cpp/helloworld/cmake_externalproject || goto :error
 cmake --build . --config Release || goto :error
 cd ..
 

--- a/tools/run_tests/artifacts/build_artifact_protoc.bat
+++ b/tools/run_tests/artifacts/build_artifact_protoc.bat
@@ -27,15 +27,9 @@ if "%GRPC_PROTOC_BUILD_COMPILER_JOBS%"=="" (
   set GRPC_PROTOC_BUILD_COMPILER_JOBS=2
 )
 
-@rem Workaround a bug where VS150COMNTOOLS is not set due to a bug in VS 2017 installer
-@rem see https://developercommunity.visualstudio.com/t/installing-visualstudio-build-tools-doesnt-add-env/17435
-If "%VS150COMNTOOLS%" == "" (
-  set "VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\"
-)
-
-@rem set cl.exe build environment to build with VS2015 tooling
+@rem set cl.exe build environment to build with VS2019 tooling
 @rem this is required for Ninja build to work
-call "%VS150COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %ARCHITECTURE%
+call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %ARCHITECTURE%
 @rem restore command echo
 echo on
 

--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -21,16 +21,10 @@ cd cmake
 mkdir build
 cd build
 
-@rem Workaround a bug where VS150COMNTOOLS is not set due to a bug in VS 2017 installer
-@rem see https://developercommunity.visualstudio.com/t/installing-visualstudio-build-tools-doesnt-add-env/17435
-If "%VS150COMNTOOLS%" == "" (
-  set "VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\"
-)
-
-If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2017" (
-  @rem set cl.exe build environment to build with VS2017 tooling
+If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2019" (
+  @rem set cl.exe build environment to build with VS2019 tooling
   @rem this is required for Ninja build to work
-  call "%VS150COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %GRPC_BUILD_VS_TOOLS_ARCHITECTURE%
+  call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %GRPC_BUILD_VS_TOOLS_ARCHITECTURE%
   @rem restore command echo
   echo on
 )

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -252,20 +252,17 @@ class CLanguage(object):
             _check_compiler(self.args.compiler, [
                 'default',
                 'cmake',
-                'cmake_ninja_vs2017',
-                'cmake_vs2017',
+                'cmake_ninja_vs2019',
                 'cmake_vs2019',
             ])
             _check_arch(self.args.arch, ['default', 'x64', 'x86'])
 
             activate_vs_tools = ''
-            if self.args.compiler == 'cmake_ninja_vs2017' or self.args.compiler == 'cmake' or self.args.compiler == 'default':
+            if self.args.compiler == 'cmake_ninja_vs2019' or self.args.compiler == 'cmake' or self.args.compiler == 'default':
                 # cmake + ninja build is the default because it is faster and supports boringssl assembly optimizations
                 # the compiler used is exactly the same as for cmake_vs2017
                 cmake_generator = 'Ninja'
-                activate_vs_tools = '2017'
-            elif self.args.compiler == 'cmake_vs2017':
-                cmake_generator = 'Visual Studio 15 2017'
+                activate_vs_tools = '2019'
             elif self.args.compiler == 'cmake_vs2019':
                 cmake_generator = 'Visual Studio 16 2019'
             else:
@@ -1479,8 +1476,7 @@ argp.add_argument(
         'electron1.6',
         'coreclr',
         'cmake',
-        'cmake_ninja_vs2017',
-        'cmake_vs2017',
+        'cmake_ninja_vs2019',
         'cmake_vs2019',
         'mono',
     ],

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -329,7 +329,7 @@ def _create_portability_test_jobs(extra_args=[],
                                 configs=['dbg'],
                                 platforms=['windows'],
                                 arch='default',
-                                compiler='cmake_vs2017',
+                                compiler='cmake_vs2019',
                                 labels=['portability', 'corelang'],
                                 extra_args=extra_args,
                                 inner_jobs=inner_jobs)
@@ -346,13 +346,15 @@ def _create_portability_test_jobs(extra_args=[],
                                 inner_jobs=inner_jobs,
                                 timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
-    # portability C and C++ on Windows using VS2017 (build only)
-    # TODO(jtattermusch): some of the tests are failing, so we force --build_only
+    # portability C and C++ on Windows using VS2019 (build only)
+    # TODO(jtattermusch): The C tests with exactly the same config are already running as part of the
+    # basictests_c suite (so we force --build_only to avoid running them twice).
+    # The C++ tests aren't all passing, so also force --build_only.
     test_jobs += _generate_jobs(languages=['c', 'c++'],
                                 configs=['dbg'],
                                 platforms=['windows'],
                                 arch='x64',
-                                compiler='cmake_ninja_vs2017',
+                                compiler='cmake_ninja_vs2019',
                                 labels=['portability', 'corelang'],
                                 extra_args=extra_args + ['--build_only'],
                                 inner_jobs=inner_jobs,


### PR DESCRIPTION
(part of removing support for VS2017)

Also see https://github.com/grpc/grpc/pull/32649
Also see https://github.com/grpc/grpc/pull/32615

The switch to grpc-win2019 windows workers has already happened: (cl/517400022).

Once this PR lands, I'll backport to 1.53.x branch as well (since that release removes the VS2017 support).
