### PR TITLE
[resolver] Ares resolver always reports TXT lookup errors

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -395,13 +395,11 @@ AresClientChannelDNSResolver::AresRequestWrapper::OnResolvedLocked(
   GRPC_CARES_TRACE_LOG("resolver:%p OnResolved() proceeding", this);
   Result result;
   result.args = resolver_->channel_args();
-  // TODO(roth): We probably should not ignore NotFound errors here, but have
-  // users of the resolver handle them appropriately.
+  // TODO(roth): We probably should not ignore NotFound errors here, but instead
+  // have users of the resolver handle them appropriately.
   if (!txt_resolved_error_.ok() && !absl::IsNotFound(txt_resolved_error_)) {
     result.service_config = txt_resolved_error_;
   }
-  // TODO(roth): Change logic to be able to report failures for addresses
-  // and service config independently of each other.
   if (addresses_ != nullptr || balancer_addresses_ != nullptr) {
     if (addresses_ != nullptr) {
       result.addresses = std::move(*addresses_);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -818,7 +818,15 @@ fail:
                       q->name(), ares_strerror(status));
   GRPC_CARES_TRACE_LOG("request:%p on_txt_done_locked %s", r,
                        error_msg.c_str());
-  error = GRPC_ERROR_CREATE(error_msg);
+  absl::StatusCode status_type;
+  switch (status) {
+    case ARES_ENOTFOUND:
+      status_type = absl::StatusCode::kNotFound;
+      break;
+    default:
+      status_type = absl::StatusCode::kUnknown;
+  }
+  error = StatusCreate(status_type, error_msg, DEBUG_LOCATION, {});
   r->error = grpc_error_add_child(error, r->error);
 }
 

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -272,10 +272,12 @@ void CheckServiceConfigResultLocked(const char* service_config_json,
     EXPECT_EQ(service_config_json, args->expected_service_config_string);
   }
   if (args->expected_service_config_error.empty()) {
-    EXPECT_TRUE(service_config_error.ok());
+    EXPECT_TRUE(service_config_error.ok())
+        << "Actual error: " << service_config_error.ToString();
   } else {
     EXPECT_THAT(service_config_error.ToString(),
-                testing::HasSubstr(args->expected_service_config_error));
+                testing::HasSubstr(args->expected_service_config_error))
+        << "Actual error: " << service_config_error.ToString();
   }
 }
 


### PR DESCRIPTION
In the c-ares-based client channel resolver, TXT lookup errors were ignored and not reported upon TXT lookup failures. They could occasionally be reported if both A/AAAA and SRV record lookups failed, and then only if the TXT record was the last query to return from c-ares.

For the purposes of our tests, presumably based on how the client channel resolver is used today, a missing TXT record is not considered an error on TXT record lookup. All other error types will now be set on the result's service config field.

I left a TODO to change client channel resolver usage so that all c-ares errors can be propagated up, and handled appropriately in client logic.