### PR TITLE
Upgrade ccache on windows

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -55,7 +55,7 @@ nasm
 
 @rem Install ccache
 mkdir C:\ccache
-curl -sSL --fail -o C:\ccache\ccache.exe https://storage.googleapis.com/grpc-build-helper/ccache-4.6-windows-64/ccache.exe || goto :error
+curl -sSL --fail -o C:\ccache\ccache.exe https://storage.googleapis.com/grpc-build-helper/ccache-4.8-windows-64/ccache.exe || goto :error
 set PATH=C:\ccache;%PATH%
 ccache --version
 


### PR DESCRIPTION
Try to avoid the `ccache: error: Failed to read from file stream` build failures that started happening once we upgraded to the grpc-win2019 image.

e.g. https://source.cloud.google.com/results/invocations/e94c2f35-6d1f-4d89-853a-be7e1e1747de/targets/github%2Fgrpc%2Ftoplevel_run_tests_invocations%2Frun_tests_c_windows_opt_native/tests

```
C:\ccache\ccache.exe C:\PROGRA~2\MICROS~1\2017\COMMUN~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x86\cl.exe  /nologo /TP -DCARES_STATICLIB -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WIN32_WINNT=0x600 -D_WINSOCK_DEPRECATED_NO_WARNINGS -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\re2 -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\zlib -IT:\altsrc\github\grpc\workspace_c_windows_opt_native -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\include -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\address_sorting\include -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\cmake\build\third_party\re2 -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\boringssl-with-bazel\src\include -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\src\core\ext\upb-generated -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\src\core\ext\upbdefs-generated -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\upb -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\xxhash -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\cmake\build\third_party\zlib -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\abseil-cpp -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\cmake\build\third_party\cares\cares -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\cares\cares -IT:\altsrc\github\grpc\workspace_c_windows_opt_native\third_party\cares\cares\include /DWIN32 /D_WINDOWS /W3 /GR /EHsc  /MP8 /wd4065 /wd4506 /wd4200 /wd4291 /wd4244 /wd4267 /wd4987 /wd4774 /wd4819 /wd4996 /wd4619 /wd4503 /utf-8 /MD /O2 /Ob2 /DNDEBUG /showIncludes /FoCMakeFiles\invalid_call_argument_test.dir\test\core\end2end\cq_verifier.cc.obj /FdCMakeFiles\invalid_call_argument_test.dir\ /FS -c T:\altsrc\github\grpc\workspace_c_windows_opt_native\test\core\end2end\cq_verifier.cc
ccache: error: Failed to read from file stream
```