### PR TITLE
increase timeout for windows C++ distribtests

### DIFF
--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -335,7 +335,7 @@ class CppDistribTest(object):
                 self.name,
                 ['test\\distrib\\cpp\\run_distrib_test_%s.bat' % self.testcase],
                 environ={},
-                timeout_seconds=30 * 60,
+                timeout_seconds=45 * 60,
                 use_workspace=True)
         else:
             raise Exception("Not supported yet.")


### PR DESCRIPTION
After switching to grpc-win2019 kokoro image, the windows C++ distribtest got slightly slower (from about ~1500sec to ~1650sec), which got us too close to the 1800sec time limit and thus we've seen the windows distribtests occasionally time out.

I'd still like to look into speeding up the distribtests, but for now we don't want frequest test timeouts in the CI.

example failure: 
https://fusion2.corp.google.com/ci;ids=1923284992/kokoro/prod:grpc%2Fcore%2Fmaster%2Fwindows%2Fgrpc_distribtests_standalone/activity/996fd2cf-bef3-4490-85da-a52765d84127/log

```
2023-03-20 23:43:44,740 TIMEOUT: distribtest.cpp_windows_x86_cmake_as_externalproject [pid=5984, time=1800.1sec]
```