### PR TITLE
[fix] Use signed millis in grpc_core::Timestamp math

### DIFF
--- a/src/core/lib/event_engine/posix_engine/timer.h
+++ b/src/core/lib/event_engine/posix_engine/timer.h
@@ -176,7 +176,7 @@ class TimerList {
   const size_t num_shards_;
   grpc_core::Mutex mu_;
   // The deadline of the next timer due across all timer shards
-  std::atomic<uint64_t> min_timer_;
+  std::atomic<int64_t> min_timer_;
   // Allow only one FindExpiredTimers at once (used as a TryLock, protects no
   // fields but ensures limits on concurrency)
   grpc_core::Mutex checker_mu_;

--- a/src/core/lib/event_engine/thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool.h
@@ -110,7 +110,7 @@ class ThreadPool final : public Forkable, public Executor {
     // After pool creation we use this to rate limit creation of threads to one
     // at a time.
     std::atomic<bool> currently_starting_one_thread{false};
-    std::atomic<uint64_t> last_started_thread{0};
+    std::atomic<int64_t> last_started_thread{0};
   };
 
   using StatePtr = std::shared_ptr<State>;

--- a/src/core/lib/gprpp/time.h
+++ b/src/core/lib/gprpp/time.h
@@ -31,16 +31,16 @@
 #include "src/core/lib/gpr/time_precise.h"
 #include "src/core/lib/gpr/useful.h"
 
-#define GRPC_LOG_EVERY_N_SEC(n, severity, format, ...)          \
-  do {                                                          \
-    static std::atomic<uint64_t> prev{0};                       \
-    uint64_t now = grpc_core::Timestamp::FromTimespecRoundDown( \
-                       gpr_now(GPR_CLOCK_MONOTONIC))            \
-                       .milliseconds_after_process_epoch();     \
-    uint64_t prev_tsamp = prev.exchange(now);                   \
-    if (prev_tsamp == 0 || now - prev_tsamp > (n)*1000) {       \
-      gpr_log(severity, format, __VA_ARGS__);                   \
-    }                                                           \
+#define GRPC_LOG_EVERY_N_SEC(n, severity, format, ...)         \
+  do {                                                         \
+    static std::atomic<int64_t> prev{0};                       \
+    int64_t now = grpc_core::Timestamp::FromTimespecRoundDown( \
+                      gpr_now(GPR_CLOCK_MONOTONIC))            \
+                      .milliseconds_after_process_epoch();     \
+    int64_t prev_tsamp = prev.exchange(now);                   \
+    if (prev_tsamp == 0 || now - prev_tsamp > (n)*1000) {      \
+      gpr_log(severity, format, __VA_ARGS__);                  \
+    }                                                          \
   } while (0)
 
 namespace grpc_core {
@@ -150,7 +150,7 @@ class Timestamp {
 
   bool is_process_epoch() const { return millis_ == 0; }
 
-  uint64_t milliseconds_after_process_epoch() const { return millis_; }
+  int64_t milliseconds_after_process_epoch() const { return millis_; }
 
   gpr_timespec as_timespec(gpr_clock_type type) const;
 

--- a/src/core/lib/gprpp/time.h
+++ b/src/core/lib/gprpp/time.h
@@ -59,6 +59,13 @@ inline int64_t MillisAdd(int64_t a, int64_t b) {
   return SaturatingAdd(a, b);
 }
 
+inline int64_t MillisSub(int64_t a, int64_t b) {
+  if (b == std::numeric_limits<int64_t>::min()) {
+    return std::numeric_limits<int64_t>::min();
+  }
+  return MillisAdd(a, -b);
+}
+
 constexpr inline int64_t MillisMul(int64_t millis, int64_t mul) {
   return millis >= std::numeric_limits<int64_t>::max() / mul
              ? std::numeric_limits<int64_t>::max()
@@ -293,7 +300,7 @@ inline Duration operator+(Duration lhs, Duration rhs) {
 
 inline Duration operator-(Duration lhs, Duration rhs) {
   return Duration::Milliseconds(
-      time_detail::MillisAdd(lhs.millis(), -rhs.millis()));
+      time_detail::MillisSub(lhs.millis(), rhs.millis()));
 }
 
 inline Timestamp operator+(Timestamp lhs, Duration rhs) {
@@ -302,16 +309,16 @@ inline Timestamp operator+(Timestamp lhs, Duration rhs) {
 }
 
 inline Timestamp operator-(Timestamp lhs, Duration rhs) {
-  return Timestamp::FromMillisecondsAfterProcessEpoch(time_detail::MillisAdd(
-      lhs.milliseconds_after_process_epoch(), -rhs.millis()));
+  return Timestamp::FromMillisecondsAfterProcessEpoch(time_detail::MillisSub(
+      lhs.milliseconds_after_process_epoch(), rhs.millis()));
 }
 
 inline Timestamp operator+(Duration lhs, Timestamp rhs) { return rhs + lhs; }
 
 inline Duration operator-(Timestamp lhs, Timestamp rhs) {
   return Duration::Milliseconds(
-      time_detail::MillisAdd(lhs.milliseconds_after_process_epoch(),
-                             -rhs.milliseconds_after_process_epoch()));
+      time_detail::MillisSub(lhs.milliseconds_after_process_epoch(),
+                             rhs.milliseconds_after_process_epoch()));
 }
 
 inline Duration operator*(Duration lhs, double rhs) {


### PR DESCRIPTION
Most uses of `Timestamp::milliseconds_after_process_epoch()` are already implicitly converting the result to `int64_t`. Using unary `operator-` on unsigned integers can be problematic, as done in Timestamp's operator- implementation - the result may be unsigned.

See 
* https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146?view=msvc-170
* https://google.github.io/styleguide/cppguide.html#Integer_Types