### PR TITLE
Removed report_atomic_races=0 option

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -101,9 +101,6 @@ build:tsan --copt=-fno-omit-frame-pointer
 build:tsan --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:tsan --copt=-DGRPC_TSAN
 build:tsan --linkopt=-fsanitize=thread
-# This is needed to address false positive problem with abseil.
-# https://github.com/google/sanitizers/issues/953
-build:tsan --test_env=TSAN_OPTIONS=report_atomic_races=0
 build:tsan --action_env=TSAN_OPTIONS=suppressions=test/core/util/tsan_suppressions.txt:halt_on_error=1:second_deadlock_stack=1
 
 build:tsan_macos --strip=never
@@ -112,7 +109,6 @@ build:tsan_macos --copt=-fno-omit-frame-pointer
 build:tsan_macos --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:tsan_macos --copt=-DGRPC_TSAN
 build:tsan_macos --linkopt=-fsanitize=thread
-build:tsan_macos --test_env=TSAN_OPTIONS=report_atomic_races=0
 build:tsan_macos --action_env=TSAN_OPTIONS=suppressions=test/core/util/tsan_suppressions.txt:halt_on_error=1:second_deadlock_stack=1
 build:tsan_macos --dynamic_mode=off
 


### PR DESCRIPTION
It appears that we can remove this `report_atomic_races=0` workaround as abseil fixed the issue by https://github.com/abseil/abseil-cpp/commit/091842beeac564776c231e7d1787b527d1c2d0d9