### PR TITLE
writes_per_rpc_test: TSAN data race fix

### DIFF
--- a/test/core/util/passthru_endpoint.cc
+++ b/test/core/util/passthru_endpoint.cc
@@ -274,7 +274,7 @@ static void me_write(grpc_endpoint* ep, grpc_slice_buffer* slices,
                      grpc_closure* cb, void* /*arg*/, int /*max_frame_size*/) {
   half* m = reinterpret_cast<half*>(ep);
   gpr_mu_lock(&m->parent->mu);
-  gpr_atm_no_barrier_fetch_add(&m->parent->stats->num_writes, (gpr_atm)1);
+  gpr_atm_full_fetch_add(&m->parent->stats->num_writes, (gpr_atm)1);
   if (m->parent->shutdown) {
     grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb,
                             GRPC_ERROR_CREATE("Endpoint already shutdown"));

--- a/test/cpp/performance/writes_per_rpc_test.cc
+++ b/test/cpp/performance/writes_per_rpc_test.cc
@@ -142,7 +142,7 @@ class InProcessCHTTP2 : public EndpointPairFixture {
     }
   }
 
-  int writes_performed() const { return stats_->num_writes; }
+  int writes_performed() const { return gpr_atm_acq_load(&stats_->num_writes); }
 
  private:
   grpc_passthru_endpoint_stats* stats_;


### PR DESCRIPTION
Fixing TSAN data races of the kind - https://source.cloud.google.com/results/invocations/c3f02253-0d0b-44e6-917d-07e4bc0d3d62/targets/%2F%2Ftest%2Fcpp%2Fperformance:writes_per_rpc_test@poller%3Dpoll/log

I think the original issue was the non-atomic load in writes_per_rpc_test.cc but also making the change to use barriers instead of relaxed atomics (probably unimportant but I'll prefer safety in the absence of otherwise comments).

Could probably also use std::atomic but feeling a bit lazy to make the changes throughout.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

