### PR TITLE
[EventEngine] Add EventEngine::*Handle equality operators

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -122,6 +122,9 @@ class EventEngine : public std::enable_shared_from_this<EventEngine> {
   /// \a Cancel method.
   struct TaskHandle {
     intptr_t keys[2];
+    static const TaskHandle kInvalid;
+    friend bool operator==(const TaskHandle& lhs, const TaskHandle& rhs);
+    friend bool operator!=(const TaskHandle& lhs, const TaskHandle& rhs);
   };
   static constexpr TaskHandle kInvalidTaskHandle{-1, -1};
   /// A handle to a cancellable connection attempt.
@@ -129,6 +132,11 @@ class EventEngine : public std::enable_shared_from_this<EventEngine> {
   /// Returned by \a Connect, and can be passed to \a CancelConnect.
   struct ConnectionHandle {
     intptr_t keys[2];
+    static const ConnectionHandle kInvalid;
+    friend bool operator==(const ConnectionHandle& lhs,
+                           const ConnectionHandle& rhs);
+    friend bool operator!=(const ConnectionHandle& lhs,
+                           const ConnectionHandle& rhs);
   };
   static constexpr ConnectionHandle kInvalidConnectionHandle{-1, -1};
   /// Thin wrapper around a platform-specific sockaddr type. A sockaddr struct
@@ -319,7 +327,13 @@ class EventEngine : public std::enable_shared_from_this<EventEngine> {
     /// Task handle for DNS Resolution requests.
     struct LookupTaskHandle {
       intptr_t keys[2];
+      static const LookupTaskHandle kInvalid;
+      friend bool operator==(const LookupTaskHandle& lhs,
+                             const LookupTaskHandle& rhs);
+      friend bool operator!=(const LookupTaskHandle& lhs,
+                             const LookupTaskHandle& rhs);
     };
+    static constexpr LookupTaskHandle kInvalidLookupTaskHandle{-1, -1};
     /// Optional configuration for DNSResolvers.
     struct ResolverOptions {
       /// If empty, default DNS servers will be used.

--- a/src/core/lib/event_engine/event_engine.cc
+++ b/src/core/lib/event_engine/event_engine.cc
@@ -20,6 +20,44 @@ namespace experimental {
 
 constexpr EventEngine::TaskHandle EventEngine::kInvalidTaskHandle;
 constexpr EventEngine::ConnectionHandle EventEngine::kInvalidConnectionHandle;
+constexpr EventEngine::DNSResolver::LookupTaskHandle
+    EventEngine::DNSResolver::kInvalidLookupTaskHandle;
+
+constexpr EventEngine::TaskHandle EventEngine::TaskHandle::kInvalid = {-1, -1};
+constexpr EventEngine::ConnectionHandle
+    EventEngine::ConnectionHandle::kInvalid = {-1, -1};
+constexpr EventEngine::DNSResolver::LookupTaskHandle
+    EventEngine::DNSResolver::LookupTaskHandle::kInvalid = {-1, -1};
+
+bool operator==(const EventEngine::TaskHandle& lhs,
+                const EventEngine::TaskHandle& rhs) {
+  return lhs.keys[0] == rhs.keys[0] && lhs.keys[1] == rhs.keys[1];
+}
+
+bool operator!=(const EventEngine::TaskHandle& lhs,
+                const EventEngine::TaskHandle& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const EventEngine::ConnectionHandle& lhs,
+                const EventEngine::ConnectionHandle& rhs) {
+  return lhs.keys[0] == rhs.keys[0] && lhs.keys[1] == rhs.keys[1];
+}
+
+bool operator!=(const EventEngine::ConnectionHandle& lhs,
+                const EventEngine::ConnectionHandle& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(const EventEngine::DNSResolver::LookupTaskHandle& lhs,
+                const EventEngine::DNSResolver::LookupTaskHandle& rhs) {
+  return lhs.keys[0] == rhs.keys[0] && lhs.keys[1] == rhs.keys[1];
+}
+
+bool operator!=(const EventEngine::DNSResolver::LookupTaskHandle& lhs,
+                const EventEngine::DNSResolver::LookupTaskHandle& rhs) {
+  return !(lhs == rhs);
+}
 
 }  // namespace experimental
 }  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/handle_containers.h
+++ b/src/core/lib/event_engine/handle_containers.h
@@ -39,34 +39,19 @@ struct TaskHandleComparator {
       return absl::Hash<HashType>()({handle.keys[0], handle.keys[1]});
     }
   };
-  struct Eq {
-    using is_transparent = void;
-    bool operator()(const TaskHandle& lhs, const TaskHandle& rhs) const {
-      return lhs.keys[0] == rhs.keys[0] && lhs.keys[1] == rhs.keys[1];
-    }
-  };
 };
 
-using TaskHandleSet = absl::flat_hash_set<
-    grpc_event_engine::experimental::EventEngine::TaskHandle,
-    TaskHandleComparator<
-        grpc_event_engine::experimental::EventEngine::TaskHandle>::Hash,
-    TaskHandleComparator<
-        grpc_event_engine::experimental::EventEngine::TaskHandle>::Eq>;
+using TaskHandleSet =
+    absl::flat_hash_set<EventEngine::TaskHandle,
+                        TaskHandleComparator<EventEngine::TaskHandle>::Hash>;
 
 using ConnectionHandleSet = absl::flat_hash_set<
-    grpc_event_engine::experimental::EventEngine::ConnectionHandle,
-    TaskHandleComparator<
-        grpc_event_engine::experimental::EventEngine::ConnectionHandle>::Hash,
-    TaskHandleComparator<
-        grpc_event_engine::experimental::EventEngine::ConnectionHandle>::Eq>;
+    EventEngine::ConnectionHandle,
+    TaskHandleComparator<EventEngine::ConnectionHandle>::Hash>;
 
 using LookupTaskHandleSet = absl::flat_hash_set<
-    grpc_event_engine::experimental::EventEngine::DNSResolver::LookupTaskHandle,
-    TaskHandleComparator<grpc_event_engine::experimental::EventEngine::
-                             DNSResolver::LookupTaskHandle>::Hash,
-    TaskHandleComparator<grpc_event_engine::experimental::EventEngine::
-                             DNSResolver::LookupTaskHandle>::Eq>;
+    EventEngine::DNSResolver::LookupTaskHandle,
+    TaskHandleComparator<EventEngine::DNSResolver::LookupTaskHandle>::Hash>;
 
 }  // namespace experimental
 }  // namespace grpc_event_engine

--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -190,6 +190,21 @@ grpc_cc_test(
     ],
 )
 
+grpc_cc_test(
+    name = "handle_tests",
+    srcs = ["handle_tests.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    language = "C++",
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//src/core:event_engine_common",
+        "//:gpr_platform",
+    ],
+)
+
 grpc_cc_library(
     name = "event_engine_test_utils",
     testonly = True,


### PR DESCRIPTION
This allows us to replace `absl::optional<TaskHandle>` with checks against the invalid handle.

This PR also replaces the differently-named invalid handle instances with a uniform way of accessing static invalid instances across all handle types, which aids a bit in testing.