### PR TITLE
[PHP] add waitThrow() function

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,6 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 tab_width = 8
+
+[*.php]
+indent_size = 4

--- a/src/php/lib/Grpc/ClientStreamingCall.php
+++ b/src/php/lib/Grpc/ClientStreamingCall.php
@@ -77,4 +77,17 @@ class ClientStreamingCall extends AbstractCall
 
         return [$this->_deserializeResponse($event->message), $status];
     }
+
+    /**
+     * Wait for the server to respond, throw an exception if an error occurred, and return response otherwise
+     *
+     * @throws Exceptions\GrpcException
+     */
+    public function waitThrow()
+    {
+        list($response, $status) = $this->wait();
+        Status::throwIfError($status);
+
+        return $response;
+    }
 }

--- a/src/php/lib/Grpc/Exceptions/AbortedException.php
+++ b/src/php/lib/Grpc/Exceptions/AbortedException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class AbortedException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/AlreadyExistsException.php
+++ b/src/php/lib/Grpc/Exceptions/AlreadyExistsException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class AlreadyExistsException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/CancelledException.php
+++ b/src/php/lib/Grpc/Exceptions/CancelledException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class CancelledException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/DataLossException.php
+++ b/src/php/lib/Grpc/Exceptions/DataLossException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class DataLossException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/DeadlineExceededException.php
+++ b/src/php/lib/Grpc/Exceptions/DeadlineExceededException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class DeadlineExceededException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/FailedPreconditionException.php
+++ b/src/php/lib/Grpc/Exceptions/FailedPreconditionException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class FailedPreconditionException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/GrpcException.php
+++ b/src/php/lib/Grpc/Exceptions/GrpcException.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+use Exception;
+
+class GrpcException extends Exception
+{
+    /** @var mixed */
+    protected $metadata;
+
+  /**
+   * @param string $message
+   * @param int $code
+   * @param mixed $metadata
+   */
+    public function __construct($message = "", $code = 0, $metadata = null)
+    {
+        parent::__construct($message, $code);
+        $this->metadata = $metadata;
+    }
+
+  /**
+   * @return mixed
+   */
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+}

--- a/src/php/lib/Grpc/Exceptions/InternalException.php
+++ b/src/php/lib/Grpc/Exceptions/InternalException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class InternalException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/InvalidArgumentException.php
+++ b/src/php/lib/Grpc/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class InvalidArgumentException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/NotFoundException.php
+++ b/src/php/lib/Grpc/Exceptions/NotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class NotFoundException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/OutOfRangeException.php
+++ b/src/php/lib/Grpc/Exceptions/OutOfRangeException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class OutOfRangeException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/PermissionDeniedException.php
+++ b/src/php/lib/Grpc/Exceptions/PermissionDeniedException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class PermissionDeniedException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/ResourceExhaustedException.php
+++ b/src/php/lib/Grpc/Exceptions/ResourceExhaustedException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class ResourceExhaustedException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/UnauthenticatedException.php
+++ b/src/php/lib/Grpc/Exceptions/UnauthenticatedException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class UnauthenticatedException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/UnavailableException.php
+++ b/src/php/lib/Grpc/Exceptions/UnavailableException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class UnavailableException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/UnimplementedException.php
+++ b/src/php/lib/Grpc/Exceptions/UnimplementedException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class UnimplementedException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/Exceptions/UnknownException.php
+++ b/src/php/lib/Grpc/Exceptions/UnknownException.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Grpc\Exceptions;
+
+class UnknownException extends GrpcException
+{
+}

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -71,6 +71,19 @@ class UnaryCall extends AbstractCall
         return [$this->_deserializeResponse($event->message), $status];
     }
 
+  /**
+   * Wait for the server to respond, throw an exception if an error occurred, and return response otherwise
+   *
+   * @throws Exceptions\GrpcException
+   */
+    public function waitThrow()
+    {
+        list($response, $status) = $this->wait();
+        Status::throwIfError($status);
+
+        return $response;
+    }
+
     /**
      * @return mixed The metadata sent by the server
      */


### PR DESCRIPTION
Current function for receiving a response, wait(), returns an array of [response, status array]. This is not ideomatic modern PHP, instead I'm adding a new function that throws an exception on error or returns a response object.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

