### PR TITLE
[Github Actions] Fix labeller Github action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,12 +36,14 @@ lang/php:
 - src/php/**
 
 lang/python:
-- bazel/python_rules.bzl
-- examples/python/**
-- requirements.bazel.txt
-- src/compiler/python*
-- src/python/**
-- "!src/python/grpcio/grpc_core_dependencies.py"
+- any:
+  - bazel/python_rules.bzl
+  - examples/python/**
+  - requirements.bazel.txt
+  - src/compiler/python*
+- any:
+  - src/python/**
+  - "!src/python/grpcio/grpc_core_dependencies.py"
 
 lang/ruby:
 - examples/ruby/**


### PR DESCRIPTION
Fix-forward for https://github.com/grpc/grpc/pull/32629. Referencing the [documentation](https://github.com/marketplace/actions/labeler), if the top-level list for a label is a list of strings, it is treated as a single `any` entry. `any` entries are ANDed together. This means that the original PR said "label lang/python if anything _besides_ grpc_core_dependencies.py changed." This is obviously not desired.

This PR makes the `any` explicit. The logic now says "label lang/python if any of these few files has changed OR if any file but grpc_core_dependencies.py under src/python has changed."

I'm still not 100% certain that this will work, but the stakes aren't super high.