### PR TITLE
[cmake] Workaround missing stdalign.h in windows portability test

### DIFF
--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -29,6 +29,20 @@ If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2019" (
   echo on
 )
 
+If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 16 2019" (
+  @rem Force using a new-enough Windows 10 SDK that supports C++11's stdalign.h
+  @rem For some reason, cmake together with visual studio generator by default
+  @rem pick an old version of Win SDK even when a newer version is installed on the system.
+  @rem When using Ninja generator, this problem doesn't happen.
+  @rem The argument corresponds to Microsoft.VisualStudio.Component.Windows10SDK.20348
+  @rem See b/275694647
+  set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0.20348.0"
+) else (
+  @rem Setting the env variable to a single space translates to passing no argument
+  @rem when evaluated on the command line.
+  set "CMAKE_SYSTEM_VERSION_ARG= "
+)
+
 If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (
   @rem Use ninja
 
@@ -41,7 +55,7 @@ If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (
 ) else (
   @rem Use one of the Visual Studio generators.
 
-  cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64 -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% %* ../.. || goto :error
+  cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" %CMAKE_SYSTEM_VERSION_ARG% -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64 -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% %* ../.. || goto :error
 
   @rem GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
   cmake --build . --target buildtests_%GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX% --config %MSBUILD_CONFIG% || goto :error


### PR DESCRIPTION
Tentative fix for b/275694647. Also see https://github.com/grpc/grpc/pull/32662

Adhoc windows/grpc_portability run: http://sponge/bb75e14c-fc77-45bb-89bd-4c4685746490

Once merged, I'll backport to 1.54.x and 1.53.x (these have switched to VS2019)


