### PR TITLE
[Github Actions] Hopefully final fix for lang/python label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,11 +36,10 @@ lang/php:
 - src/php/**
 
 lang/python:
-- any:
-  - bazel/python_rules.bzl
-  - examples/python/**
-  - requirements.bazel.txt
-  - src/compiler/python*
+- bazel/python_rules.bzl
+- examples/python/**
+- requirements.bazel.txt
+- src/compiler/python*
 - any:
   - src/python/**
   - "!src/python/grpcio/grpc_core_dependencies.py"


### PR DESCRIPTION
Follow-up to https://github.com/grpc/grpc/pull/32751. I finally broke down and put together a hacky way to mess with this manually. [This hacked up version of the implementation](https://gist.github.com/gnossen/f2f334b448eab73f383d65d5206056b6) adds some unit tests to make sure it does exactly what we want.

The final issue was that [this block](https://github.com/grpc/grpc/blob/49b9dfa644f9a278dd3dd5d4cdd8fe06e586d2f7/.github/labeler.yml#L39) would never trigger unless _all_ of the explicitly mentioned files was added there. The fix is to pull them each individually into their own [`MatcherConfig`](https://github.com/actions/labeler/blob/d8f73a2893784c165d3b624cc423d180aa6ee6de/src/labeler.ts#L6) object with a single [`any` field](https://github.com/actions/labeler/blob/d8f73a2893784c165d3b624cc423d180aa6ee6de/src/labeler.ts#L8).