### PR TITLE
[python] Python fixes for upcoming protobuf 22.x upgrade

### DIFF
--- a/src/python/grpcio/_spawn_patch.py
+++ b/src/python/grpcio/_spawn_patch.py
@@ -44,7 +44,10 @@ def _commandfile_spawn(self, command):
             escaped_args = [
                 '"' + arg.replace('\\', '\\\\') + '"' for arg in command[1:]
             ]
-            command_file.write(' '.join(escaped_args))
+            # add each arg on a separate line to avoid hitting the
+            # "line in command file contains 131071 or more characters" error
+            # (can happen for extra long link commands)
+            command_file.write(' \n'.join(escaped_args))
         modified_command = command[:1] + ['@{}'.format(command_filename)]
         try:
             _classic_spawn(self, modified_command)

--- a/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
@@ -24,8 +24,8 @@
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/command_line_interface.h>
 #include <google/protobuf/compiler/importer.h>
+#include <google/protobuf/compiler/python/generator.h>
 #include <google/protobuf/compiler/python/pyi_generator.h>
-#include <google/protobuf/compiler/python/python_generator.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -203,7 +203,11 @@ GRPC_PYTHON_PROTO_RESOURCES_NAME = '_proto'
 
 DEFINE_MACROS = ()
 if "win32" in sys.platform:
-    DEFINE_MACROS += (('WIN32_LEAN_AND_MEAN', 1),)
+    DEFINE_MACROS += (
+        ('WIN32_LEAN_AND_MEAN', 1),
+        # avoid https://github.com/abseil/abseil-cpp/issues/1425
+        ('NOMINMAX', 1),
+    )
     if '64bit' in platform.architecture()[0]:
         DEFINE_MACROS += (('MS_WIN64', 1),)
 elif "linux" in sys.platform or "darwin" in sys.platform:


### PR DESCRIPTION
Various fixes that can be merged in advance, to simplify the 22.x upgrade.

- Use NOMINMAX for grpcio_tools build to avoid build failure when absl is added as a dependency. Fixes https://github.com/grpc/grpc/issues/32779
- in spawn_patch command file, put arguments on multiple lines to avoid lines going over the limit for large link commands: Fixes https://github.com/grpc/grpc/issues/32795
- Use `python/generator.h` instead of the deprecated `python/python_generator.h` in grpcio_tools.
