### PR TITLE
[cmake] Backport VS2019 fixes to 1.53.x branch

### DIFF
--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -30,13 +30,17 @@ If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2019" (
 )
 
 If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 16 2019" (
-  @rem Force using a new-enough Windows 10 SDK that supports C++11's stdalign.h
-  @rem For some reason, cmake together with visual studio generator by default
-  @rem pick an old version of Win SDK even when a newer version is installed on the system.
+  @rem Always use the newest Windows 10 SDK available.
+  @rem A new-enough Windows 10 SDK that supports C++11's stdalign.h is required
+  @rem for a successful build.
+  @rem By default cmake together with Visual Studio generator
+  @rem pick a version of Win SDK that matches the Windows version,
+  @rem even when a newer version of the SDK available.
+  @rem Setting CMAKE_SYSTEM_VERSION=10.0 changes this behavior
+  @rem to pick the newest Windows SDK available.
   @rem When using Ninja generator, this problem doesn't happen.
-  @rem The argument corresponds to Microsoft.VisualStudio.Component.Windows10SDK.20348
-  @rem See b/275694647
-  set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0.20348.0"
+  @rem See b/275694647 and https://gitlab.kitware.com/cmake/cmake/-/issues/16202#note_140259
+  set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0"
 ) else (
   @rem Setting the env variable to a single space translates to passing no argument
   @rem when evaluated on the command line.

--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -29,6 +29,20 @@ If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2019" (
   echo on
 )
 
+If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 16 2019" (
+  @rem Force using a new-enough Windows 10 SDK that supports C++11's stdalign.h
+  @rem For some reason, cmake together with visual studio generator by default
+  @rem pick an old version of Win SDK even when a newer version is installed on the system.
+  @rem When using Ninja generator, this problem doesn't happen.
+  @rem The argument corresponds to Microsoft.VisualStudio.Component.Windows10SDK.20348
+  @rem See b/275694647
+  set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0.20348.0"
+) else (
+  @rem Setting the env variable to a single space translates to passing no argument
+  @rem when evaluated on the command line.
+  set "CMAKE_SYSTEM_VERSION_ARG= "
+)
+
 If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (
   @rem Use ninja
 
@@ -41,7 +55,7 @@ If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (
 ) else (
   @rem Use one of the Visual Studio generators.
 
-  cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64 -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% %* ../.. || goto :error
+  cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" %CMAKE_SYSTEM_VERSION_ARG% -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64 -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% %* ../.. || goto :error
 
   @rem GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
   cmake --build . --target buildtests_%GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX% --config %MSBUILD_CONFIG% || goto :error

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -336,17 +336,12 @@ class CLanguage(object):
                 if self.args.iomgr_platform in target.get('exclude_iomgrs', []):
                     continue
 
-                if self.platform == 'windows' and target['name'] in (
-                        'invalid_call_argument_test',
-                        'bad_server_response_test', 'goaway_server_test'):
-                    # A few tests fail on the win2019 workers, but since they pass on Windows bazel RBE,
-                    # it seems ok to skip them in run_tests.py temporarily.
-                    # TODO(jtattermusch): Reenable the tests.
-                    continue
-
                 if self.platform == 'windows':
-                    binary = 'cmake/build/%s/%s.exe' % (_MSBUILD_CONFIG[
-                        self.config.build_config], target['name'])
+                    if self._cmake_generator_windows == 'Ninja':
+                        binary = 'cmake/build/%s.exe' % target['name']
+                    else:
+                        binary = 'cmake/build/%s/%s.exe' % (_MSBUILD_CONFIG[
+                            self.config.build_config], target['name'])
                 else:
                     binary = 'cmake/build/%s' % target['name']
 


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/32764, https://github.com/grpc/grpc/pull/32777 and https://github.com/grpc/grpc/pull/32658