### PR TITLE
[chttp2] Better error message on metadata size exceeded message

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -837,11 +837,11 @@ class HPackParser::Parser {
                      "B)", summary.empty() ? "" : " to ", summary);
     if (exceeded_hard_limit) {
       error_message = absl::StrCat(
-          "received initial metadata size exceeds hard limit (", *frame_length_,
+          "received metadata size exceeds hard limit (", *frame_length_,
           " vs. ", metadata_early_detection_->hard_limit(), ")", summary);
     } else {
       error_message = absl::StrCat(
-          "received initial metadata size exceeds soft limit (", *frame_length_,
+          "received metadata size exceeds soft limit (", *frame_length_,
           " vs. ", metadata_early_detection_->soft_limit(),
           "), rejecting requests with some random probability", summary);
     }

--- a/test/core/end2end/tests/large_metadata.cc
+++ b/test/core/end2end/tests/large_metadata.cc
@@ -47,9 +47,8 @@ class LargeMetadataTest {
     for (int i = 0; i < count; ++i) {
       auto status = PerformOneRequest(metadata_size);
       if (status.status() == GRPC_STATUS_RESOURCE_EXHAUSTED) {
-        EXPECT_THAT(
-            status.message(),
-            ::testing::StartsWith("received initial metadata size exceeds"));
+        EXPECT_THAT(status.message(),
+                    ::testing::StartsWith("received metadata size exceeds"));
       } else {
         num_requests_accepted++;
         EXPECT_EQ(status.status(), GRPC_STATUS_OK);


### PR DESCRIPTION
This error can trigger for either initial or trailing metadata (and we've had outages where the latter was the cause).

I don't think we know at this layer if we're parsing initial or trailing - though it'd be a good exercise to plumb that through.

For now remove the word initial because it's better to give less information than wrong information.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

