### PR TITLE
Revert "XDS: enable XDS federation by default (#32711)"

### DIFF
--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -12809,7 +12809,6 @@ targets:
   build: test
   language: c++
   headers:
-  - test/core/util/scoped_env_var.h
   - test/core/xds/xds_transport_fake.h
   src:
   - src/proto/grpc/testing/xds/v3/base.proto

--- a/src/core/ext/xds/xds_bootstrap.cc
+++ b/src/core/ext/xds/xds_bootstrap.cc
@@ -25,11 +25,11 @@
 
 namespace grpc_core {
 
-// TODO(roth,apolcyn): remove this federation env var after the 1.55
-// release.
+// TODO(donnadionne): check to see if federation is enabled, this will be
+// removed once federation is fully integrated and enabled by default.
 bool XdsFederationEnabled() {
   auto value = GetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
-  if (!value.has_value()) return true;
+  if (!value.has_value()) return false;
   bool parsed_value;
   bool parse_succeeded = gpr_parse_bool_value(value->c_str(), &parsed_value);
   return parse_succeeded && parsed_value;

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -158,7 +158,6 @@ grpc_cc_test(
         "//:xds_client",
         "//src/proto/grpc/testing/xds/v3:discovery_proto",
         "//test/core/util:grpc_test_util",
-        "//test/core/util:scoped_env_var",
     ],
 )
 

--- a/test/core/xds/xds_bootstrap_test.cc
+++ b/test/core/xds/xds_bootstrap_test.cc
@@ -56,6 +56,7 @@ namespace testing {
 namespace {
 
 TEST(XdsBootstrapTest, Basic) {
+  SetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION", "true");
   const char* json_str =
       "{"
       "  \"xds_servers\": ["
@@ -191,6 +192,7 @@ TEST(XdsBootstrapTest, Basic) {
                           ::testing::Property(&Json::string_value, "1")))));
   EXPECT_EQ(bootstrap->server_listener_resource_name_template(),
             "example/resource");
+  UnsetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
 }
 
 TEST(XdsBootstrapTest, ValidWithoutNode) {
@@ -494,6 +496,7 @@ TEST(XdsBootstrapTest, CertificateProvidersUnrecognizedPluginName) {
 }
 
 TEST(XdsBootstrapTest, AuthorityXdsServerInvalidResourceTemplate) {
+  SetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION", "true");
   const char* json_str =
       "{"
       "  \"xds_servers\": ["
@@ -528,9 +531,11 @@ TEST(XdsBootstrapTest, AuthorityXdsServerInvalidResourceTemplate) {
             ".client_listener_resource_name_template error:"
             "field must begin with \"xdstp://xds.example.com/\"]")
       << bootstrap.status();
+  UnsetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
 }
 
 TEST(XdsBootstrapTest, AuthorityXdsServerMissingServerUri) {
+  SetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION", "true");
   const char* json_str =
       "{"
       "  \"xds_servers\": ["
@@ -557,6 +562,7 @@ TEST(XdsBootstrapTest, AuthorityXdsServerMissingServerUri) {
       "field:authorities[\"xds.example.com\"].xds_servers[0].server_uri "
       "error:field not present]")
       << bootstrap.status();
+  UnsetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
 }
 
 class FakeCertificateProviderFactory : public CertificateProviderFactory {
@@ -697,6 +703,7 @@ TEST(XdsBootstrapTest, CertificateProvidersFakePluginEmptyConfig) {
 }
 
 TEST(XdsBootstrapTest, XdsServerToJsonAndParse) {
+  SetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION", "true");
   const char* json_str =
       "    {"
       "      \"server_uri\": \"fake:///lb\","
@@ -717,6 +724,7 @@ TEST(XdsBootstrapTest, XdsServerToJsonAndParse) {
       LoadFromJson<GrpcXdsBootstrap::GrpcXdsServer>(output);
   ASSERT_TRUE(output_xds_server.ok()) << output_xds_server.status();
   EXPECT_EQ(*xds_server, *output_xds_server);
+  UnsetEnv("GRPC_EXPERIMENTAL_XDS_FEDERATION");
 }
 
 }  // namespace

--- a/test/core/xds/xds_client_test.cc
+++ b/test/core/xds/xds_client_test.cc
@@ -47,13 +47,13 @@
 #include "src/core/ext/xds/xds_resource_type_impl.h"
 #include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/gprpp/debug_location.h"
+#include "src/core/lib/gprpp/env.h"
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/json/json.h"
 #include "src/core/lib/json/json_args.h"
 #include "src/core/lib/json/json_object_loader.h"
 #include "src/proto/grpc/testing/xds/v3/base.pb.h"
 #include "src/proto/grpc/testing/xds/v3/discovery.pb.h"
-#include "test/core/util/scoped_env_var.h"
 #include "test/core/util/test_config.h"
 #include "test/core/xds/xds_transport_fake.h"
 
@@ -551,6 +551,18 @@ class XdsClientTest : public ::testing::Test {
 
    private:
     DiscoveryResponse response_;
+  };
+
+  class ScopedExperimentalEnvVar {
+   public:
+    explicit ScopedExperimentalEnvVar(const char* env_var) : env_var_(env_var) {
+      SetEnv(env_var_, "true");
+    }
+
+    ~ScopedExperimentalEnvVar() { UnsetEnv(env_var_); }
+
+   private:
+    const char* env_var_;
   };
 
   // Sets transport_factory_ and initializes xds_client_ with the
@@ -2312,6 +2324,7 @@ TEST_F(XdsClientTest, MultipleResourceTypes) {
 }
 
 TEST_F(XdsClientTest, Federation) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   constexpr char kAuthority[] = "xds.example.com";
   const std::string kXdstpResourceName = absl::StrCat(
       "xdstp://", kAuthority, "/", XdsFooResource::TypeUrl(), "/foo2");
@@ -2400,6 +2413,7 @@ TEST_F(XdsClientTest, Federation) {
 }
 
 TEST_F(XdsClientTest, FederationAuthorityDefaultsToTopLevelXdsServer) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   constexpr char kAuthority[] = "xds.example.com";
   const std::string kXdstpResourceName = absl::StrCat(
       "xdstp://", kAuthority, "/", XdsFooResource::TypeUrl(), "/foo2");
@@ -2488,6 +2502,7 @@ TEST_F(XdsClientTest, FederationAuthorityDefaultsToTopLevelXdsServer) {
 }
 
 TEST_F(XdsClientTest, FederationWithUnknownAuthority) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   constexpr char kAuthority[] = "xds.example.com";
   const std::string kXdstpResourceName = absl::StrCat(
       "xdstp://", kAuthority, "/", XdsFooResource::TypeUrl(), "/foo2");
@@ -2505,6 +2520,7 @@ TEST_F(XdsClientTest, FederationWithUnknownAuthority) {
 }
 
 TEST_F(XdsClientTest, FederationWithUnparseableXdstpResourceName) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   // Note: Not adding authority to bootstrap config.
   InitXdsClient();
   // Start a watch for the xdstp resource name.
@@ -2517,10 +2533,7 @@ TEST_F(XdsClientTest, FederationWithUnparseableXdstpResourceName) {
       << *error;
 }
 
-// TODO(roth,apolcyn): remove this test when the
-// GRPC_EXPERIMENTAL_XDS_FEDERATION env var is removed.
 TEST_F(XdsClientTest, FederationDisabledWithNewStyleName) {
-  testing::ScopedEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION", "false");
   // We will use this xdstp name, whose authority is not present in
   // the bootstrap config.  But since federation is not enabled, we
   // will treat this as an opaque old-style name, so we'll send it to
@@ -2568,6 +2581,7 @@ TEST_F(XdsClientTest, FederationDisabledWithNewStyleName) {
 }
 
 TEST_F(XdsClientTest, FederationChannelFailureReportedToWatchers) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   constexpr char kAuthority[] = "xds.example.com";
   const std::string kXdstpResourceName = absl::StrCat(
       "xdstp://", kAuthority, "/", XdsFooResource::TypeUrl(), "/foo2");

--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -33,6 +33,8 @@ namespace {
 
 using ClientStats = LrsServiceImpl::ClientStats;
 
+using ::grpc_core::testing::ScopedExperimentalEnvVar;
+
 //
 // XdsClientTest - basic tests of XdsClient functionality
 //
@@ -687,6 +689,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Bootstrap config default client listener template uses new-style name with
 // authority "xds.example.com".
 TEST_P(XdsFederationTest, FederationTargetNoAuthorityWithResourceTemplate) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewListenerTemplate =
       "xdstp://xds.example.com/envoy.config.listener.v3.Listener/"
@@ -743,6 +746,7 @@ TEST_P(XdsFederationTest, FederationTargetNoAuthorityWithResourceTemplate) {
 // In bootstrap config, authority has no client listener template, so we use the
 // default.
 TEST_P(XdsFederationTest, FederationTargetAuthorityDefaultResourceTemplate) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerName =
@@ -809,6 +813,7 @@ TEST_P(XdsFederationTest, FederationTargetAuthorityDefaultResourceTemplate) {
 // Channel is created with URI "xds://xds.example.com/server.example.com".
 // Bootstrap entry for that authority specifies a client listener name template.
 TEST_P(XdsFederationTest, FederationTargetAuthorityWithResourceTemplate) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerTemplate =
@@ -877,6 +882,7 @@ TEST_P(XdsFederationTest, FederationTargetAuthorityWithResourceTemplate) {
 }
 
 TEST_P(XdsFederationTest, TargetUriAuthorityUnknown) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerTemplate =
@@ -902,6 +908,7 @@ TEST_P(XdsFederationTest, TargetUriAuthorityUnknown) {
 }
 
 TEST_P(XdsFederationTest, RdsResourceNameAuthorityUnknown) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerTemplate =
@@ -945,6 +952,7 @@ TEST_P(XdsFederationTest, RdsResourceNameAuthorityUnknown) {
 }
 
 TEST_P(XdsFederationTest, CdsResourceNameAuthorityUnknown) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerTemplate =
@@ -995,6 +1003,7 @@ TEST_P(XdsFederationTest, CdsResourceNameAuthorityUnknown) {
 }
 
 TEST_P(XdsFederationTest, EdsResourceNameAuthorityUnknown) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerTemplate =
@@ -1057,6 +1066,7 @@ TEST_P(XdsFederationTest, EdsResourceNameAuthorityUnknown) {
 // Setting server_listener_resource_name_template to start with "xdstp:" and
 // look up xds server under an authority map.
 TEST_P(XdsFederationTest, FederationServer) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewListenerTemplate =
       "xdstp://xds.example.com/envoy.config.listener.v3.Listener/"
@@ -1144,11 +1154,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(XdsTestType().set_enable_rds_testing()),
     &XdsTestType::Name);
 
-// TODO(roth,apolcyn): remove this test when the
-// GRPC_EXPERIMENTAL_XDS_FEDERATION env var is removed.
 TEST_P(XdsFederationDisabledTest, FederationDisabledWithNewStyleNames) {
-  grpc_core::testing::ScopedEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION",
-                                           "false");
   const char* kNewRouteConfigName =
       "xdstp://xds.example.com/envoy.config.route.v3.RouteConfiguration/"
       "new_route_config_name";
@@ -1207,6 +1213,7 @@ INSTANTIATE_TEST_SUITE_P(
 // Sending traffic to both default balancer and authority balancer and checking
 // load reporting with each one.
 TEST_P(XdsFederationLoadReportingTest, FederationMultipleLoadReportingTest) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_FEDERATION");
   const char* kAuthority = "xds.example.com";
   const char* kNewServerName = "whee%/server.example.com";
   const char* kNewListenerTemplate =


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/32814 to 1.54.x

cc @stanley-cheung 
