### PR TITLE
[GCP Observability] Remove sleep from observability test client

### DIFF
--- a/test/cpp/interop/observability_client.cc
+++ b/test/cpp/interop/observability_client.cc
@@ -357,16 +357,6 @@ int main(int argc, char** argv) {
 
   if (absl::GetFlag(FLAGS_enable_observability)) {
     grpc::experimental::GcpObservabilityClose();
-    // TODO(stanleycheung): remove this once the observability exporter plugin
-    //                      is able to gracefully flush observability data to
-    //                      cloud at shutdown
-    const int observability_exporter_sleep_seconds = 65;
-    gpr_log(GPR_DEBUG, "Sleeping %ds before shutdown.",
-            observability_exporter_sleep_seconds);
-    gpr_sleep_until(
-        gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                     gpr_time_from_seconds(observability_exporter_sleep_seconds,
-                                           GPR_TIMESPAN)));
   }
 
   return ret;


### PR DESCRIPTION
Backport of #32817 

.. as it is now part of the `GcpObservabilityClose()` routine [itself](https://github.com/grpc/grpc/pull/32715/files#diff-e1ce0ccb4650e20b62a6d6b31655f446ad9ef72efca5849143e65f4a5a5e0310R223).

Background: #32715 may have broken the CI for observability interop testing. The client seems to be taking too long to finish. More info at b/277145074

We need to backport this to the `v1.54.x` branch.