### PR TITLE
[experiments] add check for experiment string length

### DIFF
--- a/tools/codegen/core/gen_experiments.py
+++ b/tools/codegen/core/gen_experiments.py
@@ -76,6 +76,7 @@ BZL_LIST_FOR_DEFAULTS = {
 error = False
 today = datetime.date.today()
 two_quarters_from_now = today + datetime.timedelta(days=180)
+experiment_annotation = 'gRPC experiments:'
 for attr in attrs:
     if 'name' not in attr:
         print("experiment with no name: %r" % attr)
@@ -108,6 +109,11 @@ for attr in attrs:
                   (attr['name'], attr['expiry']))
             print("expiry should be no more than two quarters from now")
             error = True
+        experiment_annotation += attr['name'] + ':0,'
+
+if len(experiment_annotation) > 2000:
+    print("comma-delimited string of experiments is too long")
+    error = True
 
 if error:
     sys.exit(1)


### PR DESCRIPTION
Since we are adding an annotation for experiments internally, we need to ensure the length of the annotation does not exceed 2 KB (used slightly lower number in the check). Added a check to gen_experiments.py for this.

