### PR TITLE
[compiler] python: don't generate empty files for sources that do not define any services

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -887,6 +887,11 @@ bool PythonGrpcGenerator::Generate(const FileDescriptor* file,
                                    const std::string& parameter,
                                    GeneratorContext* context,
                                    std::string* error) const {
+  if (file->service_count() == 0) {
+    // Nothing to do be done for this file.
+    return true;
+  }
+
   // Get output file name.
   std::string pb2_file_name;
   std::string pb2_grpc_file_name;


### PR DESCRIPTION
Fixes #32763.

I can't seem to find a super-easy way to test this. I tried running `bazel test //test/...` and half of them fail even without this patch. And I also ended up running into #24665 and didn't see any trivial work-arounds in that issue.

Hopefully it's fair to assume that whatever CI jobs will run against this PR will suss out anything that this breaks (hopefully nothing 🤞)?