### PR TITLE
[BUILD files] use grpc_package() everywhere

### DIFF
--- a/src/proto/grpc/channelz/BUILD
+++ b/src/proto/grpc/channelz/BUILD
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "channelz",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "channelz_proto",

--- a/src/proto/grpc/health/v1/BUILD
+++ b/src/proto/grpc/health/v1/BUILD
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "health",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "health_proto",

--- a/src/proto/grpc/lb/v1/BUILD
+++ b/src/proto/grpc/lb/v1/BUILD
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "lb",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "load_balancer_proto",

--- a/src/proto/grpc/lookup/v1/BUILD
+++ b/src/proto/grpc/lookup/v1/BUILD
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "src/proto/grpc/lookup/v1",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "rls_proto",

--- a/src/proto/grpc/reflection/v1/BUILD
+++ b/src/proto/grpc/reflection/v1/BUILD
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "reflection_v1",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "reflection_proto",

--- a/src/proto/grpc/reflection/v1alpha/BUILD
+++ b/src/proto/grpc/reflection/v1alpha/BUILD
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "reflection",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "reflection_proto",

--- a/src/proto/grpc/status/BUILD
+++ b/src/proto/grpc/status/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "status",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "status_proto",

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -13,15 +13,12 @@
 # limitations under the License.
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 load("//bazel:python_rules.bzl", "py_grpc_library", "py_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "testing",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "echo.proto",

--- a/src/proto/grpc/testing/duplicate/BUILD
+++ b/src/proto/grpc/testing/duplicate/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "duplicate",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "echo_duplicate_proto",

--- a/src/proto/grpc/testing/xds/v3/BUILD
+++ b/src/proto/grpc/testing/xds/v3/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_proto_library")
 load("//bazel:python_rules.bzl", "py_grpc_library", "py_proto_library")
 
 licenses(["notice"])
@@ -21,10 +21,7 @@ exports_files([
     "orca_load_report.proto",
 ])
 
-grpc_package(
-    name = "xds_v3",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "address_proto",

--- a/test/core/address_utils/BUILD
+++ b/test/core/address_utils/BUILD
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/address_utils",
-    visibility = "private",
-)
+package(default_visibility = ["//visibility:private"])
 
 grpc_cc_test(
     name = "sockaddr_utils_test",

--- a/test/core/avl/BUILD
+++ b/test/core/avl/BUILD
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/avl")
 
 grpc_cc_test(
     name = "avl_test",

--- a/test/core/bad_client/BUILD
+++ b/test/core/bad_client/BUILD
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package")
 load(":generate_tests.bzl", "grpc_bad_client_tests")
-
-grpc_package(name = "test/core/bad_client")
 
 licenses(["notice"])
 

--- a/test/core/bad_connection/BUILD
+++ b/test/core/bad_connection/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/bad_connection")
 
 grpc_cc_binary(
     name = "close_fd_test",

--- a/test/core/bad_ssl/BUILD
+++ b/test/core/bad_ssl/BUILD
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package")
 load(":generate_tests.bzl", "grpc_bad_ssl_tests")
-
-grpc_package(name = "test/core/bad_ssl")
 
 licenses(["notice"])
 

--- a/test/core/channel/BUILD
+++ b/test/core/channel/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/channel")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/client_channel")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/client_channel/lb_policy/BUILD
+++ b/test/core/client_channel/lb_policy/BUILD
@@ -16,10 +16,8 @@ load(
     "//bazel:grpc_build_system.bzl",
     "grpc_cc_library",
     "grpc_cc_test",
-    "grpc_package",
+    
 )
-
-grpc_package(name = "test/core/client_channel/lb_policy")
 
 licenses(["notice"])
 

--- a/test/core/client_channel/resolvers/BUILD
+++ b/test/core/client_channel/resolvers/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/client_channel/resolvers")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/client_idle/BUILD
+++ b/test/core/client_idle/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/client_idle")
 
 grpc_cc_test(
     name = "idle_filter_state_test",

--- a/test/core/compiler_bugs/BUILD
+++ b/test/core/compiler_bugs/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/compiler_bugs")
 
 grpc_cc_test(
     name = "miscompile_with_no_unique_address_test",

--- a/test/core/compression/BUILD
+++ b/test/core/compression/BUILD
@@ -15,11 +15,9 @@
 load(
     "//bazel:grpc_build_system.bzl",
     "grpc_cc_test",
-    "grpc_package",
+    
 )
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
-
-grpc_package(name = "test/core/compression")
 
 licenses(["notice"])
 

--- a/test/core/config/BUILD
+++ b/test/core/config/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/config")
 
 grpc_cc_test(
     name = "core_configuration_test",

--- a/test/core/debug/BUILD
+++ b/test/core/debug/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/debug")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/end2end")
 
 grpc_cc_library(
     name = "cq_verifier",

--- a/test/core/end2end/fuzzers/BUILD
+++ b/test/core/end2end/fuzzers/BUILD
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer", "grpc_proto_fuzzer")
-
-grpc_package(name = "test/core/end2end/fuzzers")
 
 licenses(["notice"])
 

--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_test(
     name = "common_closures_test",

--- a/test/core/event_engine/fuzzing_event_engine/BUILD
+++ b/test/core/event_engine/fuzzing_event_engine/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine/fuzzing_event_engine",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_library(
     name = "fuzzing_event_engine",

--- a/test/core/event_engine/posix/BUILD
+++ b/test/core/event_engine/posix/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine/posix",
-    visibility = "public",
-)  # Useful for third party devs to test their io manager implementation.
+package(default_visibility = ["//visibility:public"])  # Useful for third party devs to test their io manager implementation.
 
 grpc_cc_library(
     name = "posix_engine_test_utils",

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine/test_suite",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_library(
     name = "event_engine_test_framework",

--- a/test/core/event_engine/test_suite/posix/BUILD
+++ b/test/core/event_engine/test_suite/posix/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/event_engine/test_suite/posix")
 
 grpc_cc_library(
     name = "oracle_event_engine_posix",

--- a/test/core/event_engine/test_suite/tests/BUILD
+++ b/test/core/event_engine/test_suite/tests/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine/test_suite/tests",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 # TODO(hork): A single InitTestSuite() call should initialize all tests.
 # This can be done after each test suite specialization can explicitly opt in or out

--- a/test/core/event_engine/test_suite/tools/BUILD
+++ b/test/core/event_engine/test_suite/tools/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/event_engine/test_suite/tools")
 
 # -- Implementations --
 

--- a/test/core/event_engine/thready_event_engine/BUILD
+++ b/test/core/event_engine/thready_event_engine/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine/thready_event_engine",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_library(
     name = "thready_event_engine",

--- a/test/core/event_engine/work_queue/BUILD
+++ b/test/core/event_engine/work_queue/BUILD
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/event_engine/work_queue",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_test(
     name = "work_queue_test",

--- a/test/core/ext/filters/rbac/BUILD
+++ b/test/core/ext/filters/rbac/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/ext/filters/rbac")
 
 grpc_cc_test(
     name = "rbac_service_config_parser_test",

--- a/test/core/filters/BUILD
+++ b/test/core/filters/BUILD
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/filters")
 
 grpc_cc_library(
     name = "filter_test",

--- a/test/core/gpr/BUILD
+++ b/test/core/gpr/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/gpr")
 
 grpc_cc_test(
     name = "alloc_test",

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//bazel:custom_exec_properties.bzl", "LARGE_MACHINE")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/gprpp")
 
 grpc_cc_test(
     name = "examine_stack_test",

--- a/test/core/handshake/BUILD
+++ b/test/core/handshake/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/handshake")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
-
-grpc_package(name = "test/core/http")
 
 licenses(["notice"])
 

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 load("//bazel:custom_exec_properties.bzl", "LARGE_MACHINE")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/iomgr",
-    visibility = "public",
-)  # Useful for third party devs to test their io manager implementation.
+package(default_visibility = ["//visibility:public"])  # Useful for third party devs to test their io manager implementation.
 
 grpc_cc_library(
     name = "endpoint_tests",

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
-
-grpc_package(name = "test/core/json")
 
 licenses(["notice"])
 

--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/memory_usage")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/message_size/BUILD
+++ b/test/core/message_size/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/message_size")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/nanopb/BUILD
+++ b/test/core/nanopb/BUILD
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_package")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
-
-grpc_package(name = "test/core/nanopb")
 
 licenses(["notice"])
 

--- a/test/core/network_benchmarks/BUILD
+++ b/test/core/network_benchmarks/BUILD
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary")
 
-grpc_package(
-    name = "test/core/network_benchmarks",
-    features = [
-        "-layering_check",
-        "-parse_headers",
-    ],
-)
+package(features = [
+    "-layering_check",
+    "-parse_headers",
+])
 
 licenses(["notice"])
 

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/promise")
 
 grpc_cc_library(
     name = "test_wakeup_schedulers",

--- a/test/core/resource_quota/BUILD
+++ b/test/core/resource_quota/BUILD
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/resource_quota")
 
 grpc_cc_test(
     name = "arena_test",

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/security")
 
 grpc_fuzzer(
     name = "alts_credentials_fuzzer",

--- a/test/core/server_config_selector/BUILD
+++ b/test/core/server_config_selector/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/server_config_selector")
 
 grpc_cc_test(
     name = "server_config_selector_test",

--- a/test/core/service_config/BUILD
+++ b/test/core/service_config/BUILD
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
-
-grpc_package(name = "test/core/service_config")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
-
-grpc_package(name = "test/core/slice")
 
 licenses(["notice"])
 

--- a/test/core/surface/BUILD
+++ b/test/core/surface/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/surface")
 
 grpc_cc_test(
     name = "grpc_byte_buffer_reader_test",

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/transport")
 
 grpc_cc_test(
     name = "bdp_estimator_test",

--- a/test/core/transport/binder/BUILD
+++ b/test/core/transport/binder/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/transport/binder",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_library(
     name = "mock_objects",

--- a/test/core/transport/binder/end2end/BUILD
+++ b/test/core/transport/binder/end2end/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/transport/binder/end2end",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_library(
     name = "fake_binder",

--- a/test/core/transport/binder/end2end/fuzzers/BUILD
+++ b/test/core/transport/binder/end2end/fuzzers/BUILD
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_proto_library")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
 
-grpc_package(
-    name = "test/core/transport/binder/end2end/fuzzers",
-    features = [
-        "layering_check",
-    ],
-)
+package(features = [
+    "layering_check",
+])
 
 licenses(["notice"])
 

--- a/test/core/transport/chaotic_good/BUILD
+++ b/test/core/transport/chaotic_good/BUILD
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/transport/chaotic_good",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_test(
     name = "frame_header_test",

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer", "grpc_proto_fuzzer")
 load("//bazel:custom_exec_properties.bzl", "LARGE_MACHINE")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/transport/chttp2")
 
 grpc_proto_fuzzer(
     name = "hpack_parser_fuzzer",

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/tsi",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_library(
     name = "transport_security_test_lib",

--- a/test/core/tsi/alts/crypt/BUILD
+++ b/test/core/tsi/alts/crypt/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/tsi/alts/crypt",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_test(
     name = "alts_crypt_test",

--- a/test/core/tsi/alts/fake_handshaker/BUILD
+++ b/test/core/tsi/alts/fake_handshaker/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/tsi/alts/fake_handshaker",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_proto_library(
     name = "transport_security_common_proto",

--- a/test/core/tsi/alts/frame_protector/BUILD
+++ b/test/core/tsi/alts/frame_protector/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/tsi/alts/frame_protector")
 
 grpc_cc_test(
     name = "alts_counter_test",

--- a/test/core/tsi/alts/handshaker/BUILD
+++ b/test/core/tsi/alts/handshaker/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/tsi/alts/handshaker")
 
 grpc_cc_library(
     name = "alts_handshaker_service_api_test_lib",

--- a/test/core/tsi/alts/zero_copy_frame_protector/BUILD
+++ b/test/core/tsi/alts/zero_copy_frame_protector/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/core/tsi/alts/zero_copy_frame_protector")
 
 grpc_cc_test(
     name = "alts_grpc_record_protocol_test",

--- a/test/core/uri/BUILD
+++ b/test/core/uri/BUILD
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
-
-grpc_package(name = "test/core/uri")
 
 licenses(["notice"])
 

--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package", "grpc_proto_library")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_proto_library")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/core/util",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_library(
     name = "grpc_suppressions",

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -16,11 +16,9 @@ load(
     "//bazel:grpc_build_system.bzl",
     "grpc_cc_library",
     "grpc_cc_test",
-    "grpc_package",
+    
 )
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
-
-grpc_package(name = "test/core/xds")
 
 licenses(["notice"])
 

--- a/test/cpp/client/BUILD
+++ b/test/cpp/client/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/client")
 
 grpc_cc_test(
     name = "credentials_test",

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_test", "grpc_package", "grpc_sh_test")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_test", "grpc_sh_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/codegen")
 
 grpc_cc_test(
     name = "codegen_test_full",

--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/common")
 
 grpc_cc_test(
     name = "alarm_test",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/end2end",
-    visibility = "public",
-)  # Allows external users to implement end2end tests.
+package(default_visibility = ["//visibility:public"])  # Allows external users to implement end2end tests.
 
 grpc_cc_library(
     name = "test_service_impl",

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/end2end/xds",
-    visibility = "public",
-)  # Allows external users to implement end2end tests.
+package(default_visibility = ["//visibility:public"])  # Allows external users to implement end2end tests.
 
 grpc_cc_library(
     name = "xds_server",

--- a/test/cpp/ext/filters/census/BUILD
+++ b/test/cpp/ext/filters/census/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/ext/filters/census",
-    visibility = "tests",
-)
+package(default_visibility = ["//test:__subpackages__"])
 
 grpc_cc_library(
     name = "library",

--- a/test/cpp/ext/filters/logging/BUILD
+++ b/test/cpp/ext/filters/logging/BUILD
@@ -14,11 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/ext/filters/logging")
 
 grpc_cc_library(
     name = "logging_test_library",

--- a/test/cpp/ext/gcp/BUILD
+++ b/test/cpp/ext/gcp/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/ext/gcp")
 
 grpc_cc_test(
     name = "observability_test",

--- a/test/cpp/grpclb/BUILD
+++ b/test/cpp/grpclb/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/grpclb",
-    visibility = "public",
-)  # Allows external users to implement grpclb tests.
+package(default_visibility = ["//visibility:public"])  # Allows external users to implement grpclb tests.
 
 grpc_cc_test(
     name = "grpclb_api_test",

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/interop",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_library(
     name = "server_helper_lib",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test")
 load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/microbenchmarks")
 
 grpc_cc_test(
     name = "noop-benchmark",

--- a/test/cpp/performance/BUILD
+++ b/test/cpp/performance/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/performance")
 
 grpc_cc_test(
     name = "writes_per_rpc_test",

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 load("//test/cpp/qps:qps_benchmark_script.bzl", "json_run_localhost_batch", "qps_json_driver_batch")
 load("//bazel:custom_exec_properties.bzl", "LARGE_MACHINE")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/qps")
 
 grpc_cc_library(
     name = "parse_json",

--- a/test/cpp/security/BUILD
+++ b/test/cpp/security/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/security")
 
 grpc_cc_test(
     name = "tls_certificate_verifier_test",

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/server")
 
 grpc_cc_test(
     name = "server_builder_test",

--- a/test/cpp/server/load_reporter/BUILD
+++ b/test/cpp/server/load_reporter/BUILD
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
-
-grpc_package(name = "test/cpp/server/load_reporter")
 
 grpc_cc_test(
     name = "lb_load_data_store_test",

--- a/test/cpp/test/BUILD
+++ b/test/cpp/test/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/test",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_test(
     name = "mock_stream_test",

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/thread_manager",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_test(
     name = "thread_manager_test",

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])
 
-grpc_package(
-    name = "test/cpp/util",
-    visibility = "public",
-)
+package(default_visibility = ["//visibility:public"])
 
 grpc_cc_library(
     name = "test_config",


### PR DESCRIPTION
consolidate back to the native package rule

`grpc_package` was just a thin wrapper, and the `name` attribute was unused. This has a bit less overhead, and allows for easier copybara transforms in/around/on packages
