### PR TITLE
[PSM Interop] Switch to python 3.9

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 # Constants
-readonly PYTHON_VERSION="${PYTHON_VERSION:-3.7}"
+readonly PYTHON_VERSION="${PYTHON_VERSION:-3.9}"
 # Test driver
 readonly TEST_DRIVER_REPO_NAME="grpc"
 readonly TEST_DRIVER_REPO_URL="https://github.com/${TEST_DRIVER_REPO_OWNER:-grpc}/grpc.git"

--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -361,7 +361,7 @@ kokoro_setup_python_virtual_environment() {
   eval "$(pyenv virtualenv-init -)"
   py_latest_patch="$(pyenv versions --bare --skip-aliases | grep -E "^${PYTHON_VERSION}\.[0-9]{1,2}$" | sort --version-sort | tail -n 1)"
   echo "Activating python ${py_latest_patch} virtual environment"
-  pyenv virtualenv --no-pip "${py_latest_patch}" k8s_xds_test_runner
+  pyenv virtualenv --without-pip "${py_latest_patch}" k8s_xds_test_runner
   pyenv local k8s_xds_test_runner
   pyenv activate k8s_xds_test_runner
   python3 -m ensurepip

--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -24,7 +24,7 @@ changes to this codebase at the moment.
 ## Installation
 
 #### Requirements
-1. Python v3.7+
+1. Python v3.9+
 2. [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
 3. `kubectl`
 


### PR DESCRIPTION
Kokoro supports Python 3.9 now.
Needed for b/276761453.