### PR TITLE
[OpenCensus C++ Test] Don't depend on compression algorithm

### DIFF
--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -787,10 +787,10 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeWithCompressionAnnotations) {
   ASSERT_NE(attempt_span_data, recorded_spans.end());
   EXPECT_TRUE(
       IsAnnotationPresent(attempt_span_data, "Send message: 1026 bytes"));
-  EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
-                                  "Send compressed message:" /*  31 bytes */));
-  EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
-                                  "Received message:" /*  31 bytes */));
+  // We don't know what the exact compressed message size would be
+  EXPECT_TRUE(
+      IsAnnotationPresent(attempt_span_data, "Send compressed message:"));
+  EXPECT_TRUE(IsAnnotationPresent(attempt_span_data, "Received message:"));
   EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
                                   "Received decompressed message: 1026 bytes"));
   // Check presence of message size annotations in server span
@@ -799,10 +799,10 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeWithCompressionAnnotations) {
   ASSERT_NE(attempt_span_data, recorded_spans.end());
   EXPECT_TRUE(
       IsAnnotationPresent(server_span_data, "Send message: 1026 bytes"));
-  EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
-                                  "Send compressed message:" /*  31 bytes */));
-  EXPECT_TRUE(IsAnnotationPresent(server_span_data,
-                                  "Received message:" /*  31 bytes */));
+  // We don't know what the exact compressed message size would be
+  EXPECT_TRUE(
+      IsAnnotationPresent(attempt_span_data, "Send compressed message:"));
+  EXPECT_TRUE(IsAnnotationPresent(server_span_data, "Received message:"));
   EXPECT_TRUE(IsAnnotationPresent(server_span_data,
                                   "Received decompressed message: 1026 bytes"));
 }

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -629,7 +629,7 @@ bool IsAnnotationPresent(
     std::vector<opencensus::trace::exporter::SpanData>::const_iterator span,
     absl::string_view annotation) {
   for (const auto& event : span->annotations().events()) {
-    if (event.event().description() == annotation) {
+    if (absl::StrContains(event.event().description(), annotation)) {
       return true;
     }
   }
@@ -788,9 +788,9 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeWithCompressionAnnotations) {
   EXPECT_TRUE(
       IsAnnotationPresent(attempt_span_data, "Send message: 1026 bytes"));
   EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
-                                  "Send compressed message: 31 bytes"));
-  EXPECT_TRUE(
-      IsAnnotationPresent(attempt_span_data, "Received message: 31 bytes"));
+                                  "Send compressed message:" /*  31 bytes */));
+  EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
+                                  "Received message:" /*  31 bytes */));
   EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
                                   "Received decompressed message: 1026 bytes"));
   // Check presence of message size annotations in server span
@@ -800,9 +800,9 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeWithCompressionAnnotations) {
   EXPECT_TRUE(
       IsAnnotationPresent(server_span_data, "Send message: 1026 bytes"));
   EXPECT_TRUE(IsAnnotationPresent(attempt_span_data,
-                                  "Send compressed message: 31 bytes"));
-  EXPECT_TRUE(
-      IsAnnotationPresent(server_span_data, "Received message: 31 bytes"));
+                                  "Send compressed message:" /*  31 bytes */));
+  EXPECT_TRUE(IsAnnotationPresent(server_span_data,
+                                  "Received message:" /*  31 bytes */));
   EXPECT_TRUE(IsAnnotationPresent(server_span_data,
                                   "Received decompressed message: 1026 bytes"));
 }


### PR DESCRIPTION
We shouldn't depend on how much the compression algorithm compresses the bytes to. This is causing flakiness internally.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

