### PR TITLE
[Test] Bump the timeout of macos/grpc_basictests_c_cpp to 4h

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_c_cpp.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_c_cpp.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 180
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
It already started hitting the limit resulting in continuous failure. https://github.com/grpc/grpc/pull/32603 is believed to contribute to this time increase but let's bump it first and visit this issue later.