### PR TITLE
[test-infra] Sanity test job should only run sanity, not iwyu and clang-tidy

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -185,7 +185,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
     test_jobs += _generate_jobs(languages=['sanity', 'clang-tidy', 'iwyu'],
                                 configs=['dbg'],
                                 platforms=['linux'],
-                                labels=['basictests', 'sanity'],
+                                labels=['basictests'],
                                 extra_args=extra_args +
                                 ['--report_multi_target'],
                                 inner_jobs=inner_jobs)


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/31141.

IWYU and clang-tidy have been "moved" to a separate kokoro job, but as it turns out the sanity job still runs all of `[sanity, clang-tidy, iwyu]`, which makes the grpc_sanity jobs very slow.

The issue is that grpc_sanity selects tasks that have "sanity" label on them and as of now, clang-tidy and iwyu still do.
It can be verified by:
```
tools/run_tests/run_tests_matrix.py -f sanity --dry_run
Will run these tests:
  run_tests_sanity_linux_dbg_native: "python3 tools/run_tests/run_tests.py --use_docker -t -j 2 -x run_tests/sanity_linux_dbg_native/sponge_log.xml --report_suite_name sanity_linux_dbg_native -l sanity -c dbg --iomgr_platform native --report_multi_target"
  run_tests_clang-tidy_linux_dbg_native: "python3 tools/run_tests/run_tests.py --use_docker -t -j 2 -x run_tests/clang-tidy_linux_dbg_native/sponge_log.xml --report_suite_name clang-tidy_linux_dbg_native -l clang-tidy -c dbg --iomgr_platform native --report_multi_target"
  run_tests_iwyu_linux_dbg_native: "python3 tools/run_tests/run_tests.py --use_docker -t -j 2 -x run_tests/iwyu_linux_dbg_native/sponge_log.xml --report_suite_name iwyu_linux_dbg_native -l iwyu -c dbg --iomgr_platform native --report_multi_target"
```

This PR should fix this (be removing the umbrella "sanity" label from clang-tidy and iwyu)
