### PR TITLE
[PSM Interop] Fix the issue with URL Map test suite not cleaning up failed test client

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -362,12 +362,12 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
 
     @classmethod
     def cleanupAfterTests(cls):
-      logging.info('----- Doing cleanup after %s -----', cls.__name__)
-      cls.test_client_runner.cleanup(force=True, force_namespace=True)
-      cls.finished_test_cases.add(cls.__name__)
-      if cls.finished_test_cases == cls.test_case_names:
-          # Tear down the GCP resource after all tests finished
-          GcpResourceManager().cleanup()
+        logging.info('----- Doing cleanup after %s -----', cls.__name__)
+        cls.test_client_runner.cleanup(force=True, force_namespace=True)
+        cls.finished_test_cases.add(cls.__name__)
+        if cls.finished_test_cases == cls.test_case_names:
+            # Tear down the GCP resource after all tests finished
+            GcpResourceManager().cleanup()
 
     def _fetch_and_check_xds_config(self):
         # TODO(lidiz) find another way to store last seen xDS config

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -342,6 +342,10 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
             GcpResourceManager().setup(cls.test_case_classes)
         cls.started_test_cases.add(cls.__name__)
 
+        # Configure cleanup to run after all tests regardless of whether or not
+        # this setUpClass failed
+        cls.addClassCleanup(cls.cleanupAfterTests)
+
         # Create the test case's own client runner with it's own namespace,
         # enables concurrent running with other test cases.
         cls.test_client_runner = GcpResourceManager().create_test_client_runner(
@@ -357,12 +361,13 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
             print_response=True)
 
     @classmethod
-    def tearDownClass(cls):
-        cls.test_client_runner.cleanup(force=True, force_namespace=True)
-        cls.finished_test_cases.add(cls.__name__)
-        if cls.finished_test_cases == cls.test_case_names:
-            # Tear down the GCP resource after all tests finished
-            GcpResourceManager().cleanup()
+    def cleanupAfterTests(cls):
+      logging.info('----- Doing cleanup after %s -----', cls.__name__)
+      cls.test_client_runner.cleanup(force=True, force_namespace=True)
+      cls.finished_test_cases.add(cls.__name__)
+      if cls.finished_test_cases == cls.test_case_names:
+          # Tear down the GCP resource after all tests finished
+          GcpResourceManager().cleanup()
 
     def _fetch_and_check_xds_config(self):
         # TODO(lidiz) find another way to store last seen xDS config


### PR DESCRIPTION
`tearDownClass` is not executed when `setUpClass` failed. In URL Map test suite, this leads to a test client that failed to start not being cleaned up.
This PR change the URL Map test suite to register a custom `addClassCleanup` callback, instead of relying on the `tearDownClass`. Unlike `tearDownClass`, cleanup callbacks are executed when the `setUpClass` failed.

ref b/276761453
