### PR TITLE
Update visibility of grpc++_alts target.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1176,7 +1176,7 @@ grpc_cc_library(
     ],
     language = "c++",
     standalone = True,
-    visibility = ["@grpc:tsi"],
+    visibility = ["@grpc:public"],
     deps = [
         "alts_upb",
         "gpr",


### PR DESCRIPTION
This target must be public so that ALTS users can easily perform authZ checks based on the ALTS context.
