### PR TITLE
[example] Eliminate warning when building helloworld.

### DIFF
--- a/examples/cpp/cmake/common.cmake
+++ b/examples/cpp/cmake/common.cmake
@@ -95,7 +95,7 @@ else()
 
   # Find Protobuf installation
   # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
-  set(protobuf_MODULE_COMPATIBLE TRUE)
+  option(protobuf_MODULE_COMPATIBLE TRUE)
   find_package(Protobuf CONFIG REQUIRED)
   message(STATUS "Using protobuf ${Protobuf_VERSION}")
 


### PR DESCRIPTION
Without this change, new users get this warning:
```
CMake Warning (dev) at $MY_INSTALL_DIR/lib64/cmake/protobuf/protobuf-options.cmake:6 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'protobuf_MODULE_COMPATIBLE'.
Call Stack (most recent call first):
  $MY_INSTALL_DIR/lib64/cmake/protobuf/protobuf-config.cmake:2 (include)
  $MY_SRC_PATH/examples/cpp/cmake/common.cmake:99 (find_package)
  CMakeLists.txt:24 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

release notes: no


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

