### PR TITLE
[cmake] fix install without gRPC_BUILD_CODEGEN 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26101,10 +26101,12 @@ if(gRPC_INSTALL)
     DESTINATION ${gRPC_INSTALL_CMAKEDIR}
     NAMESPACE gRPC::
   )
-  install(EXPORT gRPCPluginTargets
-    DESTINATION ${gRPC_INSTALL_CMAKEDIR}
-    NAMESPACE gRPC::
-  )
+  if(gRPC_BUILD_CODEGEN)
+    install(EXPORT gRPCPluginTargets
+      DESTINATION ${gRPC_INSTALL_CMAKEDIR}
+      NAMESPACE gRPC::
+    )
+  endif()
 endif()
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
When compiling without codegen cmake give the following error: CMake Error: INSTALL(EXPORT) given unknown export "gRPCPluginTargets".

Check gRPC_BUILD_CODEGEN variable is before trying to install gRPCPluginTargets.

Fix https://github.com/grpc/grpc/issues/32885

@herbrechtsmeier ok with this fix ?