### PR TITLE
[tcp] Add channel argument for SO_RVCBUF size.

### DIFF
--- a/include/grpc/impl/grpc_types.h
+++ b/include/grpc/impl/grpc_types.h
@@ -368,6 +368,8 @@ typedef struct {
    issued by the tcp_write(). By default, this is set to 4. */
 #define GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS \
   "grpc.experimental.tcp_tx_zerocopy_max_simultaneous_sends"
+/* Overrides the TCP socket recieve buffer size, SO_RCVBUF. */
+#define GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE "grpc.tcp_receive_buffer_size"
 /* Timeout in milliseconds to use for calls to the grpclb load balancer.
    If 0 or unset, the balancer calls will have no deadline. */
 #define GRPC_ARG_GRPCLB_CALL_TIMEOUT_MS "grpc.grpclb_call_timeout_ms"

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
@@ -25,6 +25,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "tcp_socket_utils.h"
 
 #include <grpc/event_engine/event_engine.h>
 
@@ -172,10 +173,9 @@ PosixTcpOptions TcpOptionsFromEndpointConfig(const EndpointConfig& config) {
   options.tcp_tx_zerocopy_max_simultaneous_sends =
       AdjustValue(PosixTcpOptions::kDefaultMaxSends, 0, INT_MAX,
                   config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS));
-  auto rcvbuf_size = config.GetInt(GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE);
-  if (rcvbuf_size.has_value()) {
-    options.tcp_receive_buffer_size = *rcvbuf_size;
-  }
+  options.tcp_receive_buffer_size =
+      AdjustValue(PosixTcpOptions::kReadBufferSizeUnset, 0, INT_MAX,
+                  config.GetInt(GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE));
   options.tcp_tx_zero_copy_enabled =
       (AdjustValue(PosixTcpOptions::kZerocpTxEnabledDefault, 0, 1,
                    config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED)) != 0);

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
@@ -25,7 +25,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
-#include "tcp_socket_utils.h"
 
 #include <grpc/event_engine/event_engine.h>
 

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
@@ -126,8 +126,7 @@ absl::Status PrepareTcpClientSocket(PosixSocketWrapper sock,
   GRPC_RETURN_IF_ERROR(sock.SetSocketNonBlocking(1));
   GRPC_RETURN_IF_ERROR(sock.SetSocketCloexec(1));
   if (options.tcp_receive_buffer_size != options.kReadBufferSizeUnset) {
-    GRPC_RETURN_IF_ERROR(
-        sock.SetSocketRcvBufLength(options.tcp_receive_buffer_size));
+    GRPC_RETURN_IF_ERROR(sock.SetSocketRcvBuf(options.tcp_receive_buffer_size));
   }
   if (reinterpret_cast<const sockaddr*>(addr.address())->sa_family != AF_UNIX) {
     // If its not a unix socket address.
@@ -395,7 +394,7 @@ absl::Status PosixSocketWrapper::SetSocketSndBuf(int buffer_size_bytes) {
                                          grpc_core::StrError(errno)));
 }
 
-absl::Status PosixSocketWrapper::SetSocketRcvBufLength(int buffer_size_bytes) {
+absl::Status PosixSocketWrapper::SetSocketRcvBuf(int buffer_size_bytes) {
   return 0 == setsockopt(fd_, SOL_SOCKET, SO_RCVBUF, &buffer_size_bytes,
                          sizeof(buffer_size_bytes))
              ? absl::OkStatus()

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
@@ -58,11 +58,14 @@ struct PosixTcpOptions {
   static constexpr int kMaxChunkSize = 32 * 1024 * 1024;
   static constexpr int kDefaultMaxSends = 4;
   static constexpr size_t kDefaultSendBytesThreshold = 16 * 1024;
+  // Let the system decide the proper buffer size.
+  static constexpr int kReadBufferSizeUnset = -1;
   int tcp_read_chunk_size = kDefaultReadChunkSize;
   int tcp_min_read_chunk_size = kDefaultMinReadChunksize;
   int tcp_max_read_chunk_size = kDefaultMaxReadChunksize;
   int tcp_tx_zerocopy_send_bytes_threshold = kDefaultSendBytesThreshold;
   int tcp_tx_zerocopy_max_simultaneous_sends = kDefaultMaxSends;
+  int tcp_receive_buffer_size = kReadBufferSizeUnset;
   bool tcp_tx_zero_copy_enabled = kZerocpTxEnabledDefault;
   int keep_alive_time_ms = 0;
   int keep_alive_timeout_ms = 0;
@@ -199,7 +202,7 @@ class PosixSocketWrapper {
   absl::Status SetSocketSndBuf(int buffer_size_bytes);
 
   // Tries to set the socket's receive buffer to given size.
-  absl::Status SetSocketRcvBuf(int buffer_size_bytes);
+  absl::Status SetSocketRcvBufLength(int buffer_size_bytes);
 
   // Tries to set the socket using a grpc_socket_mutator
   absl::Status SetSocketMutator(grpc_fd_usage usage,

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.h
@@ -202,7 +202,7 @@ class PosixSocketWrapper {
   absl::Status SetSocketSndBuf(int buffer_size_bytes);
 
   // Tries to set the socket's receive buffer to given size.
-  absl::Status SetSocketRcvBufLength(int buffer_size_bytes);
+  absl::Status SetSocketRcvBuf(int buffer_size_bytes);
 
   // Tries to set the socket using a grpc_socket_mutator
   absl::Status SetSocketMutator(grpc_fd_usage usage,

--- a/src/core/lib/iomgr/socket_utils_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_posix.cc
@@ -77,6 +77,8 @@ PosixTcpOptions TcpOptionsFromEndpointConfig(const EndpointConfig& config) {
   options.tcp_tx_zerocopy_max_simultaneous_sends =
       AdjustValue(PosixTcpOptions::kDefaultMaxSends, 0, INT_MAX,
                   config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS));
+  auto rcvbuf_size = config.GetInt(GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE);
+  if (rcvbuf_size.has_value()) options.tcp_receive_buffer_size = *rcvbuf_size;
   options.tcp_tx_zero_copy_enabled =
       (AdjustValue(PosixTcpOptions::kZerocpTxEnabledDefault, 0, 1,
                    config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED)) != 0);

--- a/src/core/lib/iomgr/socket_utils_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_posix.cc
@@ -77,8 +77,9 @@ PosixTcpOptions TcpOptionsFromEndpointConfig(const EndpointConfig& config) {
   options.tcp_tx_zerocopy_max_simultaneous_sends =
       AdjustValue(PosixTcpOptions::kDefaultMaxSends, 0, INT_MAX,
                   config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS));
-  auto rcvbuf_size = config.GetInt(GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE);
-  if (rcvbuf_size.has_value()) options.tcp_receive_buffer_size = *rcvbuf_size;
+  options.tcp_receive_buffer_size =
+      AdjustValue(PosixTcpOptions::kReadBufferSizeUnset, 0, INT_MAX,
+                  config.GetInt(GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE));
   options.tcp_tx_zero_copy_enabled =
       (AdjustValue(PosixTcpOptions::kZerocpTxEnabledDefault, 0, 1,
                    config.GetInt(GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED)) != 0);

--- a/src/core/lib/iomgr/socket_utils_posix.h
+++ b/src/core/lib/iomgr/socket_utils_posix.h
@@ -50,13 +50,13 @@ struct PosixTcpOptions {
   static constexpr int kDefaultMaxSends = 4;
   static constexpr size_t kDefaultSendBytesThreshold = 16 * 1024;
   // Let the system decide the proper buffer size.
-  static constexpr int kDefaultReadBufferSize = -1;
+  static constexpr int kReadBufferSizeUnset = -1;
   int tcp_read_chunk_size = kDefaultReadChunkSize;
   int tcp_min_read_chunk_size = kDefaultMinReadChunksize;
   int tcp_max_read_chunk_size = kDefaultMaxReadChunksize;
   int tcp_tx_zerocopy_send_bytes_threshold = kDefaultSendBytesThreshold;
   int tcp_tx_zerocopy_max_simultaneous_sends = kDefaultMaxSends;
-  int tcp_receive_buffer_size = kDefaultReadBufferSize;
+  int tcp_receive_buffer_size = kReadBufferSizeUnset;
   bool tcp_tx_zero_copy_enabled = kZerocpTxEnabledDefault;
   int keep_alive_time_ms = 0;
   int keep_alive_timeout_ms = 0;
@@ -146,10 +146,6 @@ grpc_error_handle grpc_set_socket_nonblocking(int fd, int non_blocking);
 
 // set a socket to close on exec
 grpc_error_handle grpc_set_socket_cloexec(int fd, int close_on_exec);
-
-// Set a socket's SO_RCVBUF size
-grpc_error_handle grpc_maybe_set_receive_buffer_size(int fd,
-                                                     int receive_buffer_size);
 
 // set a socket to reuse old addresses
 grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse);

--- a/src/core/lib/iomgr/socket_utils_posix.h
+++ b/src/core/lib/iomgr/socket_utils_posix.h
@@ -49,11 +49,14 @@ struct PosixTcpOptions {
   static constexpr int kMaxChunkSize = 32 * 1024 * 1024;
   static constexpr int kDefaultMaxSends = 4;
   static constexpr size_t kDefaultSendBytesThreshold = 16 * 1024;
+  // Let the system decide the proper buffer size.
+  static constexpr int kDefaultReadBufferSize = -1;
   int tcp_read_chunk_size = kDefaultReadChunkSize;
   int tcp_min_read_chunk_size = kDefaultMinReadChunksize;
   int tcp_max_read_chunk_size = kDefaultMaxReadChunksize;
   int tcp_tx_zerocopy_send_bytes_threshold = kDefaultSendBytesThreshold;
   int tcp_tx_zerocopy_max_simultaneous_sends = kDefaultMaxSends;
+  int tcp_receive_buffer_size = kDefaultReadBufferSize;
   bool tcp_tx_zero_copy_enabled = kZerocpTxEnabledDefault;
   int keep_alive_time_ms = 0;
   int keep_alive_timeout_ms = 0;
@@ -143,6 +146,10 @@ grpc_error_handle grpc_set_socket_nonblocking(int fd, int non_blocking);
 
 // set a socket to close on exec
 grpc_error_handle grpc_set_socket_cloexec(int fd, int close_on_exec);
+
+// Set a socket's SO_RCVBUF size
+grpc_error_handle grpc_maybe_set_receive_buffer_size(int fd,
+                                                     int receive_buffer_size);
 
 // set a socket to reuse old addresses
 grpc_error_handle grpc_set_socket_reuse_addr(int fd, int reuse);

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -18,6 +18,8 @@
 
 #include <grpc/support/port_platform.h>
 
+#include "socket_utils_posix.h"
+
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/port.h"
 
@@ -107,6 +109,10 @@ static grpc_error_handle prepare_socket(
   if (!err.ok()) goto error;
   err = grpc_set_socket_cloexec(fd, 1);
   if (!err.ok()) goto error;
+  if (options.tcp_receive_buffer_size != options.kDefaultReadBufferSize) {
+    err = grpc_set_socket_rcvbuf(fd, options.tcp_receive_buffer_size);
+    if (!err.ok()) goto error;
+  }
   if (!grpc_is_unix_socket(addr)) {
     err = grpc_set_socket_low_latency(fd, 1);
     if (!err.ok()) goto error;

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -18,8 +18,6 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "socket_utils_posix.h"
-
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/port.h"
 
@@ -109,7 +107,7 @@ static grpc_error_handle prepare_socket(
   if (!err.ok()) goto error;
   err = grpc_set_socket_cloexec(fd, 1);
   if (!err.ok()) goto error;
-  if (options.tcp_receive_buffer_size != options.kDefaultReadBufferSize) {
+  if (options.tcp_receive_buffer_size != options.kReadBufferSizeUnset) {
     err = grpc_set_socket_rcvbuf(fd, options.tcp_receive_buffer_size);
     if (!err.ok()) goto error;
   }


### PR DESCRIPTION
Example usage:

```
ServerBuilder builder;
builder.AddChannelArgument(GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE, 1024*1024);
```