### PR TITLE
[Fuzzing] Extend FuzzingEventEngine to create mock endpoints

### DIFF
--- a/test/core/event_engine/fuzzing_event_engine/BUILD
+++ b/test/core/event_engine/fuzzing_event_engine/BUILD
@@ -25,10 +25,16 @@ grpc_cc_library(
     name = "fuzzing_event_engine",
     srcs = ["fuzzing_event_engine.cc"],
     hdrs = ["fuzzing_event_engine.h"],
+    external_deps = [
+        "absl/status",
+        "absl/strings",
+        "absl/strings:str_format",
+    ],
     deps = [
         ":fuzzing_event_engine_proto",
         "//:event_engine_base_hdrs",
         "//src/core:default_event_engine",
+        "//src/core:status_helper",
         "//src/core:time",
         "//test/core/util:grpc_test_util",
     ],

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -114,6 +114,7 @@ grpc_cc_test(
     ],
     uses_polling = False,
     deps = [
+        "//test/core/event_engine:event_engine_test_utils",
         "//test/core/event_engine/fuzzing_event_engine",
         "//test/core/event_engine/test_suite/tests:client",
         "//test/core/event_engine/test_suite/tests:server",


### PR DESCRIPTION

supports specifying timestamps at which specified bytes are read through the endpoint

