### PR TITLE
[stats] Add a test for IncrementHttp2MetadataSize(0)

### DIFF
--- a/test/core/debug/stats_test.cc
+++ b/test/core/debug/stats_test.cc
@@ -52,6 +52,11 @@ TEST(StatsTest, IncSpecificCounter) {
   EXPECT_EQ(snapshot->delta()->client_calls_created, 1);
 }
 
+TEST(StatsTest, IncrementHttp2MetadataSize) {
+  ExecCtx exec_ctx;
+  global_stats().IncrementHttp2MetadataSize(0);
+}
+
 static int FindExpectedBucket(const HistogramView& h, int value) {
   if (value < 0) {
     return 0;


### PR DESCRIPTION
This test proves that `global_stats.IncrementHttp2MetadataSize(0)` works

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

