### PR TITLE
[Infra] Fix make_grpcio_tools

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -71,7 +71,7 @@ fi
 
 tools/buildgen/generate_projects.sh
 
-if [ "${SUBMODULE_NAME}" == "protobuf" ]
+if [ "${SUBMODULE_NAME}" == "abseil-cpp" ] || [ "${SUBMODULE_NAME}" == "protobuf" ]
 then
   tools/distrib/python/make_grpcio_tools.py
 fi


### PR DESCRIPTION
When abseil changes, `make_grpcio_tools` needs to run to get an updated list of abseil files.