### PR TITLE
[Test] Upgrade Alpine Linux to 3.15

### DIFF
--- a/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
@@ -53,6 +53,7 @@
 
   <%include file="../../ccache.include"/>
   <%include file="../../run_tests_addons.include"/>
-    
+  <%include file="../../git-jenkins.include"/>
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM alpine:3.11
+  FROM alpine:3.15
   
   # Install Git and basic packages.
   RUN apk update && apk add ${'\\'}

--- a/templates/tools/dockerfile/test/python_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_alpine_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM alpine:3.11
+  FROM alpine:3.15
 
   # Install Git and basic packages.
   RUN apk update && apk add \
@@ -38,7 +38,6 @@
     wget \
     zip
 
-  RUN ln -s /usr/bin/pip3 /usr/bin/pip
   RUN ln -s /usr/bin/python3 /usr/bin/python
 
   # Install Python packages from PyPI

--- a/tools/dockerfile/test/cxx_alpine_x64.current_version
+++ b/tools/dockerfile/test/cxx_alpine_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_alpine_x64:d3e20dddefb05efd8098230dbda7a0b7da387e87@sha256:fb44326e3cb49110775d415516ed10dfaff2466b805baa3928954d0cc4cc6f2f
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_alpine_x64:946399d3635bc9bcf2f40c026b80213ce30e479c@sha256:a84a6faf639dcf4a3e32eec0f5a08169e9c9866750e5aa53bdf89e8d378d326a

--- a/tools/dockerfile/test/cxx_alpine_x64.current_version
+++ b/tools/dockerfile/test/cxx_alpine_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_alpine_x64:97eceae8524fcb5489cce962bc4d36cbdd2b36ec@sha256:b75ee67e3a268f5d7ffaa58f09bc1e3059349153135e5de8753907fee7fda26d
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_alpine_x64:d3e20dddefb05efd8098230dbda7a0b7da387e87@sha256:fb44326e3cb49110775d415516ed10dfaff2466b805baa3928954d0cc4cc6f2f

--- a/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
@@ -66,6 +66,12 @@ RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/downloa
 
 RUN mkdir /var/local/jenkins
 
-  
+#=================
+# Setup git to access working directory across docker boundary
+
+RUN git config --global --add safe.directory /var/local/jenkins/grpc
+RUN git config --global protocol.file.allow always
+
+
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
+FROM alpine:3.15
 
 # Install Git and basic packages.
 RUN apk update && apk add \

--- a/tools/dockerfile/test/python_alpine_x64.current_version
+++ b/tools/dockerfile/test/python_alpine_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/python_alpine_x64:bcf3cc18ff2b548834691242537d226466e9e513@sha256:08a2428ed1a24d1eaae58091cc5c74329387fb3200ad89299916406be0b7852c
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_alpine_x64:6368979370d58ff5f42c7879d08c4b9561f9bdf0@sha256:71e6cca08ac39dbaf9a6c3968e745a94f53234668a87eb07522c57eff1b072b6

--- a/tools/dockerfile/test/python_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/python_alpine_x64/Dockerfile
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.11
+FROM alpine:3.15
 
 # Install Git and basic packages.
 RUN apk update && apk add   autoconf   automake   bzip2   build-base   cmake   ccache   curl   gcc   git   libtool   linux-headers   make   perl   strace   python3-dev   py3-pip   unzip   wget   zip
 
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install Python packages from PyPI


### PR DESCRIPTION
Upgrade Alpine Linux version as 3.15 is the oldest supported version.