### PR TITLE
[reflection] python: reflection response returns dependencies

### DIFF
--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
@@ -29,6 +29,7 @@ def _not_found_error():
             error_message=grpc.StatusCode.NOT_FOUND.value[1].encode(),
         ))
 
+
 def _collect_transitive_dependencies(descriptor, seen_files):
     seen_files.update({descriptor.name: descriptor})
     for dependency in descriptor.dependencies:

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
@@ -29,12 +29,12 @@ def _not_found_error():
             error_message=grpc.StatusCode.NOT_FOUND.value[1].encode(),
         ))
 
-def _collect_transitive_dependencies(descriptor, pool):
-    pool.update({descriptor.name: descriptor})
+def _collect_transitive_dependencies(descriptor, seen_files):
+    seen_files.update({descriptor.name: descriptor})
     for dependency in descriptor.dependencies:
-        if not dependency.name in pool:
+        if not dependency.name in seen_files:
             # descriptors cannot have circular dependencies
-            _collect_transitive_dependencies(dependency, pool)
+            _collect_transitive_dependencies(dependency, seen_files)
 
 
 def _file_descriptor_response(descriptor):

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/_base.py
@@ -29,14 +29,29 @@ def _not_found_error():
             error_message=grpc.StatusCode.NOT_FOUND.value[1].encode(),
         ))
 
+def _collect_transitive_dependencies(descriptor, pool):
+    pool.update({descriptor.name: descriptor})
+    for dependency in descriptor.dependencies:
+        if not dependency.name in pool:
+            # descriptors cannot have circular dependencies
+            _collect_transitive_dependencies(dependency, pool)
+
 
 def _file_descriptor_response(descriptor):
-    proto = descriptor_pb2.FileDescriptorProto()
-    descriptor.CopyToProto(proto)
-    serialized_proto = proto.SerializeToString()
+    # collect all dependencies
+    descriptors = {}
+    _collect_transitive_dependencies(descriptor, descriptors)
+
+    # serialize all descriptors
+    serialized_proto_list = []
+    for d_key in descriptors:
+        proto = descriptor_pb2.FileDescriptorProto()
+        descriptors[d_key].CopyToProto(proto)
+        serialized_proto_list.append(proto.SerializeToString())
+
     return _reflection_pb2.ServerReflectionResponse(
         file_descriptor_response=_reflection_pb2.FileDescriptorResponse(
-            file_descriptor_proto=(serialized_proto,)),)
+            file_descriptor_proto=(serialized_proto_list)),)
 
 
 class BaseReflectionServicer(_reflection_pb2_grpc.ServerReflectionServicer):

--- a/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
@@ -24,8 +24,8 @@ from grpc_reflection.v1alpha import reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc
 
 from src.proto.grpc.testing import empty_pb2
-from src.proto.grpc.testing.proto2 import empty2_pb2
 from src.proto.grpc.testing.proto2 import empty2_extensions_pb2
+from src.proto.grpc.testing.proto2 import empty2_pb2
 from tests.unit import test_common
 
 _EMPTY_PROTO_FILE_NAME = 'src/proto/grpc/testing/empty.proto'
@@ -129,11 +129,11 @@ class ReflectionServicerTest(unittest.TestCase):
         expected_responses = (
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
-                file_descriptor_response=reflection_pb2.FileDescriptorResponse(
-                    file_descriptor_proto=(
-                      _file_descriptor_to_proto(empty2_extensions_pb2.DESCRIPTOR),
-                      _file_descriptor_to_proto(empty2_pb2.DESCRIPTOR),
-                    ))),
+                file_descriptor_response=reflection_pb2.
+                FileDescriptorResponse(file_descriptor_proto=(
+                    _file_descriptor_to_proto(empty2_extensions_pb2.DESCRIPTOR),
+                    _file_descriptor_to_proto(empty2_pb2.DESCRIPTOR),
+                ))),
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
                 error_response=reflection_pb2.ErrorResponse(

--- a/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
@@ -24,6 +24,7 @@ from grpc_reflection.v1alpha import reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc
 
 from src.proto.grpc.testing import empty_pb2
+from src.proto.grpc.testing.proto2 import empty2_pb2
 from src.proto.grpc.testing.proto2 import empty2_extensions_pb2
 from tests.unit import test_common
 
@@ -129,8 +130,10 @@ class ReflectionServicerTest(unittest.TestCase):
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
                 file_descriptor_response=reflection_pb2.FileDescriptorResponse(
-                    file_descriptor_proto=(_file_descriptor_to_proto(
-                        empty2_extensions_pb2.DESCRIPTOR),))),
+                    file_descriptor_proto=(
+                      _file_descriptor_to_proto(empty2_extensions_pb2.DESCRIPTOR),
+                      _file_descriptor_to_proto(empty2_pb2.DESCRIPTOR),
+                    ))),
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
                 error_response=reflection_pb2.ErrorResponse(

--- a/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
@@ -24,6 +24,7 @@ from grpc_reflection.v1alpha import reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc
 
 from src.proto.grpc.testing import empty_pb2
+from src.proto.grpc.testing.proto2 import empty2_pb2
 from src.proto.grpc.testing.proto2 import empty2_extensions_pb2
 from tests_aio.unit._test_base import AioTestBase
 
@@ -133,8 +134,10 @@ class ReflectionServicerTest(AioTestBase):
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
                 file_descriptor_response=reflection_pb2.FileDescriptorResponse(
-                    file_descriptor_proto=(_file_descriptor_to_proto(
-                        empty2_extensions_pb2.DESCRIPTOR),))),
+                    file_descriptor_proto=(
+                      _file_descriptor_to_proto(empty2_extensions_pb2.DESCRIPTOR),
+                      _file_descriptor_to_proto(empty2_pb2.DESCRIPTOR),
+                    ))),
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
                 error_response=reflection_pb2.ErrorResponse(

--- a/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests_aio/reflection/reflection_servicer_test.py
@@ -24,8 +24,8 @@ from grpc_reflection.v1alpha import reflection_pb2
 from grpc_reflection.v1alpha import reflection_pb2_grpc
 
 from src.proto.grpc.testing import empty_pb2
-from src.proto.grpc.testing.proto2 import empty2_pb2
 from src.proto.grpc.testing.proto2 import empty2_extensions_pb2
+from src.proto.grpc.testing.proto2 import empty2_pb2
 from tests_aio.unit._test_base import AioTestBase
 
 _EMPTY_PROTO_FILE_NAME = 'src/proto/grpc/testing/empty.proto'
@@ -133,11 +133,11 @@ class ReflectionServicerTest(AioTestBase):
         expected_responses = (
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
-                file_descriptor_response=reflection_pb2.FileDescriptorResponse(
-                    file_descriptor_proto=(
-                      _file_descriptor_to_proto(empty2_extensions_pb2.DESCRIPTOR),
-                      _file_descriptor_to_proto(empty2_pb2.DESCRIPTOR),
-                    ))),
+                file_descriptor_response=reflection_pb2.
+                FileDescriptorResponse(file_descriptor_proto=(
+                    _file_descriptor_to_proto(empty2_extensions_pb2.DESCRIPTOR),
+                    _file_descriptor_to_proto(empty2_pb2.DESCRIPTOR),
+                ))),
             reflection_pb2.ServerReflectionResponse(
                 valid_host='',
                 error_response=reflection_pb2.ErrorResponse(


### PR DESCRIPTION
 Fix #32899 - include all dependency-descriptors in the ServerReflectionResponse

Using the C# Server-code as blue print:
https://github.com/grpc/grpc-dotnet/blob/6bf44820a2ef6af5845830728cd4b3d1a8053ed4/src/Grpc.Reflection/ReflectionServiceImpl.cs#L148

see also:
   - The cpp-server implementation of this:
   https://github.com/grpc/grpc/blob/d299f5ecce9f8e9a8f35571f39bdcfdbb2106d36/src/cpp/ext/proto_server_reflection.cc#L208
  - The go-server implementation of this:
    https://github.com/grpc/grpc-go/blob/2cd95c7514a3d02aa2d98591c013885cb44fbdeb/reflection/serverreflection.go#L184
    `return s.fileDescWithDependencies(d.ParentFile(), sentFileDescriptors)`