### PR TITLE
[Test] Fix git on Alpine

### DIFF
--- a/templates/tools/dockerfile/test/python_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_alpine_x64/Dockerfile.template
@@ -44,5 +44,6 @@
   RUN python3 -m pip install --upgrade pip==19.3.1
 
   <%include file="../../gcp_api_libraries.include"/>
-
   <%include file="../../ccache.include"/>
+  <%include file="../../run_tests_addons.include"/>
+  <%include file="../../git-jenkins.include"/>

--- a/tools/dockerfile/test/python_alpine_x64.current_version
+++ b/tools/dockerfile/test/python_alpine_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/python_alpine_x64:6368979370d58ff5f42c7879d08c4b9561f9bdf0@sha256:71e6cca08ac39dbaf9a6c3968e745a94f53234668a87eb07522c57eff1b072b6
+us-docker.pkg.dev/grpc-testing/testing-images-public/python_alpine_x64:81425200ee33ca5370a49efc09d1d918eded5522@sha256:d10159225ae25276b7ae7bfc4230150e4b0a8ce7be833d904bdd4ecdfdc91c6e

--- a/tools/dockerfile/test/python_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/python_alpine_x64/Dockerfile
@@ -26,7 +26,6 @@ RUN python3 -m pip install --upgrade pip==19.3.1
 # These are needed for uploading test results to BigQuery (e.g. by tools/run_tests scripts)
 RUN python3 -m pip install --upgrade google-auth==1.23.0 google-api-python-client==1.12.8 oauth2client==4.1.0
 
-
 #=================
 # Install ccache
 
@@ -40,4 +39,13 @@ RUN curl -sSL -o ccache.tar.gz https://github.com/ccache/ccache/releases/downloa
     && make -j4 && make install \
     && cd ../.. \
     && rm -rf ccache-4.5.1 ccache.tar.gz
+
+
+RUN mkdir /var/local/jenkins
+
+#=================
+# Setup git to access working directory across docker boundary
+
+RUN git config --global --add safe.directory /var/local/jenkins/grpc
+RUN git config --global protocol.file.allow always
 


### PR DESCRIPTION
Fix `python_alpine` test failure with

```
fatal: detected dubious ownership in repository at '/var/local/jenkins/grpc'
To add an exception for this directory, call:

	git config --global --add safe.directory /var/local/jenkins/grpc
```