### PR TITLE
[build] Ignore possibly-leaked memory in PHP Valgrind tests

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -47,6 +47,7 @@ if [ -x "$(command -v valgrind)" ]; then
   # TODO(jtattermusch): reenable the test once https://github.com/grpc/grpc/issues/29098 is fixed.
   if [ "$(uname -m)" != "aarch64" ]; then
     $(which valgrind) --error-exitcode=10 --leak-check=yes \
+      --errors-for-leak-kinds=definite \
       -v \
       --num-callers=30 \
       --suppressions=../tests/MemoryLeakTest/ignore_leaks.supp \


### PR DESCRIPTION
Valgrind will now only fail the build on definite leaks, not "possible" leaks. A trivial example that fails the PHP valgrind test as it is configured today:

```
namespace {
grpc_core::NoDestruct<grpc_core::BackOff> g_backoff{
    grpc_core::BackOff::Options()};
}  // namespace
```

Valgrind detects a possible leak because BackOff contains an absl::BitGen, which calls `new` through a chain of ownership indirection. This is what Valgrind calls an [interior pointer](https://valgrind.org/docs/manual/mc-manual.html#mc-manual.options:~:text=%22Possibly%20lost%22.%20This,have%20interior%2Dpointers.). Our CI will no longer fail them