### PR TITLE
[Test] Used python 3.9 for python-alpine

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -783,7 +783,7 @@ class PythonLanguage(object):
         elif args.compiler == 'pypy3':
             return (pypy32_config,)
         elif args.compiler == 'python_alpine':
-            return (python38_config,)
+            return (python39_config,)
         elif args.compiler == 'all_the_cpythons':
             return (
                 python37_config,


### PR DESCRIPTION
Fix at-head tests (this is a missing piece of https://github.com/grpc/grpc/pull/32905) with the following error;

```
/var/local/git/grpc/tools/run_tests/helper_scripts/build_python.sh: line 126: python3.8: command not found
```
