### PR TITLE
[Test] Bump the timeout of at-head tests to 6hr

### DIFF
--- a/tools/internal_ci/linux/grpc_build_abseil-cpp_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_abseil-cpp_at_head.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
-timeout_mins: 300
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_build_boringssl_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_boringssl_at_head.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
-timeout_mins: 240
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/grpc_build_protobuf_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_protobuf_at_head.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
-timeout_mins: 240
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
To fix the timeout of protobuf-at-head test, we may want to reduce the test-load of these tests but let's fix the breakage first.