### PR TITLE
Add RecordMetadataInformation function to CallTracer API

### DIFF
--- a/src/core/lib/channel/call_tracer.h
+++ b/src/core/lib/channel/call_tracer.h
@@ -54,6 +54,9 @@ class CallTracerAnnotationInterface {
   // TODO(yashykt): If needed, extend this to attach attributes with
   // annotations.
   virtual void RecordAnnotation(absl::string_view annotation) = 0;
+  // Records an annotation for metadata information. `metadata` should be in
+  // proto string format.
+  virtual void RecordMetadataInformation(absl::string_view metadata_info) = 0;
   virtual std::string TraceId() = 0;
   virtual std::string SpanId() = 0;
   virtual bool IsSampled() = 0;

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -288,6 +288,11 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordAnnotation(
   context_.AddSpanAnnotation(annotation, {});
 }
 
+void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
+    RecordMetadataInformation(absl::string_view metadata_info) {
+  RecordAnnotation(metadata_info);
+}
+
 //
 // OpenCensusCallTracer
 //

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -288,6 +288,11 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordAnnotation(
   context_.AddSpanAnnotation(annotation, {});
 }
 
+void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
+    RecordMetadataInformation(absl::string_view metadata_info) {
+  RecordAnnotation(metadata_info);
+}
+
 //
 // OpenCensusCallTracer
 //
@@ -357,6 +362,11 @@ OpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
 void OpenCensusCallTracer::RecordAnnotation(absl::string_view annotation) {
   // If tracing is disabled, the following will be a no-op.
   context_.AddSpanAnnotation(annotation, {});
+}
+
+void OpenCensusCallTracer::RecordMetadataInformation(
+    absl::string_view metadata_info) {
+  RecordAnnotation(metadata_info);
 }
 
 void OpenCensusCallTracer::RecordApiLatency(absl::Duration api_latency,

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -288,9 +288,6 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordAnnotation(
   context_.AddSpanAnnotation(annotation, {});
 }
 
-void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
-    RecordMetadataInformation(absl::string_view metadata_info) {}
-
 //
 // OpenCensusCallTracer
 //

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -289,9 +289,7 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::RecordAnnotation(
 }
 
 void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
-    RecordMetadataInformation(absl::string_view metadata_info) {
-  RecordAnnotation(metadata_info);
-}
+    RecordMetadataInformation(absl::string_view metadata_info) {}
 
 //
 // OpenCensusCallTracer

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -99,6 +99,7 @@ class OpenCensusCallTracer : public grpc_core::ClientCallTracer {
     void RecordCancel(grpc_error_handle cancel_error) override;
     void RecordEnd(const gpr_timespec& /*latency*/) override;
     void RecordAnnotation(absl::string_view annotation) override;
+    void RecordMetadataInformation(absl::string_view metadata_info) override;
 
     experimental::CensusContext* context() { return &context_; }
 
@@ -136,6 +137,7 @@ class OpenCensusCallTracer : public grpc_core::ClientCallTracer {
   OpenCensusCallAttemptTracer* StartNewAttempt(
       bool is_transparent_retry) override;
   void RecordAnnotation(absl::string_view annotation) override;
+  void RecordMetadataInformation(absl::string_view metadata_info) override;
 
   // APIs to record API call latency
   void RecordApiLatency(absl::Duration api_latency,

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -99,7 +99,7 @@ class OpenCensusCallTracer : public grpc_core::ClientCallTracer {
     void RecordCancel(grpc_error_handle cancel_error) override;
     void RecordEnd(const gpr_timespec& /*latency*/) override;
     void RecordAnnotation(absl::string_view annotation) override;
-    void RecordMetadataInformation(absl::string_view metadata_info) override {}
+    void RecordMetadataInformation(absl::string_view metadata_info) override;
 
     experimental::CensusContext* context() { return &context_; }
 

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -99,7 +99,7 @@ class OpenCensusCallTracer : public grpc_core::ClientCallTracer {
     void RecordCancel(grpc_error_handle cancel_error) override;
     void RecordEnd(const gpr_timespec& /*latency*/) override;
     void RecordAnnotation(absl::string_view annotation) override;
-    void RecordMetadataInformation(absl::string_view metadata_info) override;
+    void RecordMetadataInformation(absl::string_view metadata_info) override {}
 
     experimental::CensusContext* context() { return &context_; }
 

--- a/src/cpp/ext/filters/census/server_call_tracer.cc
+++ b/src/cpp/ext/filters/census/server_call_tracer.cc
@@ -160,6 +160,11 @@ class OpenCensusServerCallTracer : public grpc_core::ServerCallTracer {
     context_.AddSpanAnnotation(annotation, {});
   }
 
+
+  void RecordMetadataInformation(absl::string_view metadata_info) override {
+    RecordAnnotation(metadata_info);
+  }
+
  private:
   experimental::CensusContext context_;
   // server method


### PR DESCRIPTION
Add new function to CallTracer API in order to track metadata sizes. 
