### PR TITLE
[Cmake] Deps are now either public or private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1520,8 +1520,8 @@ target_link_libraries(gpr
 )
 if(_gRPC_PLATFORM_ANDROID)
   target_link_libraries(gpr
-    android
-    log
+    PUBLIC android
+    PUBLIC log
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1401,9 +1401,9 @@ target_include_directories(address_sorting
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(address_sorting
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -1499,24 +1499,24 @@ target_include_directories(gpr
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(gpr
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::base
-  absl::core_headers
-  absl::flags
-  absl::flags_marshalling
-  absl::any_invocable
-  absl::memory
-  absl::random_random
-  absl::status
-  absl::cord
-  absl::str_format
-  absl::strings
-  absl::synchronization
-  absl::time
-  absl::optional
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::base
+  PUBLIC absl::core_headers
+  PUBLIC absl::flags
+  PUBLIC absl::flags_marshalling
+  PUBLIC absl::any_invocable
+  PUBLIC absl::memory
+  PUBLIC absl::random_random
+  PUBLIC absl::status
+  PUBLIC absl::cord
+  PUBLIC absl::str_format
+  PUBLIC absl::strings
+  PUBLIC absl::synchronization
+  PUBLIC absl::time
+  PUBLIC absl::optional
+  PUBLIC absl::variant
 )
 if(_gRPC_PLATFORM_ANDROID)
   target_link_libraries(gpr
@@ -2367,28 +2367,28 @@ target_include_directories(grpc
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(grpc
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_CARES_LIBRARIES}
-  ${_gRPC_ADDRESS_SORTING_LIBRARIES}
-  ${_gRPC_RE2_LIBRARIES}
-  ${_gRPC_UPB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::cleanup
-  absl::flat_hash_map
-  absl::flat_hash_set
-  absl::inlined_vector
-  absl::bind_front
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::span
-  absl::utility
-  gpr
-  ${_gRPC_SSL_LIBRARIES}
-  address_sorting
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PRIVATE ${_gRPC_CARES_LIBRARIES}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_LIBRARIES}
+  PRIVATE ${_gRPC_RE2_LIBRARIES}
+  PRIVATE ${_gRPC_UPB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::cleanup
+  PUBLIC absl::flat_hash_map
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::inlined_vector
+  PUBLIC absl::bind_front
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::span
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PRIVATE ${_gRPC_SSL_LIBRARIES}
+  PUBLIC address_sorting
+  PUBLIC upb
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc "-framework CoreFoundation")
@@ -2528,13 +2528,13 @@ target_include_directories(grpc_test_util
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(grpc_test_util
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::failure_signal_handler
-  absl::stacktrace
-  absl::symbolize
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::failure_signal_handler
+  PUBLIC absl::stacktrace
+  PUBLIC absl::symbolize
+  PUBLIC grpc
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc_test_util "-framework CoreFoundation")
@@ -2588,13 +2588,13 @@ target_include_directories(grpc_test_util_unsecure
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(grpc_test_util_unsecure
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::failure_signal_handler
-  absl::stacktrace
-  absl::symbolize
-  grpc_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::failure_signal_handler
+  PUBLIC absl::stacktrace
+  PUBLIC absl::symbolize
+  PUBLIC grpc_unsecure
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc_test_util_unsecure "-framework CoreFoundation")
@@ -3003,27 +3003,27 @@ target_include_directories(grpc_unsecure
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(grpc_unsecure
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_CARES_LIBRARIES}
-  ${_gRPC_ADDRESS_SORTING_LIBRARIES}
-  ${_gRPC_RE2_LIBRARIES}
-  ${_gRPC_UPB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::cleanup
-  absl::flat_hash_map
-  absl::flat_hash_set
-  absl::inlined_vector
-  absl::bind_front
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::span
-  absl::utility
-  gpr
-  address_sorting
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PRIVATE ${_gRPC_CARES_LIBRARIES}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_LIBRARIES}
+  PRIVATE ${_gRPC_RE2_LIBRARIES}
+  PRIVATE ${_gRPC_UPB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::cleanup
+  PUBLIC absl::flat_hash_map
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::inlined_vector
+  PUBLIC absl::bind_front
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::span
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC address_sorting
+  PUBLIC upb
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
   target_link_libraries(grpc_unsecure "-framework CoreFoundation")
@@ -3189,14 +3189,14 @@ target_include_directories(benchmark_helpers
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(benchmark_helpers
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  ${_gRPC_BENCHMARK_LIBRARIES}
-  grpc++_unsecure
-  grpc_test_util_unsecure
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PRIVATE ${_gRPC_BENCHMARK_LIBRARIES}
+  PUBLIC grpc++_unsecure
+  PUBLIC grpc_test_util_unsecure
+  PUBLIC grpc++_test_config
 )
 
 endif()
@@ -3305,11 +3305,11 @@ target_include_directories(grpc++
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 foreach(_hdr
@@ -3574,11 +3574,11 @@ target_include_directories(grpc++_alts
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_alts
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
 )
 
 foreach(_hdr
@@ -3640,11 +3640,11 @@ target_include_directories(grpc++_error_details
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_error_details
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
 )
 
 foreach(_hdr
@@ -3712,11 +3712,11 @@ target_include_directories(grpc++_reflection
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_reflection
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
 )
 
 foreach(_hdr
@@ -3786,11 +3786,11 @@ target_include_directories(grpc++_test
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
 )
 
 foreach(_hdr
@@ -3853,12 +3853,12 @@ target_include_directories(grpc++_test_config
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_test_config
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flags_parse
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flags_parse
+  PUBLIC gpr
 )
 
 
@@ -3926,12 +3926,12 @@ target_include_directories(grpc++_test_util
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_test_util
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -4010,11 +4010,11 @@ target_include_directories(grpc++_unsecure
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc++_unsecure
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_unsecure
 )
 
 foreach(_hdr
@@ -4518,23 +4518,23 @@ target_include_directories(grpc_authorization_provider
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc_authorization_provider
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_RE2_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::cleanup
-  absl::flat_hash_map
-  absl::flat_hash_set
-  absl::inlined_vector
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::span
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PRIVATE ${_gRPC_RE2_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::cleanup
+  PUBLIC absl::flat_hash_map
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::inlined_vector
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::span
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 foreach(_hdr
@@ -4668,11 +4668,11 @@ target_include_directories(grpc_plugin_support
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpc_plugin_support
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 foreach(_hdr
@@ -4742,11 +4742,11 @@ target_include_directories(grpcpp_channelz
     ${_gRPC_PROTO_GENS_DIR}
 )
 target_link_libraries(grpcpp_channelz
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
 )
 
 foreach(_hdr
@@ -4856,9 +4856,9 @@ target_include_directories(upb
     ${_gRPC_ZLIB_INCLUDE_DIR}
 )
 target_link_libraries(upb
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -4907,10 +4907,10 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(fd_conservation_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -4937,10 +4937,10 @@ target_include_directories(multiple_server_queues_test
 )
 
 target_link_libraries(multiple_server_queues_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -4967,10 +4967,10 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   )
 
   target_link_libraries(pollset_windows_starvation_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -4999,13 +4999,13 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(static_stride_scheduler_benchmark
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    absl::algorithm_container
-    absl::span
-    ${_gRPC_BENCHMARK_LIBRARIES}
-    gpr
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC absl::algorithm_container
+    PUBLIC absl::span
+    PRIVATE ${_gRPC_BENCHMARK_LIBRARIES}
+    PUBLIC gpr
   )
 
 
@@ -5046,10 +5046,10 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(tcp_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -5088,10 +5088,10 @@ target_include_directories(test_core_iomgr_timer_list_test
 )
 
 target_link_libraries(test_core_iomgr_timer_list_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5125,16 +5125,16 @@ target_include_directories(activity_test
 )
 
 target_link_libraries(activity_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -5168,12 +5168,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(address_sorting_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_config
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_config
+    PUBLIC grpc++_test_util
   )
 
 
@@ -5223,13 +5223,13 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(address_sorting_test_unsecure
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_unsecure
-    grpc_test_util_unsecure
-    grpc++_test_config
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_unsecure
+    PUBLIC grpc_test_util_unsecure
+    PUBLIC grpc++_test_config
   )
 
 
@@ -5281,13 +5281,13 @@ target_include_directories(admin_services_end2end_test
 )
 
 target_link_libraries(admin_services_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_reflection
-  grpcpp_channelz
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_reflection
+  PUBLIC grpcpp_channelz
+  PUBLIC grpc++_test_util
 )
 
 
@@ -5333,12 +5333,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(alarm_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_unsecure
-    grpc_test_util_unsecure
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_unsecure
+    PUBLIC grpc_test_util_unsecure
   )
 
 
@@ -5372,11 +5372,11 @@ target_include_directories(alloc_test
 )
 
 target_link_libraries(alloc_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5409,11 +5409,11 @@ target_include_directories(alpn_test
 )
 
 target_link_libraries(alpn_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5458,12 +5458,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(alts_concurrent_connectivity_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++
+    PUBLIC grpc_test_util
   )
 
 
@@ -5498,11 +5498,11 @@ target_include_directories(alts_counter_test
 )
 
 target_link_libraries(alts_counter_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5536,11 +5536,11 @@ target_include_directories(alts_crypt_test
 )
 
 target_link_libraries(alts_crypt_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5574,11 +5574,11 @@ target_include_directories(alts_crypter_test
 )
 
 target_link_libraries(alts_crypter_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5613,11 +5613,11 @@ target_include_directories(alts_frame_protector_test
 )
 
 target_link_libraries(alts_frame_protector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5651,11 +5651,11 @@ target_include_directories(alts_grpc_record_protocol_test
 )
 
 target_link_libraries(alts_grpc_record_protocol_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5689,11 +5689,11 @@ target_include_directories(alts_handshaker_client_test
 )
 
 target_link_libraries(alts_handshaker_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5727,11 +5727,11 @@ target_include_directories(alts_iovec_record_protocol_test
 )
 
 target_link_libraries(alts_iovec_record_protocol_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5776,11 +5776,11 @@ target_include_directories(alts_security_connector_test
 )
 
 target_link_libraries(alts_security_connector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5814,11 +5814,11 @@ target_include_directories(alts_tsi_handshaker_test
 )
 
 target_link_libraries(alts_tsi_handshaker_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5852,11 +5852,11 @@ target_include_directories(alts_tsi_utils_test
 )
 
 target_link_libraries(alts_tsi_utils_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5889,12 +5889,12 @@ target_include_directories(alts_util_test
 )
 
 target_link_libraries(alts_util_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_alts
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_alts
+  PUBLIC grpc++_test_util
 )
 
 
@@ -5928,11 +5928,11 @@ target_include_directories(alts_zero_copy_grpc_protector_test
 )
 
 target_link_libraries(alts_zero_copy_grpc_protector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -5965,11 +5965,11 @@ target_include_directories(arena_promise_test
 )
 
 target_link_libraries(arena_promise_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -6002,11 +6002,11 @@ target_include_directories(arena_test
 )
 
 target_link_libraries(arena_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -6063,11 +6063,11 @@ target_include_directories(async_end2end_test
 )
 
 target_link_libraries(async_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -6112,11 +6112,11 @@ target_include_directories(auth_context_test
 )
 
 target_link_libraries(auth_context_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6149,11 +6149,11 @@ target_include_directories(auth_property_iterator_test
 )
 
 target_link_libraries(auth_property_iterator_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -6198,11 +6198,11 @@ target_include_directories(authorization_matchers_test
 )
 
 target_link_libraries(authorization_matchers_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6236,13 +6236,13 @@ target_include_directories(authorization_policy_provider_test
 )
 
 target_link_libraries(authorization_policy_provider_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_authorization_provider
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_authorization_provider
+  PUBLIC grpc_test_util
 )
 
 
@@ -6275,12 +6275,12 @@ target_include_directories(avl_test
 )
 
 target_link_libraries(avl_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::strings
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::strings
+  PUBLIC absl::variant
 )
 
 
@@ -6325,11 +6325,11 @@ target_include_directories(aws_request_signer_test
 )
 
 target_link_libraries(aws_request_signer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6362,11 +6362,11 @@ target_include_directories(b64_test
 )
 
 target_link_libraries(b64_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6399,11 +6399,11 @@ target_include_directories(backoff_test
 )
 
 target_link_libraries(backoff_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6437,11 +6437,11 @@ target_include_directories(bad_server_response_test
 )
 
 target_link_libraries(bad_server_response_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6488,11 +6488,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(bad_ssl_alpn_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -6540,11 +6540,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(bad_ssl_cert_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -6580,11 +6580,11 @@ target_include_directories(bad_streaming_id_bad_client_test
 )
 
 target_link_libraries(bad_streaming_id_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6619,11 +6619,11 @@ target_include_directories(badreq_bad_client_test
 )
 
 target_link_libraries(badreq_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6657,11 +6657,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(bdp_estimator_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -6695,11 +6695,11 @@ target_include_directories(bin_decoder_test
 )
 
 target_link_libraries(bin_decoder_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6732,11 +6732,11 @@ target_include_directories(bin_encoder_test
 )
 
 target_link_libraries(bin_encoder_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6769,11 +6769,11 @@ target_include_directories(binder_resolver_test
 )
 
 target_link_libraries(binder_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6824,11 +6824,11 @@ target_include_directories(binder_server_test
 )
 
 target_link_libraries(binder_server_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -6926,11 +6926,11 @@ target_include_directories(binder_transport_test
 )
 
 target_link_libraries(binder_transport_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -6963,12 +6963,12 @@ target_include_directories(bitset_test
 )
 
 target_link_libraries(bitset_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::strings
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::strings
+  PUBLIC absl::variant
 )
 
 
@@ -7013,11 +7013,11 @@ target_include_directories(buffer_list_test
 )
 
 target_link_libraries(buffer_list_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7050,11 +7050,11 @@ target_include_directories(byte_buffer_test
 )
 
 target_link_libraries(byte_buffer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -7087,11 +7087,11 @@ target_include_directories(c_slice_buffer_test
 )
 
 target_link_libraries(c_slice_buffer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7124,11 +7124,11 @@ target_include_directories(call_finalization_test
 )
 
 target_link_libraries(call_finalization_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7163,12 +7163,12 @@ target_include_directories(cancel_ares_query_test
 )
 
 target_link_libraries(cancel_ares_query_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -7201,12 +7201,12 @@ target_include_directories(cancel_callback_test
 )
 
 target_link_libraries(cancel_callback_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC gpr
 )
 
 
@@ -7340,11 +7340,11 @@ target_include_directories(cel_authorization_engine_test
 )
 
 target_link_libraries(cel_authorization_engine_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7377,11 +7377,11 @@ target_include_directories(certificate_provider_registry_test
 )
 
 target_link_libraries(certificate_provider_registry_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7414,11 +7414,11 @@ target_include_directories(certificate_provider_store_test
 )
 
 target_link_libraries(certificate_provider_store_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7456,12 +7456,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(cf_event_engine_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -7512,11 +7512,11 @@ target_include_directories(cfstream_test
 )
 
 target_link_libraries(cfstream_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -7549,11 +7549,11 @@ target_include_directories(channel_args_test
 )
 
 target_link_libraries(channel_args_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7586,12 +7586,12 @@ target_include_directories(channel_arguments_test
 )
 
 target_link_libraries(channel_arguments_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -7636,11 +7636,11 @@ target_include_directories(channel_creds_registry_test
 )
 
 target_link_libraries(channel_creds_registry_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7673,12 +7673,12 @@ target_include_directories(channel_filter_test
 )
 
 target_link_libraries(channel_filter_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -7711,11 +7711,11 @@ target_include_directories(channel_stack_builder_test
 )
 
 target_link_libraries(channel_stack_builder_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7748,11 +7748,11 @@ target_include_directories(channel_stack_test
 )
 
 target_link_libraries(channel_stack_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -7790,12 +7790,12 @@ target_include_directories(channel_trace_test
 )
 
 target_link_libraries(channel_trace_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -7828,12 +7828,12 @@ target_include_directories(channelz_registry_test
 )
 
 target_link_libraries(channelz_registry_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -7883,12 +7883,12 @@ target_include_directories(channelz_service_test
 )
 
 target_link_libraries(channelz_service_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpcpp_channelz
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpcpp_channelz
+  PUBLIC grpc++_test_util
 )
 
 
@@ -7926,12 +7926,12 @@ target_include_directories(channelz_test
 )
 
 target_link_libraries(channelz_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -7976,11 +7976,11 @@ target_include_directories(check_gcp_environment_linux_test
 )
 
 target_link_libraries(check_gcp_environment_linux_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8025,11 +8025,11 @@ target_include_directories(check_gcp_environment_windows_test
 )
 
 target_link_libraries(check_gcp_environment_windows_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8087,18 +8087,18 @@ target_include_directories(chunked_vector_test
 )
 
 target_link_libraries(chunked_vector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -8157,11 +8157,11 @@ target_include_directories(cli_call_test
 )
 
 target_link_libraries(cli_call_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -8200,11 +8200,11 @@ target_include_directories(client_auth_filter_test
 )
 
 target_link_libraries(client_auth_filter_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8243,11 +8243,11 @@ target_include_directories(client_authority_filter_test
 )
 
 target_link_libraries(client_authority_filter_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8298,11 +8298,11 @@ target_include_directories(client_callback_end2end_test
 )
 
 target_link_libraries(client_callback_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -8335,11 +8335,11 @@ target_include_directories(client_channel_service_config_test
 )
 
 target_link_libraries(client_channel_service_config_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8398,11 +8398,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(client_channel_stress_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -8436,11 +8436,11 @@ target_include_directories(client_channel_test
 )
 
 target_link_libraries(client_channel_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8473,12 +8473,12 @@ target_include_directories(client_context_test_peer_test
 )
 
 target_link_libraries(client_context_test_peer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test
+  PUBLIC grpc++_test_util
 )
 
 
@@ -8529,11 +8529,11 @@ target_include_directories(client_interceptors_end2end_test
 )
 
 target_link_libraries(client_interceptors_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -8595,11 +8595,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(client_lb_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -8634,11 +8634,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(client_ssl_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -8684,11 +8684,11 @@ target_include_directories(cmdline_test
 )
 
 target_link_libraries(cmdline_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8721,12 +8721,12 @@ target_include_directories(codegen_test_full
 )
 
 target_link_libraries(codegen_test_full
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -8759,12 +8759,12 @@ target_include_directories(codegen_test_minimal
 )
 
 target_link_libraries(codegen_test_minimal
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -8810,11 +8810,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(combiner_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -8848,12 +8848,12 @@ target_include_directories(common_closures_test
 )
 
 target_link_libraries(common_closures_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -8886,11 +8886,11 @@ target_include_directories(completion_queue_threading_test
 )
 
 target_link_libraries(completion_queue_threading_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8923,11 +8923,11 @@ target_include_directories(compression_test
 )
 
 target_link_libraries(compression_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8960,11 +8960,11 @@ target_include_directories(concurrent_connectivity_test
 )
 
 target_link_libraries(concurrent_connectivity_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -8999,11 +8999,11 @@ target_include_directories(connection_prefix_bad_client_test
 )
 
 target_link_libraries(connection_prefix_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9037,11 +9037,11 @@ target_include_directories(connection_refused_test
 )
 
 target_link_libraries(connection_refused_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9086,11 +9086,11 @@ target_include_directories(connectivity_state_test
 )
 
 target_link_libraries(connectivity_state_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9140,11 +9140,11 @@ target_include_directories(context_allocator_end2end_test
 )
 
 target_link_libraries(context_allocator_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -9177,11 +9177,11 @@ target_include_directories(context_test
 )
 
 target_link_libraries(context_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC gpr
 )
 
 
@@ -9214,11 +9214,11 @@ target_include_directories(core_configuration_test
 )
 
 target_link_libraries(core_configuration_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -9347,13 +9347,13 @@ target_include_directories(core_end2end_tests
 )
 
 target_link_libraries(core_end2end_tests
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_authorization_provider
-  grpc_unsecure
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_authorization_provider
+  PUBLIC grpc_unsecure
+  PUBLIC grpc_test_util
 )
 
 
@@ -9386,10 +9386,10 @@ target_include_directories(cpp_impl_of_test
 )
 
 target_link_libraries(cpp_impl_of_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -9422,11 +9422,11 @@ target_include_directories(cpu_test
 )
 
 target_link_libraries(cpu_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9461,11 +9461,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(crl_ssl_transport_security_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -9499,11 +9499,11 @@ target_include_directories(default_engine_methods_test
 )
 
 target_link_libraries(default_engine_methods_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9553,11 +9553,11 @@ target_include_directories(delegating_channel_test
 )
 
 target_link_libraries(delegating_channel_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -9590,11 +9590,11 @@ target_include_directories(destroy_grpclb_channel_with_active_connect_stress_tes
 )
 
 target_link_libraries(destroy_grpclb_channel_with_active_connect_stress_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -9627,11 +9627,11 @@ target_include_directories(dns_resolver_cooldown_test
 )
 
 target_link_libraries(dns_resolver_cooldown_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9664,11 +9664,11 @@ target_include_directories(dns_resolver_test
 )
 
 target_link_libraries(dns_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9701,11 +9701,11 @@ target_include_directories(dual_ref_counted_test
 )
 
 target_link_libraries(dual_ref_counted_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9740,11 +9740,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(dualstack_socket_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -9780,11 +9780,11 @@ target_include_directories(duplicate_header_bad_client_test
 )
 
 target_link_libraries(duplicate_header_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -9837,11 +9837,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(end2end_binder_transport_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -9897,12 +9897,12 @@ target_include_directories(end2end_test
 )
 
 target_link_libraries(end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test
+  PUBLIC grpc++_test_util
 )
 
 
@@ -10000,11 +10000,11 @@ target_include_directories(endpoint_binder_pool_test
 )
 
 target_link_libraries(endpoint_binder_pool_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10041,13 +10041,13 @@ target_include_directories(endpoint_config_test
 )
 
 target_link_libraries(endpoint_config_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -10093,11 +10093,11 @@ target_include_directories(endpoint_pair_test
 )
 
 target_link_libraries(endpoint_pair_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10130,11 +10130,11 @@ target_include_directories(env_test
 )
 
 target_link_libraries(env_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10179,12 +10179,12 @@ target_include_directories(error_details_test
 )
 
 target_link_libraries(error_details_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_error_details
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_error_details
+  PUBLIC grpc_test_util
 )
 
 
@@ -10230,11 +10230,11 @@ target_include_directories(error_test
 )
 
 target_link_libraries(error_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10279,11 +10279,11 @@ target_include_directories(error_utils_test
 )
 
 target_link_libraries(error_utils_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10328,11 +10328,11 @@ target_include_directories(evaluate_args_test
 )
 
 target_link_libraries(evaluate_args_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10365,11 +10365,11 @@ target_include_directories(event_engine_wakeup_scheduler_test
 )
 
 target_link_libraries(event_engine_wakeup_scheduler_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -10404,11 +10404,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(event_poller_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -10443,11 +10443,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(examine_stack_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -10497,11 +10497,11 @@ target_include_directories(exception_test
 )
 
 target_link_libraries(exception_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -10550,15 +10550,15 @@ target_include_directories(exec_ctx_wakeup_scheduler_test
 )
 
 target_link_libraries(exec_ctx_wakeup_scheduler_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -10591,11 +10591,11 @@ target_include_directories(factory_test
 )
 
 target_link_libraries(factory_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -10693,11 +10693,11 @@ target_include_directories(fake_binder_test
 )
 
 target_link_libraries(fake_binder_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10730,11 +10730,11 @@ target_include_directories(fake_resolver_test
 )
 
 target_link_libraries(fake_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10768,11 +10768,11 @@ target_include_directories(fake_transport_security_test
 )
 
 target_link_libraries(fake_transport_security_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10818,11 +10818,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(fd_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -10856,11 +10856,11 @@ target_include_directories(file_watcher_certificate_provider_factory_test
 )
 
 target_link_libraries(file_watcher_certificate_provider_factory_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -10913,11 +10913,11 @@ target_include_directories(filter_end2end_test
 )
 
 target_link_libraries(filter_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -10956,12 +10956,12 @@ target_include_directories(filter_test_test
 )
 
 target_link_libraries(filter_test_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_unsecure
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_unsecure
+  PUBLIC grpc_test_util
 )
 
 
@@ -11011,11 +11011,11 @@ target_include_directories(flaky_network_test
 )
 
 target_link_libraries(flaky_network_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -11076,18 +11076,18 @@ target_include_directories(flow_control_test
 )
 
 target_link_libraries(flow_control_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -11146,18 +11146,18 @@ target_include_directories(for_each_test
 )
 
 target_link_libraries(for_each_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -11191,11 +11191,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(fork_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -11230,13 +11230,13 @@ target_include_directories(forkable_test
 )
 
 target_link_libraries(forkable_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -11285,11 +11285,11 @@ target_include_directories(format_request_test
 )
 
 target_link_libraries(format_request_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -11323,11 +11323,11 @@ target_include_directories(frame_handler_test
 )
 
 target_link_libraries(frame_handler_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -11361,14 +11361,14 @@ target_include_directories(frame_header_test
 )
 
 target_link_libraries(frame_header_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::status
-  absl::statusor
-  absl::strings
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::status
+  PUBLIC absl::statusor
+  PUBLIC absl::strings
+  PUBLIC absl::variant
 )
 
 
@@ -11629,22 +11629,22 @@ target_include_directories(frame_test
 )
 
 target_link_libraries(frame_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::cleanup
-  absl::flat_hash_map
-  absl::flat_hash_set
-  absl::inlined_vector
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::span
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::cleanup
+  PUBLIC absl::flat_hash_map
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::inlined_vector
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::span
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -11688,12 +11688,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(fuzzing_event_engine_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -11747,11 +11747,11 @@ target_include_directories(generic_end2end_test
 )
 
 target_link_libraries(generic_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -11785,11 +11785,11 @@ target_include_directories(goaway_server_test
 )
 
 target_link_libraries(goaway_server_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -11823,11 +11823,11 @@ target_include_directories(google_c2p_resolver_test
 )
 
 target_link_libraries(google_c2p_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -11861,11 +11861,11 @@ target_include_directories(google_mesh_ca_certificate_provider_factory_test
 )
 
 target_link_libraries(google_mesh_ca_certificate_provider_factory_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -11899,11 +11899,11 @@ target_include_directories(graceful_shutdown_test
 )
 
 target_link_libraries(graceful_shutdown_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -11948,11 +11948,11 @@ target_include_directories(grpc_alts_credentials_options_test
 )
 
 target_link_libraries(grpc_alts_credentials_options_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -11986,11 +11986,11 @@ target_include_directories(grpc_audit_logging_test
 )
 
 target_link_libraries(grpc_audit_logging_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12035,11 +12035,11 @@ target_include_directories(grpc_authorization_engine_test
 )
 
 target_link_libraries(grpc_authorization_engine_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12084,12 +12084,12 @@ target_include_directories(grpc_authorization_policy_provider_test
 )
 
 target_link_libraries(grpc_authorization_policy_provider_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_authorization_provider
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_authorization_provider
+  PUBLIC grpc_test_util
 )
 
 
@@ -12140,12 +12140,12 @@ target_include_directories(grpc_authz_end2end_test
 )
 
 target_link_libraries(grpc_authz_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_authorization_provider
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_authorization_provider
+  PUBLIC grpc++_test_util
 )
 
 
@@ -12178,11 +12178,11 @@ target_include_directories(grpc_byte_buffer_reader_test
 )
 
 target_link_libraries(grpc_byte_buffer_reader_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12225,12 +12225,12 @@ target_include_directories(grpc_cli
 )
 
 target_link_libraries(grpc_cli
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc++_test_config
 )
 
 
@@ -12263,11 +12263,11 @@ target_include_directories(grpc_completion_queue_test
 )
 
 target_link_libraries(grpc_completion_queue_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12294,12 +12294,12 @@ target_include_directories(grpc_cpp_plugin
 )
 
 target_link_libraries(grpc_cpp_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12336,12 +12336,12 @@ target_include_directories(grpc_csharp_plugin
 )
 
 target_link_libraries(grpc_csharp_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12396,11 +12396,11 @@ target_include_directories(grpc_ipv6_loopback_available_test
 )
 
 target_link_libraries(grpc_ipv6_loopback_available_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12427,12 +12427,12 @@ target_include_directories(grpc_node_plugin
 )
 
 target_link_libraries(grpc_node_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12469,12 +12469,12 @@ target_include_directories(grpc_objective_c_plugin
 )
 
 target_link_libraries(grpc_objective_c_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12511,12 +12511,12 @@ target_include_directories(grpc_php_plugin
 )
 
 target_link_libraries(grpc_php_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12553,12 +12553,12 @@ target_include_directories(grpc_python_plugin
 )
 
 target_link_libraries(grpc_python_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12595,12 +12595,12 @@ target_include_directories(grpc_ruby_plugin
 )
 
 target_link_libraries(grpc_ruby_plugin
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_plugin_support
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_plugin_support
 )
 
 
@@ -12655,11 +12655,11 @@ target_include_directories(grpc_tls_certificate_distributor_test
 )
 
 target_link_libraries(grpc_tls_certificate_distributor_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12704,11 +12704,11 @@ target_include_directories(grpc_tls_certificate_provider_test
 )
 
 target_link_libraries(grpc_tls_certificate_provider_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12753,11 +12753,11 @@ target_include_directories(grpc_tls_certificate_verifier_test
 )
 
 target_link_libraries(grpc_tls_certificate_verifier_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12802,11 +12802,11 @@ target_include_directories(grpc_tls_credentials_options_comparator_test
 )
 
 target_link_libraries(grpc_tls_credentials_options_comparator_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12851,11 +12851,11 @@ target_include_directories(grpc_tls_credentials_options_test
 )
 
 target_link_libraries(grpc_tls_credentials_options_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -12911,13 +12911,13 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(grpc_tool_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_reflection
-    grpc++_test_config
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_reflection
+    PUBLIC grpc++_test_config
+    PUBLIC grpc++_test_util
   )
 
 
@@ -12955,11 +12955,11 @@ target_include_directories(grpclb_api_test
 )
 
 target_link_libraries(grpclb_api_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -13018,12 +13018,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(grpclb_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_config
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_config
+    PUBLIC grpc++_test_util
   )
 
 
@@ -13065,12 +13065,12 @@ target_include_directories(h2_ssl_cert_test
 )
 
 target_link_libraries(h2_ssl_cert_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_unsecure
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_unsecure
+  PUBLIC grpc_test_util
 )
 
 
@@ -13104,11 +13104,11 @@ target_include_directories(h2_ssl_session_reuse_test
 )
 
 target_link_libraries(h2_ssl_session_reuse_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13142,11 +13142,11 @@ target_include_directories(h2_tls_peer_property_external_verifier_test
 )
 
 target_link_libraries(h2_tls_peer_property_external_verifier_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13179,11 +13179,11 @@ target_include_directories(handle_tests
 )
 
 target_link_libraries(handle_tests
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -13218,11 +13218,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(handshake_server_with_readahead_handshaker_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -13258,11 +13258,11 @@ target_include_directories(head_of_line_blocking_bad_client_test
 )
 
 target_link_libraries(head_of_line_blocking_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13297,11 +13297,11 @@ target_include_directories(headers_bad_client_test
 )
 
 target_link_libraries(headers_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13360,11 +13360,11 @@ target_include_directories(health_service_end2end_test
 )
 
 target_link_libraries(health_service_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -13409,11 +13409,11 @@ target_include_directories(histogram_test
 )
 
 target_link_libraries(histogram_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13446,11 +13446,11 @@ target_include_directories(host_port_test
 )
 
 target_link_libraries(host_port_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13495,11 +13495,11 @@ target_include_directories(hpack_encoder_test
 )
 
 target_link_libraries(hpack_encoder_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13544,11 +13544,11 @@ target_include_directories(hpack_parser_table_test
 )
 
 target_link_libraries(hpack_parser_table_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13593,11 +13593,11 @@ target_include_directories(hpack_parser_test
 )
 
 target_link_libraries(hpack_parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13642,12 +13642,12 @@ target_include_directories(http2_client
 )
 
 target_link_libraries(http2_client
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -13680,11 +13680,11 @@ target_include_directories(http_proxy_mapper_test
 )
 
 target_link_libraries(http_proxy_mapper_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13720,11 +13720,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(httpcli_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -13761,11 +13761,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(httpscli_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -13820,11 +13820,11 @@ target_include_directories(hybrid_end2end_test
 )
 
 target_link_libraries(hybrid_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -13858,10 +13858,10 @@ target_include_directories(idle_filter_state_test
 )
 
 target_link_libraries(idle_filter_state_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -13894,13 +13894,13 @@ target_include_directories(if_test
 )
 
 target_link_libraries(if_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -13933,11 +13933,11 @@ target_include_directories(init_test
 )
 
 target_link_libraries(init_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -13972,11 +13972,11 @@ target_include_directories(initial_settings_frame_bad_client_test
 )
 
 target_link_libraries(initial_settings_frame_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14021,11 +14021,11 @@ target_include_directories(insecure_security_connector_test
 )
 
 target_link_libraries(insecure_security_connector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14084,18 +14084,18 @@ target_include_directories(interceptor_list_test
 )
 
 target_link_libraries(interceptor_list_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -14144,12 +14144,12 @@ target_include_directories(interop_client
 )
 
 target_link_libraries(interop_client
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -14197,12 +14197,12 @@ target_include_directories(interop_server
 )
 
 target_link_libraries(interop_server
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -14236,11 +14236,11 @@ target_include_directories(invalid_call_argument_test
 )
 
 target_link_libraries(invalid_call_argument_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14275,11 +14275,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   )
 
   target_link_libraries(iocp_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -14318,13 +14318,13 @@ target_include_directories(istio_echo_server_test
 )
 
 target_link_libraries(istio_echo_server_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
+  PUBLIC grpc++_test_config
 )
 
 
@@ -14357,13 +14357,13 @@ target_include_directories(join_test
 )
 
 target_link_libraries(join_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -14396,11 +14396,11 @@ target_include_directories(json_object_loader_test
 )
 
 target_link_libraries(json_object_loader_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14433,11 +14433,11 @@ target_include_directories(json_test
 )
 
 target_link_libraries(json_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14482,11 +14482,11 @@ target_include_directories(json_token_test
 )
 
 target_link_libraries(json_token_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14531,11 +14531,11 @@ target_include_directories(jwt_verifier_test
 )
 
 target_link_libraries(jwt_verifier_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14569,11 +14569,11 @@ target_include_directories(lame_client_test
 )
 
 target_link_libraries(lame_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14609,14 +14609,14 @@ target_include_directories(latch_test
 )
 
 target_link_libraries(latch_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -14653,11 +14653,11 @@ target_include_directories(lb_get_cpu_stats_test
 )
 
 target_link_libraries(lb_get_cpu_stats_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14691,12 +14691,12 @@ target_include_directories(lb_load_data_store_test
 )
 
 target_link_libraries(lb_load_data_store_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -14730,12 +14730,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(lock_free_event_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    ${_gRPC_BENCHMARK_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PRIVATE ${_gRPC_BENCHMARK_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -14769,11 +14769,11 @@ target_include_directories(log_test
 )
 
 target_link_libraries(log_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -14807,11 +14807,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(log_too_many_open_files_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -14845,14 +14845,14 @@ target_include_directories(loop_test
 )
 
 target_link_libraries(loop_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -14911,18 +14911,18 @@ target_include_directories(map_pipe_test
 )
 
 target_link_libraries(map_pipe_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::function_ref
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -14955,11 +14955,11 @@ target_include_directories(match_test
 )
 
 target_link_libraries(match_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::variant
 )
 
 
@@ -15004,11 +15004,11 @@ target_include_directories(matchers_test
 )
 
 target_link_libraries(matchers_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15042,11 +15042,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(memory_quota_stress_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util_unsecure
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util_unsecure
   )
 
 
@@ -15080,11 +15080,11 @@ target_include_directories(memory_quota_test
 )
 
 target_link_libraries(memory_quota_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -15134,11 +15134,11 @@ target_include_directories(message_allocator_end2end_test
 )
 
 target_link_libraries(message_allocator_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -15183,11 +15183,11 @@ target_include_directories(message_compress_test
 )
 
 target_link_libraries(message_compress_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15220,11 +15220,11 @@ target_include_directories(message_size_service_config_test
 )
 
 target_link_libraries(message_size_service_config_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15269,11 +15269,11 @@ target_include_directories(metadata_map_test
 )
 
 target_link_libraries(metadata_map_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15306,11 +15306,11 @@ target_include_directories(minimal_stack_is_minimal_test
 )
 
 target_link_libraries(minimal_stack_is_minimal_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15343,10 +15343,10 @@ target_include_directories(miscompile_with_no_unique_address_test
 )
 
 target_link_libraries(miscompile_with_no_unique_address_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -15395,12 +15395,12 @@ target_include_directories(mock_stream_test
 )
 
 target_link_libraries(mock_stream_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test
+  PUBLIC grpc++_test_util
 )
 
 
@@ -15453,12 +15453,12 @@ target_include_directories(mock_test
 )
 
 target_link_libraries(mock_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test
+  PUBLIC grpc++_test_util
 )
 
 
@@ -15492,15 +15492,15 @@ target_include_directories(mpsc_test
 )
 
 target_link_libraries(mpsc_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::hash
-  absl::type_traits
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::hash
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -15534,11 +15534,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(mpscq_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -15572,10 +15572,10 @@ target_include_directories(no_destruct_test
 )
 
 target_link_libraries(no_destruct_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -15609,11 +15609,11 @@ target_include_directories(no_server_test
 )
 
 target_link_libraries(no_server_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15662,11 +15662,11 @@ target_include_directories(nonblocking_test
 )
 
 target_link_libraries(nonblocking_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -15699,11 +15699,11 @@ target_include_directories(notification_test
 )
 
 target_link_libraries(notification_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC gpr
 )
 
 
@@ -15736,11 +15736,11 @@ target_include_directories(num_external_connectivity_watchers_test
 )
 
 target_link_libraries(num_external_connectivity_watchers_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15779,12 +15779,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(oracle_event_engine_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -15827,11 +15827,11 @@ target_include_directories(orca_service_end2end_test
 )
 
 target_link_libraries(orca_service_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -15864,11 +15864,11 @@ target_include_directories(orphanable_test
 )
 
 target_link_libraries(orphanable_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15903,11 +15903,11 @@ target_include_directories(out_of_bounds_bad_client_test
 )
 
 target_link_libraries(out_of_bounds_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15940,11 +15940,11 @@ target_include_directories(outlier_detection_lb_config_parser_test
 )
 
 target_link_libraries(outlier_detection_lb_config_parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -15977,11 +15977,11 @@ target_include_directories(outlier_detection_test
 )
 
 target_link_libraries(outlier_detection_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16014,10 +16014,10 @@ target_include_directories(overload_test
 )
 
 target_link_libraries(overload_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -16050,11 +16050,11 @@ target_include_directories(parse_address_test
 )
 
 target_link_libraries(parse_address_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16088,11 +16088,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(parse_address_with_named_scope_id_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -16126,11 +16126,11 @@ target_include_directories(parsed_metadata_test
 )
 
 target_link_libraries(parsed_metadata_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16179,11 +16179,11 @@ target_include_directories(parser_test
 )
 
 target_link_libraries(parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16216,11 +16216,11 @@ target_include_directories(party_test
 )
 
 target_link_libraries(party_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_unsecure
 )
 
 
@@ -16253,11 +16253,11 @@ target_include_directories(percent_encoding_test
 )
 
 target_link_libraries(percent_encoding_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16306,15 +16306,15 @@ target_include_directories(periodic_update_test
 )
 
 target_link_libraries(periodic_update_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::function_ref
-  absl::hash
-  absl::statusor
-  gpr
-  upb
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::function_ref
+  PUBLIC absl::hash
+  PUBLIC absl::statusor
+  PUBLIC gpr
+  PUBLIC upb
 )
 
 
@@ -16347,11 +16347,11 @@ target_include_directories(pick_first_test
 )
 
 target_link_libraries(pick_first_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16396,11 +16396,11 @@ target_include_directories(pid_controller_test
 )
 
 target_link_libraries(pid_controller_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -16433,11 +16433,11 @@ target_include_directories(pipe_test
 )
 
 target_link_libraries(pipe_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -16470,11 +16470,11 @@ target_include_directories(poll_test
 )
 
 target_link_libraries(poll_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC gpr
 )
 
 
@@ -16524,11 +16524,11 @@ target_include_directories(port_sharing_end2end_test
 )
 
 target_link_libraries(port_sharing_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -16566,12 +16566,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(posix_endpoint_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -16606,11 +16606,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(posix_engine_listener_utils_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -16648,12 +16648,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(posix_event_engine_connect_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -16694,12 +16694,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(posix_event_engine_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -16733,13 +16733,13 @@ target_include_directories(promise_factory_test
 )
 
 target_link_libraries(promise_factory_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::bind_front
-  absl::type_traits
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::bind_front
+  PUBLIC absl::type_traits
+  PUBLIC gpr
 )
 
 
@@ -16772,12 +16772,12 @@ target_include_directories(promise_map_test
 )
 
 target_link_libraries(promise_map_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC gpr
 )
 
 
@@ -16810,12 +16810,12 @@ target_include_directories(promise_test
 )
 
 target_link_libraries(promise_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC gpr
 )
 
 
@@ -16848,11 +16848,11 @@ target_include_directories(proto_buffer_reader_test
 )
 
 target_link_libraries(proto_buffer_reader_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -16885,11 +16885,11 @@ target_include_directories(proto_buffer_writer_test
 )
 
 target_link_libraries(proto_buffer_writer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -16944,12 +16944,12 @@ target_include_directories(proto_server_reflection_test
 )
 
 target_link_libraries(proto_server_reflection_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_reflection
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_reflection
+  PUBLIC grpc++_test_util
 )
 
 
@@ -16982,12 +16982,12 @@ target_include_directories(proto_utils_test
 )
 
 target_link_libraries(proto_utils_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -17061,12 +17061,12 @@ target_include_directories(qps_json_driver
 )
 
 target_link_libraries(qps_json_driver
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -17132,12 +17132,12 @@ target_include_directories(qps_worker
 )
 
 target_link_libraries(qps_worker
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -17170,11 +17170,11 @@ target_include_directories(race_test
 )
 
 target_link_libraries(race_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC gpr
 )
 
 
@@ -17208,11 +17208,11 @@ target_include_directories(random_early_detection_test
 )
 
 target_link_libraries(random_early_detection_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::random_random
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::random_random
 )
 
 
@@ -17266,11 +17266,11 @@ target_include_directories(raw_end2end_test
 )
 
 target_link_libraries(raw_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -17303,11 +17303,11 @@ target_include_directories(rbac_service_config_parser_test
 )
 
 target_link_libraries(rbac_service_config_parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17352,12 +17352,12 @@ target_include_directories(rbac_translator_test
 )
 
 target_link_libraries(rbac_translator_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_authorization_provider
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_authorization_provider
+  PUBLIC grpc_test_util
 )
 
 
@@ -17390,11 +17390,11 @@ target_include_directories(ref_counted_ptr_test
 )
 
 target_link_libraries(ref_counted_ptr_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17427,11 +17427,11 @@ target_include_directories(ref_counted_test
 )
 
 target_link_libraries(ref_counted_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17465,11 +17465,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(remove_stream_from_stalled_lists_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -17516,12 +17516,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(resolve_address_using_ares_resolver_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    absl::flags_parse
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC absl::flags_parse
+    PUBLIC grpc_test_util
   )
 
 
@@ -17568,12 +17568,12 @@ target_include_directories(resolve_address_using_ares_resolver_test
 )
 
 target_link_libraries(resolve_address_using_ares_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
+  PUBLIC grpc++_test_config
 )
 
 
@@ -17619,12 +17619,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(resolve_address_using_native_resolver_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    absl::flags_parse
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC absl::flags_parse
+    PUBLIC grpc_test_util
   )
 
 
@@ -17671,12 +17671,12 @@ target_include_directories(resolve_address_using_native_resolver_test
 )
 
 target_link_libraries(resolve_address_using_native_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
+  PUBLIC grpc++_test_config
 )
 
 
@@ -17709,11 +17709,11 @@ target_include_directories(resource_quota_test
 )
 
 target_link_libraries(resource_quota_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -17746,11 +17746,11 @@ target_include_directories(retry_service_config_test
 )
 
 target_link_libraries(retry_service_config_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17783,11 +17783,11 @@ target_include_directories(retry_throttle_test
 )
 
 target_link_libraries(retry_throttle_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17847,12 +17847,12 @@ target_include_directories(rls_end2end_test
 )
 
 target_link_libraries(rls_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -17885,11 +17885,11 @@ target_include_directories(rls_lb_config_parser_test
 )
 
 target_link_libraries(rls_lb_config_parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17922,11 +17922,11 @@ target_include_directories(round_robin_test
 )
 
 target_link_libraries(round_robin_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -17959,11 +17959,11 @@ target_include_directories(secure_auth_context_test
 )
 
 target_link_libraries(secure_auth_context_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -17996,11 +17996,11 @@ target_include_directories(secure_channel_create_test
 )
 
 target_link_libraries(secure_channel_create_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18046,11 +18046,11 @@ target_include_directories(secure_endpoint_test
 )
 
 target_link_libraries(secure_endpoint_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18095,11 +18095,11 @@ target_include_directories(security_connector_test
 )
 
 target_link_libraries(security_connector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18132,13 +18132,13 @@ target_include_directories(seq_test
 )
 
 target_link_libraries(seq_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -18171,11 +18171,11 @@ target_include_directories(sequential_connectivity_test
 )
 
 target_link_libraries(sequential_connectivity_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18229,11 +18229,11 @@ target_include_directories(server_builder_plugin_test
 )
 
 target_link_libraries(server_builder_plugin_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -18295,12 +18295,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(server_builder_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_unsecure
-    grpc_test_util_unsecure
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_unsecure
+    PUBLIC grpc_test_util_unsecure
   )
 
 
@@ -18363,12 +18363,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(server_builder_with_socket_mutator_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_unsecure
-    grpc_test_util_unsecure
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_unsecure
+    PUBLIC grpc_test_util_unsecure
   )
 
 
@@ -18402,11 +18402,11 @@ target_include_directories(server_call_tracer_factory_test
 )
 
 target_link_libraries(server_call_tracer_factory_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18439,11 +18439,11 @@ target_include_directories(server_chttp2_test
 )
 
 target_link_libraries(server_chttp2_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18476,11 +18476,11 @@ target_include_directories(server_config_selector_test
 )
 
 target_link_libraries(server_config_selector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18513,12 +18513,12 @@ target_include_directories(server_context_test_spouse_test
 )
 
 target_link_libraries(server_context_test_spouse_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test
+  PUBLIC grpc++_test_util
 )
 
 
@@ -18567,11 +18567,11 @@ target_include_directories(server_early_return_test
 )
 
 target_link_libraries(server_early_return_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -18622,11 +18622,11 @@ target_include_directories(server_interceptors_end2end_test
 )
 
 target_link_libraries(server_interceptors_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -18661,11 +18661,11 @@ target_include_directories(server_registered_method_bad_client_test
 )
 
 target_link_libraries(server_registered_method_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18727,12 +18727,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(server_request_call_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_unsecure
-    grpc_test_util_unsecure
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_unsecure
+    PUBLIC grpc_test_util_unsecure
   )
 
 
@@ -18768,11 +18768,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(server_ssl_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -18806,11 +18806,11 @@ target_include_directories(server_test
 )
 
 target_link_libraries(server_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18864,11 +18864,11 @@ target_include_directories(service_config_end2end_test
 )
 
 target_link_libraries(service_config_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -18901,11 +18901,11 @@ target_include_directories(service_config_test
 )
 
 target_link_libraries(service_config_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -18950,11 +18950,11 @@ target_include_directories(settings_timeout_test
 )
 
 target_link_libraries(settings_timeout_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19007,11 +19007,11 @@ target_include_directories(shutdown_test
 )
 
 target_link_libraries(shutdown_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -19046,11 +19046,11 @@ target_include_directories(simple_request_bad_client_test
 )
 
 target_link_libraries(simple_request_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19083,11 +19083,11 @@ target_include_directories(single_set_ptr_test
 )
 
 target_link_libraries(single_set_ptr_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC gpr
 )
 
 
@@ -19120,11 +19120,11 @@ target_include_directories(sleep_test
 )
 
 target_link_libraries(sleep_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -19161,13 +19161,13 @@ target_include_directories(slice_string_helpers_test
 )
 
 target_link_libraries(slice_string_helpers_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::hash
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::hash
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -19200,11 +19200,11 @@ target_include_directories(smoke_test
 )
 
 target_link_libraries(smoke_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -19237,11 +19237,11 @@ target_include_directories(sockaddr_resolver_test
 )
 
 target_link_libraries(sockaddr_resolver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19274,11 +19274,11 @@ target_include_directories(sockaddr_utils_test
 )
 
 target_link_libraries(sockaddr_utils_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19324,11 +19324,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(socket_utils_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -19362,10 +19362,10 @@ target_include_directories(sorted_pack_test
 )
 
 target_link_libraries(sorted_pack_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 
 
@@ -19398,11 +19398,11 @@ target_include_directories(spinlock_test
 )
 
 target_link_libraries(spinlock_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19447,11 +19447,11 @@ target_include_directories(ssl_credentials_test
 )
 
 target_link_libraries(ssl_credentials_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19486,11 +19486,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(ssl_transport_security_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -19525,11 +19525,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(ssl_transport_security_utils_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -19564,11 +19564,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(stack_tracer_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -19602,11 +19602,11 @@ target_include_directories(stat_test
 )
 
 target_link_libraries(stat_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19640,12 +19640,12 @@ target_include_directories(static_stride_scheduler_test
 )
 
 target_link_libraries(static_stride_scheduler_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::span
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::span
+  PUBLIC gpr
 )
 
 
@@ -19678,11 +19678,11 @@ target_include_directories(stats_test
 )
 
 target_link_libraries(stats_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19727,11 +19727,11 @@ target_include_directories(status_conversion_test
 )
 
 target_link_libraries(status_conversion_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19764,11 +19764,11 @@ target_include_directories(status_helper_test
 )
 
 target_link_libraries(status_helper_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19801,11 +19801,11 @@ target_include_directories(status_util_test
 )
 
 target_link_libraries(status_util_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19852,11 +19852,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(stranded_event_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -19890,11 +19890,11 @@ target_include_directories(stream_leak_with_queued_flow_control_update_test
 )
 
 target_link_libraries(stream_leak_with_queued_flow_control_update_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19939,11 +19939,11 @@ target_include_directories(stream_map_test
 )
 
 target_link_libraries(stream_map_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -19997,11 +19997,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(streaming_throughput_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -20048,11 +20048,11 @@ target_include_directories(streams_not_seen_test
 )
 
 target_link_libraries(streams_not_seen_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20085,12 +20085,12 @@ target_include_directories(string_ref_test
 )
 
 target_link_libraries(string_ref_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -20123,11 +20123,11 @@ target_include_directories(string_test
 )
 
 target_link_libraries(string_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20160,11 +20160,11 @@ target_include_directories(sync_test
 )
 
 target_link_libraries(sync_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20209,11 +20209,11 @@ target_include_directories(system_roots_test
 )
 
 target_link_libraries(system_roots_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20246,15 +20246,15 @@ target_include_directories(table_test
 )
 
 target_link_libraries(table_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::strings
-  absl::optional
-  absl::variant
-  absl::utility
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::strings
+  PUBLIC absl::optional
+  PUBLIC absl::variant
+  PUBLIC absl::utility
 )
 
 
@@ -20300,11 +20300,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(tcp_client_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -20339,11 +20339,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(tcp_posix_socket_utils_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -20390,11 +20390,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(tcp_server_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -20428,11 +20428,11 @@ target_include_directories(tcp_socket_utils_test
 )
 
 target_link_libraries(tcp_socket_utils_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -20469,12 +20469,12 @@ target_include_directories(test_core_event_engine_posix_timer_heap_test
 )
 
 target_link_libraries(test_core_event_engine_posix_timer_heap_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -20511,12 +20511,12 @@ target_include_directories(test_core_event_engine_posix_timer_list_test
 )
 
 target_link_libraries(test_core_event_engine_posix_timer_list_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -20558,15 +20558,15 @@ target_include_directories(test_core_event_engine_slice_buffer_test
 )
 
 target_link_libraries(test_core_event_engine_slice_buffer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::hash
-  absl::statusor
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::hash
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -20599,11 +20599,11 @@ target_include_directories(test_core_gpr_time_test
 )
 
 target_link_libraries(test_core_gpr_time_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20636,11 +20636,11 @@ target_include_directories(test_core_gprpp_load_file_test
 )
 
 target_link_libraries(test_core_gprpp_load_file_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20674,12 +20674,12 @@ target_include_directories(test_core_gprpp_time_test
 )
 
 target_link_libraries(test_core_gprpp_time_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -20724,11 +20724,11 @@ target_include_directories(test_core_iomgr_load_file_test
 )
 
 target_link_libraries(test_core_iomgr_load_file_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20773,11 +20773,11 @@ target_include_directories(test_core_iomgr_timer_heap_test
 )
 
 target_link_libraries(test_core_iomgr_timer_heap_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20822,11 +20822,11 @@ target_include_directories(test_core_security_credentials_test
 )
 
 target_link_libraries(test_core_security_credentials_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20859,11 +20859,11 @@ target_include_directories(test_core_slice_slice_buffer_test
 )
 
 target_link_libraries(test_core_slice_slice_buffer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -20897,11 +20897,11 @@ target_include_directories(test_core_slice_slice_test
 )
 
 target_link_libraries(test_core_slice_slice_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -20935,12 +20935,12 @@ target_include_directories(test_cpp_client_credentials_test
 )
 
 target_link_libraries(test_cpp_client_credentials_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -20974,12 +20974,12 @@ target_include_directories(test_cpp_server_credentials_test
 )
 
 target_link_libraries(test_cpp_server_credentials_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -21012,11 +21012,11 @@ target_include_directories(test_cpp_util_slice_test
 )
 
 target_link_libraries(test_cpp_util_slice_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -21049,11 +21049,11 @@ target_include_directories(test_cpp_util_time_test
 )
 
 target_link_libraries(test_cpp_util_time_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -21086,11 +21086,11 @@ target_include_directories(thd_test
 )
 
 target_link_libraries(thd_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21123,12 +21123,12 @@ target_include_directories(thread_manager_test
 )
 
 target_link_libraries(thread_manager_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -21164,13 +21164,13 @@ target_include_directories(thread_pool_test
 )
 
 target_link_libraries(thread_pool_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::flat_hash_set
-  absl::statusor
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::flat_hash_set
+  PUBLIC absl::statusor
+  PUBLIC gpr
 )
 
 
@@ -21204,11 +21204,11 @@ target_include_directories(thread_quota_test
 )
 
 target_link_libraries(thread_quota_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC gpr
 )
 
 
@@ -21262,11 +21262,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(thread_stress_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -21308,12 +21308,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(thready_posix_event_engine_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_unsecure
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_unsecure
+    PUBLIC grpc_test_util
   )
 
 
@@ -21348,12 +21348,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(time_jump_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++
+    PUBLIC grpc_test_util
   )
 
 
@@ -21387,11 +21387,11 @@ target_include_directories(time_util_test
 )
 
 target_link_libraries(time_util_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21436,11 +21436,11 @@ target_include_directories(timeout_encoding_test
 )
 
 target_link_libraries(timeout_encoding_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21473,11 +21473,11 @@ target_include_directories(timer_manager_test
 )
 
 target_link_libraries(timer_manager_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21510,12 +21510,12 @@ target_include_directories(timer_test
 )
 
 target_link_libraries(timer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -21549,12 +21549,12 @@ target_include_directories(tls_certificate_verifier_test
 )
 
 target_link_libraries(tls_certificate_verifier_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -21603,11 +21603,11 @@ target_include_directories(tls_key_export_test
 )
 
 target_link_libraries(tls_key_export_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -21652,11 +21652,11 @@ target_include_directories(tls_security_connector_test
 )
 
 target_link_libraries(tls_security_connector_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21690,12 +21690,12 @@ target_include_directories(too_many_pings_test
 )
 
 target_link_libraries(too_many_pings_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_config
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_config
+  PUBLIC grpc++_test_util
 )
 
 
@@ -21729,11 +21729,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(traced_buffer_list_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -21767,11 +21767,11 @@ target_include_directories(transport_security_common_api_test
 )
 
 target_link_libraries(transport_security_common_api_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21804,11 +21804,11 @@ target_include_directories(transport_security_test
 )
 
 target_link_libraries(transport_security_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21905,11 +21905,11 @@ target_include_directories(transport_stream_receiver_test
 )
 
 target_link_libraries(transport_stream_receiver_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -21942,14 +21942,14 @@ target_include_directories(try_join_test
 )
 
 target_link_libraries(try_join_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -21982,11 +21982,11 @@ target_include_directories(try_seq_metadata_test
 )
 
 target_link_libraries(try_seq_metadata_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc
 )
 
 
@@ -22019,14 +22019,14 @@ target_include_directories(try_seq_test
 )
 
 target_link_libraries(try_seq_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::type_traits
-  absl::statusor
-  absl::utility
-  gpr
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::type_traits
+  PUBLIC absl::statusor
+  PUBLIC absl::utility
+  PUBLIC gpr
 )
 
 
@@ -22059,13 +22059,13 @@ target_include_directories(unique_type_name_test
 )
 
 target_link_libraries(unique_type_name_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::str_format
-  absl::strings
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::str_format
+  PUBLIC absl::strings
+  PUBLIC absl::variant
 )
 
 
@@ -22100,11 +22100,11 @@ target_include_directories(unknown_frame_bad_client_test
 )
 
 target_link_libraries(unknown_frame_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22137,11 +22137,11 @@ target_include_directories(uri_parser_test
 )
 
 target_link_libraries(uri_parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -22174,12 +22174,12 @@ target_include_directories(useful_test
 )
 
 target_link_libraries(useful_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::strings
-  absl::variant
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC absl::strings
+  PUBLIC absl::variant
 )
 
 
@@ -22213,11 +22213,11 @@ target_include_directories(uuid_v4_test
 )
 
 target_link_libraries(uuid_v4_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22250,11 +22250,11 @@ target_include_directories(validation_errors_test
 )
 
 target_link_libraries(validation_errors_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22287,11 +22287,11 @@ target_include_directories(varint_test
 )
 
 target_link_libraries(varint_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22325,11 +22325,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(wakeup_fd_posix_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -22363,11 +22363,11 @@ target_include_directories(weighted_round_robin_config_test
 )
 
 target_link_libraries(weighted_round_robin_config_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22400,11 +22400,11 @@ target_include_directories(weighted_round_robin_test
 )
 
 target_link_libraries(weighted_round_robin_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22439,11 +22439,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   )
 
   target_link_libraries(win_socket_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -22479,11 +22479,11 @@ target_include_directories(window_overflow_bad_client_test
 )
 
 target_link_libraries(window_overflow_bad_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22518,11 +22518,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   )
 
   target_link_libraries(windows_endpoint_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -22621,11 +22621,11 @@ target_include_directories(wire_reader_test
 )
 
 target_link_libraries(wire_reader_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22723,11 +22723,11 @@ target_include_directories(wire_writer_test
 )
 
 target_link_libraries(wire_writer_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -22761,11 +22761,11 @@ target_include_directories(work_queue_test
 )
 
 target_link_libraries(work_queue_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util_unsecure
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util_unsecure
 )
 
 
@@ -22799,11 +22799,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(work_serializer_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc_test_util
   )
 
 
@@ -22866,12 +22866,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(writes_per_rpc_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++
-    grpc_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++
+    PUBLIC grpc_test_util
   )
 
 
@@ -22970,12 +22970,12 @@ target_include_directories(xds_audit_logger_registry_test
 )
 
 target_link_libraries(xds_audit_logger_registry_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -23008,11 +23008,11 @@ target_include_directories(xds_bootstrap_test
 )
 
 target_link_libraries(xds_bootstrap_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -23045,11 +23045,11 @@ target_include_directories(xds_certificate_provider_test
 )
 
 target_link_libraries(xds_certificate_provider_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -23096,11 +23096,11 @@ target_include_directories(xds_client_test
 )
 
 target_link_libraries(xds_client_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -23263,11 +23263,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_cluster_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -23366,11 +23366,11 @@ target_include_directories(xds_cluster_resource_type_test
 )
 
 target_link_libraries(xds_cluster_resource_type_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -23537,11 +23537,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_cluster_type_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -23616,12 +23616,12 @@ target_include_directories(xds_common_types_test
 )
 
 target_link_libraries(xds_common_types_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -23783,11 +23783,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_core_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -23838,11 +23838,11 @@ target_include_directories(xds_credentials_end2end_test
 )
 
 target_link_libraries(xds_credentials_end2end_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_test_util
 )
 
 
@@ -23887,11 +23887,11 @@ target_include_directories(xds_credentials_test
 )
 
 target_link_libraries(xds_credentials_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -24062,11 +24062,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_csds_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -24245,12 +24245,12 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_config
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_config
+    PUBLIC grpc++_test_util
   )
 
 
@@ -24305,11 +24305,11 @@ target_include_directories(xds_endpoint_resource_type_test
 )
 
 target_link_libraries(xds_endpoint_resource_type_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -24479,11 +24479,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_fault_injection_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -24606,12 +24606,12 @@ target_include_directories(xds_http_filters_test
 )
 
 target_link_libraries(xds_http_filters_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -24675,14 +24675,14 @@ target_include_directories(xds_interop_client
 )
 
 target_link_libraries(xds_interop_client
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_reflection
-  grpcpp_channelz
-  grpc_test_util
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_reflection
+  PUBLIC grpcpp_channelz
+  PUBLIC grpc_test_util
+  PUBLIC grpc++_test_config
 )
 
 
@@ -24750,14 +24750,14 @@ target_include_directories(xds_interop_server
 )
 
 target_link_libraries(xds_interop_server
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++_reflection
-  grpcpp_channelz
-  grpc_test_util
-  grpc++_test_config
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++_reflection
+  PUBLIC grpcpp_channelz
+  PUBLIC grpc_test_util
+  PUBLIC grpc++_test_config
 )
 
 
@@ -24859,12 +24859,12 @@ target_include_directories(xds_lb_policy_registry_test
 )
 
 target_link_libraries(xds_lb_policy_registry_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -24994,12 +24994,12 @@ target_include_directories(xds_listener_resource_type_test
 )
 
 target_link_libraries(xds_listener_resource_type_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -25169,11 +25169,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_outlier_detection_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -25348,11 +25348,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_override_host_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -25386,11 +25386,11 @@ target_include_directories(xds_override_host_lb_config_parser_test
 )
 
 target_link_libraries(xds_override_host_lb_config_parser_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -25423,11 +25423,11 @@ target_include_directories(xds_override_host_test
 )
 
 target_link_libraries(xds_override_host_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc_test_util
 )
 
 
@@ -25594,11 +25594,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_ring_hash_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -25770,11 +25770,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_rls_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -25885,12 +25885,12 @@ target_include_directories(xds_route_config_resource_type_test
 )
 
 target_link_libraries(xds_route_config_resource_type_test
-  ${_gRPC_BASELIB_LIBRARIES}
-  ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  grpc++
-  grpc_test_util
+  PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+  PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+  PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+  PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+  PUBLIC grpc++
+  PUBLIC grpc_test_util
 )
 
 
@@ -26060,11 +26060,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_routing_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 
@@ -26235,11 +26235,11 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   )
 
   target_link_libraries(xds_wrr_end2end_test
-    ${_gRPC_BASELIB_LIBRARIES}
-    ${_gRPC_PROTOBUF_LIBRARIES}
-    ${_gRPC_ZLIB_LIBRARIES}
-    ${_gRPC_ALLTARGETS_LIBRARIES}
-    grpc++_test_util
+    PUBLIC ${_gRPC_BASELIB_LIBRARIES}
+    PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}
+    PRIVATE ${_gRPC_ZLIB_LIBRARIES}
+    PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}
+    PUBLIC grpc++_test_util
   )
 
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
@@ -23,8 +23,6 @@
 
 #include <memory>
 
-#include <ares.h>
-
 #include "absl/base/thread_annotations.h"
 
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -25,8 +25,6 @@
 
 #include <memory>
 
-#include <ares.h>
-
 #include "absl/base/thread_annotations.h"
 
 #include <grpc/support/log.h>
@@ -51,14 +49,17 @@ extern grpc_core::TraceFlag grpc_trace_cares_resolver;
     }                                                               \
   } while (0)
 
+struct ares_addr_port_node;
 typedef struct grpc_ares_ev_driver grpc_ares_ev_driver;
 
 struct grpc_ares_request {
+  grpc_ares_request();
+  ~grpc_ares_request();
   /// synchronizes access to this request, and also to associated
   /// ev_driver and fd_node objects
   grpc_core::Mutex mu;
   /// indicates the DNS server to use, if specified
-  struct ares_addr_port_node dns_server_addr ABSL_GUARDED_BY(mu);
+  ares_addr_port_node* dns_server_addr ABSL_GUARDED_BY(mu);
   /// following members are set in grpc_resolve_address_ares_impl
   /// closure to call when the request completes
   grpc_closure* on_done ABSL_GUARDED_BY(mu) = nullptr;
@@ -129,6 +130,9 @@ bool grpc_ares_query_ipv6();
 // Sorts destinations in lb_addrs according to RFC 6724.
 void grpc_cares_wrapper_address_sorting_sort(
     const grpc_ares_request* request, grpc_core::ServerAddressList* addresses);
+
+struct ares_channeldata;
+typedef struct ares_channeldata* ares_channel;
 
 // Exposed in this header for C-core tests only
 extern void (*grpc_ares_test_only_inject_config)(ares_channel channel);

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -71,29 +71,29 @@
 
   def get_deps(target_dict):
     deps = []
-    deps.append("${_gRPC_BASELIB_LIBRARIES}")
+    deps.append("PUBLIC ${_gRPC_BASELIB_LIBRARIES}")
     if target_dict.get('build', None) in ['protoc']:
-      deps.append("${_gRPC_PROTOBUF_PROTOC_LIBRARIES}")
+      deps.append("PUBLIC ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}")
     if target_dict.language == 'c++':
-      deps.append("${_gRPC_PROTOBUF_LIBRARIES}")
-    deps.append("${_gRPC_ZLIB_LIBRARIES}")
+      deps.append("PUBLIC ${_gRPC_PROTOBUF_LIBRARIES}")
+    deps.append("PRIVATE ${_gRPC_ZLIB_LIBRARIES}")
     if target_dict['name'] in ['grpc', 'grpc_cronet', 'grpc_unsecure']:
-      deps.append("${_gRPC_CARES_LIBRARIES}")
-      deps.append("${_gRPC_ADDRESS_SORTING_LIBRARIES}")
-      deps.append("${_gRPC_RE2_LIBRARIES}")
-      deps.append("${_gRPC_UPB_LIBRARIES}")
+      deps.append("PRIVATE ${_gRPC_CARES_LIBRARIES}")
+      deps.append("PRIVATE ${_gRPC_ADDRESS_SORTING_LIBRARIES}")
+      deps.append("PRIVATE ${_gRPC_RE2_LIBRARIES}")
+      deps.append("PRIVATE ${_gRPC_UPB_LIBRARIES}")
     if target_dict['name'] in ['grpc_authorization_provider']:
-      deps.append("${_gRPC_RE2_LIBRARIES}")
-    deps.append("${_gRPC_ALLTARGETS_LIBRARIES}")
+      deps.append("PRIVATE ${_gRPC_RE2_LIBRARIES}")
+    deps.append("PUBLIC ${_gRPC_ALLTARGETS_LIBRARIES}")
     for d in target_dict.get('deps', []):
       if d == 'benchmark':
-        deps.append("${_gRPC_BENCHMARK_LIBRARIES}")
+        deps.append("PRIVATE ${_gRPC_BENCHMARK_LIBRARIES}")
       elif d == 'libssl':
-        deps.append("${_gRPC_SSL_LIBRARIES}")
+        deps.append("PRIVATE ${_gRPC_SSL_LIBRARIES}")
       elif is_absl_lib(d):
-        deps.append(get_absl_dep(d))
+        deps.append("PUBLIC " + get_absl_dep(d))
       else:
-        deps.append(d)
+        deps.append("PUBLIC " + d)
     return deps
 
   def get_platforms_condition_begin(platforms):

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -704,8 +704,8 @@
   % if lib.name in ["gpr"]:
   if(_gRPC_PLATFORM_ANDROID)
     target_link_libraries(gpr
-      android
-      log
+      PUBLIC android
+      PUBLIC log
     )
   endif()
   % endif

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include <address_sorting/address_sorting.h>
+#include <ares.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
To address https://github.com/grpc/grpc/issues/30838 which needs a distinction of either private or public for all deps of cmake targets, Cmake template now begins to specify this all the times. As `CMakeLists.txt` is automatically generated from `BUILD` which doesn't have a concept of public or private dependency, there is no way to annotate metadata which could be used to populate this property for CMake. Therefore, this template is now doing this by statically written property (a.k.a hard coding).
