### PR TITLE
[fix] change confusing error message

### DIFF
--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -359,8 +359,8 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
         if (newval != timeout) {
           gpr_log(GPR_INFO,
                   "Setting TCP_USER_TIMEOUT to value %d ms. Actual "
-                  "TCP_USER_TIMEOUT value is %d ms" , timeout,
-                  newval);
+                  "TCP_USER_TIMEOUT value is %d ms",
+                  timeout, newval);
           return absl::OkStatus();
         }
       }

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -357,8 +357,10 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
           return absl::OkStatus();
         }
         if (newval != timeout) {
-          gpr_log(GPR_ERROR, "Setting TCP_USER_TIMEOUT to value %d ms from previous value %d",
-                  timeout, newval);
+          gpr_log(
+              GPR_ERROR,
+              "Setting TCP_USER_TIMEOUT to value %d ms from previous value %d",
+              timeout, newval);
           return absl::OkStatus();
         }
       }

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -357,8 +357,8 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
           return absl::OkStatus();
         }
         if (newval != timeout) {
-          // Do not fail on failing to set TCP_USER_TIMEOUT for now.
-          gpr_log(GPR_ERROR, "Failed to set TCP_USER_TIMEOUT");
+          gpr_log(GPR_ERROR, "Setting TCP_USER_TIMEOUT to value %d ms from previous value %d",
+                  timeout, newval);
           return absl::OkStatus();
         }
       }

--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -359,7 +359,7 @@ grpc_error_handle grpc_set_socket_tcp_user_timeout(
         if (newval != timeout) {
           gpr_log(GPR_INFO,
                   "Setting TCP_USER_TIMEOUT to value %d ms. Actual "
-                  "TCP_USER_TIMEOUT value is %d ms" timeout,
+                  "TCP_USER_TIMEOUT value is %d ms" , timeout,
                   newval);
           return absl::OkStatus();
         }


### PR DESCRIPTION
This PR tries to correct a confusing message. For my little understanding, it seems that if the code reaches that level, it is not correct to say that setting TCP_USER_TIMEOUT failed, but actually it succeeded (setsockopt returned 0) but is different to the previous value option.

I haven't found the `gpr_log` description, so I hope the PR is correct.
