### PR TITLE
[examine-stack] Try to unblock Ubuntu 20.04

### DIFF
--- a/test/core/gprpp/examine_stack_test.cc
+++ b/test/core/gprpp/examine_stack_test.cc
@@ -69,7 +69,10 @@ TEST(ExamineStackTest, AbseilStackProvider) {
   EXPECT_NE(stack_trace, absl::nullopt);
   gpr_log(GPR_INFO, "stack_trace=%s", stack_trace->c_str());
 #if !defined(NDEBUG) && !defined(GPR_MUSL_LIBC_COMPAT)
-  EXPECT_THAT(*stack_trace, ::testing::HasSubstr("GetCurrentStackTrace"));
+  // Expect to see some gtest signature on the stack (this used to be
+  // GetCurrentStackTrace, but some operating systems have trouble with the leaf
+  // function).
+  EXPECT_THAT(*stack_trace, ::testing::HasSubstr("testing::"));
 #endif
 }
 


### PR DESCRIPTION
Try a different approach to this test and check some non-leaf functions in the returned text - looks like we're running into problems getting the leaf function out of the stack trace on that platform (which is probably fine): https://source.cloud.google.com/results/invocations/09e8e1ea-df48-4fdb-96dd-916bd5014f90/targets/%2F%2Ftest%2Fcore%2Fgprpp:examine_stack_test/tests

Needed to unblock https://github.com/grpc/grpc/pull/32748

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

