### PR TITLE
[google-c2p resolver] ignore xDS resource deletion

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -247,7 +247,8 @@ void GoogleCloud2ProdResolver::StartXdsResolver() {
                    {"type", Json::FromString("google_default")},
                }),
            })},
-          {"server_features", Json::FromArray({Json::FromString("xds_v3")})},
+          {"server_features",
+           Json::FromArray({Json::FromString("ignore_resource_deletion")})},
       }),
   });
   Json bootstrap = Json::FromObject({


### PR DESCRIPTION
This enables the feature described in [gRFC A53](https://github.com/grpc/proposal/blob/master/A53-xds-ignore-resource-deletion.md) for C2P.

This also removes the now-unnecessary `xds_v3` server feature, which should have been removed as part of #31327.