### PR TITLE
[google-c2p resolver] backport to 1.55: ignore xDS resource deletion

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/google_c2p/google_c2p_resolver.cc
@@ -247,7 +247,7 @@ void GoogleCloud2ProdResolver::StartXdsResolver() {
                    {"type", "google_default"},
                },
            }},
-          {"server_features", Json::Array{"xds_v3"}},
+          {"server_features", Json::Array{"ignore_resource_deletion"}},
       },
   };
   Json bootstrap = Json::Object{


### PR DESCRIPTION
Backport #32984 to 1.55.