### PR TITLE
[channelz] Save some memory per channel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1538,6 +1538,7 @@ grpc_cc_library(
         "//src/core:no_destruct",
         "//src/core:notification",
         "//src/core:packed_table",
+        "//src/core:per_cpu",
         "//src/core:pipe",
         "//src/core:poll",
         "//src/core:pollset_set",

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -29,7 +29,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/strip.h"
 
-#include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
@@ -39,7 +38,6 @@
 #include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gpr/useful.h"
-#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/resolved_address.h"
 #include "src/core/lib/json/json_writer.h"
 #include "src/core/lib/transport/connectivity_state.h"

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -29,7 +29,6 @@
 #include <set>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -20,6 +20,7 @@
 
 #include <stdlib.h>
 
+#include <algorithm>
 #include <vector>
 
 #include "gtest/gtest.h"

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 
 #include <algorithm>
+#include <atomic>
 #include <memory>
 
 #include "absl/status/status.h"
@@ -53,9 +54,8 @@ class CallCountingHelperPeer {
   explicit CallCountingHelperPeer(CallCountingHelper* node) : node_(node) {}
 
   gpr_timespec last_call_started_time() const {
-    CallCountingHelper::CounterData data;
-    node_->CollectData(&data);
-    return gpr_cycle_counter_to_time(data.last_call_started_cycle);
+    return gpr_cycle_counter_to_time(
+        node_->last_call_started_cycle_.load(std::memory_order_relaxed));
   }
 
  private:

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <atomic>
 #include <memory>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"


### PR DESCRIPTION
Whilst the per cpu counters probably help single channel contention, we think it's likely that they're a pessimization when taken fleetwide.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

