### PR TITLE
[xDS] Protect RBAC audit logging options field with environment variable

### DIFF
--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -243,6 +243,7 @@ grpc_cc_test(
         "//src/proto/grpc/testing/xds/v3:stateful_session_proto",
         "//src/proto/grpc/testing/xds/v3:typed_struct_proto",
         "//test/core/util:grpc_test_util",
+        "//test/core/util:scoped_env_var",
         "//test/cpp/util:grpc_cli_utils",
     ],
 )

--- a/test/core/xds/xds_http_filters_test.cc
+++ b/test/core/xds/xds_http_filters_test.cc
@@ -72,6 +72,7 @@
 #include "src/proto/grpc/testing/xds/v3/stateful_session_cookie.pb.h"
 #include "src/proto/grpc/testing/xds/v3/string.pb.h"
 #include "src/proto/grpc/testing/xds/v3/typed_struct.pb.h"
+#include "test/core/util/scoped_env_var.h"
 #include "test/core/util/test_config.h"
 
 // IWYU pragma: no_include <google/protobuf/message.h>
@@ -896,6 +897,7 @@ TEST_P(XdsRbacFilterConfigTest, AllPrincipalTypes) {
 }
 
 TEST_P(XdsRbacFilterConfigTest, AuditLoggingOptions) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_RBAC_AUDIT_LOGGING");
   RBAC rbac;
   auto* rules = rbac.mutable_rules();
   rules->set_action(rules->ALLOW);
@@ -923,6 +925,7 @@ TEST_P(XdsRbacFilterConfigTest, AuditLoggingOptions) {
 }
 
 TEST_P(XdsRbacFilterConfigTest, InvalidAuditCondition) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_RBAC_AUDIT_LOGGING");
   RBAC rbac;
   auto* rules = rbac.mutable_rules();
   rules->set_action(rules->ALLOW);
@@ -945,6 +948,7 @@ TEST_P(XdsRbacFilterConfigTest, InvalidAuditCondition) {
 }
 
 TEST_P(XdsRbacFilterConfigTest, InvalidAuditLoggerConfig) {
+  ScopedExperimentalEnvVar env_var("GRPC_EXPERIMENTAL_XDS_RBAC_AUDIT_LOGGING");
   RBAC rbac;
   auto* rules = rbac.mutable_rules();
   rules->set_action(rules->ALLOW);


### PR DESCRIPTION
The protection is added at `xds_http_rbac_filter.cc` where we read the new field. With this disabling the feature, nothing from things like `xds_audit_logger_registry.cc` shall be invoked.