### PR TITLE
[PSM Interop] Bump the timeout for grpc_xds_k8s_lb_python job to 3h

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.cfg
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
The job run time was creeping to the 2h timeout. Let's bump it to 3h.
<img width="792" alt="image" src="https://user-images.githubusercontent.com/672669/236330911-d81fef2f-19ae-44b9-9d98-05474682dae4.png">

Note that this is `master` branch, so it also includes the build time every time we commit to grpc/grpc.

ref b/280784903
cc @eugeneo 