### PR TITLE
[Test] Add v1.55.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -215,7 +215,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.51.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.52.3', ReleaseInfo(runtimes=['go1.19'])),
             ('v1.53.0', ReleaseInfo(runtimes=['go1.19'])),
-            ('v1.54.0', ReleaseInfo(runtimes=['go1.19'])),
+            ('v1.54.1', ReleaseInfo(runtimes=['go1.19'])),
             ('v1.55.0', ReleaseInfo(runtimes=['go1.19'])),
         ]),
     'java':

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -215,6 +215,8 @@ LANG_RELEASE_MATRIX = {
             ('v1.51.0', ReleaseInfo(runtimes=['go1.16'])),
             ('v1.52.3', ReleaseInfo(runtimes=['go1.19'])),
             ('v1.53.0', ReleaseInfo(runtimes=['go1.19'])),
+            ('v1.54.0', ReleaseInfo(runtimes=['go1.19'])),
+            ('v1.55.0', ReleaseInfo(runtimes=['go1.19'])),
         ]),
     'java':
         OrderedDict([


### PR DESCRIPTION
I noticed that the [PR](https://github.com/grpc/grpc/pull/32683) to add v1.54.0 is still not merged. So, I added a line for that as well.