### PR TITLE
[infra] Maybe fix the title check

### DIFF
--- a/.github/workflows/pr-auto-tag-and-check-title.yaml
+++ b/.github/workflows/pr-auto-tag-and-check-title.yaml
@@ -1,7 +1,7 @@
 name: PR Title Check & Tag
 on:
   pull_request_target:
-    types: [opened, reopened, synchronized, edited]
+    types: [opened, reopened, synchronize, edited]
 permissions:
   contents: read # to determine modified files (actions/labeler)
 


### PR DESCRIPTION
`synchronized` is not a valid keyword. It's a shame this isn't reported anywhere I can see.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows