### PR TITLE
[alts] Remove CheckCallHost checks in ALTS security connector.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3156,7 +3156,6 @@ grpc_cc_library(
     external_deps = [
         "absl/status",
         "absl/strings",
-        "absl/strings:str_format",
         "absl/types:optional",
     ],
     language = "c++",

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -132,7 +132,7 @@ class grpc_alts_channel_security_connector final
   }
 
   grpc_core::ArenaPromise<absl::Status> CheckCallHost(
-      absl::string_view host, grpc_auth_context*) override {
+      absl::string_view, grpc_auth_context*) override {
     return grpc_core::ImmediateOkStatus();
   }
 

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -133,11 +133,6 @@ class grpc_alts_channel_security_connector final
 
   grpc_core::ArenaPromise<absl::Status> CheckCallHost(
       absl::string_view host, grpc_auth_context*) override {
-    if (host.empty() || host != target_name_) {
-      return grpc_core::Immediate(absl::UnauthenticatedError(absl::StrFormat(
-          "ALTS call host [%s] does not match target name [%s].", host,
-          target_name_)));
-    }
     return grpc_core::ImmediateOkStatus();
   }
 

--- a/src/core/lib/security/security_connector/alts/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts/alts_security_connector.cc
@@ -23,11 +23,9 @@
 #include <string.h>
 
 #include <algorithm>
-#include <initializer_list>
 #include <utility>
 
 #include "absl/status/status.h"
-#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 


### PR DESCRIPTION
This check compares the host portion of the target name to the authority header, but in common use cases (e.g. GCS) they may not coincide. Additionally, this check does not happen in the Go and Java ALTS stacks.