### PR TITLE
[Tools] Account for header files from the srcs attribute of cc_library in fix_build_deps.py

### DIFF
--- a/tools/distrib/fix_build_deps.py
+++ b/tools/distrib/fix_build_deps.py
@@ -343,6 +343,10 @@ def grpc_cc_library(name,
 
     for hdr in hdrs + public_hdrs:
         vendors[_get_filename(hdr, parsing_path)].append(name)
+    for src in srcs:
+        if src.endswith('.h'):
+            # headers can come from srcs as well
+            vendors[_get_filename(src, parsing_path)].append(name)
     inc = set()
     original_deps[name] = frozenset(deps)
     original_external_deps[name] = frozenset(external_deps)


### PR DESCRIPTION
Spin off from https://github.com/grpc/grpc/pull/32701. Header files can come from the `srcs` attribute of `cc_library` which makes them private to the library in terms of bazel dependency check. That seems to confuse fix_build_deps.py before this change.



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

