### PR TITLE
[PSM Interop] Allow `dev` testing version that doesn't override images

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -23,6 +23,7 @@ readonly TEST_DRIVER_REPO_URL="https://github.com/${TEST_DRIVER_REPO_OWNER:-grpc
 readonly TEST_DRIVER_BRANCH="${TEST_DRIVER_BRANCH:-master}"
 readonly TEST_DRIVER_PATH="tools/run_tests/xds_k8s_test_driver"
 readonly TEST_DRIVER_PROTOS_PATH="src/proto/grpc/testing"
+readonly FORCE_TESTING_VERSION="${FORCE_TESTING_VERSION:-}"
 
 # GKE cluster identifiers.
 readonly GKE_CLUSTER_PSM_LB="psm-lb"
@@ -373,6 +374,39 @@ kokoro_setup_python_virtual_environment() {
 }
 
 #######################################
+# Determines the version branch under test from Kokoro environment.
+# Globals:
+#   KOKORO_JOB_NAME
+#   KOKORO_BUILD_INITIATOR
+#   FORCE_TESTING_VERSION: Forces the testing version to be something else.
+#   TESTING_VERSION: Populated with the version branch under test,
+#                    f.e. master, dev, v1.42.x.
+# Outputs:
+#   Sets TESTING_VERSION global variable.
+#######################################
+kokoro_get_testing_version() {
+  if [[ -n "${FORCE_TESTING_VERSION}" ]]; then
+    # Allows to override the testing version, and force tagging the built
+    # images, if necessary.
+    readonly TESTING_VERSION="${FORCE_TESTING_VERSION}"
+  elif [[ "${KOKORO_BUILD_INITIATOR:-anonymous}" != "kokoro" ]]; then
+    # If not initiated by Kokoro, it's a dev branch.
+    # This allows to know later down the line that the built image doesn't need
+    # to be tagged, and avoid overriding an actual versioned image used in tests
+    # (e.g. v1.42.x, master) with a dev build.
+    readonly TESTING_VERSION="dev"
+  else
+    # All grpc kokoro jobs names structured to have the version identifier in the third position:
+    # - grpc/core/master/linux/...
+    # - grpc/core/v1.42.x/branch/linux/...
+    # - grpc/java/v1.47.x/branch/...
+    # - grpc/go/v1.47.x/branch/...
+    # - grpc/node/v1.6.x/...
+    readonly TESTING_VERSION=$(echo "${KOKORO_JOB_NAME}" | cut -d '/' -f3)
+  fi
+}
+
+#######################################
 # Installs and configures the test driver on Kokoro VM.
 # Globals:
 #   KOKORO_ARTIFACTS_DIR
@@ -400,13 +434,8 @@ kokoro_setup_test_driver() {
   # Capture Kokoro VM version info in the log.
   kokoro_print_version
 
-  # All grpc kokoro jobs names structured to have the version identifier in the third position:
-  # - grpc/core/master/linux/...
-  # - grpc/core/v1.42.x/branch/linux/...
-  # - grpc/java/v1.47.x/branch/...
-  # - grpc/go/v1.47.x/branch/...
-  # - grpc/node/v1.6.x/...
-  readonly TESTING_VERSION=$(echo "${KOKORO_JOB_NAME}" | cut -d '/' -f3)
+  # Get testing version from the job name.
+  kokoro_get_testing_version
 
   # Kokoro clones repo to ${KOKORO_ARTIFACTS_DIR}/github/${GITHUB_REPOSITORY}
   local github_root="${KOKORO_ARTIFACTS_DIR}/github"
@@ -455,6 +484,13 @@ local_setup_test_driver() {
   parse_src_repo_git_info "${SRC_DIR}"
   readonly KUBE_CONTEXT="${KUBE_CONTEXT:-$(kubectl config current-context)}"
   readonly SECONDARY_KUBE_CONTEXT="${SECONDARY_KUBE_CONTEXT}"
+
+  # Never override docker image for local runs, unless explicitly forced.
+  if [[ -n "${FORCE_TESTING_VERSION}" ]]; then
+    readonly TESTING_VERSION="${FORCE_TESTING_VERSION}"
+  else
+    readonly TESTING_VERSION="dev"
+  fi
 
   local test_driver_repo_dir
   test_driver_repo_dir="${TEST_DRIVER_REPO_DIR:-$(mktemp -d)/${TEST_DRIVER_REPO_NAME}}"

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/skips.py
@@ -61,12 +61,12 @@ class TestConfig:
 
         A version is greater than or equal to another version means its version
         number is greater than or equal to another version's number. Version
-        "master" is always considered latest.
+        "master" or "dev" are always considered the latest.
         E.g., master >= v1.41.x >= v1.40.x >= v1.9.x.
 
         Unspecified version is treated as 'master', but isn't explicitly set.
         """
-        if self.version == 'master' or self.version is None:
+        if self.version in ('master', 'dev', None):
             return True
         if another == 'master':
             return False

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -120,7 +120,7 @@ CLIENT_PORT = flags.DEFINE_integer(
 TESTING_VERSION = flags.DEFINE_string(
     "testing_version",
     default=None,
-    help="The testing gRPC version branch name. Like master, v1.41.x, v1.37.x")
+    help="The testing gRPC version branch name. Like master, dev, v1.55.x")
 
 FORCE_CLEANUP = flags.DEFINE_bool(
     "force_cleanup",


### PR DESCRIPTION
Resolve `TESTING_VERSION` to `dev` when the job is initiated by a user, and not the CI.  Override this behavior with setting `FORCE_TESTING_VERSION`.

This solves the problem with the manual job runs executed against a WIP branch (f.e. a PR) overriding the tag of the CI-built image we use for daily testing.

The `dev` value added to the "magic" values supported by the`--testing_version` flag, and treated as `master`: all `config.version_gte` checks resolve to `True`.

This changes will take care of all langs/branches, no backports needed.

ref b/256845629


