### PR TITLE
[ObjC] Upgrade podspec xx.deployment_target

### DIFF
--- a/examples/cpp/helloworld/cocoapods/Podfile
+++ b/examples/cpp/helloworld/cocoapods/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/auth_sample/AuthTestService.podspec
+++ b/examples/objective-c/auth_sample/AuthTestService.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "AuthTestService example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/examples/objective-c/auth_sample/Podfile
+++ b/examples/objective-c/auth_sample/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/helloworld/HelloWorld.podspec
+++ b/examples/objective-c/helloworld/HelloWorld.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "HelloWorld example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/examples/objective-c/helloworld/Podfile
+++ b/examples/objective-c/helloworld/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/helloworld_macos/HelloWorld.podspec
+++ b/examples/objective-c/helloworld_macos/HelloWorld.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "HelloWorld example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/examples/objective-c/helloworld_macos/Podfile
+++ b/examples/objective-c/helloworld_macos/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :macos, '10.10'
+platform :macos, '10.12'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/route_guide/Podfile
+++ b/examples/objective-c/route_guide/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/examples/objective-c/route_guide/RouteGuide.podspec
+++ b/examples/objective-c/route_guide/RouteGuide.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.summary = "RouteGuide example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
 
   # Base directory where the .proto files are.
   src = "../../protos"

--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -34,9 +34,10 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   s.requires_arc = false
 

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -38,10 +38,10 @@ Pod::Spec.new do |s|
   # which was released in Cocoapods v1.2.0.
   s.cocoapods_version = '>= 1.2.0'
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   s.requires_arc = false
 

--- a/gRPC-ProtoRPC.podspec
+++ b/gRPC-ProtoRPC.podspec
@@ -33,10 +33,10 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   name = 'ProtoRPC'
   s.module_name = name

--- a/gRPC-RxLibrary.podspec
+++ b/gRPC-RxLibrary.podspec
@@ -33,10 +33,10 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   name = 'RxLibrary'
   s.module_name = name

--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -45,10 +45,10 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
   }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   s.subspec 'Interface-Legacy' do |ss|
     ss.header_mappings_dir = 'src/objective-c/GRPCClient'
@@ -71,10 +71,10 @@ Pod::Spec.new do |s|
                       "src/objective-c/GRPCClient/GRPCTypes.m"
     ss.dependency "gRPC-RxLibrary/Interface", version
 
-    ss.ios.deployment_target = '9.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
   end
 
   s.subspec 'Interface' do |ss|
@@ -106,10 +106,10 @@ Pod::Spec.new do |s|
 
     ss.dependency "#{s.name}/Interface-Legacy", version
 
-    ss.ios.deployment_target = '9.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
   end
 
   s.subspec 'GRPCCore' do |ss|
@@ -142,10 +142,10 @@ Pod::Spec.new do |s|
     ss.dependency 'gRPC-Core', version
     ss.dependency 'gRPC-RxLibrary', version
 
-    ss.ios.deployment_target = '9.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
   end
 
   s.subspec 'GRPCCoreCronet' do |ss|
@@ -158,17 +158,17 @@ Pod::Spec.new do |s|
     ss.dependency 'gRPC-Core/Cronet-Implementation', version
     ss.dependency 'CronetFramework'
 
-    ss.ios.deployment_target = '9.0'
+    ss.ios.deployment_target = '10.0'
   end
 
   # CFStream is now default. Leaving this subspec only for compatibility purpose.
   s.subspec 'CFStream' do |ss|
     ss.dependency "#{s.name}/GRPCCore", version
 
-    ss.ios.deployment_target = '9.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
   end
 
   s.subspec 'InternalTesting' do |ss|
@@ -177,9 +177,9 @@ Pod::Spec.new do |s|
     ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}'
     ss.header_mappings_dir = 'src/objective-c/GRPCClient'
 
-    ss.ios.deployment_target = '9.0'
-    ss.osx.deployment_target = '10.10'
-    ss.tvos.deployment_target = '10.0'
-    ss.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
   end
 end

--- a/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
@@ -101,11 +101,11 @@ Pod::Spec.new do |s|
 
   # Restrict the protoc version to the one supported by this plugin.
   s.dependency '!ProtoCompiler', '3.23.1'
-  # For the Protobuf dependency not to complain:
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '2.0'
+
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   # This is only for local development of the plugin: If the Podfile brings this pod from a local
   # directory using `:path`, CocoaPods won't download the zip file and so the plugin won't be

--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -103,15 +103,11 @@ Pod::Spec.new do |s|
 
   # Restrict the protoc version to the one supported by this plugin.
   s.dependency '!ProtoCompiler', '3.23.1'
-  # For the Protobuf dependency not to complain:
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
 
-  # watchOS is disabled due to #20258.
-  # TODO (mxyan): Enable watchos when !ProtoCompiler.podspec is updated for
-  # support of watchos in the next release
-  # s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   # Restrict the gRPC runtime version to the one supported by this plugin.
   s.dependency 'gRPC-ProtoRPC', v

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -110,10 +110,10 @@ Pod::Spec.new do |s|
   # Restrict the protobuf runtime version to the one supported by this version of protoc.
   s.dependency 'Protobuf', '~> 3.0'
   # For the Protobuf dependency not to complain:
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   # This is only for local development of protoc: If the Podfile brings this pod from a local
   # directory using `:path`, CocoaPods won't download the zip file and so the compiler won't be

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -79,10 +79,10 @@ Pod::Spec.new do |s|
     :commit => "e46383fc18d08def901b2ed5a194295693e905c7",
   }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   name = 'openssl_grpc'
 

--- a/src/objective-c/CronetFramework.podspec
+++ b/src/objective-c/CronetFramework.podspec
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
   }
   s.vendored_framework = "Cronet.framework"
   s.author             = "The Chromium Authors"
-  s.ios.deployment_target = "9.0"
+  s.ios.deployment_target = '10.0'
   s.source       = { :http => "https://storage.googleapis.com/grpc-precompiled-binaries/cronet/Cronet.framework-v#{v}.zip"}
   s.preserve_paths = "Cronet.framework"
   s.public_header_files = "Cronet.framework/Headers/**/*{.h}"

--- a/src/objective-c/README.md
+++ b/src/objective-c/README.md
@@ -43,8 +43,10 @@ Pod::Spec.new do |s|
   s.summary = '...'
   s.source = { :git => 'https://github.com/...' }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   # Base directory where the .proto files are.
   src = '.'

--- a/src/objective-c/examples/tvOS-sample/Podfile
+++ b/src/objective-c/examples/tvOS-sample/Podfile
@@ -1,4 +1,4 @@
-platform :tvos, '10.0'
+platform :tvos, '12.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/src/objective-c/manual_tests/Podfile
+++ b/src/objective-c/manual_tests/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/src/objective-c/tests/Common/Common.podspec
+++ b/src/objective-c/tests/Common/Common.podspec
@@ -7,10 +7,10 @@ Pod::Spec.new do |s|
     s.summary = "Shared common test utils"
     s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
     s.framework = 'XCTest'
 
     s.dependency "gRPC-ProtoRPC"

--- a/src/objective-c/tests/Connectivity/Podfile
+++ b/src/objective-c/tests/Connectivity/Podfile
@@ -1,5 +1,5 @@
 install! 'cocoapods', :deterministic_uuids => false
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 # Location of gRPC's repo root relative to this file.
 GRPC_LOCAL_SRC = '../../../..'

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -27,7 +27,7 @@ target 'TvTests' do
 end
 
 target 'MacTests' do
-  platform :osx, '10.13'
+  platform :osx, '10.12'
   grpc_deps
 end
 
@@ -36,13 +36,13 @@ end
   InteropTests
 ).each do |target_name|
   target target_name do
-    platform :ios, '9.0'
+    platform :ios, '10.0'
     grpc_deps
   end
 end
 
 target 'CronetTests' do
-  platform :ios, '9.0'
+  platform :ios, '10.0'
   grpc_deps
 
   pod 'gRPC/GRPCCoreCronet',           :path => GRPC_LOCAL_SRC
@@ -50,7 +50,7 @@ target 'CronetTests' do
 end
 
 target 'PerfTests' do
-  platform :ios, '9.0'
+  platform :ios, '10.0'
   grpc_deps
 
   pod 'gRPC/GRPCCoreCronet',           :path => GRPC_LOCAL_SRC

--- a/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
@@ -7,10 +7,10 @@ Pod::Spec.new do |s|
   s.summary = "RemoteTest example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '10.0'
-  s.watchos.deployment_target = '4.0'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.0'
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.dependency "!ProtoCompiler-gRPCPlugin"

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -116,9 +116,10 @@
       :tag => "v#{version}",
     }
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     s.requires_arc = false
 

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -114,10 +114,10 @@
     # which was released in Cocoapods v1.2.0.
     s.cocoapods_version = '>= 1.2.0'
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     s.requires_arc = false
 

--- a/templates/gRPC-ProtoRPC.podspec.template
+++ b/templates/gRPC-ProtoRPC.podspec.template
@@ -35,10 +35,10 @@
       :tag => "v#{version}",
     }
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     name = 'ProtoRPC'
     s.module_name = name

--- a/templates/gRPC-RxLibrary.podspec.template
+++ b/templates/gRPC-RxLibrary.podspec.template
@@ -35,10 +35,10 @@
       :tag => "v#{version}",
     }
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     name = 'RxLibrary'
     s.module_name = name

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -47,10 +47,10 @@
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     }
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     s.subspec 'Interface-Legacy' do |ss|
       ss.header_mappings_dir = 'src/objective-c/GRPCClient'
@@ -73,10 +73,10 @@
                         "src/objective-c/GRPCClient/GRPCTypes.m"
       ss.dependency "gRPC-RxLibrary/Interface", version
 
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
-      ss.tvos.deployment_target = '10.0'
-      ss.watchos.deployment_target = '4.0'
+      s.ios.deployment_target = '10.0'
+      s.osx.deployment_target = '10.12'
+      s.tvos.deployment_target = '12.0'
+      s.watchos.deployment_target = '6.0'
     end
 
     s.subspec 'Interface' do |ss|
@@ -108,10 +108,10 @@
 
       ss.dependency "#{s.name}/Interface-Legacy", version
 
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
-      ss.tvos.deployment_target = '10.0'
-      ss.watchos.deployment_target = '4.0'
+      s.ios.deployment_target = '10.0'
+      s.osx.deployment_target = '10.12'
+      s.tvos.deployment_target = '12.0'
+      s.watchos.deployment_target = '6.0'
     end
 
     s.subspec 'GRPCCore' do |ss|
@@ -144,10 +144,10 @@
       ss.dependency 'gRPC-Core', version
       ss.dependency 'gRPC-RxLibrary', version
 
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
-      ss.tvos.deployment_target = '10.0'
-      ss.watchos.deployment_target = '4.0'
+      s.ios.deployment_target = '10.0'
+      s.osx.deployment_target = '10.12'
+      s.tvos.deployment_target = '12.0'
+      s.watchos.deployment_target = '6.0'
     end
 
     s.subspec 'GRPCCoreCronet' do |ss|
@@ -160,17 +160,17 @@
       ss.dependency 'gRPC-Core/Cronet-Implementation', version
       ss.dependency 'CronetFramework'
 
-      ss.ios.deployment_target = '9.0'
+      ss.ios.deployment_target = '10.0'
     end
 
     # CFStream is now default. Leaving this subspec only for compatibility purpose.
     s.subspec 'CFStream' do |ss|
       ss.dependency "#{s.name}/GRPCCore", version
 
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
-      ss.tvos.deployment_target = '10.0'
-      ss.watchos.deployment_target = '4.0'
+      s.ios.deployment_target = '10.0'
+      s.osx.deployment_target = '10.12'
+      s.tvos.deployment_target = '12.0'
+      s.watchos.deployment_target = '6.0'
     end
 
     s.subspec 'InternalTesting' do |ss|
@@ -179,9 +179,9 @@
       ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}'
       ss.header_mappings_dir = 'src/objective-c/GRPCClient'
 
-      ss.ios.deployment_target = '9.0'
-      ss.osx.deployment_target = '10.10'
-      ss.tvos.deployment_target = '10.0'
-      ss.watchos.deployment_target = '4.0'
+      s.ios.deployment_target = '10.0'
+      s.osx.deployment_target = '10.12'
+      s.tvos.deployment_target = '12.0'
+      s.watchos.deployment_target = '6.0'
     end
   end

--- a/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.template
@@ -103,11 +103,11 @@
 
     # Restrict the protoc version to the one supported by this plugin.
     s.dependency '!ProtoCompiler', '${settings.protobuf_version}'
-    # For the Protobuf dependency not to complain:
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '2.0'
+
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     # This is only for local development of the plugin: If the Podfile brings this pod from a local
     # directory using `:path`, CocoaPods won't download the zip file and so the plugin won't be

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -105,15 +105,11 @@
 
     # Restrict the protoc version to the one supported by this plugin.
     s.dependency '!ProtoCompiler', '${settings.protobuf_version}'
-    # For the Protobuf dependency not to complain:
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
 
-    # watchOS is disabled due to #20258.
-    # TODO (mxyan): Enable watchos when !ProtoCompiler.podspec is updated for
-    # support of watchos in the next release
-    # s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     # Restrict the gRPC runtime version to the one supported by this plugin.
     s.dependency 'gRPC-ProtoRPC', v

--- a/templates/src/objective-c/!ProtoCompiler.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler.podspec.template
@@ -112,10 +112,10 @@
     # Restrict the protobuf runtime version to the one supported by this version of protoc.
     s.dependency 'Protobuf', '~> 3.0'
     # For the Protobuf dependency not to complain:
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     # This is only for local development of protoc: If the Podfile brings this pod from a local
     # directory using `:path`, CocoaPods won't download the zip file and so the compiler won't be

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -109,10 +109,10 @@
       :commit => "${boringssl_commit}",
     }
 
-    s.ios.deployment_target = '9.0'
-    s.osx.deployment_target = '10.10'
-    s.tvos.deployment_target = '10.0'
-    s.watchos.deployment_target = '4.0'
+    s.ios.deployment_target = '10.0'
+    s.osx.deployment_target = '10.12'
+    s.tvos.deployment_target = '12.0'
+    s.watchos.deployment_target = '6.0'
 
     name = 'openssl_grpc'
 

--- a/test/core/iomgr/ios/CFStreamTests/Podfile
+++ b/test/core/iomgr/ios/CFStreamTests/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 

--- a/test/cpp/cocoapods/Podfile
+++ b/test/cpp/cocoapods/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 


### PR DESCRIPTION
Upgrade apple platform deployment_target versions to fix the cocoapods push of BoringSSL-GRPC about the following error:
```
ld: file not found: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_macosx.a
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
ref: https://developer.apple.com/forums/thread/725300

This also aligns with the versions required by [protobuf](https://github.com/protocolbuffers/protobuf/pull/10652)

```
ios.deployment_target = '10.0'
osx.deployment_target = '10.12'
tvos.deployment_target = '12.0'
watchos.deployment_target = '6.0'
```