### PR TITLE
[promises] Enable server promise calls in C++ e2e tests

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -28,6 +28,9 @@ EXPERIMENTS = {
             "promise_based_client_call",
             "promise_based_server_call",
         ],
+        "cpp_end2end_test": [
+            "promise_based_server_call",
+        ],
         "endpoint_test": [
             "tcp_frame_size_tuning",
             "tcp_rcv_lowat",
@@ -50,6 +53,9 @@ EXPERIMENTS = {
             "free_large_allocator",
             "memory_pressure_controller",
             "unconstrained_max_quota_buffer_size",
+        ],
+        "xds_end2end_test": [
+            "promise_based_server_call",
         ],
     },
     "on": {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -115,8 +115,7 @@
   default: false
   expiry: 2023/06/01
   owner: ctiller@google.com
-  test_tags: ["core_end2end_test"]
-  disabled_test_tags: ["cpp_end2end_test", "xds_end2end_test"]
+  test_tags: ["core_end2end_test", "cpp_end2end_test", "xds_end2end_test"]
 - name: transport_supplies_client_latency
   description: If set, use the transport represented value for client latency in opencensus
   default: false

--- a/src/core/lib/transport/batch_builder.cc
+++ b/src/core/lib/transport/batch_builder.cc
@@ -71,6 +71,10 @@ BatchBuilder::Batch::Batch(grpc_transport_stream_op_batch_payload* payload,
 
 BatchBuilder::Batch::~Batch() {
   auto* arena = party->arena();
+  if (grpc_call_trace.enabled()) {
+    gpr_log(GPR_DEBUG, "%s[connected] [batch %p] Destroy",
+            Activity::current()->DebugTag().c_str(), this);
+  }
   if (pending_receive_message != nullptr) {
     arena->DeletePooled(pending_receive_message);
   }


### PR DESCRIPTION
#thistimeforsure

a863532c6293eceacdddfd5ce685507091cf30a0 adds some debug to help track which batches get leaked by a transport
3203e75ec5d1e9a703a655552afbc16df78884c5 makes connected_channel respect the high level intent of cancellation better (and fixes the last reason we needed to turn these tests off)
aaf5fa036b9a483c4900a959abb96efade884024 re-enables testing of c++ e2e tests with server based promise calls

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

