### PR TITLE
[PSM Interop] Readable grpc status codes in error messages

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/grpc.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/grpc.py
@@ -1,0 +1,37 @@
+# Copyright 2023 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This contains common helpers for working with grpc data structures."""
+import functools
+from typing import Optional
+
+import grpc
+
+
+@functools.cache
+def status_from_int(grpc_status_int: int) -> Optional[grpc.StatusCode]:
+    """Converts the integer gRPC status code to the grpc.StatusCode enum."""
+    for grpc_status in grpc.StatusCode:
+        if grpc_status.value[0] == grpc_status_int:
+            return grpc_status
+    return None
+
+
+def status_eq(grpc_status_int: int, grpc_status: grpc.StatusCode) -> bool:
+    """Compares the integer gRPC status code with the grpc.StatusCode enum."""
+    return status_from_int(grpc_status_int) is grpc_status
+
+
+def status_pretty(grpc_status: grpc.StatusCode) -> str:
+    """Formats the status code as (int, NAME), f.e. (4, DEADLINE_EXCEEDED)"""
+    return f"({grpc_status.value[0]}, {grpc_status.name})"

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/grpc.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/grpc.py
@@ -18,7 +18,7 @@ from typing import Optional
 import grpc
 
 
-@functools.cache
+@functools.cache  # pylint: disable=no-member
 def status_from_int(grpc_status_int: int) -> Optional[grpc.StatusCode]:
     """Converts the integer gRPC status code to the grpc.StatusCode enum."""
     for grpc_status in grpc.StatusCode:

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -31,6 +31,7 @@ import grpc
 from framework import xds_flags
 from framework import xds_k8s_flags
 from framework import xds_url_map_testcase
+from framework.helpers import grpc as helpers_grpc
 from framework.helpers import rand as helpers_rand
 from framework.helpers import retryers
 from framework.helpers import skips
@@ -252,8 +253,9 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
 
     @staticmethod
     def diffAccumulatedStatsPerMethod(
-            before: grpc_testing.LoadBalancerAccumulatedStatsResponse,
-            after: grpc_testing.LoadBalancerAccumulatedStatsResponse):
+        before: grpc_testing.LoadBalancerAccumulatedStatsResponse,
+        after: grpc_testing.LoadBalancerAccumulatedStatsResponse
+    ) -> grpc_testing.LoadBalancerAccumulatedStatsResponse:
         """Only diffs stats_per_method, as the other fields are deprecated."""
         diff = grpc_testing.LoadBalancerAccumulatedStatsResponse()
         for method, method_stats in after.stats_per_method.items():
@@ -268,7 +270,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
     def assertRpcStatusCodes(self,
                              test_client: XdsTestClient,
                              *,
-                             status_code: grpc.StatusCode,
+                             expected_status: grpc.StatusCode,
                              duration: _timedelta,
                              method: str,
                              stray_rpc_limit: int = 0) -> None:
@@ -286,12 +288,22 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         diff_stats = self.diffAccumulatedStatsPerMethod(before_stats,
                                                         after_stats)
         stats = diff_stats.stats_per_method[method]
-        status = status_code.value[0]
-        for found_status, count in stats.result.items():
-            if found_status != status and count > stray_rpc_limit:
-                self.fail(f"Expected only status {status} but found status "
-                          f"{found_status} for method {method}:\n{diff_stats}")
-        self.assertGreater(stats.result[status_code.value[0]], 0)
+        for found_status_int, count in stats.result.items():
+            found_status = helpers_grpc.status_from_int(found_status_int)
+            if found_status != expected_status and count > stray_rpc_limit:
+                self.fail(f"Expected only status"
+                          f" {helpers_grpc.status_pretty(expected_status)},"
+                          " but found status"
+                          f" {helpers_grpc.status_pretty(found_status)}"
+                          f" for method {method}:\n{diff_stats}")
+
+        expected_status_int: int = expected_status.value[0]
+        self.assertGreater(
+            stats.result[expected_status_int],
+            0,
+            msg=("Expected non-zero RPCs with status"
+                 f" {helpers_grpc.status_pretty(expected_status)}"
+                 f" for method {method}, got:\n{diff_stats}"))
 
     def assertRpcsEventuallyGoToGivenServers(self,
                                              test_client: XdsTestClient,

--- a/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py
@@ -202,7 +202,7 @@ class AuthzTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         # b/228743575 Python has as race. Give us time to fix it.
         stray_rpc_limit = 1 if self.lang_spec.client_lang == _Lang.PYTHON else 0
         self.assertRpcStatusCodes(test_client,
-                                  status_code=status_code,
+                                  expected_status=status_code,
                                   duration=_SAMPLE_DURATION,
                                   method=rpc_type,
                                   stray_rpc_limit=stray_rpc_limit)

--- a/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py
@@ -93,7 +93,7 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         # Verify status codes from the servers have the configured one.
         with self.subTest('9_test_server_returned_configured_status_code'):
             self.assertRpcStatusCodes(test_client,
-                                      status_code=_EXPECTED_STATUS,
+                                      expected_status=_EXPECTED_STATUS,
                                       duration=datetime.timedelta(seconds=10),
                                       method='UNARY_CALL')
 


### PR DESCRIPTION
Better logging for `assertRpcStatusCodes`.
(got tired of looking up the status names)

#### Unexpected status found

Before: 
```
AssertionError: AssertionError: Expected only status 15 but found status 0 for method UNARY_CALL:
stats_per_method {
  key: "UNARY_CALL"
  value {
    result {
      key: 0
      value: 251
    }
  }
}
```

After:
```
AssertionError: Expected only status (15, DATA_LOSS), but found status (0, OK) for method UNARY_CALL:
stats_per_method {
  key: "UNARY_CALL"
  value {
    result {
      key: 0
      value: 251
    }
  }
}
```

#### No traffic with expected status
Before: 
```
AssertionError: 0 not greater than 0
```

After: 
```
AssertionError: 0 not greater than 0 : Expected non-zero RPCs with status (15, DATA_LOSS) for method UNARY_CALL, got:
stats_per_method {
  key: "UNARY_CALL"
  value {
    result {
      key: 0
      value: 251
    }
    result {
      key: 15
      value: 0
    }
  }
}
```

FYI @temawi - This is used in custom_lb, and @ejona86 - this is used in authz.