### PR TITLE
[PSM Interop] Do not dump full Channel/Subchannel into logs

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_channelz.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_channelz.py
@@ -100,6 +100,22 @@ class ChannelzServiceClient(framework.rpc.grpc.GrpcClientHelper):
                 return server_socket
         return None
 
+    @staticmethod
+    def channel_repr(channel: Channel) -> str:
+        result = f'<Channel channel_id={channel.ref.channel_id}'
+        if channel.data.target:
+            result += f' target={channel.data.target}'
+        result += f' state={ChannelState.Name(channel.data.state.state)}>'
+        return result
+
+    @staticmethod
+    def subchannel_repr(subchannel: Subchannel) -> str:
+        result = f'<Subchannel subchannel_id={subchannel.ref.subchannel_id}'
+        if subchannel.data.target:
+            result += f' target={subchannel.data.target}'
+        result += f' state={ChannelState.Name(subchannel.data.state.state)}>'
+        return result
+
     def find_channels_for_target(self, target: str,
                                  **kwargs) -> Iterator[Channel]:
         return (channel for channel in self.list_channels(**kwargs)

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -164,9 +164,10 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
         channel = retryer(self.find_server_channel_with_state,
                           state,
                           rpc_deadline=rpc_deadline)
-        logger.info('[%s] Channel to %s transitioned to state %s:\n%s',
+        logger.info('[%s] Channel to %s transitioned to state %s: %s',
                     self.hostname, self.server_target,
-                    _ChannelzChannelState.Name(state), channel)
+                    _ChannelzChannelState.Name(state),
+                    _ChannelzServiceClient.channel_repr(channel))
         return channel
 
     def find_server_channel_with_state(
@@ -181,9 +182,8 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
 
         for channel in self.get_server_channels(**rpc_params):
             channel_state: _ChannelzChannelState = channel.data.state.state
-            logger.info('[%s] Server channel: %s, state: %s', self.hostname,
-                        channel.ref.name,
-                        _ChannelzChannelState.Name(channel_state))
+            logger.info('[%s] Server channel: %s', self.hostname,
+                        _ChannelzServiceClient.channel_repr(channel))
             if channel_state is state:
                 if check_subchannel:
                     # When requested, check if the channel has at least
@@ -191,10 +191,10 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
                     try:
                         subchannel = self.find_subchannel_with_state(
                             channel, state, **rpc_params)
-                        logger.info('[%s] Found subchannel in state %s: %s',
-                                    self.hostname,
-                                    _ChannelzChannelState.Name(state),
-                                    subchannel)
+                        logger.info(
+                            '[%s] Found subchannel in state %s: %s',
+                            self.hostname, _ChannelzChannelState.Name(state),
+                            _ChannelzServiceClient.subchannel_repr(subchannel))
                     except self.NotFound as e:
                         # Otherwise, keep searching.
                         logger.info(e.message)


### PR DESCRIPTION
Before this change, `Found subchannel in state READY` and `Channel to xds:///psm-grpc-server:61404 transitioned to state ` would dump the full channel/subchannel, in some implementations that expose ChannelData.trace (f.e. go) would add 300 extra lines of log.

Now we print a brief repr-like chanel/subchannel info:
```
Found subchannel in state READY: <Subchannel subchannel_id=9 target=10.110.1.44:8080 state=READY>
Channel to xds:///psm-grpc-server:61404 transitioned to state READY: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=READY>
```

Also while waiting for the channel, we log channel_id now too:
```
Waiting to report a READY channel to xds:///psm-grpc-server:61404
Server channel: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=TRANSIENT_FAILURE>
Server channel: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=TRANSIENT_FAILURE>
Server channel: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=TRANSIENT_FAILURE>
Server channel: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=TRANSIENT_FAILURE>
Server channel: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=TRANSIENT_FAILURE>
Server channel: <Channel channel_id=2 target=xds:///psm-grpc-server:61404 state=READY>
```