### PR TITLE
[api-fuzzer] Fix memory leak

### DIFF
--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -882,6 +882,7 @@ ApiFuzzer::Result ApiFuzzer::PollCq() {
 }
 ApiFuzzer::Result ApiFuzzer::CreateChannel(
     const api_fuzzer::CreateChannel& create_channel) {
+  if (channel_ == nullptr) return Result::kComplete;
   grpc_channel_args* args =
       ReadArgs(resource_quota_, create_channel.channel_args());
   grpc_channel_credentials* creds =

--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/clusterfuzz-testcase-minimized-api_fuzzer-5949647671394304
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/clusterfuzz-testcase-minimized-api_fuzzer-5949647671394304
@@ -1,0 +1,8 @@
+actions {
+  create_channel {
+  }
+}
+actions {
+  create_channel {
+  }
+}


### PR DESCRIPTION
ApiFuzzer::CreateChannel() called twice creates two channels but doesn't delete the first.
Choose some reasonable behavior.
