### PR TITLE
[call] Dont take grpclb_client_stats from the app

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -445,6 +445,8 @@ void Call::PrepareOutgoingInitialMetadata(const grpc_op& op,
   }
   // Ignore any te metadata key value pairs specified.
   md.Remove(TeMetadata());
+  // Should never come from applications
+  md.Remove(GrpcLbClientStatsMetadata());
 }
 
 void Call::ProcessIncomingInitialMetadata(grpc_metadata_batch& md) {

--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/clusterfuzz-testcase-minimized-api_fuzzer-4617967326068736
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/clusterfuzz-testcase-minimized-api_fuzzer-4617967326068736
@@ -1,0 +1,30 @@
+actions {
+  create_channel {
+    target: "unix:"
+    channel_actions {
+      add_n_bytes_readable: 25970
+    }
+  }
+}
+actions {
+  create_call {
+    propagation_mask: 9541248
+    method {
+      value: "grpc.service_config"
+    }
+    timeout: 993774335
+  }
+}
+actions {
+  queue_batch {
+    operations {
+      send_initial_metadata {
+        metadata {
+          key {
+            value: "grpclb_client_stats"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This metadata doesn't actually encode so passing it through from an app will force a crash.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

