### PR TITLE
[compiler] Allow for empty packages in the php_generator

### DIFF
--- a/src/compiler/php_generator_helpers.h
+++ b/src/compiler/php_generator_helpers.h
@@ -60,8 +60,11 @@ inline std::string GetPHPServiceFilename(
           << grpc_generator::CapitalizeFirstLetter(tokens[i]);
     }
   }
-  return oss.str() + "/" +
-         GetPHPServiceClassname(service, class_suffix, is_server) + ".php";
+  if (!oss.str().empty()) {
+    oss << "/";
+  }
+  return oss.str() + GetPHPServiceClassname(service, class_suffix, is_server) +
+         ".php";
 }
 
 // Get leading or trailing comments in a string. Comment lines start with "// ".


### PR DESCRIPTION
When the package is empty, the joining "/" should be omitted. 

Fixes https://github.com/grpc/grpc/issues/33114
