### PR TITLE
[Fuzzing] Bound RunAfter duration in fuzzing event engine

### DIFF
--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-5703224922079232
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-5703224922079232
@@ -1,6 +1,13 @@
 actions {
   create_channel {
-    target: "unix:test"
+    target: "unix:,:,2147483653,p,,,::, H?:::c23http8:::::;::::::"
+    channel_args {
+      key: "grpc.min_reconnect_backoff_ms"
+      i: 720575938231795711
+    }
+    channel_actions {
+      wait_ms: 106
+    }
   }
 }
 actions {

--- a/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-5703224922079232
+++ b/test/core/end2end/fuzzers/api_fuzzer_corpus/testcase-5703224922079232
@@ -1,0 +1,8 @@
+actions {
+  create_channel {
+    target: "unix:test"
+  }
+}
+actions {
+  check_connectivity: true
+}


### PR DESCRIPTION

Bounds duration to 1 year. Fixes b/258949216

