### PR TITLE
[EE client channel resolver] Use std::strlen instead of sizeof in TXT record parsing

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/event_engine/event_engine_client_channel_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/event_engine/event_engine_client_channel_resolver.cc
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cstring>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -402,7 +401,8 @@ void EventEngineClientChannelDNSResolver::EventEngineDNSRequestWrapper::
       errors_.AddError(service_config.status().message());
       service_config_json_ = service_config.status();
     } else {
-      constexpr char kServiceConfigAttributePrefix[] = "grpc_config=";
+      static constexpr absl::string_view kServiceConfigAttributePrefix =
+          "grpc_config=";
       auto result = std::find_if(service_config->begin(), service_config->end(),
                                  [&](absl::string_view s) {
                                    return absl::StartsWith(
@@ -410,7 +410,7 @@ void EventEngineClientChannelDNSResolver::EventEngineDNSRequestWrapper::
                                  });
       if (result != service_config->end()) {
         service_config_json_ =
-            result->substr(std::strlen(kServiceConfigAttributePrefix));
+            result->substr(kServiceConfigAttributePrefix.size());
       } else {
         service_config_json_ = absl::UnavailableError(absl::StrCat(
             "failed to find attribute prefix: ", kServiceConfigAttributePrefix,

--- a/src/core/ext/filters/client_channel/resolver/dns/event_engine/event_engine_client_channel_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/event_engine/event_engine_client_channel_resolver.cc
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -409,7 +410,7 @@ void EventEngineClientChannelDNSResolver::EventEngineDNSRequestWrapper::
                                  });
       if (result != service_config->end()) {
         service_config_json_ =
-            result->substr(sizeof(kServiceConfigAttributePrefix));
+            result->substr(std::strlen(kServiceConfigAttributePrefix));
       } else {
         service_config_json_ = absl::UnavailableError(absl::StrCat(
             "failed to find attribute prefix: ", kServiceConfigAttributePrefix,


### PR DESCRIPTION
This is a mistake made in https://github.com/grpc/grpc/pull/33030. `sizeof()` would count the null byte terminated the C string and would cause us to skip a byte if it is used as the index to `result->substr()`. This would also crash if `result` only contains `grpc_config=` as @drfloob pointed out.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

