### PR TITLE
[testing] Temporarily skip flaky event engine tests.

### DIFF
--- a/test/core/end2end/end2end_test_suites.cc
+++ b/test/core/end2end/end2end_test_suites.cc
@@ -542,7 +542,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             }},
         CoreTestConfiguration{
             "Chttp2Fullstack",
-            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2,
+            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER,
             nullptr,
             [](const ChannelArgs& /*client_args*/,
                const ChannelArgs& /*server_args*/) {
@@ -645,7 +646,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
                               }},
         CoreTestConfiguration{
             "Chttp2FullstackWithCensus",
-            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2,
+            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
             nullptr,
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<CensusFixture>();
@@ -654,7 +656,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             "Chttp2FullstackWithProxy",
             FEATURE_MASK_SUPPORTS_REQUEST_PROXYING |
                 FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_DO_NOT_FUZZ,
+                FEATURE_MASK_DO_NOT_FUZZ |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
             nullptr,
             [](const ChannelArgs& client_args, const ChannelArgs& server_args) {
               return std::make_unique<ProxyFixture>(client_args, server_args);
@@ -662,7 +665,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
         CoreTestConfiguration{
             "Chttp2HttpProxy",
             FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_DO_NOT_FUZZ,
+                FEATURE_MASK_DO_NOT_FUZZ |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER,
             nullptr,
             [](const ChannelArgs& client_args, const ChannelArgs&) {
               return std::make_unique<HttpProxyFilter>(client_args);
@@ -682,7 +686,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             "Chttp2InsecureCredentials",
             FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
                 FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS_LEVEL_INSECURE |
-                FEATURE_MASK_IS_HTTP2,
+                FEATURE_MASK_IS_HTTP2 |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
             nullptr,
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<InsecureCredsFixture>();
@@ -721,7 +726,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
                 FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS |
                 FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
                 FEATURE_MASK_DOES_NOT_SUPPORT_CLIENT_HANDSHAKE_COMPLETE_FIRST |
-                FEATURE_MASK_IS_HTTP2,
+                FEATURE_MASK_IS_HTTP2 |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER,
             "foo.test.google.fr",
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<SslTlsFixture>(grpc_tls_version::TLS1_3);
@@ -765,7 +771,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             "Chttp2SslCredReloadTls12",
             FEATURE_MASK_IS_SECURE |
                 FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS |
-                FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2,
+                FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
             "foo.test.google.fr",
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<SslCredReloadFixture>(TLS1_2);
@@ -827,7 +834,8 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             // server: static data provider + async external verifier
             // extra: TLS 1.3
             "Chttp2StaticProviderAsyncVerifierTls13",
-            kH2TLSFeatureMask | FEATURE_MASK_DO_NOT_FUZZ,
+            kH2TLSFeatureMask | FEATURE_MASK_DO_NOT_FUZZ |
+                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
             "foo.test.google.fr",
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<TlsFixture>(

--- a/test/core/end2end/end2end_test_suites.cc
+++ b/test/core/end2end/end2end_test_suites.cc
@@ -542,8 +542,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             }},
         CoreTestConfiguration{
             "Chttp2Fullstack",
-            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER,
+            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2,
             nullptr,
             [](const ChannelArgs& /*client_args*/,
                const ChannelArgs& /*server_args*/) {
@@ -646,8 +645,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
                               }},
         CoreTestConfiguration{
             "Chttp2FullstackWithCensus",
-            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
+            FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2,
             nullptr,
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<CensusFixture>();
@@ -656,8 +654,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             "Chttp2FullstackWithProxy",
             FEATURE_MASK_SUPPORTS_REQUEST_PROXYING |
                 FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_DO_NOT_FUZZ |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
+                FEATURE_MASK_DO_NOT_FUZZ,
             nullptr,
             [](const ChannelArgs& client_args, const ChannelArgs& server_args) {
               return std::make_unique<ProxyFixture>(client_args, server_args);
@@ -665,8 +662,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
         CoreTestConfiguration{
             "Chttp2HttpProxy",
             FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_DO_NOT_FUZZ |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER,
+                FEATURE_MASK_DO_NOT_FUZZ,
             nullptr,
             [](const ChannelArgs& client_args, const ChannelArgs&) {
               return std::make_unique<HttpProxyFilter>(client_args);
@@ -686,8 +682,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             "Chttp2InsecureCredentials",
             FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
                 FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS_LEVEL_INSECURE |
-                FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
+                FEATURE_MASK_IS_HTTP2,
             nullptr,
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<InsecureCredsFixture>();
@@ -726,8 +721,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
                 FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS |
                 FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
                 FEATURE_MASK_DOES_NOT_SUPPORT_CLIENT_HANDSHAKE_COMPLETE_FIRST |
-                FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER,
+                FEATURE_MASK_IS_HTTP2,
             "foo.test.google.fr",
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<SslTlsFixture>(grpc_tls_version::TLS1_3);
@@ -771,8 +765,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             "Chttp2SslCredReloadTls12",
             FEATURE_MASK_IS_SECURE |
                 FEATURE_MASK_SUPPORTS_PER_CALL_CREDENTIALS |
-                FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2 |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
+                FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL | FEATURE_MASK_IS_HTTP2,
             "foo.test.google.fr",
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<SslCredReloadFixture>(TLS1_2);
@@ -834,8 +827,7 @@ std::vector<CoreTestConfiguration> AllConfigs() {
             // server: static data provider + async external verifier
             // extra: TLS 1.3
             "Chttp2StaticProviderAsyncVerifierTls13",
-            kH2TLSFeatureMask | FEATURE_MASK_DO_NOT_FUZZ |
-                FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT,
+            kH2TLSFeatureMask | FEATURE_MASK_DO_NOT_FUZZ,
             "foo.test.google.fr",
             [](const ChannelArgs&, const ChannelArgs&) {
               return std::make_unique<TlsFixture>(

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -81,6 +81,8 @@
 #define FEATURE_MASK_IS_MINSTACK (1 << 11)
 #define FEATURE_MASK_IS_SECURE (1 << 12)
 #define FEATURE_MASK_DO_NOT_FUZZ (1 << 13)
+#define FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT (1 << 14)
+#define FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER (1 << 15)
 
 #define FAIL_AUTH_CHECK_SERVER_ARG_NAME "fail_auth_check"
 
@@ -805,6 +807,19 @@ extern bool g_is_fuzzing_core_e2e_tests;
 #define SKIP_IF_MINSTACK()                                 \
   if (GetParam()->feature_mask & FEATURE_MASK_IS_MINSTACK) \
   GTEST_SKIP() << "Skipping test for minstack"
+
+#define SKIP_IF_USES_EVENT_ENGINE_CLIENT()                     \
+  if (grpc_core::IsEventEngineClientEnabled() &&               \
+      GetParam()->feature_mask &                               \
+          FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT) \
+  GTEST_SKIP() << "Skipping test to prevent it from using event engine client"
+
+#define SKIP_IF_USES_EVENT_ENGINE_LISTENER()                             \
+  if (grpc_core::IsEventEngineListenerEnabled() &&                       \
+      GetParam()->feature_mask &                                         \
+          FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER)         \
+  GTEST_SKIP() << "Skipping test to prevent it from using event engine " \
+                  "listener"
 
 #define SKIP_IF_FUZZING() \
   if (g_is_fuzzing_core_e2e_tests) GTEST_SKIP() << "Skipping test for fuzzing"

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -81,8 +81,6 @@
 #define FEATURE_MASK_IS_MINSTACK (1 << 11)
 #define FEATURE_MASK_IS_SECURE (1 << 12)
 #define FEATURE_MASK_DO_NOT_FUZZ (1 << 13)
-#define FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT (1 << 14)
-#define FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER (1 << 15)
 
 #define FAIL_AUTH_CHECK_SERVER_ARG_NAME "fail_auth_check"
 
@@ -808,17 +806,13 @@ extern bool g_is_fuzzing_core_e2e_tests;
   if (GetParam()->feature_mask & FEATURE_MASK_IS_MINSTACK) \
   GTEST_SKIP() << "Skipping test for minstack"
 
-#define SKIP_IF_USES_EVENT_ENGINE_CLIENT()                     \
-  if (grpc_core::IsEventEngineClientEnabled() &&               \
-      GetParam()->feature_mask &                               \
-          FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_CLIENT) \
-  GTEST_SKIP() << "Skipping test to prevent it from using event engine client"
+#define SKIP_IF_USES_EVENT_ENGINE_CLIENT()     \
+  if (grpc_core::IsEventEngineClientEnabled()) \
+  GTEST_SKIP() << "Skipping test to prevent it from using EventEngine client"
 
 #define SKIP_IF_USES_EVENT_ENGINE_LISTENER()                             \
-  if (grpc_core::IsEventEngineListenerEnabled() &&                       \
-      GetParam()->feature_mask &                                         \
-          FEATURE_MASK_SUPPORTS_DISABLING_EVENT_ENGINE_LISTENER)         \
-  GTEST_SKIP() << "Skipping test to prevent it from using event engine " \
+  if (grpc_core::IsEventEngineListenerEnabled())                         \
+  GTEST_SKIP() << "Skipping test to prevent it from using EventEngine " \
                   "listener"
 
 #define SKIP_IF_FUZZING() \

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -810,8 +810,8 @@ extern bool g_is_fuzzing_core_e2e_tests;
   if (grpc_core::IsEventEngineClientEnabled()) \
   GTEST_SKIP() << "Skipping test to prevent it from using EventEngine client"
 
-#define SKIP_IF_USES_EVENT_ENGINE_LISTENER()                             \
-  if (grpc_core::IsEventEngineListenerEnabled())                         \
+#define SKIP_IF_USES_EVENT_ENGINE_LISTENER()                            \
+  if (grpc_core::IsEventEngineListenerEnabled())                        \
   GTEST_SKIP() << "Skipping test to prevent it from using EventEngine " \
                   "listener"
 

--- a/test/core/end2end/tests/binary_metadata.cc
+++ b/test/core/end2end/tests/binary_metadata.cc
@@ -117,6 +117,7 @@ CORE_END2END_TEST(CoreEnd2endTest,
 
 CORE_END2END_TEST(CoreEnd2endTest,
                   BinaryMetadataServerHttp2FallbackClientHttp2Fallback) {
+  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   BinaryMetadata(*this, false, false);
 }
 

--- a/test/core/end2end/tests/cancel_after_accept.cc
+++ b/test/core/end2end/tests/cancel_after_accept.cc
@@ -76,6 +76,7 @@ CORE_END2END_TEST(CoreDeadlineTest, DeadlineAfterAccept) {
 }
 
 CORE_END2END_TEST(CoreClientChannelTest, DeadlineAfterAcceptWithServiceConfig) {
+  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/cancel_after_invoke.cc
+++ b/test/core/end2end/tests/cancel_after_invoke.cc
@@ -109,6 +109,7 @@ void CancelAfterInvoke3(CoreEnd2endTest& test,
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke6) {
+  SKIP_IF_USES_EVENT_ENGINE_LISTENER();
   CancelAfterInvoke6(*this, std::make_unique<CancelCancellationMode>());
 }
 
@@ -121,6 +122,7 @@ CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke4) {
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke3) {
+  SKIP_IF_USES_EVENT_ENGINE_LISTENER();
   CancelAfterInvoke3(*this, std::make_unique<CancelCancellationMode>());
 }
 

--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -81,6 +81,7 @@ CORE_END2END_TEST(CoreEnd2endTest, CancelWithStatus3) {
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelWithStatus4) {
+  SKIP_IF_USES_EVENT_ENGINE_LISTENER();
   auto c = NewClientCall("/foo").Timeout(Duration::Seconds(5)).Create();
   CoreEnd2endTest::IncomingMetadata server_initial_metadata;
   CoreEnd2endTest::IncomingStatusOnClient server_status;

--- a/test/core/end2end/tests/filtered_metadata.cc
+++ b/test/core/end2end/tests/filtered_metadata.cc
@@ -72,6 +72,7 @@ void TestRequestResponseWithMetadataToBeFiltered(
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, ContentLengthIsFiltered) {
+  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   TestRequestResponseWithMetadataToBeFiltered(*this, "content-length", "45");
 }
 

--- a/test/core/end2end/tests/retry_recv_initial_metadata.cc
+++ b/test/core/end2end/tests/retry_recv_initial_metadata.cc
@@ -35,6 +35,7 @@ namespace {
 // - first attempt receives initial metadata before trailing metadata,
 //   so no retry is done even though status was ABORTED
 CORE_END2END_TEST(RetryTest, RetryRecvInitialMetadata) {
+  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/simple_request.cc
+++ b/test/core/end2end/tests/simple_request.cc
@@ -98,7 +98,10 @@ void SimpleRequestBody(CoreEnd2endTest& test) {
             expected_calls);
 }
 
-CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest) { SimpleRequestBody(*this); }
+CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest) {
+  SKIP_IF_USES_EVENT_ENGINE_LISTENER();
+  SimpleRequestBody(*this);
+}
 
 CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest10) {
   for (int i = 0; i < 10; i++) {


### PR DESCRIPTION

Based on flaky tests reported by dashboard: https://dashboards.corp.google.com/stubby_team.grpc_flaky_dashboard#1318s66d4f

