### PR TITLE
[testing] Fix flakiness in http proxy fixture

### DIFF
--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -298,7 +298,7 @@ grpc_cc_test(
         "absl/types:optional",
         "gtest",
     ],
-    shard_count = 1,
+    shard_count = 50,
     tags = ["core_end2end_test"],
     deps = [
         "cq_verifier",

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -285,7 +285,6 @@ END2END_TEST_DATA = [
 
 grpc_cc_test(
     name = "core_end2end_tests",
-    timeout = "long",
     srcs = [
         "end2end_test_main.cc",
     ] + END2END_TEST_SRCS,
@@ -299,7 +298,7 @@ grpc_cc_test(
         "absl/types:optional",
         "gtest",
     ],
-    shard_count = 50,
+    shard_count = 1,
     tags = ["core_end2end_test"],
     deps = [
         "cq_verifier",

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -285,6 +285,7 @@ END2END_TEST_DATA = [
 
 grpc_cc_test(
     name = "core_end2end_tests",
+    timeout = "long",
     srcs = [
         "end2end_test_main.cc",
     ] + END2END_TEST_SRCS,

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -43,7 +43,6 @@
 #include "src/core/lib/channel/channel_args_preconditioning.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/event_engine/channel_args_endpoint_config.h"
-#include "src/core/lib/experiments/experiments.h"
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/status_helper.h"

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -89,7 +89,6 @@ void proxy_ref(grpc_end2end_http_proxy* proxy) { gpr_ref(&proxy->users); }
 void proxy_unref(grpc_end2end_http_proxy* proxy) {
   if (gpr_unref(&proxy->users)) {
     GRPC_COMBINER_UNREF(proxy->combiner, "test");
-    gpr_log(GPR_ERROR, "Deleting proxy");
     delete proxy;
   }
 }


### PR DESCRIPTION
Should fix the following flakes which get triggered when EventEngine is enabled.

1. https://source.cloud.google.com/results/invocations/ba343e5c-e8b0-43c9-a340-4f9da2b639e6/targets/%2F%2Ftest%2Fcore%2Fend2end:core_end2end_tests@poller%3Depoll1@experiment%3Devent_engine_listener/log
 
2. https://source.cloud.google.com/results/invocations/87d7c29d-5707-4cc3-8868-63d7bc89682b/targets/%2F%2Ftest%2Fcore%2Fend2end:core_end2end_tests@poller%3Depoll1@experiment%3Devent_engine_listener/log

These flakes are triggered by the http proxy getting deleted (thus unreffing the associated combiner) while the pending endpoint read callbacks have still not run. We fix this issue by introducing proper ref counting of the proxy.

