### PR TITLE
[Core] Fix the false sharing in struct grpc_completion_queue

### DIFF
--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -350,9 +350,13 @@ struct grpc_completion_queue {
   /// Once owning_refs drops to zero, we will destroy the cq
   grpc_core::RefCount owning_refs;
 
+  char padding_1[GPR_CACHELINE_SIZE];
   gpr_mu* mu;
 
+  char padding_2[GPR_CACHELINE_SIZE];
   const cq_vtable* vtable;
+
+  char padding_3[GPR_CACHELINE_SIZE];
   const cq_poller_vtable* poller_vtable;
 
 #ifndef NDEBUG

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -349,7 +349,7 @@ struct cq_callback_data {
 struct grpc_completion_queue {
   /// Once owning_refs drops to zero, we will destroy the cq
   grpc_core::RefCount owning_refs;
-
+  /// Add the paddings to fix the false sharing
   char padding_1[GPR_CACHELINE_SIZE];
   gpr_mu* mu;
 


### PR DESCRIPTION
For the details of the issue, please see #33157.

Add several paddings in struct grpc_comletion_quete to avoid the false sharing.

I see performance improvement with the QPS tests.


cpp_protobuf_async_streaming_qps_unconstrained_1cq_insecure: ~2.9%
cpp_protobuf_async_unary_qps_unconstrained_1cq_insecure: ~7%