### PR TITLE
[interop test docs] document --additional_metadata flag

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -39,6 +39,9 @@ Clients should accept these arguments:
 * --service_config_json=SERVICE_CONFIG_JSON
     * Disables service config lookups and sets the provided string as the
       default service config.
+* --additional_metadata=ADDITIONAL_METADATA
+    * Additional metadata to send in each request, as a semicolon-separated list
+      of key:value pairs. All character but semicolons are permitted in values.
 
 Clients must support TLS with ALPN. Clients must not disable certificate
 checking.

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -47,7 +47,8 @@ Clients should accept these arguments:
       - `abc-key:abc-value;foo-key:foo-value`
           - Key/value pairs: `abc-key`/`abc-value`, `foo-key`/`foo-value`
       - `abc-key:abc:value;foo-key:foo:value`
-          - Key/value pairs: `abc-key`/`abc:value`, `foo-key`/`foo:value`
+          - Key/value pairs: `abc-key`/`abc:value`, `foo-key`/`foo:value`.
+
       Keys must be ASCII only (no `-bin` headers allowed). Values may contain
       any character except semi-colons.
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -45,7 +45,7 @@ Clients should accept these arguments:
       The second key/value pair is separated by the next colon *following* the
       next semi-colon thereafter, and so on. For example:
       - `abc-key:abc-value;foo-key:foo-value`
-          - Key/value pairs: `abc-key`/`abc-value`, `foo-key`/`foo-value`
+          - Key/value pairs: `abc-key`/`abc-value`, `foo-key`/`foo-value`.
       - `abc-key:abc:value;foo-key:foo:value`
           - Key/value pairs: `abc-key`/`abc:value`, `foo-key`/`foo:value`.
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -41,7 +41,15 @@ Clients should accept these arguments:
       default service config.
 * --additional_metadata=ADDITIONAL_METADATA
     * Additional metadata to send in each request, as a semicolon-separated list
-      of key:value pairs. All character but semicolons are permitted in values.
+      of key:value pairs. The first key/value pair is separated by the first colon.
+      The second key/value pair is separated by the next colon *following* the
+      next semi-colon thereafter, and so on. For example:
+      - `abc-key:abc-value;foo-key:foo-value`
+          - Key/value pairs: 'abc-key`/`abc-value`, `foo-key`/`foo-value`
+      - `abc-key:abc:value;foo-key:foo:value`
+          - Key/value pairs: 'abc-key`/`abc:value`, `foo-key`/`foo:value`
+      Keys must be ASCII only (no `-bin` headers allowed). Values may contain
+      any character except semi-colons.
 
 Clients must support TLS with ALPN. Clients must not disable certificate
 checking.

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -45,9 +45,9 @@ Clients should accept these arguments:
       The second key/value pair is separated by the next colon *following* the
       next semi-colon thereafter, and so on. For example:
       - `abc-key:abc-value;foo-key:foo-value`
-          - Key/value pairs: 'abc-key`/`abc-value`, `foo-key`/`foo-value`
+          - Key/value pairs: `abc-key`/`abc-value`, `foo-key`/`foo-value`
       - `abc-key:abc:value;foo-key:foo:value`
-          - Key/value pairs: 'abc-key`/`abc:value`, `foo-key`/`foo:value`
+          - Key/value pairs: `abc-key`/`abc:value`, `foo-key`/`foo:value`
       Keys must be ASCII only (no `-bin` headers allowed). Values may contain
       any character except semi-colons.
 


### PR DESCRIPTION
The flag was introduced a while back for C++: https://github.com/grpc/grpc/pull/18156

https://github.com/grpc/grpc-go/pull/6295 and https://github.com/grpc/grpc-java/pull/10201 for the same flag in Java and Go (need this for RLS integration tests).
