### PR TITLE
[Core] Add a GPR_LIKELY in cq_pluck()

### DIFF
--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -1231,7 +1231,7 @@ static grpc_event cq_pluck(grpc_completion_queue* cq, void* tag,
     prev = &cqd->completed_head;
     while ((c = reinterpret_cast<grpc_cq_completion*>(
                 prev->next & ~uintptr_t{1})) != &cqd->completed_head) {
-      if (c->tag == tag) {
+      if (GPR_LIKELY(c->tag == tag)) {
         prev->next = (prev->next & uintptr_t{1}) | (c->next & ~uintptr_t{1});
         if (c == cqd->completed_tail) {
           cqd->completed_tail = prev;


### PR DESCRIPTION
Make the change to improve branch prediction.

For the details, please see #33204.

With the change, the QPS increases by ~0.5% in "cpp_protobuf_sync_streaming_qps_unconstrained_10mps_secure" test.
cpp_protobuf_sync_streaming_qps_unconstrained_10mps_secure: +0.515%  


