### PR TITLE
[test] Fix uninitialized value in end2end tests's IncomingCloseOnServer

### DIFF
--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -324,7 +324,7 @@ class CoreEnd2endTest : public ::testing::Test {
     grpc_op MakeOp();
 
    private:
-    int cancelled_;
+    int cancelled_ = false;
   };
 
   // Build one batch. Returned from NewBatch (use that to instantiate this!)


### PR DESCRIPTION
Example failure: https://source.cloud.google.com/results/invocations/7eacd9c4-c0f0-44ed-b93a-6b48f62599a3/targets/%2F%2Ftest%2Fcore%2Fend2end:core_end2end_tests@poller%3Dpoll/log