### PR TITLE
[test] Re-enable work stealing thread pool experiment

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -28,6 +28,7 @@ EXPERIMENTS = {
             "event_engine_listener",
             "promise_based_client_call",
             "promise_based_server_call",
+            "work_stealing",
         ],
         "cpp_end2end_test": [
             "promise_based_server_call",

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -154,7 +154,7 @@
   default: false
   expiry: 2023/06/01
   owner: hork@google.com
-  test_tags: []
+  test_tags: ["core_end2end_test"]
   allow_in_fuzzing_config: false
 - name: client_privacy
   description:


### PR DESCRIPTION
I have not been able to reproduce the non-empty pool @ shutdown bug in around 200k runs of various kinds. Now that experiments are marked flaky by default, any similar failures should not block PR submission, and this will give me good signal if the bugs reproduce more frequently in the CI environment.

I have a fix in theory, but I don't think it should be necessary. If the bug reproduces, I'll try the fix.