### PR TITLE
[JSON object loader] fix null handling

### DIFF
--- a/src/core/lib/json/json_object_loader.cc
+++ b/src/core/lib/json/json_object_loader.cc
@@ -22,6 +22,8 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/strip.h"
 
+#include <grpc/support/json.h>
+
 namespace grpc_core {
 namespace json_detail {
 

--- a/src/core/lib/json/json_object_loader.cc
+++ b/src/core/lib/json/json_object_loader.cc
@@ -166,9 +166,8 @@ void LoadMap::LoadInto(const Json& json, const JsonArgs& args, void* dst,
   }
 }
 
-void LoadOptional::LoadInto(const Json& json, const JsonArgs& args, void* dst,
-                            ValidationErrors* errors) const {
-  if (json.type() == Json::Type::kNull) return;
+void LoadWrapped::LoadInto(const Json& json, const JsonArgs& args, void* dst,
+                           ValidationErrors* errors) const {
   void* element = Emplace(dst);
   size_t starting_error_size = errors->size();
   ElementLoader()->LoadInto(json, args, element, errors);
@@ -189,7 +188,7 @@ bool LoadObject(const Json& json, const JsonArgs& args, const Element* elements,
     ValidationErrors::ScopedField field(errors,
                                         absl::StrCat(".", element.name));
     const auto& it = json.object().find(element.name);
-    if (it == json.object().end()) {
+    if (it == json.object().end() || it->second.type() == Json::Type::kNull) {
       if (element.optional) continue;
       errors->AddError("field not present");
       continue;

--- a/src/core/lib/json/json_object_loader.h
+++ b/src/core/lib/json/json_object_loader.h
@@ -253,14 +253,14 @@ class LoadMap : public LoaderInterface {
   virtual const LoaderInterface* ElementLoader() const = 0;
 };
 
-// Load an optional of some type.
-class LoadOptional : public LoaderInterface {
+// Load a wrapped value of some type.
+class LoadWrapped : public LoaderInterface {
  public:
   void LoadInto(const Json& json, const JsonArgs& args, void* dst,
                 ValidationErrors* errors) const override;
 
  protected:
-  ~LoadOptional() = default;
+  ~LoadWrapped() = default;
 
  private:
   virtual void* Emplace(void* dst) const = 0;
@@ -392,7 +392,7 @@ class AutoLoader<std::map<std::string, T>> final : public LoadMap {
 
 // Specializations of AutoLoader for absl::optional<>.
 template <typename T>
-class AutoLoader<absl::optional<T>> final : public LoadOptional {
+class AutoLoader<absl::optional<T>> final : public LoadWrapped {
  public:
   void* Emplace(void* dst) const final {
     return &static_cast<absl::optional<T>*>(dst)->emplace();
@@ -410,7 +410,7 @@ class AutoLoader<absl::optional<T>> final : public LoadOptional {
 
 // Specializations of AutoLoader for std::unique_ptr<>.
 template <typename T>
-class AutoLoader<std::unique_ptr<T>> final : public LoadOptional {
+class AutoLoader<std::unique_ptr<T>> final : public LoadWrapped {
  public:
   void* Emplace(void* dst) const final {
     auto& p = *static_cast<std::unique_ptr<T>*>(dst);
@@ -430,7 +430,7 @@ class AutoLoader<std::unique_ptr<T>> final : public LoadOptional {
 
 // Specializations of AutoLoader for RefCountedPtr<>.
 template <typename T>
-class AutoLoader<RefCountedPtr<T>> final : public LoadOptional {
+class AutoLoader<RefCountedPtr<T>> final : public LoadWrapped {
  public:
   void* Emplace(void* dst) const final {
     auto& p = *static_cast<RefCountedPtr<T>*>(dst);

--- a/test/core/json/json_object_loader_test.cc
+++ b/test/core/json/json_object_loader_test.cc
@@ -84,6 +84,7 @@ TYPED_TEST_P(SignedIntegerTest, IntegerFields) {
   EXPECT_EQ(test_struct->value, 5);
   EXPECT_EQ(test_struct->optional_value, 0);
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails to parse number from JSON string.
   test_struct = Parse<TestStruct>("{\"value\": \"foo\"}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -107,6 +108,15 @@ TYPED_TEST_P(SignedIntegerTest, IntegerFields) {
   EXPECT_EQ(test_struct->absl_optional_value, 9);
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(*test_struct->unique_ptr_value, 11);
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": 5, \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(test_struct->value, 5);
+  EXPECT_EQ(test_struct->optional_value, 0);
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": {}, "
@@ -173,6 +183,7 @@ TYPED_TEST_P(UnsignedIntegerTest, IntegerFields) {
   EXPECT_EQ(test_struct->value, 5);
   EXPECT_EQ(test_struct->optional_value, 0);
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails to parse number from JSON string.
   test_struct = Parse<TestStruct>("{\"value\": \"foo\"}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -197,6 +208,15 @@ TYPED_TEST_P(UnsignedIntegerTest, IntegerFields) {
   EXPECT_EQ(*test_struct->absl_optional_value, 9);
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(*test_struct->unique_ptr_value, 11);
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": 5, \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(test_struct->value, 5);
+  EXPECT_EQ(test_struct->optional_value, 0);
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": {}, "
@@ -250,12 +270,11 @@ TYPED_TEST_P(FloatingPointTest, FloatFields) {
   EXPECT_NEAR(test_struct->value, 5.2, 0.0001);
   EXPECT_EQ(test_struct->optional_value, 0);
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Negative number.
   test_struct = Parse<TestStruct>("{\"value\": -5.2}");
   ASSERT_TRUE(test_struct.ok()) << test_struct.status();
   EXPECT_NEAR(test_struct->value, -5.2, 0.0001);
-  EXPECT_EQ(test_struct->optional_value, 0);
-  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
   // Encoded in a JSON string.
   test_struct = Parse<TestStruct>("{\"value\": \"5.2\"}");
   ASSERT_TRUE(test_struct.ok()) << test_struct.status();
@@ -286,6 +305,15 @@ TYPED_TEST_P(FloatingPointTest, FloatFields) {
   EXPECT_NEAR(*test_struct->absl_optional_value, 9.8, 0.0001);
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_NEAR(*test_struct->unique_ptr_value, 11.5, 0.0001);
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": 5.2, \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_NEAR(test_struct->value, 5.2, 0.0001);
+  EXPECT_EQ(test_struct->optional_value, 0);
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": {}, "
@@ -340,6 +368,7 @@ TEST(JsonObjectLoader, BooleanFields) {
   EXPECT_EQ(test_struct->value, false);
   EXPECT_EQ(test_struct->optional_value, true);  // Unmodified.
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -356,6 +385,15 @@ TEST(JsonObjectLoader, BooleanFields) {
   EXPECT_EQ(test_struct->absl_optional_value, true);
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(*test_struct->unique_ptr_value, false);
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": true, \"optional_value\": null,"
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(test_struct->value, true);
+  EXPECT_EQ(test_struct->optional_value, true);  // Unmodified.
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": {}, "
@@ -399,6 +437,7 @@ TEST(JsonObjectLoader, StringFields) {
   EXPECT_EQ(test_struct->value, "foo");
   EXPECT_EQ(test_struct->optional_value, "");
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -415,6 +454,15 @@ TEST(JsonObjectLoader, StringFields) {
   EXPECT_EQ(test_struct->absl_optional_value, "baz");
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(*test_struct->unique_ptr_value, "quux");
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": \"foo\", \"optional_value\": null,"
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(test_struct->value, "foo");
+  EXPECT_EQ(test_struct->optional_value, "");
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": {}, "
@@ -458,6 +506,7 @@ TEST(JsonObjectLoader, DurationFields) {
   EXPECT_EQ(test_struct->value, Duration::Seconds(3));
   EXPECT_EQ(test_struct->optional_value, Duration::Zero());
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Invalid duration strings.
   test_struct = Parse<TestStruct>(
       "{\"value\": \"3sec\", \"optional_value\": \"foos\","
@@ -499,6 +548,15 @@ TEST(JsonObjectLoader, DurationFields) {
   EXPECT_EQ(test_struct->absl_optional_value, Duration::Seconds(10));
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(*test_struct->unique_ptr_value, Duration::Seconds(11));
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": \"3s\", \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(test_struct->value, Duration::Seconds(3));
+  EXPECT_EQ(test_struct->optional_value, Duration::Zero());
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": {}, "
@@ -542,6 +600,7 @@ TEST(JsonObjectLoader, JsonObjectFields) {
   EXPECT_EQ(JsonDump(Json::FromObject(test_struct->value)), "{\"a\":1}");
   EXPECT_EQ(JsonDump(Json::FromObject(test_struct->optional_value)), "{}");
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -562,6 +621,15 @@ TEST(JsonObjectLoader, JsonObjectFields) {
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(JsonDump(Json::FromObject(*test_struct->unique_ptr_value)),
             "{\"d\":4}");
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": {\"a\":1}, \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(JsonDump(Json::FromObject(test_struct->value)), "{\"a\":1}");
+  EXPECT_EQ(JsonDump(Json::FromObject(test_struct->optional_value)), "{}");
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": true, "
@@ -626,6 +694,15 @@ TEST(JsonObjectLoader, JsonArrayFields) {
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_EQ(JsonDump(Json::FromArray(*test_struct->unique_ptr_value)),
             "[4,\"d\"]");
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": [1, \"a\"], \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(JsonDump(Json::FromArray(test_struct->value)), "[1,\"a\"]");
+  EXPECT_EQ(JsonDump(Json::FromArray(test_struct->optional_value)), "[]");
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": {}, \"optional_value\": true, "
@@ -670,6 +747,7 @@ TEST(JsonObjectLoader, MapFields) {
               ::testing::ElementsAre(::testing::Pair("a", 1)));
   EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -692,6 +770,16 @@ TEST(JsonObjectLoader, MapFields) {
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_THAT(*test_struct->unique_ptr_value,
               ::testing::ElementsAre(::testing::Pair("d", 4)));
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": {\"a\":1}, \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_THAT(test_struct->value,
+              ::testing::ElementsAre(::testing::Pair("a", 1)));
+  EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": [], \"optional_value\": true, "
@@ -746,6 +834,7 @@ TEST(JsonObjectLoader, VectorFields) {
   EXPECT_THAT(test_struct->value, ::testing::ElementsAre(1, 2, 3));
   EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
   EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -766,6 +855,15 @@ TEST(JsonObjectLoader, VectorFields) {
               ::testing::ElementsAre(true, false, true));
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_THAT(*test_struct->unique_ptr_value, ::testing::ElementsAre(1, 2, 3));
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": [4, 5, 6], \"optional_value\": null, "
+      "\"absl_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_THAT(test_struct->value, ::testing::ElementsAre(4, 5, 6));
+  EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
+  EXPECT_FALSE(test_struct->absl_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"value\": {}, \"optional_value\": true, "
@@ -833,6 +931,7 @@ TEST(JsonObjectLoader, NestedStructFields) {
   EXPECT_EQ(test_struct->outer.inner, 1);
   EXPECT_EQ(test_struct->optional_outer.inner, 0);
   EXPECT_FALSE(test_struct->absl_optional_outer.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_outer, nullptr);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -858,6 +957,15 @@ TEST(JsonObjectLoader, NestedStructFields) {
   EXPECT_EQ(test_struct->absl_optional_outer->inner, 3);
   ASSERT_NE(test_struct->unique_ptr_outer, nullptr);
   EXPECT_EQ(test_struct->unique_ptr_outer->inner, 4);
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"outer\": {\"inner\":1}, \"optional_outer\": null, "
+      "\"absl_optional_outer\": null, \"unique_ptr_outer\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_EQ(test_struct->outer.inner, 1);
+  EXPECT_EQ(test_struct->optional_outer.inner, 0);
+  EXPECT_FALSE(test_struct->absl_optional_outer.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_outer, nullptr);
   // Wrong JSON type.
   test_struct = Parse<TestStruct>(
       "{\"outer\": \"foo\", \"optional_outer\": true, "
@@ -887,36 +995,71 @@ TEST(JsonObjectLoader, BareString) {
   auto parsed = Parse<std::string>("\"foo\"");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_EQ(*parsed, "foo");
+  parsed = Parse<std::string>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a string]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareDuration) {
   auto parsed = Parse<Duration>("\"1.5s\"");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_EQ(*parsed, Duration::Milliseconds(1500));
+  parsed = Parse<Duration>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a string]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareSignedInteger) {
   auto parsed = Parse<int32_t>("5");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_EQ(*parsed, 5);
+  parsed = Parse<int32_t>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a number]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareUnsignedInteger) {
   auto parsed = Parse<uint32_t>("5");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_EQ(*parsed, 5);
+  parsed = Parse<uint32_t>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a number]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareFloat) {
   auto parsed = Parse<float>("5.2");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_NEAR(*parsed, 5.2, 0.001);
+  parsed = Parse<float>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a number]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareBool) {
   auto parsed = Parse<bool>("true");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_TRUE(*parsed);
+  parsed = Parse<bool>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a boolean]")
+      << parsed.status();
+}
+
+TEST(JsonObjectLoader, BareOptional) {
+  auto parsed = Parse<absl::optional<uint32_t>>("3");
+  ASSERT_TRUE(parsed.ok()) << parsed.status();
+  ASSERT_TRUE(parsed->has_value());
+  EXPECT_EQ(**parsed, 3);
+  parsed = Parse<absl::optional<uint32_t>>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a number]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareUniquePtr) {
@@ -924,6 +1067,10 @@ TEST(JsonObjectLoader, BareUniquePtr) {
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   ASSERT_NE(*parsed, nullptr);
   EXPECT_EQ(**parsed, 3);
+  parsed = Parse<std::unique_ptr<uint32_t>>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not a number]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareRefCountedPtr) {
@@ -947,8 +1094,7 @@ TEST(JsonObjectLoader, BareRefCountedPtr) {
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   ASSERT_NE(*parsed, nullptr);
   EXPECT_EQ((*parsed)->value(), 3);
-  parsed = Parse<RefCountedPtr<RefCountedObject>>("5");
-  EXPECT_EQ(parsed.status().code(), absl::StatusCode::kInvalidArgument);
+  parsed = Parse<RefCountedPtr<RefCountedObject>>("null");
   EXPECT_EQ(parsed.status().message(),
             "errors validating JSON: [field: error:is not an object]")
       << parsed.status();
@@ -958,6 +1104,10 @@ TEST(JsonObjectLoader, BareVector) {
   auto parsed = Parse<std::vector<int32_t>>("[1, 2, 3]");
   ASSERT_TRUE(parsed.ok()) << parsed.status();
   EXPECT_THAT(*parsed, ::testing::ElementsAre(1, 2, 3));
+  parsed = Parse<std::vector<int32_t>>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not an array]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, BareMap) {
@@ -967,6 +1117,10 @@ TEST(JsonObjectLoader, BareMap) {
   EXPECT_THAT(*parsed, ::testing::ElementsAre(::testing::Pair("a", 1),
                                               ::testing::Pair("b", 2),
                                               ::testing::Pair("c", 3)));
+  parsed = Parse<std::map<std::string, int32_t>>("null");
+  EXPECT_EQ(parsed.status().message(),
+            "errors validating JSON: [field: error:is not an object]")
+      << parsed.status();
 }
 
 TEST(JsonObjectLoader, IgnoresUnsupportedFields) {


### PR DESCRIPTION
- Accept JSON null for any optional field.
- Do *not* accept JSON null for wrapper types (`absl::optional<>`, `std::unique_ptr<>`, and `RefCountedPtr<>`) that are *not* marked as optional fields.