### PR TITLE
[flow control] De-risk the memory flow controller

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -244,7 +244,7 @@ TransportFlowControl::TargetInitialWindowSizeBasedOnMemoryPressureAndBdp()
   //
   //          ▲
   //          │
-  // 16mb ────┤---------x----
+  //  4mb ────┤---------x----
   //          │              -----
   //  BDP ────┤                   ----x---
   //          │                           ----
@@ -259,7 +259,8 @@ TransportFlowControl::TargetInitialWindowSizeBasedOnMemoryPressureAndBdp()
   //                                                                pressure
   const double kAnythingGoesPressure = 0.2;
   const double kAdjustedToBdpPressure = 0.5;
-  const double kAnythingGoesWindow = std::max(double{1 << 24}, bdp);
+  const double kOneMegabyte = 1024.0 * 1024.0;
+  const double kAnythingGoesWindow = std::max(4.0 * kOneMegabyte, bdp);
   if (memory_pressure < kAnythingGoesPressure) {
     return kAnythingGoesWindow;
   } else if (memory_pressure < kAdjustedToBdpPressure) {


### PR DESCRIPTION
We were previously trying to adjust the initial guess flow control window *and* the adjustment methodology, which created some problems.

The latter is more important for us to get in, so don't change the former for now (we can do that later).

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

