### PR TITLE
[EventEngine] Mark worker threads busy while draining

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -398,6 +398,9 @@ bool WorkStealingThreadPool::ThreadState::Step() {
 }
 
 void WorkStealingThreadPool::ThreadState::FinishDraining() {
+  // The thread is definitionally busy while draining
+  ThreadCount::AutoThreadCount auto_busy{pool_->thread_count(),
+                                         CounterType::kBusyCount};
   // If a fork occurs at any point during shutdown, quit draining. The post-fork
   // threads will finish draining the global queue.
   while (!pool_->IsForking()) {


### PR DESCRIPTION
~5% flake introduced earlier this week, where the pool was not scaling when draining work @ shutdown. Maintaining a busy thread count at shutdown allows the lifeguard to notice when all threads are blocked, and spawn new threads if necessary.