### PR TITLE
[end2end] Force crash on failure to receive an event

### DIFF
--- a/test/core/end2end/cq_verifier.cc
+++ b/test/core/end2end/cq_verifier.cc
@@ -249,9 +249,18 @@ void CqVerifier::FailUnexpectedEvent(grpc_event* ev,
 }
 
 void CqVerifier::FailUsingGprCrash(const Failure& failure) {
-  Crash(absl::StrCat("[", failure.location.file(), ":", failure.location.line(),
-                     "] ", failure.message, "\nexpected:\n",
-                     absl::StrJoin(failure.expected, "\n")));
+  std::string message =
+      absl::StrCat(failure.message, "\nexpectation checked @ ",
+                   failure.location.file(), ":", failure.location.line());
+  if (!failure.expected.empty()) {
+    absl::StrAppend(&message, "\nexpected:\n");
+    for (const auto& line : failure.expected) {
+      absl::StrAppend(&message, "  ", line, "\n");
+    }
+  } else {
+    absl::StrAppend(&message, "\nexpected nothing");
+  }
+  CrashWithStdio(message);
 }
 
 void CqVerifier::FailUsingGtestFail(const Failure& failure) {

--- a/test/core/end2end/end2end_test_fuzzer.cc
+++ b/test/core/end2end/end2end_test_fuzzer.cc
@@ -128,7 +128,6 @@ DEFINE_PROTO_FUZZER(const core_end2end_test_fuzzer::Msg& msg) {
       std::dynamic_pointer_cast<FuzzingEventEngine>(GetDefaultEventEngine());
 
   auto test = tests[test_id].factory();
-  test->SetCrashOnStepFailure();
   test->SetQuiesceEventEngine(
       [](std::shared_ptr<grpc_event_engine::experimental::EventEngine>&& ee) {
         static_cast<FuzzingEventEngine*>(ee.get())->TickUntilIdle();

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -160,7 +160,6 @@ class CoreEnd2endTest : public ::testing::Test {
           step_fn) {
     step_fn_ = std::move(step_fn);
   }
-  void SetCrashOnStepFailure() { crash_on_step_failure_ = true; }
   void SetQuiesceEventEngine(
       absl::AnyInvocable<
           void(std::shared_ptr<grpc_event_engine::experimental::EventEngine>&&)>
@@ -687,10 +686,7 @@ class CoreEnd2endTest : public ::testing::Test {
     if (cq_verifier_ == nullptr) {
       fixture();  // ensure cq_ present
       cq_verifier_ = absl::make_unique<CqVerifier>(
-          cq_,
-          crash_on_step_failure_ ? CqVerifier::FailUsingGprCrash
-                                 : CqVerifier::FailUsingGtestFail,
-          std::move(step_fn_));
+          cq_, CqVerifier::FailUsingGprCrash, std::move(step_fn_));
     }
     return *cq_verifier_;
   }
@@ -703,7 +699,6 @@ class CoreEnd2endTest : public ::testing::Test {
   std::unique_ptr<CqVerifier> cq_verifier_;
   int expectations_ = 0;
   bool initialized_ = false;
-  bool crash_on_step_failure_ = false;
   absl::AnyInvocable<void()> post_grpc_init_func_ = []() {};
   absl::AnyInvocable<void(
       grpc_event_engine::experimental::EventEngine::Duration) const>


### PR DESCRIPTION
When I converted these tests there was an intent to use gtest failures to see past an unexpected event/no event received error - however that doesn't work out because our tests rely on the prior events happening.

What we got instead was misattributed failures, folks chasing wild theories on uninitialized data, dogs and cats living together, mass hysteria.

Let's just crash and see if it makes diagnosis actually easier.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

