### PR TITLE
[PSM Interop] Prettify LB stats output

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/run_ping_pong.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_ping_pong.py
@@ -19,6 +19,7 @@ from bin.lib import common
 from framework import xds_flags
 from framework import xds_k8s_flags
 from framework.helpers import grpc as helpers_grpc
+import framework.helpers.highlighter
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
 from framework.rpc import grpc_channelz
@@ -60,8 +61,10 @@ LoadBalancerStatsResponse = grpc_testing.LoadBalancerStatsResponse
 def get_client_rpc_stats(test_client: _XdsTestClient,
                          num_rpcs: int) -> LoadBalancerStatsResponse:
     lb_stats = test_client.get_load_balancer_stats(num_rpcs=num_rpcs)
-    logger.info('[%s] Received:\n%s', test_client.hostname,
-                helpers_grpc.lb_stats_pretty(lb_stats))
+    hl = framework.helpers.highlighter.HighlighterYaml()
+    logger.info('[%s] Received LoadBalancerStatsResponse:\n%s',
+                test_client.hostname,
+                hl.highlight(helpers_grpc.lb_stats_pretty(lb_stats)))
     return lb_stats
 
 

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_ping_pong.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_ping_pong.py
@@ -18,6 +18,7 @@ from absl import logging
 from bin.lib import common
 from framework import xds_flags
 from framework import xds_k8s_flags
+from framework.helpers import grpc as helpers_grpc
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
 from framework.rpc import grpc_channelz
@@ -59,8 +60,8 @@ LoadBalancerStatsResponse = grpc_testing.LoadBalancerStatsResponse
 def get_client_rpc_stats(test_client: _XdsTestClient,
                          num_rpcs: int) -> LoadBalancerStatsResponse:
     lb_stats = test_client.get_load_balancer_stats(num_rpcs=num_rpcs)
-    logger.info('Received LoadBalancerStatsResponse from test client %s:\n%s',
-                test_client.hostname, lb_stats)
+    logger.info('[%s] Received:\n%s', test_client.hostname,
+                helpers_grpc.lb_stats_pretty(lb_stats))
     return lb_stats
 
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/helpers/grpc.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/helpers/grpc.py
@@ -50,7 +50,7 @@ class PrettyStatsPerMethod:
     rpcs_started: int
     result: Dict[str, int]
 
-    @functools.cached_property
+    @functools.cached_property  # pylint: disable=no-member
     def total_count(self):
         return sum(self.result.values())
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc.py
@@ -66,7 +66,7 @@ class GrpcClientHelper:
 
     def _log_rpc_request(self, rpc, req, call_kwargs, log_level=logging.DEBUG):
         logger.log(logging.DEBUG if log_level is None else log_level,
-                   '[%s] RPC %s.%s(request=%s(%r), %s)', self.log_target,
+                   '[%s] >> RPC %s.%s(request=%s(%r), %s)', self.log_target,
                    self.log_service_name, rpc, req.__class__.__name__,
                    json_format.MessageToDict(req),
                    ', '.join({f'{k}={v}' for k, v in call_kwargs.items()}))

--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_testing.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_testing.py
@@ -32,6 +32,7 @@ _LoadBalancerStatsRequest = messages_pb2.LoadBalancerStatsRequest
 LoadBalancerStatsResponse = messages_pb2.LoadBalancerStatsResponse
 _LoadBalancerAccumulatedStatsRequest = messages_pb2.LoadBalancerAccumulatedStatsRequest
 LoadBalancerAccumulatedStatsResponse = messages_pb2.LoadBalancerAccumulatedStatsResponse
+MethodStats = messages_pb2.LoadBalancerAccumulatedStatsResponse.MethodStats
 
 
 class LoadBalancerStatsServiceClient(framework.rpc.grpc.GrpcClientHelper):

--- a/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_testing.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/rpc/grpc_testing.py
@@ -33,6 +33,7 @@ LoadBalancerStatsResponse = messages_pb2.LoadBalancerStatsResponse
 _LoadBalancerAccumulatedStatsRequest = messages_pb2.LoadBalancerAccumulatedStatsRequest
 LoadBalancerAccumulatedStatsResponse = messages_pb2.LoadBalancerAccumulatedStatsResponse
 MethodStats = messages_pb2.LoadBalancerAccumulatedStatsResponse.MethodStats
+RpcsByPeer = messages_pb2.LoadBalancerStatsResponse.RpcsByPeer
 
 
 class LoadBalancerStatsServiceClient(framework.rpc.grpc.GrpcClientHelper):

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/server_app.py
@@ -80,15 +80,16 @@ class XdsTestServer(framework.rpc.grpc.GrpcApp):
             log_target=f'{self.hostname}:{self.maintenance_port}')
 
     def set_serving(self):
-        logger.info('[%s] Setting health status to SERVING', self.hostname)
+        logger.info('[%s] >> Setting health status to SERVING', self.hostname)
         self.update_health_service_client.set_serving()
-        logger.info('[%s] Health status %s', self.hostname,
+        logger.info('[%s] << Health status %s', self.hostname,
                     self.health_client.check_health())
 
     def set_not_serving(self):
-        logger.info('[%s] Setting health status to NOT_SERVING', self.hostname)
+        logger.info('[%s] >> Setting health status to NOT_SERVING',
+                    self.hostname)
         self.update_health_service_client.set_not_serving()
-        logger.info('[%s] Health status %s', self.hostname,
+        logger.info('[%s] << Health status %s', self.hostname,
                     self.health_client.check_health())
 
     def set_xds_address(self, xds_host, xds_port: Optional[int] = None):

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -35,6 +35,7 @@ from framework.helpers import grpc as helpers_grpc
 from framework.helpers import rand as helpers_rand
 from framework.helpers import retryers
 from framework.helpers import skips
+import framework.helpers.highlighter
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
 from framework.infrastructure import traffic_director
@@ -174,6 +175,9 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         cls.secondary_k8s_api_manager = k8s.KubernetesApiManager(
             xds_k8s_flags.SECONDARY_KUBE_CONTEXT.value)
         cls.gcp_api_manager = gcp.api.GcpApiManager()
+
+        # Other
+        cls.yaml_highlighter = framework.helpers.highlighter.HighlighterYaml()
 
     @classmethod
     def tearDownClass(cls):

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -331,7 +331,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
                           f" {helpers_grpc.status_pretty(expected_status)},"
                           " but found status"
                           f" {helpers_grpc.status_pretty(found_status)}"
-                          f" for method {method}. Stats before:"
+                          f" for method {method}.\nStats before:"
                           f"\n{self._pretty_accumulated_stats(before_stats)}"
                           f"\nStats after:"
                           f"\n{self._pretty_accumulated_stats(after_stats)}"
@@ -344,7 +344,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
             0,
             msg=("Expected non-zero RPCs with status"
                  f" {helpers_grpc.status_pretty(expected_status)}"
-                 f" for method {method}. Stats before:"
+                 f" for method {method}.\nStats before:"
                  f"\n{self._pretty_accumulated_stats(before_stats)}"
                  f"\nStats after:"
                  f"\n{self._pretty_accumulated_stats(after_stats)}"

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -32,6 +32,7 @@ import grpc
 
 from framework import xds_k8s_testcase
 from framework import xds_url_map_test_resources
+from framework.helpers import grpc as helpers_grpc
 from framework.helpers import retryers
 from framework.helpers import skips
 from framework.infrastructure import k8s
@@ -488,12 +489,14 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
         before_stats = test_client.get_load_balancer_accumulated_stats()
         logging.info(
             'Received LoadBalancerAccumulatedStatsResponse from test client %s: before:\n%s',
-            test_client.hostname, before_stats)
+            test_client.hostname,
+            helpers_grpc.accumulated_stats_pretty(before_stats))
         time.sleep(length)
         after_stats = test_client.get_load_balancer_accumulated_stats()
         logging.info(
             'Received LoadBalancerAccumulatedStatsResponse from test client %s: after: \n%s',
-            test_client.hostname, after_stats)
+            test_client.hostname,
+            helpers_grpc.accumulated_stats_pretty(after_stats))
 
         # Validate the diff
         for expected_result in expected:

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -454,8 +454,9 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
     def test_rpc_distribution(self):
         self.rpc_distribution_validate(self.test_client)
 
-    @staticmethod
-    def configure_and_send(test_client: XdsTestClient,
+    @classmethod
+    def configure_and_send(cls,
+                           test_client: XdsTestClient,
                            *,
                            rpc_types: Iterable[str],
                            metadata: Optional[Iterable[Tuple[str, str,
@@ -467,12 +468,10 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
                                             app_timeout=app_timeout)
         # Configure RPC might race with get stats RPC on slower machines.
         time.sleep(_CLIENT_CONFIGURE_WAIT_SEC)
-        json_lb_stats = json_format.MessageToDict(
-            test_client.get_load_balancer_stats(num_rpcs=num_rpcs))
-        logging.info(
-            'Received LoadBalancerStatsResponse from test client %s:\n%s',
-            test_client.hostname, json.dumps(json_lb_stats, indent=2))
-        return RpcDistributionStats(json_lb_stats)
+        lb_stats = test_client.get_load_balancer_stats(num_rpcs=num_rpcs)
+        logging.info('[%s] Received LoadBalancerStatsResponse:\n%s',
+                     test_client.hostname, cls._pretty_lb_stats(lb_stats))
+        return RpcDistributionStats(json_format.MessageToDict(lb_stats))
 
     def assertNumEndpoints(self, xds_config: DumpedXdsConfig, k: int) -> None:
         self.assertLen(

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -469,8 +469,9 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
         # Configure RPC might race with get stats RPC on slower machines.
         time.sleep(_CLIENT_CONFIGURE_WAIT_SEC)
         lb_stats = test_client.get_load_balancer_stats(num_rpcs=num_rpcs)
-        logging.info('[%s] Received LoadBalancerStatsResponse:\n%s',
-                     test_client.hostname, cls._pretty_lb_stats(lb_stats))
+        logging.info('[%s] << Received LoadBalancerStatsResponse:\n%s',
+                     test_client.hostname,
+                     helpers_grpc.lb_stats_pretty(lb_stats))
         return RpcDistributionStats(json_format.MessageToDict(lb_stats))
 
     def assertNumEndpoints(self, xds_config: DumpedXdsConfig, k: int) -> None:


### PR DESCRIPTION
Improvements to the `LoadBalancerAccumulatedStatsRequest` output. Makes it readable.

This greatly affects `assertRpcStatusCodes()` output, used in authz and custom_lb.   
No before and after stats, just useful diff stats from now. Minimal and readable.
Also diff stats have `rpcs_started` now.

![image](https://github.com/grpc/grpc/assets/672669/a4e38d82-be5a-4f31-9d88-da2bf9712d9b)

Output example:
```
--- Starting subTest __main__.AuthzTest.test_plaintext_allow.01_host_wildcard ---
[psm-grpc-client-765bfbf868-jqjm7:51561] >> RPC LoadBalancerStatsService.GetClientAccumulatedStats(request=LoadBalancerAccumulatedStatsRequest({}), wait_for_ready=True, timeout=600)
[psm-grpc-client-765bfbf868-jqjm7:51561] >> RPC XdsUpdateClientConfigureService.Configure(request=ClientConfigureRequest({'types': ['EMPTY_CALL'], 'metadata': [{'key': 'test', 'value': 'host-wildcard'}]}), timeout=5, wait_for_ready=True)
[psm-grpc-client-765bfbf868-jqjm7:51561] >> RPC LoadBalancerStatsService.GetClientAccumulatedStats(request=LoadBalancerAccumulatedStatsRequest({}), wait_for_ready=True, timeout=600)
[psm-grpc-client-765bfbf868-jqjm7:51561] >> RPC LoadBalancerStatsService.GetClientAccumulatedStats(request=LoadBalancerAccumulatedStatsRequest({}), wait_for_ready=True, timeout=600)
[psm-grpc-client-765bfbf868-jqjm7] << Received accumulated stats difference. Expecting RPCs with status (0, OK) for method EMPTY_CALL.
- method: EMPTY_CALL
  rpcs_started: 13
  result:
    (0, OK): 14

--- Finished subTest __main__.AuthzTest.test_plaintext_allow.01_host_wildcard ---
```

In case of test failure, it'll still print all stats at the end, including before and after:
```
AssertionError: Expected only status (15, DATA_LOSS), but found status (0, OK) for method UNARY_CALL.
Stats before:
- method: UNARY_CALL
  rpcs_started: 2153
  result:
    (14, UNAVAILABLE): 1674
    (0, OK): 479

Stats after:
- method: UNARY_CALL
  rpcs_started: 2404
  result:
    (0, OK): 730
    (14, UNAVAILABLE): 1674

Diff stats:
- method: UNARY_CALL
  rpcs_started: 251
  result:
    (0, OK): 251
```

And as I was at it, also made `LoadBalancerStatsResponse` nice:

![image](https://github.com/grpc/grpc/assets/672669/b15908a7-bae4-41a0-a2f7-c903e398432a)

