### PR TITLE
[fuzzing] Handle closing after the final write in fuzzing-event-engine

### DIFF
--- a/test/core/end2end/end2end_test_corpus/clusterfuzz-testcase-minimized-core_end2end_test_fuzzer-5144784163373056
+++ b/test/core/end2end/end2end_test_corpus/clusterfuzz-testcase-minimized-core_end2end_test_fuzzer-5144784163373056
@@ -1,0 +1,16 @@
+test_id: 687392
+event_engine_actions {
+  run_delay: 7881299347898368
+  run_delay: 7881299347898368
+  connections {
+    write_size: 1702129510
+    write_size: 687392
+    write_size: 1702129510
+    write_size: 1702129510
+    write_size: 8960
+    write_size: 50331646
+    write_size: 8960
+    write_size: 8960
+    write_size: 0
+  }
+}

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
@@ -172,7 +172,7 @@ class FuzzingEventEngine : public EventEngine {
     // Address of each side of the endpoint.
     const ResolvedAddress addrs[2];
     // Is the endpoint closed?
-    bool closed ABSL_GUARDED_BY(mu_) = false;
+    bool closed[2] ABSL_GUARDED_BY(mu_) = {false, false};
     // Bytes written into each endpoint and awaiting a read.
     std::vector<uint8_t> pending[2] ABSL_GUARDED_BY(mu_);
     // The sizes of each accepted write, as determined by the fuzzer actions.


### PR DESCRIPTION
If an endpoint closes it should still report any pending writes.