### PR TITLE
[fuzzing] Increase timeout to accommodate delayed callbacks

### DIFF
--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -123,7 +123,8 @@ class TestConfigurator {
       std::initializer_list<std::pair<absl::string_view, absl::string_view>>
           client_init_metadata) {
     Init();
-    auto c = test_.NewClientCall("/foo").Timeout(Duration::Seconds(5)).Create();
+    auto c =
+        test_.NewClientCall("/foo").Timeout(Duration::Seconds(30)).Create();
     CoreEnd2endTest::IncomingStatusOnClient server_status;
     CoreEnd2endTest::IncomingMetadata server_initial_metadata;
     c.NewBatch(1)


### PR DESCRIPTION
Put enough internal delays into this test and it hits deadline exceeded... extend the deadline to cover that.

(this is likely to become a common edit over the next few weeks...)