### PR TITLE
[interop] fix C++ server to add mutex for orca_oob test

### DIFF
--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -1021,6 +1021,7 @@ bool InteropClient::DoOrcaPerRpc() {
 }
 
 bool InteropClient::DoOrcaOob() {
+  static constexpr auto TIMEOUT = absl::Seconds(10);
   gpr_log(GPR_DEBUG, "testing orca oob");
   load_report_tracker_.ResetCollectedLoadReports();
   grpc_core::CoreConfiguration::RegisterBuilder(RegisterBackendMetricsLbPolicy);
@@ -1059,7 +1060,7 @@ bool InteropClient::DoOrcaOob() {
                          }
                          return true;
                        },
-                       absl::Seconds(5), 10)
+                       TIMEOUT, 10)
                    .has_value());
   }
   {
@@ -1084,7 +1085,7 @@ bool InteropClient::DoOrcaOob() {
                 [orca_report](const auto& report) {
                   return !OrcaLoadReportsDiff(*orca_report, report).has_value();
                 },
-                absl::Seconds(5), 10)
+                TIMEOUT, 10)
             .has_value());
   }
   gpr_log(GPR_DEBUG, "orca oob successfully finished");

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -1021,7 +1021,7 @@ bool InteropClient::DoOrcaPerRpc() {
 }
 
 bool InteropClient::DoOrcaOob() {
-  static constexpr auto TIMEOUT = absl::Seconds(10);
+  static constexpr auto TIMEOUT = absl::Seconds(5);
   gpr_log(GPR_DEBUG, "testing orca oob");
   load_report_tracker_.ResetCollectedLoadReports();
   grpc_core::CoreConfiguration::RegisterBuilder(RegisterBackendMetricsLbPolicy);

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -1021,7 +1021,7 @@ bool InteropClient::DoOrcaPerRpc() {
 }
 
 bool InteropClient::DoOrcaOob() {
-  static constexpr auto TIMEOUT = absl::Seconds(5);
+  static constexpr auto kTimeout = absl::Seconds(10);
   gpr_log(GPR_DEBUG, "testing orca oob");
   load_report_tracker_.ResetCollectedLoadReports();
   grpc_core::CoreConfiguration::RegisterBuilder(RegisterBackendMetricsLbPolicy);
@@ -1060,7 +1060,7 @@ bool InteropClient::DoOrcaOob() {
                          }
                          return true;
                        },
-                       TIMEOUT, 10)
+                       kTimeout, 10)
                    .has_value());
   }
   {
@@ -1085,7 +1085,7 @@ bool InteropClient::DoOrcaOob() {
                 [orca_report](const auto& report) {
                   return !OrcaLoadReportsDiff(*orca_report, report).has_value();
                 },
-                TIMEOUT, 10)
+                kTimeout, 10)
             .has_value());
   }
   gpr_log(GPR_DEBUG, "orca oob successfully finished");


### PR DESCRIPTION
Following improvements were made to `orca_oob` interop test to increase compatibility and stability:

1. Timeout was increased to 10s (see #33098)
2. Server will block clients trying to run this test concurrently.
3. Data is cleared in the beginning of the call.