### PR TITLE
[EventEngine] Disable EventEngine polling in gRPC Python

### DIFF
--- a/bazel/cython_library.bzl
+++ b/bazel/cython_library.bzl
@@ -65,6 +65,7 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
         )
 
     shared_objects = []
+    defines = kwargs.pop("defines", [])
     for src in pyx_srcs:
         stem = src.split(".")[0]
         shared_object_name = stem + ".so"
@@ -72,6 +73,7 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
             name = shared_object_name,
             srcs = [stem + ".cpp"],
             deps = deps + ["@local_config_python//:python_headers"],
+            defines = defines,
             linkshared = 1,
         )
         shared_objects.append(shared_object_name)

--- a/setup.py
+++ b/setup.py
@@ -413,6 +413,10 @@ else:
         ('GRPC_ENABLE_FORK_SUPPORT', 1),
     )
 
+# Fix for multiprocessing support on Apple devices.
+# TODO(vigneshbabu): Remove this once the poll poller gets fork support.
+DEFINE_MACROS += (('GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER', 1))
+
 LDFLAGS = tuple(EXTRA_LINK_ARGS)
 CFLAGS = tuple(EXTRA_COMPILE_ARGS)
 if "linux" in sys.platform or "darwin" in sys.platform:

--- a/setup.py
+++ b/setup.py
@@ -415,7 +415,7 @@ else:
 
 # Fix for multiprocessing support on Apple devices.
 # TODO(vigneshbabu): Remove this once the poll poller gets fork support.
-DEFINE_MACROS += (('GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER', 1))
+DEFINE_MACROS += (('GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER', 1),)
 
 LDFLAGS = tuple(EXTRA_LINK_ARGS)
 CFLAGS = tuple(EXTRA_COMPILE_ARGS)

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -63,7 +63,8 @@
 
 // TODO(eryu): remove this GRPC_CFSTREAM condition when the CFEngine is ready.
 // The posix poller currently crashes iOS.
-#if defined(GRPC_POSIX_SOCKET_TCP) && !defined(GRPC_CFSTREAM)
+#if defined(GRPC_POSIX_SOCKET_TCP) && !defined(GRPC_CFSTREAM) && \
+    !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
 #define GRPC_PLATFORM_SUPPORTS_POSIX_POLLING true
 #else
 #define GRPC_PLATFORM_SUPPORTS_POSIX_POLLING false

--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -32,6 +32,7 @@ pyx_library(
         "cygrpc.pyx",
     ],
     data = [":copy_roots_pem"],
+    defines = ["GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER=1"],
     deps = [
         "//:grpc",
     ],


### PR DESCRIPTION
This is a hack to get around an issue on Apple devices caused by the PosixEventEngine's `poll` poller not supporting fork. This PR disables the EventEngine poller entirely in Python builds. It will therefore prevent the release of the EventEngine generally, and prevent any testing of EventEngine integration with gRPC Python, until the `poll` poller is fixed.