### PR TITLE
[PSM Interop] Fix an issue with restarting k8s runner

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -14,7 +14,6 @@
 """
 Run xDS Test Client on Kubernetes.
 """
-import datetime
 import logging
 from typing import Optional
 
@@ -151,7 +150,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
 
         # Verify the deployment reports all pods started as well.
         self._wait_deployment_with_available_replicas(self.deployment_name)
-        self.time_start_completed = datetime.datetime.now()
+        self._start_completed()
 
         return self._xds_test_client_for_pod(pod, server_target=server_target)
 
@@ -171,6 +170,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
 
     # pylint: disable=arguments-differ
     def cleanup(self, *, force=False, force_namespace=False):
+        # TODO(sergiitk): rename to stop().
         try:
             if self.deployment or force:
                 self._delete_deployment(self.deployment_name)
@@ -185,7 +185,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
                 self.service_account = None
             self._cleanup_namespace(force=force_namespace and force)
         finally:
-            self.time_stopped = datetime.datetime.now()
+            self._stop()
 
     # pylint: enable=arguments-differ
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -14,7 +14,6 @@
 """
 Run xDS Test Client on Kubernetes.
 """
-import datetime
 import logging
 from typing import List, Optional
 
@@ -197,7 +196,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
         # Verify the deployment reports all pods started as well.
         self._wait_deployment_with_available_replicas(self.deployment_name,
                                                       replica_count)
-        self.time_start_completed = datetime.datetime.now()
+        self._start_completed()
 
         servers: List[XdsTestServer] = []
         for pod in pods:
@@ -239,6 +238,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
 
     # pylint: disable=arguments-differ
     def cleanup(self, *, force=False, force_namespace=False):
+        # TODO(sergiitk): rename to stop().
         try:
             if self.deployment or force:
                 self._delete_deployment(self.deployment_name)
@@ -256,7 +256,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
                 self.service_account = None
             self._cleanup_namespace(force=(force_namespace and force))
         finally:
-            self.time_stopped = datetime.datetime.now()
+            self._stop()
 
     # pylint: enable=arguments-differ
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -512,8 +512,8 @@ class IsolatedXdsKubernetesTestCase(XdsKubernetesBaseTestCase,
             logger.exception('Got error during teardown')
         finally:
             logger.info('----- Test client/server logs -----')
-            self.client_runner.logs_explorer_link()
-            self.server_runner.logs_explorer_link()
+            self.client_runner.logs_explorer_run_history_links()
+            self.server_runner.logs_explorer_run_history_links()
 
             # Fail if any of the pods restarted.
             self.assertEqual(

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -395,7 +395,7 @@ class XdsUrlMapTestCase(absltest.TestCase, metaclass=_MetaXdsUrlMapTestCase):
         finally:
             if hasattr(cls, 'test_client_runner') and cls.test_client_runner:
                 logging.info('----- Test client logs -----')
-                cls.test_client_runner.logs_explorer_link()
+                cls.test_client_runner.logs_explorer_run_history_links()
 
             # Fail if any of the pods restarted.
             error_msg = (

--- a/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py
@@ -70,8 +70,11 @@ class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         rpc_distribution = collections.defaultdict(int)
         with self.subTest('07_start_test_client'):
             for i in range(_NUM_CLIENTS):
-                # Clean created client pods if there is any
-                self.client_runner.cleanup(force=True)
+                # Clean created client pods if there is any.
+                if self.client_runner.time_start_requested:
+                    # TODO(sergiitk): Speed up by reusing the namespace.
+                    self.client_runner.cleanup()
+
                 # Create a test client
                 test_client: _XdsTestClient = self.startTestClient(
                     test_servers[0])


### PR DESCRIPTION
Fixes the issue introduced in https://github.com/grpc/grpc/pull/33104, where stopping the current run didn't reset `self.time_start_requested`, `self.time_start_completed`, `self.time_start_stopped`. Because of this, the subsetting test (the only one [redeploying the client app](https://github.com/grpc/grpc/blob/10001d16a9d4f00c4c7962cb1c310c80d4b9c992/tools/run_tests/xds_k8s_test_driver/tests/subsetting_test.py#L73C1-L74)) started failing with:

```py
Traceback (most recent call last):
  File "xds_k8s_test_driver/tests/subsetting_test.py", line 76, in test_subsetting_basic
    test_client: _XdsTestClient = self.startTestClient(
  File "xds_k8s_test_driver/framework/xds_k8s_testcase.py", line 615, in startTestClient
    test_client = self.client_runner.run(server_target=test_server.xds_uri,
  File "xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_client_runner.py", line 110, in run
    super().run()
  File "xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py", line 112, in run
    raise RuntimeError(
RuntimeError: Deployment psm-grpc-client: has already been started at 2023-05-27T13:47:15.262461
```

This PR:
1. Instead of relying on the `time_start_requested`, `time_start_stopped` to produce GCP links, tracks the history run of each deployment. This fixes the issue described above, and adds support for listing all past runs executed by a k8s runner.
2. Minor: remove the unnecessary call to `test_client.cleanup()` when there's no past deployment runs (e.g. at the first iteration of `for i in range(_NUM_CLIENTS):`)
