### PR TITLE
[core] checking the status of thread creation

### DIFF
--- a/src/core/lib/gprpp/thd.h
+++ b/src/core/lib/gprpp/thd.h
@@ -85,14 +85,14 @@ class Thread {
   /// Normal constructor to create a thread with name \a thd_name,
   /// which will execute a thread based on function \a thd_body
   /// with argument \a arg once it is started.
-  /// The optional \a success argument indicates whether the thread
+  /// The \a success argument indicates whether the thread
   /// is successfully created.
   /// The optional \a options can be used to set the thread detachable.
   Thread(const char* thd_name, void (*thd_body)(void* arg), void* arg,
-         bool* success = nullptr, const Options& options = Options());
+         bool* success, const Options& options = Options());
 
-  Thread(const char* thd_name, absl::AnyInvocable<void()> fn,
-         bool* success = nullptr, const Options& options = Options())
+  Thread(const char* thd_name, absl::AnyInvocable<void()> fn, bool* success,
+         const Options& options = Options())
       : Thread(
             thd_name,
             [](void* p) {

--- a/src/core/lib/iomgr/ev_apple.cc
+++ b/src/core/lib/iomgr/ev_apple.cc
@@ -194,8 +194,10 @@ static void pollset_global_init(void) {
       grpc_apple_register_write_stream_run_loop;
 
   grpc_core::MutexLock lock(&gGlobalRunLoopContext->mu);
+  bool success = false;
   gGlobalRunLoopThread =
-      new grpc_core::Thread("apple_ev", GlobalRunLoopFunc, nullptr);
+      new grpc_core::Thread("apple_ev", GlobalRunLoopFunc, nullptr, &success);
+  GPR_ASSERT(success);
   gGlobalRunLoopThread->Start();
   while (gGlobalRunLoopContext->run_loop == NULL)
     gGlobalRunLoopContext->init_cv.Wait(&gGlobalRunLoopContext->mu);

--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -161,7 +161,10 @@ void Executor::SetThreading(bool threading) {
       thd_state_[i].elems = GRPC_CLOSURE_LIST_INIT;
     }
 
-    thd_state_[0].thd = Thread(name_, &Executor::ThreadMain, &thd_state_[0]);
+    bool success = false;
+    thd_state_[0].thd =
+        Thread(name_, &Executor::ThreadMain, &thd_state_[0], &success);
+    GPR_ASSERT(success);
     thd_state_[0].thd.Start();
   } else {  // !threading
     if (curr_num_threads == 0) {
@@ -350,13 +353,17 @@ void Executor::Enqueue(grpc_closure* closure, grpc_error_handle error,
     if (try_new_thread && gpr_spinlock_trylock(&adding_thread_lock_)) {
       cur_thread_count = static_cast<size_t>(gpr_atm_acq_load(&num_threads_));
       if (cur_thread_count < max_threads_) {
-        // Increment num_threads (safe to do a store instead of a cas because we
-        // always increment num_threads under the 'adding_thread_lock')
-        gpr_atm_rel_store(&num_threads_, cur_thread_count + 1);
-
+        bool success = false;
         thd_state_[cur_thread_count].thd =
-            Thread(name_, &Executor::ThreadMain, &thd_state_[cur_thread_count]);
-        thd_state_[cur_thread_count].thd.Start();
+            Thread(name_, &Executor::ThreadMain, &thd_state_[cur_thread_count],
+                   &success);
+        if (success) {
+          thd_state_[cur_thread_count].thd.Start();
+
+          // Increment num_threads (safe to do a store instead of a cas because
+          // we always increment num_threads under the 'adding_thread_lock')
+          gpr_atm_rel_store(&num_threads_, cur_thread_count + 1);
+        }
       }
       gpr_spinlock_unlock(&adding_thread_lock_);
     }

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -80,7 +80,7 @@ static void gc_completed_threads(void) {
   }
 }
 
-static void start_timer_thread_and_unlock(void) {
+static bool start_timer_thread_and_unlock(void) {
   GPR_ASSERT(g_threaded);
   ++g_waiter_count;
   ++g_thread_count;
@@ -90,8 +90,12 @@ static void start_timer_thread_and_unlock(void) {
   }
   completed_thread* ct =
       static_cast<completed_thread*>(gpr_malloc(sizeof(*ct)));
-  ct->thd = grpc_core::Thread("grpc_global_timer", timer_thread, ct);
-  ct->thd.Start();
+  bool success = false;
+  ct->thd = grpc_core::Thread("grpc_global_timer", timer_thread, ct, &success);
+  if (success) {
+    ct->thd.Start();
+  }
+  return success;
 }
 
 void grpc_timer_manager_tick() {
@@ -116,7 +120,13 @@ static void run_some_timers() {
     // The number of timer threads is always increasing until all the threads
     // are stopped. In rare cases, if a large number of timers fire
     // simultaneously, we may end up using a large number of threads.
-    start_timer_thread_and_unlock();
+    if (!start_timer_thread_and_unlock()) {
+      gpr_log(GPR_ERROR, "unable to start additional timer threads");
+      gpr_mu_lock(&g_mu);
+      --g_waiter_count;
+      --g_thread_count;
+      gpr_mu_unlock(&g_mu);
+    }
   } else {
     // if there's no thread waiting with a timeout, kick an existing untimed
     // waiter so that the next deadline is not missed
@@ -291,7 +301,7 @@ static void start_threads(void) {
   gpr_mu_lock(&g_mu);
   if (!g_threaded) {
     g_threaded = true;
-    start_timer_thread_and_unlock();
+    GPR_ASSERT(start_timer_thread_and_unlock());
   } else {
     gpr_mu_unlock(&g_mu);
   }

--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -126,9 +126,11 @@ FileWatcherAuthorizationPolicyProvider::FileWatcherAuthorizationPolicyProvider(
       }
     }
   };
+  bool success = false;
   refresh_thread_ = std::make_unique<Thread>(
       "FileWatcherAuthorizationPolicyProvider_refreshing_thread", thread_lambda,
-      WeakRef().release());
+      WeakRef().release(), &success);
+  GPR_ASSERT(success);
   refresh_thread_->Start();
 }
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -147,8 +147,10 @@ FileWatcherCertificateProvider::FileWatcherCertificateProvider(
       provider->ForceUpdate();
     }
   };
+  bool success = false;
   refresh_thread_ = Thread("FileWatcherCertificateProvider_refreshing_thread",
-                           thread_lambda, this);
+                           thread_lambda, this, &success);
+  GPR_ASSERT(success);
   refresh_thread_.Start();
   distributor_->SetWatchStatusCallback([this](std::string cert_name,
                                               bool root_being_watched,

--- a/src/core/tsi/alts/handshaker/alts_shared_resource.cc
+++ b/src/core/tsi/alts/handshaker/alts_shared_resource.cc
@@ -68,8 +68,10 @@ void grpc_alts_shared_resource_dedicated_start(
     grpc_channel_credentials_release(creds);
     g_alts_resource_dedicated.cq =
         grpc_completion_queue_create_for_next(nullptr);
-    g_alts_resource_dedicated.thread =
-        grpc_core::Thread("alts_tsi_handshaker", &thread_worker, nullptr);
+    bool success = false;
+    g_alts_resource_dedicated.thread = grpc_core::Thread(
+        "alts_tsi_handshaker", &thread_worker, nullptr, &success);
+    GPR_ASSERT(success);
     g_alts_resource_dedicated.interested_parties = grpc_pollset_set_create();
     grpc_pollset_set_add_pollset(g_alts_resource_dedicated.interested_parties,
                                  grpc_cq_pollset(g_alts_resource_dedicated.cq));

--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -43,8 +43,10 @@ void LoadReporterAsyncServiceImpl::CallableTag::Run(bool ok) {
 LoadReporterAsyncServiceImpl::LoadReporterAsyncServiceImpl(
     std::unique_ptr<ServerCompletionQueue> cq)
     : cq_(std::move(cq)) {
-  thread_ =
-      std::make_unique<grpc_core::Thread>("server_load_reporting", Work, this);
+  bool success = false;
+  thread_ = std::make_unique<grpc_core::Thread>("server_load_reporting", Work,
+                                                this, &success);
+  GPR_ASSERT(success);
   std::unique_ptr<CpuStatsProvider> cpu_stats_provider = nullptr;
 #if defined(GPR_LINUX) || defined(GPR_WINDOWS) || defined(GPR_APPLE)
   cpu_stats_provider = std::make_unique<CpuStatsProviderDefaultImpl>();

--- a/test/core/bad_client/bad_client.cc
+++ b/test/core/bad_client/bad_client.cc
@@ -238,7 +238,8 @@ void grpc_run_bad_client_test(
   a.validator = server_validator;
   // Start validator
 
-  grpc_core::Thread server_validator_thd("grpc_bad_client", thd_func, &a);
+  grpc_core::Thread server_validator_thd("grpc_bad_client", thd_func, &a,
+                                         nullptr);
   server_validator_thd.Start();
   for (int i = 0; i < num_args; i++) {
     grpc_run_client_side_validator(&args[i], i == (num_args - 1) ? flags : 0,

--- a/test/core/end2end/bad_server_response_test.cc
+++ b/test/core/end2end/bad_server_response_test.cc
@@ -310,8 +310,8 @@ static grpc_core::Thread* poll_server_until_read_done(
   poll_args* pa = static_cast<poll_args*>(gpr_malloc(sizeof(*pa)));
   pa->server = server;
   pa->signal_when_done = signal_when_done;
-  auto* th =
-      new grpc_core::Thread("grpc_poll_server", actually_poll_server, pa);
+  auto* th = new grpc_core::Thread("grpc_poll_server", actually_poll_server, pa,
+                                   nullptr);
   th->Start();
   return th;
 }

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -672,7 +672,8 @@ grpc_end2end_http_proxy* grpc_end2end_http_proxy_create(
   grpc_tcp_server_start(proxy->server, &proxy->pollset);
 
   // Start proxy thread.
-  proxy->thd = grpc_core::Thread("grpc_http_proxy", thread_main, proxy);
+  proxy->thd =
+      grpc_core::Thread("grpc_http_proxy", thread_main, proxy, nullptr);
   proxy->thd.Start();
   return proxy;
 }

--- a/test/core/end2end/fixtures/proxy.cc
+++ b/test/core/end2end/fixtures/proxy.cc
@@ -124,7 +124,8 @@ grpc_end2end_proxy* grpc_end2end_proxy_create(
   grpc_server_start(proxy->server);
 
   grpc_call_details_init(&proxy->new_call_details);
-  proxy->thd = grpc_core::Thread("grpc_end2end_proxy", thread_main, proxy);
+  proxy->thd =
+      grpc_core::Thread("grpc_end2end_proxy", thread_main, proxy, nullptr);
   proxy->thd.Start();
 
   request_call(proxy);

--- a/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
+++ b/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
@@ -197,13 +197,13 @@ PosixOracleEndpoint::PosixOracleEndpoint(int socket_fd)
       [](void* arg) {
         static_cast<PosixOracleEndpoint*>(arg)->ProcessReadOperations();
       },
-      this);
+      this, nullptr);
   write_ops_ = grpc_core::Thread(
       "write_ops_thread",
       [](void* arg) {
         static_cast<PosixOracleEndpoint*>(arg)->ProcessWriteOperations();
       },
-      this);
+      this, nullptr);
   read_ops_.Start();
   write_ops_.Start();
 }
@@ -320,7 +320,7 @@ absl::Status PosixOracleListener::Start() {
       [](void* arg) {
         static_cast<PosixOracleListener*>(arg)->HandleIncomingConnections();
       },
-      this);
+      this, nullptr);
   serve_.Start();
   return absl::OkStatus();
 }

--- a/test/core/gpr/cpu_test.cc
+++ b/test/core/gpr/cpu_test.cc
@@ -118,7 +118,7 @@ static void cpu_test(void) {
       static_cast<grpc_core::Thread*>(gpr_malloc(sizeof(*thd) * nthreads));
 
   for (i = 0; i < nthreads; i++) {
-    thd[i] = grpc_core::Thread("grpc_cpu_test", &worker_thread, &ct);
+    thd[i] = grpc_core::Thread("grpc_cpu_test", &worker_thread, &ct, nullptr);
     thd[i].Start();
   }
   gpr_mu_lock(&ct.mu);

--- a/test/core/gpr/spinlock_test.cc
+++ b/test/core/gpr/spinlock_test.cc
@@ -68,7 +68,7 @@ static void test_destroy(struct test* m) {
 static void test_create_threads(struct test* m, void (*body)(void* arg)) {
   int i;
   for (i = 0; i != m->thread_count; i++) {
-    m->threads[i] = grpc_core::Thread("grpc_create_threads", body, m);
+    m->threads[i] = grpc_core::Thread("grpc_create_threads", body, m, nullptr);
     m->threads[i].Start();
   }
 }

--- a/test/core/gpr/sync_test.cc
+++ b/test/core/gpr/sync_test.cc
@@ -195,7 +195,7 @@ static void test_destroy(struct test* m) {
 static void test_create_threads(struct test* m, void (*body)(void* arg)) {
   int i;
   for (i = 0; i != m->nthreads; i++) {
-    m->threads[i] = grpc_core::Thread("grpc_create_threads", body, m);
+    m->threads[i] = grpc_core::Thread("grpc_create_threads", body, m, nullptr);
     m->threads[i].Start();
   }
 }
@@ -256,7 +256,7 @@ static void test(const char* name, void (*body)(void* m),
     m = test_new(10, iterations, incr_step);
     grpc_core::Thread extra_thd;
     if (extra != nullptr) {
-      extra_thd = grpc_core::Thread(name, extra, m);
+      extra_thd = grpc_core::Thread(name, extra, m, nullptr);
       extra_thd.Start();
       m->done++;  // one more thread to wait for
     }

--- a/test/core/gprpp/fork_test.cc
+++ b/test/core/gprpp/fork_test.cc
@@ -76,8 +76,9 @@ TEST(ForkTest, ThdCount) {
   for (int i = 0; i < CONCURRENT_TEST_THREADS; i++) {
     intptr_t sleep_time_ms =
         (i * THREAD_DELAY_MS) / (CONCURRENT_TEST_THREADS - 1);
-    thds[i] = grpc_core::Thread("grpc_fork_test", sleeping_thd,
-                                reinterpret_cast<void*>(sleep_time_ms));
+    thds[i] =
+        grpc_core::Thread("grpc_fork_test", sleeping_thd,
+                          reinterpret_cast<void*>(sleep_time_ms), nullptr);
     thds[i].Start();
   }
   grpc_core::Fork::AwaitThreads();
@@ -116,8 +117,8 @@ TEST(ForkTest, ExecCount) {
 
   // Test that block_exec_ctx() blocks grpc_core::Fork::IncExecCtxCount
   bool exec_ctx_created = false;
-  grpc_core::Thread thd =
-      grpc_core::Thread("grpc_fork_test", exec_ctx_thread, &exec_ctx_created);
+  grpc_core::Thread thd = grpc_core::Thread("grpc_fork_test", exec_ctx_thread,
+                                            &exec_ctx_created, nullptr);
   grpc_core::Fork::IncExecCtxCount();
   ASSERT_TRUE(grpc_core::Fork::BlockExecCtx());
   grpc_core::Fork::DecExecCtxCount();

--- a/test/core/gprpp/mpscq_test.cc
+++ b/test/core/gprpp/mpscq_test.cc
@@ -87,7 +87,7 @@ TEST(MpscqTest, Mt) {
     ta[i].ctr = 0;
     ta[i].q = &q;
     ta[i].start = &start;
-    thds[i] = grpc_core::Thread("grpc_mt_test", test_thread, &ta[i]);
+    thds[i] = grpc_core::Thread("grpc_mt_test", test_thread, &ta[i], nullptr);
     thds[i].Start();
   }
   size_t num_done = 0;
@@ -155,7 +155,8 @@ TEST(MpscqTest, MtMultipop) {
     ta[i].ctr = 0;
     ta[i].q = &q;
     ta[i].start = &start;
-    thds[i] = grpc_core::Thread("grpc_multipop_test", test_thread, &ta[i]);
+    thds[i] =
+        grpc_core::Thread("grpc_multipop_test", test_thread, &ta[i], nullptr);
     thds[i].Start();
   }
   pull_args pa;
@@ -167,7 +168,8 @@ TEST(MpscqTest, MtMultipop) {
   pa.start = &start;
   gpr_mu_init(&pa.mu);
   for (size_t i = 0; i < GPR_ARRAY_SIZE(pull_thds); i++) {
-    pull_thds[i] = grpc_core::Thread("grpc_multipop_pull", pull_thread, &pa);
+    pull_thds[i] =
+        grpc_core::Thread("grpc_multipop_pull", pull_thread, &pa, nullptr);
     pull_thds[i].Start();
   }
   gpr_event_set(&start, reinterpret_cast<void*>(1));

--- a/test/core/gprpp/thd_test.cc
+++ b/test/core/gprpp/thd_test.cc
@@ -59,7 +59,7 @@ TEST(ThreadTest, CanCreateWaitAndJoin) {
   t.n = NUM_THREADS;
   t.is_done = 0;
   for (auto& th : thds) {
-    th = grpc_core::Thread("grpc_thread_body1_test", &thd_body1, &t);
+    th = grpc_core::Thread("grpc_thread_body1_test", &thd_body1, &t, nullptr);
     th.Start();
   }
   gpr_mu_lock(&t.mu);

--- a/test/core/gprpp/work_serializer_test.cc
+++ b/test/core/gprpp/work_serializer_test.cc
@@ -79,7 +79,8 @@ TEST(WorkSerializerTest, ExecuteOneScheduleAndDrain) {
 class TestThread {
  public:
   explicit TestThread(WorkSerializer* lock)
-      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this, nullptr) {
+      : lock_(lock),
+        thread_("grpc_execute_many", ExecuteManyLoop, this, nullptr) {
     gpr_event_init(&done_);
     thread_.Start();
   }
@@ -138,7 +139,8 @@ TEST(WorkSerializerTest, ExecuteMany) {
 class TestThreadScheduleAndDrain {
  public:
   explicit TestThreadScheduleAndDrain(WorkSerializer* lock)
-      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this, nullptr) {
+      : lock_(lock),
+        thread_("grpc_execute_many", ExecuteManyLoop, this, nullptr) {
     gpr_event_init(&done_);
     thread_.Start();
   }

--- a/test/core/gprpp/work_serializer_test.cc
+++ b/test/core/gprpp/work_serializer_test.cc
@@ -79,7 +79,7 @@ TEST(WorkSerializerTest, ExecuteOneScheduleAndDrain) {
 class TestThread {
  public:
   explicit TestThread(WorkSerializer* lock)
-      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this) {
+      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this, nullptr) {
     gpr_event_init(&done_);
     thread_.Start();
   }
@@ -138,7 +138,7 @@ TEST(WorkSerializerTest, ExecuteMany) {
 class TestThreadScheduleAndDrain {
  public:
   explicit TestThreadScheduleAndDrain(WorkSerializer* lock)
-      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this) {
+      : lock_(lock), thread_("grpc_execute_many", ExecuteManyLoop, this, nullptr) {
     gpr_event_init(&done_);
     thread_.Start();
   }

--- a/test/core/iomgr/combiner_test.cc
+++ b/test/core/iomgr/combiner_test.cc
@@ -105,7 +105,8 @@ TEST(CombinerTest, TestExecuteMany) {
     ta[i].ctr = 0;
     ta[i].lock = lock;
     gpr_event_init(&ta[i].done);
-    thds[i] = grpc_core::Thread("grpc_execute_many", execute_many_loop, &ta[i]);
+    thds[i] = grpc_core::Thread("grpc_execute_many", execute_many_loop, &ta[i],
+                                nullptr);
     thds[i].Start();
   }
   for (size_t i = 0; i < GPR_ARRAY_SIZE(thds); i++) {

--- a/test/core/iomgr/pollset_windows_starvation_test.cc
+++ b/test/core/iomgr/pollset_windows_starvation_test.cc
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
           gpr_cv_signal(&tparams->cv);
           gpr_mu_unlock(&tparams->mu);
         },
-        &params);
+        &params, nullptr);
     thd.Start();
     threads.push_back(std::move(thd));
   }

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -118,7 +118,8 @@ static void actually_poll(void* argsp) {
 }
 
 static void poll_pollset_until_request_done(args_struct* args) {
-  args->thd = grpc_core::Thread("grpc_poll_pollset", actually_poll, args);
+  args->thd =
+      grpc_core::Thread("grpc_poll_pollset", actually_poll, args, nullptr);
   args->thd.Start();
 }
 

--- a/test/core/network_benchmarks/low_level_ping_pong.cc
+++ b/test/core/network_benchmarks/low_level_ping_pong.cc
@@ -595,7 +595,8 @@ static int run_benchmark(const char* socket_type, thread_args* client_args,
   gpr_log(GPR_INFO, "Starting test %s %s %zu", client_args->strategy_name,
           socket_type, client_args->msg_size);
 
-  grpc_core::Thread server("server_thread", server_thread_wrap, server_args);
+  grpc_core::Thread server("server_thread", server_thread_wrap, server_args,
+                           nullptr);
   server.Start();
   client_thread(client_args);
   server.Join();

--- a/test/core/resource_quota/arena_test.cc
+++ b/test/core/resource_quota/arena_test.cc
@@ -132,7 +132,7 @@ TEST_F(ArenaTest, ConcurrentAlloc) {
             *static_cast<char*>(a->arena->Alloc(1)) = static_cast<char>(i);
           }
         },
-        &args);
+        &args, nullptr);
     thds[i].Start();
   }
 
@@ -163,7 +163,7 @@ TEST_F(ArenaTest, ConcurrentManagedNew) {
                 std::make_unique<int>(static_cast<int>(i)));
           }
         },
-        &args);
+        &args, nullptr);
     thds[i].Start();
   }
 
@@ -285,7 +285,7 @@ TEST_F(ArenaTest, ConcurrentMakePooled) {
             EXPECT_EQ(a->arena->MakePooled<Type1>()->Foo(), 1);
           }
         },
-        &args);
+        &args, nullptr);
     thds1[i].Start();
 
     thds2[i] = Thread(
@@ -297,7 +297,7 @@ TEST_F(ArenaTest, ConcurrentMakePooled) {
             EXPECT_EQ(a->arena->MakePooled<Type2>()->Foo(), 2);
           }
         },
-        &args);
+        &args, nullptr);
     thds2[i].Start();
   }
 

--- a/test/core/surface/completion_queue_threading_test.cc
+++ b/test/core/surface/completion_queue_threading_test.cc
@@ -103,8 +103,8 @@ static void test_too_many_plucks(void) {
     }
     thread_states[i].cc = cc;
     thread_states[i].tag = tags[i];
-    threads[i] =
-        grpc_core::Thread("grpc_pluck_test", pluck_one, thread_states + i);
+    threads[i] = grpc_core::Thread("grpc_pluck_test", pluck_one,
+                                   thread_states + i, nullptr);
     threads[i].Start();
   }
 

--- a/test/core/surface/concurrent_connectivity_test.cc
+++ b/test/core/surface/concurrent_connectivity_test.cc
@@ -198,7 +198,7 @@ TEST(ConcurrentConnectivityTest, RunConcurrentConnectivityTest) {
     args.addr = "localhost:54321";
     for (auto& th : threads) {
       th = grpc_core::Thread("grpc_wave_1", create_loop_destroy,
-                             const_cast<char*>(args.addr.c_str()));
+                             const_cast<char*>(args.addr.c_str()), nullptr);
       th.Start();
     }
     for (auto& th : threads) {
@@ -219,13 +219,14 @@ TEST(ConcurrentConnectivityTest, RunConcurrentConnectivityTest) {
     args.cq = grpc_completion_queue_create_for_next(nullptr);
     grpc_server_register_completion_queue(args.server, args.cq, nullptr);
     grpc_server_start(args.server);
-    grpc_core::Thread server2("grpc_wave_2_server", server_thread, &args);
+    grpc_core::Thread server2("grpc_wave_2_server", server_thread, &args,
+                              nullptr);
     server2.Start();
 
     grpc_core::Thread threads[NUM_THREADS];
     for (auto& th : threads) {
       th = grpc_core::Thread("grpc_wave_2", create_loop_destroy,
-                             const_cast<char*>(args.addr.c_str()));
+                             const_cast<char*>(args.addr.c_str()), nullptr);
       th.Start();
     }
     for (auto& th : threads) {
@@ -245,14 +246,15 @@ TEST(ConcurrentConnectivityTest, RunConcurrentConnectivityTest) {
     grpc_pollset_init(pollset, &args.mu);
     args.pollset.push_back(pollset);
     gpr_event_init(&args.ready);
-    grpc_core::Thread server3("grpc_wave_3_server", bad_server_thread, &args);
+    grpc_core::Thread server3("grpc_wave_3_server", bad_server_thread, &args,
+                              nullptr);
     server3.Start();
     gpr_event_wait(&args.ready, gpr_inf_future(GPR_CLOCK_MONOTONIC));
 
     grpc_core::Thread threads[NUM_THREADS];
     for (auto& th : threads) {
       th = grpc_core::Thread("grpc_wave_3", create_loop_destroy,
-                             const_cast<char*>(args.addr.c_str()));
+                             const_cast<char*>(args.addr.c_str()), nullptr);
       th.Start();
     }
     for (auto& th : threads) {
@@ -307,7 +309,7 @@ TEST(ConcurrentConnectivityTest, RunConcurrentWatchesWithShortTimeoutsTest) {
   grpc_core::Thread threads[NUM_THREADS];
   for (auto& th : threads) {
     th = grpc_core::Thread("grpc_short_watches", watches_with_short_timeouts,
-                           const_cast<char*>("localhost:54321"));
+                           const_cast<char*>("localhost:54321"), nullptr);
     th.Start();
   }
   for (auto& th : threads) {

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -107,7 +107,8 @@ static void run_test(const test_fixture* fixture, bool share_subchannel) {
   grpc_server_start(server);
 
   server_thread_args sta = {server, server_cq};
-  grpc_core::Thread server_thread("grpc_server", server_thread_func, &sta);
+  grpc_core::Thread server_thread("grpc_server", server_thread_func, &sta,
+                                  nullptr);
   server_thread.Start();
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);

--- a/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
+++ b/test/core/transport/binder/end2end/end2end_binder_transport_test.cc
@@ -474,7 +474,7 @@ TEST_P(End2EndBinderTransportTest, BiDirStreamingCall) {
   };
 
   grpc_core::Thread writer_thread("writer-thread", writer_fn,
-                                  static_cast<void*>(&writer_args));
+                                  static_cast<void*>(&writer_args), nullptr);
   writer_thread.Start();
   for (size_t i = 0; i < kBiDirStreamingCounts; ++i) {
     grpc::testing::EchoResponse response;
@@ -522,7 +522,7 @@ TEST_P(End2EndBinderTransportTest,
   };
 
   grpc_core::Thread writer_thread("writer-thread", writer_fn,
-                                  static_cast<void*>(&writer_args));
+                                  static_cast<void*>(&writer_args), nullptr);
   writer_thread.Start();
   for (size_t i = 0; i < kBiDirStreamingCounts / 2; ++i) {
     grpc::testing::EchoResponse response;

--- a/test/core/transport/binder/end2end/fake_binder.cc
+++ b/test/core/transport/binder/end2end/fake_binder.cc
@@ -162,7 +162,7 @@ TransactionProcessor::TransactionProcessor(absl::Duration delay)
             auto* self = static_cast<TransactionProcessor*>(arg);
             self->ProcessLoop();
           },
-          this),
+          this, nullptr),
       terminated_(false) {
   tx_thread_.Start();
 }

--- a/test/core/transport/binder/end2end/fake_binder_test.cc
+++ b/test/core/transport/binder/end2end/fake_binder_test.cc
@@ -328,7 +328,8 @@ TEST_P(FakeBinderTest, StressTest) {
     args[i].num_transactions_per_pair = kNumTransactionsPerPair;
     args[i].mu = &mu;
     thr_names[i] = absl::StrFormat("thread-%d", i);
-    thrs[i] = grpc_core::Thread(thr_names[i].c_str(), th_function, &args[i]);
+    thrs[i] =
+        grpc_core::Thread(thr_names[i].c_str(), th_function, &args[i], nullptr);
   }
   for (auto& th : thrs) th.Start();
   for (auto& th : thrs) th.Join();

--- a/test/core/transport/binder/end2end/testing_channel_create.cc
+++ b/test/core/transport/binder/end2end/testing_channel_create.cc
@@ -85,7 +85,7 @@ CreateClientServerBindersPairForTesting() {
             std::make_shared<
                 grpc::experimental::binder::UntrustedSecurityPolicy>());
       },
-      &args);
+      &args, nullptr);
   client_thread.Start();
   grpc_transport* server_transport = grpc_create_binder_transport_server(
       helper.WaitForClientBinder(),

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -1074,7 +1074,7 @@ TEST(AltsTsiHandshakerTest, CheckHandshakerNextFailsAfterShutdown) {
   cb_event = nullptr;
   // Tests.
   grpc_core::Thread thd("alts_tsi_handshaker_test",
-                        &check_handle_response_with_shutdown, nullptr);
+                        &check_handle_response_with_shutdown, nullptr, nullptr);
   thd.Start();
   check_handshaker_next_with_shutdown();
   thd.Join();
@@ -1090,7 +1090,7 @@ TEST(AltsTsiHandshakerTest, CheckHandshakerSuccess) {
   notification_init(&tsi_to_caller_notification);
   // Tests.
   grpc_core::Thread thd("alts_tsi_handshaker_test",
-                        &check_handle_response_success, nullptr);
+                        &check_handle_response_success, nullptr, nullptr);
   thd.Start();
   check_handshaker_next_success();
   thd.Join();

--- a/test/core/util/tls_utils.h
+++ b/test/core/util/tls_utils.h
@@ -105,7 +105,8 @@ class AsyncExternalVerifier {
  public:
   explicit AsyncExternalVerifier(bool success)
       : success_(success),
-        thread_("AsyncExternalVerifierWorkerThread", WorkerThread, this),
+        thread_("AsyncExternalVerifierWorkerThread", WorkerThread, this,
+                nullptr),
         base_{this, Verify, Cancel, Destruct} {
     grpc_init();
     thread_.Start();

--- a/test/cpp/util/tls_test_utils.cc
+++ b/test/cpp/util/tls_test_utils.cc
@@ -41,7 +41,8 @@ bool SyncCertificateVerifier::Verify(TlsCustomVerificationCheckRequest*,
 
 AsyncCertificateVerifier::AsyncCertificateVerifier(bool success)
     : success_(success),
-      thread_("AsyncCertificateVerifierWorkerThread", WorkerThread, this) {
+      thread_("AsyncCertificateVerifierWorkerThread", WorkerThread, this,
+              nullptr) {
   thread_.Start();
 }
 


### PR DESCRIPTION
It is possible for allocation of a system resource to fail. While the Thread abstraction in the core allows for a 'success' parameter, it is optional and not generally checked where used. This can lead to degenerate behavior which is hard to diagnose. In particular, the Executors assign Closures to their queues regardless of whether the thread handling to queue is actually running, leading those async requests to hang.

This change makes the 'success' parameter required and tries to make the correct decision on how to proceed in the code where those Threads are started.  For the Executor, we will attempt to carry on with the number of threads we were able to create.  In other areas, we assert, assuming that whatever function is being performed by the allocated thread is critical to the overall function of the library.

For the tests, we ignore the value of 'success' as we assume the tests will fail if thread creation failed. This is no different than the existing behavior.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

