### PR TITLE
[Test] Disable gcc10.2_openssl102 from portability tests

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -302,7 +302,9 @@ def _create_portability_test_jobs(extra_args=[],
     for compiler in [
             'gcc7',
             # 'gcc10.2_openssl102', // TODO(b/283304471): Enable this later
-            'gcc12', 'gcc_musl', 'clang6',
+            'gcc12',
+            'gcc_musl',
+            'clang6',
             'clang15'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -300,7 +300,9 @@ def _create_portability_test_jobs(extra_args=[],
 
     # portability C and C++ on x64
     for compiler in [
-            'gcc7', 'gcc10.2_openssl102', 'gcc12', 'gcc_musl', 'clang6',
+            'gcc7',
+            # 'gcc10.2_openssl102', // TODO(b/283304471): Enable this later
+            'gcc12', 'gcc_musl', 'clang6',
             'clang15'
     ]:
         test_jobs += _generate_jobs(languages=['c', 'c++'],


### PR DESCRIPTION
b/283304471: Currently h2_ssl_cert_test failing under openssl102 so this is being disabled temporarily until it's fixed.