### PR TITLE
[PSM interop] Don't fail target if sub-target already failed (#33222) (v1.49.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
@@ -174,9 +174,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
@@ -166,9 +166,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_xlang.sh
@@ -131,9 +131,6 @@ main() {
   set +x
   echo "Failed test suites list: ${failed_string}"
   echo "Successful test suites list: ${successful_string}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/tools/internal_ci/linux/psm-security-python.sh
+++ b/tools/internal_ci/linux/psm-security-python.sh
@@ -179,9 +179,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"

--- a/tools/internal_ci/linux/psm-security.sh
+++ b/tools/internal_ci/linux/psm-security.sh
@@ -163,9 +163,6 @@ main() {
     run_test $test || (( ++failed_tests ))
   done
   echo "Failed test suites: ${failed_tests}"
-  if (( failed_tests > 0 )); then
-    exit 1
-  fi
 }
 
 main "$@"


### PR DESCRIPTION
Backport of #33222 to v1.49.x.
---
We configured TestGrid to file bug separately for each failed sub-target, if we still fail the main target, TestGrid will fail duplicate bugs.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

