### PR TITLE
[EventEngine] Enable work stealing thread pool generally

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -28,7 +28,6 @@ EXPERIMENTS = {
             "event_engine_listener",
             "promise_based_client_call",
             "promise_based_server_call",
-            "work_stealing",
         ],
         "cpp_end2end_test": [
             "promise_based_server_call",
@@ -61,5 +60,8 @@ EXPERIMENTS = {
         ],
     },
     "on": {
+        "core_end2end_test": [
+            "work_stealing",
+        ],
     },
 }

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -125,7 +125,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, false, false},
     {"work_stealing", description_work_stealing,
-     additional_constraints_work_stealing, false, false},
+     additional_constraints_work_stealing, true, false},
     {"client_privacy", description_client_privacy,
      additional_constraints_client_privacy, false, false},
     {"canary_client_privacy", description_canary_client_privacy,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -73,7 +73,8 @@ inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
-inline bool IsWorkStealingEnabled() { return false; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_WORK_STEALING
+inline bool IsWorkStealingEnabled() { return true; }
 inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsCanaryClientPrivacyEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -53,7 +53,7 @@
 - name: event_engine_dns
   default: false
 - name: work_stealing
-  default: false
+  default: true
 - name: client_privacy
   default: false
 - name: canary_client_privacy


### PR DESCRIPTION
To be merged after a few more days of flake-free CI experiment runs, not before June 5th, 2023.