### PR TITLE
[Bazel Python3.11] Update Bazel dependencies for Python 3.11

### DIFF
--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -39,9 +39,9 @@ def grpc_python_deps():
         http_archive(
             name = "cython",
             build_file = "@com_github_grpc_grpc//third_party:cython.BUILD",
-            sha256 = "bb72b2f0ef029472759c711f0a4bded6e15e3f9bda3797550cef3c1d87d02283",
-            strip_prefix = "cython-0.29.26",
+            sha256 = "a2da56cc22be823acf49741b9aa3aa116d4f07fa8e8b35a3cb08b8447b37c607",
+            strip_prefix = "cython-0.29.35",
             urls = [
-                "https://github.com/cython/cython/archive/0.29.26.tar.gz",
+                "https://github.com/cython/cython/archive/0.29.35.tar.gz",
             ],
         )

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -11,7 +11,7 @@ chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
 googleapis-common-protos==1.5.5
-gevent==21.12.0
+gevent==22.08.0
 zope.event==4.5.0
 setuptools==44.1.1
 xds-protos==0.0.11


### PR DESCRIPTION
We just found out that our current Bazel setup does not support Python 3.11.

Thus PR updates some dependencies to allow using Bazel in Python 3.11.

Cython:
 * Cython [backported Python 3.11 support change to 0.29x](https://github.com/cython/cython/issues/4500), but it appears that the Cython version we are using in Bazel does not include the fix, so we're using the latest stable version instead.

Gevent:
* The first version of gevent that supports [Python 3.11 is 22.08.0](https://github.com/gevent/gevent/issues/1903#issuecomment-1303227507).

#### Testing
* Tested locally using Python 3.11 virtual environment, was able to reproduce the issue and verified that those changes were able to fix it.