### PR TITLE
[Rls] Backport "[Rls] de-experimentalize RLS in XDS (#33290)" to v1.56.x

### DIFF
--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -80,10 +80,10 @@
 
 namespace grpc_core {
 
-// TODO(donnadionne): Remove once RLS is no longer experimental
+// TODO(apolcyn): remove this flag by the 1.58 release
 bool XdsRlsEnabled() {
   auto value = GetEnv("GRPC_EXPERIMENTAL_XDS_RLS_LB");
-  if (!value.has_value()) return false;
+  if (!value.has_value()) return true;
   bool parsed_value;
   bool parse_succeeded = gpr_parse_bool_value(value->c_str(), &parsed_value);
   return parse_succeeded && parsed_value;

--- a/test/core/xds/xds_route_config_resource_type_test.cc
+++ b/test/core/xds/xds_route_config_resource_type_test.cc
@@ -1886,6 +1886,7 @@ TEST_F(RlsTest, NotUsedInAllVirtualHosts) {
 }
 
 TEST_F(RlsTest, ClusterSpecifierPluginsIgnoredWhenNotEnabled) {
+  testing::ScopedEnvVar env_var("GRPC_EXPERIMENTAL_XDS_RLS_LB", "false");
   RouteConfiguration route_config;
   route_config.set_name("foo");
   auto* cluster_specifier_plugin = route_config.add_cluster_specifier_plugins();

--- a/test/cpp/end2end/xds/xds_rls_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_rls_end2end_test.cc
@@ -163,6 +163,8 @@ TEST_P(RlsTest, XdsRoutingClusterSpecifierPlugin) {
 }
 
 TEST_P(RlsTest, XdsRoutingClusterSpecifierPluginDisabled) {
+  grpc_core::testing::ScopedEnvVar env_var("GRPC_EXPERIMENTAL_XDS_RLS_LB",
+                                           "false");
   CreateAndStartBackends(1);
   // Populate new EDS resources.
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends()}});


### PR DESCRIPTION
Backport #33290 to 1.56.x.