### PR TITLE
[fuzzing] Tune down max delay

### DIFF
--- a/test/core/end2end/end2end_test_fuzzer.cc
+++ b/test/core/end2end/end2end_test_fuzzer.cc
@@ -121,7 +121,7 @@ DEFINE_PROTO_FUZZER(const core_end2end_test_fuzzer::Msg& msg) {
   grpc_event_engine::experimental::SetEventEngineFactory(
       [actions = msg.event_engine_actions()]() {
         FuzzingEventEngine::Options options;
-        options.max_delay_run_after = std::chrono::milliseconds(1500);
+        options.max_delay_run_after = std::chrono::milliseconds(500);
         return std::make_unique<FuzzingEventEngine>(options, actions);
       });
   auto engine =


### PR DESCRIPTION
This had been intended to be 500ms for the first round, but inadvertently got bumped up during some last minute investigations.

Tune it back down, let things settle out, and then see whether we want to increase it or not.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

