### PR TITLE
[PSM Interop] Improve assertRpcStatusCodes before/after stats logging

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -352,7 +352,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         #    the expected_status.
         self.assertGreater(stats.result[expected_status_int],
                            0,
-                           msg=("Expected non-zero RPCs with status"
+                           msg=("Expected non-zero completed RPCs with status"
                                 f" {expected_status_fmt} for method {method}."
                                 f"\nDiff stats:\n{diff_stats_fmt}"))
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -337,7 +337,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
             found_status = helpers_grpc.status_from_int(found_status_int)
             if found_status != expected_status and count > stray_rpc_limit:
                 self.fail(f"Expected only status {expected_status_fmt},"
-                          f" but found status"
+                          " but found status"
                           f" {helpers_grpc.status_pretty(found_status)}"
                           f" for method {method}."
                           f"\nDiff stats:\n{diff_stats_fmt}")

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -336,32 +336,19 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         for found_status_int, count in stats.result.items():
             found_status = helpers_grpc.status_from_int(found_status_int)
             if found_status != expected_status and count > stray_rpc_limit:
-                found_status_fmt = helpers_grpc.status_pretty(found_status)
-                logger.error(
-                    "Expected only status %s, but found status %s"
-                    " for method %s.\nDiff stats:\n%s"
-                    "\n(Stats below are for debugging purposes only)"
-                    "\nStats before:\n%s"
-                    "\nStats after:\n%s", expected_status_fmt, found_status_fmt,
-                    method, diff_stats_fmt, before_stats_fmt, after_stats_fmt)
                 self.fail(f"Expected only status {expected_status_fmt},"
-                          f" but found status {found_status_fmt}"
+                          f" but found status"
+                          f" {helpers_grpc.status_pretty(found_status)}"
                           f" for method {method}."
                           f"\nDiff stats:\n{diff_stats_fmt}")
 
         # 2. Verify there are completed RPCs of the given method with
         #    the expected_status.
-        if not stats.result[expected_status_int]:
-            logger.error(
-                "Expected non-zero RPCs with status %s for method %s."
-                "\nDiff stats:\n%s"
-                "\n(Stats below are for debugging purposes only)"
-                "\nStats before:\n%s"
-                "\nStats after:\n%s", expected_status_fmt, method,
-                diff_stats_fmt, before_stats_fmt, after_stats_fmt)
-            self.fail("Expected non-zero RPCs with status"
-                      f" {expected_status_fmt} for method {method}."
-                      f"\nDiff stats:\n{diff_stats_fmt}")
+        self.assertGreater(stats.result[expected_status_int],
+                           0,
+                           msg=("Expected non-zero RPCs with status"
+                                f" {expected_status_fmt} for method {method}."
+                                f"\nDiff stats:\n{diff_stats_fmt}"))
 
     def assertRpcsEventuallyGoToGivenServers(self,
                                              test_client: XdsTestClient,

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -301,6 +301,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
                              method: str,
                              stray_rpc_limit: int = 0) -> None:
         """Assert all RPCs for a method are completing with a certain status."""
+        # pylint: disable=too-many-locals
         expected_status_int: int = expected_status.value[0]
         expected_status_fmt: str = helpers_grpc.status_pretty(expected_status)
 
@@ -353,7 +354,7 @@ class XdsKubernetesBaseTestCase(absltest.TestCase):
         if not stats.result[expected_status_int]:
             logger.error(
                 "Expected non-zero RPCs with status %s for method %s."
-                f"\nDiff stats:\n%s"
+                "\nDiff stats:\n%s"
                 "\n(Stats below are for debugging purposes only)"
                 "\nStats before:\n%s"
                 "\nStats after:\n%s", expected_status_fmt, method,


### PR DESCRIPTION
Do not clutter the final error we see at the end with the before/after stats. 

#### Examples

###### Expected only status A, but found status B for method M:

```
[  FAILED  ] CustomLbTest.test_custom_lb_config
======================================================================
FAIL: test_custom_lb_config (__main__.CustomLbTest)
CustomLbTest.test_custom_lb_config
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sergiitk/Development/grpc/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py", line 113, in test_custom_lb_config
    self.assertRpcStatusCodes(test_client,
  File "/Users/sergiitk/Development/grpc/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py", line 345, in assertRpcStatusCodes
    found_status = helpers_grpc.status_from_int(found_status_int)
AssertionError: Expected only status (15, DATA_LOSS), but found status (0, OK) for method UNARY_CALL.
Diff stats:
- method: UNARY_CALL
  rpcs_started: 251
  result:
    (0, OK): 251
```

###### Expected non-zero RPCs with status A for method M.
```
[  FAILED  ] AuthzTest.test_plaintext_allow
======================================================================
FAIL: test_plaintext_allow (__main__.AuthzTest)
AuthzTest.test_plaintext_allow
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sergiitk/Development/grpc/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py", line 224, in test_plaintext_allow
    self.configure_and_assert(test_client, 'host-wildcard',
  File "/Users/sergiitk/Development/grpc/tools/run_tests/xds_k8s_test_driver/tests/authz_test.py", line 204, in configure_and_assert
    self.assertRpcStatusCodes(test_client,
  File "/Users/sergiitk/Development/grpc/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py", line 355, in assertRpcStatusCodes
    self.assertGreater(stats.result[expected_status_int],
AssertionError: 0 not greater than 0 : Expected non-zero completed RPCs with status (0, OK) for method EMPTY_CALL.
Diff stats:
- method: EMPTY_CALL
  rpcs_started: 13
  result: {}
```