### PR TITLE
[python O11Y] Add OpenCensus StackDriver exporter

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -3,16 +3,15 @@ coverage==4.5.4
 cython==0.29.21
 protobuf>=3.5.0.post1, < 4.0dev
 wheel==0.38.1
-google-auth==1.24.0
 oauth2client==4.1.0
 requests==2.25.1
 urllib3==1.26.5
 chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
-googleapis-common-protos==1.5.5
 gevent==22.08.0
 zope.event==4.5.0
 setuptools==44.1.1
 xds-protos==0.0.11
 opencensus==0.10.0
+opencensus-ext-stackdriver==0.8.0

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1122,6 +1122,8 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         if state is None:
             raise rendezvous  # pylint: disable-msg=raising-bad-type
         else:
+            state.rpc_start_time = datetime.utcnow()
+            state.method = _common.decode(self._method)
             call = self._channel.segregated_call(
                 cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
                 self._method,
@@ -1137,8 +1139,6 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
                 ),
                 self._context,
             )
-            state.rpc_start_time = datetime.utcnow()
-            state.method = _common.decode(self._method)
             event = call.next_event()
             _handle_event(event, state, self._response_deserializer)
             return state, call
@@ -1193,6 +1193,8 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
             raise rendezvous  # pylint: disable-msg=raising-bad-type
         else:
             event_handler = _event_handler(state, self._response_deserializer)
+            state.rpc_start_time = datetime.utcnow()
+            state.method = _common.decode(self._method)
             call = self._managed_call(
                 cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
                 self._method,
@@ -1204,8 +1206,6 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
                 event_handler,
                 self._context,
             )
-            state.rpc_start_time = datetime.utcnow()
-            state.method = _common.decode(self._method)
             return _MultiThreadedRendezvous(
                 state, call, self._response_deserializer, deadline
             )
@@ -1277,6 +1277,8 @@ class _SingleThreadedUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
             (cygrpc.ReceiveInitialMetadataOperation(_EMPTY_FLAGS),),
         )
         operations_and_tags = tuple((ops, None) for ops in operations)
+        state.rpc_start_time = datetime.utcnow()
+        state.method = _common.decode(self._method)
         call = self._channel.segregated_call(
             cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
             self._method,
@@ -1287,8 +1289,6 @@ class _SingleThreadedUnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
             operations_and_tags,
             self._context,
         )
-        state.rpc_start_time = datetime.utcnow()
-        state.method = _common.decode(self._method)
         return _SingleThreadedRendezvous(
             state, call, self._response_deserializer, deadline
         )
@@ -1353,6 +1353,8 @@ class _UnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
                 ),
                 (cygrpc.ReceiveInitialMetadataOperation(_EMPTY_FLAGS),),
             )
+            state.rpc_start_time = datetime.utcnow()
+            state.method = _common.decode(self._method)
             call = self._managed_call(
                 cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
                 self._method,
@@ -1364,8 +1366,6 @@ class _UnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
                 _event_handler(state, self._response_deserializer),
                 self._context,
             )
-            state.rpc_start_time = datetime.utcnow()
-            state.method = _common.decode(self._method)
             return _MultiThreadedRendezvous(
                 state, call, self._response_deserializer, deadline
             )
@@ -1412,6 +1412,8 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         augmented_metadata = _compression.augment_metadata(
             metadata, compression
         )
+        state.rpc_start_time = datetime.utcnow()
+        state.method = _common.decode(self._method)
         call = self._channel.segregated_call(
             cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
             self._method,
@@ -1424,8 +1426,6 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
             ),
             self._context,
         )
-        state.rpc_start_time = datetime.utcnow()
-        state.method = _common.decode(self._method)
         _consume_request_iterator(
             request_iterator, state, call, self._request_serializer, None
         )
@@ -1500,6 +1500,8 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         augmented_metadata = _compression.augment_metadata(
             metadata, compression
         )
+        state.rpc_start_time = datetime.utcnow()
+        state.method = _common.decode(self._method)
         call = self._managed_call(
             cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
             self._method,
@@ -1513,8 +1515,6 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
             event_handler,
             self._context,
         )
-        state.rpc_start_time = datetime.utcnow()
-        state.method = _common.decode(self._method)
         _consume_request_iterator(
             request_iterator,
             state,
@@ -1578,6 +1578,8 @@ class _StreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
             (cygrpc.ReceiveInitialMetadataOperation(_EMPTY_FLAGS),),
         )
         event_handler = _event_handler(state, self._response_deserializer)
+        state.rpc_start_time = datetime.utcnow()
+        state.method = _common.decode(self._method)
         call = self._managed_call(
             cygrpc.PropagationConstants.GRPC_PROPAGATE_DEFAULTS,
             self._method,
@@ -1589,8 +1591,6 @@ class _StreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
             event_handler,
             self._context,
         )
-        state.rpc_start_time = datetime.utcnow()
-        state.method = _common.decode(self._method)
         _consume_request_iterator(
             request_iterator,
             state,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -78,6 +78,10 @@ cdef class _CallState:
     _observability.delete_call_tracer(self.call_tracer_capsule)
 
   cdef void maybe_set_client_call_tracer_on_call(self, bytes method_name) except *:
+    # TODO(xuanwn): use channel args to exclude those metrics.
+    for exclude_prefix in _observability._SERVICES_TO_EXCLUDE:
+      if exclude_prefix in method_name:
+        return
     with _observability.get_plugin() as plugin:
       if not (plugin and plugin.observability_enabled):
         return

--- a/src/python/grpcio_observability/grpc_observability/BUILD.bazel
+++ b/src/python/grpcio_observability/grpc_observability/BUILD.bazel
@@ -74,7 +74,7 @@ py_library(
     ],
     srcs_version = "PY3ONLY",
     visibility = [
-        "//:__subpackages__"
+        "//:__subpackages__",
     ],
     deps = [
         ":cyobservability",

--- a/src/python/grpcio_observability/grpc_observability/BUILD.bazel
+++ b/src/python/grpcio_observability/grpc_observability/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 load("//bazel:cython_library.bzl", "pyx_library")
 
 package(default_visibility = ["//visibility:public"])
@@ -59,14 +60,11 @@ py_library(
     name = "pyobservability",
     srcs = [
         "__init__.py",
-        "_observability.py",
         "_gcp_observability.py",
+        "_measures.py",
+        "_observability.py",
         "_open_census_exporter.py",
-        # The fllowing files are used only for OC stackdriver extension.
-        # TODO(xuanwn): Uncomment after those files are implemented.
-        # "_measures.py",
-        # "_open_census.py",
-        # "_views.py",
+        "_views.py",
     ],
     imports = [
         ".",
@@ -76,5 +74,7 @@ py_library(
     deps = [
         ":cyobservability",
         "//src/python/grpcio/grpc:grpcio",
+        requirement("opencensus"),
+        requirement("opencensus-ext-stackdriver"),
     ],
 )

--- a/src/python/grpcio_observability/grpc_observability/BUILD.bazel
+++ b/src/python/grpcio_observability/grpc_observability/BUILD.bazel
@@ -74,7 +74,8 @@ py_library(
     ],
     srcs_version = "PY3ONLY",
     visibility = [
-        "//:__subpackages__"],
+        "//:__subpackages__"
+    ],
     deps = [
         ":cyobservability",
         "//src/python/grpcio/grpc:grpcio",

--- a/src/python/grpcio_observability/grpc_observability/BUILD.bazel
+++ b/src/python/grpcio_observability/grpc_observability/BUILD.bazel
@@ -56,6 +56,8 @@ pyx_library(
     ],
 )
 
+# Since `opencensus` and `opencensus-ext-stackdriver` are non-hermetic,
+# pyobservability is for internal use only.
 py_library(
     name = "pyobservability",
     srcs = [
@@ -71,6 +73,8 @@ py_library(
         "../",
     ],
     srcs_version = "PY3ONLY",
+    visibility = [
+        "//:__subpackages__"],
     deps = [
         ":cyobservability",
         "//src/python/grpcio/grpc:grpcio",

--- a/src/python/grpcio_observability/grpc_observability/_cyobservability.pxd
+++ b/src/python/grpcio_observability/grpc_observability/_cyobservability.pxd
@@ -126,6 +126,7 @@ cdef extern from "constants.h" namespace "grpc_observability":
     kRpcClientReceivedMessagesPerRpcMeasureName
     kRpcClientReceivedBytesPerRpcMeasureName
     kRpcClientRoundtripLatencyMeasureName
+    kRpcClientCompletedRpcMeasureName
     kRpcClientServerLatencyMeasureName
     kRpcClientStartedRpcsMeasureName
     kRpcClientRetriesPerCallMeasureName
@@ -139,6 +140,7 @@ cdef extern from "constants.h" namespace "grpc_observability":
     kRpcServerReceivedMessagesPerRpcMeasureName
     kRpcServerReceivedBytesPerRpcMeasureName
     kRpcServerServerLatencyMeasureName
+    kRpcServerCompletedRpcMeasureName
     kRpcServerStartedRpcsMeasureName
 
   string kClientMethod

--- a/src/python/grpcio_observability/grpc_observability/_cyobservability.pyx
+++ b/src/python/grpcio_observability/grpc_observability/_cyobservability.pyx
@@ -35,6 +35,7 @@ cdef object GLOBAL_EXPORT_THREAD
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class _CyMetricsName:
   CY_CLIENT_API_LATENCY = kRpcClientApiLatencyMeasureName
   CY_CLIENT_SNET_MESSSAGES_PER_RPC = kRpcClientSentMessagesPerRpcMeasureName
@@ -42,6 +43,7 @@ class _CyMetricsName:
   CY_CLIENT_RECEIVED_MESSAGES_PER_RPC = kRpcClientReceivedMessagesPerRpcMeasureName
   CY_CLIENT_RECEIVED_BYTES_PER_RPC = kRpcClientReceivedBytesPerRpcMeasureName
   CY_CLIENT_ROUNDTRIP_LATENCY = kRpcClientRoundtripLatencyMeasureName
+  CY_CLIENT_COMPLETED_RPC = kRpcClientCompletedRpcMeasureName
   CY_CLIENT_SERVER_LATENCY = kRpcClientServerLatencyMeasureName
   CY_CLIENT_STARTED_RPCS = kRpcClientStartedRpcsMeasureName
   CY_CLIENT_RETRIES_PER_CALL = kRpcClientRetriesPerCallMeasureName
@@ -53,6 +55,7 @@ class _CyMetricsName:
   CY_SERVER_RECEIVED_MESSAGES_PER_RPC = kRpcServerReceivedMessagesPerRpcMeasureName
   CY_SERVER_RECEIVED_BYTES_PER_RPC = kRpcServerReceivedBytesPerRpcMeasureName
   CY_SERVER_SERVER_LATENCY = kRpcServerServerLatencyMeasureName
+  CY_SERVER_COMPLETED_RPC = kRpcServerCompletedRpcMeasureName
   CY_SERVER_STARTED_RPCS = kRpcServerStartedRpcsMeasureName
 
 @enum.unique
@@ -64,6 +67,7 @@ class MetricsName(enum.Enum):
   CLIENT_RECEIVED_MESSAGES_PER_RPC = _CyMetricsName.CY_CLIENT_RECEIVED_MESSAGES_PER_RPC
   CLIENT_RECEIVED_BYTES_PER_RPC = _CyMetricsName.CY_CLIENT_RECEIVED_BYTES_PER_RPC
   CLIENT_ROUNDTRIP_LATENCY = _CyMetricsName.CY_CLIENT_ROUNDTRIP_LATENCY
+  CLIENT_COMPLETED_RPC = _CyMetricsName.CY_CLIENT_COMPLETED_RPC
   CLIENT_SERVER_LATENCY = _CyMetricsName.CY_CLIENT_SERVER_LATENCY
   CLIENT_RETRIES_PER_CALL = _CyMetricsName.CY_CLIENT_RETRIES_PER_CALL
   CLIENT_TRANSPARENT_RETRIES_PER_CALL = _CyMetricsName.CY_CLIENT_TRANSPARENT_RETRIES_PER_CALL
@@ -74,6 +78,7 @@ class MetricsName(enum.Enum):
   SERVER_RECEIVED_MESSAGES_PER_RPC = _CyMetricsName.CY_SERVER_RECEIVED_MESSAGES_PER_RPC
   SERVER_RECEIVED_BYTES_PER_RPC = _CyMetricsName.CY_SERVER_RECEIVED_BYTES_PER_RPC
   SERVER_SERVER_LATENCY = _CyMetricsName.CY_SERVER_SERVER_LATENCY
+  SERVER_COMPLETED_RPC = _CyMetricsName.CY_SERVER_COMPLETED_RPC
   SERVER_STARTED_RPCS = _CyMetricsName.CY_SERVER_STARTED_RPCS
 
 # Delay map creation due to circular dependencies

--- a/src/python/grpcio_observability/grpc_observability/_gcp_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_gcp_observability.py
@@ -22,6 +22,7 @@ from typing import Any, Mapping, Optional
 
 import grpc
 from grpc_observability import _cyobservability  # pytype: disable=pyi-error
+from grpc_observability._open_census_exporter import CENSUS_UPLOAD_INTERVAL_SECS
 from grpc_observability._open_census_exporter import OpenCensusExporter
 from opencensus.trace import execution_context
 from opencensus.trace import span_context as span_context_module
@@ -107,19 +108,23 @@ class GCPOpenCensusObservability(grpc._observability.ObservabilityPlugin):
 
     config: GcpObservabilityPythonConfig
     exporter: "grpc_observability.Exporter"
+    use_open_census_exporter: bool
 
     def __init__(self, exporter: "grpc_observability.Exporter" = None):
         self.exporter = None
         self.config = GcpObservabilityPythonConfig.get()
-        if exporter:
-            self.exporter = exporter
-        else:
-            self.exporter = OpenCensusExporter(self.config.get().labels)
+        self.use_open_census_exporter = False
         config_valid = _cyobservability.set_gcp_observability_config(
             self.config
         )
         if not config_valid:
             raise ValueError("Invalid configuration")
+
+        if exporter:
+            self.exporter = exporter
+        else:
+            self.exporter = OpenCensusExporter(self.config)
+            self.use_open_census_exporter = True
 
         if self.config.tracing_enabled:
             self.set_tracing(True)
@@ -144,10 +149,14 @@ class GCPOpenCensusObservability(grpc._observability.ObservabilityPlugin):
         # immediately after exit, it's possible that core didn't call RecordEnd
         # in callTracer, and all data recorded by calling RecordEnd will be
         # lost.
-        # The time equals to the time in AwaitNextBatchLocked.
+        # CENSUS_EXPORT_BATCH_INTERVAL_SECS: The time equals to the time in
+        # AwaitNextBatchLocked.
         # TODO(xuanwn): explicit synchronization
         # https://github.com/grpc/grpc/issues/33262
         time.sleep(_cyobservability.CENSUS_EXPORT_BATCH_INTERVAL_SECS)
+        if self.use_open_census_exporter:
+            # Sleep so StackDriver can upload data to GCP.
+            time.sleep(CENSUS_UPLOAD_INTERVAL_SECS)
         self.set_tracing(False)
         self.set_stats(False)
         _cyobservability.observability_deinit()

--- a/src/python/grpcio_observability/grpc_observability/_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_measures.py
@@ -1,0 +1,91 @@
+# Copyright 2023 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from opencensus.stats import measure as measure_module
+
+# These measure definitions should be kept in sync across opencensus implementations.
+# https://github.com/census-instrumentation/opencensus-java/blob/master/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java.
+
+# Unit constatns
+UNIT_BYTES = "By"
+UNIT_MILLISECONDS = "ms"
+UNIT_COUNT = "1"
+
+# Client
+CLIENT_STARTED_RPCS_MEASURE = measure_module.MeasureInt(
+    "grpc.io/client/started_rpcs",
+    "The total number of client RPCs ever opened, including those that have not been completed.",
+    UNIT_COUNT,
+)
+
+CLIENT_COMPLETED_RPCS_MEASURE = measure_module.MeasureInt(
+    "grpc.io/client/completed_rpcs",
+    "The total number of completed client RPCs",
+    UNIT_COUNT,
+)
+
+CLIENT_ROUNDTRIP_LATENCY_MEASURE = measure_module.MeasureFloat(
+    "grpc.io/client/roundtrip_latency",
+    "Time between first byte of request sent to last byte of response received, or terminal error",
+    UNIT_MILLISECONDS,
+)
+
+CLIENT_API_LATENCY_MEASURE = measure_module.MeasureInt(
+    "grpc.io/client/api_latency",
+    "End-to-end time taken to complete an RPC",
+    UNIT_MILLISECONDS,
+)
+
+CLIENT_SEND_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+    "grpc.io/client/sent_bytes_per_rpc",
+    "Total bytes sent across all request messages per RPC",
+    UNIT_BYTES,
+)
+
+CLIENT_RECEIVED_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+    "grpc.io/client/received_bytes_per_rpc",
+    "Total bytes received across all response messages per RPC",
+    UNIT_BYTES,
+)
+
+# Server
+SERVER_STARTED_RPCS_MEASURE = measure_module.MeasureInt(
+    "grpc.io/server/started_rpcs",
+    "Total bytes sent across all request messages per RPC",
+    UNIT_COUNT,
+)
+
+SERVER_COMPLETED_RPCS_MEASURE = measure_module.MeasureInt(
+    "grpc.io/server/completed_rpcs",
+    "The total number of completed server RPCs",
+    UNIT_COUNT,
+)
+
+SERVER_SENT_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+    "grpc.io/server/sent_bytes_per_rpc",
+    "Total bytes sent across all messages per RPC",
+    UNIT_BYTES,
+)
+
+SERVER_RECEIVED_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+    "grpc.io/server/received_bytes_per_rpc",
+    "Total bytes received across all messages per RPC",
+    UNIT_BYTES,
+)
+
+SERVER_SERVER_LATENCY_MEASURE = measure_module.MeasureFloat(
+    "grpc.io/server/server_latency",
+    "Time between first byte of request received to last byte of response sent, or terminal error",
+    UNIT_MILLISECONDS,
+)

--- a/src/python/grpcio_observability/grpc_observability/_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_measures.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from opencensus.stats import measure as measure_module
+from opencensus.stats import measure
 
 # These measure definitions should be kept in sync across opencensus implementations.
 # https://github.com/census-instrumentation/opencensus-java/blob/master/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java.
@@ -23,68 +23,68 @@ UNIT_MILLISECONDS = "ms"
 UNIT_COUNT = "1"
 
 # Client
-CLIENT_STARTED_RPCS_MEASURE = measure_module.MeasureInt(
+CLIENT_STARTED_RPCS_MEASURE = measure.MeasureInt(
     "grpc.io/client/started_rpcs",
     "The total number of client RPCs ever opened, including those that have not been completed.",
     UNIT_COUNT,
 )
 
-CLIENT_COMPLETED_RPCS_MEASURE = measure_module.MeasureInt(
+CLIENT_COMPLETED_RPCS_MEASURE = measure.MeasureInt(
     "grpc.io/client/completed_rpcs",
     "The total number of completed client RPCs",
     UNIT_COUNT,
 )
 
-CLIENT_ROUNDTRIP_LATENCY_MEASURE = measure_module.MeasureFloat(
+CLIENT_ROUNDTRIP_LATENCY_MEASURE = measure.MeasureFloat(
     "grpc.io/client/roundtrip_latency",
     "Time between first byte of request sent to last byte of response received, or terminal error",
     UNIT_MILLISECONDS,
 )
 
-CLIENT_API_LATENCY_MEASURE = measure_module.MeasureInt(
+CLIENT_API_LATENCY_MEASURE = measure.MeasureInt(
     "grpc.io/client/api_latency",
     "End-to-end time taken to complete an RPC",
     UNIT_MILLISECONDS,
 )
 
-CLIENT_SEND_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+CLIENT_SEND_BYTES_PER_RPC_MEASURE = measure.MeasureFloat(
     "grpc.io/client/sent_bytes_per_rpc",
     "Total bytes sent across all request messages per RPC",
     UNIT_BYTES,
 )
 
-CLIENT_RECEIVED_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+CLIENT_RECEIVED_BYTES_PER_RPC_MEASURE = measure.MeasureFloat(
     "grpc.io/client/received_bytes_per_rpc",
     "Total bytes received across all response messages per RPC",
     UNIT_BYTES,
 )
 
 # Server
-SERVER_STARTED_RPCS_MEASURE = measure_module.MeasureInt(
+SERVER_STARTED_RPCS_MEASURE = measure.MeasureInt(
     "grpc.io/server/started_rpcs",
     "Total bytes sent across all request messages per RPC",
     UNIT_COUNT,
 )
 
-SERVER_COMPLETED_RPCS_MEASURE = measure_module.MeasureInt(
+SERVER_COMPLETED_RPCS_MEASURE = measure.MeasureInt(
     "grpc.io/server/completed_rpcs",
     "The total number of completed server RPCs",
     UNIT_COUNT,
 )
 
-SERVER_SENT_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+SERVER_SENT_BYTES_PER_RPC_MEASURE = measure.MeasureFloat(
     "grpc.io/server/sent_bytes_per_rpc",
     "Total bytes sent across all messages per RPC",
     UNIT_BYTES,
 )
 
-SERVER_RECEIVED_BYTES_PER_RPC_MEASURE = measure_module.MeasureFloat(
+SERVER_RECEIVED_BYTES_PER_RPC_MEASURE = measure.MeasureFloat(
     "grpc.io/server/received_bytes_per_rpc",
     "Total bytes received across all messages per RPC",
     UNIT_BYTES,
 )
 
-SERVER_SERVER_LATENCY_MEASURE = measure_module.MeasureFloat(
+SERVER_SERVER_LATENCY_MEASURE = measure.MeasureFloat(
     "grpc.io/server/server_latency",
     "Time between first byte of request received to last byte of response sent, or terminal error",
     UNIT_MILLISECONDS,

--- a/src/python/grpcio_observability/grpc_observability/_open_census_exporter.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_census_exporter.py
@@ -23,7 +23,6 @@ from opencensus.common.transports import async_
 from opencensus.ext.stackdriver import stats_exporter
 from opencensus.ext.stackdriver import trace_exporter
 from opencensus.stats import stats as stats_module
-from opencensus.stats.measurement_map import MeasurementMap
 from opencensus.stats.stats_recorder import StatsRecorder
 from opencensus.stats.view_manager import ViewManager
 from opencensus.tags.tag_key import TagKey

--- a/src/python/grpcio_observability/grpc_observability/_open_census_exporter.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_census_exporter.py
@@ -12,23 +12,294 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from typing import List
+from datetime import datetime
+import os
+from typing import Any, List, Mapping, Optional, Tuple
 
+from google.rpc import code_pb2
 from grpc_observability import _observability  # pytype: disable=pyi-error
+from grpc_observability import _views
+from opencensus.common.transports import async_
+from opencensus.ext.stackdriver import stats_exporter
+from opencensus.ext.stackdriver import trace_exporter
+from opencensus.stats import stats as stats_module
+from opencensus.stats.measurement_map import MeasurementMap
+from opencensus.stats.stats_recorder import StatsRecorder
+from opencensus.stats.view_manager import ViewManager
+from opencensus.tags.tag_key import TagKey
+from opencensus.tags.tag_map import TagMap
+from opencensus.tags.tag_value import TagValue
+from opencensus.trace import execution_context
+from opencensus.trace import samplers
+from opencensus.trace import span
+from opencensus.trace import span_context as span_context_module
+from opencensus.trace import span_data as span_data_module
+from opencensus.trace import status
+from opencensus.trace import time_event
+from opencensus.trace import trace_options as trace_options_module
+from opencensus.trace import tracer
 
-logger = logging.getLogger(__name__)
+_gcp_observability = Any  # grpc_observability.py imports this module.
+
+# 60s is the default time for open census to call export.
+CENSUS_UPLOAD_INTERVAL_SECS = int(
+    os.environ.get("GRPC_PYTHON_CENSUS_EXPORT_UPLOAD_INTERVAL_SECS", 20)
+)
+
+
+class StackDriverAsyncTransport(async_.AsyncTransport):
+    """Wrapper class used to pass wait_period.
+
+    This is required because current StackDriver Tracing Exporter doesn't allow
+    us pass wait_period to AsyncTransport directly.
+
+    Args:
+      exporter: An opencensus.trace.base_exporter.Exporter object.
+    """
+
+    def __init__(self, exporter):
+        super().__init__(exporter, wait_period=CENSUS_UPLOAD_INTERVAL_SECS)
 
 
 class OpenCensusExporter(_observability.Exporter):
+    config: "_gcp_observability.GcpObservabilityPythonConfig"
+    default_labels: Optional[Mapping[str, str]]
+    project_id: str
+    tracer: Optional[tracer.Tracer]
+    stats_recorder: Optional[StatsRecorder]
+    view_manager: Optional[ViewManager]
+
+    def __init__(
+        self, config: "_gcp_observability.GcpObservabilityPythonConfig"
+    ):
+        self.config = config.get()
+        self.default_labels = self.config.labels
+        self.project_id = self.config.project_id
+        self.tracer = None
+        self.stats_recorder = None
+        self.view_manager = None
+        self._setup_open_census_stackdriver_exporter()
+
+    def _setup_open_census_stackdriver_exporter(self) -> None:
+        if self.config.stats_enabled:
+            stats = stats_module.stats
+            self.stats_recorder = stats.stats_recorder
+            self.view_manager = stats.view_manager
+            # If testing locally please add resource="global" to Options, otherwise
+            # StackDriver might override project_id based on detected resource.
+            options = stats_exporter.Options(project_id=self.project_id)
+            metrics_exporter = stats_exporter.new_stats_exporter(
+                options, interval=CENSUS_UPLOAD_INTERVAL_SECS
+            )
+            self.view_manager.register_exporter(metrics_exporter)
+            self._register_open_census_views()
+
+        if self.config.tracing_enabled:
+            current_tracer = execution_context.get_opencensus_tracer()
+            trace_id = current_tracer.span_context.trace_id
+            span_id = current_tracer.span_context.span_id
+            if not span_id:
+                span_id = span_context_module.generate_span_id()
+            span_context = span_context_module.SpanContext(
+                trace_id=trace_id, span_id=span_id
+            )
+            # Create and Saves Tracer and Sampler to ContextVar
+            sampler = samplers.ProbabilitySampler(
+                rate=self.config.sampling_rate
+            )
+            self.trace_exporter = trace_exporter.StackdriverExporter(
+                project_id=self.project_id,
+                transport=StackDriverAsyncTransport,
+            )
+            self.tracer = tracer.Tracer(
+                sampler=sampler,
+                span_context=span_context,
+                exporter=self.trace_exporter,
+            )
+
     def export_stats_data(
         self, stats_data: List[_observability.StatsData]
     ) -> None:
-        # TODO(xuanwn): Add implementation
-        raise NotImplementedError()
+        if not self.config.stats_enabled:
+            return
+        for data in stats_data:
+            measure = _views.METRICS_NAME_TO_MEASURE.get(data.name, None)
+            if not measure:
+                continue
+            # Create a measurement map for each metric, otherwise metrics will
+            # be override instead of accumulate.
+            measurement_map = self.stats_recorder.new_measurement_map()
+            # Add data label to default labels.
+            labels = data.labels
+            labels.update(self.default_labels)
+            tag_map = TagMap()
+            for key, value in labels.items():
+                tag_map.insert(TagKey(key), TagValue(value))
+
+            if data.measure_double:
+                measurement_map.measure_float_put(measure, data.value_float)
+            else:
+                measurement_map.measure_int_put(measure, data.value_int)
+            measurement_map.record(tag_map)
 
     def export_tracing_data(
         self, tracing_data: List[_observability.TracingData]
     ) -> None:
-        # TODO(xuanwn): Add implementation
-        raise NotImplementedError()
+        if not self.config.tracing_enabled:
+            return
+        for span_data in tracing_data:
+            # Only traced data will be exported, thus TraceOptions=1.
+            span_context = span_context_module.SpanContext(
+                trace_id=span_data.trace_id,
+                span_id=span_data.span_id,
+                trace_options=trace_options_module.TraceOptions(1),
+            )
+            span_datas = _get_span_datas(
+                span_data, span_context, self.default_labels
+            )
+            self.trace_exporter.export(span_datas)
+
+    def _register_open_census_views(self) -> None:
+        # Client
+        self.view_manager.register_view(
+            _views.client_started_rpcs(self.default_labels)
+        )
+        self.view_manager.register_view(
+            _views.client_completed_rpcs(self.default_labels)
+        )
+        self.view_manager.register_view(
+            _views.client_roundtrip_latency(self.default_labels)
+        )
+        self.view_manager.register_view(
+            _views.client_api_latency(self.default_labels)
+        )
+        self.view_manager.register_view(
+            _views.client_sent_compressed_message_bytes_per_rpc(
+                self.default_labels
+            )
+        )
+        self.view_manager.register_view(
+            _views.client_received_compressed_message_bytes_per_rpc(
+                self.default_labels
+            )
+        )
+
+        # Server
+        self.view_manager.register_view(
+            _views.server_started_rpcs(self.default_labels)
+        )
+        self.view_manager.register_view(
+            _views.server_completed_rpcs(self.default_labels)
+        )
+        self.view_manager.register_view(
+            _views.server_sent_compressed_message_bytes_per_rpc(
+                self.default_labels
+            )
+        )
+        self.view_manager.register_view(
+            _views.server_received_compressed_message_bytes_per_rpc(
+                self.default_labels
+            )
+        )
+        self.view_manager.register_view(
+            _views.server_server_latency(self.default_labels)
+        )
+
+
+def _get_span_annotations(
+    span_annotations: List[Tuple[str, str]]
+) -> List[time_event.Annotation]:
+    annotations = []
+
+    for time_stamp, description in span_annotations:
+        time = datetime.fromisoformat(time_stamp)
+        annotations.append(time_event.Annotation(time, description))
+
+    return annotations
+
+
+# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-branches
+def _status_to_span_status(span_status: str) -> Optional[status.Status]:
+    if status == "OK":
+        return status.Status(code_pb2.OK, message=span_status)
+    elif status == "CANCELLED":
+        return status.Status(code_pb2.CANCELLED, message=span_status)
+    elif status == "UNKNOWN":
+        return status.Status(code_pb2.UNKNOWN, message=span_status)
+    elif status == "INVALID_ARGUMENT":
+        return status.Status(code_pb2.INVALID_ARGUMENT, message=span_status)
+    elif status == "DEADLINE_EXCEEDED":
+        return status.Status(code_pb2.DEADLINE_EXCEEDED, message=span_status)
+    elif status == "NOT_FOUND":
+        return status.Status(code_pb2.NOT_FOUND, message=span_status)
+    elif status == "ALREADY_EXISTS":
+        return status.Status(code_pb2.ALREADY_EXISTS, message=span_status)
+    elif status == "PERMISSION_DENIED":
+        return status.Status(code_pb2.PERMISSION_DENIED, message=span_status)
+    elif status == "UNAUTHENTICATED":
+        return status.Status(code_pb2.UNAUTHENTICATED, message=span_status)
+    elif status == "RESOURCE_EXHAUSTED":
+        return status.Status(code_pb2.RESOURCE_EXHAUSTED, message=span_status)
+    elif status == "FAILED_PRECONDITION":
+        return status.Status(code_pb2.FAILED_PRECONDITION, message=span_status)
+    elif status == "ABORTED":
+        return status.Status(code_pb2.ABORTED, message=span_status)
+    elif status == "OUT_OF_RANGE":
+        return status.Status(code_pb2.OUT_OF_RANGE, message=span_status)
+    elif status == "UNIMPLEMENTED":
+        return status.Status(code_pb2.UNIMPLEMENTED, message=span_status)
+    elif status == "INTERNAL":
+        return status.Status(code_pb2.INTERNAL, message=span_status)
+    elif status == "UNAVAILABLE":
+        return status.Status(code_pb2.UNAVAILABLE, message=span_status)
+    elif status == "DATA_LOSS":
+        return status.Status(code_pb2.DATA_LOSS, message=span_status)
+    else:
+        return None
+
+
+def _get_span_datas(
+    span_data: _observability.TracingData,
+    span_context: span_context_module.SpanContext,
+    labels: Mapping[str, str],
+) -> List[span_data_module.SpanData]:
+    """Extracts a list of SpanData tuples from a span.
+
+    Args:
+    span_data: _observability.TracingData to convert.
+    span_context: The context related to the span_data.
+    labels: Labels to be added to SpanData.
+
+    Returns:
+    A list of opencensus.trace.span_data.SpanData.
+    """
+    span_attributes = span_data.span_labels
+    span_attributes.update(labels)
+    span_status = _status_to_span_status(span_data.status)
+    span_annotations = _get_span_annotations(span_data.span_annotations)
+    span_datas = [
+        span_data_module.SpanData(
+            name=span_data.name,
+            context=span_context,
+            span_id=span_data.span_id,
+            parent_span_id=span_data.parent_span_id
+            if span_data.parent_span_id
+            else None,
+            attributes=span_attributes,
+            start_time=span_data.start_time,
+            end_time=span_data.end_time,
+            child_span_count=span_data.child_span_count,
+            stack_trace=None,
+            annotations=span_annotations,
+            message_events=None,
+            links=None,
+            status=span_status,
+            same_process_as_parent_span=True
+            if span_data.parent_span_id
+            else None,
+            span_kind=span.SpanKind.UNSPECIFIED,
+        )
+    ]
+
+    return span_datas

--- a/src/python/grpcio_observability/grpc_observability/_open_census_exporter.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_census_exporter.py
@@ -35,7 +35,7 @@ from opencensus.trace import span_context as span_context_module
 from opencensus.trace import span_data as span_data_module
 from opencensus.trace import status
 from opencensus.trace import time_event
-from opencensus.trace import trace_options as trace_options_module
+from opencensus.trace import trace_options
 from opencensus.trace import tracer
 
 _gcp_observability = Any  # grpc_observability.py imports this module.
@@ -151,9 +151,9 @@ class OpenCensusExporter(_observability.Exporter):
             span_context = span_context_module.SpanContext(
                 trace_id=span_data.trace_id,
                 span_id=span_data.span_id,
-                trace_options=trace_options_module.TraceOptions(1),
+                trace_options=trace_options.TraceOptions(1),
             )
-            span_datas = _get_span_datas(
+            span_datas = _get_span_data(
                 span_data, span_context, self.default_labels
             )
             self.trace_exporter.export(span_datas)
@@ -258,7 +258,7 @@ def _status_to_span_status(span_status: str) -> Optional[status.Status]:
         return None
 
 
-def _get_span_datas(
+def _get_span_data(
     span_data: _observability.TracingData,
     span_context: span_context_module.SpanContext,
     labels: Mapping[str, str],

--- a/src/python/grpcio_observability/grpc_observability/_views.py
+++ b/src/python/grpcio_observability/grpc_observability/_views.py
@@ -16,7 +16,7 @@ from typing import Mapping
 
 from grpc_observability import _measures
 from grpc_observability._cyobservability import MetricsName
-from opencensus.stats import aggregation as aggregation_module
+from opencensus.stats import aggregation
 from opencensus.stats import view as view_module
 from opencensus.tags.tag_key import TagKey
 
@@ -54,17 +54,13 @@ def server_status_tag_key():
     return TagKey("server_status_tag_key")
 
 
-def count_distribution_aggregation() -> (
-    aggregation_module.DistributionAggregation
-):
+def count_distribution_aggregation() -> aggregation.DistributionAggregation:
     exponential_boundaries = _get_exponential_boundaries(17, 1.0, 2.0)
-    return aggregation_module.DistributionAggregation(exponential_boundaries)
+    return aggregation.DistributionAggregation(exponential_boundaries)
 
 
-def bytes_distribution_aggregation() -> (
-    aggregation_module.DistributionAggregation
-):
-    return aggregation_module.DistributionAggregation(
+def bytes_distribution_aggregation() -> aggregation.DistributionAggregation:
+    return aggregation.DistributionAggregation(
         [
             1024,
             2048,
@@ -83,10 +79,8 @@ def bytes_distribution_aggregation() -> (
     )
 
 
-def millis_distribution_aggregation() -> (
-    aggregation_module.DistributionAggregation
-):
-    return aggregation_module.DistributionAggregation(
+def millis_distribution_aggregation() -> aggregation.DistributionAggregation:
+    return aggregation.DistributionAggregation(
         [
             0.01,
             0.05,
@@ -140,7 +134,7 @@ def client_started_rpcs(labels: Mapping[str, str]) -> view_module.View:
         + " that have not completed.",
         [TagKey(key) for key in labels.keys()] + [client_method_tag_key()],
         _measures.CLIENT_STARTED_RPCS_MEASURE,
-        aggregation_module.CountAggregation(),
+        aggregation.CountAggregation(),
     )
     return view
 
@@ -153,7 +147,7 @@ def client_completed_rpcs(labels: Mapping[str, str]) -> view_module.View:
         [TagKey(key) for key in labels.keys()]
         + [client_method_tag_key(), client_status_tag_key()],
         _measures.CLIENT_COMPLETED_RPCS_MEASURE,
-        aggregation_module.CountAggregation(),
+        aggregation.CountAggregation(),
     )
     return view
 
@@ -221,7 +215,7 @@ def server_started_rpcs(labels: Mapping[str, str]) -> view_module.View:
         + " that have not completed.",
         [TagKey(key) for key in labels.keys()] + [server_method_tag_key()],
         _measures.SERVER_STARTED_RPCS_MEASURE,
-        aggregation_module.CountAggregation(),
+        aggregation.CountAggregation(),
     )
     return view
 
@@ -234,7 +228,7 @@ def server_completed_rpcs(labels: Mapping[str, str]) -> view_module.View:
         [TagKey(key) for key in labels.keys()]
         + [server_method_tag_key(), server_status_tag_key()],
         _measures.SERVER_COMPLETED_RPCS_MEASURE,
-        aggregation_module.CountAggregation(),
+        aggregation.CountAggregation(),
     )
     return view
 

--- a/src/python/grpcio_observability/grpc_observability/_views.py
+++ b/src/python/grpcio_observability/grpc_observability/_views.py
@@ -1,0 +1,293 @@
+# Copyright 2023 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Mapping
+
+from grpc_observability import _measures
+from grpc_observability._cyobservability import MetricsName
+from opencensus.stats import aggregation as aggregation_module
+from opencensus.stats import view as view_module
+from opencensus.tags.tag_key import TagKey
+
+METRICS_NAME_TO_MEASURE = {
+    MetricsName.CLIENT_STARTED_RPCS: _measures.CLIENT_STARTED_RPCS_MEASURE,
+    MetricsName.CLIENT_ROUNDTRIP_LATENCY: _measures.CLIENT_ROUNDTRIP_LATENCY_MEASURE,
+    MetricsName.CLIENT_COMPLETED_RPC: _measures.CLIENT_COMPLETED_RPCS_MEASURE,
+    MetricsName.CLIENT_API_LATENCY: _measures.CLIENT_API_LATENCY_MEASURE,
+    MetricsName.CLIENT_SEND_BYTES_PER_RPC: _measures.CLIENT_SEND_BYTES_PER_RPC_MEASURE,
+    MetricsName.CLIENT_RECEIVED_BYTES_PER_RPC: _measures.CLIENT_RECEIVED_BYTES_PER_RPC_MEASURE,
+    MetricsName.SERVER_STARTED_RPCS: _measures.SERVER_STARTED_RPCS_MEASURE,
+    MetricsName.SERVER_SENT_BYTES_PER_RPC: _measures.SERVER_SENT_BYTES_PER_RPC_MEASURE,
+    MetricsName.SERVER_RECEIVED_BYTES_PER_RPC: _measures.SERVER_RECEIVED_BYTES_PER_RPC_MEASURE,
+    MetricsName.SERVER_SERVER_LATENCY: _measures.SERVER_SERVER_LATENCY_MEASURE,
+    MetricsName.SERVER_COMPLETED_RPC: _measures.SERVER_COMPLETED_RPCS_MEASURE,
+}
+
+
+# These measure definitions should be kept in sync across opencensus
+# implementations--see
+# https://github.com/census-instrumentation/opencensus-java/blob/master/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java.
+def client_method_tag_key():
+    return TagKey("grpc_client_method")
+
+
+def client_status_tag_key():
+    return TagKey("grpc_client_status")
+
+
+def server_method_tag_key():
+    return TagKey("grpc_server_method")
+
+
+def server_status_tag_key():
+    return TagKey("server_status_tag_key")
+
+
+def count_distribution_aggregation() -> (
+    aggregation_module.DistributionAggregation
+):
+    exponential_boundaries = _get_exponential_boundaries(17, 1.0, 2.0)
+    return aggregation_module.DistributionAggregation(exponential_boundaries)
+
+
+def bytes_distribution_aggregation() -> (
+    aggregation_module.DistributionAggregation
+):
+    return aggregation_module.DistributionAggregation(
+        [
+            1024,
+            2048,
+            4096,
+            16384,
+            65536,
+            262144,
+            1048576,
+            4194304,
+            16777216,
+            67108864,
+            268435456,
+            1073741824,
+            4294967296,
+        ]
+    )
+
+
+def millis_distribution_aggregation() -> (
+    aggregation_module.DistributionAggregation
+):
+    return aggregation_module.DistributionAggregation(
+        [
+            0.01,
+            0.05,
+            0.1,
+            0.3,
+            0.6,
+            0.8,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            8,
+            10,
+            13,
+            16,
+            20,
+            25,
+            30,
+            40,
+            50,
+            65,
+            80,
+            100,
+            130,
+            160,
+            200,
+            250,
+            300,
+            400,
+            500,
+            650,
+            800,
+            1000,
+            2000,
+            5000,
+            10000,
+            20000,
+            50000,
+            100000,
+        ]
+    )
+
+
+# Client
+def client_started_rpcs(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/client/started_rpcs",
+        "The count of RPCs ever received at the server, including RPCs"
+        + " that have not completed.",
+        [TagKey(key) for key in labels.keys()] + [client_method_tag_key()],
+        _measures.CLIENT_STARTED_RPCS_MEASURE,
+        aggregation_module.CountAggregation(),
+    )
+    return view
+
+
+def client_completed_rpcs(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/client/completed_rpcs",
+        "The total count of RPCs completed, for example, when a response"
+        + " is sent by the server.",
+        [TagKey(key) for key in labels.keys()]
+        + [client_method_tag_key(), client_status_tag_key()],
+        _measures.CLIENT_COMPLETED_RPCS_MEASURE,
+        aggregation_module.CountAggregation(),
+    )
+    return view
+
+
+def client_roundtrip_latency(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/client/roundtrip_latency",
+        "End-to-end time taken to complete an RPC attempt including the time"
+        + " it takes to pick a subchannel.",
+        [TagKey(key) for key in labels.keys()] + [client_method_tag_key()],
+        _measures.CLIENT_ROUNDTRIP_LATENCY_MEASURE,
+        millis_distribution_aggregation(),
+    )
+    return view
+
+
+def client_api_latency(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/client/api_latency",
+        "The total time taken by the gRPC library to complete an RPC from"
+        + " the application's perspective.",
+        [TagKey(key) for key in labels.keys()]
+        + [client_method_tag_key(), client_status_tag_key()],
+        _measures.CLIENT_API_LATENCY_MEASURE,
+        millis_distribution_aggregation(),
+    )
+    return view
+
+
+def client_sent_compressed_message_bytes_per_rpc(
+    labels: Mapping[str, str]
+) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/client/sent_compressed_message_bytes_per_rpc",
+        "The total bytes (compressed, not encrypted) sent across all"
+        + " request messages per RPC attempt.",
+        [TagKey(key) for key in labels.keys()]
+        + [client_method_tag_key(), client_status_tag_key()],
+        _measures.CLIENT_SEND_BYTES_PER_RPC_MEASURE,
+        bytes_distribution_aggregation(),
+    )
+    return view
+
+
+def client_received_compressed_message_bytes_per_rpc(
+    labels: Mapping[str, str]
+) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/client/received_compressed_message_bytes_per_rpc",
+        "The total bytes (compressed, not encrypted) received across"
+        + " all response messages per RPC attempt.",
+        [TagKey(key) for key in labels.keys()]
+        + [client_method_tag_key(), client_status_tag_key()],
+        _measures.CLIENT_RECEIVED_BYTES_PER_RPC_MEASURE,
+        bytes_distribution_aggregation(),
+    )
+    return view
+
+
+# Server
+def server_started_rpcs(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/server/started_rpcs",
+        "The count of RPCs ever received at the server, including RPCs"
+        + " that have not completed.",
+        [TagKey(key) for key in labels.keys()] + [server_method_tag_key()],
+        _measures.SERVER_STARTED_RPCS_MEASURE,
+        aggregation_module.CountAggregation(),
+    )
+    return view
+
+
+def server_completed_rpcs(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/server/completed_rpcs",
+        "The total count of RPCs completed, for example, when a response"
+        + " is sent by the server.",
+        [TagKey(key) for key in labels.keys()]
+        + [server_method_tag_key(), server_status_tag_key()],
+        _measures.SERVER_COMPLETED_RPCS_MEASURE,
+        aggregation_module.CountAggregation(),
+    )
+    return view
+
+
+def server_sent_compressed_message_bytes_per_rpc(
+    labels: Mapping[str, str]
+) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/server/sent_compressed_message_bytes_per_rpc",
+        "The total bytes (compressed not encrypted) sent across all response"
+        + " messages per RPC.",
+        [TagKey(key) for key in labels.keys()]
+        + [server_method_tag_key(), server_status_tag_key()],
+        _measures.SERVER_SENT_BYTES_PER_RPC_MEASURE,
+        bytes_distribution_aggregation(),
+    )
+    return view
+
+
+def server_received_compressed_message_bytes_per_rpc(
+    labels: Mapping[str, str]
+) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/server/received_compressed_message_bytes_per_rpc",
+        "The total bytes (compressed not encrypted) received across all"
+        + " request messages per RPC.",
+        [TagKey(key) for key in labels.keys()]
+        + [server_method_tag_key(), server_status_tag_key()],
+        _measures.SERVER_RECEIVED_BYTES_PER_RPC_MEASURE,
+        bytes_distribution_aggregation(),
+    )
+    return view
+
+
+def server_server_latency(labels: Mapping[str, str]) -> view_module.View:
+    view = view_module.View(
+        "grpc.io/server/server_latency",
+        "The total time taken by an RPC from server transport's"
+        + " (HTTP2 / inproc / cronet) perspective.",
+        [TagKey(key) for key in labels.keys()]
+        + [server_method_tag_key(), server_status_tag_key()],
+        _measures.SERVER_SERVER_LATENCY_MEASURE,
+        millis_distribution_aggregation(),
+    )
+    return view
+
+
+def _get_exponential_boundaries(
+    num_finite_buckets: int, scale: float, grrowth_factor: float
+) -> list:
+    boundaries = []
+    upper_bound = scale
+    for _ in range(num_finite_buckets):
+        boundaries.append(upper_bound)
+        upper_bound *= grrowth_factor
+    return boundaries

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -224,6 +224,7 @@ void PythonOpenCensusCallTracer::PythonOpenCensusCallAttemptTracer::
   RecordDoubleMetric(kRpcClientRoundtripLatencyMeasureName,
                      absl::ToDoubleMilliseconds(absl::Now() - start_time_),
                      context_.Labels());
+  RecordIntMetric(kRpcClientCompletedRpcMeasureName, 1, context_.Labels());
   if (grpc_core::IsTransportSuppliesClientLatencyEnabled()) {
     if (transport_stream_stats != nullptr &&
         gpr_time_cmp(transport_stream_stats->latency,

--- a/src/python/grpcio_observability/grpc_observability/constants.h
+++ b/src/python/grpcio_observability/grpc_observability/constants.h
@@ -35,6 +35,7 @@ typedef enum {
   kRpcClientReceivedMessagesPerRpcMeasureName,
   kRpcClientReceivedBytesPerRpcMeasureName,
   kRpcClientRoundtripLatencyMeasureName,
+  kRpcClientCompletedRpcMeasureName,
   kRpcClientServerLatencyMeasureName,
   kRpcClientStartedRpcsMeasureName,
   kRpcClientRetriesPerCallMeasureName,
@@ -46,6 +47,7 @@ typedef enum {
   kRpcServerReceivedMessagesPerRpcMeasureName,
   kRpcServerReceivedBytesPerRpcMeasureName,
   kRpcServerServerLatencyMeasureName,
+  kRpcServerCompletedRpcMeasureName,
   kRpcServerStartedRpcsMeasureName
 } MetricsName;
 

--- a/src/python/grpcio_observability/grpc_observability/observability_util.cc
+++ b/src/python/grpcio_observability/grpc_observability/observability_util.cc
@@ -41,9 +41,7 @@ std::condition_variable g_census_data_buffer_cv;
 // Assume buffer will store 100 CensusData and start export when buffer is 70%
 // full.
 constexpr float kExportThreshold = 0.7;
-// Please note that the maximun batch size of metrics stackDriver can upload is
-// 200.
-constexpr int kMaxExportBufferSize = 100;
+constexpr int kMaxExportBufferSize = 10000;
 
 namespace {
 

--- a/src/python/grpcio_observability/grpc_observability/observability_util.cc
+++ b/src/python/grpcio_observability/grpc_observability/observability_util.cc
@@ -41,6 +41,8 @@ std::condition_variable g_census_data_buffer_cv;
 // Assume buffer will store 100 CensusData and start export when buffer is 70%
 // full.
 constexpr float kExportThreshold = 0.7;
+// Please note that the maximun batch size of metrics stackDriver can upload is
+// 200.
 constexpr int kMaxExportBufferSize = 100;
 
 namespace {

--- a/src/python/grpcio_observability/grpc_observability/python_census_context.cc
+++ b/src/python/grpcio_observability/grpc_observability/python_census_context.cc
@@ -223,6 +223,11 @@ Span Span::StartSpan(absl::string_view name,
   std::string parent_span_id = parent_context.SpanId();
   std::string span_id = GenerateSpanId();
   bool should_sample = parent_context.IsSampled();
+  if (!should_sample) {
+    // Resampling here so that it's possible to collect trace on server side
+    // if client tracing is not enabled.
+    should_sample = ShouldSample(std::string(trace_id));
+  }
   auto start_time = absl::Now();
   SpanContext context(trace_id, span_id, should_sample);
   return Span(std::string(name), parent_span_id, start_time, context);

--- a/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
@@ -215,8 +215,7 @@ void PythonOpenCensusServerCallTracer::RecordEnd(
                        static_cast<double>(request_size), context_.Labels());
     RecordDoubleMetric(kRpcServerServerLatencyMeasureName, elapsed_time_ms,
                        context_.Labels());
-    RecordIntMetric(kRpcServerCompletedRpcMeasureName,
-                    1, context_.Labels());
+    RecordIntMetric(kRpcServerCompletedRpcMeasureName, 1, context_.Labels());
     RecordIntMetric(kRpcServerSentMessagesPerRpcMeasureName,
                     sent_message_count_, context_.Labels());
     RecordIntMetric(kRpcServerReceivedMessagesPerRpcMeasureName,

--- a/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
@@ -215,6 +215,8 @@ void PythonOpenCensusServerCallTracer::RecordEnd(
                        static_cast<double>(request_size), context_.Labels());
     RecordDoubleMetric(kRpcServerServerLatencyMeasureName, elapsed_time_ms,
                        context_.Labels());
+    RecordIntMetric(kRpcServerCompletedRpcMeasureName,
+                    1, context_.Labels());
     RecordIntMetric(kRpcServerSentMessagesPerRpcMeasureName,
                     sent_message_count_, context_.Labels());
     RecordIntMetric(kRpcServerReceivedMessagesPerRpcMeasureName,

--- a/src/python/grpcio_tests/tests/observability/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/observability/BUILD.bazel
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-
 package(default_visibility = ["//visibility:public"])
 
 py_test(
@@ -25,6 +23,5 @@ py_test(
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_observability/grpc_observability:pyobservability",
         "//src/python/grpcio_tests/tests/testing",
-        requirement("opencensus"),
     ],
 )


### PR DESCRIPTION
Add OC StackDriver exporter.

### Testing
* StackDriver requires integration with GCP thus not included in Bazel tests, this will only be tested in integration tests.
* Tested locally, was able to publish metrics and spans to GCP:
  * Span:
  * <img width="1501" alt="CloudTrace" src="https://github.com/grpc/grpc/assets/24593237/e6574d05-a6c1-4925-89b1-f9dc1213d9bd">
  * Metric:
  * ![CloudMonitoring](https://github.com/grpc/grpc/assets/24593237/2625815d-2512-46d6-b216-61d93b1ad4ed)
