### PR TITLE
[Test] Dedup vs2019 test in the Windows test

### DIFF
--- a/tools/internal_ci/windows/grpc_run_tests_matrix.bat
+++ b/tools/internal_ci/windows/grpc_run_tests_matrix.bat
@@ -22,6 +22,9 @@ IF "%cd%"=="T:\src" (
 )
 endlocal
 
+@rem Info on disk usage
+dir t:\
+
 @rem enter repo root
 cd /d %~dp0\..\..\..
 
@@ -47,5 +50,8 @@ set RUNTESTS_EXITCODE=%errorlevel%
 
 @rem show ccache stats
 ccache --show-stats
+
+@rem Info on disk usage after test
+dir t:\
 
 exit /b %RUNTESTS_EXITCODE%

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -354,15 +354,16 @@ def _create_portability_test_jobs(extra_args=[],
     # TODO(jtattermusch): The C tests with exactly the same config are already running as part of the
     # basictests_c suite (so we force --build_only to avoid running them twice).
     # The C++ tests aren't all passing, so also force --build_only.
-    test_jobs += _generate_jobs(languages=['c', 'c++'],
-                                configs=['dbg'],
-                                platforms=['windows'],
-                                arch='x64',
-                                compiler='cmake_ninja_vs2019',
-                                labels=['portability', 'corelang'],
-                                extra_args=extra_args + ['--build_only'],
-                                inner_jobs=inner_jobs,
-                                timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
+    # NOTE(veblush): This is not neded as default=cmake_ninja_vs2019
+    #test_jobs += _generate_jobs(languages=['c', 'c++'],
+    #                            configs=['dbg'],
+    #                            platforms=['windows'],
+    #                            arch='x64',
+    #                            compiler='cmake_ninja_vs2019',
+    #                            labels=['portability', 'corelang'],
+    #                            extra_args=extra_args + ['--build_only'],
+    #                            inner_jobs=inner_jobs,
+    #                            timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
     # C and C++ with no-exceptions on Linux
     test_jobs += _generate_jobs(languages=['c', 'c++'],


### PR DESCRIPTION
`cmake_ninja_vs2019` and `default` are using the same `cmake_ninja_vs2019` so having two tests are waste so this is removing `cmake_ninja_vs2019` leaving `default` which does `cmake_ninja_vs2019`.

This change can cut the space consumption by half and with 250GB disc, 

- Pre-test: 267,770,322,944 bytes free 
- Post-test: 134,499,295,232 bytes free
 
