### PR TITLE
[EventEngine] Return work stealing experiment to CI-only

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -18,9 +18,6 @@
 
 EXPERIMENTS = {
     "dbg": {
-        "core_end2end_test": [
-            "work_stealing",
-        ],
     },
     "off": {
         "census_test": [
@@ -31,6 +28,7 @@ EXPERIMENTS = {
             "event_engine_listener",
             "promise_based_client_call",
             "promise_based_server_call",
+            "work_stealing",
         ],
         "cpp_end2end_test": [
             "promise_based_server_call",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -86,11 +86,6 @@ const char* const description_canary_client_privacy =
 const char* const additional_constraints_canary_client_privacy = "{}";
 const char* const description_server_privacy = "If set, server privacy";
 const char* const additional_constraints_server_privacy = "{}";
-#ifdef NDEBUG
-const bool kDefaultForDebugOnly = false;
-#else
-const bool kDefaultForDebugOnly = true;
-#endif
 }  // namespace
 
 namespace grpc_core {
@@ -130,7 +125,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, false, false},
     {"work_stealing", description_work_stealing,
-     additional_constraints_work_stealing, kDefaultForDebugOnly, false},
+     additional_constraints_work_stealing, false, false},
     {"client_privacy", description_client_privacy,
      additional_constraints_client_privacy, false, false},
     {"canary_client_privacy", description_canary_client_privacy,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -73,16 +73,7 @@ inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
-#ifndef NDEBUG
-#define GRPC_EXPERIMENT_IS_INCLUDED_WORK_STEALING
-#endif
-inline bool IsWorkStealingEnabled() {
-#ifdef NDEBUG
-  return false;
-#else
-  return true;
-#endif
-}
+inline bool IsWorkStealingEnabled() { return false; }
 inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsCanaryClientPrivacyEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -53,7 +53,7 @@
 - name: event_engine_dns
   default: false
 - name: work_stealing
-  default: debug
+  default: false
 - name: client_privacy
   default: false
 - name: canary_client_privacy


### PR DESCRIPTION
There is potential for a long shutdown process under load (seconds instead of milliseconds).