### PR TITLE
[git] Ignore python style LSC #33138 in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Migrated python code style from yapf to black
+de6ed9ba9fd59f753bbfd4c9a88ff15e03a89de7


### PR DESCRIPTION
PR #33138 is the Large Scale Change in which python style is changed from yapf to black. Nearly all python files were reformatted. This PR configures git clients supporting `.git-blame-ignore-revs` feature to show the original author in `git blame`.

Details: https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html  
GitHub uses this feature by default: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view  
Local git clients can enable this feature with `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

cc @gnossen @XuanWang-Amos @ctiller