### PR TITLE
[fuzzing] Remove ambiguity in test case, make fuzzer pass

### DIFF
--- a/test/core/end2end/end2end_test_corpus/retry_transparent_max_concurrent_streams/clusterfuzz-testcase-minimized-retry_transparent_max_concurrent_streams_fuzzer-5252699478097920.test
+++ b/test/core/end2end/end2end_test_corpus/retry_transparent_max_concurrent_streams/clusterfuzz-testcase-minimized-retry_transparent_max_concurrent_streams_fuzzer-5252699478097920.test
@@ -1,0 +1,10 @@
+test_id: 1024
+event_engine_actions {
+  connections {
+  }
+  connections {
+    write_size: 117440513
+    write_size: 10
+    write_size: 216
+  }
+}

--- a/test/core/end2end/end2end_test_corpus/retry_transparent_max_concurrent_streams/clusterfuzz-testcase-minimized-retry_transparent_max_concurrent_streams_fuzzer-6459052896878592.test
+++ b/test/core/end2end/end2end_test_corpus/retry_transparent_max_concurrent_streams/clusterfuzz-testcase-minimized-retry_transparent_max_concurrent_streams_fuzzer-6459052896878592.test
@@ -1,0 +1,10 @@
+test_id: 1852400173
+event_engine_actions {
+  connections {
+  }
+  connections {
+    write_size: 240
+    write_size: 240
+    write_size: 0
+  }
+}

--- a/test/core/end2end/tests/retry_transparent_max_concurrent_streams.cc
+++ b/test/core/end2end/tests/retry_transparent_max_concurrent_streams.cc
@@ -77,6 +77,8 @@ CORE_END2END_TEST(RetryHttp2Test, RetryTransparentMaxConcurrentStreams) {
   // Server handles the first call.
   IncomingMessage client_message;
   s.NewBatch(103).RecvMessage(client_message);
+  Expect(103, true);
+  Step();
   IncomingCloseOnServer client_close;
   s.NewBatch(104)
       .RecvCloseOnServer(client_close)
@@ -86,7 +88,6 @@ CORE_END2END_TEST(RetryHttp2Test, RetryTransparentMaxConcurrentStreams) {
   // Server completes first call and shutdown.
   // Client completes first call.
   Expect(104, true);
-  Expect(103, true);
   Expect(102, true);
   Expect(1, true);
   Step();


### PR DESCRIPTION
Here the recv message batch 103 was returning end of stream.

Per the reasoning in https://github.com/grpc/proposal/blob/master/L104-core-ban-recv-with-send-status.md
Sending status is the final thing for a call on the server, so requiring a recv message to complete when we've sent status is getting into at best a gray area in out spec.

Add a strict ordering between that recv and the sending of status to make a more deterministic test.

fixes b/286708835, b/286727273
