### PR TITLE
[ruby] Revert "make sure to always receive initial metadata in ruby (#29155)"

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -164,13 +164,7 @@ module GRPC
     end
 
     def receive_and_check_status
-      ops = { RECV_STATUS_ON_CLIENT => nil }
-      ops[RECV_INITIAL_METADATA] = nil unless @metadata_received
-      batch_result = @call.run_batch(ops)
-      unless @metadata_received
-        @call.metadata = batch_result.metadata
-        @metadata_received = true
-      end
+      batch_result = @call.run_batch(RECV_STATUS_ON_CLIENT => nil)
       set_input_stream_done
       attach_status_results_and_complete_call(batch_result)
     end


### PR DESCRIPTION
#29155  caused the Ruby client to return `grpc_call_start_batch failed with outstanding read or write present (code=8)` instead of `DeadlineExceeded`.

This reverts commit fe1345650439ebdec5aa7fc882f10168cf60e696.

Closes #33283




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

