### PR TITLE
[client_channel] fix dumb bug in data watcher comparator

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -567,18 +567,14 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
 
   void AddDataWatcher(std::unique_ptr<DataWatcherInterface> watcher) override
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
-    std::unique_ptr<InternalSubchannelDataWatcherInterface> internal_watcher(
-        static_cast<InternalSubchannelDataWatcherInterface*>(
-            watcher.release()));
-    internal_watcher->SetSubchannel(subchannel_.get());
-    data_watchers_.insert(std::move(internal_watcher));
+    static_cast<InternalSubchannelDataWatcherInterface*>(watcher.get())
+        ->SetSubchannel(subchannel_.get());
+    GPR_ASSERT(data_watchers_.insert(std::move(watcher)).second);
   }
 
   void CancelDataWatcher(DataWatcherInterface* watcher) override
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
-    auto* internal_watcher =
-        static_cast<InternalSubchannelDataWatcherInterface*>(watcher);
-    auto it = data_watchers_.find(internal_watcher);
+    auto it = data_watchers_.find(watcher);
     if (it != data_watchers_.end()) data_watchers_.erase(it);
   }
 
@@ -694,24 +690,19 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
 
   // A heterogenous lookup comparator for data watchers that allows
   // unique_ptr keys to be looked up as raw pointers.
-  struct DataWatcherCompare {
+  struct DataWatcherLessThan {
     using is_transparent = void;
-    bool operator()(
-        const std::unique_ptr<InternalSubchannelDataWatcherInterface>& p1,
-        const std::unique_ptr<InternalSubchannelDataWatcherInterface>& p2)
-        const {
-      return p1 == p2;
+    bool operator()(const std::unique_ptr<DataWatcherInterface>& p1,
+                    const std::unique_ptr<DataWatcherInterface>& p2) const {
+      return p1 < p2;
     }
-    bool operator()(
-        const std::unique_ptr<InternalSubchannelDataWatcherInterface>& p1,
-        const InternalSubchannelDataWatcherInterface* p2) const {
-      return p1.get() == p2;
+    bool operator()(const std::unique_ptr<DataWatcherInterface>& p1,
+                    const DataWatcherInterface* p2) const {
+      return p1.get() < p2;
     }
-    bool operator()(
-        const InternalSubchannelDataWatcherInterface* p1,
-        const std::unique_ptr<InternalSubchannelDataWatcherInterface>& p2)
-        const {
-      return p1 == p2.get();
+    bool operator()(const DataWatcherInterface* p1,
+                    const std::unique_ptr<DataWatcherInterface>& p2) const {
+      return p1 < p2.get();
     }
   };
 
@@ -724,8 +715,7 @@ class ClientChannel::SubchannelWrapper : public SubchannelInterface {
   // corresponding WrapperWatcher to cancel on the underlying subchannel.
   std::map<ConnectivityStateWatcherInterface*, WatcherWrapper*> watcher_map_
       ABSL_GUARDED_BY(*chand_->work_serializer_);
-  std::set<std::unique_ptr<InternalSubchannelDataWatcherInterface>,
-           DataWatcherCompare>
+  std::set<std::unique_ptr<DataWatcherInterface>, DataWatcherLessThan>
       data_watchers_ ABSL_GUARDED_BY(*chand_->work_serializer_);
 };
 


### PR DESCRIPTION
This fixes a dumb bug from #33359, where I used `==` instead of `<` in the comparator functor.

It also avoids unnecessary down-casting of the `unique_ptr<>`.