### PR TITLE
[promises] run finalizers in destruction path

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -2156,14 +2156,9 @@ class PromiseBasedCall : public Call,
                    grpc_metadata_batch* batch);
 
   // At the end of the call run any finalization actions.
-  void RunFinalization(grpc_status_code status, const char* status_details) {
-    grpc_call_final_info final_info;
-    final_info.stats = final_stats_;
-    final_info.final_status = status;
-    final_info.error_string = status_details;
-    final_info.stats.latency =
-        gpr_cycle_counter_sub(gpr_get_cycle_counter(), start_time());
-    finalization_.Run(&final_info);
+  void SetFinalizationStatus(grpc_status_code status, Slice status_details) {
+    final_message_ = std::move(status_details);
+    final_status_ = status;
   }
 
   std::string PresentAndCompletionText(const char* caption, bool has,
@@ -2314,6 +2309,19 @@ class PromiseBasedCall : public Call,
   void PartyOver() override {
     {
       ScopedContext ctx(this);
+      std::string message;
+      grpc_call_final_info final_info;
+      final_info.stats = final_stats_;
+      final_info.final_status = final_status_;
+      // TODO(ctiller): change type here so we don't need to copy this string.
+      final_info.error_string = nullptr;
+      if (!final_message_.empty()) {
+        message = std::string(final_message_.begin(), final_message_.end());
+        final_info.error_string = message.c_str();
+      }
+      final_info.stats.latency =
+          gpr_cycle_counter_sub(gpr_get_cycle_counter(), start_time());
+      finalization_.Run(&final_info);
       CancelRemainingParticipants();
       arena()->DestroyManagedNewObjects();
     }
@@ -2327,6 +2335,8 @@ class PromiseBasedCall : public Call,
   grpc_completion_queue* cq_;
   CompletionInfo completion_info_[6];
   grpc_call_stats final_stats_{};
+  Slice final_message_;
+  grpc_status_code final_status_;
   CallFinalization finalization_;
   // Current deadline.
   Mutex deadline_mu_;
@@ -3009,20 +3019,13 @@ void ClientPromiseBasedCall::StartRecvStatusOnClient(
             trailing_metadata->get(GrpcStatusMetadata())
                 .value_or(GRPC_STATUS_UNKNOWN);
         *op_args.status = status;
-        absl::string_view message_string;
+        Slice message_slice;
         if (Slice* message =
                 trailing_metadata->get_pointer(GrpcMessageMetadata())) {
-          message_string = message->as_string_view();
-          *op_args.status_details = message->Ref().TakeCSlice();
-        } else {
-          *op_args.status_details = grpc_empty_slice();
+          message_slice = message->Ref();
         }
-        if (message_string.empty()) {
-          RunFinalization(status, nullptr);
-        } else {
-          std::string error_string(message_string);
-          RunFinalization(status, error_string.c_str());
-        }
+        SetFinalizationStatus(status, message_slice.Ref());
+        *op_args.status_details = message_slice.TakeCSlice();
         if (op_args.error_string != nullptr && status != GRPC_STATUS_OK) {
           *op_args.error_string =
               gpr_strdup(MakeErrorString(trailing_metadata.get()).c_str());
@@ -3245,17 +3248,12 @@ void ServerPromiseBasedCall::Finish(ServerMetadataHandle result) {
   if (server_initial_metadata_ != nullptr) {
     server_initial_metadata_->Close();
   }
-  absl::string_view message_string;
+  Slice message_slice;
   if (Slice* message = result->get_pointer(GrpcMessageMetadata())) {
-    message_string = message->as_string_view();
+    message_slice = message->Ref();
   }
   AcceptTransportStatsFromContext();
-  if (message_string.empty()) {
-    RunFinalization(status, nullptr);
-  } else {
-    std::string error_string(message_string);
-    RunFinalization(status, error_string.c_str());
-  }
+  SetFinalizationStatus(status, std::move(message_slice));
   set_completed();
   ResetDeadline();
   PropagateCancellationToChildren();


### PR DESCRIPTION
Previously we were running these at call termination, but internally we have things that want to access finalizer cleaned up data after that point.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

