### PR TITLE
Update googleauth to ~> 1.0

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 1.41.0'
   s.add_development_dependency 'signet',             '~> 0.7'
-  s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.10'
+  s.add_development_dependency 'googleauth',         '~> 1.0'
 
   s.extensions = %w(src/ruby/ext/grpc/extconf.rb)
 


### PR DESCRIPTION
Update googleauth ruby gem to ~> 1.0. This fixes #33435 




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

