### PR TITLE
[print backtrace] Print exception backtrace for all exceptions

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -569,7 +569,9 @@ def _call_behavior(
                         details = (
                             "Calling application raised unprintable Exception!"
                         )
-                        _LOGGER.exception(traceback.format_exception(exception))
+                        _LOGGER.exception(
+                            traceback.format_exception(exception)
+                        )  # pylint: disable=no-value-for-parameter
                     traceback.print_exc()
                     _LOGGER.exception(details)
                     _abort(

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -570,8 +570,12 @@ def _call_behavior(
                             "Calling application raised unprintable Exception!"
                         )
                         _LOGGER.exception(
-                            traceback.format_exception(exception)
-                        )  # pylint: disable=no-value-for-parameter
+                            traceback.format_exception(
+                                type(exception),
+                                exception,
+                                exception.__traceback__,
+                            )
+                        )
                     traceback.print_exc()
                     _LOGGER.exception(details)
                     _abort(

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -569,7 +569,7 @@ def _call_behavior(
                         details = (
                             "Calling application raised unprintable Exception!"
                         )
-                        traceback.print_exc()
+                    traceback.print_exc()
                     _LOGGER.exception(details)
                     _abort(
                         state,

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -569,6 +569,7 @@ def _call_behavior(
                         details = (
                             "Calling application raised unprintable Exception!"
                         )
+                        _LOGGER.exception(traceback.format_exception(exception))
                     traceback.print_exc()
                     _LOGGER.exception(details)
                     _abort(


### PR DESCRIPTION
Action item from: https://github.com/grpc/grpc/issues/33364
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

### Before change:

* Printable Exception (Only printing exception):
```
ERROR:grpc._server:Exception calling application: Test exception
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2110/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: Test exception
ERROR
```

* Un-Printable Exception (Only printing traceback):
```
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2112/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: <unprintable TestException object>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2112/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 574, in _call_behavior
    details = "Exception calling application: {}".format(
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2112/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 536, in __str__
    return 'Test exception {0}'.format(self.val)
AttributeError: 'TestException' object has no attribute 'val'
ERROR:grpc._server:Calling application raised unprintable Exception!
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2112/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: <unprintable TestException object>
ERROR
```

### After change:

* Printable Exception (Printing both exception and traceback):
```
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2114/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: Test exception
ERROR:grpc._server:Exception calling application: Test exception
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2114/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: Test exception
ERROR
```

* Un-Printable Exception (Printing both exception and traceback):
```
ERROR:grpc._server:['Traceback (most recent call last):\n', '  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2116/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior\n    raise TestException\n', 'grpc._server.TestException: <unprintable TestException object>\n']
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2116/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: <unprintable TestException object>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2116/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 574, in _call_behavior
    details = "Exception calling application: {}".format(
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2116/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 536, in __str__
    return 'Test exception {0}'.format(self.val)
AttributeError: 'TestException' object has no attribute 'val'
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2116/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: <unprintable TestException object>
ERROR:grpc._server:Calling application raised unprintable Exception!
Traceback (most recent call last):
  File "/usr/local/google/home/xuanwn/.cache/bazel/_bazel_xuanwn/da3828576aa39e99a5c826cc2e2e22fb/sandbox/linux-sandbox/2116/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/src/python/grpcio_tests/tests/unit/_metadata_test.native.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_server.py", line 561, in _call_behavior
    raise TestException
grpc._server.TestException: <unprintable TestException object>
ERROR
```