### PR TITLE
Made Android docker to have NDK & CMake installed

### DIFF
--- a/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
+++ b/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
@@ -38,6 +38,11 @@
   ENV ANDROID_HOME /opt/android-sdk
   RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licenses
 
+  # Install Android NDK & CMake
+  # This is not required but desirable to reduce the time to download and the chance of download failure.
+  RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
+  RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.10.2.4988404'
+
   # Install gcloud
   RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && ${'\\'}
       tar -xf google-cloud-cli-407.0.0-linux-x86_64.tar.gz && ${'\\'}

--- a/tools/dockerfile/test/android_ndk.current_version
+++ b/tools/dockerfile/test/android_ndk.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:47e2befd3ceab97fa3e8ad5b8499b684380d624d@sha256:256ff2bb8fd6c6921cd7653f79fa495669c6466f78df96f71867f89f6d487ff3
+us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:b21742719ae22d6ac607d98b4a8d794cebe68542@sha256:2bddf36ae504968b35f97e4a6c9b74864473689e84049675c30afb70f868d897

--- a/tools/dockerfile/test/android_ndk/Dockerfile
+++ b/tools/dockerfile/test/android_ndk/Dockerfile
@@ -105,6 +105,11 @@ ENV ANDROID_SDK_PATH /opt/android-sdk
 ENV ANDROID_HOME /opt/android-sdk
 RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licenses
 
+# Install Android NDK & CMake
+# This is not required but desirable to reduce the time to download and the chance of download failure.
+RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
+RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.10.2.4988404'
+
 # Install gcloud
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && \
     tar -xf google-cloud-cli-407.0.0-linux-x86_64.tar.gz && \


### PR DESCRIPTION
It is not uncommon for Android tests to fail due to an NDK download failure. To address this issue, the Android Docker image has been updated to include NDK and CMake. This will help to avoid download problem.

