### PR TITLE
[PollingResolver] Allow subclasses to utilize the work serializer

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.cc
@@ -150,12 +150,6 @@ void PollingResolver::OnRequestComplete(Result result) {
       DEBUG_LOCATION);
 }
 
-void PollingResolver::RequestReresolution() {
-  Ref(DEBUG_LOCATION, "RequestReresolution").release();
-  work_serializer_->Run([this]() mutable { RequestReresolutionLocked(); },
-                        DEBUG_LOCATION);
-}
-
 void PollingResolver::OnRequestCompleteLocked(Result result) {
   if (GPR_UNLIKELY(tracer_ != nullptr && tracer_->enabled())) {
     gpr_log(GPR_INFO, "[polling resolver %p] request complete", this);

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.cc
@@ -150,6 +150,12 @@ void PollingResolver::OnRequestComplete(Result result) {
       DEBUG_LOCATION);
 }
 
+void PollingResolver::RequestReresolution() {
+  Ref(DEBUG_LOCATION, "RequestReresolution").release();
+  work_serializer_->Run([this]() mutable { RequestReresolutionLocked(); },
+                        DEBUG_LOCATION);
+}
+
 void PollingResolver::OnRequestCompleteLocked(Result result) {
   if (GPR_UNLIKELY(tracer_ != nullptr && tracer_->enabled())) {
     gpr_log(GPR_INFO, "[polling resolver %p] request complete", this);

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -64,11 +64,6 @@ class PollingResolver : public Resolver {
   // To be invoked by the subclass when a request is complete.
   void OnRequestComplete(Result result);
 
-  // Can be used by the subclass to request a re-resolution.
-  // Subclasses might not be able to RequestReresolution if they don't have
-  // access to the work_serializer, so this provides a clean alternative.
-  void RequestReresolution();
-
   // Convenient accessor methods for subclasses.
   const std::string& authority() const { return authority_; }
   const std::string& name_to_resolve() const { return name_to_resolve_; }

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -69,7 +69,7 @@ class PollingResolver : public Resolver {
   const std::string& name_to_resolve() const { return name_to_resolve_; }
   grpc_pollset_set* interested_parties() const { return interested_parties_; }
   const ChannelArgs& channel_args() const { return channel_args_; }
-  std::shared_ptr<WorkSerializer> work_serializer() { return work_serializer_; }
+  WorkSerializer* work_serializer() { return work_serializer_.get(); }
 
  private:
   void MaybeStartResolvingLocked();

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -64,6 +64,11 @@ class PollingResolver : public Resolver {
   // To be invoked by the subclass when a request is complete.
   void OnRequestComplete(Result result);
 
+  // Can be used by the subclass to request a re-resolution.
+  // Subclasses might not be able to RequestReresolution if they don't have
+  // access to the work_serializer, so this provides a clean alternative.
+  void RequestReresolution();
+
   // Convenient accessor methods for subclasses.
   const std::string& authority() const { return authority_; }
   const std::string& name_to_resolve() const { return name_to_resolve_; }

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -74,6 +74,7 @@ class PollingResolver : public Resolver {
   const std::string& name_to_resolve() const { return name_to_resolve_; }
   grpc_pollset_set* interested_parties() const { return interested_parties_; }
   const ChannelArgs& channel_args() const { return channel_args_; }
+  std::shared_ptr<WorkSerializer> work_serializer() {return work_serializer_;}
 
  private:
   void MaybeStartResolvingLocked();

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -69,7 +69,7 @@ class PollingResolver : public Resolver {
   const std::string& name_to_resolve() const { return name_to_resolve_; }
   grpc_pollset_set* interested_parties() const { return interested_parties_; }
   const ChannelArgs& channel_args() const { return channel_args_; }
-  std::shared_ptr<WorkSerializer> work_serializer() {return work_serializer_;}
+  std::shared_ptr<WorkSerializer> work_serializer() { return work_serializer_;}
 
  private:
   void MaybeStartResolvingLocked();

--- a/src/core/ext/filters/client_channel/resolver/polling_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/polling_resolver.h
@@ -69,7 +69,7 @@ class PollingResolver : public Resolver {
   const std::string& name_to_resolve() const { return name_to_resolve_; }
   grpc_pollset_set* interested_parties() const { return interested_parties_; }
   const ChannelArgs& channel_args() const { return channel_args_; }
-  std::shared_ptr<WorkSerializer> work_serializer() { return work_serializer_;}
+  std::shared_ptr<WorkSerializer> work_serializer() { return work_serializer_; }
 
  private:
   void MaybeStartResolvingLocked();


### PR DESCRIPTION
Child classes of polling resolvers might have use cases where they would want to request a resolution explicitly which honor the min time between requests. As RequestReresolutionLocked needs to be called in from work_serializer which is usually owned by polling resolver completely, allow passing the work serializer back to the child class.


cc: @markdroth 

