### PR TITLE
[Test] Add v1.56.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -285,6 +285,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.53.0", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.54.1", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.55.0", ReleaseInfo(runtimes=["go1.19"])),
+            ("v1.56.0", ReleaseInfo(runtimes=["go1.19"])),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
Add grpc-go v1.56.0 to interop matrix