### PR TITLE
[test] Disable cq verifier logs for stress test

### DIFF
--- a/test/core/end2end/cq_verifier.cc
+++ b/test/core/end2end/cq_verifier.cc
@@ -344,8 +344,10 @@ grpc_event CqVerifier::Step(gpr_timespec deadline) {
 
 void CqVerifier::Verify(Duration timeout, SourceLocation location) {
   if (expectations_.empty()) return;
-  gpr_log(GPR_ERROR, "Verify %s for %s", ToShortString().c_str(),
-          timeout.ToString().c_str());
+  if (log_verifications_) {
+    gpr_log(GPR_ERROR, "Verify %s for %s", ToShortString().c_str(),
+            timeout.ToString().c_str());
+  }
   const gpr_timespec deadline =
       grpc_timeout_milliseconds_to_deadline(timeout.millis());
   while (!expectations_.empty()) {
@@ -402,8 +404,10 @@ bool CqVerifier::AllMaybes() const {
 }
 
 void CqVerifier::VerifyEmpty(Duration timeout, SourceLocation location) {
-  gpr_log(GPR_ERROR, "Verify empty completion queue for %s",
-          timeout.ToString().c_str());
+  if (log_verifications_) {
+    gpr_log(GPR_ERROR, "Verify empty completion queue for %s",
+            timeout.ToString().c_str());
+  }
   const gpr_timespec deadline =
       gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC), timeout.as_timespec());
   GPR_ASSERT(expectations_.empty());

--- a/test/core/end2end/cq_verifier.h
+++ b/test/core/end2end/cq_verifier.h
@@ -110,6 +110,13 @@ class CqVerifier {
   std::string ToShortString() const;
   std::vector<std::string> ToShortStrings() const;
 
+  // Logging verifications helps debug CI problems a lot.
+  // Only disable if the logging prevents a stress test like scenario from
+  // passing.
+  void SetLogVerifications(bool log_verifications) {
+    log_verifications_ = log_verifications;
+  }
+
   static void* tag(intptr_t t) { return reinterpret_cast<void*>(t); }
 
  private:
@@ -134,6 +141,7 @@ class CqVerifier {
   absl::AnyInvocable<void(
       grpc_event_engine::experimental::EventEngine::Duration) const>
       step_fn_;
+  bool log_verifications_ = true;
 };
 
 }  // namespace grpc_core

--- a/test/core/iomgr/stranded_event_test.cc
+++ b/test/core/iomgr/stranded_event_test.cc
@@ -102,6 +102,7 @@ void StartCall(TestCall* test_call) {
       test_call->call, ops, static_cast<size_t>(op - ops), tag, nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_core::CqVerifier cqv(test_call->cq);
+  cqv.SetLogVerifications(false);
   cqv.Expect(tag, true);
   cqv.Verify();
 }
@@ -123,6 +124,7 @@ void SendMessage(grpc_call* call, grpc_completion_queue* cq) {
       call, ops, static_cast<size_t>(op - ops), tag, nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_core::CqVerifier cqv(cq);
+  cqv.SetLogVerifications(false);
   cqv.Expect(tag, true);
   cqv.Verify();
   grpc_byte_buffer_destroy(request_payload);
@@ -143,6 +145,7 @@ void ReceiveMessage(grpc_call* call, grpc_completion_queue* cq) {
       call, ops, static_cast<size_t>(op - ops), tag, nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
   grpc_core::CqVerifier cqv(cq);
+  cqv.SetLogVerifications(false);
   cqv.Expect(tag, true);
   cqv.Verify();
   grpc_byte_buffer_destroy(request_payload);


### PR DESCRIPTION
They were tipping this test off into timeout land... but they're proving useful for non-stress tests, so added an option just for here to disable.