### PR TITLE
[cleanups] Silence a -Wformat compiler warning

### DIFF
--- a/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_policy_provider.cc
@@ -121,7 +121,8 @@ FileWatcherAuthorizationPolicyProvider::FileWatcherAuthorizationPolicyProvider(
       if (GRPC_TRACE_FLAG_ENABLED(grpc_authz_trace) && !status.ok()) {
         gpr_log(GPR_ERROR,
                 "authorization policy reload status. code=%d error_details=%s",
-                status.code(), std::string(status.message()).c_str());
+                static_cast<int>(status.code()),
+                std::string(status.message()).c_str());
       }
     }
   };


### PR DESCRIPTION
New versions of Clang (and GCC) warn about this

grpc_authorization_policy_provider.cc:124:17: error: format specifies type 'int' but the argument has type 'absl::StatusCode' [-Werror,-Wformat]
  124 |                 "authorization policy reload status. code=%d error_details=%s",
      |                                                           ~~
  125 |                 status.code(), std::string(status.message()).c_str());




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

