### PR TITLE
Revert "[logging] Handle trailers-only responses (#33461)"

### DIFF
--- a/src/core/ext/filters/logging/logging_sink.h
+++ b/src/core/ext/filters/logging/logging_sink.h
@@ -107,7 +107,6 @@ class LoggingSink {
     std::string trace_id;
     std::string span_id;
     bool is_sampled = false;
-    bool is_trailer_only;
   };
 
   virtual ~LoggingSink() = default;


### PR DESCRIPTION
This reverts commit cb9fe64fa5e10851f716213037a5de1e01f6066c.

This broke tests https://fusion2.corp.google.com/ci/kokoro/prod:grpc-gcp%2Ftools%2Fobservability%2Fmaster%2Fcontinuous_cpp/activity/8c408662-43bd-4377-a6b9-9a89490cea83/tests

Attempting to add a test in https://github.com/grpc/grpc/pull/33486


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

