### PR TITLE
[Test] Use `ssl.SSLContext.wrap_socket`, not `ssl.wrap_socket`

### DIFF
--- a/test/core/http/test_server.py
+++ b/test/core/http/test_server.py
@@ -71,7 +71,7 @@ class Handler(BaseHTTPRequestHandler):
 
 httpd = HTTPServer(("localhost", args.port), Handler)
 if args.ssl:
-    httpd.socket = ssl.wrap_socket(
-        httpd.socket, certfile=_PEM, keyfile=_KEY, server_side=True
-    )
+    ctx = ssl.SSLContext()
+    ctx.load_cert_chain(certfile=_PEM, keyfile=_KEY)
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
 httpd.serve_forever()


### PR DESCRIPTION
In the HTTP(S) test server in the core tests, use `ssl.SSLContext.wrap_socket`, not `ssl.wrap_socket`. The latter emits a `DeprecationWarning` since Python 3.10 and is [removed in Python 3.12](https://github.com/python/cpython/issues/94199).

This fixes the core tests (but not necessarily the `grpcio` tests) for Python 3.12.

This is relevant to https://github.com/grpc/grpc/issues/33063.