### PR TITLE
[too_many_pings] Raise deadline to avoid flake

### DIFF
--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -250,7 +250,7 @@ grpc_status_code PerformWaitingCall(grpc_channel* channel, grpc_server* server,
   grpc_status_code status;
   grpc_call_error error;
   grpc_slice details;
-  gpr_timespec deadline = grpc_timeout_seconds_to_deadline(15);
+  gpr_timespec deadline = grpc_timeout_seconds_to_deadline(30);
   // Start a call
   c = grpc_channel_create_call(channel, nullptr, GRPC_PROPAGATE_DEFAULTS, cq,
                                grpc_slice_from_static_string("/foo"), nullptr,


### PR DESCRIPTION
Observed flake: https://source.cloud.google.com/results/invocations/cd5c168d-19cc-4257-ac28-3556f7ddd7f9/targets/%2F%2Ftest%2Fcore%2Ftransport%2Fchttp2:too_many_pings_test/log