### PR TITLE
[alts] Remove ExecCtx check from alts_zero_copy_grpc_protector_create function.

### DIFF
--- a/src/core/tsi/alts/zero_copy_frame_protector/alts_grpc_record_protocol_common.cc
+++ b/src/core/tsi/alts/zero_copy_frame_protector/alts_grpc_record_protocol_common.cc
@@ -124,9 +124,8 @@ tsi_result alts_grpc_record_protocol_init(alts_grpc_record_protocol* rp,
 tsi_result alts_grpc_record_protocol_protect(
     alts_grpc_record_protocol* self, grpc_slice_buffer* unprotected_slices,
     grpc_slice_buffer* protected_slices) {
-  if (grpc_core::ExecCtx::Get() == nullptr || self == nullptr ||
-      self->vtable == nullptr || unprotected_slices == nullptr ||
-      protected_slices == nullptr) {
+  if (self == nullptr || self->vtable == nullptr ||
+      unprotected_slices == nullptr || protected_slices == nullptr) {
     return TSI_INVALID_ARGUMENT;
   }
   if (self->vtable->protect == nullptr) {
@@ -138,9 +137,8 @@ tsi_result alts_grpc_record_protocol_protect(
 tsi_result alts_grpc_record_protocol_unprotect(
     alts_grpc_record_protocol* self, grpc_slice_buffer* protected_slices,
     grpc_slice_buffer* unprotected_slices) {
-  if (grpc_core::ExecCtx::Get() == nullptr || self == nullptr ||
-      self->vtable == nullptr || protected_slices == nullptr ||
-      unprotected_slices == nullptr) {
+  if (self == nullptr || self->vtable == nullptr ||
+      protected_slices == nullptr || unprotected_slices == nullptr) {
     return TSI_INVALID_ARGUMENT;
   }
   if (self->vtable->unprotect == nullptr) {

--- a/src/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector.cc
+++ b/src/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector.cc
@@ -263,8 +263,7 @@ tsi_result alts_zero_copy_grpc_protector_create(
     bool is_integrity_only, bool enable_extra_copy,
     size_t* max_protected_frame_size,
     tsi_zero_copy_grpc_protector** protector) {
-  if (grpc_core::ExecCtx::Get() == nullptr || key == nullptr ||
-      protector == nullptr) {
+  if (key == nullptr || protector == nullptr) {
     gpr_log(
         GPR_ERROR,
         "Invalid nullptr arguments to alts_zero_copy_grpc_protector create.");

--- a/test/core/tsi/alts/zero_copy_frame_protector/alts_grpc_record_protocol_test.cc
+++ b/test/core/tsi/alts/zero_copy_frame_protector/alts_grpc_record_protocol_test.cc
@@ -24,7 +24,6 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
-#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/tsi/alts/zero_copy_frame_protector/alts_grpc_integrity_only_record_protocol.h"
 #include "src/core/tsi/alts/zero_copy_frame_protector/alts_grpc_privacy_integrity_record_protocol.h"
@@ -244,12 +243,10 @@ static void alts_grpc_record_protocol_test_fixture_destroy(
   if (fixture == nullptr) {
     return;
   }
-  grpc_core::ExecCtx exec_ctx;
   alts_grpc_record_protocol_destroy(fixture->client_protect);
   alts_grpc_record_protocol_destroy(fixture->client_unprotect);
   alts_grpc_record_protocol_destroy(fixture->server_protect);
   alts_grpc_record_protocol_destroy(fixture->server_unprotect);
-  grpc_core::ExecCtx::Get()->Flush();
   gpr_free(fixture);
 }
 
@@ -290,7 +287,6 @@ static void alts_grpc_record_protocol_test_var_destroy(
 
 static void random_seal_unseal(alts_grpc_record_protocol* sender,
                                alts_grpc_record_protocol* receiver) {
-  grpc_core::ExecCtx exec_ctx;
   for (size_t i = 0; i < kSealRepeatTimes; i++) {
     alts_grpc_record_protocol_test_var* var =
         alts_grpc_record_protocol_test_var_create();
@@ -308,12 +304,10 @@ static void random_seal_unseal(alts_grpc_record_protocol* sender,
         are_slice_buffers_equal(&var->unprotected_sb, &var->duplicate_sb));
     alts_grpc_record_protocol_test_var_destroy(var);
   }
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 static void empty_seal_unseal(alts_grpc_record_protocol* sender,
                               alts_grpc_record_protocol* receiver) {
-  grpc_core::ExecCtx exec_ctx;
   for (size_t i = 0; i < kSealRepeatTimes; i++) {
     alts_grpc_record_protocol_test_var* var =
         alts_grpc_record_protocol_test_var_create();
@@ -331,12 +325,10 @@ static void empty_seal_unseal(alts_grpc_record_protocol* sender,
         are_slice_buffers_equal(&var->unprotected_sb, &var->duplicate_sb));
     alts_grpc_record_protocol_test_var_destroy(var);
   }
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 static void unsync_seal_unseal(alts_grpc_record_protocol* sender,
                                alts_grpc_record_protocol* receiver) {
-  grpc_core::ExecCtx exec_ctx;
   tsi_result status;
   alts_grpc_record_protocol_test_var* var =
       alts_grpc_record_protocol_test_var_create();
@@ -354,12 +346,10 @@ static void unsync_seal_unseal(alts_grpc_record_protocol* sender,
                                                &var->unprotected_sb);
   ASSERT_EQ(status, TSI_INTERNAL_ERROR);
   alts_grpc_record_protocol_test_var_destroy(var);
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 static void corrupted_data(alts_grpc_record_protocol* sender,
                            alts_grpc_record_protocol* receiver) {
-  grpc_core::ExecCtx exec_ctx;
   tsi_result status;
   alts_grpc_record_protocol_test_var* var =
       alts_grpc_record_protocol_test_var_create();
@@ -373,11 +363,9 @@ static void corrupted_data(alts_grpc_record_protocol* sender,
                                                &var->unprotected_sb);
   ASSERT_EQ(status, TSI_INTERNAL_ERROR);
   alts_grpc_record_protocol_test_var_destroy(var);
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 static void input_check(alts_grpc_record_protocol* rp) {
-  grpc_core::ExecCtx exec_ctx;
   tsi_result status;
   alts_grpc_record_protocol_test_var* var =
       alts_grpc_record_protocol_test_var_create();
@@ -406,7 +394,6 @@ static void input_check(alts_grpc_record_protocol* rp) {
   ASSERT_EQ(status, TSI_INVALID_ARGUMENT);
   grpc_slice_buffer_destroy(&temp_sb);
   alts_grpc_record_protocol_test_var_destroy(var);
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 // --- Test cases. ---

--- a/test/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector_test.cc
+++ b/test/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector_test.cc
@@ -25,7 +25,6 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
-#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/tsi/alts/crypt/gsec.h"
 #include "src/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol.h"
@@ -111,7 +110,6 @@ alts_zero_copy_grpc_protector_test_fixture_create(bool rekey,
   alts_zero_copy_grpc_protector_test_fixture* fixture =
       static_cast<alts_zero_copy_grpc_protector_test_fixture*>(
           gpr_zalloc(sizeof(alts_zero_copy_grpc_protector_test_fixture)));
-  grpc_core::ExecCtx exec_ctx;
   size_t key_length = rekey ? kAes128GcmRekeyKeyLength : kAes128GcmKeyLength;
   uint8_t* key;
   size_t max_protected_frame_size = 1024;
@@ -134,7 +132,6 @@ alts_zero_copy_grpc_protector_test_fixture_create(bool rekey,
             TSI_OK);
   EXPECT_EQ(actual_max_protected_frame_size, max_protected_frame_size);
   gpr_free(key);
-  grpc_core::ExecCtx::Get()->Flush();
   return fixture;
 }
 
@@ -143,10 +140,8 @@ static void alts_zero_copy_grpc_protector_test_fixture_destroy(
   if (fixture == nullptr) {
     return;
   }
-  grpc_core::ExecCtx exec_ctx;
   tsi_zero_copy_grpc_protector_destroy(fixture->client);
   tsi_zero_copy_grpc_protector_destroy(fixture->server);
-  grpc_core::ExecCtx::Get()->Flush();
   gpr_free(fixture);
 }
 
@@ -180,7 +175,6 @@ static void alts_zero_copy_grpc_protector_test_var_destroy(
 
 static void seal_unseal_small_buffer(tsi_zero_copy_grpc_protector* sender,
                                      tsi_zero_copy_grpc_protector* receiver) {
-  grpc_core::ExecCtx exec_ctx;
   for (size_t i = 0; i < kSealRepeatTimes; i++) {
     int min_progress_size;
     alts_zero_copy_grpc_protector_test_var* var =
@@ -219,12 +213,10 @@ static void seal_unseal_small_buffer(tsi_zero_copy_grpc_protector* sender,
     ASSERT_EQ(min_progress_size, 1);
     alts_zero_copy_grpc_protector_test_var_destroy(var);
   }
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 static void seal_unseal_large_buffer(tsi_zero_copy_grpc_protector* sender,
                                      tsi_zero_copy_grpc_protector* receiver) {
-  grpc_core::ExecCtx exec_ctx;
   for (size_t i = 0; i < kSealRepeatTimes; i++) {
     alts_zero_copy_grpc_protector_test_var* var =
         alts_zero_copy_grpc_protector_test_var_create();
@@ -254,7 +246,6 @@ static void seal_unseal_large_buffer(tsi_zero_copy_grpc_protector* sender,
         are_slice_buffers_equal(&var->unprotected_sb, &var->duplicate_sb));
     alts_zero_copy_grpc_protector_test_var_destroy(var);
   }
-  grpc_core::ExecCtx::Get()->Flush();
 }
 
 // --- Test cases. ---


### PR DESCRIPTION
I'm fixing the ALTS/Envoy transport socket extension (which is currently broken). Along the way, I'm trying to remove as many uses of gRPC internals as possible (with the eventual goal of only relying on public gRPC APIs and the alts_zero_copy_grpc_protector). To this end, I need to remove the ExecCtx check in the alts_zero_copy_grpc_protector_create function, so that Envoy can call into this function without needing to create an ExecCtx.
