### PR TITLE
[fork] simplify Fork::SetResetChildPollingEngineFunc to fix nested forking

### DIFF
--- a/src/core/lib/gprpp/fork.cc
+++ b/src/core/lib/gprpp/fork.cc
@@ -189,19 +189,16 @@ void Fork::DoDecExecCtxCount() {
   NoDestructSingleton<ExecCtxState>::Get()->DecExecCtxCount();
 }
 
-void Fork::SetResetChildPollingEngineFunc(
+bool Fork::RegisterResetChildPollingEngineFunc(
     Fork::child_postfork_func reset_child_polling_engine) {
   if (reset_child_polling_engine_ == nullptr) {
-    reset_child_polling_engine_ = new std::vector<Fork::child_postfork_func>();
+    reset_child_polling_engine_ = new std::set<Fork::child_postfork_func>();
   }
-  if (reset_child_polling_engine == nullptr) {
-    reset_child_polling_engine_->clear();
-  } else {
-    reset_child_polling_engine_->emplace_back(reset_child_polling_engine);
-  }
+  auto ret = reset_child_polling_engine_->inset(reset_child_polling_engine);
+  return ret.second;
 }
 
-const std::vector<Fork::child_postfork_func>&
+const std::set<Fork::child_postfork_func>&
 Fork::GetResetChildPollingEngineFunc() {
   return *reset_child_polling_engine_;
 }
@@ -238,6 +235,6 @@ void Fork::AwaitThreads() {
 
 std::atomic<bool> Fork::support_enabled_(false);
 bool Fork::override_enabled_ = false;
-std::vector<Fork::child_postfork_func>* Fork::reset_child_polling_engine_ =
+std::set<Fork::child_postfork_func>* Fork::reset_child_polling_engine_ =
     nullptr;
 }  // namespace grpc_core

--- a/src/core/lib/gprpp/fork.cc
+++ b/src/core/lib/gprpp/fork.cc
@@ -194,7 +194,7 @@ bool Fork::RegisterResetChildPollingEngineFunc(
   if (reset_child_polling_engine_ == nullptr) {
     reset_child_polling_engine_ = new std::set<Fork::child_postfork_func>();
   }
-  auto ret = reset_child_polling_engine_->inset(reset_child_polling_engine);
+  auto ret = reset_child_polling_engine_->insert(reset_child_polling_engine);
   return ret.second;
 }
 

--- a/src/core/lib/gprpp/fork.cc
+++ b/src/core/lib/gprpp/fork.cc
@@ -20,6 +20,8 @@
 
 #include "src/core/lib/gprpp/fork.h"
 
+#include <utility>
+
 #include <grpc/support/atm.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>

--- a/src/core/lib/gprpp/fork.h
+++ b/src/core/lib/gprpp/fork.h
@@ -22,7 +22,7 @@
 #include <grpc/support/port_platform.h>
 
 #include <atomic>
-#include <vector>
+#include <set>
 
 //
 // NOTE: FORKING IS NOT GENERALLY SUPPORTED, THIS IS ONLY INTENDED TO WORK
@@ -57,10 +57,11 @@ class Fork {
 
   // Provide a function that will be invoked in the child's postfork handler to
   // reset the polling engine's internal state.
-  static void SetResetChildPollingEngineFunc(
+  // Returns true if reset_child_polling_engine was not previously registered,
+  // otherwise returns false and does nothing.
+  static bool RegisterResetChildPollingEngineFunc(
       child_postfork_func reset_child_polling_engine);
-  static const std::vector<child_postfork_func>&
-  GetResetChildPollingEngineFunc();
+  static const std::set<child_postfork_func>& GetResetChildPollingEngineFunc();
 
   // Check if there is a single active ExecCtx
   // (the one used to invoke this function).  If there are more,
@@ -89,7 +90,7 @@ class Fork {
 
   static std::atomic<bool> support_enabled_;
   static bool override_enabled_;
-  static std::vector<child_postfork_func>* reset_child_polling_engine_;
+  static std::set<child_postfork_func>* reset_child_polling_engine_;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1404,10 +1404,11 @@ const grpc_event_engine_vtable grpc_ev_poll_posix = {
         return false;
       }
       if (grpc_core::Fork::Enabled()) {
-        track_fds_for_fork = true;
-        gpr_mu_init(&fork_fd_list_mu);
-        grpc_core::Fork::SetResetChildPollingEngineFunc(
-            reset_event_manager_on_fork);
+        if (grpc_core::Fork::RegisterResetChildPollingEngineFunc(
+                reset_event_manager_on_fork)) {
+          track_fds_for_fork = true;
+          gpr_mu_init(&fork_fd_list_mu);
+        }
       }
       return true;
     },


### PR DESCRIPTION
Noticed this in a nested forking test in https://github.com/grpc/grpc/pull/33430 (by nested fork - forked child process forks again).

Before this change, the EventEngine and non-EventEngine pollers were competing with each other in their calls to `Fork::SetResetChildPollingEngineFunc`. In the first child's after-fork handler, the EE engine would [clear out](https://github.com/grpc/grpc/blob/123da4a866d278b898516c27fb44962f3d7bae32/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc#L260) the post-fork handlers of the non-EE poller, leaving the grandchild without the right post-fork cleanup method.

