### PR TITLE
[Test] Do not use importlib find_module API, removed in Python 3.12

### DIFF
--- a/bazel/_gevent_test_main.py
+++ b/bazel/_gevent_test_main.py
@@ -42,6 +42,7 @@ import unittest
 import sys
 import os
 import pkgutil
+import importlib
 
 def trace_callback(event, args):
     if event in ("switch", "throw"):
@@ -73,7 +74,9 @@ class SingleLoader(object):
         tests = []
         for importer, module_name, is_package in pkgutil.walk_packages([os.path.dirname(os.path.relpath(__file__))]):
             if pattern in module_name:
-                module = importer.find_module(module_name).load_module(module_name)
+                spec = importer.find_spec(module_name)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
                 tests.append(loader.loadTestsFromModule(module))
         if len(tests) != 1:
             raise AssertionError("Expected only 1 test module. Found {}".format(tests))

--- a/src/python/grpcio_tests/tests/_loader.py
+++ b/src/python/grpcio_tests/tests/_loader.py
@@ -103,12 +103,13 @@ class Loader(object):
         for importer, module_name, is_package in pkgutil.walk_packages(
             [package_path], prefix
         ):
-            found_module = importer.find_module(module_name)
             module = None
             if module_name in sys.modules:
                 module = sys.modules[module_name]
             else:
-                module = found_module.load_module(module_name)
+                spec = importer.find_spec(module_name)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
             self.visit_module(module)
 
     def visit_module(self, module):


### PR DESCRIPTION
This API was [removed in Python 3.12](https://github.com/python/cpython/issues/98040).

Fixes Python 3.12 support in `grpcio` tests.

This is relevant to https://github.com/grpc/grpc/issues/33063.

See also https://github.com/grpc/grpc/pull/33492.

----

I have actually only tested this in a form backported to grpc 1.48.4, and I am not able to test the change to `bazel/_gevent_test_main.py` directly. However, the backported form allows me to build grpc 1.48.4 for Fedora Rawhide with Python 3.12, and I believe the version in this PR to be correct—especially, if CI passes for Python 3.11, I believe this part of the test code will continue to work in Python 3.12.