### PR TITLE
[Ruby] add -weak_framework CoreFoundation to ruby extension

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -141,7 +141,7 @@ end
 
 ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', ext_export_filename())
 $LDFLAGS << ' -Wl,--version-script="' + ext_export_file + '.gcc"' if linux
-$LDFLAGS << ' -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"' if apple_toolchain
+$LDFLAGS << ' -weak_framework CoreFoundation -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"' if apple_toolchain
 
 $LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgrpc.a') unless windows
 if grpc_config == 'gcov'


### PR DESCRIPTION
Fixes Undefined symbols of _CFXxxx on arm MacOS.


Fixes https://github.com/grpc/grpc/issues/33483