### PR TITLE
[ruby] Add `-weak_framework CoreFoundation` to link line

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -141,7 +141,10 @@ end
 
 ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', ext_export_filename())
 $LDFLAGS << ' -Wl,--version-script="' + ext_export_file + '.gcc"' if linux
-$LDFLAGS << ' -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"' if apple_toolchain
+if apple_toolchain
+  $LDFLAGS << ' -weak_framework CoreFoundation' if RUBY_PLATFORM =~ /arm64/
+  $LDFLAGS << ' -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"'
+end
 
 $LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgrpc.a') unless windows
 if grpc_config == 'gcov'


### PR DESCRIPTION
Add -weak_framework CoreFoundation to the ruby extension link line on arm64-darwin, to address "undefined symbols" issues from #33483 

This is a variation on #33513 in response to feedback and so I've made sure @alto-ruby is credited as co-author.

Closes #33483

Supersedes #33513

cc @apolcyn 