### PR TITLE
[PSM Interop] Bump the canonical server from v1.48.1 to v1.56.0

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -5,9 +5,9 @@
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,
 # or missing a feature required for the test.
-# TODO(sergiitk): Update every ~ 6 months; next 2023-02.
-# https://github.com/grpc/grpc-java/commits/v1.48.1
---server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:d56f8fbe1d2822bc4f91515dd471ad49493fc385
+# TODO(sergiitk): Update every ~ 6 months; next 2024-01.
+# https://github.com/grpc/grpc-java/commits/v1.56.0
+--server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:d25095c2a714bb9abccdb6622a13b8bc768dc18a
 
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -6,8 +6,11 @@
 # Can be used in tests where language-specific xDS test server does not exist,
 # or missing a feature required for the test.
 # TODO(sergiitk): Update every ~ 6 months; next 2024-01.
+# Commit:
+# https://github.com/grpc/grpc-java/commit/558b5b0bfac8e21755c223063274a779b3898afe
+# Closest tag:
 # https://github.com/grpc/grpc-java/commits/v1.56.0
---server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:d25095c2a714bb9abccdb6622a13b8bc768dc18a
+--server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:558b5b0bfac8e21755c223063274a779b3898afe
 
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0


### PR DESCRIPTION
### From:

* Closest tag: `v1.48.1`
* Branch: https://github.com/grpc/grpc-java/commits/v1.48.x
* Commit: grpc/grpc-java@d56f8fbe1d2822bc4f91515dd471ad49493fc385
* Image: gcr.io/grpc-testing/xds-interop/java-server:d56f8fbe1d2822bc4f91515dd471ad49493fc385


### To:

* Closest tag: `v1.56.0`
* Branch: https://github.com/grpc/grpc-java/commits/v1.56.x
* Commit: grpc/grpc-java@558b5b0bfac8e21755c223063274a779b3898afe
* Image: gcr.io/grpc-testing/xds-interop/java-server:558b5b0bfac8e21755c223063274a779b3898afe

