### PR TITLE
[Test] Explicitly cast `enum class` to `int` before passing it with a format string

### DIFF
--- a/test/cpp/qps/parse_json.cc
+++ b/test/cpp/qps/parse_json.cc
@@ -40,7 +40,7 @@ void ParseJson(const std::string& json, const std::string& type,
   if (!status.ok()) {
     std::string errmsg(status.message());
     gpr_log(GPR_ERROR, "Failed to convert json to binary: errcode=%d msg=%s",
-            status.code(), errmsg.c_str());
+            static_cast<int>(status.code()), errmsg.c_str());
     grpc_core::Crash(absl::StrFormat("JSON: %s", json.c_str()));
   }
   GPR_ASSERT(msg->ParseFromString(binary));


### PR DESCRIPTION
Corresponding internal cl/542804880

> Explicitly cast `enum class` to `int` before passing it with a format string.
> 
> Next version of the crosstool will start warning about this (see:
> [https://github.com/llvm/llvm-project/issues/38717](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fllvm%2Fllvm-project%2Fissues%2F38717))

