### PR TITLE
[python O11Y] Refactor census propagation flow.

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -1251,7 +1251,6 @@ def _start(state: _ServerState) -> None:
         state.server.start()
         state.stage = _ServerStage.STARTED
         _request_call(state)
-
         thread = threading.Thread(target=_serve, args=(state,))
         thread.daemon = True
         thread.start()

--- a/src/python/grpcio_observability/grpc_observability/_gcp_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_gcp_observability.py
@@ -203,7 +203,6 @@ class GCPOpenCensusObservability(grpc._observability.ObservabilityPlugin):
             trace_id=trace_id,
             span_id=span_id,
             trace_options=trace_options,
-            from_header=True,
         )
         execution_context.set_opencensus_attr(GRPC_SPAN_CONTEXT, span_context)
 

--- a/src/python/grpcio_tests/tests/observability/_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_observability_test.py
@@ -93,7 +93,9 @@ def handle_unary_unary(request, servicer_context):
             if "port" in k:
                 unary_unary_call(port=int(v))
             if "to_new_server" in k:
-                second_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+                second_server = grpc.server(
+                    futures.ThreadPoolExecutor(max_workers=10)
+                )
                 second_server.add_generic_rpc_handlers((_GenericHandler(),))
                 second_server_port = second_server.add_insecure_port("[::]:0")
                 second_server.start()
@@ -186,7 +188,10 @@ class ObservabilityTest(unittest.TestCase):
             exporter=self.test_exporter
         ):
             port = self._start_server()
-            metadata = (TRIGGER_RPC_METADATA, ("port", str(port)),)
+            metadata = (
+                TRIGGER_RPC_METADATA,
+                ("port", str(port)),
+            )
             unary_unary_call(port=port, metadata=metadata)
 
         # 2 of each for ["Recv", "Sent", "Attempt"]
@@ -206,8 +211,10 @@ class ObservabilityTest(unittest.TestCase):
             exporter=self.test_exporter
         ):
             port = self._start_server()
-            metadata = (TRIGGER_RPC_METADATA,
-                        TRIGGER_RPC_TO_NEW_SERVER_METADATA,)
+            metadata = (
+                TRIGGER_RPC_METADATA,
+                TRIGGER_RPC_TO_NEW_SERVER_METADATA,
+            )
             unary_unary_call(port=port, metadata=metadata)
 
         # 2 of each for ["Recv", "Sent", "Attempt"]


### PR DESCRIPTION
Refactored OpenCensus context propagation flow, now propagation happens for each call and context will be automatically propagated from gRPC server to gRPC client.

 We're using `execution_context` in OpenCensus since the context is related to OpenCensus and it helps wrap `contextVar` for us.

### Testing
* Added a new Bazel test case for context propagation. 

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

