### PR TITLE
[distribute] Add LICENSE to python ancillary packages.

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -81,6 +81,21 @@ then
   export GRPC_BUILD_OVERRIDE_BORING_SSL_ASM_PLATFORM="linux-arm"
 fi
 
+ancillary_package_dir=(
+  "src/python/grpcio_admin/"
+  "src/python/grpcio_channelz/"
+  "src/python/grpcio_csds/"
+  "src/python/grpcio_health_checking/"
+  "src/python/grpcio_reflection/"
+  "src/python/grpcio_status/"
+  "src/python/grpcio_testing/"
+)
+
+# Copy license to ancillary package directories so it will be distributed.
+for directory in "${ancillary_package_dir[@]}"; do
+  cp "LICENSE" "${directory}"
+done
+
 # Build the source distribution first because MANIFEST.in cannot override
 # exclusion of built shared objects among package resources (for some
 # inexplicable reason).


### PR DESCRIPTION
Fix: #33557

### Testing
* Verified through `distribtests_python` that `LICENSE` file exists in both [.tar.gz](https://storage.googleapis.com/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/f69791e2-b7fd-4729-b55e-caca9171a170/1/20230629-092736/github/grpc/artifacts/grpcio-status-1.57.0.dev0.tar.gz) and [.whl](https://storage.googleapis.com/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/f69791e2-b7fd-4729-b55e-caca9171a170/1/20230629-092736/github/grpc/artifacts/grpcio_status-1.57.0.dev0-py3-none-any.whl).

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

