### PR TITLE
[PSM Interop] Bump URL Map canonical server from 1.40.0 to 1.56.0

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -2,12 +2,14 @@
 --strategy=reuse
 --server_xds_port=8848
 
-# TODO(sergiitk): Use --server_image_canonical instead.
 # NOTE(lidiz) we pin the server image to java-server because:
 # 1. Only Java server understands the rpc-behavior metadata.
 # 2. All UrlMap tests today are testing client-side logic.
-# grpc-java master: 438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa TODO: use v1.40.0
---server_image=gcr.io/grpc-testing/xds-interop/java-server:438f8d9e7880b2f6ae2b376a35a9f5f32b4dbeaa
+#
+# Commit: https://github.com/grpc/grpc-java/commit/558b5b0bfac8e21755c223063274a779b3898afe
+# Closest tag: https://github.com/grpc/grpc-java/commits/v1.56.0
+# TODO(sergiitk): Use --server_image_canonical instead.
+--server_image=gcr.io/grpc-testing/xds-interop/java-server:558b5b0bfac8e21755c223063274a779b3898afe
 
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc/pull/33542.

Note that there's a ticket to automatically use the one specified in the --server_image_canonical flag, but for now we just hardcode.

ref b/261911148, b/282106799.