### PR TITLE
[PSM Interop] Set canonical server via canonical-* tag, not commit sha

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -6,11 +6,7 @@
 # Can be used in tests where language-specific xDS test server does not exist,
 # or missing a feature required for the test.
 # TODO(sergiitk): Update every ~ 6 months; next 2024-01.
-# Commit:
-# https://github.com/grpc/grpc-java/commit/558b5b0bfac8e21755c223063274a779b3898afe
-# Closest tag:
-# https://github.com/grpc/grpc-java/commits/v1.56.0
---server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:558b5b0bfac8e21755c223063274a779b3898afe
+--server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:canonical-v1.56
 
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/url-map.cfg
@@ -6,10 +6,8 @@
 # 1. Only Java server understands the rpc-behavior metadata.
 # 2. All UrlMap tests today are testing client-side logic.
 #
-# Commit: https://github.com/grpc/grpc-java/commit/558b5b0bfac8e21755c223063274a779b3898afe
-# Closest tag: https://github.com/grpc/grpc-java/commits/v1.56.0
 # TODO(sergiitk): Use --server_image_canonical instead.
---server_image=gcr.io/grpc-testing/xds-interop/java-server:558b5b0bfac8e21755c223063274a779b3898afe
+--server_image=gcr.io/grpc-testing/xds-interop/java-server:canonical-v1.56
 
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None


### PR DESCRIPTION
While this is less transparent, it makes it significantly easier to deliver images with latest security patches.