### PR TITLE
[PSM Interop] Update Kokoro to Ubuntu 22.04

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 # Constants
-readonly PYTHON_VERSION="${PYTHON_VERSION:-3.9}"
+readonly PYTHON_VERSION="${PYTHON_VERSION:-3.10}"
 # Test driver
 readonly TEST_DRIVER_REPO_NAME="grpc"
 readonly TEST_DRIVER_REPO_URL="https://github.com/${TEST_DRIVER_REPO_OWNER:-grpc}/grpc.git"
@@ -97,9 +97,11 @@ activate_secondary_gke_cluster() {
 #   Writes the output of given command to stdout, stderr
 #######################################
 run_ignore_exit_code() {
-  local exit_code=-1
+  local exit_code=0
   "$@" || exit_code=$?
-  echo "Exit code: ${exit_code}"
+  if [[ $exit_code != 0 ]]; then
+    echo "Cmd: '$*', exit code: ${exit_code}"
+  fi
 }
 
 #######################################
@@ -152,18 +154,6 @@ is_version_branch() {
 #######################################
 gcloud_gcr_list_image_tags() {
   gcloud container images list-tags --format="table[box](tags,digest,timestamp.date())" --filter="tags:$2" "$1"
-}
-
-#######################################
-# A helper to execute `gcloud -q components update`.
-# Arguments:
-#   None
-# Outputs:
-#   Writes the output of `gcloud` command to stdout, stderr
-#######################################
-gcloud_update() {
-  echo "Update gcloud components:"
-  gcloud -q components update
 }
 
 #######################################
@@ -239,7 +229,7 @@ test_driver_pip_install() {
       echo "Found python virtual environment directory: ${venv_dir}"
     else
       echo "Creating python virtual environment: ${venv_dir}"
-      "python${PYTHON_VERSION}" -m venv "${venv_dir}"
+      "python${PYTHON_VERSION}" -m venv "${venv_dir}" --upgrade-deps
     fi
     # Intentional: No need to check python venv activate script.
     # shellcheck source=/dev/null
@@ -305,18 +295,17 @@ test_driver_install() {
 }
 
 #######################################
-# Outputs Kokoro image version and Ubuntu's lsb_release
+# Outputs Ubuntu's lsb_release and system python, pip versions
 # Arguments:
 #   None
 # Outputs:
 #   Writes the output to stdout
 #######################################
 kokoro_print_version() {
-  echo "Kokoro VM version:"
-  if [[ -f /VERSION ]]; then
-    cat /VERSION
-  fi
+  echo "Kokoro Ubuntu version:"
   run_ignore_exit_code lsb_release -a
+  run_ignore_exit_code "python${PYTHON_VERSION}" --version
+  run_ignore_exit_code "python${PYTHON_VERSION}" -m pip --version
 }
 
 #######################################
@@ -349,28 +338,22 @@ EOF
 }
 
 #######################################
-# Configure Python virtual environment on Kokoro VM.
+# Install packages via apt.
 # Arguments:
 #   None
 # Outputs:
-#   Writes the output of `pyenv` commands to stdout
+#   Writes the output of `apt` commands to stdout
 #######################################
-kokoro_setup_python_virtual_environment() {
-  # Kokoro provides pyenv, so use it instead of `python -m venv`
-  echo "Setup pyenv environment"
-  eval "$(pyenv init -)"
-  eval "$(pyenv virtualenv-init -)"
-  py_latest_patch="$(pyenv versions --bare --skip-aliases | grep -E "^${PYTHON_VERSION}\.[0-9]{1,2}$" | sort --version-sort | tail -n 1)"
-  echo "Activating python ${py_latest_patch} virtual environment"
-  pyenv virtualenv --without-pip "${py_latest_patch}" k8s_xds_test_runner
-  pyenv local k8s_xds_test_runner
-  pyenv activate k8s_xds_test_runner
-  python3 -m ensurepip
-  # pip is fixed to 21.0.1 due to issue https://github.com/pypa/pip/pull/9835
-  # internal details: b/186411224
-  # TODO(sergiitk): revert https://github.com/grpc/grpc/pull/26087 when 21.1.1 released
-  python3 -m pip install -U pip==21.0.1
-  python3 -m pip --version
+kokoro_install_dependencies() {
+  # needrestart checks which daemons need to be restarted after library
+  # upgrades. It's useless to us in non-interactive mode.
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -qq remove needrestart
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install --auto-remove \
+    "python${PYTHON_VERSION}-venv" \
+    google-cloud-sdk-gke-gcloud-auth-plugin \
+    kubectl
+  sudo rm -rf /var/lib/apt/lists
 }
 
 #######################################
@@ -437,6 +420,8 @@ kokoro_get_testing_version() {
 #   Writes the output to stdout, stderr, files
 #######################################
 kokoro_setup_test_driver() {
+  # Unset noisy verbose mode often set in the parent script.
+  set +x
   local src_repository_name="${1:?Usage kokoro_setup_test_driver GITHUB_REPOSITORY_NAME}"
   # Capture Kokoro VM version info in the log.
   kokoro_print_version
@@ -447,18 +432,20 @@ kokoro_setup_test_driver() {
   # Kokoro clones repo to ${KOKORO_ARTIFACTS_DIR}/github/${GITHUB_REPOSITORY}
   local github_root="${KOKORO_ARTIFACTS_DIR}/github"
   readonly SRC_DIR="${github_root}/${src_repository_name}"
-  local test_driver_repo_dir
-  test_driver_repo_dir="${TEST_DRIVER_REPO_DIR:-$(mktemp -d)/${TEST_DRIVER_REPO_NAME}}"
   parse_src_repo_git_info SRC_DIR
   kokoro_write_sponge_properties
-  kokoro_setup_python_virtual_environment
+  kokoro_install_dependencies
 
-  # gcloud requires python, so this should be executed after pyenv setup
-  gcloud_update
+  # Get kubectl cluster credentials.
   gcloud_get_cluster_credentials
+
+  # Install the driver.
+  local test_driver_repo_dir
+  test_driver_repo_dir="${TEST_DRIVER_REPO_DIR:-$(mktemp -d)/${TEST_DRIVER_REPO_NAME}}"
   test_driver_install "${test_driver_repo_dir}"
   # shellcheck disable=SC2034  # Used in the main script
   readonly TEST_DRIVER_FLAGFILE="config/grpc-testing.cfg"
+
   # Test artifacts dir: xml reports, logs, etc.
   local artifacts_dir="${KOKORO_ARTIFACTS_DIR}/artifacts"
   # Folders after $artifacts_dir reported as target name


### PR DESCRIPTION
Makes the changes necessary to run the new PSM interop framework on Ubuntu 22.04:

- Install dependencies via apt: `kubectl`, `google-cloud-sdk-gke-gcloud-auth-plugin` (previously were pre-provisioned or available as part of gcloud distribution)
- Use venv instead of pyenv
- Use python 3.10 instead of python3 .9

Other changes:
- Do not update gcloud components - the one provisioned is relatively recent, and expected to be updated as new base images are released
- Unpin pip from `21.0.1`. Not sure if we're OK about using the latest one `venv --upgrade-deps`, or if we should just pin it to something more recent (currently it resolves to `pip 22.0.2` and `setuptools 68.0.0`)

ref b/274944592, cl/547690787