### PR TITLE
[Ruby] remove objs and strip libs in ruby extension build

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -93,6 +93,9 @@ output_dir = File.expand_path(RbConfig::CONFIG['topdir'])
 grpc_lib_dir = File.join(output_dir, 'libs', grpc_config)
 ENV['BUILDDIR'] = output_dir
 
+strip_tool = RbConfig::CONFIG['STRIP']
+strip_tool += ' -x' if apple_toolchain
+
 unless windows
   puts 'Building internal gRPC into ' + grpc_lib_dir
   nproc = 4
@@ -107,6 +110,17 @@ unless windows
   puts "Building grpc native library: #{cmd}"
   system(cmd)
   exit 1 unless $? == 0
+
+  if grpc_config == 'opt'
+    rm_obj_cmd = "rm -rf #{File.join(output_dir, 'objs')}"
+    puts "Removing grpc object files: #{rm_obj_cmd}"
+    system(rm_obj_cmd)
+    exit 1 unless $? == 0
+    strip_cmd = "#{strip_tool} #{grpc_lib_dir}/*.a"
+    puts "Stripping grpc native library: #{strip_cmd}"
+    system(strip_cmd)
+    exit 1 unless $? == 0
+  end
 end
 
 $CFLAGS << ' -DGRPC_RUBY_WINDOWS_UCRT' if windows_ucrt
@@ -171,9 +185,6 @@ $CFLAGS << ' -pedantic '
 output = File.join('grpc', 'grpc_c')
 puts 'Generating Makefile for ' + output
 create_makefile(output)
-
-strip_tool = RbConfig::CONFIG['STRIP']
-strip_tool += ' -x' if apple_toolchain
 
 if grpc_config == 'opt'
   File.open('Makefile.new', 'w') do |o|


### PR DESCRIPTION
Remove `src/ruby/ext/grpc/objs/` and strip `src/ruby/ext/grpc/libs/` in ruby build dir to save some space.
This can reduce the grpc gem size from more than 1G to about 70~80M.
This only affects opt build, dbg build remains the same.

A proper fix maybe use the same makefile to build c-core and the extension rather than building c-core when generating the extension makefile.

fixes: https://github.com/grpc/grpc/issues/33412