### PR TITLE
[ssl] Temporarily increase default BIO buffer size from 17kb to 30kb.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -309,8 +309,6 @@ let package = Package(
         "src/core/ext/transport/chttp2/transport/internal.h",
         "src/core/ext/transport/chttp2/transport/parsing.cc",
         "src/core/ext/transport/chttp2/transport/stream_lists.cc",
-        "src/core/ext/transport/chttp2/transport/stream_map.cc",
-        "src/core/ext/transport/chttp2/transport/stream_map.h",
         "src/core/ext/transport/chttp2/transport/varint.cc",
         "src/core/ext/transport/chttp2/transport/varint.h",
         "src/core/ext/transport/chttp2/transport/writing.cc",

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <cstddef>
 #include <initializer_list>
 #include <string>
 #include <utility>

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -58,6 +58,8 @@
 #include "src/core/tsi/transport_security_interface.h"
 
 namespace {
+const std::size_t kBioBufferSize = 30000;
+
 grpc_error_handle ssl_check_peer(
     const char* peer_name, const tsi_peer* peer,
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context) {
@@ -137,12 +139,14 @@ class grpc_ssl_channel_security_connector final
                        grpc_core::HandshakeManager* handshake_mgr) override {
     // Instantiate TSI handshaker.
     tsi_handshaker* tsi_hs = nullptr;
+    // TODO(matthewstevenson88): Remove the hardcoded large BIO buffer size when
+    // BIO I/O is fixed.
     tsi_result result = tsi_ssl_client_handshaker_factory_create_handshaker(
         client_handshaker_factory_,
         overridden_target_name_.empty() ? target_name_.c_str()
                                         : overridden_target_name_.c_str(),
-        /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        /*network_bio_buf_size=*/kBioBufferSize,
+        /*ssl_bio_buf_size=*/kBioBufferSize, &tsi_hs);
     if (result != TSI_OK) {
       gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
               tsi_result_to_string(result));
@@ -282,9 +286,11 @@ class grpc_ssl_server_security_connector
     // Instantiate TSI handshaker.
     try_fetch_ssl_server_credentials();
     tsi_handshaker* tsi_hs = nullptr;
+    // TODO(matthewstevenson88): Remove the hardcoded large BIO buffer size when
+    // BIO I/O is fixed.
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
-        server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        server_handshaker_factory_, /*network_bio_buf_size=*/kBioBufferSize,
+        /*ssl_bio_buf_size=*/kBioBufferSize, &tsi_hs);
     if (result != TSI_OK) {
       gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
               tsi_result_to_string(result));

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -55,6 +55,8 @@ namespace grpc_core {
 
 namespace {
 
+const std::size_t kBioBufferSize = 30000;
+
 char* CopyCoreString(char* src, size_t length) {
   char* target = static_cast<char*>(gpr_malloc(length + 1));
   memcpy(target, src, length);
@@ -347,13 +349,15 @@ void TlsChannelSecurityConnector::add_handshakers(
   MutexLock lock(&mu_);
   tsi_handshaker* tsi_hs = nullptr;
   if (client_handshaker_factory_ != nullptr) {
+    // TODO(matthewstevenson88): Remove the hardcoded large BIO buffer size when
+    // BIO I/O is fixed.
     // Instantiate TSI handshaker.
     tsi_result result = tsi_ssl_client_handshaker_factory_create_handshaker(
         client_handshaker_factory_,
         overridden_target_name_.empty() ? target_name_.c_str()
                                         : overridden_target_name_.c_str(),
-        /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        /*network_bio_buf_size=*/kBioBufferSize,
+        /*ssl_bio_buf_size=*/kBioBufferSize, &tsi_hs);
     if (result != TSI_OK) {
       gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
               tsi_result_to_string(result));
@@ -634,10 +638,12 @@ void TlsServerSecurityConnector::add_handshakers(
   MutexLock lock(&mu_);
   tsi_handshaker* tsi_hs = nullptr;
   if (server_handshaker_factory_ != nullptr) {
+    // TODO(matthewstevenson88): Remove the hardcoded large BIO buffer size when
+    // BIO I/O is fixed.
     // Instantiate TSI handshaker.
     tsi_result result = tsi_ssl_server_handshaker_factory_create_handshaker(
-        server_handshaker_factory_, /*network_bio_buf_size=*/0,
-        /*ssl_bio_buf_size=*/0, &tsi_hs);
+        server_handshaker_factory_, /*network_bio_buf_size=*/kBioBufferSize,
+        /*ssl_bio_buf_size=*/kBioBufferSize, &tsi_hs);
     if (result != TSI_OK) {
       gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
               tsi_result_to_string(result));

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
There is a bug in the SSL stack that was only partially fixed in #29176: if more than 17kb is written to the BIO buffer, then everything over 17kb will be discarded, and the SSL handshake will fail with a bad record mac error.

It's relatively uncommon to hit this bug, because the TLS handshake messages need to be much larger than normal for you to have a chance of hitting this bug. However, there was a separate bug in the SSL stack (recently fixed in #33558) that causes the ServerHello produced by a gRPC-C++ TLS server to grow linearly in size with the size of the trust bundle. 

The correct fix to this bug is to (a) keep the default BIO buffer size at 17kb, and (b) add logic in `ssl_transport_security.cc` to never write more than 17kb at one time to the BIO. This is a bit delicate to do (specifically, setting up a test to reproduce the problem) and will happen in a follow-up PR, but this PR is being sent as a temporary mitigation for clients built from g3 that are often failing because of the combination of these 2 bugs.

To emphasize: this PR is temporary and will be replaced with a long-term fix when it is ready, likely early next week.