### PR TITLE
[ruby] Fix re2 compilation when different system version installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -534,12 +534,14 @@ CPPFLAGS := -Ithird_party/address_sorting/include $(CPPFLAGS)
 
 GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
 GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
+CPPFLAGS := -Ithird_party/abseil-cpp $(CPPFLAGS)
 
 # Setup re2 dependency
 
 RE2_DEP = $(LIBDIR)/$(CONFIG)/libre2.a
 RE2_MERGE_OBJS = $(LIBRE2_OBJS)
 RE2_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libre2.a
+CPPFLAGS := -Ithird_party/re2 $(CPPFLAGS)
 
 # Setup upb dependency
 

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -439,12 +439,14 @@
 
   GRPC_ABSEIL_DEP = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
   GRPC_ABSEIL_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libgrpc_abseil.a
+  CPPFLAGS := -Ithird_party/abseil-cpp $(CPPFLAGS)
 
   # Setup re2 dependency
 
   RE2_DEP = $(LIBDIR)/$(CONFIG)/libre2.a
   RE2_MERGE_OBJS = $(LIBRE2_OBJS)
   RE2_MERGE_LIBS = $(LIBDIR)/$(CONFIG)/libre2.a
+  CPPFLAGS := -Ithird_party/re2 $(CPPFLAGS)
 
   # Setup upb dependency
 


### PR DESCRIPTION
re2 or abseil previously failed to compile if:

1. A different and incompatible version were installed with a non-standard system prefix, such as `/opt/local`.
2. The Ruby interpreter has CPPFLAGS to include the prefix, such as `CPPFLAGS=-I/opt/local/include`.

Running `make` would result in method prototype mismatches because the Makefile would previously attempt to use the headers from `/opt/local/include/re2` before the `third_party/re2/re2` directory.

To ensure the current directories receive priority, include the relevant re2 and abseil directories in the include path.

Relates to https://github.com/grpc/grpc/issues/33615

