### PR TITLE
[C++] Fix two compilation warnings in grpcpp/support/proto_buffer_reader.h.

### DIFF
--- a/include/grpcpp/support/proto_buffer_reader.h
+++ b/include/grpcpp/support/proto_buffer_reader.h
@@ -154,7 +154,7 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
       }
       uint64_t slice_length = GRPC_SLICE_LENGTH(*slice());
       set_byte_count(ByteCount() + slice_length);
-      if (slice_length <= count) {
+      if (slice_length <= static_cast<uint64_t>(count)) {
         cord->Append(MakeCordFromSlice(grpc_slice_ref(*slice())));
         count -= slice_length;
       } else {
@@ -188,7 +188,7 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
     return absl::MakeCordFromExternal(
         absl::string_view(reinterpret_cast<char*>(GRPC_SLICE_START_PTR(slice)),
                           GRPC_SLICE_LENGTH(slice)),
-        [slice](absl::string_view view) { grpc_slice_unref(slice); });
+        [slice](absl::string_view /* view */) { grpc_slice_unref(slice); });
   }
 #endif  // GRPC_PROTOBUF_CORD_SUPPORT_ENABLED
 


### PR DESCRIPTION
Detected with gcc 13:
```
In file included from /data/mwrep/res/osp/Grpc/23-0-0-0/include/grpcpp/impl/proto_utils.h:31,
                 from ./include/generated/gacms.object.grpc.pb.h:18,
                 from ./include/generated/gacms.object.grpc.pb.cc:6:
/data/mwrep/res/osp/Grpc/23-0-0-0/include/grpcpp/support/proto_buffer_reader.h: In member function 'virtual bool grpc::ProtoBufferReader::ReadCord(absl::lts_20230125::Cord*, int)': /data/mwrep/res/osp/Grpc/23-0-0-0/include/grpcpp/support/proto_buffer_reader.h:157:24: error: comparison of integer expressions of different signedness: 'uint64_t' {aka 'long unsigned int'} and 'int' [-Werror=sign-compare]
  157 |       if (slice_length <= count) {
      |           ~~~~~~~~~~~~~^~~~~~~~
/data/mwrep/res/osp/Grpc/23-0-0-0/include/grpcpp/support/proto_buffer_reader.h: In lambda function:
/data/mwrep/res/osp/Grpc/23-0-0-0/include/grpcpp/support/proto_buffer_reader.h:191:35: warning: unused parameter 'view' [-Wunused-parameter]
  191 |         [slice](absl::string_view view) { grpc_slice_unref(slice); });
      |                 ~~~~~~~~~~~~~~~~~~^~~~
cc1plus: all warnings being treated as errors
```