### PR TITLE
[ssl] Fix SSL stack to handle large handshake messages whose length exceeds the BIO buffer size.

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1543,21 +1543,18 @@ static tsi_result ssl_handshaker_next(tsi_handshaker* self,
   if (received_bytes_size > 0) {
     unsigned char* remaining_bytes_to_write_to_network_io =
         const_cast<unsigned char*>(received_bytes);
-    std::size_t remaining_bytes_to_write_to_network_io_size =
-        received_bytes_size;
-    std::size_t number_bio_write_attempts = 0;
+    size_t remaining_bytes_to_write_to_network_io_size = received_bytes_size;
+    size_t number_bio_write_attempts = 0;
     while (remaining_bytes_to_write_to_network_io_size > 0 &&
            (status == TSI_OK || status == TSI_INCOMPLETE_DATA) &&
            number_bio_write_attempts < TSI_SSL_MAX_BIO_WRITE_ATTEMPTS) {
-      number_bio_write_attempts++;
-
+      ++number_bio_write_attempts;
       // Try to write all of the remaining bytes to the BIO.
-      std::size_t bytes_written_to_network_io =
+      size_t bytes_written_to_network_io =
           remaining_bytes_to_write_to_network_io_size;
       status = ssl_handshaker_process_bytes_from_peer(
           impl, remaining_bytes_to_write_to_network_io,
           &bytes_written_to_network_io, error);
-
       // As long as the BIO is full, drive the SSL handshake to consume bytes
       // from the BIO. If the SSL handshake returns any bytes, write them to the
       // peer.
@@ -1567,7 +1564,6 @@ static tsi_result ssl_handshaker_next(tsi_handshaker* self,
         if (status != TSI_OK) return status;
         status = ssl_handshaker_do_handshake(impl, error);
       }
-
       // Move the pointer to the first byte not yet successfully written to the
       // BIO.
       remaining_bytes_to_write_to_network_io_size -=

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1541,20 +1541,20 @@ static tsi_result ssl_handshaker_next(tsi_handshaker* self,
   tsi_result status = TSI_OK;
   size_t bytes_written = 0;
   if (received_bytes_size > 0) {
-    unsigned char* remaining_bytes_to_write_to_network_io =
+    unsigned char* remaining_bytes_to_write_to_openssl =
         const_cast<unsigned char*>(received_bytes);
-    size_t remaining_bytes_to_write_to_network_io_size = received_bytes_size;
+    size_t remaining_bytes_to_write_to_openssl_size = received_bytes_size;
     size_t number_bio_write_attempts = 0;
-    while (remaining_bytes_to_write_to_network_io_size > 0 &&
+    while (remaining_bytes_to_write_to_openssl_size > 0 &&
            (status == TSI_OK || status == TSI_INCOMPLETE_DATA) &&
            number_bio_write_attempts < TSI_SSL_MAX_BIO_WRITE_ATTEMPTS) {
       ++number_bio_write_attempts;
       // Try to write all of the remaining bytes to the BIO.
-      size_t bytes_written_to_network_io =
-          remaining_bytes_to_write_to_network_io_size;
+      size_t bytes_written_to_openssl =
+          remaining_bytes_to_write_to_openssl_size;
       status = ssl_handshaker_process_bytes_from_peer(
-          impl, remaining_bytes_to_write_to_network_io,
-          &bytes_written_to_network_io, error);
+          impl, remaining_bytes_to_write_to_openssl, &bytes_written_to_openssl,
+          error);
       // As long as the BIO is full, drive the SSL handshake to consume bytes
       // from the BIO. If the SSL handshake returns any bytes, write them to the
       // peer.
@@ -1566,9 +1566,8 @@ static tsi_result ssl_handshaker_next(tsi_handshaker* self,
       }
       // Move the pointer to the first byte not yet successfully written to the
       // BIO.
-      remaining_bytes_to_write_to_network_io_size -=
-          bytes_written_to_network_io;
-      remaining_bytes_to_write_to_network_io += bytes_written_to_network_io;
+      remaining_bytes_to_write_to_openssl_size -= bytes_written_to_openssl;
+      remaining_bytes_to_write_to_openssl += bytes_written_to_openssl;
     }
   }
   if (status != TSI_OK) return status;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1572,9 +1572,7 @@ static tsi_result ssl_handshaker_next(tsi_handshaker* self,
       // BIO.
       remaining_bytes_to_write_to_network_io_size -=
           bytes_written_to_network_io;
-      if (remaining_bytes_to_write_to_network_io_size > 0) {
-        remaining_bytes_to_write_to_network_io += bytes_written_to_network_io;
-      }
+      remaining_bytes_to_write_to_network_io += bytes_written_to_network_io;
     }
   }
   if (status != TSI_OK) return status;

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -25,6 +25,10 @@ grpc_cc_library(
     name = "transport_security_test_lib",
     srcs = ["transport_security_test_lib.cc"],
     hdrs = ["transport_security_test_lib.h"],
+    external_deps = [
+        "libssl",
+        "libcrypto",
+    ],
     deps = [
         "//:grpc",
     ],
@@ -90,7 +94,10 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/strings",
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -661,12 +661,10 @@ void ssl_tsi_test_do_handshake_with_large_server_handshake_messages(
   fixture->handshake_buffer_size = 18000;
   ssl_tsi_test_fixture* ssl_fixture =
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
-
   // Make a copy of the root cert and free the original.
   std::string root_cert(ssl_fixture->key_cert_lib->root_cert);
   gpr_free(ssl_fixture->key_cert_lib->root_cert);
   ssl_fixture->key_cert_lib->root_cert = nullptr;
-
   // Create a new root store, consisting of the root cert that is actually
   // needed and 200 self-signed certs.
   std::string effective_trust_bundle = absl::StrCat(root_cert, trust_bundle);
@@ -677,7 +675,6 @@ void ssl_tsi_test_do_handshake_with_large_server_handshake_messages(
       tsi_ssl_root_certs_store_create(effective_trust_bundle.c_str());
   ssl_fixture->key_cert_lib->use_root_store = true;
   ssl_fixture->force_client_auth = true;
-
   tsi_test_do_handshake(fixture);
   // Overwrite the root_cert pointer so that tsi_test_fixture_destroy does not
   // try to gpr_free it.

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -661,7 +661,7 @@ void ssl_tsi_test_do_handshake_with_large_server_handshake_messages(
   // Create a new root store, consisting of the root cert that is actually
   // needed and 200 self-signed certs.
   std::string effective_trust_bundle = absl::StrCat(root_cert, trust_bundle);
-  gpr_free(ssl_fixture->key_cert_lib->root_store);
+  tsi_ssl_root_certs_store_destroy(ssl_fixture->key_cert_lib->root_store);
   ssl_fixture->key_cert_lib->root_cert =
       const_cast<char*>(effective_trust_bundle.c_str());
   ssl_fixture->key_cert_lib->root_store =

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -518,7 +518,7 @@ static std::string GenerateTrustBundle() {
   // certs have subject DNs that are sufficiently big and complex that they
   // substantially increase the server handshake message size.
   std::string trust_bundle;
-  std::size_t trust_bundle_size = is_slow_build() ? 20 : 200;
+  int trust_bundle_size = is_slow_build() ? 20 : 200;
   for (int i = 0; i < trust_bundle_size; ++i) {
     SelfSignedCertificateOptions options;
     options.common_name =

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -519,7 +519,7 @@ static std::string GenerateTrustBundle() {
   // substantially increase the server handshake message size.
   std::string trust_bundle;
   std::size_t trust_bundle_size = is_slow_build() ? 20 : 200;
-  for (int i = 0; i < 200; ++i) {
+  for (int i = 0; i < trust_bundle_size; ++i) {
     SelfSignedCertificateOptions options;
     options.common_name =
         absl::StrCat("{46f0eaed-6e05-43f5-9289-379104612fc", i, "}");

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -27,6 +27,8 @@
 #include <openssl/err.h>
 #include <openssl/pem.h>
 
+#include "absl/strings/str_cat.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -180,6 +182,7 @@ static void ssl_test_setup_handshakers(tsi_test_fixture* fixture) {
     server_options.client_certificate_request =
         TSI_DONT_REQUEST_CLIENT_CERTIFICATE;
   }
+  server_options.send_client_ca_list = test_send_client_ca_list;
   server_options.session_ticket_key = ssl_fixture->session_ticket_key;
   server_options.session_ticket_key_size = ssl_fixture->session_ticket_key_size;
   server_options.min_tls_version = test_tls_version;
@@ -502,6 +505,23 @@ static char* load_file(const char* dir_path, const char* file_name) {
   return data;
 }
 
+static std::string GenerateTrustBundle() {
+  // Create a trust bundle, consisting of 200 self-signed certs. The self-signed
+  // certs have subject DNs that are sufficiently big and complex that they
+  // substantially increase the server handshake message size.
+  std::string trust_bundle;
+  for (int i = 0; i < 200; ++i) {
+    SelfSignedCertificateOptions options;
+    options.common_name =
+        absl::StrCat("{46f0eaed-6e05-43f5-9289-379104612fc", i, "}");
+    options.organization = absl::StrCat("organization-", i);
+    options.organizational_unit = absl::StrCat("organizational-unit-", i);
+    std::string self_signed_cert = GenerateSelfSignedCertificate(options);
+    trust_bundle.append(self_signed_cert);
+  }
+  return trust_bundle;
+}
+
 static tsi_test_fixture* ssl_tsi_test_fixture_create() {
   ssl_tsi_test_fixture* ssl_fixture = grpc_core::Zalloc<ssl_tsi_test_fixture>();
   tsi_test_fixture_init(&ssl_fixture->base);
@@ -619,6 +639,40 @@ void ssl_tsi_test_do_handshake_with_root_store() {
       reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
   ssl_fixture->key_cert_lib->use_root_store = true;
   tsi_test_do_handshake(fixture);
+  tsi_test_fixture_destroy(fixture);
+}
+
+void ssl_tsi_test_do_handshake_with_large_server_handshake_messages(
+    const std::string& trust_bundle) {
+  gpr_log(GPR_INFO,
+          "ssl_tsi_test_do_handshake_with_large_server_handshake_messages");
+  tsi_test_fixture* fixture = ssl_tsi_test_fixture_create();
+  // Force the test to read more handshake bytes from the peer than we have room
+  // for in the BIO. The default BIO buffer size is 17kB.
+  fixture->handshake_buffer_size = 18000;
+  ssl_tsi_test_fixture* ssl_fixture =
+      reinterpret_cast<ssl_tsi_test_fixture*>(fixture);
+
+  // Make a copy of the root cert and free the original.
+  std::string root_cert(ssl_fixture->key_cert_lib->root_cert);
+  gpr_free(ssl_fixture->key_cert_lib->root_cert);
+  ssl_fixture->key_cert_lib->root_cert = nullptr;
+
+  // Create a new root store, consisting of the root cert that is actually
+  // needed and 200 self-signed certs.
+  std::string effective_trust_bundle = absl::StrCat(root_cert, trust_bundle);
+  gpr_free(ssl_fixture->key_cert_lib->root_store);
+  ssl_fixture->key_cert_lib->root_cert =
+      const_cast<char*>(effective_trust_bundle.c_str());
+  ssl_fixture->key_cert_lib->root_store =
+      tsi_ssl_root_certs_store_create(effective_trust_bundle.c_str());
+  ssl_fixture->key_cert_lib->use_root_store = true;
+  ssl_fixture->force_client_auth = true;
+
+  tsi_test_do_handshake(fixture);
+  // Overwrite the root_cert pointer so that tsi_test_fixture_destroy does not
+  // try to gpr_free it.
+  ssl_fixture->key_cert_lib->root_cert = nullptr;
   tsi_test_fixture_destroy(fixture);
 }
 
@@ -1166,6 +1220,7 @@ void ssl_tsi_test_do_handshake_with_custom_bio_pair() {
 
 TEST(SslTransportSecurityTest, MainTest) {
   grpc_init();
+  std::string trust_bundle = GenerateTrustBundle();
   const size_t number_tls_versions = 2;
   const tsi_tls_version tls_versions[] = {tsi_tls_version::TSI_TLS1_2,
                                           tsi_tls_version::TSI_TLS1_3};
@@ -1178,6 +1233,8 @@ TEST(SslTransportSecurityTest, MainTest) {
       ssl_tsi_test_do_handshake_small_handshake_buffer();
       ssl_tsi_test_do_handshake();
       ssl_tsi_test_do_handshake_with_root_store();
+      ssl_tsi_test_do_handshake_with_large_server_handshake_messages(
+          trust_bundle);
       ssl_tsi_test_do_handshake_with_client_authentication();
       ssl_tsi_test_do_handshake_with_client_authentication_and_root_store();
       ssl_tsi_test_do_handshake_with_server_name_indication_exact_domain();

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -691,11 +691,9 @@ std::string GenerateSelfSignedCertificate(
       RSA_generate_key_ex(rsa, /*key_size=*/2048, bignum, /*cb=*/nullptr));
   EVP_PKEY* key = EVP_PKEY_new();
   GPR_ASSERT(EVP_PKEY_assign_RSA(key, rsa));
-
   // Create the X509 object.
   X509* x509 = X509_new();
   GPR_ASSERT(X509_set_version(x509, X509_VERSION_3));
-
   // Set the not_before/after fields to infinite past/future. The value for
   // infinite future is from RFC 5280 Section 4.1.2.5.1.
   ASN1_UTCTIME* infinite_past = ASN1_UTCTIME_new();
@@ -707,7 +705,6 @@ std::string GenerateSelfSignedCertificate(
       ASN1_GENERALIZEDTIME_set_string(infinite_future, "99991231235959Z"));
   GPR_ASSERT(X509_set1_notAfter(x509, infinite_future));
   ASN1_GENERALIZEDTIME_free(infinite_future);
-
   // Set the subject DN.
   X509_NAME* subject_name = X509_NAME_new();
   GPR_ASSERT(X509_NAME_add_entry_by_txt(
@@ -728,11 +725,9 @@ std::string GenerateSelfSignedCertificate(
                                  /*set=*/0));
   GPR_ASSERT(X509_set_subject_name(x509, subject_name));
   X509_NAME_free(subject_name);
-
   // Set the public key and sign the certificate.
   GPR_ASSERT(X509_set_pubkey(x509, key));
   GPR_ASSERT(X509_sign(x509, key, EVP_sha256()));
-
   // Convert to PEM.
   BIO* bio = BIO_new(BIO_s_mem());
   GPR_ASSERT(PEM_write_bio_X509(bio, x509));
@@ -740,7 +735,6 @@ std::string GenerateSelfSignedCertificate(
   size_t len = 0;
   GPR_ASSERT(BIO_mem_contents(bio, &data, &len));
   std::string pem = std::string(reinterpret_cast<const char*>(data), len);
-
   // Cleanup all of the OpenSSL objects and return the PEM-encoded cert.
   EVP_PKEY_free(key);
   X509_free(x509);

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -413,6 +413,11 @@ void tsi_test_do_handshake(tsi_test_fixture* fixture) {
     if (!server_args->error.ok()) {
       break;
     }
+    // If this assertion is hit, this is likely an indication that the client
+    // and server handshakers are hanging, each thinking that the other is
+    // responsible for sending the next chunk of bytes to the other. This can
+    // happen e.g. when a bug in the handshaker code results in some bytes being
+    // dropped instead of passed to the BIO or SSL objects.
     GPR_ASSERT(client_args->transferred_data || server_args->transferred_data);
   } while (fixture->client_result == nullptr ||
            fixture->server_result == nullptr);
@@ -703,7 +708,7 @@ std::string GenerateSelfSignedCertificate(
   GPR_ASSERT(X509_set1_notAfter(x509, infinite_future));
   ASN1_GENERALIZEDTIME_free(infinite_future);
 
-  // Set the common name.
+  // Set the subject DN.
   X509_NAME* subject_name = X509_NAME_new();
   GPR_ASSERT(X509_NAME_add_entry_by_txt(
       subject_name, "CN", MBSTRING_ASC,

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -22,6 +22,17 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <openssl/asn1.h>
+#include <openssl/base.h>
+#include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/digest.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -663,4 +674,72 @@ void tsi_test_frame_protector_fixture_destroy(
   tsi_frame_protector_destroy(fixture->client_frame_protector);
   tsi_frame_protector_destroy(fixture->server_frame_protector);
   gpr_free(fixture);
+}
+
+std::string GenerateSelfSignedCertificate(
+    const SelfSignedCertificateOptions& options) {
+  // Generate an RSA keypair.
+  RSA* rsa = RSA_new();
+  BIGNUM* bignum = BN_new();
+  GPR_ASSERT(BN_set_word(bignum, RSA_F4));
+  GPR_ASSERT(
+      RSA_generate_key_ex(rsa, /*key_size=*/2048, bignum, /*cb=*/nullptr));
+  EVP_PKEY* key = EVP_PKEY_new();
+  GPR_ASSERT(EVP_PKEY_assign_RSA(key, rsa));
+
+  // Create the X509 object.
+  X509* x509 = X509_new();
+  GPR_ASSERT(X509_set_version(x509, X509_VERSION_3));
+
+  // Set the not_before/after fields to infinite past/future. The value for
+  // infinite future is from RFC 5280 Section 4.1.2.5.1.
+  ASN1_UTCTIME* infinite_past = ASN1_UTCTIME_new();
+  GPR_ASSERT(ASN1_UTCTIME_set(infinite_past, /*posix_time=*/0));
+  GPR_ASSERT(X509_set1_notBefore(x509, infinite_past));
+  ASN1_UTCTIME_free(infinite_past);
+  ASN1_GENERALIZEDTIME* infinite_future = ASN1_GENERALIZEDTIME_new();
+  GPR_ASSERT(
+      ASN1_GENERALIZEDTIME_set_string(infinite_future, "99991231235959Z"));
+  GPR_ASSERT(X509_set1_notAfter(x509, infinite_future));
+  ASN1_GENERALIZEDTIME_free(infinite_future);
+
+  // Set the common name.
+  X509_NAME* subject_name = X509_NAME_new();
+  GPR_ASSERT(X509_NAME_add_entry_by_txt(
+      subject_name, "CN", MBSTRING_ASC,
+      reinterpret_cast<const unsigned char*>(options.common_name.c_str()),
+      /*len=*/-1, /*loc=*/-1,
+      /*set=*/0));
+  GPR_ASSERT(X509_NAME_add_entry_by_txt(
+      subject_name, "O", MBSTRING_ASC,
+      reinterpret_cast<const unsigned char*>(options.organization.c_str()),
+      /*len=*/-1, /*loc=*/-1,
+      /*set=*/0));
+  GPR_ASSERT(
+      X509_NAME_add_entry_by_txt(subject_name, "OU", MBSTRING_ASC,
+                                 reinterpret_cast<const unsigned char*>(
+                                     options.organizational_unit.c_str()),
+                                 /*len=*/-1, /*loc=*/-1,
+                                 /*set=*/0));
+  GPR_ASSERT(X509_set_subject_name(x509, subject_name));
+  X509_NAME_free(subject_name);
+
+  // Set the public key and sign the certificate.
+  GPR_ASSERT(X509_set_pubkey(x509, key));
+  GPR_ASSERT(X509_sign(x509, key, EVP_sha256()));
+
+  // Convert to PEM.
+  BIO* bio = BIO_new(BIO_s_mem());
+  GPR_ASSERT(PEM_write_bio_X509(bio, x509));
+  const uint8_t* data = nullptr;
+  size_t len = 0;
+  GPR_ASSERT(BIO_mem_contents(bio, &data, &len));
+  std::string pem = std::string(reinterpret_cast<const char*>(data), len);
+
+  // Cleanup all of the OpenSSL objects and return the PEM-encoded cert.
+  EVP_PKEY_free(key);
+  X509_free(x509);
+  BIO_free(bio);
+  BN_free(bignum);
+  return pem;
 }

--- a/test/core/tsi/transport_security_test_lib.cc
+++ b/test/core/tsi/transport_security_test_lib.cc
@@ -711,17 +711,17 @@ std::string GenerateSelfSignedCertificate(
   // Set the subject DN.
   X509_NAME* subject_name = X509_NAME_new();
   GPR_ASSERT(X509_NAME_add_entry_by_txt(
-      subject_name, "CN", MBSTRING_ASC,
+      subject_name, /*field=*/"CN", MBSTRING_ASC,
       reinterpret_cast<const unsigned char*>(options.common_name.c_str()),
       /*len=*/-1, /*loc=*/-1,
       /*set=*/0));
   GPR_ASSERT(X509_NAME_add_entry_by_txt(
-      subject_name, "O", MBSTRING_ASC,
+      subject_name, /*field=*/"O", MBSTRING_ASC,
       reinterpret_cast<const unsigned char*>(options.organization.c_str()),
       /*len=*/-1, /*loc=*/-1,
       /*set=*/0));
   GPR_ASSERT(
-      X509_NAME_add_entry_by_txt(subject_name, "OU", MBSTRING_ASC,
+      X509_NAME_add_entry_by_txt(subject_name, /*field=*/"OU", MBSTRING_ASC,
                                  reinterpret_cast<const unsigned char*>(
                                      options.organizational_unit.c_str()),
                                  /*len=*/-1, /*loc=*/-1,

--- a/test/core/tsi/transport_security_test_lib.h
+++ b/test/core/tsi/transport_security_test_lib.h
@@ -228,4 +228,14 @@ void tsi_test_do_round_trip(tsi_test_fixture* fixture);
 void tsi_test_frame_protector_do_round_trip_no_handshake(
     tsi_test_frame_protector_fixture* fixture);
 
+struct SelfSignedCertificateOptions {
+  std::string common_name;
+  std::string organization;
+  std::string organizational_unit;
+};
+
+// Returns a PEM-encoded self-signed certificate.
+std::string GenerateSelfSignedCertificate(
+    const SelfSignedCertificateOptions& options);
+
 #endif  // GRPC_TEST_CORE_TSI_TRANSPORT_SECURITY_TEST_LIB_H


### PR DESCRIPTION
There is a bug in the SSL stack that was only partially fixed in #29176: if more than 17kb is written to the BIO buffer, then everything over 17kb will be discarded, and the SSL handshake will fail with a bad record mac error or hang if not enough bytes have arrived yet.

It's relatively uncommon to hit this bug, because the TLS handshake messages need to be much larger than normal for you to have a chance of hitting this bug. However, there was a separate bug in the SSL stack (recently fixed in #33558) that causes the ServerHello produced by a gRPC-C++ TLS server to grow linearly in size with the size of the trust bundle; these 2 bugs combined to cause a large number of TLS handshake failures for gRPC-C++ clients talking to gRPC-C++ servers when the server had a large trust bundle.

This PR fixes the bug by ensuring that all bytes are successfully written to the BIO buffer. An initial quick fix for this bug was planned in #33611, but abandoned because we were worried about temporarily doubling the memory footprint of all SSL channels.

The complexity in this PR is mostly in the test: it is fairly tricky to force gRPC-C++'s SSL stack to generate a sufficiently large ServerHello to trigger this bug.
