### PR TITLE
[logging] Handle trailers-only responses

### DIFF
--- a/src/core/ext/filters/logging/logging_filter.cc
+++ b/src/core/ext/filters/logging/logging_filter.cc
@@ -257,6 +257,7 @@ class CallData {
                        const ServerMetadata* metadata) {
     LoggingSink::Entry entry;
     if (metadata != nullptr) {
+      entry.is_trailer_only = metadata->get(GrpcTrailersOnly()).value_or(false);
       if (is_client) {
         if (auto* value = metadata->get_pointer(PeerString())) {
           peer_ = PeerStringToAddress(*value);
@@ -280,6 +281,7 @@ class CallData {
     SetCommonEntryFields(&entry, is_client, tracer,
                          LoggingSink::Entry::EventType::kServerTrailer);
     if (metadata != nullptr) {
+      entry.is_trailer_only = metadata->get(GrpcTrailersOnly()).value_or(false);
       MetadataEncoder encoder(&entry.payload, &entry.payload.status_details,
                               config_.max_metadata_bytes());
       metadata->Encode(&encoder);

--- a/src/core/ext/filters/logging/logging_sink.h
+++ b/src/core/ext/filters/logging/logging_sink.h
@@ -107,6 +107,7 @@ class LoggingSink {
     std::string trace_id;
     std::string span_id;
     bool is_sampled = false;
+    bool is_trailer_only = false;
   };
 
   virtual ~LoggingSink() = default;

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -682,6 +682,7 @@ static grpc_error_handle init_header_frame_parser(grpc_chttp2_transport* t,
         }
         s->parsed_trailers_only = true;
         s->trailing_metadata_buffer.Set(grpc_core::GrpcTrailersOnly(), true);
+        s->initial_metadata_buffer.Set(grpc_core::GrpcTrailersOnly(), true);
         incoming_metadata_buffer = &s->trailing_metadata_buffer;
         frame_type = HPackParser::LogInfo::kTrailers;
       } else {


### PR DESCRIPTION
Try again to get a trailers only signal through to the logging filter.

(this needs a change for non-chttp2 transports... I think we wait until we have actual users using binary logging on non http2 transports to do that work)