### PR TITLE
[Ruby] remove manual strip in ruby ext conf

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -186,20 +186,6 @@ output = File.join('grpc', 'grpc_c')
 puts 'Generating Makefile for ' + output
 create_makefile(output)
 
-if grpc_config == 'opt'
-  File.open('Makefile.new', 'w') do |o|
-    o.puts 'hijack: all strip'
-    o.puts
-    File.foreach('Makefile') do |i|
-      o.puts i
-    end
-    o.puts
-    o.puts 'strip: $(DLLIB)'
-    o.puts "\t$(ECHO) Stripping $(DLLIB)"
-    o.puts "\t$(Q) #{strip_tool} $(DLLIB)"
-  end
-  File.rename('Makefile.new', 'Makefile')
-end
 if ENV['GRPC_RUBY_TEST_ONLY_WORKAROUND_MAKE_INSTALL_BUG']
   # Note: this env var setting is intended to work around a problem observed
   # with the ginstall command on grpc's macos automated test infrastructure,


### PR DESCRIPTION
Custom strip invalidates the signature, caused the arm64-darwin gem failed to run on M1 macs.
Error in mac console: `Exception Type:        EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))`

Warning in gem build log:
```
# linking shared-object grpc/grpc_c.bundle
# Stripping grpc_c.bundle
# /opt/osxcross/target/bin/aarch64-apple-darwin20.2-strip: warning: changes being made to the file will invalidate the code signature in: /Users/jeff/work/ruby/grpc/tmp/arm64-darwin/grpc_c/3.2.0/grpc_c.bundle
```

Custom stripping is not really needed (any more), this diff removes it from `src/ruby/ext/grpc/extconf.rb`, the [gem artifact](https://console.cloud.google.com/storage/browser/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/grpc_distribtests_ruby/19833/20230708-181642/github/grpc/artifacts?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&prefix=&forceOnObjectsSortingFiltering=false) size didn't change and arm64-darwin gem runs fine on M1 mac.

fixes: #28631
fixes: #29100