### PR TITLE
[C++] Fix clang's -Winconsistent-missing-override in proto reader/writer.

### DIFF
--- a/include/grpcpp/support/proto_buffer_reader.h
+++ b/include/grpcpp/support/proto_buffer_reader.h
@@ -124,10 +124,14 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
 
 #ifdef GRPC_PROTOBUF_CORD_SUPPORT_ENABLED
   /// Read the next `count` bytes and append it to the given Cord.
-  // (override is intentionally omitted here to support old Protobuf which
+  // (override is conditionally omitted here to support old Protobuf which
   //  doesn't have ReadCord method)
   // NOLINTNEXTLINE(modernize-use-override)
-  virtual bool ReadCord(absl::Cord* cord, int count) {
+  virtual bool ReadCord(absl::Cord* cord, int count)
+#if PROTOBUF_VERSION >= 4022000
+      override
+#endif
+  {
     if (!status().ok()) {
       return false;
     }

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -154,10 +154,14 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
 #ifdef GRPC_PROTOBUF_CORD_SUPPORT_ENABLED
   /// Writes cord to the backing byte_buffer, sharing the memory between the
   /// blocks of the cord, and the slices of the byte_buffer.
-  // (override is intentionally omitted here to support old Protobuf which
+  // (override is conditionally omitted here to support old Protobuf which
   //  doesn't have ReadCord method)
   // NOLINTNEXTLINE(modernize-use-override)
-  virtual bool WriteCord(const absl::Cord& cord) {
+  virtual bool WriteCord(const absl::Cord& cord)
+#if PROTOBUF_VERSION >= 4022000
+      override
+#endif
+  {
     grpc_slice_buffer* buffer = slice_buffer();
     size_t cur = 0;
     for (absl::string_view chunk : cord.Chunks()) {


### PR DESCRIPTION
The "override" is not added on purpose to remain compatible with Protobuf < 22.x, as already written in the comment on top of these two functions.

CC @veblush as the author of this code.

Note: I am personally not super enthousiastic about this change. As an alternative, I can propose to selectively add the `override` keyword, based on the value of the `PROTOBUF_VERSION` macro (comparing it to `4022000`). Tell me if you prefer this version instead.