### PR TITLE
[PSM Interop] Loosen affinity test assertions

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -144,6 +144,8 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                 ),
             )
 
+            # Any remaining subchannels may be in any state.
+
             # Remember the backend inuse, and turn it down later.
             first_backend_inuse = list(
                 rpc_distribution.raw["rpcsByPeer"].keys()

--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -143,20 +143,7 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                     f" {len(ready_channels)} instead."
                 ),
             )
-            # The rest should be IDLE.
-            expected_idle_channels = _REPLICA_COUNT - 1
-            idle_channels = test_client.find_subchannels_with_state(
-                _ChannelzChannelState.IDLE
-            )
-            self.assertLen(
-                idle_channels,
-                expected_idle_channels,
-                msg=(
-                    "(AffinityTest) The client expected to have IDLE"
-                    f" subchannels to {expected_idle_channels} of the test"
-                    f" servers. Found {len(idle_channels)} instead."
-                ),
-            )
+
             # Remember the backend inuse, and turn it down later.
             first_backend_inuse = list(
                 rpc_distribution.raw["rpcsByPeer"].keys()

--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/affinity_test.py
@@ -126,10 +126,9 @@ class TestHeaderBasedAffinity(xds_url_map_testcase.XdsUrlMapTestCase):
             ),
             1,
         )
-        self.assertLen(
-            test_client.find_subchannels_with_state(_ChannelzChannelState.IDLE),
-            2,
-        )
+
+	# Any remaining subchannels may be in any state.
+
         # Send 150 RPCs without headers. RPCs without headers will pick random
         # backends. After this, we expect to see all backends to be connected.
         rpc_distribution = self.configure_and_send(
@@ -202,10 +201,9 @@ class TestHeaderBasedAffinityMultipleHeaders(
             ),
             1,
         )
-        self.assertLen(
-            test_client.find_subchannels_with_state(_ChannelzChannelState.IDLE),
-            2,
-        )
+
+        # Any remaining subchannels may be in any state.
+
         empty_call_peer = list(
             rpc_distribution.raw["rpcsByMethod"]["EmptyCall"][
                 "rpcsByPeer"
@@ -260,10 +258,7 @@ class TestHeaderBasedAffinityMultipleHeaders(
             ),
             2,
         )
-        self.assertLen(
-            test_client.find_subchannels_with_state(_ChannelzChannelState.IDLE),
-            1,
-        )
+        # Any remaining subchannels may be in any state.
 
 
 # TODO: add more test cases


### PR DESCRIPTION
As part of the dualstack backend designs, subchannels will be created lazily. Therefore, instead of asserting that there is 1 READY subchannel and `n - 1` IDLE subchannels, we just assert that there is 1 READY subchannel.

ref b/290264214