### PR TITLE
[hpack] Fix benchmarking timeout

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -151,6 +151,8 @@ grpc_cc_test(
         "no_mac",
         "no_windows",
         "nomsan",
+        "notsan",
+        "noubsan",
     ],
     deps = [
         ":helpers",


### PR DESCRIPTION
Disable uninteresting sanitizers for this benchmark