### PR TITLE
[boringssl] Simplify BoringSSL assembly build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -417,7 +417,7 @@ if BUILD_WITH_BORING_SSL_ASM and not BUILD_WITH_SYSTEM_OPENSSL:
     # by the preprocessor. Provided the platform has a gas-compatible assembler
     # (i.e. not Windows), we can include the assembly files and let BoringSSL
     # decide which ones should and shouldn't be used for the build.
-    if "win32" not in boringssl_asm_platform:
+    if not boringssl_asm_platform.startswith("win"):
         asm_key = "crypto_asm"
     else:
         print(

--- a/setup.py
+++ b/setup.py
@@ -413,19 +413,12 @@ if BUILD_WITH_BORING_SSL_ASM and not BUILD_WITH_SYSTEM_OPENSSL:
         if BUILD_OVERRIDE_BORING_SSL_ASM_PLATFORM
         else util.get_platform()
     )
-    LINUX_X86_64 = "linux-x86_64"
-    LINUX_ARM = "linux-arm"
-    LINUX_AARCH64 = "linux-aarch64"
-    if LINUX_X86_64 == boringssl_asm_platform:
-        asm_key = "crypto_linux_x86_64"
-    elif LINUX_ARM == boringssl_asm_platform:
-        asm_key = "crypto_linux_arm"
-    elif LINUX_AARCH64 == boringssl_asm_platform:
-        asm_key = "crypto_linux_aarch64"
-    elif "mac" in boringssl_asm_platform and "x86_64" in boringssl_asm_platform:
-        asm_key = "crypto_apple_x86_64"
-    elif "mac" in boringssl_asm_platform and "arm64" in boringssl_asm_platform:
-        asm_key = "crypto_apple_aarch64"
+    # BoringSSL's gas-compatible assembly files are all internally conditioned
+    # by the preprocessor. Provided the platform has a gas-compatible assembler
+    # (i.e. not Windows), we can include the assembly files and let BoringSSL
+    # decide which ones should and shouldn't be used for the build.
+    if "win32" not in boringssl_asm_platform:
+        asm_key = "crypto_asm"
     else:
         print(
             "ASM Builds for BoringSSL currently not supported on:",

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -143,7 +143,6 @@ class PythonArtifact:
         if self.platform == "macos":
             environ["ARCHFLAGS"] = "-arch arm64 -arch x86_64"
             environ["GRPC_UNIVERSAL2_REPAIR"] = "true"
-            environ["GRPC_BUILD_WITH_BORING_SSL_ASM"] = "false"
 
         if self.platform == "linux_extra":
             # Crosscompilation build for armv7 (e.g. Raspberry Pi)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -334,11 +334,6 @@ class CLanguage(object):
                 self._cmake_configure_extra_args,
             ) = self._compiler_options(self.args.use_docker, self.args.compiler)
 
-            if self.args.arch == "x86":
-                # disable boringssl asm optimizations when on x86
-                # see https://github.com/grpc/grpc/blob/b5b8578b3f8b4a9ce61ed6677e19d546e43c5c68/tools/run_tests/artifacts/artifact_targets.py#L253
-                self._cmake_configure_extra_args.append("-DOPENSSL_NO_ASM=ON")
-
     def test_specs(self):
         out = []
         binaries = get_c_tests(self.args.travis, self.test_lang)


### PR DESCRIPTION
~~NB: I haven't tested this at all and am hoping the CI will tell me where I've (undoubtedly) messed something up.~~ Edit: looks like CI is now clear!

BoringSSL's gas-compatible assembly files, like its C files, are now wrapped with preprocessor ifdefs to capture which platforms each file should be enabled on. This means that, provided the platform can process .S files it all (i.e. not Windows), we no longer need to detect the exact CPU architecture in the build.

Switch gRPC's build to take advantage of this. I've retained BUILD_OVERRIDE_BORING_SSL_ASM_PLATFORM, on the off chance anyone is using it to cross-compile between Windows and non-Windows, though I doubt that works particularly well.

As part of this, restore assembly optimizations in a few places where they were seemingly disabled for issues relating to this:

- https://github.com/grpc/grpc/pull/31747 had to disable the assembly, because at the time assembly required the library be built differently for each architecture and then stitched back together. This should now work.

- tools/run_tests/run_tests.py disabled x86 assembly due to some issues with CMAKE_SYSTEM_PROCESSOR in a Docker image. This too should now be moot.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

