### PR TITLE
[fix] Remove GRPC_MUST_USE_RESULT from class definition

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -75,7 +75,7 @@ enum class StallEdge { kNoChange, kStalled, kUnstalled };
 // Encapsulates a collections of actions the transport needs to take with
 // regard to flow control. Each action comes with urgencies that tell the
 // transport how quickly the action must take place.
-class GRPC_MUST_USE_RESULT FlowControlAction {
+class FlowControlAction {
  public:
   enum class Urgency : uint8_t {
     // Nothing to be done.


### PR DESCRIPTION
Problem introduced in https://github.com/grpc/grpc/pull/31676. The PHP distribtests have been failing for 8 months with:

```
/tmp/pear/temp/grpc/src/core/ext/transport/chttp2/transport/flow_control.h:78:28: warning: 'warn_unused_result' attribute only applies to function types [-Wattributes]
 class GRPC_MUST_USE_RESULT FlowControlAction {
                            ^~~~~~~~~~~~~~~~~
```

This only fails on the following distribtest, which is not built every time. So the master build only fails sporadically.

```
  python_linux_x64_buster, labels ['distribtest', 'python', 'linux', 'x64', 'buster', 'presubmit']
```