### PR TITLE
[release] Teach make_grpcio_tools script to delete temporary files

### DIFF
--- a/tools/distrib/python/make_grpcio_tools.py
+++ b/tools/distrib/python/make_grpcio_tools.py
@@ -240,8 +240,13 @@ def _delete_source_tree(target):
 
 def main():
     parser = argparse.ArgumentParser()
+    # In Step 1 below, the third_party folder is copied to a location required
+    # by the build scripts. This folder does not need to be committed to the 
+    # repo, so you can pass `--cleanup_third_party` in automated scripts to 
+    # ensure that the temporary folders are deleted after the script runs.
+    # See Jan's TODO in _copy_source_tree above.
     parser.add_argument(
-        "--cleanup-third-party", default=False, action="store_true", help="Delete the temporary third_party folder"
+        "--cleanup_third_party", default=False, action="store_true", help="Delete the temporary third_party folder"
     )
     args = parser.parse_args()
     os.chdir(GRPC_ROOT)


### PR DESCRIPTION
This (or something like it) is necessary for the automated protobuf upgrade script, to ensure we don't commit a redundant third_party tree to the repo. Here is an example of the protobuf upgrade without this fix: https://github.com/grpc/grpc/pull/33625

One alternative could be adding the filepaths to `.gitignore`.

Spun off from https://github.com/grpc/grpc/pull/33695