### PR TITLE
[EventEngine] fix bug in unix-abstract socket URI processing

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <sys/socket.h>
 
 #include <algorithm>
 #include <cctype>
@@ -65,6 +66,10 @@
 #include <sys/resource.h>      // IWYU pragma: keep
 #endif
 #include <netinet/in.h>  // IWYU pragma: keep
+
+#ifdef GRPC_HAVE_UNIX_SOCKET
+#include <sys/un.h>  // IWYU pragma: keep
+#endif
 
 #ifndef SOL_TCP
 #define SOL_TCP IPPROTO_TCP
@@ -1253,10 +1258,24 @@ PosixEndpointImpl::PosixEndpointImpl(EventHandle* handle,
   if (local_address.ok()) {
     local_address_ = *local_address;
   }
+
   auto peer_address = sock.PeerAddress();
   if (peer_address.ok()) {
     peer_address_ = *peer_address;
+#ifdef GRPC_HAVE_UNIX_SOCKET
+  } else if (local_address_.address()->sa_family == AF_UNIX) {
+    // If this is a unix domain socket, peer_address may not be populated
+    // depending on whether the remote end called bind.
+    memset(const_cast<sockaddr*>(peer_address_.address()), 0,
+           EventEngine::ResolvedAddress::MAX_SIZE_BYTES);
+    struct sockaddr_un* un = reinterpret_cast<struct sockaddr_un*>(
+        const_cast<sockaddr*>(peer_address_.address()));
+    un->sun_family = AF_UNIX;
+    un->sun_path[0] = '\0';
   }
+#else
+  }
+#endif
   target_length_ = static_cast<double>(options.tcp_read_chunk_size);
   bytes_read_this_round_ = 0;
   min_read_chunk_size_ = options.tcp_min_read_chunk_size;

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
@@ -153,11 +153,11 @@ void PosixEngineListenerImpl::AsyncConnectionAcceptor::NotifyOnAccept(
     }
 
     // For UNIX sockets, the accept call might not fill up the member
-    // sun_path of sockaddr_un, so explicitly call getsockname to get it.
+    // sun_path of sockaddr_un, so explicitly call getpeername to get it.
     if (addr.address()->sa_family == AF_UNIX) {
       socklen_t len = EventEngine::ResolvedAddress::MAX_SIZE_BYTES;
-      if (getsockname(fd, const_cast<sockaddr*>(addr.address()), &len) < 0) {
-        gpr_log(GPR_ERROR, "Closing acceptor. Failed getsockname: %s",
+      if (getpeername(fd, const_cast<sockaddr*>(addr.address()), &len) < 0) {
+        gpr_log(GPR_ERROR, "Closing acceptor. Failed getpeername: %s",
                 strerror(errno));
         close(fd);
         // Shutting down the acceptor. Unref the ref grabbed in

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
@@ -110,6 +110,8 @@ class PosixEngineListenerImpl
     }
     ListenerSocketsContainer::ListenerSocket& Socket() { return socket_; }
     ~AsyncConnectionAcceptor() {
+      // If uds socket, unlink it so that the corresponding file is deleted.
+      UnlinkIfUnixDomainSocket(*socket_.sock.LocalAddress());
       handle_->OrphanHandle(nullptr, nullptr, "");
       delete notify_on_accept_;
     }

--- a/src/core/lib/event_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/tcp_socket_utils.cc
@@ -100,12 +100,13 @@ absl::StatusOr<std::string> ResolvedAddrToUnixPathIfPossible(
 #else
   int len = resolved_addr->size() - sizeof(unix_addr->sun_family) - 1;
 #endif
-  bool abstract = (len < 0 || unix_addr->sun_path[0] == '\0');
+  if (len <= 0) {
+    return "";
+  }
+  bool abstract = (unix_addr->sun_path[0] == '\0');
   std::string path;
   if (abstract) {
-    if (len >= 0) {
-      path = std::string(unix_addr->sun_path + 1, len);
-    }
+    path = std::string(unix_addr->sun_path + 1, len);
     path = absl::StrCat(std::string(1, '\0'), path);
   } else {
     size_t maxlen = sizeof(unix_addr->sun_path);

--- a/src/core/lib/event_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/tcp_socket_utils.cc
@@ -124,7 +124,7 @@ absl::StatusOr<std::string> ResolvedAddrToUriUnixIfPossible(
   GRPC_RETURN_IF_ERROR(path.status());
   std::string scheme;
   std::string path_string;
-  if (path->at(0) == '\0' && path->length() > 1) {
+  if (!path->empty() && path->at(0) == '\0' && path->length() > 1) {
     scheme = "unix-abstract";
     path_string = path->substr(1, std::string::npos);
   } else {

--- a/src/core/lib/event_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/tcp_socket_utils.cc
@@ -123,9 +123,9 @@ absl::StatusOr<std::string> ResolvedAddrToUriUnixIfPossible(
   GRPC_RETURN_IF_ERROR(path.status());
   std::string scheme;
   std::string path_string;
-  if (path->at(0) == '\0') {
+  if (path->at(0) == '\0' && path->length() > 1) {
     scheme = "unix-abstract";
-    path_string = path->length() > 1 ? path->substr(1, std::string::npos) : "";
+    path_string = path->substr(1, std::string::npos);
   } else {
     scheme = "unix";
     path_string = std::move(*path);

--- a/src/core/lib/event_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/tcp_socket_utils.cc
@@ -100,12 +100,10 @@ absl::StatusOr<std::string> ResolvedAddrToUnixPathIfPossible(
 #else
   int len = resolved_addr->size() - sizeof(unix_addr->sun_family) - 1;
 #endif
-  if (len <= 0) {
-    return "";
-  }
-  bool abstract = (unix_addr->sun_path[0] == '\0');
+  if (len <= 0) return "";
   std::string path;
-  if (abstract) {
+  if (unix_addr->sun_path[0] == '\0') {
+    // unix-abstract socket processing.
     path = std::string(unix_addr->sun_path + 1, len);
     path = absl::StrCat(std::string(1, '\0'), path);
   } else {


### PR DESCRIPTION
URI should be resolved to unix abstract only if the first byte is NULL but the path length is > 1 (i.e there is more than one byte in the path). Otherwise treat is as unix URI.

Moreover, when the AsyncConnectionAcceptor is destroyed, if it was managing a unix domain socket, then the socket should be unlinked to ensure we dont leave the underlying file hanging around forever.
