### PR TITLE
[PSM Interop] Legacy test builds always pull the driver from master (v1.53.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -17,10 +17,7 @@ trap 'date' DEBUG
 set -ex -o igncr || set -ex
 
 mkdir -p /var/local/git
-git clone /var/local/jenkins/grpc /var/local/git/grpc
-(cd /var/local/jenkins/grpc/ && git submodule foreach 'cd /var/local/git/grpc \
-&& git submodule update --init --reference /var/local/jenkins/grpc/${name} \
-${name}')
+git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git /var/local/git/grpc
 cd /var/local/git/grpc
 
 python3 -m pip install virtualenv


### PR DESCRIPTION
Backport of #33699 to v1.53.x.
---
Similar to https://github.com/grpc/grpc-java/pull/8982.
All other languages already to this.

Needed for easier deployment of https://github.com/grpc/grpc/pull/33685.

ref b/274944592


