### PR TITLE
[deps] Upgrade google/benchmark dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,6 +99,7 @@ swift_rules_dependencies()
 # This loads the libpfm transitive dependency.
 # See https://github.com/google/benchmark/pull/1520
 load("@com_github_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps")
+
 benchmark_deps()
 
 # TODO: Enable below once https://github.com/bazel-xcode/PodToBUILD/issues/232 is resolved
@@ -119,4 +120,3 @@ benchmark_deps()
 #    podspec_url = "https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/2/e/1/CronetFramework/0.0.5/CronetFramework.podspec.json",
 #    url = "https://storage.googleapis.com/grpc-precompiled-binaries/cronet/Cronet.framework-v0.0.5.zip",
 #)
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,6 +96,11 @@ load(
 
 swift_rules_dependencies()
 
+# This loads the libpfm transitive dependency.
+# See https://github.com/google/benchmark/pull/1520
+load("@com_github_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps")
+benchmark_deps()
+
 # TODO: Enable below once https://github.com/bazel-xcode/PodToBUILD/issues/232 is resolved
 #
 #http_archive(
@@ -114,3 +119,4 @@ swift_rules_dependencies()
 #    podspec_url = "https://raw.githubusercontent.com/CocoaPods/Specs/master/Specs/2/e/1/CronetFramework/0.0.5/CronetFramework.podspec.json",
 #    url = "https://storage.googleapis.com/grpc-precompiled-binaries/cronet/Cronet.framework-v0.0.5.zip",
 #)
+

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -307,8 +307,8 @@ def grpc_deps():
             sha256 = "2aab2980d0376137f969d92848fbb68216abb07633034534fc8c65cc4e7a0e93",
             strip_prefix = "benchmark-1.8.2",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"
-                "https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz",
+                "https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz",
             ],
         )
 

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -304,11 +304,11 @@ def grpc_deps():
     if "com_github_google_benchmark" not in native.existing_rules():
         http_archive(
             name = "com_github_google_benchmark",
-            sha256 = "2aab2980d0376137f969d92848fbb68216abb07633034534fc8c65cc4e7a0e93",
-            strip_prefix = "benchmark-1.8.2",
+            sha256 = "4e47ca279d5ae967c506c136bd8afb42eedcaf010aebb48a0e87790cae4b488a",
+            strip_prefix = "benchmark-015d1a091af6937488242b70121858bce8fd40e9",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz",
-                "https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz",
+                # v1.8.2
+                "https://github.com/google/benchmark/archive/015d1a091af6937488242b70121858bce8fd40e9.tar.gz",
             ],
         )
 

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -304,11 +304,11 @@ def grpc_deps():
     if "com_github_google_benchmark" not in native.existing_rules():
         http_archive(
             name = "com_github_google_benchmark",
-            sha256 = "3a43368d3ec48afe784573cf962fe98c084e89a1e3d176c00715a84366316e7d",
-            strip_prefix = "benchmark-361e8d1cfe0c6c36d30b39f1b61302ece5507320",
+            sha256 = "2aab2980d0376137f969d92848fbb68216abb07633034534fc8c65cc4e7a0e93",
+            strip_prefix = "benchmark-1.8.2",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/361e8d1cfe0c6c36d30b39f1b61302ece5507320.tar.gz",
-                "https://github.com/google/benchmark/archive/361e8d1cfe0c6c36d30b39f1b61302ece5507320.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"
+                "https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"
             ],
         )
 

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -2319,7 +2319,6 @@
         'third_party/benchmark/src/json_reporter.cc',
         'third_party/benchmark/src/perf_counters.cc',
         'third_party/benchmark/src/reporter.cc',
-        'third_party/benchmark/src/sleep.cc',
         'third_party/benchmark/src/statistics.cc',
         'third_party/benchmark/src/string_util.cc',
         'third_party/benchmark/src/sysinfo.cc',

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -26,7 +26,7 @@ want_submodules=$(mktemp /tmp/submXXXXXX)
 git submodule | awk '{ print $2 " " $1 }' | sort >"$submodules"
 cat <<EOF | sort >"$want_submodules"
 third_party/abseil-cpp c2435f8342c2d0ed8101cb43adfd605fdc52dca2
-third_party/benchmark 361e8d1cfe0c6c36d30b39f1b61302ece5507320
+third_party/benchmark 015d1a091af6937488242b70121858bce8fd40e9
 third_party/bloaty 60209eb1ccc34d5deefb002d1b7f37545204f7f2
 third_party/boringssl-with-bazel 342e805bc1f5dfdd650e3f031686d6c939b095d9
 third_party/cares/cares 6360e96b5cf8e5980c887ce58ef727e53d77243a


### PR DESCRIPTION
Some command line arguments have changed, and the public docs no longer describe how to use the 1-year-old version.