### PR TITLE
[PSM Interop] Fix PyYAML Cython build / Upgrade PyYAML to 6.0

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/.gitignore
+++ b/tools/run_tests/xds_k8s_test_driver/.gitignore
@@ -1,4 +1,5 @@
 config/local-*.cfg
 src/proto
 venv/
+venv-*/
 out/

--- a/tools/run_tests/xds_k8s_test_driver/requirements.lock
+++ b/tools/run_tests/xds_k8s_test_driver/requirements.lock
@@ -1,5 +1,5 @@
 Mako==1.2.4
-PyYAML==5.4.1
+PyYAML==6.0
 absl-py==0.15.0
 google-api-python-client==1.12.11
 google-cloud-secret-manager==2.15.1

--- a/tools/run_tests/xds_k8s_test_driver/requirements.txt
+++ b/tools/run_tests/xds_k8s_test_driver/requirements.txt
@@ -1,5 +1,5 @@
 Mako~=1.1
-PyYAML~=5.3
+PyYAML~=6.0
 absl-py~=0.11
 google-api-python-client~=1.12
 google-cloud-secret-manager~=2.1


### PR DESCRIPTION
Upgrades PyYAML from 5.4.1 to 6.0 to address cython build issue: https://github.com/yaml/pyyaml/issues/601.

Changelog: https://github.com/yaml/pyyaml/blob/master/CHANGES

```
6.0 (2021-10-13)
* https://github.com/yaml/pyyaml/pull/327 -- Change README format to Markdown
* https://github.com/yaml/pyyaml/pull/483 -- Add a test for YAML 1.1 types
* https://github.com/yaml/pyyaml/pull/497 -- fix float resolver to ignore `.` and `._`
* https://github.com/yaml/pyyaml/pull/550 -- drop Python 2.7
* https://github.com/yaml/pyyaml/pull/553 -- Fix spelling of “hexadecimal”
* https://github.com/yaml/pyyaml/pull/556 -- fix representation of Enum subclasses
* https://github.com/yaml/pyyaml/pull/557 -- fix libyaml extension compiler warnings
* https://github.com/yaml/pyyaml/pull/560 -- fix ResourceWarning on leaked file descriptors
* https://github.com/yaml/pyyaml/pull/561 -- always require `Loader` arg to `yaml.load()`
* https://github.com/yaml/pyyaml/pull/564 -- remove remaining direct distutils usage

```

Build error:

<details>
<summary>pip install log</summary>

```
Collecting PyYAML==5.4.1 (from -r requirements.lock (line 2))
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 7.7 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [62 lines of output]
      /[tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py:293](https://cs.corp.google.com/piper///depot/google3/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/config/setupcfg.py?l=293): _DeprecatedConfig: Deprecated config in `setup.cfg`
      !!
      
              ********************************************************************************
              The license_file parameter is deprecated, use license_files instead.
      
              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See [https://setuptools.pypa.io/en/latest/userguide/declarative_config.html](https://www.google.com/url?q=https://setuptools.pypa.io/en/latest/userguide/declarative_config.html&sa=D) for details.
              ********************************************************************************
      
      !!
        parsed = self.parsers.get(option_name, lambda x: x)(value)
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/tmp/tmp.w7fwsDqeYu/grpc/tools/run_tests/xds_k8s_test_driver/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/tmp/tmp.w7fwsDqeYu/grpc/tools/run_tests/xds_k8s_test_driver/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/tmp/tmp.w7fwsDqeYu/grpc/tools/run_tests/xds_k8s_test_driver/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 271, in <module>
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/__init__.py", line 107, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/dist.py", line 1234, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 314, in run
          self.find_sources()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
          mm.run()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 551, in run
          self.add_defaults()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
        File "<string>", line 201, in get_source_files
        File "/tmp/pip-build-env-s70cyo0y/overlay/lib/python3.10/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.
```

</details>