### PR TITLE
[dockerfiles] Improvements and fixes to push_testing_images.sh script

### DIFF
--- a/tools/dockerfile/distribtest/cpp_stretch_aarch64_cross_x64.current_version
+++ b/tools/dockerfile/distribtest/cpp_stretch_aarch64_cross_x64.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_stretch_aarch64_cross_x64:936bd8a34fcd95c00b40e1e08ad31a39fb5211a6@sha256:5f43add221246deb62fbdff53fe3819c66c854a3913bf77f2f5b785b6a94900b

--- a/tools/dockerfile/distribtest/cpp_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/cpp_stretch_x64.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_stretch_x64:02187d31870bf506ac5868b46c2192e01e94fa0a@sha256:1711316cc325618ca43e1d04804833d373166f8313bf439eb4c33e4dbaa905e9

--- a/tools/dockerfile/distribtest/csharp_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/csharp_stretch_x64.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_stretch_x64:d2178edef3faf5fb811b8c4d10fa98ab8e8bd189@sha256:fec8c0637c0163308ba1e2b2592dfbabba8d89c0391e58065bf10ea2659d9d59

--- a/tools/dockerfile/distribtest/php7_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/php7_stretch_x64.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/php7_stretch_x64:6cb7b602cb33592b27bd512966d6f8f93687d349@sha256:ac384de1434b4f922a0b68c7acde5c5811fc89b8f78a67d195222487c0f83fa5

--- a/tools/dockerfile/distribtest/ruby_stretch_x64.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64:10177ff0d2d316c3bb7552726524137c2ae19c90@sha256:fb3c9a4fb54aaf0c2e759be4b544cce7a8c9e115902f8f80b5e5992dcf110021

--- a/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_6.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_6.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64_ruby_2_6:4b215aa6d7029aaa63679881d54b8ca620e2d775@sha256:b9cc471908386767a9dbf3baffb7a67aa93c4cd1057c4ba8572c691c8ba4b3e6

--- a/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_7.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_2_7.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64_ruby_2_7:ab78ab5469a4245bff384c61814f940403206afe@sha256:086280e74db8a0f3c4bdc54626f94011284f02d5e787d9d55413261c35526394

--- a/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_3_0.current_version
+++ b/tools/dockerfile/distribtest/ruby_stretch_x64_ruby_3_0.current_version
@@ -1,1 +1,0 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_stretch_x64_ruby_3_0:bbc6812686a00d8f9d1254acdbe86e0ef0d00d28@sha256:a28654540308499bc45592118f115fbdbf4813fd692438219bbe8574235c902e


### PR DESCRIPTION
- add check that there are no unwanted .current_version files left in the repo after foobar/Dockerfile gets deleted.
- revisit the logic for repo digest vs id digest of docker images.