### PR TITLE
[ruby] fix crash when prefork/postfork is used without previously using grpc

### DIFF
--- a/src/ruby/end2end/prefork_without_using_grpc_test.rb
+++ b/src/ruby/end2end/prefork_without_using_grpc_test.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
+fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+
+this_dir = File.expand_path(File.dirname(__FILE__))
+protos_lib_dir = File.join(this_dir, 'lib')
+grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
+$LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
+$LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
+$LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
+
+require 'grpc'
+require 'end2end_common'
+
+def main
+  with_logging("GRPC.pre_fork") { GRPC.prefork }
+  pid = fork do
+    with_logging("child: GRPC.postfork_child") { GRPC.postfork_child }
+    STDERR.puts "child: done"
+  end
+  with_logging("parent: GRPC.postfork_parent") { GRPC.postfork_parent }
+  Process.wait pid
+  STDERR.puts "parent: done"
+end
+
+main

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -944,6 +944,7 @@ class RubyLanguage(object):
         for test in [
             "src/ruby/end2end/fork_test.rb",
             "src/ruby/end2end/simple_fork_test.rb",
+            "src/ruby/end2end/prefork_without_using_grpc_test.rb",
             "src/ruby/end2end/secure_fork_test.rb",
             "src/ruby/end2end/bad_usage_fork_test.rb",
             "src/ruby/end2end/sig_handling_test.rb",
@@ -967,6 +968,7 @@ class RubyLanguage(object):
                 "src/ruby/end2end/simple_fork_test.rb",
                 "src/ruby/end2end/secure_fork_test.rb",
                 "src/ruby/end2end/bad_usage_fork_test.rb",
+                "src/ruby/end2end/prefork_without_using_grpc_test.rb",
             ]:
                 if platform_string() == "mac":
                     # Skip fork tests on mac, it's only supported on linux.


### PR DESCRIPTION
Should fix https://github.com/grpc/grpc/issues/33787

