### PR TITLE
[test] Run PHP distribtests with -j 2 instead of 4

### DIFF
--- a/tools/internal_ci/linux/grpc_distribtests_php.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_php.sh
@@ -24,7 +24,7 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 # Build all PHP linux artifacts
-tools/run_tests/task_runner.py -f artifact linux php ${TASK_RUNNER_EXTRA_FILTERS} -j 4 -x build_artifacts/sponge_log.xml || FAILED="true"
+tools/run_tests/task_runner.py -f artifact linux php ${TASK_RUNNER_EXTRA_FILTERS} -j 2 -x build_artifacts/sponge_log.xml || FAILED="true"
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
 rm -rf input_artifacts
@@ -44,7 +44,7 @@ cp -r artifacts/* input_artifacts/ || true
 # Run all PHP linux distribtests
 # We run the distribtests even if some of the artifacts have failed to build, since that gives
 # a better signal about which distribtest are affected by the currently broken artifact builds.
-tools/run_tests/task_runner.py -f distribtest linux php ${TASK_RUNNER_EXTRA_FILTERS} -j 4 -x distribtests/sponge_log.xml || FAILED="true"
+tools/run_tests/task_runner.py -f distribtest linux php ${TASK_RUNNER_EXTRA_FILTERS} -j 2 -x distribtests/sponge_log.xml || FAILED="true"
 
 tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh
 


### PR DESCRIPTION
We are seeing `g++: fatal error: Killed signal terminated program cc1plus` on PHP distribtest builds. In case it's an OOM, let's try reducing the build parallelism to see if it helps.