### PR TITLE
[PSM Interop] Legacy tests: fix xDS test client build (v1.52.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -16,11 +16,9 @@
 trap 'date' DEBUG
 set -ex -o igncr || set -ex
 
+
 mkdir -p /var/local/git
-git clone /var/local/jenkins/grpc /var/local/git/grpc
-(cd /var/local/jenkins/grpc/ && git submodule foreach 'cd /var/local/git/grpc \
-&& git submodule update --init --reference /var/local/jenkins/grpc/${name} \
-${name}')
+git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git /var/local/git/grpc
 cd /var/local/git/grpc
 
 python3 -m pip install virtualenv
@@ -62,13 +60,14 @@ touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
     --grpc_python_out=${TOOLS_DIR} \
     ${HEALTH_PROTO_SOURCE_DIR}/health.proto
 
+cd /var/local/jenkins/grpc/
 bazel build //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client
 
 # Test cases "path_matching" and "header_matching" are not included in "all",
 # because not all interop clients in all languages support these new tests.
 export PYTHONUNBUFFERED=true
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
-  tools/run_tests/run_xds_tests.py \
+  /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
     --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -59,6 +59,7 @@ touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
     --grpc_python_out=${TOOLS_DIR} \
     ${HEALTH_PROTO_SOURCE_DIR}/health.proto
 
+cd /var/local/jenkins/grpc/
 bazel build test/cpp/interop:xds_interop_client
 
 # Test cases "path_matching" and "header_matching" are not included in "all",
@@ -67,7 +68,7 @@ bazel build test/cpp/interop:xds_interop_client
 # TODO: remove "path_matching" and "header_matching" from --test_case after
 # they are added into "all".
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
-  tools/run_tests/run_xds_tests.py \
+   /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
     --test_case="ping_pong,circuit_breaking" \
     --project_id=grpc-testing \


### PR DESCRIPTION
Backport of #33796 to v1.52.x.
---
https://github.com/grpc/grpc/pull/33699 incorrectly changed the legacy builds to not just use the test driver from the master, but also to build from it. This PR fixes the issue, and also updates the python job to work use the driver from master.