### PR TITLE
[CI breakage] Skip some dns tests as a temporary workaround

### DIFF
--- a/test/core/event_engine/test_suite/tests/dns_test.cc
+++ b/test/core/event_engine/test_suite/tests/dns_test.cc
@@ -142,10 +142,18 @@ class EventEngineDNSTest : public EventEngineTest {
     });
     int status = health_check.Join();
     // TODO(yijiem): make this portable for Windows
-    ASSERT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    // TODO(yijiem): remove the if block and reenable the ASSERT_TRUE below once
+    // we have added twisted to the docker images.
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+      skip_end2end_tests_ = true;
+    }
+    // ASSERT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0);
   }
 
   static void TearDownTestSuite() {
+    if (skip_end2end_tests_) {
+      return;
+    }
     dns_server_.server_process->Interrupt();
     dns_server_.server_process->Join();
     delete dns_server_.server_process;
@@ -186,6 +194,7 @@ class EventEngineDNSTest : public EventEngineTest {
     grpc::SubProcess* server_process;
   };
   grpc_core::Notification dns_resolver_signal_;
+  static bool skip_end2end_tests_;
 
  private:
   static DNSServer dns_server_;
@@ -193,8 +202,13 @@ class EventEngineDNSTest : public EventEngineTest {
 };
 
 EventEngineDNSTest::DNSServer EventEngineDNSTest::dns_server_;
+bool EventEngineDNSTest::skip_end2end_tests_ = false;
 
 TEST_F(EventEngineDNSTest, QueryNXHostname) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -210,6 +224,10 @@ TEST_F(EventEngineDNSTest, QueryNXHostname) {
 }
 
 TEST_F(EventEngineDNSTest, QueryWithIPLiteral) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -225,6 +243,10 @@ TEST_F(EventEngineDNSTest, QueryWithIPLiteral) {
 }
 
 TEST_F(EventEngineDNSTest, QueryARecord) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -242,6 +264,10 @@ TEST_F(EventEngineDNSTest, QueryARecord) {
 }
 
 TEST_F(EventEngineDNSTest, QueryAAAARecord) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -262,6 +288,10 @@ TEST_F(EventEngineDNSTest, QueryAAAARecord) {
 }
 
 TEST_F(EventEngineDNSTest, TestAddressSorting) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -279,6 +309,10 @@ TEST_F(EventEngineDNSTest, TestAddressSorting) {
 }
 
 TEST_F(EventEngineDNSTest, QuerySRVRecord) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   const SRVRecord kExpectedRecords[] = {
       {/*host=*/"ipv4-only-multi-target.dns-test.event-engine", /*port=*/1234,
        /*priority=*/0, /*weight=*/0},
@@ -297,6 +331,10 @@ TEST_F(EventEngineDNSTest, QuerySRVRecord) {
 }
 
 TEST_F(EventEngineDNSTest, QuerySRVRecordWithLocalhost) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupSRV(
       [this](auto result) {
@@ -309,6 +347,10 @@ TEST_F(EventEngineDNSTest, QuerySRVRecordWithLocalhost) {
 }
 
 TEST_F(EventEngineDNSTest, QueryTXTRecord) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   // clang-format off
   const std::string kExpectedRecord =
       "grpc_config=[{"
@@ -338,6 +380,10 @@ TEST_F(EventEngineDNSTest, QueryTXTRecord) {
 }
 
 TEST_F(EventEngineDNSTest, QueryTXTRecordWithLocalhost) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupTXT(
       [this](auto result) {
@@ -350,6 +396,10 @@ TEST_F(EventEngineDNSTest, QueryTXTRecordWithLocalhost) {
 }
 
 TEST_F(EventEngineDNSTest, TestCancelActiveDNSQuery) {
+  // TODO(yijiem): remove once the docker images are fixed.
+  if (skip_end2end_tests_) {
+    return;
+  }
   const std::string name = "dont-care-since-wont-be-resolved.test.com:1234";
   auto dns_resolver = CreateDNSResolverWithNonResponsiveServer();
   dns_resolver->LookupHostname(

--- a/test/core/event_engine/test_suite/tests/dns_test.cc
+++ b/test/core/event_engine/test_suite/tests/dns_test.cc
@@ -151,9 +151,6 @@ class EventEngineDNSTest : public EventEngineTest {
   }
 
   static void TearDownTestSuite() {
-    if (skip_end2end_tests_) {
-      return;
-    }
     dns_server_.server_process->Interrupt();
     dns_server_.server_process->Join();
     delete dns_server_.server_process;
@@ -207,7 +204,7 @@ bool EventEngineDNSTest::skip_end2end_tests_ = false;
 TEST_F(EventEngineDNSTest, QueryNXHostname) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
@@ -226,7 +223,7 @@ TEST_F(EventEngineDNSTest, QueryNXHostname) {
 TEST_F(EventEngineDNSTest, QueryWithIPLiteral) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
@@ -245,7 +242,7 @@ TEST_F(EventEngineDNSTest, QueryWithIPLiteral) {
 TEST_F(EventEngineDNSTest, QueryARecord) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
@@ -266,7 +263,7 @@ TEST_F(EventEngineDNSTest, QueryARecord) {
 TEST_F(EventEngineDNSTest, QueryAAAARecord) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
@@ -290,7 +287,7 @@ TEST_F(EventEngineDNSTest, QueryAAAARecord) {
 TEST_F(EventEngineDNSTest, TestAddressSorting) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
@@ -311,7 +308,7 @@ TEST_F(EventEngineDNSTest, TestAddressSorting) {
 TEST_F(EventEngineDNSTest, QuerySRVRecord) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   const SRVRecord kExpectedRecords[] = {
       {/*host=*/"ipv4-only-multi-target.dns-test.event-engine", /*port=*/1234,
@@ -333,7 +330,7 @@ TEST_F(EventEngineDNSTest, QuerySRVRecord) {
 TEST_F(EventEngineDNSTest, QuerySRVRecordWithLocalhost) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupSRV(
@@ -349,7 +346,7 @@ TEST_F(EventEngineDNSTest, QuerySRVRecordWithLocalhost) {
 TEST_F(EventEngineDNSTest, QueryTXTRecord) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   // clang-format off
   const std::string kExpectedRecord =
@@ -382,7 +379,7 @@ TEST_F(EventEngineDNSTest, QueryTXTRecord) {
 TEST_F(EventEngineDNSTest, QueryTXTRecordWithLocalhost) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupTXT(
@@ -398,7 +395,7 @@ TEST_F(EventEngineDNSTest, QueryTXTRecordWithLocalhost) {
 TEST_F(EventEngineDNSTest, TestCancelActiveDNSQuery) {
   // TODO(yijiem): remove once the docker images are fixed.
   if (skip_end2end_tests_) {
-    return;
+    GTEST_SKIP();
   }
   const std::string name = "dont-care-since-wont-be-resolved.test.com:1234";
   auto dns_resolver = CreateDNSResolverWithNonResponsiveServer();


### PR DESCRIPTION
Those tests are failing on CIs which do not have twisted installed. Skip them for now and will fix the docker images next.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

