### PR TITLE
[Test] Fix load test configuration generation for `node`.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -94,6 +94,7 @@ buildConfigs() {
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
+        --allow_server_language=node \
         -o "loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -108,6 +108,7 @@ buildConfigs() {
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
+        --allow_server_language=node \
         -o "loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -47,6 +47,10 @@ CONFIGURATION_FILE_HEADER_COMMENT = """
 
 def safe_name(language: str) -> str:
     """Returns a name that is safe to use in labels and file names."""
+    # The language "node_purejs" differs from "node" only in the scenarios
+    # covered, so it is treated the same as "node".
+    if language == "node_purejs":
+        return scenario_config.LANGUAGES["node"].safename
     return scenario_config.LANGUAGES[language].safename
 
 


### PR DESCRIPTION
Scenarios for language `node` specify the server language as `node` (instead of leaving it blank), so a flag must be added to `--allow_server_language=node`.

Scenarios for language `node_purejs` differ in name and in scenario settings, but otherwise run on identical clients and servers. This change treats `node_purejs` as `node` for the purpose of generating load test configurations.