### PR TITLE
[ssl] Disable slow SSL transport security tests for UBSAN builds.

### DIFF
--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -509,7 +509,7 @@ static bool is_slow_build() {
 #if defined(GPR_ARCH_32) || defined(__APPLE__)
   return true;
 #else
-  return BuiltUnderMsan() || BuiltUnderTsan();
+  return BuiltUnderMsan() || BuiltUnderTsan() || BuiltUnderUbsan();
 #endif
 }
 


### PR DESCRIPTION
This PR is expected to fix the flakes of `//test/core/tsi:ssl_transport_security_test` when built under UBSAN.

Why is this needed? There are several tests in `ssl_transport_security_test.cc` that involve doing many expensive operations and PR #33638 recently added one more (namely, repeatedly signing with an ECDSA key). The slow tests are already altered for MSAN and TSAN, and now we need to do the same for UBSAN.

