### PR TITLE
[backport][test] Run PHP distribtests with make -j8 (#33831)

### DIFF
--- a/test/distrib/php/run_distrib_test.sh
+++ b/test/distrib/php/run_distrib_test.sh
@@ -23,6 +23,6 @@ cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 # the exact version string in advance)
 GRPC_PEAR_PACKAGE_NAME=$(find . -regex '.*/grpc-[0-9].*.tgz' | sed 's|./||')
 
-MAKEFLAGS=-j pecl install "${GRPC_PEAR_PACKAGE_NAME}"
+MAKEFLAGS=-j8 pecl install "${GRPC_PEAR_PACKAGE_NAME}"
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php


### PR DESCRIPTION
Related to https://github.com/grpc/grpc/pull/33795.

The tests are still OOMing, and I found that this distribtest script is still running `make -j ...` on a 16-core machine. Reducing it to `8` to see if that helps. Example OOM:
https://fusion2.corp.google.com/invocations/c306e6b9-24e3-498d-8971-3e914feea29b/log