### PR TITLE
[chaotic-good] Clean up unused requested_read_args in PromiseEndpoint::ReadCallback.

### DIFF
--- a/src/core/lib/transport/promise_endpoint.cc
+++ b/src/core/lib/transport/promise_endpoint.cc
@@ -86,9 +86,8 @@ void PromiseEndpoint::ReadCallback(absl::Status status,
       // A further read is needed.
       // Set read args with number of bytes needed as hint.
       grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs
-          read_args;
-      read_args.read_hint_bytes =
-          static_cast<int64_t>(num_bytes_requested - read_buffer_.Length());
+          read_args = {static_cast<int64_t>(num_bytes_requested -
+                                            read_buffer_.Length())};
       // If `Read()` returns true immediately, the callback will not be
       // called. We still need to call our callback to pick up the result and
       // maybe do further reads.

--- a/src/core/lib/transport/promise_endpoint.cc
+++ b/src/core/lib/transport/promise_endpoint.cc
@@ -68,11 +68,8 @@ void PromiseEndpoint::WriteCallback(absl::Status status) {
   write_waker_.Wakeup();
 }
 
-void PromiseEndpoint::ReadCallback(
-    absl::Status status, size_t num_bytes_requested,
-    absl::optional<
-        struct grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs>
-        requested_read_args) {
+void PromiseEndpoint::ReadCallback(absl::Status status,
+                                   size_t num_bytes_requested) {
   if (!status.ok()) {
     // Invalidates all previous reads.
     pending_read_buffer_.Clear();
@@ -88,18 +85,17 @@ void PromiseEndpoint::ReadCallback(
     if (read_buffer_.Length() < num_bytes_requested) {
       // A further read is needed.
       // Set read args with number of bytes needed as hint.
-      requested_read_args = {
-          static_cast<int64_t>(num_bytes_requested - read_buffer_.Length())};
+      grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs
+          read_args;
+      read_args.read_hint_bytes =
+          static_cast<int64_t>(num_bytes_requested - read_buffer_.Length());
       // If `Read()` returns true immediately, the callback will not be
       // called. We still need to call our callback to pick up the result and
       // maybe do further reads.
       if (endpoint_->Read(std::bind(&PromiseEndpoint::ReadCallback, this,
-                                    std::placeholders::_1, num_bytes_requested,
-                                    requested_read_args),
-                          &pending_read_buffer_,
-                          &(requested_read_args.value()))) {
-        ReadCallback(absl::OkStatus(), num_bytes_requested,
-                     requested_read_args);
+                                    std::placeholders::_1, num_bytes_requested),
+                          &pending_read_buffer_, &read_args)) {
+        ReadCallback(absl::OkStatus(), num_bytes_requested);
       }
     } else {
       MutexLock lock(&read_mutex_);

--- a/src/core/lib/transport/promise_endpoint.h
+++ b/src/core/lib/transport/promise_endpoint.h
@@ -107,8 +107,7 @@ class PromiseEndpoint {
       lock.Release();
       // Set read args with hinted bytes.
       grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs
-          read_args;
-      read_args.read_hint_bytes = num_bytes;
+          read_args = {static_cast<int64_t>(num_bytes)};
       // If `Read()` returns true immediately, the callback will not be
       // called. We still need to call our callback to pick up the result and
       // maybe do further reads.
@@ -158,8 +157,7 @@ class PromiseEndpoint {
       lock.Release();
       // Set read args with num_bytes as hint.
       grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs
-          read_args;
-      read_args.read_hint_bytes = num_bytes;
+          read_args = {static_cast<int64_t>(num_bytes)};
       // If `Read()` returns true immediately, the callback will not be
       // called. We still need to call our callback to pick up the result
       // and maybe do further reads.


### PR DESCRIPTION
This is a clean up PR for discussion in #33257. 
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

