### PR TITLE
[C#] Add null reference types support to gRPC C# plugin

### DIFF
--- a/src/compiler/csharp_generator.h
+++ b/src/compiler/csharp_generator.h
@@ -25,7 +25,7 @@ namespace grpc_csharp_generator {
 
 std::string GetServices(const grpc::protobuf::FileDescriptor* file,
                         bool generate_client, bool generate_server,
-                        bool internal_access);
+                        bool internal_access, bool enable_nrt);
 
 }  // namespace grpc_csharp_generator
 

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -43,6 +43,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     bool generate_client = true;
     bool generate_server = true;
     bool internal_access = false;
+    bool enable_nrt = false;  // null reference types
     std::string base_namespace = "";
 
     // the suffix that will get appended to the name generated from the name
@@ -62,6 +63,8 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
         // The option may be removed or file names generated may change
         // in the future.
         base_namespace = options[i].second;
+      } else if (options[i].first == "nullable_reference_types") {
+        enable_nrt = true;
       } else {
         *error = "Unknown generator option: " + options[i].first;
         return false;
@@ -69,7 +72,7 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     }
 
     std::string code = grpc_csharp_generator::GetServices(
-        file, generate_client, generate_server, internal_access);
+        file, generate_client, generate_server, internal_access, enable_nrt);
     if (code.size() == 0) {
       return true;  // don't generate a file if there are no services
     }

--- a/test/csharp/codegen/BUILD
+++ b/test/csharp/codegen/BUILD
@@ -75,3 +75,22 @@ grpc_sh_test(
     ],
     uses_polling = False,
 )
+
+grpc_sh_test(
+    name = "csharp_codegen_nullable_test",
+    size = "small",
+    srcs = ["csharp_codegen_nullable_test.sh"],
+    data = [
+        "nullable/proto/nullabletest.proto",
+        "//src/compiler:grpc_csharp_plugin",
+        "@com_google_protobuf//:protoc",
+    ],
+    tags = [
+        "no_windows",
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+    ],
+    uses_polling = False,
+)

--- a/test/csharp/codegen/csharp_codegen_nullable_test.sh
+++ b/test/csharp/codegen/csharp_codegen_nullable_test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright 2023 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run this script via bazel test
+# It expects that protoc and grpc_csharp_plugin have already been built.
+
+# Simple test - compare generated output to expected files
+
+set -x
+
+TESTNAME=nullable
+
+# protoc and grpc_csharp_plugin binaries are supplied as "data" in bazel
+PROTOC=./external/com_google_protobuf/protoc
+PLUGIN=./src/compiler/grpc_csharp_plugin
+
+# where to find the test data
+DATA_DIR=./test/csharp/codegen/${TESTNAME}
+
+# output directory for the generated files
+PROTO_OUT=./proto_out
+rm -rf ${PROTO_OUT}
+mkdir -p ${PROTO_OUT}
+
+# run protoc and the plugin
+$PROTOC \
+    --plugin=protoc-gen-grpc=$PLUGIN \
+    --csharp_out=${PROTO_OUT} \
+    --grpc-csharp_out=${PROTO_OUT} \
+    --grpc_out=${PROTO_OUT} \
+    --grpc-csharp_opt=nullable_reference_types \
+    -I ${DATA_DIR}/proto \
+    ${DATA_DIR}/proto/nullabletest.proto
+
+# log the files generated
+ls -l ./proto_out
+
+# Rather than doing a diff against a known file, just using grep to
+# check for some of the code changes when "nullable_reference_types" is specified.
+# This isn't bullet proof but does avoid tests breaking when other
+# codegen changes are made.
+
+# check "#nullable enabled" directive is present
+nmatches=$(grep -c "#nullable enabled" ${PROTO_OUT}/NullabletestGrpc.cs)
+if [ "$nmatches" -ne 1 ]
+then
+    echo >&2 "Missing #nullable directive"
+    exit 1
+fi
+
+# check annotation on "headers" parameter in the service methods
+nmatches=$(grep -c -F "grpc::Metadata? headers" ${PROTO_OUT}/NullabletestGrpc.cs)
+if [ "$nmatches" -eq 0 ]
+then
+    echo >&2 "Missing annotation on headers parameter"
+    exit 1
+fi
+
+# check annotation for null forgiving operator in AddMethod
+nmatches=$(grep -c "AddMethod(.*null!" ${PROTO_OUT}/NullabletestGrpc.cs)
+if [ "$nmatches" -eq 0 ]
+then
+    echo >&2 "Missing null forgiving operator in AddMethod"
+    exit 1
+fi
+
+# Run again without the nullable_reference_types options to check the code generated
+
+rm -rf ${PROTO_OUT}
+mkdir -p ${PROTO_OUT}
+
+$PROTOC \
+    --plugin=protoc-gen-grpc=$PLUGIN \
+    --csharp_out=${PROTO_OUT} \
+    --grpc-csharp_out=${PROTO_OUT} \
+    --grpc_out=${PROTO_OUT} \
+    -I ${DATA_DIR}/proto \
+    ${DATA_DIR}/proto/nullabletest.proto
+
+# log the files generated
+ls -l ./proto_out
+
+# check "#nullable enabled" directive is not present
+nmatches=$(grep -c "#nullable enabled" ${PROTO_OUT}/NullabletestGrpc.cs)
+if [ "$nmatches" -ne 0 ]
+then
+    echo >&2 "Unexpected #nullable directive"
+    exit 1
+fi
+
+# check annotation on "headers" parameter in the service methods
+nmatches=$(grep -c -F "grpc::Metadata? headers" ${PROTO_OUT}/NullabletestGrpc.cs)
+if [ "$nmatches" -ne 0 ]
+then
+    echo >&2 "Unexpected annotation on headers parameter"
+    exit 1
+fi
+
+# check annotation for null forgiving operator in AddMethod
+nmatches=$(grep -c "AddMethod(.*null!" ${PROTO_OUT}/NullabletestGrpc.cs)
+if [ "$nmatches" -ne 0 ]
+then
+    echo >&2 "Unexpected null forgiving operator in AddMethod"
+    exit 1
+fi
+
+rm -rf ${PROTO_OUT}
+mkdir -p ${PROTO_OUT}
+
+# Run one extra command to clear $? before exiting the script to prevent
+# failing even when tests pass.
+echo "Plugin test: ${TESTNAME}: passed."

--- a/test/csharp/codegen/nullable/proto/nullabletest.proto
+++ b/test/csharp/codegen/nullable/proto/nullabletest.proto
@@ -1,0 +1,35 @@
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package test.csharp.codegen.nullable.test;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  rpc SayHelloStreamReply (HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
Add support for null reference types to gRPC C# plugin.

To enable, add the option "nullable_reference_types" to the plugin, e.g.
```bash
protoc --plugin=protoc-gen-grpc=grpc_csharp_plugin \
    --csharp_out=. --grpc-csharp_out=. \
    --grpc-csharp_opt=nullable_reference_types \
    myproto.proto
```

This PR is a prerequisite for adding support to Grpc.Tools - see https://github.com/grpc/grpc/issues/20729

Note: this is the gRPC plugin only - adding support to `protoc` code generation is separate (see https://github.com/protocolbuffers/protobuf/pull/13218 for one PR doing this)
