### PR TITLE
[C#] Grpc.Tools changes to support nullable reference types

### DIFF
--- a/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
@@ -32,6 +32,13 @@
   </Target>
 
   <Target Name="_gRPC_PrepareCompileOptions" AfterTargets="Protobuf_PrepareCompileOptions">
+
+    <PropertyGroup>
+      <!-- Enable nullabe reference types if enabled in the project and not been overridden
+           by setting gRPC_NullableReferenceTypes -->
+      <gRPC_NullableReferenceTypes Condition=" '$(gRPC_NullableReferenceTypes)' == '' and '$(Nullable)' == 'Enable' ">Enable</gRPC_NullableReferenceTypes>
+    </PropertyGroup>
+
     <ItemGroup Condition=" '$(Language)' == 'C#' ">
       <Protobuf_Compile Condition=" %(Protobuf_Compile.GrpcServices) != 'None' ">
         <GrpcPluginExe Condition=" '%(Protobuf_Compile.GrpcPluginExe)' == '' ">$(gRPC_PluginFullPath)</GrpcPluginExe>
@@ -44,6 +51,11 @@
       <Protobuf_Compile Condition=" '%(Protobuf_Compile.GrpcServices)' == 'Server' ">
         <_GrpcOutputOptions>%(Protobuf_Compile._GrpcOutputOptions);no_client</_GrpcOutputOptions>
       </Protobuf_Compile>
+
+      <Protobuf_Compile Condition=" '$(gRPC_NullableReferenceTypes)' == 'Enable' ">
+        <_GrpcOutputOptions>%(Protobuf_Compile._GrpcOutputOptions);nullable_reference_types</_GrpcOutputOptions>
+      </Protobuf_Compile>
+
     </ItemGroup>
   </Target>
 </Project>

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -266,9 +266,16 @@
   <!-- Extension point: Plugins massage metadata into recognized metadata
        values passed to the ProtoCompile task. -->
   <Target Name="Protobuf_PrepareCompileOptions" Condition=" '@(Protobuf_Compile)' != '' ">
+    <PropertyGroup>
+      <!-- Enable nullabe reference types if enabled in the project and not been overridden
+           by setting Protobuf_NullableReferenceTypes -->
+      <Protobuf_NullableReferenceTypes Condition=" '$(Protobuf_NullableReferenceTypes)' == '' and '$(Nullable)' == 'Enable' ">Enable</Protobuf_NullableReferenceTypes>
+    </PropertyGroup>
+
     <ItemGroup>
       <Protobuf_Compile>
         <_OutputOptions Condition=" '%(Protobuf_Compile.Access)' == 'Internal' ">%(Protobuf_Compile._OutputOptions);internal_access</_OutputOptions>
+        <_OutputOptions Condition=" '$(Protobuf_NullableReferenceTypes)' == 'Enable' ">%(Protobuf_Compile._OutputOptions);nullable_reference_types</_OutputOptions>
       </Protobuf_Compile>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
A support to Grpc.Tools to support nullable reference types.

This **should NOT BE MERGED** until nullable reference types are supported in the protoc and gRPC C# plugin code generators.
See:

- https://github.com/grpc/grpc/pull/33878
- https://github.com/protocolbuffers/protobuf/pull/13218
- https://github.com/protocolbuffers/protobuf/issues/6632
- https://github.com/grpc/grpc/issues/20729

Grpc.Tools detects of `<Nullable>enable<\Nullable>` is in the project file and adds the appropriate options to `protoc` and the plugin.

These can be overridden by setting the following properties to `enable` or `disable`:
- `gRPC_NullableReferenceTypes` for the plugin
- `Protobuf_NullableReferenceTypes` for protoc

Maybe just one property for both?

TODO:
- adding tests
- updating documentation (to do after NuGet package is published)
