### PR TITLE
Revert "[CI breakage] Skip some dns tests as a temporary workaround"

### DIFF
--- a/test/core/event_engine/test_suite/tests/dns_test.cc
+++ b/test/core/event_engine/test_suite/tests/dns_test.cc
@@ -142,12 +142,7 @@ class EventEngineDNSTest : public EventEngineTest {
     });
     int status = health_check.Join();
     // TODO(yijiem): make this portable for Windows
-    // TODO(yijiem): remove the if block and reenable the ASSERT_TRUE below once
-    // we have added twisted to the docker images.
-    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-      skip_end2end_tests_ = true;
-    }
-    // ASSERT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    ASSERT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0);
   }
 
   static void TearDownTestSuite() {
@@ -191,7 +186,6 @@ class EventEngineDNSTest : public EventEngineTest {
     grpc::SubProcess* server_process;
   };
   grpc_core::Notification dns_resolver_signal_;
-  static bool skip_end2end_tests_;
 
  private:
   static DNSServer dns_server_;
@@ -199,13 +193,8 @@ class EventEngineDNSTest : public EventEngineTest {
 };
 
 EventEngineDNSTest::DNSServer EventEngineDNSTest::dns_server_;
-bool EventEngineDNSTest::skip_end2end_tests_ = false;
 
 TEST_F(EventEngineDNSTest, QueryNXHostname) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -221,10 +210,6 @@ TEST_F(EventEngineDNSTest, QueryNXHostname) {
 }
 
 TEST_F(EventEngineDNSTest, QueryWithIPLiteral) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -240,10 +225,6 @@ TEST_F(EventEngineDNSTest, QueryWithIPLiteral) {
 }
 
 TEST_F(EventEngineDNSTest, QueryARecord) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -261,10 +242,6 @@ TEST_F(EventEngineDNSTest, QueryARecord) {
 }
 
 TEST_F(EventEngineDNSTest, QueryAAAARecord) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -285,10 +262,6 @@ TEST_F(EventEngineDNSTest, QueryAAAARecord) {
 }
 
 TEST_F(EventEngineDNSTest, TestAddressSorting) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupHostname(
       [this](auto result) {
@@ -306,10 +279,6 @@ TEST_F(EventEngineDNSTest, TestAddressSorting) {
 }
 
 TEST_F(EventEngineDNSTest, QuerySRVRecord) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   const SRVRecord kExpectedRecords[] = {
       {/*host=*/"ipv4-only-multi-target.dns-test.event-engine", /*port=*/1234,
        /*priority=*/0, /*weight=*/0},
@@ -328,10 +297,6 @@ TEST_F(EventEngineDNSTest, QuerySRVRecord) {
 }
 
 TEST_F(EventEngineDNSTest, QuerySRVRecordWithLocalhost) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupSRV(
       [this](auto result) {
@@ -344,10 +309,6 @@ TEST_F(EventEngineDNSTest, QuerySRVRecordWithLocalhost) {
 }
 
 TEST_F(EventEngineDNSTest, QueryTXTRecord) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   // clang-format off
   const std::string kExpectedRecord =
       "grpc_config=[{"
@@ -377,10 +338,6 @@ TEST_F(EventEngineDNSTest, QueryTXTRecord) {
 }
 
 TEST_F(EventEngineDNSTest, QueryTXTRecordWithLocalhost) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   auto dns_resolver = CreateDefaultDNSResolver();
   dns_resolver->LookupTXT(
       [this](auto result) {
@@ -393,10 +350,6 @@ TEST_F(EventEngineDNSTest, QueryTXTRecordWithLocalhost) {
 }
 
 TEST_F(EventEngineDNSTest, TestCancelActiveDNSQuery) {
-  // TODO(yijiem): remove once the docker images are fixed.
-  if (skip_end2end_tests_) {
-    GTEST_SKIP();
-  }
   const std::string name = "dont-care-since-wont-be-resolved.test.com:1234";
   auto dns_resolver = CreateDNSResolverWithNonResponsiveServer();
   dns_resolver->LookupHostname(


### PR DESCRIPTION
Reverts grpc/grpc#33819

Verified that it passed these jobs:
`grpc/core/master/linux/grpc_basictests_c_cpp_dbg`
`grpc/core/master/linux/grpc_basictests_c_cpp_opt`
`grpc/core/master/linux/grpc_portability`