### PR TITLE
[v1.50.x][Interop] Revert Phusion and use apt upgrade

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
@@ -1,6 +1,7 @@
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM phusion/baseimage:master@sha256:65ea10d5f757e5e86272625f8675d437dd83d8db64bdb429e2354d58f5462750
 
 RUN apt-get update -y && \
+	apt-get upgrade -y && \
         apt-get install -y \
             build-essential \
             clang \
@@ -16,13 +17,13 @@ COPY . .
 RUN tools/bazel build -c dbg //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client
 RUN cp -rL /workdir/bazel-bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client* /artifacts/
 
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM phusion/baseimage:master@sha256:65ea10d5f757e5e86272625f8675d437dd83d8db64bdb429e2354d58f5462750
 COPY --from=0 /artifacts ./
 
 ENV GRPC_VERBOSITY="DEBUG"
 ENV GRPC_TRACE="xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb,ring_hash_lb,outlier_detection_lb"
 
-RUN apt-get update -y && apt-get install -y python3
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y python3
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ENTRYPOINT ["/xds_interop_client"]

--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server
@@ -1,6 +1,7 @@
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM phusion/baseimage:master@sha256:65ea10d5f757e5e86272625f8675d437dd83d8db64bdb429e2354d58f5462750
 
 RUN apt-get update -y && \
+	apt-get upgrade -y && \
         apt-get install -y \
             build-essential \
             clang \
@@ -16,13 +17,13 @@ COPY . .
 RUN tools/bazel build -c dbg //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_server
 RUN cp -rL /workdir/bazel-bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server* /artifacts/
 
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM phusion/baseimage:master@sha256:65ea10d5f757e5e86272625f8675d437dd83d8db64bdb429e2354d58f5462750
 COPY --from=0 /artifacts ./
 
 ENV GRPC_VERBOSITY="DEBUG"
 ENV GRPC_TRACE="xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb"
 
-RUN apt-get update -y && apt-get install -y python3
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y python3
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ENTRYPOINT ["/xds_interop_server"]


### PR DESCRIPTION
This fixes the build failure and security advisories.