### PR TITLE
[Aio AioRpcError] Allow pickle AioRpcError

### DIFF
--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -153,6 +153,17 @@ class AioRpcError(grpc.RpcError):
     def __str__(self) -> str:
         return self._repr()
 
+    def __reduce__(self):
+        return (
+            type(self),
+            (
+                self._code,
+                self._initial_metadata,
+                self._trailing_metadata,
+                self._details,
+                self._debug_error_string,
+            ),
+        )
 
 def _create_rpc_error(
     initial_metadata: Metadata, status: cygrpc.AioRpcStatus

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -165,6 +165,7 @@ class AioRpcError(grpc.RpcError):
             ),
         )
 
+
 def _create_rpc_error(
     initial_metadata: Metadata, status: cygrpc.AioRpcStatus
 ) -> AioRpcError:

--- a/src/python/grpcio_tests/tests_aio/unit/aio_rpc_error_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/aio_rpc_error_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests AioRpcError class."""
 
+import pickle
 import logging
 import unittest
 
@@ -50,6 +51,28 @@ class TestAioRpcError(unittest.TestCase):
         )
         self.assertEqual(
             aio_rpc_error.debug_error_string(), _TEST_DEBUG_ERROR_STRING
+        )
+
+    def test_pickle(self):
+        aio_rpc_error = AioRpcError(
+            grpc.StatusCode.CANCELLED,
+            initial_metadata=_TEST_INITIAL_METADATA,
+            trailing_metadata=_TEST_TRAILING_METADATA,
+            details="details",
+            debug_error_string=_TEST_DEBUG_ERROR_STRING,
+        )
+        dump_error = pickle.dumps(aio_rpc_error)
+        loaded_error = pickle.loads(dump_error)
+        self.assertEqual(loaded_error.code(), grpc.StatusCode.CANCELLED)
+        self.assertEqual(loaded_error.details(), "details")
+        self.assertEqual(
+            loaded_error.initial_metadata(), _TEST_INITIAL_METADATA
+        )
+        self.assertEqual(
+            loaded_error.trailing_metadata(), _TEST_TRAILING_METADATA
+        )
+        self.assertEqual(
+            loaded_error.debug_error_string(), _TEST_DEBUG_ERROR_STRING
         )
 
 

--- a/src/python/grpcio_tests/tests_aio/unit/aio_rpc_error_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/aio_rpc_error_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 """Tests AioRpcError class."""
 
-import pickle
 import logging
+import pickle
 import unittest
 
 import grpc


### PR DESCRIPTION
Fix: #33643.

This change adds `__reduce__` to `AioRpcError` to allow pickle.

### Testing

Added bazel unit test, without this change, test will fail with error:
```
TypeError: AioRpcError.__init__() missing 3 required positional arguments: 'code', 'initial_metadata', and 'trailing_metadata'
```