### PR TITLE
[PSM Interop] Fix bootstrap generator interop test

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -119,6 +119,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
         secure_mode: bool = False,
         replica_count: int = 1,
         log_to_stdout: bool = False,
+        bootstrap_version: Optional[str] = None,
     ) -> List[XdsTestServer]:
         if not maintenance_port:
             maintenance_port = self._get_default_maintenance_port(secure_mode)
@@ -202,6 +203,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
             test_port=test_port,
             maintenance_port=maintenance_port,
             secure_mode=secure_mode,
+            bootstrap_version=bootstrap_version,
         )
 
         pod_names = self._wait_deployment_pod_count(

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -65,7 +65,11 @@ spec:
             % if xds_server_uri:
             - "--xds-server-uri=${xds_server_uri}"
             % endif
+            % if bootstrap_version=="v0.11.0" or bootstrap_version=="v0.12.0":
+            - "--node-metadata-experimental=app=${namespace_name}-${deployment_name}"
+            % else:
             - "--node-metadata=app=${namespace_name}-${deployment_name}"
+            % endif
           resources:
             limits:
               cpu: 100m

--- a/tools/run_tests/xds_k8s_test_driver/tests/bootstrap_generator_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/bootstrap_generator_test.py
@@ -205,6 +205,7 @@ class BootstrapGeneratorServerTest(
             maintenance_port=self.server_maintenance_port,
             xds_host=self.server_xds_host,
             xds_port=self.server_xds_port,
+            bootstrap_version=version
         )
 
         # Load backends.

--- a/tools/run_tests/xds_k8s_test_driver/tests/bootstrap_generator_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/bootstrap_generator_test.py
@@ -205,7 +205,7 @@ class BootstrapGeneratorServerTest(
             maintenance_port=self.server_maintenance_port,
             xds_host=self.server_xds_host,
             xds_port=self.server_xds_port,
-            bootstrap_version=version
+            bootstrap_version=version,
         )
 
         # Load backends.


### PR DESCRIPTION
This PR fixes the bootstrap generator interop test by making the node metadata flag dependent on version, which was causing a breakage previously as all bootstrap generator version's don't necessarily support the deexpiermentalized flag.