### PR TITLE
[benchmark] Allow PSM categories to be exported

### DIFF
--- a/tools/run_tests/performance/scenario_config_exporter.py
+++ b/tools/run_tests/performance/scenario_config_exporter.py
@@ -188,7 +188,7 @@ def main() -> None:
     argp.add_argument(
         "--category",
         default="all",
-        choices=["all", "inproc", "scalable", "smoketest", "sweep"],
+        choices=["all", "inproc", "scalable", "smoketest", "sweep", "psm"],
         help="Select scenarios for a category of tests.",
     )
     argp.add_argument(


### PR DESCRIPTION
I don't personally need this, but it seems like a missed piece of https://github.com/grpc/grpc/pull/29336