### PR TITLE
[channel-args] Do not mutate the AVL if there is no change

### DIFF
--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -217,7 +217,7 @@ ChannelArgs ChannelArgs::Remove(absl::string_view name) const {
 ChannelArgs ChannelArgs::RemoveAllKeysWithPrefix(
     absl::string_view prefix) const {
   auto args = args_;
-  args_.ForEach([&args, prefix](const std::string& key, const Value& value) {
+  args_.ForEach([&args, prefix](const std::string& key, const Value&) {
     if (absl::StartsWith(key, prefix)) args.Remove(key);
   });
   return ChannelArgs(std::move(args));

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -218,7 +218,7 @@ ChannelArgs ChannelArgs::RemoveAllKeysWithPrefix(
     absl::string_view prefix) const {
   auto args = args_;
   args_.ForEach([&args, prefix](const std::string& key, const Value&) {
-    if (absl::StartsWith(key, prefix)) args.Remove(key);
+    if (absl::StartsWith(key, prefix)) args = args.Remove(key);
   });
   return ChannelArgs(std::move(args));
 }

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -33,7 +33,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "channel_args.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>


### PR DESCRIPTION
Inserts and removals create `O(log(n))` new nodes with a persistent AVL - which is nice - but if there's ultimately no mutation even this is wasteful. Do some extra work in channel args to verify that there is indeed a mutation, otherwise continue to share the same underlying object.