### PR TITLE
[Documentation] Fix Python documentation CSS

### DIFF
--- a/doc/python/sphinx/_static/custom.css
+++ b/doc/python/sphinx/_static/custom.css
@@ -1,4 +1,8 @@
 dl.field-list > dt {
     word-break: keep-all !important;
 }
-.sphinxsidebarwrapper {  overflow-y: scroll; }
+.sphinxsidebar {
+    overflow-y: scroll;
+    top: 0;
+    bottom: 0;
+}

--- a/doc/python/sphinx/_static/custom.css
+++ b/doc/python/sphinx/_static/custom.css
@@ -1,3 +1,4 @@
 dl.field-list > dt {
     word-break: keep-all !important;
 }
+.sphinxsidebarwrapper {  overflow-y: scroll; }


### PR DESCRIPTION
Fix python documentation website sidebar.

### Before:
<img width="1168" alt="Screenshot 2023-07-27 at 4 49 25 PM" src="https://github.com/grpc/grpc/assets/24593237/1434ac63-7fc3-4f5c-a931-9a939fb67de6">

### After:
![Screenshot 2023-07-28 at 1 04 01 PM](https://github.com/grpc/grpc/assets/24593237/c7cc16b6-926f-4c8b-bc54-6cedfebb62b4)


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

