### PR TITLE
[EventEngine] Enable the work_stealing experiment in debug builds

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -29,7 +29,6 @@ EXPERIMENTS = {
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "unique_metadata_strings",
-                "work_stealing",
             ],
             "cpp_end2end_test": [
                 "promise_based_server_call",
@@ -62,6 +61,9 @@ EXPERIMENTS = {
             ],
         },
         "on": {
+            "core_end2end_test": [
+                "work_stealing",
+            ],
         },
     },
     "ios": {
@@ -76,7 +78,6 @@ EXPERIMENTS = {
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "unique_metadata_strings",
-                "work_stealing",
             ],
             "cpp_end2end_test": [
                 "promise_based_server_call",
@@ -109,6 +110,9 @@ EXPERIMENTS = {
             ],
         },
         "on": {
+            "core_end2end_test": [
+                "work_stealing",
+            ],
         },
     },
     "posix": {
@@ -127,7 +131,6 @@ EXPERIMENTS = {
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "unique_metadata_strings",
-                "work_stealing",
             ],
             "cpp_end2end_test": [
                 "promise_based_server_call",
@@ -166,6 +169,9 @@ EXPERIMENTS = {
             ],
         },
         "on": {
+            "core_end2end_test": [
+                "work_stealing",
+            ],
         },
     },
 }

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -97,6 +97,11 @@ const char* const description_keepalive_fix =
     "Allows overriding keepalive_permit_without_calls. Refer "
     "https://github.com/grpc/grpc/pull/33428 for more information.";
 const char* const additional_constraints_keepalive_fix = "{}";
+#ifdef NDEBUG
+const bool kDefaultForDebugOnly = false;
+#else
+const bool kDefaultForDebugOnly = true;
+#endif
 }  // namespace
 
 namespace grpc_core {
@@ -136,7 +141,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, false, false},
     {"work_stealing", description_work_stealing,
-     additional_constraints_work_stealing, false, false},
+     additional_constraints_work_stealing, kDefaultForDebugOnly, false},
     {"client_privacy", description_client_privacy,
      additional_constraints_client_privacy, false, false},
     {"canary_client_privacy", description_canary_client_privacy,
@@ -228,6 +233,11 @@ const char* const description_keepalive_fix =
     "Allows overriding keepalive_permit_without_calls. Refer "
     "https://github.com/grpc/grpc/pull/33428 for more information.";
 const char* const additional_constraints_keepalive_fix = "{}";
+#ifdef NDEBUG
+const bool kDefaultForDebugOnly = false;
+#else
+const bool kDefaultForDebugOnly = true;
+#endif
 }  // namespace
 
 namespace grpc_core {
@@ -267,7 +277,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, false, false},
     {"work_stealing", description_work_stealing,
-     additional_constraints_work_stealing, false, false},
+     additional_constraints_work_stealing, kDefaultForDebugOnly, false},
     {"client_privacy", description_client_privacy,
      additional_constraints_client_privacy, false, false},
     {"canary_client_privacy", description_canary_client_privacy,
@@ -359,6 +369,11 @@ const char* const description_keepalive_fix =
     "Allows overriding keepalive_permit_without_calls. Refer "
     "https://github.com/grpc/grpc/pull/33428 for more information.";
 const char* const additional_constraints_keepalive_fix = "{}";
+#ifdef NDEBUG
+const bool kDefaultForDebugOnly = false;
+#else
+const bool kDefaultForDebugOnly = true;
+#endif
 }  // namespace
 
 namespace grpc_core {
@@ -398,7 +413,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, false, false},
     {"work_stealing", description_work_stealing,
-     additional_constraints_work_stealing, false, false},
+     additional_constraints_work_stealing, kDefaultForDebugOnly, false},
     {"client_privacy", description_client_privacy,
      additional_constraints_client_privacy, false, false},
     {"canary_client_privacy", description_canary_client_privacy,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -75,7 +75,16 @@ inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
-inline bool IsWorkStealingEnabled() { return false; }
+#ifndef NDEBUG
+#define GRPC_EXPERIMENT_IS_INCLUDED_WORK_STEALING
+#endif
+inline bool IsWorkStealingEnabled() {
+#ifdef NDEBUG
+  return false;
+#else
+  return true;
+#endif
+}
 inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsCanaryClientPrivacyEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }
@@ -99,7 +108,16 @@ inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
-inline bool IsWorkStealingEnabled() { return false; }
+#ifndef NDEBUG
+#define GRPC_EXPERIMENT_IS_INCLUDED_WORK_STEALING
+#endif
+inline bool IsWorkStealingEnabled() {
+#ifdef NDEBUG
+  return false;
+#else
+  return true;
+#endif
+}
 inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsCanaryClientPrivacyEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }
@@ -123,7 +141,16 @@ inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
-inline bool IsWorkStealingEnabled() { return false; }
+#ifndef NDEBUG
+#define GRPC_EXPERIMENT_IS_INCLUDED_WORK_STEALING
+#endif
+inline bool IsWorkStealingEnabled() {
+#ifdef NDEBUG
+  return false;
+#else
+  return true;
+#endif
+}
 inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsCanaryClientPrivacyEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -79,7 +79,7 @@
     # implemented
     windows: broken
 - name: work_stealing
-  default: false
+  default: debug
 - name: client_privacy
   default: false
 - name: canary_client_privacy


### PR DESCRIPTION
Over the past 5 days, this experiment has not introduced any new flakes, nor increased any flake rates. Let's enable it for debug builds. To prevent issues over the weekend, I plan to merge it next week, July 31st (with announcement).