### PR TITLE
[Interop Test] Use distroless for C++ xDS tests

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
@@ -14,7 +14,7 @@
 
 # Dockerfile for building //test/cpp/interop:xds_interop_client
 
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM debian:11
 
 RUN apt-get update -y && \
     apt-get install -y \
@@ -32,7 +32,7 @@ COPY . .
 RUN tools/bazel build //test/cpp/interop:xds_interop_client
 RUN cp -rL /workdir/bazel-bin/test/cpp/interop/xds_interop_client /artifacts/
 
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM gcr.io/distroless/cc-debian11@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc
 COPY --from=0 /artifacts ./
 
 ENV GRPC_VERBOSITY="DEBUG"

--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server
@@ -14,7 +14,7 @@
 
 # Dockerfile for building //test/cpp/interop:xds_interop_client
 
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM debian:11
 
 RUN apt-get update -y && \
     apt-get install -y \
@@ -32,7 +32,7 @@ COPY . .
 RUN tools/bazel build //test/cpp/interop:xds_interop_server
 RUN cp -rL /workdir/bazel-bin/test/cpp/interop/xds_interop_server /artifacts/
 
-FROM phusion/baseimage:master@sha256:e757fe8c7adcb9f798c0eb9dfff31bbf7d91538a1002031d7cdf3e5bf9cf71fc
+FROM gcr.io/distroless/cc-debian11@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc
 COPY --from=0 /artifacts ./
 
 ENV GRPC_VERBOSITY="DEBUG"


### PR DESCRIPTION
This should drastically reduce number of vulnerabilities.

Tested locally by running the test