### PR TITLE
[CI] Build resolver tests related python scripts for Python3

### DIFF
--- a/test/cpp/naming/utils/BUILD
+++ b/test/cpp/naming/utils/BUILD
@@ -27,6 +27,7 @@ licenses(["notice"])
 grpc_py_binary(
     name = "dns_server",
     testonly = True,
+    python_version = "PY3",
     srcs = ["dns_server.py"],
     external_deps = [
         "twisted",
@@ -37,6 +38,7 @@ grpc_py_binary(
 grpc_py_binary(
     name = "dns_resolver",
     testonly = True,
+    python_version = "PY3",
     srcs = ["dns_resolver.py"],
     external_deps = [
         "twisted",
@@ -46,11 +48,13 @@ grpc_py_binary(
 grpc_py_binary(
     name = "tcp_connect",
     testonly = True,
+    python_version = "PY3",
     srcs = ["tcp_connect.py"],
 )
 
 grpc_py_binary(
     name = "health_check",
     testonly = True,
+    python_version = "PY3",
     srcs = ["health_check.py"],
 )


### PR DESCRIPTION
The `arm64v8/debian:11` docker environment does not have Python2 which is the default python version used in the Bazel wrapper (as in our build rule). These scripts have been upgraded to Python3 so now we tell Bazel to build for Python3.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

