### PR TITLE
[Deps] Update pyyaml to 6.0.1 for bazel build system

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -533,11 +533,11 @@ def grpc_test_only_deps():
     if "com_github_yaml_pyyaml" not in native.existing_rules():
         http_archive(
             name = "com_github_yaml_pyyaml",
-            sha256 = "6b4314b1b2051ddb9d4fcd1634e1fa9c1bb4012954273c9ff3ef689f6ec6c93e",
-            strip_prefix = "pyyaml-3.12",
+            sha256 = "e34d97db6d846f5e2ad51417fd646e7ce6a3a70726ccea2a857e0580a7155f39",
+            strip_prefix = "pyyaml-6.0.1",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/yaml/pyyaml/archive/3.12.zip",
-                "https://github.com/yaml/pyyaml/archive/3.12.zip",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/yaml/pyyaml/archive/6.0.1.zip",
+                "https://github.com/yaml/pyyaml/archive/6.0.1.zip",
             ],
             build_file = "@com_github_grpc_grpc//third_party:yaml.BUILD",
         )

--- a/test/cpp/naming/utils/BUILD
+++ b/test/cpp/naming/utils/BUILD
@@ -27,34 +27,34 @@ licenses(["notice"])
 grpc_py_binary(
     name = "dns_server",
     testonly = True,
-    python_version = "PY3",
     srcs = ["dns_server.py"],
     external_deps = [
         "twisted",
         "yaml",
     ],
+    python_version = "PY3",
 )
 
 grpc_py_binary(
     name = "dns_resolver",
     testonly = True,
-    python_version = "PY3",
     srcs = ["dns_resolver.py"],
     external_deps = [
         "twisted",
     ],
+    python_version = "PY3",
 )
 
 grpc_py_binary(
     name = "tcp_connect",
     testonly = True,
-    python_version = "PY3",
     srcs = ["tcp_connect.py"],
+    python_version = "PY3",
 )
 
 grpc_py_binary(
     name = "health_check",
     testonly = True,
-    python_version = "PY3",
     srcs = ["health_check.py"],
+    python_version = "PY3",
 )

--- a/test/cpp/naming/utils/BUILD
+++ b/test/cpp/naming/utils/BUILD
@@ -27,6 +27,7 @@ licenses(["notice"])
 grpc_py_binary(
     name = "dns_server",
     testonly = True,
+    python_version = "PY3",
     srcs = ["dns_server.py"],
     external_deps = [
         "twisted",
@@ -37,6 +38,7 @@ grpc_py_binary(
 grpc_py_binary(
     name = "dns_resolver",
     testonly = True,
+    python_version = "PY3",
     srcs = ["dns_resolver.py"],
     external_deps = [
         "twisted",
@@ -46,11 +48,13 @@ grpc_py_binary(
 grpc_py_binary(
     name = "tcp_connect",
     testonly = True,
+    python_version = "PY3",
     srcs = ["tcp_connect.py"],
 )
 
 grpc_py_binary(
     name = "health_check",
     testonly = True,
+    python_version = "PY3",
     srcs = ["health_check.py"],
 )


### PR DESCRIPTION
The previous version (`3.12`) is 7 years old and does not support the newest Python 3 versions. This causes issues to move certain test targets (which depends on `pyyaml`) to Python 3 when some CI environment (e.g. `arm64v8/debian:11`) does not have Python 2 installed. And in general, we should move away from Python 2. Thus, updated `pyyaml` to the latest version.

This hopefully should also fix the `prod:grpc/core/master/linux/arm64/grpc_bazel_test_c_cpp` job breakage.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

