### PR TITLE
[php] Initialise fields of the structure

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -208,7 +208,7 @@ target_bound_le_t* update_and_get_target_upper_bound(char* target, int bound) {
   if (!(PHP_GRPC_PERSISTENT_LIST_FIND(&grpc_target_upper_bound_map, target,
       key_len, rsrc))) {
     // Target is not persisted.
-    php_grpc_zend_resource new_rsrc;
+    php_grpc_zend_resource new_rsrc = {0};
     target_bound_status = malloc(sizeof(target_bound_le_t));
     if (bound == -1) {
       // If the bound is not set, use 1 as default.s
@@ -281,7 +281,7 @@ void create_and_add_channel_to_persistent_list(
     }
   }
   // There is space in the persistent map.
-  php_grpc_zend_resource new_rsrc;
+  php_grpc_zend_resource new_rsrc = {0};
   channel_persistent_le_t *le;
   // this links each persistent list entry to a destructor
   new_rsrc.type = le_plink;


### PR DESCRIPTION
Polaris by Sinopsis reported "Uninitialized Scalar Variable" here. I tend to agree that "gc" isn't initialised properly. It might be not a problem at the moment but if `zend_resource` changes at some point, we might get into a trouble.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

