### PR TITLE
[benchmark] Increase the C++ benchmarks' warmup times

### DIFF
--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -18,6 +18,7 @@ import math
 
 WARMUP_SECONDS = 5
 JAVA_WARMUP_SECONDS = 15  # Java needs more warmup time for JIT to kick in.
+CXX_WARMUP_SECONDS = 30  # Core needs more warmup time for the thread pool to scale appropriately.
 BENCHMARK_SECONDS = 30
 
 SMOKETEST = "smoketest"
@@ -278,6 +279,7 @@ class CXXLanguage(Language):
             secure=False,
             async_server_threads=1,
             categories=[PSM],
+            warmup_seconds=CXX_WARMUP_SECONDS,
         )
 
         # TODO(ctiller): add 70% load latency test
@@ -294,6 +296,7 @@ class CXXLanguage(Language):
             num_clients=1,
             secure=False,
             categories=[SWEEP],
+            warmup_seconds=CXX_WARMUP_SECONDS,
         )
 
         yield _ping_pong_scenario(
@@ -309,6 +312,7 @@ class CXXLanguage(Language):
             num_clients=1,
             secure=False,
             categories=[SWEEP],
+            warmup_seconds=CXX_WARMUP_SECONDS,
         )
 
         # Scenario was added in https://github.com/grpc/grpc/pull/12987, but its purpose is unclear
@@ -328,6 +332,7 @@ class CXXLanguage(Language):
             async_server_threads=16,
             server_threads_per_cq=1,
             categories=[SCALABLE],
+            warmup_seconds=CXX_WARMUP_SECONDS,
         )
 
         for secure in [True, False]:
@@ -346,6 +351,7 @@ class CXXLanguage(Language):
                 categories=smoketest_categories
                 + inproc_categories
                 + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -362,6 +368,7 @@ class CXXLanguage(Language):
                 categories=smoketest_categories
                 + inproc_categories
                 + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             for mps in geometric_progression(10, 20, 10):
@@ -379,6 +386,7 @@ class CXXLanguage(Language):
                     categories=smoketest_categories
                     + inproc_categories
                     + [SCALABLE],
+                    warmup_seconds=CXX_WARMUP_SECONDS,
                 )
 
             for mps in geometric_progression(1, 200, math.sqrt(10)):
@@ -394,6 +402,7 @@ class CXXLanguage(Language):
                     messages_per_stream=mps,
                     minimal_stack=not secure,
                     categories=[SWEEP],
+                    warmup_seconds=CXX_WARMUP_SECONDS,
                 )
 
             yield _ping_pong_scenario(
@@ -410,6 +419,7 @@ class CXXLanguage(Language):
                 categories=inproc_categories + [SCALABLE],
                 channels=1,
                 outstanding=100,
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -425,6 +435,7 @@ class CXXLanguage(Language):
                 secure=secure,
                 minimal_stack=not secure,
                 categories=inproc_categories + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -438,6 +449,7 @@ class CXXLanguage(Language):
                 client_threads_per_cq=1000000,
                 server_threads_per_cq=1000000,
                 categories=[SWEEP],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -451,6 +463,7 @@ class CXXLanguage(Language):
                 client_threads_per_cq=1000000,
                 server_threads_per_cq=1000000,
                 categories=inproc_categories + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -463,6 +476,7 @@ class CXXLanguage(Language):
                 client_threads_per_cq=1000000,
                 server_threads_per_cq=1000000,
                 categories=inproc_categories + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -476,6 +490,7 @@ class CXXLanguage(Language):
                 minimal_stack=not secure,
                 secure=secure,
                 categories=[SWEEP],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -490,6 +505,7 @@ class CXXLanguage(Language):
                 categories=smoketest_categories
                 + inproc_categories
                 + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -505,6 +521,7 @@ class CXXLanguage(Language):
                 secure=secure,
                 minimal_stack=not secure,
                 categories=inproc_categories + [SCALABLE],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -517,6 +534,7 @@ class CXXLanguage(Language):
                 secure=secure,
                 minimal_stack=not secure,
                 categories=[SWEEP],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             yield _ping_pong_scenario(
@@ -531,6 +549,7 @@ class CXXLanguage(Language):
                 categories=smoketest_categories
                 + inproc_categories
                 + [SCALABLE, DASHBOARD],
+                warmup_seconds=CXX_WARMUP_SECONDS,
             )
 
             for rpc_type in [
@@ -553,6 +572,7 @@ class CXXLanguage(Language):
                         minimal_stack=not secure,
                         secure=secure,
                         categories=list(DEFAULT_CATEGORIES) + maybe_dashboard,
+                        warmup_seconds=CXX_WARMUP_SECONDS,
                     )
 
                     for size in geometric_progression(
@@ -570,6 +590,7 @@ class CXXLanguage(Language):
                             secure=secure,
                             minimal_stack=not secure,
                             categories=[SWEEP],
+                            warmup_seconds=CXX_WARMUP_SECONDS,
                         )
 
                     maybe_scalable = [SCALABLE]
@@ -602,6 +623,7 @@ class CXXLanguage(Language):
                         categories=inproc_categories
                         + maybe_scalable
                         + maybe_dashboard,
+                        warmup_seconds=CXX_WARMUP_SECONDS,
                     )
 
                     # TODO(vjpai): Re-enable this test. It has a lot of timeouts
@@ -615,6 +637,7 @@ class CXXLanguage(Language):
                     #     unconstrained_client=synchronicity,
                     #     secure=secure,
                     #     categories=smoketest_categories+[SCALABLE],
+                    #     warmup_seconds=CXX_WARMUP_SECONDS,
                     #     resource_quota_size=500*1024)
 
                     if rpc_type == "streaming":
@@ -630,6 +653,7 @@ class CXXLanguage(Language):
                                 messages_per_stream=mps,
                                 minimal_stack=not secure,
                                 categories=inproc_categories + [SCALABLE],
+                                warmup_seconds=CXX_WARMUP_SECONDS,
                             )
 
                         for mps in geometric_progression(1, 200, math.sqrt(10)):
@@ -644,6 +668,7 @@ class CXXLanguage(Language):
                                 messages_per_stream=mps,
                                 minimal_stack=not secure,
                                 categories=[SWEEP],
+                                warmup_seconds=CXX_WARMUP_SECONDS,
                             )
 
                     for channels in geometric_progression(
@@ -674,6 +699,7 @@ class CXXLanguage(Language):
                                 categories=[SWEEP],
                                 channels=channels,
                                 outstanding=outstanding,
+                                warmup_seconds=CXX_WARMUP_SECONDS,
                             )
 
     def __str__(self):


### PR DESCRIPTION
The Core/C++ implementation needs more warmup time to scale the thread pool.