### PR TITLE
[benchmark] Delete references to `node_purejs`.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -111,7 +111,6 @@ buildConfigs() {
         --prefix="${LOAD_TEST_PREFIX}" -u "${UNIQUE_IDENTIFIER}" -u "${pool}" \
         -a pool="${pool}" --category=scalable \
         --allow_client_language=c++ --allow_server_language=c++ \
-        --allow_server_language=node \
         -o "loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
@@ -141,7 +140,7 @@ configLangArgs32core+=( -l java )
 runnerLangArgs+=( -l "java:${GRPC_JAVA_REPO}:${GRPC_JAVA_COMMIT}" )
 
 # node
-configLangArgs8core+=( -l node_purejs )  # 8-core only.
+configLangArgs8core+=( -l node )  # 8-core only.
 runnerLangArgs+=( -l "node:${GRPC_NODE_REPO}:${GRPC_NODE_COMMIT}" )
 
 # python

--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -34,24 +34,26 @@ The following example counts scenarios in the `scalable` category:
 $ ./tools/run_tests/performance/scenario_config_exporter.py --count_scenarios --category=scalable
 Scenario count for all languages (category: scalable):
 Count  Language         Client   Server   Categories
-   77  c++                                scalable
+   56  c++                                scalable
    19  python_asyncio                     scalable
    16  java                               scalable
    12  go                                 scalable
-   12  node                      node     scalable
-   12  node_purejs               node     scalable
+   12  node                               scalable
     9  csharp                             scalable
+    9  dotnet                             scalable
     7  python                             scalable
     5  ruby                               scalable
     4  csharp                    c++      scalable
+    4  dotnet                    c++      scalable
     4  php7                      c++      scalable
     4  php7_protobuf_c           c++      scalable
     3  python_asyncio            c++      scalable
     2  ruby                      c++      scalable
     2  python                    c++      scalable
     1  csharp           c++               scalable
+    1  dotnet           c++               scalable
 
-  189  total scenarios (category: scalable)
+  170  total scenarios (category: scalable)
 ```
 
 Client and server languages are only set for cross-language scenarios, where the

--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -66,7 +66,7 @@ do
     # See https://github.com/grpc/grpc/issues/11581
     (cd third_party/zlib; git checkout zconf.h)
     ;;
-  "node"|"node_purejs")
+  "node")
     tools/run_tests/performance/build_performance_node.sh
     ;;
   "python")

--- a/tools/run_tests/performance/loadtest_config.py
+++ b/tools/run_tests/performance/loadtest_config.py
@@ -47,10 +47,6 @@ CONFIGURATION_FILE_HEADER_COMMENT = """
 
 def safe_name(language: str) -> str:
     """Returns a name that is safe to use in labels and file names."""
-    # The language "node_purejs" differs from "node" only in the scenarios
-    # covered, so it is treated the same as "node".
-    if language == "node_purejs":
-        return scenario_config.LANGUAGES["node"].safename
     return scenario_config.LANGUAGES[language].safename
 
 

--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -105,7 +105,6 @@ basic_example() {
         -s client_pool= -s server_pool= -s big_query_table= \
         -s timeout_seconds=900 --prefix=examples -u basic -r "^${scenario}$" \
         --allow_client_language=c++ --allow_server_language=c++ \
-        --allow_server_language=node \
         -o "${outputdir}/${outputfile}"
     echo "Created example: ${outputdir}/${outputfile}"
 }
@@ -127,7 +126,6 @@ prebuilt_example() {
         -s prebuilt_image_tag="\${prebuilt_image_tag}" --prefix=examples -u prebuilt \
         -a pool="\${workers_pool}" -r "^${scenario}$" \
         --allow_client_language=c++ --allow_server_language=c++ \
-        --allow_server_language=node \
         -o "${outputdir}/${outputfile}"
     echo "Created example: ${outputdir}/${outputfile}"
 }
@@ -150,7 +148,6 @@ psm_basic_example() {
         -s timeout_seconds=900 --prefix=psm-examples -u "${uniquifier}" -r "^${scenario}$" \
         -a enablePrometheus=true \
         --allow_client_language=c++ --allow_server_language=c++ \
-        --allow_server_language=node \
         --client_channels=8 \
         --category=psm \
         --server_threads=16 \
@@ -181,7 +178,6 @@ psm_prebuilt_example() {
         -a pool="\${workers_pool}" \
         -a enablePrometheus=true \
         --allow_client_language=c++ --allow_server_language=c++ \
-        --allow_server_language=node \
         --client_channels=8 \
         --category=psm \
         --server_threads=16 \

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1659,12 +1659,8 @@ class GoLanguage(Language):
 
 
 class NodeLanguage(Language):
-    def __init__(self, node_purejs=False):
-        super().__init__()
-        self.node_purejs = node_purejs
-
     def worker_cmdline(self):
-        fixture = "native_js" if self.node_purejs else "native_native"
+        fixture = "native_js"
         return [
             "tools/run_tests/performance/run_worker_node.sh",
             fixture,
@@ -1672,20 +1668,14 @@ class NodeLanguage(Language):
         ]
 
     def worker_port_offset(self):
-        if self.node_purejs:
-            return 1100
-        return 1000
+        return 1100
 
     def scenarios(self):
-        node_implementation = "node_purejs" if self.node_purejs else "node"
-
         yield _ping_pong_scenario(
-            "%s_to_node_protobuf_async_unary_5000rpcs_1KB_psm"
-            % (node_implementation),
+            "node_to_node_protobuf_async_unary_5000rpcs_1KB_psm",
             rpc_type="UNARY",
             client_type="ASYNC_CLIENT",
             server_type="ASYNC_SERVER",
-            server_language="node",
             req_size=1024,
             resp_size=1024,
             outstanding=5000,
@@ -1701,12 +1691,10 @@ class NodeLanguage(Language):
             smoketest_categories = ([SMOKETEST] if secure else []) + [SCALABLE]
 
             yield _ping_pong_scenario(
-                "%s_to_node_generic_async_streaming_ping_pong_%s"
-                % (node_implementation, secstr),
+                "node_to_node_generic_async_streaming_ping_pong_%s" % secstr,
                 rpc_type="STREAMING",
                 client_type="ASYNC_CLIENT",
                 server_type="ASYNC_GENERIC_SERVER",
-                server_language="node",
                 use_generic_payload=True,
                 async_server_threads=1,
                 secure=secure,
@@ -1714,59 +1702,52 @@ class NodeLanguage(Language):
             )
 
             yield _ping_pong_scenario(
-                "%s_to_node_protobuf_async_streaming_ping_pong_%s"
-                % (node_implementation, secstr),
+                "node_to_node_protobuf_async_streaming_ping_pong_%s" % secstr,
                 rpc_type="STREAMING",
                 client_type="ASYNC_CLIENT",
                 server_type="ASYNC_SERVER",
-                server_language="node",
                 async_server_threads=1,
                 secure=secure,
             )
 
             yield _ping_pong_scenario(
-                "%s_to_node_protobuf_async_unary_ping_pong_%s"
-                % (node_implementation, secstr),
+                "node_to_node_protobuf_async_unary_ping_pong_%s" % secstr,
                 rpc_type="UNARY",
                 client_type="ASYNC_CLIENT",
                 server_type="ASYNC_SERVER",
-                server_language="node",
                 async_server_threads=1,
                 secure=secure,
                 categories=smoketest_categories,
             )
 
             yield _ping_pong_scenario(
-                "%s_to_node_protobuf_async_unary_qps_unconstrained_%s"
-                % (node_implementation, secstr),
+                "node_to_node_protobuf_async_unary_qps_unconstrained_%s"
+                % secstr,
                 rpc_type="UNARY",
                 client_type="ASYNC_CLIENT",
                 server_type="ASYNC_SERVER",
-                server_language="node",
                 unconstrained_client="async",
                 secure=secure,
                 categories=smoketest_categories + [SCALABLE],
             )
 
             yield _ping_pong_scenario(
-                "%s_to_node_protobuf_async_streaming_qps_unconstrained_%s"
-                % (node_implementation, secstr),
+                "node_to_node_protobuf_async_streaming_qps_unconstrained_%s"
+                % secstr,
                 rpc_type="STREAMING",
                 client_type="ASYNC_CLIENT",
                 server_type="ASYNC_SERVER",
-                server_language="node",
                 unconstrained_client="async",
                 secure=secure,
                 categories=[SCALABLE],
             )
 
             yield _ping_pong_scenario(
-                "%s_to_node_generic_async_streaming_qps_unconstrained_%s"
-                % (node_implementation, secstr),
+                "node_to_node_generic_async_streaming_qps_unconstrained_%s"
+                % secstr,
                 rpc_type="STREAMING",
                 client_type="ASYNC_CLIENT",
                 server_type="ASYNC_GENERIC_SERVER",
-                server_language="node",
                 unconstrained_client="async",
                 use_generic_payload=True,
                 secure=secure,
@@ -1776,8 +1757,6 @@ class NodeLanguage(Language):
             # TODO(murgatroid99): add scenarios node vs C++
 
     def __str__(self):
-        if self.node_purejs:
-            return "node_purejs"
         return "node"
 
 
@@ -1792,6 +1771,5 @@ LANGUAGES = {
     "python": PythonLanguage(),
     "python_asyncio": PythonAsyncIOLanguage(),
     "go": GoLanguage(),
-    "node": NodeLanguage(),
-    "node_purejs": NodeLanguage(node_purejs=True),
+    "node": NodeLanguage(),  # 'node' means 'node_purejs'.
 }

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -1660,7 +1660,7 @@ class GoLanguage(Language):
 
 class NodeLanguage(Language):
     def worker_cmdline(self):
-        fixture = "native_js"
+        fixture = "js_js"
         return [
             "tools/run_tests/performance/run_worker_node.sh",
             fixture,

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -20,16 +20,11 @@ import argparse
 import collections
 import itertools
 import json
-import multiprocessing
 import os
 import pipes
 import re
-import subprocess
 import sys
-import tempfile
 import time
-import traceback
-import uuid
 
 import six
 
@@ -216,7 +211,7 @@ def archive_repo(languages):
         cmdline.append("../grpc-java")
     if "go" in languages:
         cmdline.append("../grpc-go")
-    if "node" in languages or "node_purejs" in languages:
+    if "node" in languages:
         cmdline.append("../grpc-node")
 
     archive_job = jobset.JobSpec(


### PR DESCRIPTION
There is only one supported implementation for performance benchmarks, so the name is unified to `node` (previously `node_purejs`).