### PR TITLE
[bazelified tests] Bazelify the build artifact -> build package -> distribtests flow (on linux).

### DIFF
--- a/tools/bazelify_tests/grpc_build_artifact_task.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+ARCHIVE_WITH_SUBMODULES="$1"
+OUTFILE="$2"
+BUILD_SCRIPT="$3"
+shift 3
+
+# Extract grpc repo archive
+tar -xopf ${ARCHIVE_WITH_SUBMODULES}
+cd grpc
+
+mkdir -p artifacts
+
+../"${BUILD_SCRIPT}" "$@" || FAILED="true"
+
+# TODO: deterministic tar
+tar -czvf ../"${OUTFILE}" artifacts
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi
+

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_package")
-load("//tools/bazelify_tests:build_defs.bzl", "grpc_run_tests_py_test")
+load("//tools/bazelify_tests:build_defs.bzl", "grpc_run_tests_py_test", "grpc_build_artifact_task")
 load(":portability_tests.bzl", "generate_run_tests_portability_tests")
 
 licenses(["notice"])
@@ -21,6 +21,12 @@ licenses(["notice"])
 grpc_package(name = "tools/bazelify_tests/test")
 
 generate_run_tests_portability_tests(name = "portability_tests_linux")
+
+grpc_build_artifact_task(
+    name = "artifact_protoc_linux_x64",
+    build_script = "build_artifact_protoc.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_centos6_x64.current_version",
+)
 
 # C/C++
 grpc_run_tests_py_test(

--- a/tools/bazelify_tests/test/build_artifact_protoc.sh
+++ b/tools/bazelify_tests/test/build_artifact_protoc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+export LDFLAGS="${LDFLAGS} -static-libgcc -static-libstdc++ -s"
+
+mkdir -p artifacts
+
+ARTIFACTS_OUT=artifacts tools/run_tests/artifacts/build_artifact_protoc.sh
+


### PR DESCRIPTION
e.g. here:
https://source.cloud.google.com/results/invocations/065c4100-e719-4833-880f-ff36553a05e3/targets

TODO: provide target.log for  the genrule output.
