### PR TITLE
[bazel] Disable flaky bazelified run_tests.py tests

### DIFF
--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -141,7 +141,8 @@ test_suite(
         ":runtests_cpp_linux_opt_build_only",
         ":runtests_csharp_linux_dbg",
         ":runtests_csharp_linux_opt",
-        ":runtests_php_linux_dbg",
+        # TODO(jtattermusch): reenable the test once not flaky anymore
+        #":runtests_php_linux_dbg",
         ":runtests_php_linux_opt",
         #":runtests_python_linux_opt",
         #":runtests_ruby_linux_dbg",

--- a/tools/bazelify_tests/test/portability_tests.bzl
+++ b/tools/bazelify_tests/test/portability_tests.bzl
@@ -55,7 +55,8 @@ def generate_run_tests_portability_tests(name):
         compiler_configs = [
             # TODO(b/283304471): Add 'gcc10.2_openssl102' once possible
             ["gcc_7", "", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
-            ["gcc_12", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_12_x64.current_version"],
+            # TODO(jtattermusch): re-enable once not flaky anymore
+            #["gcc_12", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_12_x64.current_version"],
             # TODO(jtattermusch): Re-enable once the build can finish in reasonable time (looks like ccache is not being used?)
             #["gcc_musl", "", "tools/dockerfile/test/cxx_alpine_x64.current_version"],
             ["clang_6", "--cmake_configure_extra_args=-DCMAKE_C_COMPILER=clang --cmake_configure_extra_args=-DCMAKE_CXX_COMPILER=clang++", "tools/dockerfile/test/cxx_clang_6_x64.current_version"],


### PR DESCRIPTION
Most runs of these tests currently fail.
Disabling them for now before I get a chance to investigate what's causing the failures.

Example failures:
https://source.cloud.google.com/results/invocations/9916fe8e-0fe1-4c33-a885-79a41e69c9fe

https://source.cloud.google.com/results/invocations/9251a25c-0758-421d-84bd-12379f9cf10c
