### PR TITLE
[DNS resolver] enable resolver component tests on windows

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -47,9 +47,9 @@
 #include "src/core/lib/iomgr/sockaddr_windows.h"
 #include "src/core/lib/iomgr/socket_windows.h"
 #include "src/core/lib/iomgr/tcp_windows.h"
+#include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/slice/slice.h"
 #include "src/core/lib/slice/slice_internal.h"
-#include "src/core/lib/iomgr/timer.h"
 
 // TODO(apolcyn): remove this hack after fixing upstream.
 // Our grpc/c-ares code on Windows uses the ares_set_socket_functions API,

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -262,7 +262,7 @@ class GrpcPolledFdWindows {
   bool IsFdStillReadableLocked() { return read_buf_has_data_; }
 
   void ShutdownLocked(grpc_error_handle /* error */) {
-    GPR_ASSERT(!shutdown_called_) return;
+    GPR_ASSERT(!shutdown_called_);
     shutdown_called_ = true;
     if (have_schedule_write_closure_after_delay_) {
       grpc_timer_cancel(&schedule_write_closure_after_delay_);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -22,7 +22,7 @@
 
 #include <string.h>
 
-#include <function>
+#include <functional>
 #include <map>
 #include <memory>
 #include <unordered_set>

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -722,7 +722,7 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
                                 from_len);
   }
 
-  static int CloseSocket(SOCKET s, void* user_data) {}
+  static int CloseSocket(SOCKET s, void* user_data) { return 0; }
 
   const struct ares_socket_functions kCustomSockFuncs = {
       &GrpcPolledFdFactoryWindows::Socket /* socket */,

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -650,7 +650,8 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
       // reused.
       self->sockets_.erase(s);
     };
-    auto polled_fd = new GrpcPolledFdWindows(s, self->mu_, af, type, std::move(on_shutdown_locked));
+    auto polled_fd = new GrpcPolledFdWindows(s, self->mu_, af, type,
+                                             std::move(on_shutdown_locked));
     GRPC_CARES_TRACE_LOG(
         "fd:|%s| created with params af:%d type:%d protocol:%d",
         polled_fd->GetName(), af, type, protocol);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -657,8 +657,8 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
       // reused.
       self->sockets_.erase(s);
     };
-    auto polled_fd = new GrpcPolledFdWindows>(
-        s, self->mu_, af, type, std::move(on_shutdown_locked));
+    auto polled_fd = new GrpcPolledFdWindows >
+                     (s, self->mu_, af, type, std::move(on_shutdown_locked));
     GRPC_CARES_TRACE_LOG(
         "fd:|%s| created with params af:%d type:%d protocol:%d",
         polled_fd->GetName(), af, type, protocol);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -130,9 +130,8 @@ class GrpcPolledFdWindows {
   }
 
   ~GrpcPolledFdWindows() {
-    GRPC_CARES_TRACE_LOG(
-        "fd:|%s| ~GrpcPolledFdWindows shutdown_called_: %d ", GetName(),
-        shutdown_called_);
+    GRPC_CARES_TRACE_LOG("fd:|%s| ~GrpcPolledFdWindows shutdown_called_: %d ",
+                         GetName(), shutdown_called_);
     CSliceUnref(read_buf_);
     GPR_ASSERT(read_closure_ == nullptr);
     GPR_ASSERT(write_closure_ == nullptr);
@@ -446,7 +445,6 @@ class GrpcPolledFdWindows {
   int ConnectUDP(WSAErrorContext* wsa_error_ctx, const struct sockaddr* target,
                  ares_socklen_t target_len) {
     GRPC_CARES_TRACE_LOG("fd:%s ConnectUDP", GetName());
-    GPR_ASSERT(connect_state_ == STARTING);
     GPR_ASSERT(wsa_connect_error_ == 0);
     SOCKET s = grpc_winsocket_wrapped_socket(winsocket_);
     int out =
@@ -720,7 +718,7 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
   std::map<SOCKET, GrpcPolledFdWindows*> sockets_;
 };
 
-} // namespace
+}  // namespace
 
 std::unique_ptr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Mutex* mu) {
   return std::make_unique<GrpcPolledFdFactoryWindows>(mu);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -203,7 +203,7 @@ class GrpcPolledFdWindows {
       }
       GPR_ASSERT(pending_continue_register_for_on_writeable_locked_ == false);
       pending_continue_register_for_on_writeable_locked_ = true;
-    } else if {
+    } else {
       ContinueRegisterForOnWriteableLocked();
     }
   }
@@ -249,7 +249,7 @@ class GrpcPolledFdWindows {
       //      but pace ourselves to not burn CPU.
       GPR_ASSERT(!have_schedule_write_closure_after_delay_);
       have_schedule_write_closure_after_delay_ = true;
-      grpc_timer_init(schedule_write_closure_after_delay_,
+      grpc_timer_init(&schedule_write_closure_after_delay_,
                       Timestamp::Now() + Duration::Seconds(1),
                       &on_schedule_write_closure_after_delay_);
     }
@@ -677,14 +677,14 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
       auto it = self->sockets_.find(s);
       GPR_ASSERT(it != self->sockets_.end());
       self->sockets_.erase(it);
-      self->inactive_polled_fds.insert(std::move(it->second));
+      self->inactive_polled_fds_.insert(std::move(it->second));
     };
     auto polled_fd = std::make_unique<GrpcPolledFdWindows>(
         s, self->mu_, af, type, std::move(on_shutdown_locked));
     GRPC_CARES_TRACE_LOG(
         "fd:|%s| created with params af:%d type:%d protocol:%d",
         polled_fd->GetName(), af, type, protocol);
-    auto insert_result = sockets_.insert(s, std::move(polled_fd));
+    auto insert_result = self->sockets_.insert(s, std::move(polled_fd));
     GPR_ASSERT(insert_result->second);
     return s;
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -254,7 +254,7 @@ class GrpcPolledFdWindows {
       have_schedule_write_closure_after_delay_ = true;
       grpc_timer_init(
           schedule_write_closure_after_delay_,
-          grpc_core::Timestamp::Now() + grpc_core::Duration::Seconds(1),
+          Timestamp::Now() + Duration::Seconds(1),
           &on_schedule_write_closure_after_delay_);
     }
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -206,7 +206,7 @@ class GrpcPolledFdWindows {
       }
       GPR_ASSERT(pending_continue_register_for_on_writeable_locked_ == false);
       pending_continue_register_for_on_writeable_locked_ = true;
-    } else if ({
+    } else if {
       ContinueRegisterForOnWriteableLocked();
     }
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -684,7 +684,7 @@ class GrpcPolledFdFactoryWindows : public GrpcPolledFdFactory {
     GRPC_CARES_TRACE_LOG(
         "fd:|%s| created with params af:%d type:%d protocol:%d",
         polled_fd->GetName(), af, type, protocol);
-    auto insert_result = self->sockets_.insert(s, std::move(polled_fd));
+    auto insert_result = self->sockets_.insert({s, std::move(polled_fd)});
     GPR_ASSERT(insert_result->second);
     return s;
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -252,10 +252,9 @@ class GrpcPolledFdWindows {
       //      but pace ourselves to not burn CPU.
       GPR_ASSERT(!have_schedule_write_closure_after_delay_);
       have_schedule_write_closure_after_delay_ = true;
-      grpc_timer_init(
-          schedule_write_closure_after_delay_,
-          Timestamp::Now() + Duration::Seconds(1),
-          &on_schedule_write_closure_after_delay_);
+      grpc_timer_init(schedule_write_closure_after_delay_,
+                      Timestamp::Now() + Duration::Seconds(1),
+                      &on_schedule_write_closure_after_delay_);
     }
   }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -611,8 +611,6 @@ class GrpcPolledFdWindowsWrapper : public GrpcPolledFd {
   explicit GrpcPolledFdWindowsWrapper(GrpcPolledFdWindows* wrapped)
       : wrapped_(wrapped) {}
 
-  ~GrpcPolledFdWindowsWrapper() {}
-
   void RegisterForOnReadableLocked(grpc_closure* read_closure) override {
     wrapped_->RegisterForOnReadableLocked(read_closure);
   }

--- a/test/cpp/naming/generate_resolver_component_tests.bzl
+++ b/test/cpp/naming/generate_resolver_component_tests.bzl
@@ -42,7 +42,6 @@ def generate_resolver_component_tests():
                 "//:gpr",
                 "//test/cpp/util:test_config",
             ],
-            tags = ["no_windows"],
         )
 
         # meant to be invoked only through the top-level shell script driver
@@ -65,7 +64,6 @@ def generate_resolver_component_tests():
                 "//src/core:ares_resolver",
                 "//test/cpp/util:test_config",
             ],
-            tags = ["no_windows"],
         )
         grpc_cc_test(
             name = "resolver_component_tests_runner_invoker%s" % unsecure_build_config_suffix,
@@ -98,5 +96,5 @@ def generate_resolver_component_tests():
             # The test is highly flaky on AWS workers that we use for running ARM64 tests.
             # The "no_arm64" tag can be used to skip it.
             # (see https://github.com/grpc/grpc/issues/25289).
-            tags = ["no_windows", "no_mac", "no_arm64", "resolver_component_tests_runner_invoker"],
+            tags = ["no_mac", "no_arm64", "resolver_component_tests_runner_invoker"],
         )


### PR DESCRIPTION
I can't see a reason why windows is skipped with these now - there should be no test dependency issues on bazel RBE.
