### PR TITLE
[Interop test] Install curl

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
@@ -1,6 +1,6 @@
-FROM python:3.9-slim
+FROM python:3.9-slim-bullseye
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential clang
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential clang curl
 
 WORKDIR /workdir
 
@@ -11,7 +11,7 @@ COPY . .
 RUN tools/bazel build -c dbg //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client
 RUN cp -rL /workdir/bazel-bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client* /artifacts/
 
-FROM python:3.9-slim
+FROM python:3.9-slim-bullseye
 
 COPY --from=0 /artifacts ./
 

--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server
@@ -1,6 +1,6 @@
-FROM python:3.9-slim
+FROM python:3.9-slim-bullseye
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential clang
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential clang curl
 
 WORKDIR /workdir
 
@@ -11,7 +11,7 @@ COPY . .
 RUN tools/bazel build -c dbg //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_server
 RUN cp -rL /workdir/bazel-bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server* /artifacts/
 
-FROM python:3.9-slim
+FROM python:3.9-slim-bullseye
 
 COPY --from=0 /artifacts ./
 

--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
@@ -14,14 +14,9 @@
 
 # Dockerfile for building //test/cpp/interop:xds_interop_client
 
-FROM debian:11
+FROM python:3.9-slim-bullseye
 
-RUN apt-get update -y && \
-    apt-get install -y \
-    build-essential \
-    clang \
-    python3 \
-    python3-dev
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential clang curl
 
 WORKDIR /workdir
 

--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server
@@ -14,14 +14,9 @@
 
 # Dockerfile for building //test/cpp/interop:xds_interop_client
 
-FROM debian:11
+FROM python:3.9-slim-bullseye
 
-RUN apt-get update -y && \
-    apt-get install -y \
-    build-essential \
-    clang \
-    python3 \
-    python3-dev
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y build-essential clang curl
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Curl is required to install Bazel during the build. This also unifies all build images to use Python base image.