### PR TITLE
[Debuggability][ChannelArgs] Making GRPC C++ channel arguments more debuggable

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.h
+++ b/src/core/ext/filters/client_channel/client_channel.h
@@ -170,6 +170,10 @@ class ClientChannel {
       const RefCountedPtr<SubchannelPoolInterface>& subchannel_pool,
       const std::string& channel_default_authority);
 
+  std::vector<std::vector<std::string>> GetChannelArgsDebugInfo() const {
+    return channel_args_.GetChannelArgsDebugInfo();
+  }
+
  private:
   class CallData;
   class FilterBasedCallData;

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -313,6 +313,18 @@ std::string ChannelArgs::ToString() const {
   return absl::StrCat("{", absl::StrJoin(arg_strings, ", "), "}");
 }
 
+std::vector<std::vector<std::string>> ChannelArgs::GetChannelArgsDebugInfo()
+    const {
+  std::vector<std::vector<std::string>> arg_strings;
+  args_.ForEach([&arg_strings](const RcStringValue& key, const Value& value) {
+    std::vector<std::string> arg_row;
+    arg_row.push_back(key.c_str());
+    arg_row.push_back(value.ToString());
+    arg_strings.push_back(arg_row);
+  });
+  return arg_strings;
+}
+
 ChannelArgs ChannelArgs::UnionWith(ChannelArgs other) const {
   if (args_.Empty()) return other;
   if (other.args_.Empty()) return *this;

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -389,7 +389,9 @@ class ChannelArgs {
 
     std::string ToString() const;
 
-    std::vector<std::vector<std::string>> GetChannelArgsDebugInfo();
+    std::vector<std::vector<std::string>> GetChannelArgsDebugInfo() const {
+      return channel_args_.GetChannelArgsDebugInfo();
+    }
 
     grpc_arg MakeCArg(const char* name) const;
 

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -389,6 +389,8 @@ class ChannelArgs {
 
     std::string ToString() const;
 
+    std::vector<std::vector<std::string>> GetChannelArgsDebugInfo();
+
     grpc_arg MakeCArg(const char* name) const;
 
     bool operator<(const Value& rhs) const { return rep_ < rhs.rep_; }

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -127,6 +127,9 @@ class Server : public InternallyRefCounted<Server>,
 
   const ChannelArgs& channel_args() const { return channel_args_; }
   channelz::ServerNode* channelz_node() const { return channelz_node_.get(); }
+  std::vector<std::vector<std::string>> GetChannelArgsDebugInfo() const {
+    return channel_args_.GetChannelArgsDebugInfo();
+  }
 
   // Do not call this before Start(). Returns the pollsets. The
   // vector itself is immutable, but the pollsets inside are mutable. The


### PR DESCRIPTION
Part 1 : Converting the current values of channel arguments to a vector of strings which can be displayed . 

Part 2 : Also capturing the line of code which set the channel argument. This will be available in the next PR.  

release notes: no
CC : @yousukseung 
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

