### PR TITLE
[promises] Make Sleep promise movable

### DIFF
--- a/src/core/lib/promise/sleep.h
+++ b/src/core/lib/promise/sleep.h
@@ -18,11 +18,11 @@
 #include <grpc/support/port_platform.h>
 
 #include <atomic>
+#include <utility>
 
 #include "absl/status/status.h"
 
 #include <grpc/event_engine/event_engine.h>
-#include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/promise/activity.h"

--- a/src/core/lib/promise/sleep.h
+++ b/src/core/lib/promise/sleep.h
@@ -38,17 +38,12 @@ class Sleep final {
 
   Sleep(const Sleep&) = delete;
   Sleep& operator=(const Sleep&) = delete;
-  Sleep(Sleep&& other) noexcept : deadline_(other.deadline_) {
-    // Promises can be moved only until they're polled, and since we only create
-    // the closure when first polled we can assume it's nullptr here.
-    GPR_DEBUG_ASSERT(other.closure_ == nullptr);
-  };
+  Sleep(Sleep&& other) noexcept
+      : deadline_(other.deadline_),
+        closure_(std::exchange(other.closure_, nullptr)) {}
   Sleep& operator=(Sleep&& other) noexcept {
-    // Promises can be moved only until they're polled, and since we only create
-    // the closure when first polled we can assume it's nullptr here.
-    GPR_DEBUG_ASSERT(closure_ == nullptr);
-    GPR_DEBUG_ASSERT(other.closure_ == nullptr);
     deadline_ = other.deadline_;
+    std::swap(closure_, other.closure_);
     return *this;
   };
 

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -501,6 +501,7 @@ grpc_cc_test(
     deps = [
         "test_wakeup_schedulers",
         "//:exec_ctx",
+        "//:gpr",
         "//:grpc",
         "//src/core:default_event_engine",
         "//src/core:exec_ctx_wakeup_scheduler",

--- a/test/core/promise/sleep_test.cc
+++ b/test/core/promise/sleep_test.cc
@@ -24,6 +24,7 @@
 #include "gtest/gtest.h"
 
 #include <grpc/grpc.h>
+#include <grpc/support/log.h>
 
 #include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/gprpp/notification.h"


### PR DESCRIPTION
I have a cool optimization in mind for promises - but it requires that we can move them after polling, which is a contract change. I'm going to work through the set of primitives we have in the coming weeks and change that contract to enable the optimization.