### PR TITLE
[test][DO NOT SUBMIT] Print use_count in port_server.py

### DIFF
--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -48,7 +48,7 @@ if args.logfile is not None:
     sys.stdin.close()
     sys.stderr.close()
     sys.stdout.close()
-    sys.stderr = open(args.logfile, "w")
+    sys.stderr = open(args.logfile, "w", buffering=1)
     sys.stdout = sys.stderr
 
 print("port server running on port %d" % args.port)
@@ -224,6 +224,7 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             p = allocate_port(self)
             self.log_message("allocated port %d" % p)
+            self.log_message("in_use=%d", len(in_use))
             self.wfile.write(str(p).encode("ascii"))
         elif self.path[0:6] == "/drop/":
             self.send_response(200)
@@ -239,6 +240,7 @@ class Handler(BaseHTTPRequestHandler):
                 k = "unknown"
             mu.release()
             self.log_message("drop %s port %d" % (k, p))
+            self.log_message("in_use=%d", len(in_use))
         elif self.path == "/version_number":
             # fetch a version string and the current process pid
             self.send_response(200)


### PR DESCRIPTION
This is how I determined we should allow ~3000 concurrent ports in https://github.com/grpc/grpc/pull/34009. It modifies the port-server code to print the current port use-count on every `/get` and `/grop/<port>` request. I then ran `bazel test -c dbg --test_output=summary --test_filter="-no_linux" //test/core/... //test/cpp/...` on a 128-core machine, and found that the most ports concurrently claimed at any time is 1596. I ~doubled this number as our concurrent port limit, and I expect that A) the RBE environment has much more test isolation between actions, and B) we won't have >= 128-core CI machines any time soon.