### PR TITLE
[ruby] update google auth to ~> 1.0

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 1.41.0'
   s.add_development_dependency 'signet',             '~> 0.7'
-  s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.10'
+  s.add_development_dependency 'googleauth',         '~> 1.0'
 
   s.extensions = %w(src/ruby/ext/grpc/extconf.rb)
 

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -45,7 +45,7 @@
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 1.41.0'
     s.add_development_dependency 'signet',             '~> 0.7'
-    s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.10'
+    s.add_development_dependency 'googleauth',         '~> 1.0'
 
     s.extensions = %w(src/ruby/ext/grpc/extconf.rb)
   <%


### PR DESCRIPTION
Supersedes https://github.com/grpc/grpc/pull/33436

Fixes https://github.com/grpc/grpc/issues/33435

