### PR TITLE
[ruby] improve handling for recv_message op failures

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -262,6 +262,9 @@ module GRPC
         @metadata_received = true
       end
       get_message_from_batch_result(batch_result)
+    rescue GRPC::Core::CallError => e
+      GRPC.logger.info("remote_read: #{e}")
+      nil
     end
 
     def get_message_from_batch_result(recv_message_batch_result)
@@ -328,14 +331,7 @@ module GRPC
     def each_remote_read_then_finish
       return enum_for(:each_remote_read_then_finish) unless block_given?
       loop do
-        resp =
-          begin
-            remote_read
-          rescue GRPC::Core::CallError => e
-            GRPC.logger.warn("In each_remote_read_then_finish: #{e}")
-            nil
-          end
-
+        resp = remote_read
         break if resp.nil?  # the last response was received
         yield resp
       end

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -668,9 +668,9 @@ describe GRPC::RpcServer do
       def check_multi_req_view_of_finished_call(call)
         common_check_of_finished_server_call(call)
 
-        expect do
-          call.each_remote_read.each { |r| p r }
-        end.to raise_error(GRPC::Core::CallError)
+        l = []
+        call.each_remote_read.each { |r| l << r }
+        expect(l.size).t eq(0)
       end
 
       def common_check_of_finished_server_call(call)

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -670,7 +670,7 @@ describe GRPC::RpcServer do
 
         l = []
         call.each_remote_read.each { |r| l << r }
-        expect(l.size).t eq(0)
+        expect(l.size).to eq(0)
       end
 
       def common_check_of_finished_server_call(call)


### PR DESCRIPTION
Try to fix errors noticed in original PR behind https://github.com/grpc/grpc/pull/33945 

https://fusion2.corp.google.com/ci;ids=1923284992/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_basictests_ruby/activity/cb4bacef-7809-4de7-ab87-c9dc4f67dfac/invocations/cb4bacef-7809-4de7-ab87-c9dc4f67dfac/targets/github%2Fgrpc%2Frun_tests%2Fruby_linux_dbg_native%2Ftools%2Frun_tests%2Fhelper_scripts%2Frun_ruby.sh/tests

failure excerpt:

```
  1) ClientStub #bidi_streamer without a call operation behaves like bidi streaming surfacing of errors when sending requests non-GRPC errors from the write loop surface when raised at the start of a request stream
     Failure/Error: m = server_call.remote_read

     GRPC::Core::CallError:
       call#run_batch failed somehow
     Shared Example Group: "bidi streaming" called from ./src/ruby/spec/generic/client_stub_spec.rb:843
     # ./src/ruby/lib/grpc/generic/active_call.rb:259:in `run_batch'
     # ./src/ruby/lib/grpc/generic/active_call.rb:259:in `remote_read'
     # ./src/ruby/spec/generic/client_stub_spec.rb:671:in `block in run_server_bidi_send_one_then_read_indefinitely'
     # ./src/ruby/spec/generic/client_stub_spec.rb:670:in `loop'
     # ./src/ruby/spec/generic/client_stub_spec.rb:670:in `run_server_bidi_send_one_then_read_indefinitely'
     # ./src/ruby/spec/generic/client_stub_spec.rb:717:in `block in run_error_in_client_request_stream_test'
     # /usr/local/rvm/gems/ruby-2.7.2/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'

  2) ClientStub #bidi_streamer without a call operation behaves like bidi streaming surfacing of errors when sending requests non-GRPC errors from the write loop surface when raised during the middle of a request stream
     Failure/Error: m = server_call.remote_read

     GRPC::Core::CallError:
       call#run_batch failed somehow
     Shared Example Group: "bidi streaming" called from ./src/ruby/spec/generic/client_stub_spec.rb:843
     # ./src/ruby/lib/grpc/generic/active_call.rb:259:in `run_batch'
     # ./src/ruby/lib/grpc/generic/active_call.rb:259:in `remote_read'
     # ./src/ruby/spec/generic/client_stub_spec.rb:671:in `block in run_server_bidi_send_one_then_read_indefinitely'
     # ./src/ruby/spec/generic/client_stub_spec.rb:670:in `loop'
     # ./src/ruby/spec/generic/client_stub_spec.rb:670:in `run_server_bidi_send_one_then_read_indefinitely'
     # ./src/ruby/spec/generic/client_stub_spec.rb:717:in `block in run_error_in_client_request_stream_test'
     # /usr/local/rvm/gems/ruby-2.7.2/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'

  3) ClientStub #bidi_streamer via a call operation behaves like bidi streaming surfacing of errors when sending requests non-GRPC errors from the write loop surface when raised at the start of a request stream
     Failure/Error: m = server_call.remote_read

     GRPC::Core::CallError:
       call#run_batch failed somehow
     Shared Example Group: "bidi streaming" called from ./src/ruby/spec/generic/client_stub_spec.rb:862
     # ./src/ruby/lib/grpc/generic/active_call.rb:259:in `run_batch'
     # ./src/ruby/lib/grpc/generic/active_call.rb:259:in `remote_read'
     # ./src/ruby/spec/generic/client_stub_spec.rb:671:in `block in run_server_bidi_send_one_then_read_indefinitely'
     # ./src/ruby/spec/generic/client_stub_spec.rb:670:in `loop'
     # ./src/ruby/spec/generic/client_stub_spec.rb:670:in `run_server_bidi_send_one_then_read_indefinitely'
     # ./src/ruby/spec/generic/client_stub_spec.rb:717:in `block in run_error_in_client_request_stream_test'
     # /usr/local/rvm/gems/ruby-2.7.2/gems/logging-2.3.1/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
```

