### PR TITLE
[EventEngine] Improve lock contention in WorkStealingThreadPool

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -537,8 +537,8 @@ size_t WorkStealingThreadPool::ThreadCount::WaitForCountChange(
              kWaitForThreadCountUnset);
   do {
     {
-      grpc_core::MutexLock lock(&mu_);
-      wait_cvs_[counter_type].WaitWithTimeout(&mu_, deadline - now);
+      grpc_core::MutexLock lock(&wait_mu_);
+      wait_cvs_[counter_type].WaitWithTimeout(&wait_mu_, deadline - now);
     }
     count = GetCount(counter_type);
     if (count == desired_threads) break;
@@ -553,7 +553,7 @@ void WorkStealingThreadPool::ThreadCount::CheckAndNotifyCountChange(
     CounterType counter_type, size_t new_value) {
   auto count = wait_for_thread_counts_[counter_type].load();
   if (count != kWaitForThreadCountUnset && new_value == count) {
-    grpc_core::MutexLock lock(&mu_);
+    grpc_core::MutexLock lock(&wait_mu_);
     wait_cvs_[counter_type].Signal();
   }
 }

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -533,8 +533,6 @@ size_t WorkStealingThreadPool::ThreadCount::WaitForCountChange(
   auto now = absl::Now();
   const auto deadline = now + absl::Milliseconds(timeout.millis());
   // Set up the count change notification
-  // The notification must be set up before the desired thread count is stored,
-  // or else a race can happen around Notification access.
   {
     grpc_core::MutexLock lock(&mu_);
     wait_notifications_[counter_type] =

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
@@ -99,8 +99,6 @@ class WorkStealingThreadPool final : public ThreadPool {
                                const char* why, WorkSignal* work_signal);
     // Returns the current thread count for the tracked type.
     size_t GetCount(CounterType counter_type);
-    // Returns the current thread count for the tracked type.
-    size_t GetCountLocked(CounterType counter_type);
 
     // Adds and removes thread counts on construction and destruction
     class AutoThreadCount {
@@ -127,8 +125,8 @@ class WorkStealingThreadPool final : public ThreadPool {
     // will be notified.
     void CheckAndNotifyCountChange(CounterType counter_type, size_t new_value);
 
-    grpc_core::Mutex mu_;
-    grpc_core::CondVar wait_cvs_[2] ABSL_GUARDED_BY(mu_);
+    grpc_core::Mutex wait_mu_;
+    grpc_core::CondVar wait_cvs_[2] ABSL_GUARDED_BY(wait_mu_);
     std::atomic<size_t> wait_for_thread_counts_[2]{{kWaitForThreadCountUnset},
                                                    {kWaitForThreadCountUnset}};
     std::atomic<size_t> thread_counts_[2]{{0}, {0}};

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
@@ -122,12 +122,25 @@ class WorkStealingThreadPool final : public ThreadPool {
     size_t WaitForCountChange(CounterType counter_type, size_t desired_threads,
                               grpc_core::Duration timeout);
 
+    // Implementation of the loop body for WaitForCountChange
+    //
+    // The notifier is guaranteed not to be modified while this loop is running,
+    // so thread safety analysis is disabled to avoid having to claim the mutex.
+    size_t WaitForCountChangeLoopBody(CounterType counter_type,
+                                      absl::Duration timeout)
+        ABSL_NO_THREAD_SAFETY_ANALYSIS;
+
     // Any changes to thread counts will check if a caller is waiting in
     // WaitForCountChange. If so, and the desired count is reached, the waiter
     // will be notified.
     void CheckAndNotifyCountChange(CounterType counter_type, size_t new_value);
 
-    std::unique_ptr<grpc_core::Notification> wait_notifications_[2];
+    // Protects the Notifications from concurrent access & deletion.
+    // Note that Notification creation cannot race, and WaitForCountChange only
+    // really needs to claim the lock during destruction.
+    grpc_core::Mutex mu_;
+    std::unique_ptr<grpc_core::Notification>
+        wait_notifications_[2] ABSL_GUARDED_BY(mu_);
     std::atomic<size_t> wait_for_thread_counts_[2]{{kWaitForThreadCountUnset},
                                                    {kWaitForThreadCountUnset}};
     std::atomic<size_t> thread_counts_[2]{{0}, {0}};

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
@@ -124,8 +124,9 @@ class WorkStealingThreadPool final : public ThreadPool {
 
     // Implementation of the loop body for WaitForCountChange
     //
-    // The notifier is guaranteed not to be modified while this loop is running,
-    // so thread safety analysis is disabled to avoid having to claim the mutex.
+    // The notifier is guaranteed to exist while this loop is running, and
+    // Notification operations are thread-safe, so thread safety analysis is
+    // disabled to avoid having to claim the mutex.
     size_t WaitForCountChangeLoopBody(CounterType counter_type,
                                       absl::Duration timeout)
         ABSL_NO_THREAD_SAFETY_ANALYSIS;


### PR DESCRIPTION
Via CPU profiling, I found that AutoThreadCount mutex operations were taking up 33% of the time in the `bm_thread_pool` benchmarks. I replaced the thread counts with atomics (reducing the set of things done while the mutexes are held), which resulted in a 15% decrease in time spent changing and waiting on thread counts.

The `BM_ThreadPool_Closure_FanOut/2/70` benchmark went from ~8~ 12 million operations per second to ~10~ 16 million. (changed CPU governor to "performance")