### PR TITLE
[bazel] enable more bazelified C++ distribtests

### DIFF
--- a/test/distrib/cpp/run_distrib_test_cmake.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake.sh
@@ -62,9 +62,11 @@ make "-j${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS}" install
 popd
 
 # Just before installing gRPC, wipe out contents of all the submodules to simulate
-# a standalone build from an archive
-# shellcheck disable=SC2016
-git submodule foreach 'cd $toplevel; rm -rf $name'
+# a standalone build from an archive.
+# Get list of submodules from the .gitmodules file since for running "git submodule foreach"
+# we'd need to be in a git workspace (and that's not the case when running
+# distribtests as a bazel action)
+grep 'path = ' .gitmodules | sed 's/^.*path = //' | xargs rm -rf
 
 # Install gRPC
 mkdir -p "cmake/build"

--- a/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
@@ -66,9 +66,11 @@ make "-j${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS}" install
 popd
 
 # Just before installing gRPC, wipe out contents of all the submodules to simulate
-# a standalone build from an archive
-# shellcheck disable=SC2016
-git submodule foreach 'cd $toplevel; rm -rf $name'
+# a standalone build from an archive.
+# Get list of submodules from the .gitmodules file since for "git submodule foreach"
+# we'd need to be in a git workspace (and that's not the case when running
+# distribtests as a bazel action)
+grep 'path = ' .gitmodules | sed 's/^.*path = //' | xargs rm -rf
 
 # Install gRPC
 # TODO(jtattermusch): avoid the need for setting utf8_range_DIR

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -150,13 +150,12 @@ test_suite(
     ],
 )
 
-# TODO(jtattermusch): Reintroduce the test once it passes.
-# grpc_run_cpp_distribtest_test(
-#     name = "cpp_distribtest_cmake_linux",
-#     size = "enormous",
-#     args = ["test/distrib/cpp/run_distrib_test_cmake.sh"],
-#     docker_image_version = "tools/dockerfile/distribtest/cpp_debian10_x64.current_version",
-# )
+grpc_run_cpp_distribtest_test(
+    name = "cpp_distribtest_cmake_linux",
+    size = "enormous",
+    args = ["test/distrib/cpp/run_distrib_test_cmake.sh"],
+    docker_image_version = "tools/dockerfile/distribtest/cpp_debian10_x64.current_version",
+)
 
 grpc_run_cpp_distribtest_test(
     name = "cpp_distribtest_cmake_as_submodule_linux",
@@ -186,13 +185,12 @@ grpc_run_cpp_distribtest_test(
     docker_image_version = "tools/dockerfile/distribtest/cpp_debian10_x64.current_version",
 )
 
-# TODO(jtattermusch): Reintroduce the test once it passes.
-# grpc_run_cpp_distribtest_test(
-#     name = "cpp_distribtest_cmake_pkgconfig_linux",
-#     size = "enormous",
-#     args = ["test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh"],
-#     docker_image_version = "tools/dockerfile/distribtest/cpp_debian10_x64.current_version",
-# )
+grpc_run_cpp_distribtest_test(
+    name = "cpp_distribtest_cmake_pkgconfig_linux",
+    size = "enormous",
+    args = ["test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh"],
+    docker_image_version = "tools/dockerfile/distribtest/cpp_debian10_x64.current_version",
+)
 
 grpc_run_cpp_distribtest_test(
     name = "cpp_distribtest_cmake_aarch64_cross_linux",
@@ -208,9 +206,9 @@ test_suite(
         ":cpp_distribtest_cmake_as_externalproject_linux",
         ":cpp_distribtest_cmake_as_submodule_linux",
         ":cpp_distribtest_cmake_fetchcontent_linux",
-        #":cpp_distribtest_cmake_linux",
+        ":cpp_distribtest_cmake_linux",
         ":cpp_distribtest_cmake_module_install_linux",
-        #":cpp_distribtest_cmake_pkgconfig_linux",
+        ":cpp_distribtest_cmake_pkgconfig_linux",
     ],
 )
 


### PR DESCRIPTION
Reenable the bazelified version of `cpp_distribtest_cmake_linux` and `cpp_distribtest_cmake_pkgconfig_linux` distribtests 
