### PR TITLE
[promises] Fix flake noticed internally

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -3353,6 +3353,7 @@ void ServerPromiseBasedCall::CommitBatch(const grpc_op* ops, size_t nops,
         break;
       case GRPC_OP_RECV_MESSAGE:
         if (cancelled_.load(std::memory_order_relaxed)) {
+          set_failed_before_recv_message();
           FailCompletion(completion);
           break;
         }


### PR DESCRIPTION
Another case where we need to raise the 'failed before receive completed' flag prior to actually failing -- I think once promises are all rolled out I'd like to consider ways to remove this flag.