### PR TITLE
Revert "[absl] Swisstables dont allow calling begin/extract after move"

### DIFF
--- a/src/core/lib/promise/wait_set.h
+++ b/src/core/lib/promise/wait_set.h
@@ -64,9 +64,7 @@ class WaitSet final {
   };
 
   GRPC_MUST_USE_RESULT WakeupSet TakeWakeupSet() {
-    auto ret = WakeupSet(std::move(pending_));
-    pending_.clear();  // reinitialize after move.
-    return ret;
+    return WakeupSet(std::move(pending_));
   }
 
  private:


### PR DESCRIPTION
Reverts grpc/grpc#34066. Breaks an internal test.