### PR TITLE
Revert "Revert "[absl] Swisstables dont allow calling begin/extract after move""

### DIFF
--- a/src/core/lib/promise/wait_set.h
+++ b/src/core/lib/promise/wait_set.h
@@ -64,7 +64,9 @@ class WaitSet final {
   };
 
   GRPC_MUST_USE_RESULT WakeupSet TakeWakeupSet() {
-    return WakeupSet(std::move(pending_));
+    auto ret = WakeupSet(std::move(pending_));
+    pending_.clear();  // reinitialize after move.
+    return ret;
   }
 
  private:


### PR DESCRIPTION
Reverts grpc/grpc#34072

This code is not used in anything related to production at this point and so could not have caused any breakage.