### PR TITLE
[bazelified tests] Reenable gcc_12 bazelified portability test

### DIFF
--- a/tools/bazelify_tests/test/portability_tests.bzl
+++ b/tools/bazelify_tests/test/portability_tests.bzl
@@ -55,8 +55,7 @@ def generate_run_tests_portability_tests(name):
         compiler_configs = [
             # TODO(b/283304471): Add 'gcc10.2_openssl102' once possible
             ["gcc_7", "", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
-            # TODO(jtattermusch): re-enable once not flaky anymore
-            #["gcc_12", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_12_x64.current_version"],
+            ["gcc_12", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_12_x64.current_version"],
             # TODO(jtattermusch): Re-enable once the build can finish in reasonable time (looks like ccache is not being used?)
             #["gcc_musl", "", "tools/dockerfile/test/cxx_alpine_x64.current_version"],
             ["clang_6", "--cmake_configure_extra_args=-DCMAKE_C_COMPILER=clang --cmake_configure_extra_args=-DCMAKE_CXX_COMPILER=clang++", "tools/dockerfile/test/cxx_clang_6_x64.current_version"],


### PR DESCRIPTION
Needs https://github.com/grpc/grpc/pull/34035 to be merged first. With newer ccache in available in the gcc12 test image, the build is now faster so we can reenable the test.

