### PR TITLE
[Observability] Fix CPP observability test docker build

### DIFF
--- a/tools/dockerfile/observability-test/cpp/Dockerfile
+++ b/tools/dockerfile/observability-test/cpp/Dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update && apt-get install -y clang curl git
 WORKDIR /grpc
 COPY . .
 
-RUN git submodule update --init --recursive && \
-  /grpc/tools/bazel build test/cpp/interop:observability_interop_test
+RUN /grpc/tools/bazel build test/cpp/interop:observability_interop_test
 
 
 


### PR DESCRIPTION
CPP Observability test started failing about [2 weeks ago](https://fusion2.corp.google.com/ci/kokoro/prod:grpc-gcp%2Ftools%2Fobservability%2Fmaster%2Fcontinuous_cpp/activity/401f3183-4097-4090-9142-d2cfe19bdf8a/log). 

Turns out the `grpc/grpc` repo [added](https://github.com/grpc/grpc/commit/c73e743637a2598c2fbb4e6297c2818b5858f4f7#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) a `.dockerignore` file which ignores `.git` directory on `COPY` commands. This broke the observability test docker build stage because there was a `git submodule update` command. 

But on the other hand, this `git submodule update` command in the Observability test docker file isn't necessary and can be removed.

Adhoc test run based on this PR passed: https://fusion2.corp.google.com/invocations/09ce384f-c077-4666-9a85-3ca890db6a80/log