### PR TITLE
[PSM Interop] Extend headers matching.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26095,8 +26095,6 @@ if(gRPC_BUILD_TESTS)
 add_executable(wait_for_callback_test
   src/core/lib/promise/activity.cc
   test/core/promise/wait_for_callback_test.cc
-  third_party/googletest/googletest/src/gtest-all.cc
-  third_party/googletest/googlemock/src/gmock-all.cc
 )
 target_compile_features(wait_for_callback_test PUBLIC cxx_std_14)
 target_include_directories(wait_for_callback_test
@@ -26121,8 +26119,8 @@ target_include_directories(wait_for_callback_test
 target_link_libraries(wait_for_callback_test
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_PROTOBUF_LIBRARIES}
-  ${_gRPC_ZLIB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  gtest
   absl::type_traits
   absl::statusor
   gpr

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -16459,6 +16459,7 @@ targets:
   - src/core/lib/promise/activity.cc
   - test/core/promise/wait_for_callback_test.cc
   deps:
+  - gtest
   - absl/meta:type_traits
   - absl/status:statusor
   - gpr

--- a/test/cpp/interop/xds_stats_watcher.h
+++ b/test/cpp/interop/xds_stats_watcher.h
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "absl/status/status.h"
@@ -99,7 +100,8 @@ class XdsStatsWatcher {
   LoadBalancerAccumulatedStatsResponse accumulated_stats_;
   std::mutex m_;
   std::condition_variable cv_;
-  std::vector<std::string> metadata_keys_;
+  std::unordered_set<std::string> metadata_keys_;
+  bool include_all_metadata_ = false;
   std::map<std::string, LoadBalancerStatsResponse::MetadataByPeer>
       metadata_by_peer_;
 };


### PR DESCRIPTION
1. Headers will now be matched ignoring the case.
2. "*" can now be set to return all metadata values.