### PR TITLE
[clang-cl] Fix compile error found by clang-cl with strict warnings

### DIFF
--- a/test/core/util/build.cc
+++ b/test/core/util/build.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "test/core/util/build.h"
+
 bool BuiltUnderValgrind() {
 #ifdef RUNNING_ON_VALGRIND
   return true;


### PR DESCRIPTION
This fix the following compile error using clang-cl with strict warnings on Windows:

```
test/core/util/build.cc(15,6): error: no previous prototype for function 'BuiltUnderValgrind' [-Werror,-Wmissing-prototypes]
bool BuiltUnderValgrind() {
     ^
test/core/util/build.cc(15,1): note: declare 'static' if the function is not intended to be used outside of this translation unit
bool BuiltUnderValgrind() {
^
static
test/core/util/build.cc(23,6): error: no previous prototype for function 'BuiltUnderTsan' [-Werror,-Wmissing-prototypes]
bool BuiltUnderTsan() {
     ^
test/core/util/build.cc(23,1): note: declare 'static' if the function is not intended to be used outside of this translation unit
bool BuiltUnderTsan() {
^
static
test/core/util/build.cc(39,6): error: no previous prototype for function 'BuiltUnderAsan' [-Werror,-Wmissing-prototypes]
bool BuiltUnderAsan() {
     ^
test/core/util/build.cc(39,1): note: declare 'static' if the function is not intended to be used outside of this translation unit
bool BuiltUnderAsan() {
^
static
test/core/util/build.cc(55,6): error: no previous prototype for function 'BuiltUnderMsan' [-Werror,-Wmissing-prototypes]
bool BuiltUnderMsan() {
     ^
test/core/util/build.cc(55,1): note: declare 'static' if the function is not intended to be used outside of this translation unit
bool BuiltUnderMsan() {
^
static
test/core/util/build.cc(71,6): error: no previous prototype for function 'BuiltUnderUbsan' [-Werror,-Wmissing-prototypes]
bool BuiltUnderUbsan() {
     ^
test/core/util/build.cc(71,1): note: declare 'static' if the function is not intended to be used outside of this translation unit
bool BuiltUnderUbsan() {
^
static
5 errors generated.
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

