### PR TITLE
[experiments] Remove unused experiment

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -21,9 +21,6 @@ EXPERIMENTS = {
         "dbg": {
         },
         "off": {
-            "census_test": [
-                "transport_supplies_client_latency",
-            ],
             "core_end2end_test": [
                 "event_engine_listener",
                 "promise_based_client_call",
@@ -70,9 +67,6 @@ EXPERIMENTS = {
         "dbg": {
         },
         "off": {
-            "census_test": [
-                "transport_supplies_client_latency",
-            ],
             "core_end2end_test": [
                 "event_engine_listener",
                 "promise_based_client_call",
@@ -121,9 +115,6 @@ EXPERIMENTS = {
         "off": {
             "cancel_ares_query_test": [
                 "event_engine_dns",
-            ],
-            "census_test": [
-                "transport_supplies_client_latency",
             ],
             "core_end2end_test": [
                 "event_engine_client",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -60,11 +60,6 @@ const char* const description_promise_based_server_call =
     "If set, use the new gRPC promise based call code when it's appropriate "
     "(ie when all filters in a stack are promise based)";
 const char* const additional_constraints_promise_based_server_call = "{}";
-const char* const description_transport_supplies_client_latency =
-    "If set, use the transport represented value for client latency in "
-    "opencensus";
-const char* const additional_constraints_transport_supplies_client_latency =
-    "{}";
 const char* const description_event_engine_listener =
     "Use EventEngine listeners instead of iomgr's grpc_tcp_server";
 const char* const additional_constraints_event_engine_listener = "{}";
@@ -132,9 +127,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_free_large_allocator, false, true},
     {"promise_based_server_call", description_promise_based_server_call,
      additional_constraints_promise_based_server_call, false, true},
-    {"transport_supplies_client_latency",
-     description_transport_supplies_client_latency,
-     additional_constraints_transport_supplies_client_latency, false, true},
     {"event_engine_listener", description_event_engine_listener,
      additional_constraints_event_engine_listener, false, true},
     {"schedule_cancellation_over_write",
@@ -202,11 +194,6 @@ const char* const description_promise_based_server_call =
     "If set, use the new gRPC promise based call code when it's appropriate "
     "(ie when all filters in a stack are promise based)";
 const char* const additional_constraints_promise_based_server_call = "{}";
-const char* const description_transport_supplies_client_latency =
-    "If set, use the transport represented value for client latency in "
-    "opencensus";
-const char* const additional_constraints_transport_supplies_client_latency =
-    "{}";
 const char* const description_event_engine_listener =
     "Use EventEngine listeners instead of iomgr's grpc_tcp_server";
 const char* const additional_constraints_event_engine_listener = "{}";
@@ -274,9 +261,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_free_large_allocator, false, true},
     {"promise_based_server_call", description_promise_based_server_call,
      additional_constraints_promise_based_server_call, false, true},
-    {"transport_supplies_client_latency",
-     description_transport_supplies_client_latency,
-     additional_constraints_transport_supplies_client_latency, false, true},
     {"event_engine_listener", description_event_engine_listener,
      additional_constraints_event_engine_listener, false, true},
     {"schedule_cancellation_over_write",
@@ -344,11 +328,6 @@ const char* const description_promise_based_server_call =
     "If set, use the new gRPC promise based call code when it's appropriate "
     "(ie when all filters in a stack are promise based)";
 const char* const additional_constraints_promise_based_server_call = "{}";
-const char* const description_transport_supplies_client_latency =
-    "If set, use the transport represented value for client latency in "
-    "opencensus";
-const char* const additional_constraints_transport_supplies_client_latency =
-    "{}";
 const char* const description_event_engine_listener =
     "Use EventEngine listeners instead of iomgr's grpc_tcp_server";
 const char* const additional_constraints_event_engine_listener = "{}";
@@ -416,9 +395,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_free_large_allocator, false, true},
     {"promise_based_server_call", description_promise_based_server_call,
      additional_constraints_promise_based_server_call, false, true},
-    {"transport_supplies_client_latency",
-     description_transport_supplies_client_latency,
-     additional_constraints_transport_supplies_client_latency, false, true},
     {"event_engine_listener", description_event_engine_listener,
      additional_constraints_event_engine_listener, false, true},
     {"schedule_cancellation_over_write",

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -70,7 +70,6 @@ inline bool IsMonitoringExperimentEnabled() { return true; }
 inline bool IsPromiseBasedClientCallEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsPromiseBasedServerCallEnabled() { return false; }
-inline bool IsTransportSuppliesClientLatencyEnabled() { return false; }
 inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
@@ -104,7 +103,6 @@ inline bool IsMonitoringExperimentEnabled() { return true; }
 inline bool IsPromiseBasedClientCallEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsPromiseBasedServerCallEnabled() { return false; }
-inline bool IsTransportSuppliesClientLatencyEnabled() { return false; }
 inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
@@ -138,7 +136,6 @@ inline bool IsMonitoringExperimentEnabled() { return true; }
 inline bool IsPromiseBasedClientCallEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsPromiseBasedServerCallEnabled() { return false; }
-inline bool IsTransportSuppliesClientLatencyEnabled() { return false; }
 inline bool IsEventEngineListenerEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
@@ -186,36 +183,32 @@ inline bool IsPromiseBasedClientCallEnabled() { return IsExperimentEnabled(7); }
 inline bool IsFreeLargeAllocatorEnabled() { return IsExperimentEnabled(8); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PROMISE_BASED_SERVER_CALL
 inline bool IsPromiseBasedServerCallEnabled() { return IsExperimentEnabled(9); }
-#define GRPC_EXPERIMENT_IS_INCLUDED_TRANSPORT_SUPPLIES_CLIENT_LATENCY
-inline bool IsTransportSuppliesClientLatencyEnabled() {
-  return IsExperimentEnabled(10);
-}
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
-inline bool IsEventEngineListenerEnabled() { return IsExperimentEnabled(11); }
+inline bool IsEventEngineListenerEnabled() { return IsExperimentEnabled(10); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_SCHEDULE_CANCELLATION_OVER_WRITE
 inline bool IsScheduleCancellationOverWriteEnabled() {
-  return IsExperimentEnabled(12);
+  return IsExperimentEnabled(11);
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_TRACE_RECORD_CALLOPS
-inline bool IsTraceRecordCallopsEnabled() { return IsExperimentEnabled(13); }
+inline bool IsTraceRecordCallopsEnabled() { return IsExperimentEnabled(12); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
-inline bool IsEventEngineDnsEnabled() { return IsExperimentEnabled(14); }
+inline bool IsEventEngineDnsEnabled() { return IsExperimentEnabled(13); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_WORK_STEALING
-inline bool IsWorkStealingEnabled() { return IsExperimentEnabled(15); }
+inline bool IsWorkStealingEnabled() { return IsExperimentEnabled(14); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CLIENT_PRIVACY
-inline bool IsClientPrivacyEnabled() { return IsExperimentEnabled(16); }
+inline bool IsClientPrivacyEnabled() { return IsExperimentEnabled(15); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CANARY_CLIENT_PRIVACY
-inline bool IsCanaryClientPrivacyEnabled() { return IsExperimentEnabled(17); }
+inline bool IsCanaryClientPrivacyEnabled() { return IsExperimentEnabled(16); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_SERVER_PRIVACY
-inline bool IsServerPrivacyEnabled() { return IsExperimentEnabled(18); }
+inline bool IsServerPrivacyEnabled() { return IsExperimentEnabled(17); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_UNIQUE_METADATA_STRINGS
-inline bool IsUniqueMetadataStringsEnabled() { return IsExperimentEnabled(19); }
+inline bool IsUniqueMetadataStringsEnabled() { return IsExperimentEnabled(18); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_KEEPALIVE_FIX
-inline bool IsKeepaliveFixEnabled() { return IsExperimentEnabled(20); }
+inline bool IsKeepaliveFixEnabled() { return IsExperimentEnabled(19); }
 #define GRPC_EXPERIMENT_IS_INCLUDED_KEEPALIVE_SERVER_FIX
-inline bool IsKeepaliveServerFixEnabled() { return IsExperimentEnabled(21); }
+inline bool IsKeepaliveServerFixEnabled() { return IsExperimentEnabled(20); }
 
-constexpr const size_t kNumExperiments = 22;
+constexpr const size_t kNumExperiments = 21;
 extern const ExperimentMetadata g_experiment_metadata[kNumExperiments];
 
 #endif

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -94,11 +94,6 @@
   expiry: 2023/11/01
   owner: ctiller@google.com
   test_tags: ["core_end2end_test", "cpp_end2end_test", "xds_end2end_test", "logging_test"]
-- name: transport_supplies_client_latency
-  description: If set, use the transport represented value for client latency in opencensus
-  expiry: 2023/09/01
-  owner: ctiller@google.com
-  test_tags: [census_test]
 - name: event_engine_listener
   description: Use EventEngine listeners instead of iomgr's grpc_tcp_server
   expiry: 2024/01/01

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -62,8 +62,6 @@
   default: false
 - name: promise_based_server_call
   default: false
-- name: transport_supplies_client_latency
-  default: false
 - name: event_engine_listener
   default: false
 - name: schedule_cancellation_over_write

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -1057,7 +1057,7 @@ static void maybe_make_read_slices(grpc_tcp* tcp)
   static const int kBigAlloc = 64 * 1024;
   static const int kSmallAlloc = 8 * 1024;
   if (tcp->incoming_buffer->length <
-      static_cast<size_t>(tcp->min_progress_size)) {
+      std::max<size_t>(tcp->min_progress_size, 1)) {
     size_t allocate_length = tcp->min_progress_size;
     const size_t target_length = static_cast<size_t>(tcp->target_length);
     // If memory pressure is low and we think there will be more than
@@ -1067,8 +1067,8 @@ static void maybe_make_read_slices(grpc_tcp* tcp)
     if (low_memory_pressure && target_length > allocate_length) {
       allocate_length = target_length;
     }
-    int extra_wanted =
-        allocate_length - static_cast<int>(tcp->incoming_buffer->length);
+    int extra_wanted = std::max<int>(
+        1, allocate_length - static_cast<int>(tcp->incoming_buffer->length));
     if (extra_wanted >=
         (low_memory_pressure ? kSmallAlloc * 3 / 2 : kBigAlloc)) {
       while (extra_wanted > 0) {

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -235,16 +235,6 @@ void OpenCensusCallTracer::OpenCensusCallAttemptTracer::
          {RpcClientRoundtripLatency(),
           absl::ToDoubleMilliseconds(absl::Now() - start_time_)}},
         tags);
-    if (grpc_core::IsTransportSuppliesClientLatencyEnabled()) {
-      if (transport_stream_stats != nullptr &&
-          gpr_time_cmp(transport_stream_stats->latency,
-                       gpr_inf_future(GPR_TIMESPAN)) != 0) {
-        double latency_ms = absl::ToDoubleMilliseconds(absl::Microseconds(
-            gpr_timespec_to_micros(transport_stream_stats->latency)));
-        ::opencensus::stats::Record({{RpcClientTransportLatency(), latency_ms}},
-                                    tags);
-      }
-    }
   }
 }
 

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -246,16 +246,6 @@ void PythonOpenCensusCallTracer::PythonOpenCensusCallAttemptTracer::
                      absl::ToDoubleMilliseconds(absl::Now() - start_time_),
                      context_.Labels());
   RecordIntMetric(kRpcClientCompletedRpcMeasureName, 1, context_.Labels());
-  if (grpc_core::IsTransportSuppliesClientLatencyEnabled()) {
-    if (transport_stream_stats != nullptr &&
-        gpr_time_cmp(transport_stream_stats->latency,
-                     gpr_inf_future(GPR_TIMESPAN)) != 0) {
-      double latency_ms = absl::ToDoubleMilliseconds(absl::Microseconds(
-          gpr_timespec_to_micros(transport_stream_stats->latency)));
-      RecordDoubleMetric(kRpcClientTransportLatencyMeasureName, latency_ms,
-                         context_.Labels());
-    }
-  }
 }
 
 void PythonOpenCensusCallTracer::PythonOpenCensusCallAttemptTracer::

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -261,25 +261,6 @@ TEST_F(StatsPluginEnd2EndTest, Latency) {
               ::testing::Property(&Distribution::mean,
                                   ::testing::Lt(client_latency))))));
 
-  // Transport time is a subinterval of total latency.
-  if (grpc_core::IsTransportSuppliesClientLatencyEnabled()) {
-    const auto client_transport_latency =
-        client_transport_latency_view.GetData()
-            .distribution_data()
-            .find({client_method_name_})
-            ->second.mean();
-    EXPECT_THAT(
-        client_server_latency_view.GetData().distribution_data(),
-        ::testing::UnorderedElementsAre(::testing::Pair(
-            ::testing::ElementsAre(client_method_name_),
-            ::testing::AllOf(
-                ::testing::Property(&Distribution::count, 1),
-                ::testing::Property(&Distribution::mean, ::testing::Gt(0.0)),
-                ::testing::Property(
-                    &Distribution::mean,
-                    ::testing::Lt(client_transport_latency))))));
-  }
-
   // client api latency should be less than max time but greater than client
   // roundtrip (attempt) latency view.
   EXPECT_THAT(


### PR DESCRIPTION
We added this as an exploratory measure for a customer that thought they were using open census (this turned out to be emphatically false). Remove it since it's probably not how we ultimately want to do this, and wait for something better to come along.