### PR TITLE
Revert "[EventEngine] C++ Alarm migration and PosixEventEngine perfor…

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2028,7 +2028,6 @@ grpc_cc_library(
         "//src/core:channel_args",
         "//src/core:channel_init",
         "//src/core:closure",
-        "//src/core:default_event_engine",
         "//src/core:error",
         "//src/core:gpr_atm",
         "//src/core:gpr_manual_constructor",

--- a/include/grpcpp/alarm.h
+++ b/include/grpcpp/alarm.h
@@ -23,7 +23,6 @@
 
 #include <functional>
 
-#include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 #include <grpcpp/completion_queue.h>
 #include <grpcpp/impl/completion_queue_tag.h>
@@ -32,15 +31,9 @@
 
 namespace grpc {
 
-/// Trigger a \a CompletionQueue event, or asynchronous callback execution,
-/// after some deadline.
-///
-/// The \a Alarm API has separate \a Set methods for CompletionQueues and
-/// callbacks, but only one can be used at any given time. After an alarm has
-/// been triggered or cancelled, the same Alarm object may reused.
 class Alarm : private grpc::internal::GrpcLibrary {
  public:
-  /// Create an unset Alarm.
+  /// Create an unset completion queue alarm
   Alarm();
 
   /// Destroy the given completion queue alarm, cancelling it in the process.

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -475,10 +475,6 @@ void PosixEventEngine::Run(EventEngine::Closure* closure) {
 
 EventEngine::TaskHandle PosixEventEngine::RunAfterInternal(
     Duration when, absl::AnyInvocable<void()> cb) {
-  if (when <= Duration::zero()) {
-    Run(std::move(cb));
-    return TaskHandle::kInvalid;
-  }
   auto when_ts = ToTimestamp(timer_manager_.Now(), when);
   auto* cd = new ClosureData;
   cd->cb = std::move(cb);

--- a/src/cpp/common/alarm.cc
+++ b/src/cpp/common/alarm.cc
@@ -17,14 +17,9 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <atomic>
 #include <functional>
-#include <memory>
 #include <utility>
 
-#include "absl/status/status.h"
-
-#include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
@@ -33,27 +28,22 @@
 #include <grpcpp/completion_queue.h>
 #include <grpcpp/impl/completion_queue_tag.h>
 
-#include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/gprpp/time.h"
+#include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/executor.h"
+#include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/surface/completion_queue.h"
 
 namespace grpc {
 
 namespace internal {
-
-namespace {
-using grpc_event_engine::experimental::EventEngine;
-}  // namespace
-
 class AlarmImpl : public grpc::internal::CompletionQueueTag {
  public:
-  AlarmImpl()
-      : event_engine_(grpc_event_engine::experimental::GetDefaultEventEngine()),
-        cq_(nullptr),
-        tag_(nullptr) {
+  AlarmImpl() : cq_(nullptr), tag_(nullptr) {
     gpr_ref_init(&refs_, 1);
+    grpc_timer_init_unset(&timer_);
   }
   ~AlarmImpl() override {}
   bool FinalizeResult(void** tag, bool* /*status*/) override {
@@ -62,41 +52,61 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
     return true;
   }
   void Set(grpc::CompletionQueue* cq, gpr_timespec deadline, void* tag) {
+    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
     grpc_core::ExecCtx exec_ctx;
     GRPC_CQ_INTERNAL_REF(cq->cq(), "alarm");
     cq_ = cq->cq();
     tag_ = tag;
     GPR_ASSERT(grpc_cq_begin_op(cq_, this));
-    Ref();
-    GPR_ASSERT(cq_armed_.exchange(true) == false);
-    GPR_ASSERT(!callback_armed_.load());
-    cq_timer_handle_ = event_engine_->RunAfter(
-        grpc_core::Timestamp::FromTimespecRoundUp(deadline) -
-            grpc_core::ExecCtx::Get()->Now(),
-        [this] { OnCQAlarm(absl::OkStatus()); });
+    GRPC_CLOSURE_INIT(
+        &on_alarm_,
+        [](void* arg, grpc_error_handle error) {
+          // queue the op on the completion queue
+          AlarmImpl* alarm = static_cast<AlarmImpl*>(arg);
+          alarm->Ref();
+          // Preserve the cq and reset the cq_ so that the alarm
+          // can be reset when the alarm tag is delivered.
+          grpc_completion_queue* cq = alarm->cq_;
+          alarm->cq_ = nullptr;
+          grpc_cq_end_op(
+              cq, alarm, error,
+              [](void* /*arg*/, grpc_cq_completion* /*completion*/) {}, arg,
+              &alarm->completion_);
+          GRPC_CQ_INTERNAL_UNREF(cq, "alarm");
+        },
+        this, grpc_schedule_on_exec_ctx);
+    grpc_timer_init(&timer_,
+                    grpc_core::Timestamp::FromTimespecRoundUp(deadline),
+                    &on_alarm_);
   }
   void Set(gpr_timespec deadline, std::function<void(bool)> f) {
+    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
     grpc_core::ExecCtx exec_ctx;
     // Don't use any CQ at all. Instead just use the timer to fire the function
     callback_ = std::move(f);
     Ref();
-    GPR_ASSERT(callback_armed_.exchange(true) == false);
-    GPR_ASSERT(!cq_armed_.load());
-    callback_timer_handle_ = event_engine_->RunAfter(
-        grpc_core::Timestamp::FromTimespecRoundUp(deadline) -
-            grpc_core::ExecCtx::Get()->Now(),
-        [this] { OnCallbackAlarm(true); });
+    GRPC_CLOSURE_INIT(
+        &on_alarm_,
+        [](void* arg, grpc_error_handle error) {
+          grpc_core::Executor::Run(GRPC_CLOSURE_CREATE(
+                                       [](void* arg, grpc_error_handle error) {
+                                         AlarmImpl* alarm =
+                                             static_cast<AlarmImpl*>(arg);
+                                         alarm->callback_(error.ok());
+                                         alarm->Unref();
+                                       },
+                                       arg, nullptr),
+                                   error);
+        },
+        this, grpc_schedule_on_exec_ctx);
+    grpc_timer_init(&timer_,
+                    grpc_core::Timestamp::FromTimespecRoundUp(deadline),
+                    &on_alarm_);
   }
   void Cancel() {
+    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
     grpc_core::ExecCtx exec_ctx;
-    if (callback_armed_.load() &&
-        event_engine_->Cancel(callback_timer_handle_)) {
-      event_engine_->Run([this] { OnCallbackAlarm(/*is_ok=*/false); });
-    }
-    if (cq_armed_.load() && event_engine_->Cancel(cq_timer_handle_)) {
-      event_engine_->Run(
-          [this] { OnCQAlarm(absl::CancelledError("cancelled")); });
-    }
+    grpc_timer_cancel(&timer_);
   }
   void Destroy() {
     Cancel();
@@ -104,29 +114,6 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
   }
 
  private:
-  void OnCQAlarm(grpc_error_handle error) {
-    cq_armed_.store(false);
-    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
-    grpc_core::ExecCtx exec_ctx;
-    // Preserve the cq and reset the cq_ so that the alarm
-    // can be reset when the alarm tag is delivered.
-    grpc_completion_queue* cq = cq_;
-    cq_ = nullptr;
-    grpc_cq_end_op(
-        cq, this, error,
-        [](void* /*arg*/, grpc_cq_completion* /*completion*/) {}, nullptr,
-        &completion_);
-    GRPC_CQ_INTERNAL_UNREF(cq, "alarm");
-  }
-
-  void OnCallbackAlarm(bool is_ok) {
-    callback_armed_.store(false);
-    grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
-    grpc_core::ExecCtx exec_ctx;
-    callback_(is_ok);
-    Unref();
-  }
-
   void Ref() { gpr_ref(&refs_); }
   void Unref() {
     if (gpr_unref(&refs_)) {
@@ -134,13 +121,9 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
     }
   }
 
-  std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine_;
-  std::atomic<bool> cq_armed_{false};
-  EventEngine::TaskHandle cq_timer_handle_ = EventEngine::TaskHandle::kInvalid;
-  std::atomic<bool> callback_armed_{false};
-  EventEngine::TaskHandle callback_timer_handle_ =
-      EventEngine::TaskHandle::kInvalid;
+  grpc_timer timer_;
   gpr_refcount refs_;
+  grpc_closure on_alarm_;
   grpc_cq_completion completion_;
   // completion queue where events about this alarm will be posted
   grpc_completion_queue* cq_;


### PR DESCRIPTION
…mance enhancements (#34056)"

This reverts commit 0d5dc5c45b891f8a02cbedb00bac7780dd4fbd55.

Reason: there's a race on task handle access, between setting the alarm and canceling it. b/296397861