### PR TITLE
[gke benchmarks] Reenable dotnet GKE benchmarks

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -130,10 +130,10 @@ configLangArgs8core+=( -l c++ )
 configLangArgs32core+=( -l c++ )
 runnerLangArgs+=( -l "cxx:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}" )
 
-# # dotnet
-# configLangArgs8core+=( -l dotnet )
-# configLangArgs32core+=( -l dotnet )
-# runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
+# dotnet
+configLangArgs8core+=( -l dotnet )
+configLangArgs32core+=( -l dotnet )
+runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
 
 # # go
 # configLangArgs8core+=( -l go )

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -124,10 +124,10 @@ configLangArgs8core+=( -l c++ )
 configLangArgs32core+=( -l c++ )
 runnerLangArgs+=( -l "cxx:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}" )
 
-# # dotnet
-# configLangArgs8core+=( -l dotnet )
-# configLangArgs32core+=( -l dotnet )
-# runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
+# dotnet
+configLangArgs8core+=( -l dotnet )
+configLangArgs32core+=( -l dotnet )
+runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
 
 # # go
 # configLangArgs8core+=( -l go )


### PR DESCRIPTION
https://github.com/grpc/test-infra/pull/379 needs to be merged first.

This partially reverts https://github.com/grpc/grpc/pull/34080 and re-enables the dotnet benchmarks.
