### PR TITLE
[pick_first] fix test flake

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -450,6 +450,7 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
   // with the first subchannel.
   if (!old_state.has_value()) {
     subchannel_list()->subchannel(0)->ReactToConnectivityStateLocked();
+    return;
   }
   // Ignore any other updates for subchannels we're not currently trying to
   // connect to.

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -841,9 +841,8 @@ TEST_F(PickFirstTest, BackOffInitialReconnect) {
       channel.get(),
       [&](grpc_connectivity_state state) {
         if (state == GRPC_CHANNEL_TRANSIENT_FAILURE) return true;
-        EXPECT_THAT(
-            state,
-            ::testing::AnyOf(GRPC_CHANNEL_IDLE, GRPC_CHANNEL_CONNECTING));
+        EXPECT_THAT(state, ::testing::AnyOf(GRPC_CHANNEL_IDLE,
+                                            GRPC_CHANNEL_CONNECTING));
         return false;
       },
       /*try_to_connect=*/true));

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -852,8 +852,7 @@ TEST_F(PickFirstTest, BackOffInitialReconnect) {
   // Now the channel will become connected.
   ASSERT_TRUE(WaitForChannelReady(channel.get()));
   // Check how long it took.
-  const grpc_core::Timestamp t1 = grpc_core::Timestamp::Now();
-  const grpc_core::Duration waited = t1 - t0;
+  const grpc_core::Duration waited = grpc_core::Timestamp::Now() - t0;
   gpr_log(GPR_DEBUG, "Waited %" PRId64 " milliseconds", waited.millis());
   // We should have waited at least kInitialBackOffMs. We substract one to
   // account for test and precision accuracy drift.


### PR DESCRIPTION
CNR the flake, but I've changed the test (which is very old) to use some of our more modern helper functions that have saner timeouts.

Also re-add a `return` statement that was accidentally removed in #33753, which I noticed while working on this.  Its absence doesn't cause a real problem, but it does cause us to needlessly trigger a duplicate connection attempt or report a duplicate CONNECTING update in some cases.