### PR TITLE
[EventEngine] Enable event_engine_listener in Windows debug builds

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -25,7 +25,6 @@ EXPERIMENTS = {
                 "transport_supplies_client_latency",
             ],
             "core_end2end_test": [
-                "event_engine_listener",
                 "promise_based_client_call",
                 "promise_based_server_call",
             ],
@@ -35,9 +34,6 @@ EXPERIMENTS = {
             "endpoint_test": [
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "event_engine_listener_test": [
-                "event_engine_listener",
             ],
             "flow_control_test": [
                 "peer_state_based_framing",
@@ -61,7 +57,11 @@ EXPERIMENTS = {
         },
         "on": {
             "core_end2end_test": [
+                "event_engine_listener",
                 "work_stealing",
+            ],
+            "event_engine_listener_test": [
+                "event_engine_listener",
             ],
         },
     },
@@ -73,7 +73,6 @@ EXPERIMENTS = {
                 "transport_supplies_client_latency",
             ],
             "core_end2end_test": [
-                "event_engine_listener",
                 "promise_based_client_call",
                 "promise_based_server_call",
             ],
@@ -83,9 +82,6 @@ EXPERIMENTS = {
             "endpoint_test": [
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "event_engine_listener_test": [
-                "event_engine_listener",
             ],
             "flow_control_test": [
                 "peer_state_based_framing",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -278,7 +278,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_transport_supplies_client_latency,
      additional_constraints_transport_supplies_client_latency, false, true},
     {"event_engine_listener", description_event_engine_listener,
-     additional_constraints_event_engine_listener, false, true},
+     additional_constraints_event_engine_listener, kDefaultForDebugOnly, true},
     {"schedule_cancellation_over_write",
      description_schedule_cancellation_over_write,
      additional_constraints_schedule_cancellation_over_write, false, true},

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -106,7 +106,16 @@ inline bool IsPromiseBasedClientCallEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsPromiseBasedServerCallEnabled() { return false; }
 inline bool IsTransportSuppliesClientLatencyEnabled() { return false; }
-inline bool IsEventEngineListenerEnabled() { return false; }
+#ifndef NDEBUG
+#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
+#endif
+inline bool IsEventEngineListenerEnabled() {
+#ifdef NDEBUG
+  return false;
+#else
+  return true;
+#endif
+}
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsTraceRecordCallopsEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -65,7 +65,11 @@
 - name: transport_supplies_client_latency
   default: false
 - name: event_engine_listener
-  default: false
+  default:
+    # not tested on iOS at all
+    ios: broken
+    posix: false
+    windows: debug
 - name: schedule_cancellation_over_write
   default: false
 - name: trace_record_callops
@@ -75,7 +79,7 @@
     # not tested on iOS at all
     ios: broken
     posix: false
-    # TODO(yijiem): resolve when the WindowsEventEngine DNS Resolver is 
+    # TODO(yijiem): resolve when the WindowsEventEngine DNS Resolver is
     # implemented
     windows: broken
 - name: work_stealing


### PR DESCRIPTION
This turns on the event_engine_listener experiment across Windows debug builds.

If you encounter problems, please file an issue. The experiment can be disabled immediately by setting the environment variable `GRPC_EXPERIMENTS="-event_engine_listener"` and running the same binary.