### PR TITLE
[Windows] Make resolver_component_tests_runner_invoker run with Bazel on Windows

### DIFF
--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -47,7 +47,7 @@ def test_runner_log(msg):
   sys.stderr.write('\n%s: %s\n' % (__file__, msg))
 
 def python_args(arg_list):
-  if platform.system() == 'Windows':
+  if platform.system() == 'Windows' and arg_list[0].endswith('.py'):
     return [sys.executable] + arg_list
   return arg_list
 

--- a/test/cpp/naming/BUILD
+++ b/test/cpp/naming/BUILD
@@ -54,4 +54,9 @@ grpc_cc_test(
     ],
 )
 
+filegroup(
+    name = "resolver_test_record_groups",
+    srcs = ["resolver_test_record_groups.yaml"],
+)
+
 generate_resolver_component_tests()

--- a/test/cpp/naming/generate_resolver_component_tests.bzl
+++ b/test/cpp/naming/generate_resolver_component_tests.bzl
@@ -75,6 +75,7 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/flags:flag",
+                "absl/strings",
             ],
             deps = [
                 "//test/cpp/util:test_util%s" % unsecure_build_config_suffix,
@@ -83,6 +84,7 @@ def generate_resolver_component_tests():
                 "//:grpc%s" % unsecure_build_config_suffix,
                 "//:gpr",
                 "//test/cpp/util:test_config",
+                "//test/cpp/util/windows:manifest_file",
             ],
             data = [
                 ":resolver_component_tests_runner",
@@ -90,7 +92,7 @@ def generate_resolver_component_tests():
                 "//test/cpp/naming/utils:dns_server",
                 "//test/cpp/naming/utils:dns_resolver",
                 "//test/cpp/naming/utils:tcp_connect",
-                "resolver_test_record_groups.yaml",  # include the transitive dependency so that the dns server py binary can locate this
+                "//test/cpp/naming:resolver_test_record_groups",  # include the transitive dependency so that the dns server py binary can locate this
             ],
             args = [
                 "--test_bin_name=resolver_component_test%s" % unsecure_build_config_suffix,
@@ -99,5 +101,5 @@ def generate_resolver_component_tests():
             # The test is highly flaky on AWS workers that we use for running ARM64 tests.
             # The "no_arm64" tag can be used to skip it.
             # (see https://github.com/grpc/grpc/issues/25289).
-            tags = ["no_windows", "no_mac", "no_arm64", "resolver_component_tests_runner_invoker"],
+            tags = ["no_mac", "no_arm64", "resolver_component_tests_runner_invoker"],
         )

--- a/test/cpp/naming/generate_resolver_component_tests.bzl
+++ b/test/cpp/naming/generate_resolver_component_tests.bzl
@@ -101,5 +101,5 @@ def generate_resolver_component_tests():
             # The test is highly flaky on AWS workers that we use for running ARM64 tests.
             # The "no_arm64" tag can be used to skip it.
             # (see https://github.com/grpc/grpc/issues/25289).
-            tags = ["no_mac", "no_arm64", "resolver_component_tests_runner_invoker"],
+            tags = ["no_windows", "no_mac", "no_arm64", "resolver_component_tests_runner_invoker"],
         )

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -47,7 +47,7 @@ def test_runner_log(msg):
   sys.stderr.write('\n%s: %s\n' % (__file__, msg))
 
 def python_args(arg_list):
-  if platform.system() == 'Windows':
+  if platform.system() == 'Windows' and arg_list[0].endswith('.py'):
     return [sys.executable] + arg_list
   return arg_list
 

--- a/test/cpp/util/windows/BUILD
+++ b/test/cpp/util/windows/BUILD
@@ -1,0 +1,39 @@
+# Copyright 2023 The gRPC Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package")
+
+licenses(["notice"])
+
+grpc_package(
+    name="test/cpp/util/windows",
+    visibility="tests",
+)
+
+grpc_cc_library(
+    name = "manifest_file",
+    testonly = True,
+    srcs = [
+        "manifest_file.cc"
+    ],
+    hdrs = [
+        "manifest_file.h"
+    ],
+    external_deps = [
+        "absl/strings"
+    ],
+    deps = [
+        "//:gpr"
+    ],
+)

--- a/test/cpp/util/windows/BUILD
+++ b/test/cpp/util/windows/BUILD
@@ -17,23 +17,23 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_package")
 licenses(["notice"])
 
 grpc_package(
-    name="test/cpp/util/windows",
-    visibility="tests",
+    name = "test/cpp/util/windows",
+    visibility = "tests",
 )
 
 grpc_cc_library(
     name = "manifest_file",
     testonly = True,
     srcs = [
-        "manifest_file.cc"
+        "manifest_file.cc",
     ],
     hdrs = [
-        "manifest_file.h"
+        "manifest_file.h",
     ],
     external_deps = [
-        "absl/strings"
+        "absl/strings",
     ],
     deps = [
-        "//:gpr"
+        "//:gpr",
     ],
 )

--- a/test/cpp/util/windows/manifest_file.cc
+++ b/test/cpp/util/windows/manifest_file.cc
@@ -1,0 +1,71 @@
+// Copyright 2023 The gRPC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/cpp/util/windows/manifest_file.h"
+
+#include <grpc/support/port_platform.h>
+
+#ifdef GPR_WINDOWS
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
+
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gprpp/crash.h"
+
+namespace grpc {
+namespace testing {
+
+std::string NormalizeFilePath(const std::string& filepath) {
+  return absl::StrReplaceAll(filepath, {{"/", "\\"}});
+}
+
+ManifestFile::ManifestFile(const std::string& filepath)
+    : filestream_(filepath, std::ios::in | std::ios::binary) {
+  if (!filestream_.is_open()) {
+    grpc_core::Crash(absl::StrFormat("Failed to open %s", filepath));
+  }
+}
+
+std::string ManifestFile::Get(const std::string& key) {
+  auto iter = cache_.find(key);
+  if (iter != cache_.end()) {
+    return iter->second;
+  }
+  do {
+    std::string line;
+    std::getline(filestream_, line);
+    if (!line.empty()) {
+      std::vector<std::string> kv = absl::StrSplit(line, " ");
+      GPR_ASSERT(kv.size() == 2);
+      cache_.emplace(kv[0], kv[1]);
+      if (kv[0] == key) {
+        return kv[1];
+      }
+    }
+  } while (!filestream_.eof() && !filestream_.fail());
+  grpc_core::Crash(
+      absl::StrFormat("Failed to find key: %s in MANIFEST file", key));
+}
+
+}  // namespace testing
+}  // namespace grpc
+
+#endif  // GPR_WINDOWS

--- a/test/cpp/util/windows/manifest_file.cc
+++ b/test/cpp/util/windows/manifest_file.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "test/cpp/util/windows/manifest_file.h"
-
 #include <grpc/support/port_platform.h>
+
+#include "test/cpp/util/windows/manifest_file.h"
 
 #ifdef GPR_WINDOWS
 

--- a/test/cpp/util/windows/manifest_file.h
+++ b/test/cpp/util/windows/manifest_file.h
@@ -1,0 +1,47 @@
+// Copyright 2023 The gRPC Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_TEST_CPP_UTIL_WINDOWS_MANIFEST_FILE_H
+#define GRPC_TEST_CPP_UTIL_WINDOWS_MANIFEST_FILE_H
+
+#include <grpc/support/port_platform.h>
+
+#ifdef GPR_WINDOWS
+
+#include <fstream>
+#include <string>
+#include <unordered_map>
+
+namespace grpc {
+namespace testing {
+
+std::string NormalizeFilePath(const std::string& filepath);
+
+class ManifestFile {
+ public:
+  explicit ManifestFile(const std::string& filepath);
+
+  std::string Get(const std::string& key);
+
+ private:
+  std::fstream filestream_;
+  std::unordered_map<std::string, std::string> cache_;
+};
+
+}  // namespace testing
+}  // namespace grpc
+
+#endif  // GPR_WINDOWS
+
+#endif  // GRPC_TEST_CPP_UTIL_WINDOWS_MANIFEST_FILE_H

--- a/test/cpp/util/windows/manifest_file.h
+++ b/test/cpp/util/windows/manifest_file.h
@@ -28,6 +28,16 @@ namespace testing {
 
 std::string NormalizeFilePath(const std::string& filepath);
 
+// This class is used for handling Runfiles for a Bazel target on Windows (e.g.
+// the output of targets specified in the data attribute of the target). On
+// Linux/macOS, Bazel creates a runfiles tree which contains symlinks to the
+// actual runfiles. But on Windows, it only creates a MANIFEST file which
+// contains a list of <symlink relative path, absolute symlink target path>.
+// Thus one initializes a ManifestFile object with the filepath to a MANIFEST
+// file and uses it as a key-value datastore by querying the absolute symlink
+// target path with the imaginative symlink relative path. See
+// https://github.com/bazelbuild/bazel/issues/4261#issuecomment-350723457 for
+// more details.
 class ManifestFile {
  public:
   explicit ManifestFile(const std::string& filepath);


### PR DESCRIPTION
Local Bazel invocation succeeds:

```
C:\Users\yijiem\projects\grpc>bazel --output_base=C:\bazel2 test --dynamic_mode=off --verbose_failures //test/cpp/naming:resolver_component_tests_runner_invoker@poller=epoll1
INFO: Analyzed target //test/cpp/naming:resolver_component_tests_runner_invoker@poller=epoll1 (0 packages loaded, 0 targets configured).
INFO: Found 1 test target...
Target //test/cpp/naming:resolver_component_tests_runner_invoker@poller=epoll1 up-to-date:
  bazel-bin/test/cpp/naming/resolver_component_tests_runner_invoker@poller=epoll1.exe
INFO: Elapsed time: 199.262s, Critical Path: 193.48s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
//test/cpp/naming:resolver_component_tests_runner_invoker@poller=epoll1  PASSED in 193.4s

Executed 1 out of 1 test: 1 test passes.
```

The local invocation of RBE failed with linker error `LINK : error LNK2001: unresolved external symbol mainCRTStartup`, but that does not limited to this target: https://gist.github.com/yijiem/2c6cbd9a31209a6de8fd711afbf2b479.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

