### PR TITLE
[ObjC] Enable DNS resolver with `GRPC_IOS_EVENT_ENGINE_CLIENT`

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/dns_resolver_plugin.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/dns_resolver_plugin.cc
@@ -32,6 +32,12 @@
 namespace grpc_core {
 
 void RegisterDnsResolver(CoreConfiguration::Builder* builder) {
+#ifdef GRPC_IOS_EVENT_ENGINE_CLIENT
+  gpr_log(GPR_DEBUG, "Using EventEngine dns resolver");
+  builder->resolver_registry()->RegisterResolverFactory(
+      std::make_unique<EventEngineClientChannelDNSResolverFactory>());
+  return;
+#endif
   if (IsEventEngineDnsEnabled()) {
     gpr_log(GPR_DEBUG, "Using EventEngine dns resolver");
     builder->resolver_registry()->RegisterResolverFactory(


### PR DESCRIPTION
Now that iOS DNS resolver is ready, we can also enable it with `GRPC_IOS_EVENT_ENGINE_CLIENT`, so we can ask users to experiment with it.

