### PR TITLE
[C++] Stop using std::aligned_storage.

### DIFF
--- a/include/grpcpp/server_context.h
+++ b/include/grpcpp/server_context.h
@@ -545,8 +545,7 @@ class ServerContextBase {
     const std::function<void(grpc::Status s)> func_;
   };
 
-  typename std::aligned_storage<sizeof(Reactor), alignof(Reactor)>::type
-      default_reactor_;
+  alignas(Reactor) char default_reactor_[sizeof(Reactor)];
   std::atomic_bool default_reactor_used_{false};
 
   std::atomic_bool marked_cancelled_{false};

--- a/src/core/lib/gprpp/manual_constructor.h
+++ b/src/core/lib/gprpp/manual_constructor.h
@@ -25,7 +25,6 @@
 
 #include <stddef.h>
 
-#include <type_traits>
 #include <utility>
 
 #include "src/core/lib/gprpp/construct_destruct.h"
@@ -139,7 +138,7 @@ class ManualConstructor {
   void Destroy() { Destruct(get()); }
 
  private:
-  typename std::aligned_storage<sizeof(Type), alignof(Type)>::type space_;
+  alignas(Type) char space_[sizeof(Type)];
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/gprpp/no_destruct.h
+++ b/src/core/lib/gprpp/no_destruct.h
@@ -68,7 +68,7 @@ class NoDestruct {
   const T* get() const { return reinterpret_cast<const T*>(&space_); }
 
  private:
-  typename std::aligned_storage<sizeof(T), alignof(T)>::type space_;
+  alignas(T) char space_[sizeof(T)];
 };
 
 // Helper for when a program desires a single *process wide* instance of a

--- a/src/core/lib/iomgr/event_engine_shims/endpoint.cc
+++ b/src/core/lib/iomgr/event_engine_shims/endpoint.cc
@@ -60,10 +60,8 @@ class EventEngineEndpointWrapper {
   struct grpc_event_engine_endpoint {
     grpc_endpoint base;
     EventEngineEndpointWrapper* wrapper;
-    std::aligned_storage<sizeof(SliceBuffer), alignof(SliceBuffer)>::type
-        read_buffer;
-    std::aligned_storage<sizeof(SliceBuffer), alignof(SliceBuffer)>::type
-        write_buffer;
+    alignas(SliceBuffer) char read_buffer[sizeof(SliceBuffer)];
+    alignas(SliceBuffer) char write_buffer[sizeof(SliceBuffer)];
   };
 
   explicit EventEngineEndpointWrapper(

--- a/src/core/lib/promise/arena_promise.h
+++ b/src/core/lib/promise/arena_promise.h
@@ -19,6 +19,7 @@
 
 #include <stdlib.h>
 
+#include <cstddef>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -34,7 +35,10 @@ namespace grpc_core {
 
 namespace arena_promise_detail {
 
-using ArgType = std::aligned_storage_t<sizeof(void*)>;
+struct ArgType {
+  alignas(std::max_align_t) char buffer[sizeof(void*)];
+};
+
 template <typename T>
 T*& ArgAsPtr(ArgType* arg) {
   static_assert(sizeof(ArgType) >= sizeof(T**),

--- a/test/core/gprpp/ref_counted_test.cc
+++ b/test/core/gprpp/ref_counted_test.cc
@@ -119,8 +119,8 @@ class ValueInExternalAllocation
 };
 
 TEST(RefCounted, CallDtorUponUnref) {
-  std::aligned_storage<sizeof(ValueInExternalAllocation),
-                       alignof(ValueInExternalAllocation)>::type storage;
+  alignas(ValueInExternalAllocation) char
+      storage[sizeof(ValueInExternalAllocation)];
   RefCountedPtr<ValueInExternalAllocation> value(
       new (&storage) ValueInExternalAllocation(5));
   EXPECT_EQ(value->value(), 5);


### PR DESCRIPTION
Indeed this is now deprecated since C++23.

Fix #32848.

