### PR TITLE
[Python] Add `grpc.aio.ServicerContext.abort_with_status`

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1217,8 +1217,8 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
             termination of the RPC.
 
         Raises:
-          Exception: An exception is always raised to signal the abortion the
-            RPC to the gRPC runtime.
+          Exception: An exception is always raised to signal the abortion of
+            the RPC to the gRPC runtime.
         """
         raise NotImplementedError()
 
@@ -1236,8 +1236,8 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
             StatusCode.OK.
 
         Raises:
-          Exception: An exception is always raised to signal the abortion the
-            RPC to the gRPC runtime.
+          Exception: An exception is always raised to signal the abortion of
+            the RPC to the gRPC runtime.
         """
         raise NotImplementedError()
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -29,6 +29,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    NoReturn,
     Optional,
     Sequence,
     Set,
@@ -389,7 +390,7 @@ class _Context(grpc.ServicerContext):
     def trailing_metadata(self) -> Optional[MetadataType]:
         return self._state.trailing_metadata
 
-    def abort(self, code: grpc.StatusCode, details: str) -> None:
+    def abort(self, code: grpc.StatusCode, details: str) -> NoReturn:
         # treat OK like other invalid arguments: fail the RPC
         if code == grpc.StatusCode.OK:
             _LOGGER.error(
@@ -403,7 +404,7 @@ class _Context(grpc.ServicerContext):
             self._state.aborted = True
             raise Exception()
 
-    def abort_with_status(self, status: grpc.Status) -> None:
+    def abort_with_status(self, status: grpc.Status) -> NoReturn:
         self._state.trailing_metadata = status.trailing_metadata
         self.abort(status.code, status.details)
 

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -197,9 +197,27 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
             :term:`metadata`.
 
         Raises:
-          Exception: An exception is always raised to signal the abortion the
-            RPC to the gRPC runtime.
+          Exception: An exception is always raised to signal the abortion of
+            the RPC to the gRPC runtime.
         """
+
+    async def abort_with_status(self, status: grpc.Status) -> NoReturn:
+        """Raises an exception to terminate the RPC with a non-OK status.
+
+        The status passed as argument will supercede any existing status code,
+        status message and trailing metadata.
+
+        This is an EXPERIMENTAL API.
+
+        Args:
+          status: A grpc.Status object. The status code in it must not be
+            StatusCode.OK.
+
+        Raises:
+          Exception: An exception is always raised to signal the abortion of
+            the RPC to the gRPC runtime.
+        """
+        await self.abort(status.code, status.details, status.trailing_metadata)
 
     @abc.abstractmethod
     def set_trailing_metadata(self, trailing_metadata: MetadataType) -> None:


### PR DESCRIPTION
This method is present on grpc.ServicerContext, but is missing on the asynchronous context.

Fixes #27970
