### PR TITLE
[EventEngine] Always finish ExecCtx execution in FinishPendingWrite before unreffing

### DIFF
--- a/src/core/lib/iomgr/event_engine_shims/endpoint.cc
+++ b/src/core/lib/iomgr/event_engine_shims/endpoint.cc
@@ -175,12 +175,10 @@ class EventEngineEndpointWrapper {
     }
     grpc_closure* cb = pending_write_cb_;
     pending_write_cb_ = nullptr;
-    if (grpc_core::ExecCtx::Get() == nullptr) {
+    {
       grpc_core::ApplicationCallbackExecCtx app_ctx;
       grpc_core::ExecCtx exec_ctx;
       grpc_core::ExecCtx::Run(DEBUG_LOCATION, cb, status);
-    } else {
-      grpc_core::Closure::Run(DEBUG_LOCATION, cb, status);
     }
     // For the ref taken in EventEngineEndpointWrapper::Write().
     Unref();


### PR DESCRIPTION
This ensures that all nested calls to ExecCtx::Run from within the `Write` callback are executed before the endpoint shim is unreffed. This allows ExecCtx to exist along the async write path, which would otherwise lead to race conditions.