### PR TITLE
[PSM Interop] Fixes server language check with urlmap.timeout_test

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/url_map/timeout_test.py
@@ -89,7 +89,7 @@ class TestTimeoutInRouteRule(_BaseXdsTimeOutTestCase):
     def is_supported(config: skips.TestConfig) -> bool:
         # TODO(lidiz) either add support for rpc-behavior to other languages, or we
         # should always use Java server as backend.
-        if config.server_lang != "java":
+        if config.server_lang != skips.Lang.JAVA:
             return False
         if config.client_lang == skips.Lang.NODE:
             return config.version_gte("v1.4.x")
@@ -128,7 +128,7 @@ class TestTimeoutInApplication(_BaseXdsTimeOutTestCase):
     def is_supported(config: skips.TestConfig) -> bool:
         # TODO(lidiz) either add support for rpc-behavior to other languages, or we
         # should always use Java server as backend.
-        if config.server_lang != "java":
+        if config.server_lang != skips.Lang.JAVA:
             return False
         if config.client_lang == skips.Lang.NODE:
             return config.version_gte("v1.4.x")


### PR DESCRIPTION
The tests are skipped incorrectly because `config.server_lang` is incorrectly compared with the string value "java", instead of `skips.Lang.JAVA`.

This has been broken since #26998. 

```
xds_url_map_testcase.py:372] ----- Testing TestTimeoutInRouteRule -----
xds_url_map_testcase.py:373] Logs timezone: UTC
skips.py:121] Skipping TestConfig(client_lang='java', server_lang='java', version='v1.57.x')
[  SKIPPED ] setUpClass (timeout_test.TestTimeoutInRouteRule)
xds_url_map_testcase.py:372] ----- Testing TestTimeoutInApplication -----
xds_url_map_testcase.py:373] Logs timezone: UTC
skips.py:121] Skipping TestConfig(client_lang='java', server_lang='java', version='v1.57.x')
[  SKIPPED ] setUpClass (timeout_test.TestTimeoutInApplication)
```
