### PR TITLE
[ruby] Fix linking errors on x86-darwin

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -142,7 +142,7 @@ end
 ext_export_file = File.join(grpc_root, 'src', 'ruby', 'ext', 'grpc', ext_export_filename())
 $LDFLAGS << ' -Wl,--version-script="' + ext_export_file + '.gcc"' if linux
 if apple_toolchain
-  $LDFLAGS << ' -weak_framework CoreFoundation' if RUBY_PLATFORM =~ /arm64/
+  $LDFLAGS << ' -weak_framework CoreFoundation'
   $LDFLAGS << ' -Wl,-exported_symbols_list,"' + ext_export_file + '.clang"'
 end
 


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/33538 added `-weak_framework CoreFoundation` in `DLDFLAGS` for only `arm64-darwin` builds, but the issue reported in https://github.com/grpc/grpc/issues/33483 can also happen on `x86-darwin` builds. This can happen if:

1. The Ruby interpreter is compiled without `-Wl,-undefined,dynamic_lookup`.
2. This happens if the Ruby interpreter is built with XCode 14.0 to 14.2 (https://bugs.ruby-lang.org/issues/19005).

Simplify the logic and always include `-weak_framework CoreFoundation` for macOS builds.

