### PR TITLE
[EventEngine] Wake thread pool workers on locally queued work

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -180,9 +180,11 @@ void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Run(
   GPR_DEBUG_ASSERT(quiesced_.load(std::memory_order_relaxed) == false);
   if (g_local_queue != nullptr) {
     g_local_queue->Add(closure);
-    return;
+  } else {
+    queue_.Add(closure);
   }
-  queue_.Add(closure);
+  // Signal a worker in any case, even if work was added to a local queue. This
+  // improves performance on 32-core streaming benchmarks with small payloads.
   work_signal_.Signal();
 }
 


### PR DESCRIPTION
This WorkStealingThreadPool change improves the (lagging) `cpp_protobuf_async_streaming_qps_unconstrained_secure` 32-core benchmark.

Baseline OriginalThreadPool QPS: 830k
Previous average WorkStealingThreadPool QPS: 755k
New WorkStealingThreadPool average (2 runs) QPS: 850k