### PR TITLE
[benchmark] Remove work_stealing experiment benchmark

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
@@ -17,7 +17,7 @@ set -ex
 # Purpose: Run the C++ "dashboard" benchmarks for a set of gRPC-core experiments.
 #
 # To run the benchmarks, add your experiment to the set below.
-GRPC_EXPERIMENTS=("event_engine_listener" "work_stealing" "event_engine_listener,work_stealing")
+GRPC_EXPERIMENTS=("event_engine_listener" "event_engine_listener,work_stealing")
 
 # Enter the gRPC repo root.
 cd "$(dirname "$0")/../../.."


### PR DESCRIPTION
The `work_stealing` experiment on its own is not very valuable, so let's delete it and save CI resources. We have a benchmark for `GRPC_EXPERIMENTS=event_engine_listener,work_stealing`, which is really what we care about right now.