### PR TITLE
Enable xDS custom LB interop tests for Node

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/custom_lb_test.py
@@ -59,6 +59,8 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             return config.version_gte("v1.55.x")
         if config.client_lang == _Lang.GO:
             return config.version_gte("v1.56.x")
+        if config.client_lang == _Lang.NODE:
+            return config.version_gte("v1.10.x")
         return False
 
     def test_custom_lb_config(self):


### PR DESCRIPTION
v1.10.x is the next version, so this will only run on master for now. This won't work until grpc/grpc-node#2555 is merged.