### PR TITLE
[logging-filter] Work around bug in promise_based_filter destruction

### DIFF
--- a/src/core/ext/filters/logging/logging_filter.cc
+++ b/src/core/ext/filters/logging/logging_filter.cc
@@ -433,13 +433,15 @@ class ClientLoggingFilter final : public ChannelFilter {
                   md.get());
               return md;
             }),
-        [calld]() {
+        // TODO(yashykt/ctiller): GetContext<grpc_call_context_element> is not
+        // valid for the cancellation function requiring us to capture it here.
+        // This ought to be easy to fix once client side promises are completely
+        // rolled out.
+        [calld, ctx = GetContext<grpc_call_context_element>()]() {
           calld->LogCancel(
               /*is_client=*/true,
               static_cast<CallTracerAnnotationInterface*>(
-                  GetContext<grpc_call_context_element>()
-                      [GRPC_CONTEXT_CALL_TRACER_ANNOTATION_INTERFACE]
-                          .value));
+                  ctx[GRPC_CONTEXT_CALL_TRACER_ANNOTATION_INTERFACE].value));
         });
   }
 


### PR DESCRIPTION
Fixes internal b/297030898.

This ought not be necessary, but getting context from the promise based filter wrapper code at call destruction is unwieldy.

Hacking around it here and fixing it properly post client rollout seems wiser.