### PR TITLE
Make the code generator pointer mutable in PluginMain

### DIFF
--- a/src/compiler/config.h
+++ b/src/compiler/config.h
@@ -41,7 +41,7 @@ namespace compiler {
 typedef GRPC_CUSTOM_CODEGENERATOR CodeGenerator;
 typedef GRPC_CUSTOM_GENERATORCONTEXT GeneratorContext;
 static inline int PluginMain(int argc, char* argv[],
-                             const CodeGenerator* generator) {
+                             CodeGenerator* generator) {
   return GRPC_CUSTOM_PLUGINMAIN(argc, argv, generator);
 }
 static inline void ParseGeneratorParameter(


### PR DESCRIPTION
This will allow us to pass some extra initialization information from the protobuf plugin code before the build actually starts

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

