### PR TITLE
Add __init__.py to xds-protos to make up for lack of transitive importing

### DIFF
--- a/tools/distrib/python/xds_protos/README.rst
+++ b/tools/distrib/python/xds_protos/README.rst
@@ -4,6 +4,9 @@ Each generated Python file can be imported according to their proto package. For
 
 ::
 
+  # Populate symbol db
+  import xds_protos
+
   # Import the message definitions
   from envoy.service.status.v3 import csds_pb2
   # Import the gRPC service and stub

--- a/tools/distrib/python/xds_protos/build.py
+++ b/tools/distrib/python/xds_protos/build.py
@@ -55,7 +55,7 @@ WELL_KNOWN_PROTOS_INCLUDE = pkg_resources.resource_filename(
 OUTPUT_PATH = WORK_DIR
 
 # Prepare the test file generation
-TEST_FILE_NAME = "generated_file_import_test.py"
+INIT_FILE_NAME = "__init__.py"
 TEST_IMPORTS = []
 
 # The pkgutil-style namespace packaging __init__.py
@@ -162,13 +162,14 @@ def main():
         "validate",
         "xds",
         "opentelemetry",
+        "contrib",
     ]:
         for root, _, _ in os.walk(os.path.join(WORK_DIR, proto_root_module)):
             package_path = os.path.relpath(root, WORK_DIR)
             create_init_file(root, package_path)
 
     # Generate test file
-    with open(os.path.join(WORK_DIR, TEST_FILE_NAME), "w") as f:
+    with open(os.path.join(WORK_DIR, INIT_FILE_NAME), "w") as f:
         f.writelines(TEST_IMPORTS)
 
 

--- a/tools/distrib/python/xds_protos/build_validate_upload.sh
+++ b/tools/distrib/python/xds_protos/build_validate_upload.sh
@@ -30,7 +30,7 @@ python3 setup.py bdist_wheel
 pushd $(mktemp -d '/tmp/test_xds_protos.XXXXXX')
 python3 -m virtualenv env
 env/bin/python -m pip install ${WORK_DIR}/dist/*.whl
-cp ${WORK_DIR}/generated_file_import_test.py generated_file_import_test.py
+cp ${WORK_DIR}/__init__.py generated_file_import_test.py
 env/bin/python generated_file_import_test.py
 popd
 

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -30,7 +30,7 @@ EXCLUDE_PYTHON_FILES = ["generated_file_import_test.py", "build.py"]
 # Use setuptools to build Python package
 with open(os.path.join(WORK_DIR, "README.rst"), "r") as f:
     LONG_DESCRIPTION = f.read()
-PACKAGES = setuptools.find_packages(where=".", exclude=EXCLUDE_PYTHON_FILES)
+PACKAGES = ["."] + setuptools.find_packages(where=".", exclude=EXCLUDE_PYTHON_FILES)
 CLASSIFIERS = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",


### PR DESCRIPTION
We ran into issues serializing Any protos in xDS interop tests after the upgrade. This offers an easy entrypoint for populating the protobuf symbol db.