### PR TITLE
[Ruby] replace strdup with gpr_strdup

### DIFF
--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -24,7 +24,9 @@
 #include "rb_grpc_imports.generated.h"
 
 #include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
+#include <grpc/support/string_util.h>
 
 static rb_data_type_t grpc_rb_channel_args_data_type = {
     "grpc_channel_args",
@@ -74,14 +76,14 @@ static int grpc_rb_channel_create_in_process_add_args_hash_cb(VALUE key,
     case T_SYMBOL:
       args->args[args->num_args - 1].type = GRPC_ARG_STRING;
       args->args[args->num_args - 1].value.string =
-          strdup(rb_id2name(SYM2ID(val)));
+          gpr_strdup(rb_id2name(SYM2ID(val)));
       --args->num_args;
       return ST_CONTINUE;
 
     case T_STRING:
       args->args[args->num_args - 1].type = GRPC_ARG_STRING;
       args->args[args->num_args - 1].value.string =
-          strdup(StringValueCStr(val));
+          gpr_strdup(StringValueCStr(val));
       --args->num_args;
       return ST_CONTINUE;
 
@@ -162,8 +164,8 @@ void grpc_rb_channel_args_destroy(grpc_channel_args* args) {
   if (args->args == NULL) return;
   for (int i = 0; i < args->num_args; i++) {
     if (args->args[i].type == GRPC_ARG_STRING) {
-      // we own string pointers, which were created with strdup
-      free(args->args[i].value.string);
+      // we own string pointers, which were created with gpr_strdup
+      gpr_free(args->args[i].value.string);
     }
   }
   xfree(args->args);


### PR DESCRIPTION
grpc 1.57.0 crashes win ruby and alpine due to no `strdup` in musl libc.
This diff replace `strdup` with `grp_strdup`

```
Thread 1 "ruby" received signal SIGSEGV, Segmentation fault.
0x00000000000a4596 in ?? ()
(gdb) bt
#0  0x00000000000a4596 in ?? ()
#1  0x00007ffff14e298c in grpc_rb_channel_create_in_process_add_args_hash_cb (key=<optimized out>, val=<optimized out>, args_obj=<optimized out>) at rb_channel_args.c:84
#2  0x00007ffff7c2b9ea in hash_ar_foreach_iter (error=0, argp=140737488344784, value=<optimized out>, key=<optimized out>) at hash.c:1341
```

fixes #34044
closes #27995