### PR TITLE
[PMS Interop] Don't run PSM Interop GH action against version branches

### DIFF
--- a/.github/workflows/psm-interop.yaml
+++ b/.github/workflows/psm-interop.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - 'v1.*'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adding the version branches was an oversight: we always use the framework from the main branch.