### PR TITLE
[c-ares] fix spin loop bug when c-ares gives up on a socket that still has data left in its read buffer

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -236,7 +236,6 @@ void AresClientChannelDNSResolver::AresRequestWrapper::OnHostnameResolved(
     MutexLock lock(&self->on_resolved_mu_);
     self->hostname_request_.reset();
     result = self->OnResolvedLocked(error);
-    gpr_log(GPR_DEBUG, "apolcyn result.addresses: %s", result->addresses.status().ToString().c_str());
   }
   if (result.has_value()) {
     self->resolver_->OnRequestComplete(std::move(*result));
@@ -298,9 +297,6 @@ AresClientChannelDNSResolver::AresRequestWrapper::OnResolvedLocked(
   // and service config independently of each other.
   if (addresses_ != nullptr || balancer_addresses_ != nullptr) {
     if (addresses_ != nullptr) {
-      for (int i = 0; i < addresses_->size(); i++) {
-        gpr_log(GPR_DEBUG, "apolcyn OnResolved addresses_[%d]: %s", i, (*addresses_)[i].ToString().c_str());
-      }
       result.addresses = std::move(*addresses_);
     } else {
       result.addresses = ServerAddressList();

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -236,6 +236,7 @@ void AresClientChannelDNSResolver::AresRequestWrapper::OnHostnameResolved(
     MutexLock lock(&self->on_resolved_mu_);
     self->hostname_request_.reset();
     result = self->OnResolvedLocked(error);
+    gpr_log(GPR_DEBUG, "apolcyn result.addresses: %s", result->addresses.status().ToString().c_str());
   }
   if (result.has_value()) {
     self->resolver_->OnRequestComplete(std::move(*result));
@@ -297,6 +298,9 @@ AresClientChannelDNSResolver::AresRequestWrapper::OnResolvedLocked(
   // and service config independently of each other.
   if (addresses_ != nullptr || balancer_addresses_ != nullptr) {
     if (addresses_ != nullptr) {
+      for (int i = 0; i < addresses_->size(); i++) {
+        gpr_log(GPR_DEBUG, "apolcyn OnResolved addresses_[%d]: %s", i, (*addresses_)[i].ToString().c_str());
+      }
       result.addresses = std::move(*addresses_);
     } else {
       result.addresses = ServerAddressList();

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -366,10 +366,7 @@ static void on_readable(void* arg, grpc_error_handle error) {
   GRPC_CARES_TRACE_LOG("request:%p readable on %s", fdn->ev_driver->request,
                        fdn->grpc_polled_fd->GetName());
   if (error.ok() && !ev_driver->shutting_down) {
-    do {
-      gpr_log(GPR_INFO, "apolcyn on_readable shutdown: %d", ev_driver->shutting_down);
-      ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
-    } while (fdn->grpc_polled_fd->IsFdStillReadableLocked());
+    ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
   } else {
     // If error is not absl::OkStatus() or the resolution was cancelled, it
     // means the fd has been shutdown or timed out. The pending lookups made on
@@ -411,6 +408,7 @@ static void on_writable(void* arg, grpc_error_handle error) {
 // driver_closure with these filedescriptors.
 static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(&grpc_ares_request::mu) {
+  gpr_log(GPR_INFO, "apolcyn notify on event locked shutting down: %d", ev_driver->shutting_down);
   fd_node* new_list = nullptr;
   if (!ev_driver->shutting_down) {
     ares_socket_t socks[ARES_GETSOCK_MAXNUM];
@@ -439,12 +437,21 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver)
         if (ARES_GETSOCK_READABLE(socks_bitmask, i) &&
             !fdn->readable_registered) {
           grpc_ares_ev_driver_ref(ev_driver);
-          GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
-                               ev_driver->request,
-                               fdn->grpc_polled_fd->GetName());
           GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable, fdn,
                             grpc_schedule_on_exec_ctx);
-          fdn->grpc_polled_fd->RegisterForOnReadableLocked(&fdn->read_closure);
+          if (fdn->grpc_polled_fd->IsFdStillReadableLocked()) {
+            GRPC_CARES_TRACE_LOG("request:%p schedule direct read on: %s",
+                                 ev_driver->request,
+                                 fdn->grpc_polled_fd->GetName());
+            grpc_core::ExecCtx::Run(DEBUG_LOCATION, &fdn->read_closure,
+                                    absl::OkStatus());
+          } else {
+            GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
+                                 ev_driver->request,
+                                 fdn->grpc_polled_fd->GetName());
+            fdn->grpc_polled_fd->RegisterForOnReadableLocked(
+                &fdn->read_closure);
+          }
           fdn->readable_registered = true;
         }
         // Register write_closure if the socket is writable and write_closure
@@ -606,6 +613,7 @@ static void grpc_ares_request_unref_locked(grpc_ares_request* r)
 void grpc_ares_complete_request_locked(grpc_ares_request* r)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(r->mu) {
   // Invoke on_done callback and destroy the request
+  gpr_log(GPR_DEBUG, "apolcyn complete request"); 
   r->ev_driver = nullptr;
   if (r->addresses_out != nullptr && *r->addresses_out != nullptr) {
     grpc_cares_wrapper_address_sorting_sort(r, r->addresses_out->get());

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -443,7 +443,7 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver)
                                  ev_driver->request,
                                  fdn->grpc_polled_fd->GetName());
             grpc_core::ExecCtx::Run(DEBUG_LOCATION, &fdn->read_closure,
-                                    GRPC_ERROR_NONE);
+                                    absl::OkStatus());
           } else {
             GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
                                  ev_driver->request,

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -408,7 +408,6 @@ static void on_writable(void* arg, grpc_error_handle error) {
 // driver_closure with these filedescriptors.
 static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(&grpc_ares_request::mu) {
-  gpr_log(GPR_INFO, "apolcyn notify on event locked shutting down: %d", ev_driver->shutting_down);
   fd_node* new_list = nullptr;
   if (!ev_driver->shutting_down) {
     ares_socket_t socks[ARES_GETSOCK_MAXNUM];
@@ -613,7 +612,6 @@ static void grpc_ares_request_unref_locked(grpc_ares_request* r)
 void grpc_ares_complete_request_locked(grpc_ares_request* r)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(r->mu) {
   // Invoke on_done callback and destroy the request
-  gpr_log(GPR_DEBUG, "apolcyn complete request"); 
   r->ev_driver = nullptr;
   if (r->addresses_out != nullptr && *r->addresses_out != nullptr) {
     grpc_cares_wrapper_address_sorting_sort(r, r->addresses_out->get());

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -366,9 +366,7 @@ static void on_readable(void* arg, grpc_error_handle error) {
   GRPC_CARES_TRACE_LOG("request:%p readable on %s", fdn->ev_driver->request,
                        fdn->grpc_polled_fd->GetName());
   if (error.ok() && !ev_driver->shutting_down) {
-    do {
-      ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
-    } while (fdn->grpc_polled_fd->IsFdStillReadableLocked());
+    ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
   } else {
     // If error is not absl::OkStatus() or the resolution was cancelled, it
     // means the fd has been shutdown or timed out. The pending lookups made on
@@ -438,12 +436,21 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver)
         if (ARES_GETSOCK_READABLE(socks_bitmask, i) &&
             !fdn->readable_registered) {
           grpc_ares_ev_driver_ref(ev_driver);
-          GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
-                               ev_driver->request,
-                               fdn->grpc_polled_fd->GetName());
           GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable, fdn,
                             grpc_schedule_on_exec_ctx);
-          fdn->grpc_polled_fd->RegisterForOnReadableLocked(&fdn->read_closure);
+          if (fdn->grpc_polled_fd->IsFdStillReadableLocked()) {
+            GRPC_CARES_TRACE_LOG("request:%p schedule direct read on: %s",
+                                 ev_driver->request,
+                                 fdn->grpc_polled_fd->GetName());
+            grpc_core::ExecCtx::Run(DEBUG_LOCATION, &fdn->read_closure,
+                                    GRPC_ERROR_NONE);
+          } else {
+            GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
+                                 ev_driver->request,
+                                 fdn->grpc_polled_fd->GetName());
+            fdn->grpc_polled_fd->RegisterForOnReadableLocked(
+                &fdn->read_closure);
+          }
           fdn->readable_registered = true;
         }
         // Register write_closure if the socket is writable and write_closure

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -366,7 +366,10 @@ static void on_readable(void* arg, grpc_error_handle error) {
   GRPC_CARES_TRACE_LOG("request:%p readable on %s", fdn->ev_driver->request,
                        fdn->grpc_polled_fd->GetName());
   if (error.ok() && !ev_driver->shutting_down) {
-    ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
+    do {
+      gpr_log(GPR_INFO, "apolcyn on_readable shutdown: %d", ev_driver->shutting_down);
+      ares_process_fd(ev_driver->channel, as, ARES_SOCKET_BAD);
+    } while (fdn->grpc_polled_fd->IsFdStillReadableLocked());
   } else {
     // If error is not absl::OkStatus() or the resolution was cancelled, it
     // means the fd has been shutdown or timed out. The pending lookups made on
@@ -436,21 +439,12 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver)
         if (ARES_GETSOCK_READABLE(socks_bitmask, i) &&
             !fdn->readable_registered) {
           grpc_ares_ev_driver_ref(ev_driver);
+          GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
+                               ev_driver->request,
+                               fdn->grpc_polled_fd->GetName());
           GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable, fdn,
                             grpc_schedule_on_exec_ctx);
-          if (fdn->grpc_polled_fd->IsFdStillReadableLocked()) {
-            GRPC_CARES_TRACE_LOG("request:%p schedule direct read on: %s",
-                                 ev_driver->request,
-                                 fdn->grpc_polled_fd->GetName());
-            grpc_core::ExecCtx::Run(DEBUG_LOCATION, &fdn->read_closure,
-                                    absl::OkStatus());
-          } else {
-            GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
-                                 ev_driver->request,
-                                 fdn->grpc_polled_fd->GetName());
-            fdn->grpc_polled_fd->RegisterForOnReadableLocked(
-                &fdn->read_closure);
-          }
+          fdn->grpc_polled_fd->RegisterForOnReadableLocked(&fdn->read_closure);
           fdn->readable_registered = true;
         }
         // Register write_closure if the socket is writable and write_closure

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -213,8 +213,6 @@ FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer(int bytes_received_size,
 FakeUdpAndTcpServer::ProcessReadResult
 FakeUdpAndTcpServer::SendThreeAllZeroBytes(int bytes_received_size,
                                            int read_error, int s) {
-  gpr_log(GPR_DEBUG,
-          "apolcyn here");
   if (bytes_received_size < 0 && !ErrorIsRetryable(read_error)) {
     gpr_log(GPR_ERROR, "Read failed from peer socket: %d. errno: %d", s,
             read_error);
@@ -223,7 +221,8 @@ FakeUdpAndTcpServer::SendThreeAllZeroBytes(int bytes_received_size,
   char buf[3] = {0, 0, 0};
   int bytes_sent = send(s, buf, sizeof(buf), 0);
   gpr_log(GPR_DEBUG,
-          "Fake TCP server sent %d bytes {%x, %x, %x} on peer socket: %d.", bytes_sent, buf[0], buf[1], buf[2], s);
+          "Fake TCP server sent %d all-zero bytes on peer socket: %d.",
+          bytes_sent, s);
   return FakeUdpAndTcpServer::ProcessReadResult::kCloseSocket;
 }
 

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -224,7 +224,7 @@ FakeUdpAndTcpServer::SendBytesUntilPeerCloses(int bytes_received_size,
   int bytes_sent = send(s, buf, sizeof(buf), 0);
   gpr_log(GPR_DEBUG,
           "Fake TCP server sent %d bytes {%x, %x, %x} on peer socket: %d.", bytes_sent, buf[0], buf[1], buf[2], s);
-  return FakeUdpAndTcpServer::ProcessReadResult::kContinueReading;
+  return FakeUdpAndTcpServer::ProcessReadResult::kCloseSocket;
 }
 
 FakeUdpAndTcpServer::FakeUdpAndTcpServerPeer::FakeUdpAndTcpServerPeer(int fd)

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -210,6 +210,36 @@ FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer(int bytes_received_size,
   return FakeUdpAndTcpServer::ProcessReadResult::kContinueReading;
 }
 
+FakeUdpAndTcpServer::Send1ByteAfterDelay(
+    FakeUdpAndTcpServer::FakeUdpAndTcpServerPeer* peer, int bytes_received_size, int read_error) {
+  if (bytes_received_size < 0 && !ErrorIsRetryable(read_error)) {
+    gpr_log(GPR_ERROR, "Failed to receive from peer socket: %d. errno: %d", s,
+            read_error);
+    GPR_ASSERT(0);
+  }
+  if (bytes_received_size >= 0) {
+    gpr_log(GPR_DEBUG,
+            "Fake TCP server received %d bytes from peer socket: %d. Close "
+            "the "
+            "connection.",
+            bytes_received_size, peer->fd());
+    if (!bytes_received_.has_value()) {
+      bytes_received_ = absl::Now();
+    }
+  }
+  if (bytes_received_.has_value()) {
+    if (absl::Now() - *bytes_received_ > absl::Seconds(10)) {
+      GPR_ASSERT(total_bytes_sent_ == 0);
+      char buf[1] = {0};
+      total_bytes_sent = send(peer->fd(), buf, 1, 0);
+      if (total_bytes_sent == 1) {
+        return FakeUdpAndTcpServer::ProcessReadResult::kCloseSocket;
+      }
+    }
+  }
+  return FakeUdpAndTcpServer::ProcessReadResult::kContinueReading;
+}
+
 FakeUdpAndTcpServer::FakeUdpAndTcpServerPeer::FakeUdpAndTcpServerPeer(int fd)
     : fd_(fd) {}
 
@@ -282,7 +312,7 @@ void FakeUdpAndTcpServer::RunServerLoop() {
       char buf[100];
       int bytes_received_size = recv(peer->fd(), buf, 100, 0);
       FakeUdpAndTcpServer::ProcessReadResult r =
-          process_read_cb_(bytes_received_size, ERRNO, peer->fd());
+          process_read_cb_(peer, bytes_received_size, ERRNO);
       if (r == FakeUdpAndTcpServer::ProcessReadResult::kCloseSocket) {
         it = peers.erase(it);
       } else {

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -214,8 +214,14 @@ FakeUdpAndTcpServer::ProcessReadResult
 FakeUdpAndTcpServer::SendThreeAllZeroBytes(int bytes_received_size,
                                            int read_error, int s) {
   if (bytes_received_size < 0 && !ErrorIsRetryable(read_error)) {
-    gpr_log(GPR_ERROR, "Read failed from peer socket: %d. errno: %d", s,
+    gpr_log(GPR_ERROR, "Failed to receive from peer socket: %d. errno: %d", s,
             read_error);
+    GPR_ASSERT(0);
+  }
+  if (bytes_received_size == 0) {
+    // The peer has shut down the connection.
+    gpr_log(GPR_DEBUG, "Fake TCP server received 0 bytes from peer socket: %d.",
+            s);
     return FakeUdpAndTcpServer::ProcessReadResult::kCloseSocket;
   }
   char buf[3] = {0, 0, 0};

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -223,7 +223,7 @@ FakeUdpAndTcpServer::SendBytesUntilPeerCloses(int bytes_received_size,
   char buf[3] = {0, 0, 0};
   int bytes_sent = send(s, buf, sizeof(buf), 0);
   gpr_log(GPR_DEBUG,
-          "Fake TCP server sent %d bytes on peer socket: %d.", bytes_sent, s);
+          "Fake TCP server sent %d bytes {%x, %x, %x} on peer socket: %d.", bytes_sent, buf[0], buf[1], buf[2], s);
   return FakeUdpAndTcpServer::ProcessReadResult::kContinueReading;
 }
 

--- a/test/core/util/fake_udp_and_tcp_server.cc
+++ b/test/core/util/fake_udp_and_tcp_server.cc
@@ -211,8 +211,8 @@ FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer(int bytes_received_size,
 }
 
 FakeUdpAndTcpServer::ProcessReadResult
-FakeUdpAndTcpServer::SendBytesUntilPeerCloses(int bytes_received_size,
-                                              int read_error, int s) {
+FakeUdpAndTcpServer::SendThreeAllZeroBytes(int bytes_received_size,
+                                           int read_error, int s) {
   gpr_log(GPR_DEBUG,
           "apolcyn here");
   if (bytes_received_size < 0 && !ErrorIsRetryable(read_error)) {
@@ -298,7 +298,6 @@ void FakeUdpAndTcpServer::RunServerLoop() {
       }
       char buf[100];
       int bytes_received_size = recv(peer->fd(), buf, 100, 0);
-      gpr_log(GPR_ERROR, "apolcyn recv on conn");
       FakeUdpAndTcpServer::ProcessReadResult r =
           process_read_cb_(bytes_received_size, ERRNO, peer->fd());
       if (r == FakeUdpAndTcpServer::ProcessReadResult::kCloseSocket) {

--- a/test/core/util/fake_udp_and_tcp_server.h
+++ b/test/core/util/fake_udp_and_tcp_server.h
@@ -96,6 +96,9 @@ class FakeUdpAndTcpServer {
   static ProcessReadResult CloseSocketUponCloseFromPeer(int bytes_received_size,
                                                         int read_error, int s);
 
+  static ProcessReadResult Send1ByteAfterDelay(int bytes_received_size,
+                                               int read_error, int s);
+
   void ReadFromUdpSocket();
 
   // Run a loop that periodically, every 10 ms:
@@ -118,6 +121,7 @@ class FakeUdpAndTcpServer {
    private:
     int fd_;
     int total_bytes_sent_ = 0;
+    absl::optional<absl::Time> bytes_received_;
   };
 
   int accept_socket_;

--- a/test/core/util/fake_udp_and_tcp_server.h
+++ b/test/core/util/fake_udp_and_tcp_server.h
@@ -96,8 +96,8 @@ class FakeUdpAndTcpServer {
   static ProcessReadResult CloseSocketUponCloseFromPeer(int bytes_received_size,
                                                         int read_error, int s);
 
-  static ProcessReadResult SendBytesUntilPeerCloses(int bytes_received_size,
-                                                    int read_error, int s);
+  static ProcessReadResult SendThreeAllZeroBytes(int bytes_received_size,
+                                                 int read_error, int s);
 
   void ReadFromUdpSocket();
 

--- a/test/core/util/fake_udp_and_tcp_server.h
+++ b/test/core/util/fake_udp_and_tcp_server.h
@@ -96,6 +96,9 @@ class FakeUdpAndTcpServer {
   static ProcessReadResult CloseSocketUponCloseFromPeer(int bytes_received_size,
                                                         int read_error, int s);
 
+  static ProcessReadResult SendBytesUntilPeerCloses(int bytes_received_size,
+                                                    int read_error, int s);
+
   void ReadFromUdpSocket();
 
   // Run a loop that periodically, every 10 ms:

--- a/test/core/util/fake_udp_and_tcp_server.h
+++ b/test/core/util/fake_udp_and_tcp_server.h
@@ -96,9 +96,6 @@ class FakeUdpAndTcpServer {
   static ProcessReadResult CloseSocketUponCloseFromPeer(int bytes_received_size,
                                                         int read_error, int s);
 
-  static ProcessReadResult Send1ByteAfterDelay(int bytes_received_size,
-                                               int read_error, int s);
-
   void ReadFromUdpSocket();
 
   // Run a loop that periodically, every 10 ms:
@@ -121,7 +118,6 @@ class FakeUdpAndTcpServer {
    private:
     int fd_;
     int total_bytes_sent_ = 0;
-    absl::optional<absl::Time> bytes_received_;
   };
 
   int accept_socket_;

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -286,10 +286,10 @@ void TestCancelDuringActiveQuery(
     grpc_status_code expected_status_code,
     absl::string_view expected_error_message_substring,
     gpr_timespec rpc_deadline, int dns_query_timeout_ms,
-    int /*fake_dns_server_port*/) {
+    int fake_dns_server_port) {
   // Create a call that will try to use the fake DNS server
   std::string client_target =
-      absl::StrFormat("dns:///%s", kFakeName);
+      absl::StrFormat("dns://[::1]:%d/%s", fake_dns_server_port, kFakeName);
   grpc_channel_args* client_args = nullptr;
   if (dns_query_timeout_ms >= 0) {
     grpc_arg arg;
@@ -366,135 +366,110 @@ void TestCancelDuringActiveQuery(
   EndTest(client, cq);
 }
 
-TEST_F(CancelDuringAresQuery,
-       TestHitDeadlineAndDestroyChannelDuringAresResolutionIsGraceful) {
-  grpc_core::testing::SocketUseAfterCloseDetector
-      socket_use_after_close_detector;
-  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
-      grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
-          kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
-  grpc_status_code expected_status_code = GRPC_STATUS_DEADLINE_EXCEEDED;
-  // The RPC deadline should go off well before the DNS resolution
-  // timeout fires.
-  gpr_timespec rpc_deadline = grpc_timeout_milliseconds_to_deadline(100);
-  int dns_query_timeout_ms = -1;  // don't set query timeout
-  TestCancelDuringActiveQuery(
-      expected_status_code, "" /* expected error message substring */,
-      rpc_deadline, dns_query_timeout_ms, fake_dns_server.port());
-}
-
-TEST_F(
-    CancelDuringAresQuery,
-    TestHitDeadlineAndDestroyChannelDuringAresResolutionWithQueryTimeoutIsGraceful) {
-  grpc_core::testing::SocketUseAfterCloseDetector
-      socket_use_after_close_detector;
-  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
-      grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
-          kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
-  grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
-  std::string expected_error_message_substring;
-  if (grpc_core::IsEventEngineDnsEnabled()) {
-    expected_error_message_substring =
-        absl::StrCat("errors resolving ", kFakeName);
-  } else {
-    expected_error_message_substring =
-        absl::StrCat("DNS resolution failed for ", kFakeName);
-  }
-  // The DNS resolution timeout should fire well before the
-  // RPC's deadline expires.
-  gpr_timespec rpc_deadline = grpc_timeout_seconds_to_deadline(10);
-  int dns_query_timeout_ms = 1;
-  TestCancelDuringActiveQuery(expected_status_code,
-                              expected_error_message_substring, rpc_deadline,
-                              dns_query_timeout_ms, fake_dns_server.port());
-}
-
-TEST_F(
-    CancelDuringAresQuery,
-    TestHitDeadlineAndDestroyChannelDuringAresResolutionWithZeroQueryTimeoutIsGraceful) {
-  grpc_core::testing::SocketUseAfterCloseDetector
-      socket_use_after_close_detector;
-  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
-      grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
-          kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
-  grpc_status_code expected_status_code = GRPC_STATUS_DEADLINE_EXCEEDED;
-  // The RPC deadline should go off well before the DNS resolution
-  // timeout fires.
-  gpr_timespec rpc_deadline = grpc_timeout_milliseconds_to_deadline(100);
-  int dns_query_timeout_ms = 0;  // disable query timeouts
-  TestCancelDuringActiveQuery(
-      expected_status_code, "" /* expected error message substring */,
-      rpc_deadline, dns_query_timeout_ms, fake_dns_server.port());
-}
-
-TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
-  grpc_core::testing::SocketUseAfterCloseDetector
-      socket_use_after_close_detector;
-  // Use a fake TCP server that immediately closes the socket and causes
-  // c-ares to pick up a socket read error, while the previous socket
-  // connect/writes succeeded. Meanwhile, force c-ares to only use TCP.
-  // The goal is to hit a socket use-after-close bug described in
-  // https://github.com/grpc/grpc/pull/33871.
-  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
-      grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
-          kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::
-          CloseSocketUponReceivingBytesFromPeer);
-  if (grpc_core::IsEventEngineDnsEnabled()) {
-    g_event_engine_grpc_ares_test_only_force_tcp = true;
-  } else {
-    g_grpc_ares_test_only_force_tcp = true;
-  }
-  grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
-  std::string expected_error_message_substring;
-  if (grpc_core::IsEventEngineDnsEnabled()) {
-    expected_error_message_substring =
-        absl::StrCat("errors resolving ", kFakeName);
-  } else {
-    expected_error_message_substring =
-        absl::StrCat("DNS resolution failed for ", kFakeName);
-  }
-  // Don't really care about the deadline - we should quickly hit a DNS
-  // resolution failure.
-  gpr_timespec rpc_deadline = grpc_timeout_seconds_to_deadline(100);
-  int dns_query_timeout_ms = -1;  // don't set query timeout
-  TestCancelDuringActiveQuery(expected_status_code,
-                              expected_error_message_substring, rpc_deadline,
-                              dns_query_timeout_ms, fake_dns_server.port());
-  if (grpc_core::IsEventEngineDnsEnabled()) {
-    g_event_engine_grpc_ares_test_only_force_tcp = false;
-  } else {
-    g_grpc_ares_test_only_force_tcp = false;
-  }
-}
-
-int g_fake_dns_server_zero_streamer_port;
-int g_fake_dns_server_non_responsive_port;
-
-void InjectConfigForTestQueryFailsWithDataInBuffer(ares_channel* channel) {
-  struct ares_addr_port_node dns_server_addrs[2];
-  memset(dns_server_addrs, 0, sizeof(dns_server_addrs));
-  gpr_log(GPR_INFO,
-          "Injecting broken nameserver list. Zero-streaming server address:|[::1]:%d|. "
-          "Non responsive server address:|[::1]:%d|",
-          g_fake_dns_server_zero_streamer_port,
-          g_fake_dns_server_non_responsive_port);
-  dns_server_addrs[0].family = AF_INET6;
-  (reinterpret_cast<char*>(&dns_server_addrs[0].addr.addr6))[15] = 0x1;
-  dns_server_addrs[0].tcp_port = g_fake_dns_server_zero_streamer_port;
-  dns_server_addrs[0].udp_port = g_fake_dns_server_zero_streamer_port;
-  dns_server_addrs[0].next = &dns_server_addrs[1];
-  dns_server_addrs[1].family = AF_INET6;
-  (reinterpret_cast<char*>(&dns_server_addrs[0].addr.addr6))[15] = 0x1;
-  dns_server_addrs[1].tcp_port = g_fake_dns_server_non_responsive_port;
-  dns_server_addrs[1].udp_port = g_fake_dns_server_non_responsive_port;
-  dns_server_addrs[1].next = nullptr;
-  GPR_ASSERT(ares_set_servers_ports(*channel, dns_server_addrs) ==
-             ARES_SUCCESS);
-}
+//    TEST_F(CancelDuringAresQuery,
+//           TestHitDeadlineAndDestroyChannelDuringAresResolutionIsGraceful) {
+//      grpc_core::testing::SocketUseAfterCloseDetector
+//          socket_use_after_close_detector;
+//      grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
+//          grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
+//              kWaitForClientToSendFirstBytes,
+//          grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
+//      grpc_status_code expected_status_code = GRPC_STATUS_DEADLINE_EXCEEDED;
+//      // The RPC deadline should go off well before the DNS resolution
+//      // timeout fires.
+//      gpr_timespec rpc_deadline = grpc_timeout_milliseconds_to_deadline(100);
+//      int dns_query_timeout_ms = -1;  // don't set query timeout
+//      TestCancelDuringActiveQuery(
+//          expected_status_code, "" /* expected error message substring */,
+//          rpc_deadline, dns_query_timeout_ms, fake_dns_server.port());
+//    }
+//    
+//    TEST_F(
+//        CancelDuringAresQuery,
+//        TestHitDeadlineAndDestroyChannelDuringAresResolutionWithQueryTimeoutIsGraceful) {
+//      grpc_core::testing::SocketUseAfterCloseDetector
+//          socket_use_after_close_detector;
+//      grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
+//          grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
+//              kWaitForClientToSendFirstBytes,
+//          grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
+//      grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
+//      std::string expected_error_message_substring;
+//      if (grpc_core::IsEventEngineDnsEnabled()) {
+//        expected_error_message_substring =
+//            absl::StrCat("errors resolving ", kFakeName);
+//      } else {
+//        expected_error_message_substring =
+//            absl::StrCat("DNS resolution failed for ", kFakeName);
+//      }
+//      // The DNS resolution timeout should fire well before the
+//      // RPC's deadline expires.
+//      gpr_timespec rpc_deadline = grpc_timeout_seconds_to_deadline(10);
+//      int dns_query_timeout_ms = 1;
+//      TestCancelDuringActiveQuery(expected_status_code,
+//                                  expected_error_message_substring, rpc_deadline,
+//                                  dns_query_timeout_ms, fake_dns_server.port());
+//    }
+//    
+//    TEST_F(
+//        CancelDuringAresQuery,
+//        TestHitDeadlineAndDestroyChannelDuringAresResolutionWithZeroQueryTimeoutIsGraceful) {
+//      grpc_core::testing::SocketUseAfterCloseDetector
+//          socket_use_after_close_detector;
+//      grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
+//          grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
+//              kWaitForClientToSendFirstBytes,
+//          grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
+//      grpc_status_code expected_status_code = GRPC_STATUS_DEADLINE_EXCEEDED;
+//      // The RPC deadline should go off well before the DNS resolution
+//      // timeout fires.
+//      gpr_timespec rpc_deadline = grpc_timeout_milliseconds_to_deadline(100);
+//      int dns_query_timeout_ms = 0;  // disable query timeouts
+//      TestCancelDuringActiveQuery(
+//          expected_status_code, "" /* expected error message substring */,
+//          rpc_deadline, dns_query_timeout_ms, fake_dns_server.port());
+//    }
+//    
+//    TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
+//      grpc_core::testing::SocketUseAfterCloseDetector
+//          socket_use_after_close_detector;
+//      // Use a fake TCP server that immediately closes the socket and causes
+//      // c-ares to pick up a socket read error, while the previous socket
+//      // connect/writes succeeded. Meanwhile, force c-ares to only use TCP.
+//      // The goal is to hit a socket use-after-close bug described in
+//      // https://github.com/grpc/grpc/pull/33871.
+//      grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
+//          grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
+//              kWaitForClientToSendFirstBytes,
+//          grpc_core::testing::FakeUdpAndTcpServer::
+//              CloseSocketUponReceivingBytesFromPeer);
+//      if (grpc_core::IsEventEngineDnsEnabled()) {
+//        g_event_engine_grpc_ares_test_only_force_tcp = true;
+//      } else {
+//        g_grpc_ares_test_only_force_tcp = true;
+//      }
+//      grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
+//      std::string expected_error_message_substring;
+//      if (grpc_core::IsEventEngineDnsEnabled()) {
+//        expected_error_message_substring =
+//            absl::StrCat("errors resolving ", kFakeName);
+//      } else {
+//        expected_error_message_substring =
+//            absl::StrCat("DNS resolution failed for ", kFakeName);
+//      }
+//      // Don't really care about the deadline - we should quickly hit a DNS
+//      // resolution failure.
+//      gpr_timespec rpc_deadline = grpc_timeout_seconds_to_deadline(100);
+//      int dns_query_timeout_ms = -1;  // don't set query timeout
+//      TestCancelDuringActiveQuery(expected_status_code,
+//                                  expected_error_message_substring, rpc_deadline,
+//                                  dns_query_timeout_ms, fake_dns_server.port());
+//      if (grpc_core::IsEventEngineDnsEnabled()) {
+//        g_event_engine_grpc_ares_test_only_force_tcp = false;
+//      } else {
+//        g_grpc_ares_test_only_force_tcp = false;
+//      }
+//    }
 
 TEST_F(
     CancelDuringAresQuery,
@@ -506,23 +481,15 @@ TEST_F(
       grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
           kWaitForClientToSendFirstBytes,
       grpc_core::testing::FakeUdpAndTcpServer::SendBytesUntilPeerCloses);
-  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server_non_responsive(
-      grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
-          kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::CloseSocketUponCloseFromPeer);
-  g_fake_dns_server_zero_streamer_port = fake_dns_server_zero_streamer.port();
-  g_fake_dns_server_non_responsive_port = fake_dns_server_non_responsive.port();
-  grpc_ares_test_only_inject_config = InjectConfigForTestQueryFailsWithDataInBuffer;
   grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
   // Don't really care about the deadline - we'll hit a DNS
-  // resolution failure.
+  // resolution failure quickly.
   gpr_timespec rpc_deadline = grpc_timeout_seconds_to_deadline(100);
-  int dns_query_timeout_ms = -1;  // don't set query timeout
+  int dns_query_timeout_ms = 100;  // set a short query timeout
   TestCancelDuringActiveQuery(
       expected_status_code, "" /* expected error message substring */,
-      rpc_deadline, dns_query_timeout_ms, 0);
+      rpc_deadline, dns_query_timeout_ms, fake_dns_server_zero_streamer.port());
   g_grpc_ares_test_only_force_tcp = false;
-  grpc_ares_test_only_inject_config = nullptr;
 }
 
 }  // namespace

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -471,9 +471,7 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
   }
 }
 
-TEST_F(
-    CancelDuringAresQuery,
-    TestQueryFailsWithDataRemainingInReadBuffer) {
+TEST_F(CancelDuringAresQuery, TestQueryFailsWithDataRemainingInReadBuffer) {
   g_grpc_ares_test_only_force_tcp = true;
   grpc_core::testing::SocketUseAfterCloseDetector
       socket_use_after_close_detector;

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -472,7 +472,11 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
 }
 
 TEST_F(CancelDuringAresQuery, TestQueryFailsWithDataRemainingInReadBuffer) {
-  g_grpc_ares_test_only_force_tcp = true;
+  if (grpc_core::IsEventEngineDnsEnabled()) {
+    g_event_engine_grpc_ares_test_only_force_tcp = true;
+  } else {
+    g_grpc_ares_test_only_force_tcp = true;
+  }
   grpc_core::testing::SocketUseAfterCloseDetector
       socket_use_after_close_detector;
   grpc_core::testing::FakeUdpAndTcpServer fake_dns_server_zero_streamer(
@@ -487,7 +491,11 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsWithDataRemainingInReadBuffer) {
   TestCancelDuringActiveQuery(
       expected_status_code, "" /* expected error message substring */,
       rpc_deadline, dns_query_timeout_ms, fake_dns_server_zero_streamer.port());
-  g_grpc_ares_test_only_force_tcp = false;
+  if (grpc_core::IsEventEngineDnsEnabled()) {
+    g_event_engine_grpc_ares_test_only_force_tcp = false;
+  } else {
+    g_grpc_ares_test_only_force_tcp = false;
+  }
 }
 
 }  // namespace

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -505,6 +505,11 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
 //      But c-ares will never try to read from that socket again, so we have an
 //      infinite busy loop.
 TEST_F(CancelDuringAresQuery, TestQueryFailsWithDataRemainingInReadBuffer) {
+#ifdef GPR_WINDOWS
+  GTEST_SKIP() << "TODO(apolcyn): try to unskip this test on windows after "
+                  "https://github.com/grpc/grpc/pull/33965";
+  return;
+#endif
   if (grpc_core::IsEventEngineDnsEnabled()) {
     g_event_engine_grpc_ares_test_only_force_tcp = true;
   } else {

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -473,13 +473,14 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
 
 TEST_F(
     CancelDuringAresQuery,
-    TestQueryTimesOutWithDataInReadBuffer) {
+    TestQueryFailsWithDataInBuffer) {
+  g_grpc_ares_test_only_force_tcp = true;
   grpc_core::testing::SocketUseAfterCloseDetector
       socket_use_after_close_detector;
   grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
       grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
           kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::Send1ByteAfterDelay);
+      grpc_core::testing::FakeUdpAndTcpServer::SendBytesUntilPeerCloses);
   grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
   // Don't really care about the deadline - we should quickly hit a DNS
   // resolution failure.
@@ -488,6 +489,7 @@ TEST_F(
   TestCancelDuringActiveQuery(
       expected_status_code, "" /* expected error message substring */,
       rpc_deadline, dns_query_timeout_ms, fake_dns_server.port());
+  g_grpc_ares_test_only_force_tcp = false;
 }
 
 }  // namespace

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -492,8 +492,9 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
 //   4) Because the first two bytes were zero, c-ares attempts to malloc a
 //      zero-length buffer:
 //      https://github.com/c-ares/c-ares/blob/6360e96b5cf8e5980c887ce58ef727e53d77243a/src/lib/ares_process.c#L428.
-//   5) Because malloc(0) returns NULL, c-ares invokes handle_error and stops
-//      reading on the socket:
+//   5) Because c-ares' default_malloc(0) returns NULL
+//      (https://github.com/c-ares/c-ares/blob/7f3262312f246556d8c1bdd8ccc1844847f42787/src/lib/ares_library_init.c#L38),
+//      c-ares invokes handle_error and stops reading on the socket:
 //      https://github.com/c-ares/c-ares/blob/6360e96b5cf8e5980c887ce58ef727e53d77243a/src/lib/ares_process.c#L430.
 //   6) Because we overwrite the socket "close" method, c-ares attempt to close
 //      the socket in handle_error does nothing except for removing the socket

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -478,7 +478,7 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsWithDataRemainingInReadBuffer) {
   grpc_core::testing::FakeUdpAndTcpServer fake_dns_server_zero_streamer(
       grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
           kWaitForClientToSendFirstBytes,
-      grpc_core::testing::FakeUdpAndTcpServer::SendBytesUntilPeerCloses);
+      grpc_core::testing::FakeUdpAndTcpServer::SendThreeAllZeroBytes);
   grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
   // Don't really care about the deadline - we'll hit a DNS
   // resolution failure quickly.

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -479,18 +479,18 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsWithDataRemainingInReadBuffer) {
   }
   grpc_core::testing::SocketUseAfterCloseDetector
       socket_use_after_close_detector;
-  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server_zero_streamer(
+  grpc_core::testing::FakeUdpAndTcpServer fake_dns_server(
       grpc_core::testing::FakeUdpAndTcpServer::AcceptMode::
           kWaitForClientToSendFirstBytes,
       grpc_core::testing::FakeUdpAndTcpServer::SendThreeAllZeroBytes);
   grpc_status_code expected_status_code = GRPC_STATUS_UNAVAILABLE;
   // Don't really care about the deadline - we'll hit a DNS
-  // resolution failure quickly.
+  // resolution failure quickly in any case.
   gpr_timespec rpc_deadline = grpc_timeout_seconds_to_deadline(100);
-  int dns_query_timeout_ms = 100;  // set a short query timeout
+  int dns_query_timeout_ms = -1;  // don't set query timeout
   TestCancelDuringActiveQuery(
       expected_status_code, "" /* expected error message substring */,
-      rpc_deadline, dns_query_timeout_ms, fake_dns_server_zero_streamer.port());
+      rpc_deadline, dns_query_timeout_ms, fake_dns_server.port());
   if (grpc_core::IsEventEngineDnsEnabled()) {
     g_event_engine_grpc_ares_test_only_force_tcp = false;
   } else {

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -474,15 +474,15 @@ TEST_F(CancelDuringAresQuery, TestQueryFailsBecauseTcpServerClosesSocket) {
 // This test is meant to repro a bug noticed in internal issue b/297538255.
 // The general issue is the loop in
 // https://github.com/grpc/grpc/blob/f6a994229e72bc771963706de7a0cd8aa9150bb6/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L371.
-// The problem with that loop is that c-ares *can* in certain situations stop caring about the fd
-// being processed without reading all of the data out of the read buffer. In
-// that case, we keep looping because IsFdStillReadableLocked() keeps returning
-// true, but we never make progress. Meanwhile, we are holding a lock which
-// prevents cancellation or timeouts from kicking in, and thus we spin-loop
-// forever.
+// The problem with that loop is that c-ares *can* in certain situations stop
+// caring about the fd being processed without reading all of the data out of
+// the read buffer. In that case, we keep looping because
+// IsFdStillReadableLocked() keeps returning true, but we never make progress.
+// Meanwhile, we are holding a lock which prevents cancellation or timeouts from
+// kicking in, and thus we spin-loop forever.
 //
-// At the time of writing, this test case illustrates one way to hit that bug. It
-// works as follows:
+// At the time of writing, this test case illustrates one way to hit that bug.
+// It works as follows:
 //   1) We force c-ares to use TCP for its DNS queries
 //   2) We stand up a fake DNS server that, for each incoming connection, sends
 //      three all-zero bytes and then closes the socket.


### PR DESCRIPTION
If we get a readable event on an fd and both the following happens:

- c-ares does *not* read all bytes off the fd

- c-ares removes the fd from the set ARES_GETSOCK_READABLE

... then we have a busy loop here, where we'd keep asking c-ares to process an fd that it no longer cares about.

This is indirectly related to a change in this code one month ago: https://github.com/grpc/grpc/pull/33942 - before that change, c-ares would close the socket when it called [handle_error](https://github.com/c-ares/c-ares/blob/7f3262312f246556d8c1bdd8ccc1844847f42787/src/lib/ares_process.c#L707) and so `IsFdStillReadableLocked` would start returning `false`, causing us to get away with [this loop](https://github.com/grpc/grpc/blob/f6a994229e72bc771963706de7a0cd8aa9150bb6/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc#L371). Now, because `IsFdStillReadableLocked` will keep returning true (because of our overridden `close` API), we'll loop forever. 

The test illustrates one concrete example of how this bug can be hit.

Note that the EE version of this code already [gets this right](https://github.com/grpc/grpc/blob/f6fd5172added1ba92658a227302346540ad2022/src/core/lib/event_engine/ares_resolver.cc#L369).

Related: internal issue b/297538255

