### PR TITLE
[logs] Remove unsafe use of grpc_transport_stream_op_batch_string

### DIFF
--- a/src/core/lib/transport/batch_builder.cc
+++ b/src/core/lib/transport/batch_builder.cc
@@ -35,11 +35,9 @@ void BatchBuilder::PendingCompletion::CompletionCallback(
   auto* pc = static_cast<PendingCompletion*>(self);
   auto* party = pc->batch->party.get();
   if (grpc_call_trace.enabled()) {
-    gpr_log(
-        GPR_DEBUG, "%sFinish batch-component %s for %s: status=%s",
-        pc->batch->DebugPrefix(party).c_str(), std::string(pc->name()).c_str(),
-        grpc_transport_stream_op_batch_string(&pc->batch->batch, false).c_str(),
-        error.ToString().c_str());
+    gpr_log(GPR_DEBUG, "%sFinish batch-component %s: status=%s",
+            pc->batch->DebugPrefix(party).c_str(),
+            std::string(pc->name()).c_str(), error.ToString().c_str());
   }
   party->Spawn(
       "batch-completion",


### PR DESCRIPTION
Batch completions can run after the Server promise call finishes and deallocates the server trailing metadata. Remove the use of grpc_transport_stream_op_batch_string so that such batch completions dont end up de-referencing an already free'ed grpc_metadata_batch.

