### PR TITLE
[PSM Interop] Enable GAMMA test suite

### DIFF
--- a/tools/internal_ci/linux/psm-gamma.sh
+++ b/tools/internal_ci/linux/psm-gamma.sh
@@ -154,9 +154,7 @@ main() {
   else
     local_setup_test_driver "${script_dir}"
   fi
-
   build_docker_images_if_needed
-
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0

--- a/tools/internal_ci/linux/psm-gamma.sh
+++ b/tools/internal_ci/linux/psm-gamma.sh
@@ -108,9 +108,9 @@ run_test() {
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --flagfile="config/gamma.cfg" \
     --kube_context="${KUBE_CONTEXT}" \
-    --testing_version="${TESTING_VERSION}" \
     --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
+    --testing_version="${TESTING_VERSION}" \
     --force_cleanup \
     --collect_app_logs \
     --log_dir="${out_dir}" \

--- a/tools/internal_ci/linux/psm-gamma.sh
+++ b/tools/internal_ci/linux/psm-gamma.sh
@@ -163,7 +163,7 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
   test_suites=(
-    "gamma.baseline_test"
+    "gamma.gamma_baseline_test"
     # "gamma.session_affinity_test"
   )
   for test in "${test_suites[@]}"; do

--- a/tools/internal_ci/linux/psm-gamma.sh
+++ b/tools/internal_ci/linux/psm-gamma.sh
@@ -108,11 +108,11 @@ run_test() {
   set -x
   python3 -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
+    --flagfile="config/gamma.cfg" \
     --kube_context="${KUBE_CONTEXT}" \
     --testing_version="${TESTING_VERSION}" \
     --server_image=gcr.io/grpc-testing/xds-interop/java-server:v1.57.x \
     --client_image=gcr.io/grpc-testing/xds-interop/java-client:v1.57.x \
-    --nocheck_local_certs \
     --force_cleanup \
     --collect_app_logs \
     --log_dir="${out_dir}" \

--- a/tools/internal_ci/linux/psm-gamma.sh
+++ b/tools/internal_ci/linux/psm-gamma.sh
@@ -103,16 +103,14 @@ run_test() {
   local test_name="${1:?Usage: run_test test_name}"
   local out_dir="${TEST_XML_OUTPUT_DIR}/${test_name}"
   mkdir -pv "${out_dir}"
-  # --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
-  # --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
   set -x
   python3 -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --flagfile="config/gamma.cfg" \
     --kube_context="${KUBE_CONTEXT}" \
     --testing_version="${TESTING_VERSION}" \
-    --server_image=gcr.io/grpc-testing/xds-interop/java-server:v1.57.x \
-    --client_image=gcr.io/grpc-testing/xds-interop/java-client:v1.57.x \
+    --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
+    --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
     --force_cleanup \
     --collect_app_logs \
     --log_dir="${out_dir}" \
@@ -157,7 +155,7 @@ main() {
     local_setup_test_driver "${script_dir}"
   fi
 
-  # build_docker_images_if_needed
+  build_docker_images_if_needed
 
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"

--- a/tools/internal_ci/linux/psm-gamma.sh
+++ b/tools/internal_ci/linux/psm-gamma.sh
@@ -103,13 +103,15 @@ run_test() {
   local test_name="${1:?Usage: run_test test_name}"
   local out_dir="${TEST_XML_OUTPUT_DIR}/${test_name}"
   mkdir -pv "${out_dir}"
+  # --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
+  # --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
   set -x
   python3 -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
     --kube_context="${KUBE_CONTEXT}" \
-    --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
-    --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
     --testing_version="${TESTING_VERSION}" \
+    --server_image=gcr.io/grpc-testing/xds-interop/java-server:v1.57.x \
+    --client_image=gcr.io/grpc-testing/xds-interop/java-client:v1.57.x \
     --nocheck_local_certs \
     --force_cleanup \
     --collect_app_logs \
@@ -139,9 +141,6 @@ run_test() {
 #   Writes the output of test execution to stdout, stderr
 #######################################
 main() {
-  # TODO(sergiitk): Just a stub to create a Kokoro job. Remove tests are ready.
-  exit 0
-
   local script_dir
   script_dir="$(dirname "$0")"
 
@@ -157,7 +156,9 @@ main() {
   else
     local_setup_test_driver "${script_dir}"
   fi
-  build_docker_images_if_needed
+
+  # build_docker_images_if_needed
+
   # Run tests
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0

--- a/tools/run_tests/xds_k8s_test_driver/config/gamma.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/gamma.cfg
@@ -1,0 +1,2 @@
+# Common config file for GAMMA PSM tests.
+--resource_prefix=psm-gamma


### PR DESCRIPTION
Enable `grpc/core/master/linux/psm-gamma` test job that runs GAMMA test suite. Includes only the baseline test.