### PR TITLE
[Build] Workaround for upb 24.x warnings

### DIFF
--- a/test/distrib/cpp/run_distrib_test_cmake.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake.sh
@@ -66,7 +66,8 @@ popd
 # Get list of submodules from the .gitmodules file since for running "git submodule foreach"
 # we'd need to be in a git workspace (and that's not the case when running
 # distribtests as a bazel action)
-grep 'path = ' .gitmodules | sed 's/^.*path = //' | xargs rm -rf
+# TODO(veblush): Remove upb exception
+grep 'path = ' .gitmodules | sed 's/^.*path = //' | grep -v 'third_party/upb' | xargs rm -rf
 
 # Install gRPC
 mkdir -p "cmake/build"

--- a/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
@@ -70,7 +70,8 @@ popd
 # Get list of submodules from the .gitmodules file since for "git submodule foreach"
 # we'd need to be in a git workspace (and that's not the case when running
 # distribtests as a bazel action)
-grep 'path = ' .gitmodules | sed 's/^.*path = //' | xargs rm -rf
+# TODO(veblush): Remove upb exception
+grep 'path = ' .gitmodules | sed 's/^.*path = //' | grep -v 'third_party/upb' | xargs rm -rf
 
 # Install gRPC
 # TODO(jtattermusch): avoid the need for setting utf8_range_DIR

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -12,6 +12,10 @@ build:macos   --host_cxxopt='-std=c++14'
 build:freebsd   --cxxopt='-std=c++14'
 build:freebsd   --host_cxxopt='-std=c++14'
 
+# TODO(veblush): Remove these once upb is upgraded to 25.x or later
+build:linux --copt=-Wno-typedef-redefinition
+build:linux --host_copt=-Wno-typedef-redefinition
+
 # Don't trigger --config=<host platform> when cross-compiling.
 build:android --noenable_platform_specific_config
 build:ios --noenable_platform_specific_config
@@ -21,10 +25,6 @@ build --copt=-DGRPC_BAZEL_BUILD
 build --host_copt=-DGRPC_BAZEL_BUILD
 build --action_env=GRPC_BAZEL_RUNTIME=1
 build --define=use_fast_cpp_protos=true
-
-# TODO(veblush): Remove these once upb is upgraded to 25.x or later
-build --copt=-Wno-typedef-redefinition
-build --host_copt=-Wno-typedef-redefinition
 
 build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -15,6 +15,8 @@ build:freebsd   --host_cxxopt='-std=c++14'
 # TODO(veblush): Remove these once upb is upgraded to 25.x or later
 build:linux --copt=-Wno-typedef-redefinition
 build:linux --host_copt=-Wno-typedef-redefinition
+build:macos --copt=-Wno-typedef-redefinition
+build:macos --host_copt=-Wno-typedef-redefinition
 
 # Don't trigger --config=<host platform> when cross-compiling.
 build:android --noenable_platform_specific_config

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -22,6 +22,10 @@ build --host_copt=-DGRPC_BAZEL_BUILD
 build --action_env=GRPC_BAZEL_RUNTIME=1
 build --define=use_fast_cpp_protos=true
 
+# TODO(veblush): Remove these once upb is upgraded to 25.x or later
+build --copt=-Wno-typedef-redefinition
+build --host_copt=-Wno-typedef-redefinition
+
 build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
 


### PR DESCRIPTION
This is to address too many warnings coming from upb 24.x

```
In file included from external/upb/upb/mini_table/field.h:32:
external/upb/upb/mini_table/internal/message.h:36:14:
 warning: redefinition of typedef 'upb_Message' is a C11 feature [-Wtypedef-redefinition]
typedef void upb_Message;
             ^
external/upb/upb/message/tagged_ptr.h:40:14: note: previous definition is here
typedef void upb_Message;
             ^
1 warning generated.
```

