### PR TITLE
Revert previous change to PluginMain

### DIFF
--- a/src/compiler/config.h
+++ b/src/compiler/config.h
@@ -40,7 +40,8 @@ namespace protobuf {
 namespace compiler {
 typedef GRPC_CUSTOM_CODEGENERATOR CodeGenerator;
 typedef GRPC_CUSTOM_GENERATORCONTEXT GeneratorContext;
-static inline int PluginMain(int argc, char* argv[], CodeGenerator* generator) {
+static inline int PluginMain(int argc, char* argv[],
+                             const CodeGenerator* generator) {
   return GRPC_CUSTOM_PLUGINMAIN(argc, argv, generator);
 }
 static inline void ParseGeneratorParameter(


### PR DESCRIPTION
This reverts https://github.com/grpc/grpc/pull/34170.  We (protobuf) have decided not to release the plugin feature that would have required this without an actual use-case asking for it.  Since this is *technically* a breaking change, it's better to roll it back in gRPC until we actually need it.