### PR TITLE
[PSM Interop] update td bootstrap generator image for prod tests

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,6 +1,5 @@
 --resource_prefix=psm-interop
-# https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.14.0
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:d6baaf7b0e0c63054ac4d9bedc09021ff261d599
+--td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:d47f36f78aef8fe9d67303be1aba480f2fe9a77c
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,


### PR DESCRIPTION
This change is to update the TD bootstrap generator for prod tests. This is part of the TD release process. The new image has already been merged to staging and tested locally in google3. 

cc: @sergiitk PTAL. 
