### PR TITLE
[Debuggability][C++] Making channel args more debuggable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10630,6 +10630,7 @@ target_include_directories(endpoint_config_test
 target_link_libraries(endpoint_config_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -7775,6 +7775,7 @@ targets:
   - test/core/event_engine/endpoint_config_test.cc
   deps:
   - gtest
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2702,6 +2702,7 @@ grpc_cc_library(
         "lib/channel/channel_args.h",
     ],
     external_deps = [
+        "absl/functional:function_ref",
         "absl/meta:type_traits",
         "absl/strings",
         "absl/strings:str_format",

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -281,6 +281,14 @@ absl::optional<bool> ChannelArgs::GetBool(absl::string_view name) const {
   }
 }
 
+void ChannelArgs::ForEach(
+    absl::FunctionRef<void(absl::string_view, const Value&)> callback) const {
+  args_.ForEach(
+      [callback](const RefCountedStringValue& key, const Value& value) {
+        callback(key.as_string_view(), value);
+      });
+}
+
 std::string ChannelArgs::Value::ToString() const {
   if (rep_.c_vtable() == &int_vtable_) {
     return std::to_string(reinterpret_cast<intptr_t>(rep_.c_pointer()));
@@ -294,11 +302,9 @@ std::string ChannelArgs::Value::ToString() const {
 
 std::string ChannelArgs::ToString() const {
   std::vector<std::string> arg_strings;
-  args_.ForEach(
-      [&arg_strings](const RefCountedStringValue& key, const Value& value) {
-        arg_strings.push_back(
-            absl::StrCat(key.as_string_view(), "=", value.ToString()));
-      });
+  ForEach([&arg_strings](absl::string_view key, const Value& value) {
+    arg_strings.push_back(absl::StrCat(key, "=", value.ToString()));
+  });
   return absl::StrCat("{", absl::StrJoin(arg_strings, ", "), "}");
 }
 

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -473,6 +473,13 @@ class ChannelArgs {
   bool WantMinimalStack() const;
   std::string ToString() const;
 
+  // Iterate over each key/value pair, calling `callback` for each.
+  // We use a FunctionRef here because this is expected to be used for
+  // infrequent/slow path operations and so it's better to use runtime
+  // polymorphism to avoid bloating our customers binaries.
+  void ForEach(
+      absl::FunctionRef<void(absl::string_view, const Value&)> callback) const;
+
  private:
   explicit ChannelArgs(AVL<RefCountedStringValue, Value> args);
 


### PR DESCRIPTION
Part 1 of 5:
Making channel args more debuggable by being able to check their value at runtime.
Adding a function to check the current value of channel args.
This version will return the actual value of the channel arg, instead of the strings.

Part 2 of 5 : (Next PR)
ChannelArgs class changes.
GetChannelArgsDebugInfo() will also give the source code details of where a channel arg was set.

release notes: no

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

