### PR TITLE
[experiments] Sort initial printout

### DIFF
--- a/src/core/lib/experiments/config.cc
+++ b/src/core/lib/experiments/config.cc
@@ -166,11 +166,14 @@ bool IsTestExperimentEnabled(size_t experiment_id) {
 
 void PrintExperimentsList() {
   size_t max_experiment_length = 0;
+  std::map<absl::string_view, size_t> visitation_order;
   for (size_t i = 0; i < kNumExperiments; i++) {
     max_experiment_length =
         std::max(max_experiment_length, strlen(g_experiment_metadata[i].name));
+    visitation_order[g_experiment_metadata[i].name] = i;
   }
-  for (size_t i = 0; i < kNumExperiments; i++) {
+  for (auto name_index : visitation_order) {
+    const size_t i = name_index.second;
     gpr_log(
         GPR_DEBUG, "%s",
         absl::StrCat(

--- a/src/core/lib/experiments/config.cc
+++ b/src/core/lib/experiments/config.cc
@@ -166,6 +166,10 @@ bool IsTestExperimentEnabled(size_t experiment_id) {
 
 void PrintExperimentsList() {
   size_t max_experiment_length = 0;
+  // Populate visitation order into a std::map so that iteration results in a
+  // lexical ordering of experiment names.
+  // The lexical ordering makes it nice and easy to find the experiment you're
+  // looking for in the output spam that we generate.
   std::map<absl::string_view, size_t> visitation_order;
   for (size_t i = 0; i < kNumExperiments; i++) {
     max_experiment_length =


### PR DESCRIPTION
We print the status of all experiments at grpc init time, but that status is in experiment declaration order - which isn't particularly useful for being able to find if your experiment is enabled or not quickly.

Change that to lexically sort experiments.