### PR TITLE
[bazelified tests] Reenable runtests_php_linux_dbg after #34257

### DIFF
--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -142,8 +142,7 @@ test_suite(
         ":runtests_cpp_linux_opt_build_only",
         ":runtests_csharp_linux_dbg",
         ":runtests_csharp_linux_opt",
-        # TODO(jtattermusch): reenable the test once not flaky anymore
-        #":runtests_php_linux_dbg",
+        ":runtests_php_linux_dbg",
         ":runtests_php_linux_opt",
         ":runtests_python_linux_opt",
         ":runtests_ruby_linux_dbg",


### PR DESCRIPTION
The valgrind based test (removed in https://github.com/grpc/grpc/pull/34257) was the reason why the dbg test was disabled in the past.
