### PR TITLE
[Python Misc] Remove fetch_build_eggs & Fix run_test

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -337,12 +337,7 @@ class Gather(setuptools.Command):
         pass
 
     def run(self):
-        if self.install and self.distribution.install_requires:
-            self.distribution.fetch_build_eggs(
-                self.distribution.install_requires
-            )
-        if self.test and self.distribution.tests_require:
-            self.distribution.fetch_build_eggs(self.distribution.tests_require)
+        pass
 
 
 class Clean(setuptools.Command):

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -89,8 +89,6 @@ class TestLite(setuptools.Command):
         pass
 
     def run(self):
-        self._add_eggs_to_path()
-
         import tests
 
         loader = tests.Loader()
@@ -99,11 +97,6 @@ class TestLite(setuptools.Command):
         result = runner.run(loader.suite)
         if not result.wasSuccessful():
             sys.exit("Test failure")
-
-    def _add_eggs_to_path(self):
-        """Fetch install and test requirements"""
-        self.distribution.fetch_build_eggs(self.distribution.install_requires)
-        self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
 
 class TestPy3Only(setuptools.Command):
@@ -123,7 +116,6 @@ class TestPy3Only(setuptools.Command):
         pass
 
     def run(self):
-        self._add_eggs_to_path()
         import tests
 
         loader = tests.Loader()
@@ -132,10 +124,6 @@ class TestPy3Only(setuptools.Command):
         result = runner.run(loader.suite)
         if not result.wasSuccessful():
             sys.exit("Test failure")
-
-    def _add_eggs_to_path(self):
-        self.distribution.fetch_build_eggs(self.distribution.install_requires)
-        self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
 
 class TestAio(setuptools.Command):
@@ -151,8 +139,6 @@ class TestAio(setuptools.Command):
         pass
 
     def run(self):
-        self._add_eggs_to_path()
-
         import tests
 
         loader = tests.Loader()
@@ -164,11 +150,6 @@ class TestAio(setuptools.Command):
         result = runner.run(loader.suite)
         if not result.wasSuccessful():
             sys.exit("Test failure")
-
-    def _add_eggs_to_path(self):
-        """Fetch install and test requirements"""
-        self.distribution.fetch_build_eggs(self.distribution.install_requires)
-        self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
 
 class TestGevent(setuptools.Command):
@@ -310,12 +291,6 @@ class RunInterop(test.test):
             )
 
     def run(self):
-        if self.distribution.install_requires:
-            self.distribution.fetch_build_eggs(
-                self.distribution.install_requires
-            )
-        if self.distribution.tests_require:
-            self.distribution.fetch_build_eggs(self.distribution.tests_require)
         if self.client:
             self.run_client()
         elif self.server:
@@ -359,12 +334,6 @@ class RunFork(test.test):
         pass
 
     def run(self):
-        if self.distribution.install_requires:
-            self.distribution.fetch_build_eggs(
-                self.distribution.install_requires
-            )
-        if self.distribution.tests_require:
-            self.distribution.fetch_build_eggs(self.distribution.tests_require)
         # We import here to ensure that our setuptools parent has had a chance to
         # edit the Python system path.
         from tests.fork import client

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -779,9 +779,7 @@ class PythonLanguage(object):
                             + [self._TEST_COMMAND[io_platform]],
                             timeout_seconds=8 * 60,
                             environ=dict(
-                                GRPC_PYTHON_TESTRUNNER_FILTER=str(
-                                    test_case
-                                ),
+                                GRPC_PYTHON_TESTRUNNER_FILTER=str(test_case),
                                 **environment,
                             ),
                             shortname=f"{python_config.name}.{io_platform}.{test_case}",

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -772,23 +772,23 @@ class PythonLanguage(object):
                 # overrides threading settings in C-Core.
                 if io_platform != "native":
                     environment["GRPC_ENABLE_FORK_SUPPORT"] = "0"
-                    jobs.extend(
-                        [
-                            self.config.job_spec(
-                                python_config.run
-                                + [self._TEST_COMMAND[io_platform]],
-                                timeout_seconds=8 * 60,
-                                environ=dict(
-                                    GRPC_PYTHON_TESTRUNNER_FILTER=str(
-                                        test_case
-                                    ),
-                                    **environment,
+                jobs.extend(
+                    [
+                        self.config.job_spec(
+                            python_config.run
+                            + [self._TEST_COMMAND[io_platform]],
+                            timeout_seconds=8 * 60,
+                            environ=dict(
+                                GRPC_PYTHON_TESTRUNNER_FILTER=str(
+                                    test_case
                                 ),
-                                shortname=f"{python_config.name}.{io_platform}.{test_case}",
-                            )
-                            for test_case in test_cases
-                        ]
-                    )
+                                **environment,
+                            ),
+                            shortname=f"{python_config.name}.{io_platform}.{test_case}",
+                        )
+                        for test_case in test_cases
+                    ]
+                )
         return jobs
 
     def pre_build_steps(self):


### PR DESCRIPTION
* Remove `fetch_build_eggs` since they're deprecated and those deps will be installed by `setuptools`.
* Fix indentation on `run_test` so we don't miss `native` test cases.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

