### PR TITLE
[Python] Specify noexcept for cdef functions.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -48,7 +48,7 @@ cdef class CallbackWrapper:
     @staticmethod
     cdef void functor_run(
             grpc_completion_queue_functor* functor,
-            int succeed)
+            int succeed) noexcept
 
     cdef grpc_completion_queue_functor *c_functor(self)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -50,7 +50,7 @@ cdef class CallbackWrapper:
     @staticmethod
     cdef void functor_run(
             grpc_completion_queue_functor* functor,
-            int success):
+            int success) noexcept:
         cdef CallbackContext *context = <CallbackContext *>functor
         cdef object waiter = <object>context.waiter
         if not waiter.cancelled():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -314,7 +314,7 @@ def server_credentials_ssl_dynamic_cert_config(initial_cert_config,
   return credentials
 
 cdef grpc_ssl_certificate_config_reload_status _server_cert_config_fetcher_wrapper(
-        void* user_data, grpc_ssl_server_certificate_config **config) with gil:
+        void* user_data, grpc_ssl_server_certificate_config **config) noexcept with gil:
   # This is a credentials.ServerCertificateConfig
   cdef ServerCertificateConfig cert_config = None
   if not user_data:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pyx.pxi
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 # TODO(https://github.com/grpc/grpc/issues/15662): Reform this.
-cdef void* _copy_pointer(void* pointer):
+cdef void* _copy_pointer(void* pointer) noexcept:
   return pointer
 
 
 # TODO(https://github.com/grpc/grpc/issues/15662): Reform this.
-cdef void _destroy_pointer(void* pointer):
+cdef void _destroy_pointer(void* pointer) noexcept:
   pass
 
 
-cdef int _compare_pointer(void* first_pointer, void* second_pointer):
+cdef int _compare_pointer(void* first_pointer, void* second_pointer) noexcept:
   if first_pointer < second_pointer:
     return -1
   elif first_pointer > second_pointer:


### PR DESCRIPTION
To build against cython 3.0, cdef functions that do not raise exceptions need to be explicitly declared as noexcept. Fixes issue #33918.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

