### PR TITLE
[PSM Interop] Enable xDS affinity test for Node

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/affinity_test.py
@@ -63,7 +63,7 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             #      the issue is fixed.
             return False
         elif config.client_lang == _Lang.NODE:
-            return False
+            return config.version_gte("v1.10.x")
         return True
 
     def test_affinity(self) -> None:  # pylint: disable=too-many-statements


### PR DESCRIPTION
Similar to #34146, this will only run on master for now. This will work after grpc/grpc-node#2568 is merged.