### PR TITLE
[Python] Use same contextvars.Context for interceptors and RPC handler

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1390,6 +1390,13 @@ class ServerInterceptor(abc.ABC):
     def intercept_service(self, continuation, handler_call_details):
         """Intercepts incoming RPCs before handing them over to a handler.
 
+        State can be passed from an interceptor to downstream interceptors
+        via contextvars. The first interceptor is called from an empty
+        contextvars.Context, and the same Context is used for downstream
+        interceptors and for the final handler call. Note that there are no
+        guarantees that interceptors and handlers will be called from the
+        same thread.
+
         Args:
           continuation: A function that takes a HandlerCallDetails and
             proceeds to invoke the next interceptor in the chain, if any,

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -69,6 +69,13 @@ class ServerInterceptor(metaclass=ABCMeta):
     ) -> grpc.RpcMethodHandler:
         """Intercepts incoming RPCs before handing them over to a handler.
 
+        State can be passed from an interceptor to downstream interceptors
+        via contextvars. The first interceptor is called from an empty
+        contextvars.Context, and the same Context is used for downstream
+        interceptors and for the final handler call. Note that there are no
+        guarantees that interceptors and handlers will be called from the
+        same thread.
+
         Args:
             continuation: A function that takes a HandlerCallDetails and
                 proceeds to invoke the next interceptor in the chain, if any,

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -15,6 +15,7 @@
 
 import collections
 from concurrent import futures
+from contextvars import ContextVar
 import itertools
 import logging
 import os
@@ -39,6 +40,8 @@ _UNARY_UNARY = "/test/UnaryUnary"
 _UNARY_STREAM = "/test/UnaryStream"
 _STREAM_UNARY = "/test/StreamUnary"
 _STREAM_STREAM = "/test/StreamStream"
+
+_TEST_CONTEXT_VAR: ContextVar[str] = ContextVar("")
 
 
 class _ApplicationErrorStandin(Exception):
@@ -65,10 +68,18 @@ class _Callback(object):
 
 
 class _Handler(object):
-    def __init__(self, control):
+    def __init__(self, control, record):
         self._control = control
+        self._record = record
+
+    def _append_to_log(self, message: str) -> None:
+        context_var_value = _TEST_CONTEXT_VAR.get("")
+        if context_var_value:
+            context_var_value = "[{}]".format(context_var_value)
+        self._record.append("handler:" + message + context_var_value)
 
     def handle_unary_unary(self, request, servicer_context):
+        self._append_to_log("handle_unary_unary")
         self._control.control()
         if servicer_context is not None:
             servicer_context.set_trailing_metadata(
@@ -84,6 +95,7 @@ class _Handler(object):
         return request
 
     def handle_unary_stream(self, request, servicer_context):
+        self._append_to_log("handle_unary_stream")
         if request == _EXCEPTION_REQUEST:
             raise _ApplicationErrorStandin()
         for _ in range(test_constants.STREAM_LENGTH):
@@ -101,6 +113,7 @@ class _Handler(object):
             )
 
     def handle_stream_unary(self, request_iterator, servicer_context):
+        self._append_to_log("handle_stream_unary")
         if servicer_context is not None:
             servicer_context.invocation_metadata()
         self._control.control()
@@ -123,6 +136,7 @@ class _Handler(object):
         return b"".join(response_elements)
 
     def handle_stream_stream(self, request_iterator, servicer_context):
+        self._append_to_log("handle_stream_stream")
         self._control.control()
         if servicer_context is not None:
             servicer_context.set_trailing_metadata(
@@ -293,6 +307,21 @@ class _GenericClientInterceptor(
         return postprocess(response_it) if postprocess else response_it
 
 
+class _ContextVarSettingInterceptor(grpc.ServerInterceptor):
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def intercept_service(self, continuation, handler_call_details):
+        old_value = _TEST_CONTEXT_VAR.get("")
+        assert (
+            not old_value
+        ), "expected context var to have no value but was '{}'".format(
+            old_value
+        )
+        _TEST_CONTEXT_VAR.set(self.value)
+        return continuation(handler_call_details)
+
+
 class _LoggingInterceptor(
     grpc.ServerInterceptor,
     grpc.UnaryUnaryClientInterceptor,
@@ -304,12 +333,18 @@ class _LoggingInterceptor(
         self.tag = tag
         self.record = record
 
+    def _append_to_log(self, message: str) -> None:
+        context_var_value = _TEST_CONTEXT_VAR.get("")
+        if context_var_value:
+            context_var_value = "[{}]".format(context_var_value)
+        self.record.append(self.tag + message + context_var_value)
+
     def intercept_service(self, continuation, handler_call_details):
-        self.record.append(self.tag + ":intercept_service")
+        self._append_to_log(":intercept_service")
         return continuation(handler_call_details)
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
-        self.record.append(self.tag + ":intercept_unary_unary")
+        self._append_to_log(":intercept_unary_unary")
         result = continuation(client_call_details, request)
         assert isinstance(
             result, grpc.Call
@@ -326,13 +361,13 @@ class _LoggingInterceptor(
     def intercept_unary_stream(
         self, continuation, client_call_details, request
     ):
-        self.record.append(self.tag + ":intercept_unary_stream")
+        self._append_to_log(":intercept_unary_stream")
         return continuation(client_call_details, request)
 
     def intercept_stream_unary(
         self, continuation, client_call_details, request_iterator
     ):
-        self.record.append(self.tag + ":intercept_stream_unary")
+        self._append_to_log(":intercept_stream_unary")
         result = continuation(client_call_details, request_iterator)
         assert isinstance(
             result, grpc.Call
@@ -345,7 +380,7 @@ class _LoggingInterceptor(
     def intercept_stream_stream(
         self, continuation, client_call_details, request_iterator
     ):
-        self.record.append(self.tag + ":intercept_stream_stream")
+        self._append_to_log(":intercept_stream_stream")
         return continuation(client_call_details, request_iterator)
 
 
@@ -420,10 +455,10 @@ def _filter_server_interceptor(condition, interceptor):
 class InterceptorTest(unittest.TestCase):
     def setUp(self):
         self._control = test_control.PauseFailControl()
-        self._handler = _Handler(self._control)
+        self._record = []
+        self._handler = _Handler(self._control, self._record)
         self._server_pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
 
-        self._record = []
         conditional_interceptor = _filter_server_interceptor(
             lambda x: ("secret", "42") in x.invocation_metadata,
             _LoggingInterceptor("s3", self._record),
@@ -435,6 +470,7 @@ class InterceptorTest(unittest.TestCase):
             interceptors=(
                 _LoggingInterceptor("s1", self._record),
                 conditional_interceptor,
+                _ContextVarSettingInterceptor("context-var-value"),
                 _LoggingInterceptor("s2", self._record),
             ),
         )
@@ -543,7 +579,8 @@ class InterceptorTest(unittest.TestCase):
                 "c2:intercept_unary_unary",
                 "s1:intercept_service",
                 "s3:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_unary_unary[context-var-value]",
             ],
         )
 
@@ -572,7 +609,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_unary_unary",
                 "c2:intercept_unary_unary",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_unary_unary[context-var-value]",
             ],
         )
 
@@ -631,7 +669,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_unary_unary",
                 "c2:intercept_unary_unary",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_unary_unary[context-var-value]",
             ],
         )
 
@@ -658,7 +697,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_unary_unary",
                 "c2:intercept_unary_unary",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_unary_unary[context-var-value]",
             ],
         )
 
@@ -685,7 +725,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_unary_stream",
                 "c2:intercept_unary_stream",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_unary_stream[context-var-value]",
             ],
         )
 
@@ -741,7 +782,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_stream_unary",
                 "c2:intercept_stream_unary",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_stream_unary[context-var-value]",
             ],
         )
 
@@ -775,7 +817,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_stream_unary",
                 "c2:intercept_stream_unary",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_stream_unary[context-var-value]",
             ],
         )
 
@@ -805,7 +848,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_stream_unary",
                 "c2:intercept_stream_unary",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_stream_unary[context-var-value]",
             ],
         )
 
@@ -863,7 +907,8 @@ class InterceptorTest(unittest.TestCase):
                 "c1:intercept_stream_stream",
                 "c2:intercept_stream_stream",
                 "s1:intercept_service",
-                "s2:intercept_service",
+                "s2:intercept_service[context-var-value]",
+                "handler:handle_stream_stream[context-var-value]",
             ],
         )
 

--- a/src/python/grpcio_tests/tests_aio/unit/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_test_server.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import asyncio
+from contextvars import ContextVar
 import datetime
+from typing import Optional
 
 import grpc
 from grpc.experimental import aio
@@ -26,6 +28,8 @@ from tests_aio.unit import _constants
 
 _INITIAL_METADATA_KEY = "x-grpc-test-echo-initial"
 _TRAILING_METADATA_KEY = "x-grpc-test-echo-trailing-bin"
+
+TEST_CONTEXT_VAR: ContextVar[str] = ContextVar("")
 
 
 async def _maybe_echo_metadata(servicer_context):
@@ -56,7 +60,14 @@ async def _maybe_echo_status(
 
 
 class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
+    def __init__(self, record: Optional[list] = None):
+        self.record = record if record is not None else []
+
+    def _append_to_log(self):
+        self.record.append("servicer:" + TEST_CONTEXT_VAR.get("service"))
+
     async def UnaryCall(self, request, context):
+        self._append_to_log()
         await _maybe_echo_metadata(context)
         await _maybe_echo_status(request, context)
         return messages_pb2.SimpleResponse(
@@ -67,11 +78,13 @@ class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
         )
 
     async def EmptyCall(self, request, context):
+        self._append_to_log()
         return empty_pb2.Empty()
 
     async def StreamingOutputCall(
         self, request: messages_pb2.StreamingOutputCallRequest, unused_context
     ):
+        self._append_to_log()
         for response_parameters in request.response_parameters:
             if response_parameters.interval_us != 0:
                 await asyncio.sleep(
@@ -93,10 +106,12 @@ class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
     # when the sever is instantiated. They are not being provided by
     # the proto file.
     async def UnaryCallWithSleep(self, unused_request, unused_context):
+        self._append_to_log()
         await asyncio.sleep(_constants.UNARY_CALL_WITH_SLEEP_VALUE)
         return messages_pb2.SimpleResponse()
 
     async def StreamingInputCall(self, request_async_iterator, unused_context):
+        self._append_to_log()
         aggregate_size = 0
         async for request in request_async_iterator:
             if request.payload is not None and request.payload.body:
@@ -106,6 +121,7 @@ class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
         )
 
     async def FullDuplexCall(self, request_async_iterator, context):
+        self._append_to_log()
         await _maybe_echo_metadata(context)
         async for request in request_async_iterator:
             await _maybe_echo_status(request, context)
@@ -143,12 +159,16 @@ def _create_extra_generic_handler(servicer: TestServiceServicer):
 
 
 async def start_test_server(
-    port=0, secure=False, server_credentials=None, interceptors=None
+    port=0,
+    secure=False,
+    server_credentials=None,
+    interceptors=None,
+    record: Optional[list] = None,
 ):
     server = aio.server(
         options=(("grpc.so_reuseport", 0),), interceptors=interceptors
     )
-    servicer = TestServiceServicer()
+    servicer = TestServiceServicer(record)
     test_pb2_grpc.add_TestServiceServicer_to_server(servicer, server)
 
     server.add_generic_rpc_handlers((_create_extra_generic_handler(servicer),))


### PR DESCRIPTION
Fixes #33071

