### PR TITLE
[Build] re-enable grpc++_unsecure library without ssl dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,10 @@ set(gRPC_UPB_GEN_DUPL_SRC
   src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
   src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c
 )
+set(gRPC_ADDITIONAL_DLL_SRC
+  src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
+  src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+)
 
 endif() # BUILD_SHARED_LIBS AND WIN32
 
@@ -2396,6 +2400,7 @@ add_library(grpc
   src/core/lib/security/credentials/plugin/plugin_credentials.cc
   src/core/lib/security/credentials/ssl/ssl_credentials.cc
   src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
+  src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc
   src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
   src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
   src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc
@@ -3154,6 +3159,7 @@ add_library(grpc_unsecure
   third_party/upb/upb/mini_descriptor/decode.c
   third_party/upb/upb/mini_descriptor/internal/base92.c
   third_party/upb/upb/mini_descriptor/link.c
+  ${gRPC_ADDITIONAL_DLL_SRC}
 )
 
 target_compile_features(grpc_unsecure PUBLIC cxx_std_14)
@@ -4515,29 +4521,6 @@ target_link_libraries(grpc++_test_util
 endif()
 
 
-# for DLL build just compile a dummy grpc++_unsecure
-# This is a temporary situation until some code restructuring
-# obviates the need to exclude this library
-if(BUILD_SHARED_LIBS AND MSVC)
-add_library(grpc++_unsecure
-  src/cpp/common/version_cc.cc
-)
-target_include_directories(grpc++_unsecure
-  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-foreach(_hdr
-  include/grpcpp/grpcpp.h
-)
-  string(REPLACE "include/" "" _path ${_hdr})
-  get_filename_component(_path ${_path} PATH)
-  install(FILES ${_hdr}
-    DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
-  )
-endforeach()
-else()
 add_library(grpc++_unsecure
   src/cpp/client/channel_cc.cc
   src/cpp/client/client_callback.cc
@@ -4829,7 +4812,6 @@ foreach(_hdr
     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
   )
 endforeach()
-endif() # BUILD_SHARED_LIBS AND MSVC
 
 
 if(gRPC_INSTALL)

--- a/Makefile
+++ b/Makefile
@@ -1629,6 +1629,7 @@ LIBGRPC_SRC = \
     src/core/lib/security/credentials/plugin/plugin_credentials.cc \
     src/core/lib/security/credentials/ssl/ssl_credentials.cc \
     src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc \
+    src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc \
     src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc \
     src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc \
     src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc \
@@ -3674,6 +3675,7 @@ src/core/lib/security/credentials/local/local_credentials.cc: $(OPENSSL_DEP)
 src/core/lib/security/credentials/oauth2/oauth2_credentials.cc: $(OPENSSL_DEP)
 src/core/lib/security/credentials/ssl/ssl_credentials.cc: $(OPENSSL_DEP)
 src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc: $(OPENSSL_DEP)
+src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc: $(OPENSSL_DEP)
 src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc: $(OPENSSL_DEP)
 src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc: $(OPENSSL_DEP)
 src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc: $(OPENSSL_DEP)

--- a/Package.swift
+++ b/Package.swift
@@ -1574,6 +1574,7 @@ let package = Package(
         "src/core/lib/security/credentials/ssl/ssl_credentials.h",
         "src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc",
         "src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h",
+        "src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc",
         "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc",
         "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h",
         "src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc",

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -1704,6 +1704,7 @@ libs:
   - src/core/lib/security/credentials/plugin/plugin_credentials.cc
   - src/core/lib/security/credentials/ssl/ssl_credentials.cc
   - src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
+  - src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc
   - src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
   - src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
   - src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc

--- a/config.m4
+++ b/config.m4
@@ -762,6 +762,7 @@ if test "$PHP_GRPC" != "no"; then
     src/core/lib/security/credentials/plugin/plugin_credentials.cc \
     src/core/lib/security/credentials/ssl/ssl_credentials.cc \
     src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc \
+    src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc \
     src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc \
     src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc \
     src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc \

--- a/config.w32
+++ b/config.w32
@@ -727,6 +727,7 @@ if (PHP_GRPC != "no") {
     "src\\core\\lib\\security\\credentials\\plugin\\plugin_credentials.cc " +
     "src\\core\\lib\\security\\credentials\\ssl\\ssl_credentials.cc " +
     "src\\core\\lib\\security\\credentials\\tls\\grpc_tls_certificate_distributor.cc " +
+    "src\\core\\lib\\security\\credentials\\tls\\grpc_tls_certificate_match.cc " +
     "src\\core\\lib\\security\\credentials\\tls\\grpc_tls_certificate_provider.cc " +
     "src\\core\\lib\\security\\credentials\\tls\\grpc_tls_certificate_verifier.cc " +
     "src\\core\\lib\\security\\credentials\\tls\\grpc_tls_credentials_options.cc " +

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -1671,6 +1671,7 @@ Pod::Spec.new do |s|
                       'src/core/lib/security/credentials/ssl/ssl_credentials.h',
                       'src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc',
                       'src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h',
+                      'src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc',
                       'src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc',
                       'src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h',
                       'src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc',

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -1576,6 +1576,7 @@ Gem::Specification.new do |s|
   s.files += %w( src/core/lib/security/credentials/ssl/ssl_credentials.h )
   s.files += %w( src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc )
   s.files += %w( src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h )
+  s.files += %w( src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc )
   s.files += %w( src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc )
   s.files += %w( src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h )
   s.files += %w( src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc )

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -945,6 +945,7 @@
         'src/core/lib/security/credentials/plugin/plugin_credentials.cc',
         'src/core/lib/security/credentials/ssl/ssl_credentials.cc',
         'src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc',
+        'src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc',
         'src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc',
         'src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc',
         'src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc',

--- a/package.xml
+++ b/package.xml
@@ -1558,6 +1558,7 @@
     <file baseinstalldir="/" name="src/core/lib/security/credentials/ssl/ssl_credentials.h" role="src" />
     <file baseinstalldir="/" name="src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc" role="src" />
     <file baseinstalldir="/" name="src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h" role="src" />
+    <file baseinstalldir="/" name="src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc" role="src" />
     <file baseinstalldir="/" name="src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc" role="src" />
     <file baseinstalldir="/" name="src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h" role="src" />
     <file baseinstalldir="/" name="src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc" role="src" />

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -3300,6 +3300,7 @@ grpc_cc_library(
     name = "grpc_tls_credentials",
     srcs = [
         "lib/security/credentials/tls/grpc_tls_certificate_distributor.cc",
+        "lib/security/credentials/tls/grpc_tls_certificate_match.cc",
         "lib/security/credentials/tls/grpc_tls_certificate_provider.cc",
         "lib/security/credentials/tls/grpc_tls_certificate_verifier.cc",
         "lib/security/credentials/tls/grpc_tls_credentials_options.cc",

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc
@@ -16,10 +16,6 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h"
-
-#include <stdint.h>
-
 #include <openssl/bio.h>
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
@@ -27,6 +23,10 @@
 #include <openssl/x509.h>
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+#include "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h"
 
 namespace grpc_core {
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc
@@ -1,0 +1,86 @@
+//
+// Copyright 2020 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h"
+
+#include <stdint.h>
+
+#include <openssl/bio.h>
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include "absl/status/status.h"
+
+namespace grpc_core {
+
+absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
+    absl::string_view private_key, absl::string_view cert_chain) {
+  if (private_key.empty()) {
+    return absl::InvalidArgumentError("Private key string is empty.");
+  }
+  if (cert_chain.empty()) {
+    return absl::InvalidArgumentError("Certificate string is empty.");
+  }
+  BIO* cert_bio =
+      BIO_new_mem_buf(cert_chain.data(), static_cast<int>(cert_chain.size()));
+  if (cert_bio == nullptr) {
+    return absl::InvalidArgumentError(
+        "Conversion from certificate string to BIO failed.");
+  }
+  // Reads the first cert from the cert_chain which is expected to be the leaf
+  // cert
+  X509* x509 = PEM_read_bio_X509(cert_bio, nullptr, nullptr, nullptr);
+  BIO_free(cert_bio);
+  if (x509 == nullptr) {
+    return absl::InvalidArgumentError(
+        "Conversion from PEM string to X509 failed.");
+  }
+  EVP_PKEY* public_evp_pkey = X509_get_pubkey(x509);
+  X509_free(x509);
+  if (public_evp_pkey == nullptr) {
+    return absl::InvalidArgumentError(
+        "Extraction of public key from x.509 certificate failed.");
+  }
+  BIO* private_key_bio =
+      BIO_new_mem_buf(private_key.data(), static_cast<int>(private_key.size()));
+  if (private_key_bio == nullptr) {
+    EVP_PKEY_free(public_evp_pkey);
+    return absl::InvalidArgumentError(
+        "Conversion from private key string to BIO failed.");
+  }
+  EVP_PKEY* private_evp_pkey =
+      PEM_read_bio_PrivateKey(private_key_bio, nullptr, nullptr, nullptr);
+  BIO_free(private_key_bio);
+  if (private_evp_pkey == nullptr) {
+    EVP_PKEY_free(public_evp_pkey);
+    return absl::InvalidArgumentError(
+        "Conversion from PEM string to EVP_PKEY failed.");
+  }
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+  bool result = EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
+#else
+  bool result = EVP_PKEY_eq(private_evp_pkey, public_evp_pkey) == 1;
+#endif
+  EVP_PKEY_free(private_evp_pkey);
+  EVP_PKEY_free(public_evp_pkey);
+  return result;
+}
+
+}  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -25,12 +25,6 @@
 #include <utility>
 #include <vector>
 
-#include <openssl/bio.h>
-#include <openssl/crypto.h>
-#include <openssl/evp.h>
-#include <openssl/pem.h>
-#include <openssl/x509.h>
-
 #include "absl/status/status.h"
 
 #include <grpc/slice.h>
@@ -392,59 +386,6 @@ FileWatcherCertificateProvider::ReadIdentityKeyCertPairFromFiles(
 int64_t FileWatcherCertificateProvider::TestOnlyGetRefreshIntervalSecond()
     const {
   return refresh_interval_sec_;
-}
-
-absl::StatusOr<bool> PrivateKeyAndCertificateMatch(
-    absl::string_view private_key, absl::string_view cert_chain) {
-  if (private_key.empty()) {
-    return absl::InvalidArgumentError("Private key string is empty.");
-  }
-  if (cert_chain.empty()) {
-    return absl::InvalidArgumentError("Certificate string is empty.");
-  }
-  BIO* cert_bio =
-      BIO_new_mem_buf(cert_chain.data(), static_cast<int>(cert_chain.size()));
-  if (cert_bio == nullptr) {
-    return absl::InvalidArgumentError(
-        "Conversion from certificate string to BIO failed.");
-  }
-  // Reads the first cert from the cert_chain which is expected to be the leaf
-  // cert
-  X509* x509 = PEM_read_bio_X509(cert_bio, nullptr, nullptr, nullptr);
-  BIO_free(cert_bio);
-  if (x509 == nullptr) {
-    return absl::InvalidArgumentError(
-        "Conversion from PEM string to X509 failed.");
-  }
-  EVP_PKEY* public_evp_pkey = X509_get_pubkey(x509);
-  X509_free(x509);
-  if (public_evp_pkey == nullptr) {
-    return absl::InvalidArgumentError(
-        "Extraction of public key from x.509 certificate failed.");
-  }
-  BIO* private_key_bio =
-      BIO_new_mem_buf(private_key.data(), static_cast<int>(private_key.size()));
-  if (private_key_bio == nullptr) {
-    EVP_PKEY_free(public_evp_pkey);
-    return absl::InvalidArgumentError(
-        "Conversion from private key string to BIO failed.");
-  }
-  EVP_PKEY* private_evp_pkey =
-      PEM_read_bio_PrivateKey(private_key_bio, nullptr, nullptr, nullptr);
-  BIO_free(private_key_bio);
-  if (private_evp_pkey == nullptr) {
-    EVP_PKEY_free(public_evp_pkey);
-    return absl::InvalidArgumentError(
-        "Conversion from PEM string to EVP_PKEY failed.");
-  }
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-  bool result = EVP_PKEY_cmp(private_evp_pkey, public_evp_pkey) == 1;
-#else
-  bool result = EVP_PKEY_eq(private_evp_pkey, public_evp_pkey) == 1;
-#endif
-  EVP_PKEY_free(private_evp_pkey);
-  EVP_PKEY_free(public_evp_pkey);
-  return result;
 }
 
 }  // namespace grpc_core

--- a/src/python/grpcio/grpc_core_dependencies.py
+++ b/src/python/grpcio/grpc_core_dependencies.py
@@ -736,6 +736,7 @@ CORE_SOURCE_FILES = [
     'src/core/lib/security/credentials/plugin/plugin_credentials.cc',
     'src/core/lib/security/credentials/ssl/ssl_credentials.cc',
     'src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc',
+    'src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc',
     'src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc',
     'src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc',
     'src/core/lib/security/credentials/tls/grpc_tls_credentials_options.cc',

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -527,6 +527,10 @@
     src/core/ext/upb-generated/src/proto/grpc/health/v1/health.upb.c
     src/core/ext/upb-generated/src/proto/grpc/gcp/transport_security_common.upb.c
   )
+  set(gRPC_ADDITIONAL_DLL_SRC
+    src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
+    src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+  )
 
   endif() # BUILD_SHARED_LIBS AND WIN32
 
@@ -770,31 +774,6 @@
   % endif
   % endif
 
-  % if lib.name == 'grpc++_unsecure':
-  # for DLL build just compile a dummy grpc++_unsecure
-  # This is a temporary situation until some code restructuring
-  # obviates the need to exclude this library
-  if(BUILD_SHARED_LIBS AND MSVC)
-  add_library(grpc++_unsecure
-    src/cpp/common/version_cc.cc
-  )
-  target_include_directories(grpc++_unsecure
-    PUBLIC <%text>$<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include></%text>
-    PRIVATE
-      <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>
-  )
-
-  foreach(_hdr
-    include/grpcpp/grpcpp.h
-  )
-    string(REPLACE "include/" "" _path <%text>${_hdr})</%text>
-    get_filename_component(_path <%text>${_path}</%text> PATH)
-    install(FILES <%text>${_hdr}</%text>
-      DESTINATION <%text>"${gRPC_INSTALL_INCLUDEDIR}/${_path}"</%text>
-    )
-  endforeach()
-  else()
-  % endif
   add_library(${lib.name}${lib_type_for_lib(lib.name)}
   % for src in lib.src:
   % if not proto_re.match(src):
@@ -811,6 +790,9 @@
   % endfor
   % if lib.name in ['grpc++_alts', 'grpc++_unsecure', 'grpc++']:
     ${'${gRPC_UPB_GEN_DUPL_SRC}'}
+  % endif
+  % if lib.name in ['grpc_unsecure']:
+    ${'${gRPC_ADDITIONAL_DLL_SRC}'}
   % endif
   )
 
@@ -908,9 +890,6 @@
   % endif
   % if any(proto_re.match(src) for src in lib.src):
   endif()
-  % endif
-  % if lib.name == 'grpc++_unsecure':
-  endif() # BUILD_SHARED_LIBS AND MSVC
   % endif
   </%def>
 

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -2573,6 +2573,7 @@ src/core/lib/security/credentials/ssl/ssl_credentials.cc \
 src/core/lib/security/credentials/ssl/ssl_credentials.h \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h \
+src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc \

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -2354,6 +2354,7 @@ src/core/lib/security/credentials/ssl/ssl_credentials.cc \
 src/core/lib/security/credentials/ssl/ssl_credentials.h \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h \
+src/core/lib/security/credentials/tls/grpc_tls_certificate_match.cc \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h \
 src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc \


### PR DESCRIPTION
This is a follow up to https://github.com/grpc/grpc/pull/34103

That pull request explicitly aimed to introduce shared library builds for Windows (DLLs) while effecting zero material change to the existing build pipelines. That aspiration meant that the grpc++_unsecure library had to be effectively excluded from the build (because including it would have also included a dependency on openssl, which makes no sense given its purpose)

This PR addresses that by:
* Extracting the single function in grpc_tls_certificate_provider with a dependency on openssl into a separate compilation unit
* Including that new .cc file into the grpc library
* Including grpc_tls_certificate_provider and one other source file into grpc_unsecure for the Windows DLL build only.
* Reinstating the grpc++_unsecure library which is a prerequisite for many tests.
* Regenerating all files affected by the changes in Bazel BUILD that introduce the new source file.

This change does affect the operation of other build pipelines - I have confirmed that it does not break the Linux Bazel build.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

