### PR TITLE
[doc] Fix typo in xds-test-descriptions.md

### DIFF
--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -22,7 +22,7 @@ In addition, when handling requests, if the initial request metadata contains th
  - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before resuming behavior matching and RPC processing.
  - If the value matches `keep-open`, the server should never respond to the request and behavior matching ends.
  - If the value matches `error-code-<int>`, the server should respond with the specified status code and behavior matching ends.
- - If the value matches `success-on-retry-attempt-<int>`, and the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number, the normal RPC processing should resume and behavior matching ends.
+ - If the value matches `succeed-on-retry-attempt-<int>`, and the value of the `grpc-previous-rpc-attempts` metadata field is equal to the specified number, the normal RPC processing should resume and behavior matching ends.
  - A value can have a prefix `hostname=<string>` followed by a space. In that case, the rest of the value should only be applied if the specified hostname matches the server's hostname.
 
 The `rpc-behavior` header value can have multiple options separated by commas. In that case, the value should be split by commas and the options should be applied in the order specified. If a request has multiple `rpc-behavior` metadata values, each one should be processed that way in order.


### PR DESCRIPTION
`succeed-on-retry-attempt-<int>` is what is being currently used in the Java server implementation and also by the test client. The spec was probably written after the stuff was implemented and this typo is better fixed before other languages implement their server side logic. Go is in the process of doing so.

