### PR TITLE
[PSM Interop] Log Google Cloud API debug header

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -593,12 +593,12 @@ class ComputeV1(
             def _log_debug_header(resp, contents):
                 if DEBUG_HEADER_IN_RESPONSE in resp:
                     logger.info(
-                        f"Received debug headers: {resp[DEBUG_HEADER_IN_RESPONSE]}\n"
+                        f"Received debug headers: {resp[DEBUG_HEADER_IN_RESPONSE]}"
                     )
                 return old_postproc(resp, contents)
 
             logger.info(
-                f"Adding debug headers for method: {request.methodId}\n"
+                f"Adding debug headers for method: {request.methodId}"
             )
             request.headers[DEBUG_HEADER_KEY] = DEBUG_HEADER_VALUE
             request.postproc = _log_debug_header

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 DEBUG_HEADER_IN_RESPONSE = "x-encrypted-debug-headers"
 DEBUG_HEADER_KEY = "X-Return-Encrypted-Headers"
-DISABLE_DEBUG_HEADER_VALUE = "disable_gfe_debug_header"
 
 
 class ComputeV1(
@@ -39,7 +38,7 @@ class ComputeV1(
     _WAIT_FOR_BACKEND_SEC = 60 * 10
     _WAIT_FOR_BACKEND_SLEEP_SEC = 4
     _WAIT_FOR_OPERATION_SEC = 60 * 10
-    gfe_debug_header: str
+    gfe_debug_header: Optional[str]
 
     @dataclasses.dataclass(frozen=True)
     class GcpResource:
@@ -61,7 +60,7 @@ class ComputeV1(
         self,
         api_manager: gcp.api.GcpApiManager,
         project: str,
-        gfe_debug_header: str = DISABLE_DEBUG_HEADER_VALUE,
+        gfe_debug_header: Optional[str] = None,
         version: str = "v1",
     ):
         super().__init__(api_manager.compute(version), project)
@@ -594,7 +593,7 @@ class ComputeV1(
     def _execute(  # pylint: disable=arguments-differ
         self, request, *, timeout_sec=_WAIT_FOR_OPERATION_SEC
     ):
-        if self.gfe_debug_header != DISABLE_DEBUG_HEADER_VALUE:
+        if self.gfe_debug_header:
             logger.info("Adding debug headers for method: %s", request.methodId)
             request.headers[DEBUG_HEADER_KEY] = self.gfe_debug_header
             request.add_response_callback(self._log_debug_header)

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -587,7 +587,7 @@ class ComputeV1(
     def _execute(  # pylint: disable=arguments-differ
         self, request, *, timeout_sec=_WAIT_FOR_OPERATION_SEC
     ):
-        if xds_flags.IS_STAGING.value:
+        if xds_flags.ENABLE_GFE_DEBUG_HEADER.value:
             old_postproc = request.postproc
 
             def _log_debug_header(resp, contents):

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -593,13 +593,12 @@ class ComputeV1(
             def _log_debug_header(resp, contents):
                 if DEBUG_HEADER_IN_RESPONSE in resp:
                     logger.info(
-                        f"Received debug headers: {resp[DEBUG_HEADER_IN_RESPONSE]}"
+                        "Received debug headers: %s",
+                        resp[DEBUG_HEADER_IN_RESPONSE],
                     )
                 return old_postproc(resp, contents)
 
-            logger.info(
-                f"Adding debug headers for method: {request.methodId}"
-            )
+            logger.info("Adding debug headers for method: %s", request.methodId)
             request.headers[DEBUG_HEADER_KEY] = DEBUG_HEADER_VALUE
             request.postproc = _log_debug_header
         operation = request.execute(num_retries=self._GCP_API_RETRIES)

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -49,14 +49,6 @@ class ComputeV1(
     class ZonalGcpResource(GcpResource):
         zone: str
 
-    @staticmethod
-    def _log_debug_header(resp: httplib2.Response):
-        if DEBUG_HEADER_IN_RESPONSE in resp:
-            logger.info(
-                "Received GCP debug headers: %s",
-                resp[DEBUG_HEADER_IN_RESPONSE],
-            )
-
     def __init__(
         self,
         api_manager: gcp.api.GcpApiManager,
@@ -590,6 +582,14 @@ class ComputeV1(
     @staticmethod
     def _operation_status_done(operation):
         return "status" in operation and operation["status"] == "DONE"
+
+    @staticmethod
+    def _log_debug_header(resp: httplib2.Response):
+        if DEBUG_HEADER_IN_RESPONSE in resp:
+            logger.info(
+                "Received GCP debug headers: %s",
+                resp[DEBUG_HEADER_IN_RESPONSE],
+            )
 
     def _execute(  # pylint: disable=arguments-differ
         self, request, *, timeout_sec=_WAIT_FOR_OPERATION_SEC

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -49,7 +49,8 @@ class ComputeV1(
     class ZonalGcpResource(GcpResource):
         zone: str
 
-    def _log_debug_header(self, resp: httplib2.Response):
+    @staticmethod
+    def _log_debug_header(resp: httplib2.Response):
         if DEBUG_HEADER_IN_RESPONSE in resp:
             logger.info(
                 "Received GCP debug headers: %s",

--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/traffic_director.py
@@ -79,7 +79,10 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
     ):
         # API
         self.compute = _ComputeV1(
-            gcp_api_manager, project, version=compute_api_version
+            gcp_api_manager,
+            project,
+            version=compute_api_version,
+            gfe_debug_header=xds_flags.GFE_DEBUG_HEADER.value,
         )
 
         # Settings

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -173,10 +173,16 @@ SOCKET_DEFAULT_TIMEOUT = flags.DEFINE_float(
     ),
 )
 
-ENABLE_GFE_DEBUG_HEADER = flags.DEFINE_bool(
-    "enable_gfe_debug_header",
-    default=False,
-    help="Whether to enable GFE debug headers.",
+GFE_DEBUG_HEADER = flags.DEFINE_enum(
+    "gfe_debug_header",
+    default="disable_gfe_debug_header",
+    enum_values=[
+        "disable_gfe_debug_header",
+        "gfe_response_only",
+        "all_response",
+        "request_and_response",
+    ],
+    help="Whether to enable GFE debug headers and what value to use.",
 )
 
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -173,10 +173,10 @@ SOCKET_DEFAULT_TIMEOUT = flags.DEFINE_float(
     ),
 )
 
-IS_STAGING = flags.DEFINE_bool(
-    "is_staging",
+ENABLE_GFE_DEBUG_HEADER = flags.DEFINE_bool(
+    "enable_gfe_debug_header",
     default=False,
-    help="If tests are running under staging environment",
+    help="Whether to enable GFE debug headers.",
 )
 
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -175,9 +175,8 @@ SOCKET_DEFAULT_TIMEOUT = flags.DEFINE_float(
 
 GFE_DEBUG_HEADER = flags.DEFINE_enum(
     "gfe_debug_header",
-    default="disable_gfe_debug_header",
+    default=None,
     enum_values=[
-        "disable_gfe_debug_header",
         "gfe_response_only",
         "all_response",
         "request_and_response",

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_flags.py
@@ -173,6 +173,12 @@ SOCKET_DEFAULT_TIMEOUT = flags.DEFINE_float(
     ),
 )
 
+IS_STAGING = flags.DEFINE_bool(
+    "is_staging",
+    default=False,
+    help="If tests are running under staging environment",
+)
+
 
 def set_socket_default_timeout_from_flag() -> None:
     """A helper to configure default socket timeout from a flag.


### PR DESCRIPTION
Add Google Cloud API debug header and read response.

#### Testing

* Triggered in Prod, no header was logged: https://source.cloud.google.com/results/invocations/c91c6e81-5e5b-4545-8abf-28594d4493a5
* Triggered in Prod with debug header enabled: https://source.cloud.google.com/results/invocations/cfda4dd5-e3a9-4519-a4e7-85220f780cbf
* Also tested locally in staging.
* Example log:
```
I0913 01:04:19.688863 139651983066944 traffic_director.py:187] Creating GRPC Health Check "xds-k8s-test-health-check-dev"
I0913 01:04:19.692854 139651983066944 compute.py:538] Creating compute resource:
---
grpcHealthCheck:
  portSpecification: USE_SERVING_PORT
name: xds-k8s-test-health-check-dev
type: GRPC
...

I0913 01:04:19.693941 139651983066944 compute.py:600] Adding debug headers for method: compute.healthChecks.insert
I0913 01:04:20.726086 139651983066944 compute.py:595] Received debug headers:
ADViAh6vFBtRL4YCoe622ssZK297mvPAmEmv7mbNs+CgHLLXi7hwphTvxN5Ssh9LNB+Jgdu3Go3/12y1yxh9qRaTjov2Gukiqf9yDkgE9VywDwmXk6FNHkYwWO9Rq5AyfkBYL82d90fC7mH8ZdLqzrGhXiGwl5jtF4hA1xg9c1dnKEsSWlrBBPePHzpVb52CKy6C/I4SXdeiXTp9ORHJJwGu1qA75xCqMEf4btOw0GML+j3e...
I0913 01:04:20.726562 139651983066944 compute.py:610] Waiting 600 sec for compute operation id: operation-1694567059990-6053323a8a81a-5340529e-bf5d5c03
I0913 01:04:23.383233 139651983066944 xds_k8s_testcase.py:272] --- Finished subTest __main__.BaselineTest.test_traffic_director_grpc_setup.0_create_health_check ---
```
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

