### PR TITLE
[PSM Interop] Enable GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client-secure.deployment.yaml
@@ -51,6 +51,8 @@ spec:
             value: "true"
           - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
             value: "true"
+          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+            value: "true"
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/client.deployment.yaml
@@ -51,9 +51,11 @@ spec:
             value: "true"
           - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY
             value: "true"
+          - name: GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION
+            value: "true"
           - name: GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG
             value: "true"
-          - name: GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION
+          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
             value: "true"
         volumeMounts:
           - mountPath: /tmp/grpc-xds/

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server-secure.deployment.yaml
@@ -54,6 +54,8 @@ spec:
             value: "true"
           - name: GRPC_XDS_EXPERIMENTAL_RBAC
             value: "true"
+          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+            value: "true"
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
+++ b/tools/run_tests/xds_k8s_test_driver/kubernetes-manifests/server.deployment.yaml
@@ -44,6 +44,8 @@ spec:
             value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
           - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
             value: "true"
+          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+            value: "true"
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf


### PR DESCRIPTION
Backport: [PSM Interop] Enable GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST (#34205)