### PR TITLE
[Build] Fix DLL build when run with gRPC_BUILD_TESTS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ set(PACKAGE_TARNAME       "${PACKAGE_NAME}-${PACKAGE_VERSION}")
 set(PACKAGE_BUGREPORT     "https://github.com/grpc/grpc/issues/")
 project(${PACKAGE_NAME} LANGUAGES C CXX)
 
+if(BUILD_SHARED_LIBS AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 set(gRPC_INSTALL_BINDIR "bin" CACHE STRING "Installation directory for executables")
 set(gRPC_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries")
 set(gRPC_INSTALL_INCLUDEDIR "include" CACHE STRING "Installation directory for headers")
@@ -267,6 +271,8 @@ if(MSVC)
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4503")
   # Tell MSVC to build grpc using utf-8
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /utf-8")
+  # Inconsistent object sizes can cause stack corruption and should be treated as an error
+  set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /we4789")
 endif()
 if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)
@@ -440,14 +446,20 @@ if(BUILD_SHARED_LIBS AND WIN32)
 # include redundant duplicate code. Hence, the duplication is only activated
 # for DLL builds - and should be completely removed when source files are
 # generated with the necessary __declspec annotations.
+# TODO (@dawidcha) remove this when DLL export macros available for upb-generated code.
 set(gRPC_UPB_GEN_DUPL_SRC
   src/core/ext/upb-gen/src/proto/grpc/gcp/altscontext.upb_minitable.c
   src/core/ext/upb-gen/src/proto/grpc/health/v1/health.upb_minitable.c
   src/core/ext/upb-gen/src/proto/grpc/gcp/transport_security_common.upb_minitable.c
 )
+
+# All upb sources for inclusion in tests that depend on them
+set(gRPC_UPB_GEN_DUPL_TEST_SRC
+)
 set(gRPC_ADDITIONAL_DLL_SRC
   src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
   src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+  src/cpp/common/tls_certificate_provider.cc
 )
 
 endif() # BUILD_SHARED_LIBS AND WIN32
@@ -1643,9 +1655,11 @@ if(WIN32 AND MSVC)
   set_target_properties(gpr PROPERTIES COMPILE_PDB_NAME "gpr"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
-  set_target_properties(gpr PROPERTIES DEFINE_SYMBOL "GPR_DLL_EXPORTS")
   if(BUILD_SHARED_LIBS)
-    target_compile_definitions(gpr INTERFACE GPR_DLL_IMPORTS)
+    target_compile_definitions(gpr
+    PRIVATE
+      "GPR_DLL_EXPORTS"
+    )
   endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gpr.pdb
@@ -2544,9 +2558,12 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc PROPERTIES COMPILE_PDB_NAME "grpc"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
-  set_target_properties(grpc PROPERTIES DEFINE_SYMBOL "GRPC_DLL_EXPORTS")
   if(BUILD_SHARED_LIBS)
-    target_compile_definitions(grpc INTERFACE GRPC_DLL_IMPORTS)
+    target_compile_definitions(grpc
+    PRIVATE
+      "GRPC_DLL_EXPORTS"
+      "GPR_DLL_IMPORTS"
+    )
   endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc.pdb
@@ -2716,6 +2733,13 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc_test_util PROPERTIES COMPILE_PDB_NAME "grpc_test_util"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_test_util
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_test_util.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -2775,6 +2799,13 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc_test_util_unsecure PROPERTIES COMPILE_PDB_NAME "grpc_test_util_unsecure"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_test_util_unsecure
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_test_util_unsecure.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -3221,9 +3252,12 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc_unsecure PROPERTIES COMPILE_PDB_NAME "grpc_unsecure"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
-  set_target_properties(grpc_unsecure PROPERTIES DEFINE_SYMBOL "GRPC_DLL_EXPORTS")
   if(BUILD_SHARED_LIBS)
-    target_compile_definitions(grpc_unsecure INTERFACE GRPC_DLL_IMPORTS)
+    target_compile_definitions(grpc_unsecure
+    PRIVATE
+      "GRPC_DLL_EXPORTS"
+      "GPR_DLL_IMPORTS"
+    )
   endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_unsecure.pdb
@@ -3366,7 +3400,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 
-add_library(gtest
+add_library(gtest ${_gRPC_STATIC_WIN32}
   third_party/googletest/googlemock/src/gmock-cardinalities.cc
   third_party/googletest/googlemock/src/gmock-internal-utils.cc
   third_party/googletest/googlemock/src/gmock-matchers.cc
@@ -3806,7 +3840,7 @@ if(gRPC_BUILD_TESTS)
 
 if(gRPC_BUILD_CODEGEN)
 
-add_library(benchmark_helpers
+add_library(benchmark_helpers ${_gRPC_STATIC_WIN32}
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.pb.h
@@ -3848,6 +3882,14 @@ if(WIN32 AND MSVC)
   set_target_properties(benchmark_helpers PROPERTIES COMPILE_PDB_NAME "benchmark_helpers"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(benchmark_helpers
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/benchmark_helpers.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -3962,9 +4004,13 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++ PROPERTIES COMPILE_PDB_NAME "grpc++"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
-  set_target_properties(grpc++ PROPERTIES DEFINE_SYMBOL "GRPCXX_DLL_EXPORTS")
   if(BUILD_SHARED_LIBS)
-    target_compile_definitions(grpc++ INTERFACE GRPCXX_DLL_IMPORTS)
+    target_compile_definitions(grpc++
+    PRIVATE
+      "GRPCXX_DLL_EXPORTS"
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
   endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++.pdb
@@ -4236,6 +4282,14 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_alts PROPERTIES COMPILE_PDB_NAME "grpc++_alts"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_alts
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_alts.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -4300,6 +4354,14 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_error_details PROPERTIES COMPILE_PDB_NAME "grpc++_error_details"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_error_details
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_error_details.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -4350,7 +4412,7 @@ endif()
 
 if(gRPC_BUILD_CODEGEN)
 
-add_library(grpc++_reflection
+add_library(grpc++_reflection ${_gRPC_STATIC_WIN32}
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.pb.h
@@ -4374,6 +4436,14 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_reflection PROPERTIES COMPILE_PDB_NAME "grpc++_reflection"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_reflection
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_reflection.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -4442,6 +4512,14 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_test PROPERTIES COMPILE_PDB_NAME "grpc++_test"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_test.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -4508,6 +4586,12 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_test_config PROPERTIES COMPILE_PDB_NAME "grpc++_test_config"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_test_config
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_test_config.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -4575,6 +4659,14 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_test_util PROPERTIES COMPILE_PDB_NAME "grpc++_test_util"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_test_util
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_test_util.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -4657,9 +4749,13 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc++_unsecure PROPERTIES COMPILE_PDB_NAME "grpc++_unsecure"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
-  set_target_properties(grpc++_unsecure PROPERTIES DEFINE_SYMBOL "GRPCXX_DLL_EXPORTS")
   if(BUILD_SHARED_LIBS)
-    target_compile_definitions(grpc++_unsecure INTERFACE GRPCXX_DLL_IMPORTS)
+    target_compile_definitions(grpc++_unsecure
+    PRIVATE
+      "GRPCXX_DLL_EXPORTS"
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
   endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_unsecure.pdb
@@ -5205,6 +5301,12 @@ if(WIN32 AND MSVC)
   set_target_properties(grpc_authorization_provider PROPERTIES COMPILE_PDB_NAME "grpc_authorization_provider"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_authorization_provider
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc_authorization_provider.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -5414,7 +5516,7 @@ endif()
 # See https://github.com/grpc/grpc/issues/19473
 if(gRPC_BUILD_CODEGEN AND NOT gRPC_USE_PROTO_LITE)
 
-add_library(grpcpp_channelz
+add_library(grpcpp_channelz ${_gRPC_STATIC_WIN32}
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.pb.h
@@ -5434,6 +5536,14 @@ if(WIN32 AND MSVC)
   set_target_properties(grpcpp_channelz PROPERTIES COMPILE_PDB_NAME "grpcpp_channelz"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
   )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpcpp_channelz
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
   if(gRPC_INSTALL)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpcpp_channelz.pdb
       DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
@@ -5502,6 +5612,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(fd_conservation_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(fd_conservation_posix_test PUBLIC cxx_std_14)
   target_include_directories(fd_conservation_posix_test
     PRIVATE
@@ -5530,6 +5649,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(multiple_server_queues_test
   test/core/end2end/multiple_server_queues_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(multiple_server_queues_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(multiple_server_queues_test PUBLIC cxx_std_14)
 target_include_directories(multiple_server_queues_test
   PRIVATE
@@ -5558,6 +5686,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   add_executable(pollset_windows_starvation_test
     test/core/iomgr/pollset_windows_starvation_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(pollset_windows_starvation_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(pollset_windows_starvation_test PUBLIC cxx_std_14)
   target_include_directories(pollset_windows_starvation_test
     PRIVATE
@@ -5588,6 +5725,14 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     src/core/ext/filters/client_channel/lb_policy/weighted_round_robin/static_stride_scheduler.cc
     test/core/client_channel/lb_policy/static_stride_scheduler_benchmark.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(static_stride_scheduler_benchmark
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(static_stride_scheduler_benchmark PUBLIC cxx_std_14)
   target_include_directories(static_stride_scheduler_benchmark
     PRIVATE
@@ -5629,6 +5774,15 @@ add_executable(test_core_iomgr_timer_list_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_iomgr_timer_list_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_iomgr_timer_list_test PUBLIC cxx_std_14)
 target_include_directories(test_core_iomgr_timer_list_test
   PRIVATE
@@ -5659,6 +5813,14 @@ add_executable(activity_test
   src/core/lib/promise/trace.cc
   test/core/promise/activity_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(activity_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(activity_test PUBLIC cxx_std_14)
 target_include_directories(activity_test
   PRIVATE
@@ -5696,6 +5858,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(address_sorting_test
     test/cpp/naming/address_sorting_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(address_sorting_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(address_sorting_test PUBLIC cxx_std_14)
   target_include_directories(address_sorting_test
     PRIVATE
@@ -5747,6 +5919,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/util/string_ref_helper.cc
     test/cpp/util/subprocess.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(address_sorting_test_unsecure
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(address_sorting_test_unsecure PUBLIC cxx_std_14)
   target_include_directories(address_sorting_test_unsecure
     PRIVATE
@@ -5801,6 +5983,16 @@ add_executable(admin_services_end2end_test
   src/cpp/server/csds/csds.cc
   test/cpp/end2end/admin_services_end2end_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(admin_services_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(admin_services_end2end_test PUBLIC cxx_std_14)
 target_include_directories(admin_services_end2end_test
   PRIVATE
@@ -5847,6 +6039,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/tracer_util.cc
     test/cpp/common/alarm_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(alarm_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(alarm_test PUBLIC cxx_std_14)
   target_include_directories(alarm_test
     PRIVATE
@@ -5882,6 +6084,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(alloc_test
   test/core/gpr/alloc_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alloc_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alloc_test PUBLIC cxx_std_14)
 target_include_directories(alloc_test
   PRIVATE
@@ -5915,6 +6126,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(alpn_test
   test/core/transport/chttp2/alpn_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alpn_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alpn_test PUBLIC cxx_std_14)
 target_include_directories(alpn_test
   PRIVATE
@@ -5960,6 +6180,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/core/tsi/alts/handshaker/alts_concurrent_connectivity_test.cc
     test/core/util/fake_udp_and_tcp_server.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(alts_concurrent_connectivity_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(alts_concurrent_connectivity_test PUBLIC cxx_std_14)
   target_include_directories(alts_concurrent_connectivity_test
     PRIVATE
@@ -5996,6 +6226,15 @@ add_executable(alts_counter_test
   test/core/tsi/alts/crypt/gsec_test_util.cc
   test/core/tsi/alts/frame_protector/alts_counter_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_counter_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_counter_test PUBLIC cxx_std_14)
 target_include_directories(alts_counter_test
   PRIVATE
@@ -6030,6 +6269,15 @@ add_executable(alts_crypt_test
   test/core/tsi/alts/crypt/aes_gcm_test.cc
   test/core/tsi/alts/crypt/gsec_test_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_crypt_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_crypt_test PUBLIC cxx_std_14)
 target_include_directories(alts_crypt_test
   PRIVATE
@@ -6064,6 +6312,15 @@ add_executable(alts_crypter_test
   test/core/tsi/alts/crypt/gsec_test_util.cc
   test/core/tsi/alts/frame_protector/alts_crypter_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_crypter_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_crypter_test PUBLIC cxx_std_14)
 target_include_directories(alts_crypter_test
   PRIVATE
@@ -6099,6 +6356,15 @@ add_executable(alts_frame_protector_test
   test/core/tsi/alts/frame_protector/alts_frame_protector_test.cc
   test/core/tsi/transport_security_test_lib.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_frame_protector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_frame_protector_test PUBLIC cxx_std_14)
 target_include_directories(alts_frame_protector_test
   PRIVATE
@@ -6133,6 +6399,15 @@ add_executable(alts_grpc_record_protocol_test
   test/core/tsi/alts/crypt/gsec_test_util.cc
   test/core/tsi/alts/zero_copy_frame_protector/alts_grpc_record_protocol_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_grpc_record_protocol_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_grpc_record_protocol_test PUBLIC cxx_std_14)
 target_include_directories(alts_grpc_record_protocol_test
   PRIVATE
@@ -6166,7 +6441,17 @@ if(gRPC_BUILD_TESTS)
 add_executable(alts_handshaker_client_test
   test/core/tsi/alts/handshaker/alts_handshaker_client_test.cc
   test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_handshaker_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_handshaker_client_test PUBLIC cxx_std_14)
 target_include_directories(alts_handshaker_client_test
   PRIVATE
@@ -6201,6 +6486,15 @@ add_executable(alts_iovec_record_protocol_test
   test/core/tsi/alts/crypt/gsec_test_util.cc
   test/core/tsi/alts/zero_copy_frame_protector/alts_iovec_record_protocol_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_iovec_record_protocol_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_iovec_record_protocol_test PUBLIC cxx_std_14)
 target_include_directories(alts_iovec_record_protocol_test
   PRIVATE
@@ -6244,6 +6538,15 @@ add_executable(alts_security_connector_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_security_connector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_security_connector_test PUBLIC cxx_std_14)
 target_include_directories(alts_security_connector_test
   PRIVATE
@@ -6277,7 +6580,17 @@ if(gRPC_BUILD_TESTS)
 add_executable(alts_tsi_handshaker_test
   test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.cc
   test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_tsi_handshaker_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_tsi_handshaker_test PUBLIC cxx_std_14)
 target_include_directories(alts_tsi_handshaker_test
   PRIVATE
@@ -6311,7 +6624,17 @@ if(gRPC_BUILD_TESTS)
 add_executable(alts_tsi_utils_test
   test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.cc
   test/core/tsi/alts/handshaker/alts_tsi_utils_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_tsi_utils_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_tsi_utils_test PUBLIC cxx_std_14)
 target_include_directories(alts_tsi_utils_test
   PRIVATE
@@ -6344,7 +6667,18 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(alts_util_test
   test/cpp/common/alts_util_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_util_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_util_test PUBLIC cxx_std_14)
 target_include_directories(alts_util_test
   PRIVATE
@@ -6380,6 +6714,15 @@ add_executable(alts_zero_copy_grpc_protector_test
   test/core/tsi/alts/crypt/gsec_test_util.cc
   test/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(alts_zero_copy_grpc_protector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(alts_zero_copy_grpc_protector_test PUBLIC cxx_std_14)
 target_include_directories(alts_zero_copy_grpc_protector_test
   PRIVATE
@@ -6413,6 +6756,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(arena_promise_test
   test/core/promise/arena_promise_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(arena_promise_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(arena_promise_test PUBLIC cxx_std_14)
 target_include_directories(arena_promise_test
   PRIVATE
@@ -6446,6 +6798,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(arena_test
   test/core/resource_quota/arena_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(arena_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(arena_test PUBLIC cxx_std_14)
 target_include_directories(arena_test
   PRIVATE
@@ -6503,6 +6864,16 @@ add_executable(async_end2end_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/async_end2end_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(async_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(async_end2end_test PUBLIC cxx_std_14)
 target_include_directories(async_end2end_test
   PRIVATE
@@ -6546,6 +6917,15 @@ add_executable(auth_context_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(auth_context_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(auth_context_test PUBLIC cxx_std_14)
 target_include_directories(auth_context_test
   PRIVATE
@@ -6579,6 +6959,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(auth_property_iterator_test
   test/cpp/common/auth_property_iterator_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(auth_property_iterator_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(auth_property_iterator_test PUBLIC cxx_std_14)
 target_include_directories(auth_property_iterator_test
   PRIVATE
@@ -6622,6 +7012,15 @@ add_executable(authorization_matchers_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(authorization_matchers_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(authorization_matchers_test PUBLIC cxx_std_14)
 target_include_directories(authorization_matchers_test
   PRIVATE
@@ -6656,6 +7055,16 @@ add_executable(authorization_policy_provider_test
   src/cpp/server/authorization_policy_provider.cc
   test/cpp/server/authorization_policy_provider_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(authorization_policy_provider_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(authorization_policy_provider_test PUBLIC cxx_std_14)
 target_include_directories(authorization_policy_provider_test
   PRIVATE
@@ -6691,6 +7100,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(avl_test
   test/core/avl/avl_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(avl_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(avl_test PUBLIC cxx_std_14)
 target_include_directories(avl_test
   PRIVATE
@@ -6735,6 +7152,15 @@ add_executable(aws_request_signer_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(aws_request_signer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(aws_request_signer_test PUBLIC cxx_std_14)
 target_include_directories(aws_request_signer_test
   PRIVATE
@@ -6768,6 +7194,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(b64_test
   test/core/slice/b64_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(b64_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(b64_test PUBLIC cxx_std_14)
 target_include_directories(b64_test
   PRIVATE
@@ -6801,6 +7236,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(backoff_test
   test/core/backoff/backoff_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(backoff_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(backoff_test PUBLIC cxx_std_14)
 target_include_directories(backoff_test
   PRIVATE
@@ -6843,6 +7287,15 @@ add_executable(bad_ping_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(bad_ping_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(bad_ping_test PUBLIC cxx_std_14)
 target_include_directories(bad_ping_test
   PRIVATE
@@ -6879,6 +7332,15 @@ add_executable(bad_server_response_test
   test/core/end2end/bad_server_response_test.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(bad_server_response_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(bad_server_response_test PUBLIC cxx_std_14)
 target_include_directories(bad_server_response_test
   PRIVATE
@@ -6926,6 +7388,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(bad_ssl_alpn_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(bad_ssl_alpn_test PUBLIC cxx_std_14)
   target_include_directories(bad_ssl_alpn_test
     PRIVATE
@@ -6974,6 +7445,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(bad_ssl_cert_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(bad_ssl_cert_test PUBLIC cxx_std_14)
   target_include_directories(bad_ssl_cert_test
     PRIVATE
@@ -7010,6 +7490,15 @@ add_executable(bad_streaming_id_bad_client_test
   test/core/bad_client/tests/bad_streaming_id.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(bad_streaming_id_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(bad_streaming_id_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(bad_streaming_id_bad_client_test
   PRIVATE
@@ -7045,6 +7534,15 @@ add_executable(badreq_bad_client_test
   test/core/bad_client/tests/badreq.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(badreq_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(badreq_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(badreq_bad_client_test
   PRIVATE
@@ -7078,6 +7576,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(basic_work_queue_test
   test/core/event_engine/work_queue/basic_work_queue_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(basic_work_queue_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(basic_work_queue_test PUBLIC cxx_std_14)
 target_include_directories(basic_work_queue_test
   PRIVATE
@@ -7112,6 +7619,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(bdp_estimator_test
     test/core/transport/bdp_estimator_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(bdp_estimator_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(bdp_estimator_test PUBLIC cxx_std_14)
   target_include_directories(bdp_estimator_test
     PRIVATE
@@ -7146,6 +7662,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(bin_decoder_test
   test/core/transport/chttp2/bin_decoder_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(bin_decoder_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(bin_decoder_test PUBLIC cxx_std_14)
 target_include_directories(bin_decoder_test
   PRIVATE
@@ -7179,6 +7704,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(bin_encoder_test
   test/core/transport/chttp2/bin_encoder_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(bin_encoder_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(bin_encoder_test PUBLIC cxx_std_14)
 target_include_directories(bin_encoder_test
   PRIVATE
@@ -7221,6 +7755,15 @@ add_executable(binary_metadata_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(binary_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(binary_metadata_test PUBLIC cxx_std_14)
 target_include_directories(binary_metadata_test
   PRIVATE
@@ -7256,6 +7799,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(binder_resolver_test
   test/core/client_channel/resolvers/binder_resolver_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(binder_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(binder_resolver_test PUBLIC cxx_std_14)
 target_include_directories(binder_resolver_test
   PRIVATE
@@ -7307,6 +7859,16 @@ add_executable(binder_server_test
   test/core/transport/binder/end2end/fake_binder.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(binder_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(binder_server_test PUBLIC cxx_std_14)
 target_include_directories(binder_server_test
   PRIVATE
@@ -7402,7 +7964,17 @@ add_executable(binder_transport_test
   src/cpp/util/time_cc.cc
   test/core/transport/binder/binder_transport_test.cc
   test/core/transport/binder/mock_objects.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(binder_transport_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(binder_transport_test PUBLIC cxx_std_14)
 target_include_directories(binder_transport_test
   PRIVATE
@@ -7479,6 +8051,15 @@ add_executable(buffer_list_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(buffer_list_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(buffer_list_test PUBLIC cxx_std_14)
 target_include_directories(buffer_list_test
   PRIVATE
@@ -7512,6 +8093,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(byte_buffer_test
   test/cpp/util/byte_buffer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(byte_buffer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(byte_buffer_test PUBLIC cxx_std_14)
 target_include_directories(byte_buffer_test
   PRIVATE
@@ -7545,6 +8136,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(c_slice_buffer_test
   test/core/slice/c_slice_buffer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(c_slice_buffer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(c_slice_buffer_test PUBLIC cxx_std_14)
 target_include_directories(c_slice_buffer_test
   PRIVATE
@@ -7587,6 +8187,15 @@ add_executable(call_creds_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(call_creds_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(call_creds_test PUBLIC cxx_std_14)
 target_include_directories(call_creds_test
   PRIVATE
@@ -7622,6 +8231,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(call_finalization_test
   test/core/channel/call_finalization_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(call_finalization_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(call_finalization_test PUBLIC cxx_std_14)
 target_include_directories(call_finalization_test
   PRIVATE
@@ -7664,6 +8282,15 @@ add_executable(call_host_override_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(call_host_override_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(call_host_override_test PUBLIC cxx_std_14)
 target_include_directories(call_host_override_test
   PRIVATE
@@ -7699,6 +8326,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(call_tracer_test
   test/core/channel/call_tracer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(call_tracer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(call_tracer_test PUBLIC cxx_std_14)
 target_include_directories(call_tracer_test
   PRIVATE
@@ -7741,6 +8377,15 @@ add_executable(cancel_after_accept_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_after_accept_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_after_accept_test PUBLIC cxx_std_14)
 target_include_directories(cancel_after_accept_test
   PRIVATE
@@ -7785,6 +8430,15 @@ add_executable(cancel_after_client_done_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_after_client_done_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_after_client_done_test PUBLIC cxx_std_14)
 target_include_directories(cancel_after_client_done_test
   PRIVATE
@@ -7829,6 +8483,15 @@ add_executable(cancel_after_invoke_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_after_invoke_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_after_invoke_test PUBLIC cxx_std_14)
 target_include_directories(cancel_after_invoke_test
   PRIVATE
@@ -7873,6 +8536,15 @@ add_executable(cancel_after_round_trip_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_after_round_trip_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_after_round_trip_test PUBLIC cxx_std_14)
 target_include_directories(cancel_after_round_trip_test
   PRIVATE
@@ -7911,6 +8583,16 @@ add_executable(cancel_ares_query_test
   test/core/util/socket_use_after_close_detector.cc
   test/cpp/naming/cancel_ares_query_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_ares_query_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_ares_query_test PUBLIC cxx_std_14)
 target_include_directories(cancel_ares_query_test
   PRIVATE
@@ -7954,6 +8636,15 @@ add_executable(cancel_before_invoke_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_before_invoke_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_before_invoke_test PUBLIC cxx_std_14)
 target_include_directories(cancel_before_invoke_test
   PRIVATE
@@ -7989,6 +8680,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(cancel_callback_test
   test/core/promise/cancel_callback_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_callback_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_callback_test PUBLIC cxx_std_14)
 target_include_directories(cancel_callback_test
   PRIVATE
@@ -8032,6 +8731,15 @@ add_executable(cancel_in_a_vacuum_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_in_a_vacuum_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_in_a_vacuum_test PUBLIC cxx_std_14)
 target_include_directories(cancel_in_a_vacuum_test
   PRIVATE
@@ -8076,6 +8784,15 @@ add_executable(cancel_with_status_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cancel_with_status_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cancel_with_status_test PUBLIC cxx_std_14)
 target_include_directories(cancel_with_status_test
   PRIVATE
@@ -8209,6 +8926,15 @@ add_executable(cel_authorization_engine_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cel_authorization_engine_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cel_authorization_engine_test PUBLIC cxx_std_14)
 target_include_directories(cel_authorization_engine_test
   PRIVATE
@@ -8242,6 +8968,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(certificate_provider_registry_test
   test/core/security/certificate_provider_registry_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(certificate_provider_registry_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(certificate_provider_registry_test PUBLIC cxx_std_14)
 target_include_directories(certificate_provider_registry_test
   PRIVATE
@@ -8275,6 +9010,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(certificate_provider_store_test
   test/core/xds/certificate_provider_store_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(certificate_provider_store_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(certificate_provider_store_test PUBLIC cxx_std_14)
 target_include_directories(certificate_provider_store_test
   PRIVATE
@@ -8309,6 +9053,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(cf_engine_test
     test/core/event_engine/cf/cf_engine_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(cf_engine_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(cf_engine_test PUBLIC cxx_std_14)
   target_include_directories(cf_engine_test
     PRIVATE
@@ -8349,6 +9102,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/test_suite/tests/client_test.cc
     test/core/event_engine/test_suite/tests/timer_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(cf_event_engine_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(cf_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(cf_event_engine_test
     PRIVATE
@@ -8400,6 +9162,16 @@ add_executable(cfstream_test
   test/cpp/end2end/cfstream_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cfstream_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cfstream_test PUBLIC cxx_std_14)
 target_include_directories(cfstream_test
   PRIVATE
@@ -8433,6 +9205,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(channel_args_test
   test/core/channel/channel_args_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_args_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_args_test PUBLIC cxx_std_14)
 target_include_directories(channel_args_test
   PRIVATE
@@ -8466,6 +9247,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(channel_arguments_test
   test/cpp/common/channel_arguments_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_arguments_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_arguments_test PUBLIC cxx_std_14)
 target_include_directories(channel_arguments_test
   PRIVATE
@@ -8510,6 +9301,15 @@ add_executable(channel_creds_registry_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_creds_registry_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_creds_registry_test PUBLIC cxx_std_14)
 target_include_directories(channel_creds_registry_test
   PRIVATE
@@ -8543,6 +9343,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(channel_init_test
   test/core/surface/channel_init_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_init_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_init_test PUBLIC cxx_std_14)
 target_include_directories(channel_init_test
   PRIVATE
@@ -8576,6 +9385,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(channel_stack_builder_test
   test/core/channel/channel_stack_builder_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_stack_builder_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_stack_builder_test PUBLIC cxx_std_14)
 target_include_directories(channel_stack_builder_test
   PRIVATE
@@ -8609,6 +9427,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(channel_stack_test
   test/core/channel/channel_stack_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_stack_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_stack_test PUBLIC cxx_std_14)
 target_include_directories(channel_stack_test
   PRIVATE
@@ -8647,6 +9474,16 @@ add_executable(channel_trace_test
   test/core/channel/channel_trace_test.cc
   test/cpp/util/channel_trace_proto_helper.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channel_trace_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channel_trace_test PUBLIC cxx_std_14)
 target_include_directories(channel_trace_test
   PRIVATE
@@ -8681,6 +9518,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(channelz_registry_test
   test/core/channel/channelz_registry_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channelz_registry_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channelz_registry_test PUBLIC cxx_std_14)
 target_include_directories(channelz_registry_test
   PRIVATE
@@ -8733,6 +9580,16 @@ add_executable(channelz_service_test
   test/cpp/end2end/channelz_service_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(channelz_service_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(channelz_service_test PUBLIC cxx_std_14)
 target_include_directories(channelz_service_test
   PRIVATE
@@ -8777,6 +9634,15 @@ add_executable(check_gcp_environment_linux_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(check_gcp_environment_linux_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(check_gcp_environment_linux_test PUBLIC cxx_std_14)
 target_include_directories(check_gcp_environment_linux_test
   PRIVATE
@@ -8820,6 +9686,15 @@ add_executable(check_gcp_environment_windows_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(check_gcp_environment_windows_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(check_gcp_environment_windows_test PUBLIC cxx_std_14)
 target_include_directories(check_gcp_environment_windows_test
   PRIVATE
@@ -8899,6 +9774,14 @@ add_executable(chunked_vector_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(chunked_vector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(chunked_vector_test PUBLIC cxx_std_14)
 target_include_directories(chunked_vector_test
   PRIVATE
@@ -8964,6 +9847,16 @@ add_executable(cli_call_test
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cli_call_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cli_call_test PUBLIC cxx_std_14)
 target_include_directories(cli_call_test
   PRIVATE
@@ -9004,6 +9897,15 @@ add_executable(client_auth_filter_test
   test/core/filters/client_auth_filter_test.cc
   test/core/filters/filter_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_auth_filter_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_auth_filter_test PUBLIC cxx_std_14)
 target_include_directories(client_auth_filter_test
   PRIVATE
@@ -9044,6 +9946,15 @@ add_executable(client_authority_filter_test
   test/core/filters/client_authority_filter_test.cc
   test/core/filters/filter_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_authority_filter_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_authority_filter_test PUBLIC cxx_std_14)
 target_include_directories(client_authority_filter_test
   PRIVATE
@@ -9096,6 +10007,16 @@ add_executable(client_callback_end2end_test
   test/cpp/end2end/interceptors_util.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_callback_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_callback_end2end_test PUBLIC cxx_std_14)
 target_include_directories(client_callback_end2end_test
   PRIVATE
@@ -9129,6 +10050,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(client_channel_service_config_test
   test/core/client_channel/client_channel_service_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_channel_service_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_channel_service_config_test PUBLIC cxx_std_14)
 target_include_directories(client_channel_service_config_test
   PRIVATE
@@ -9162,6 +10092,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(client_channel_test
   test/core/client_channel/client_channel_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_channel_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_channel_test PUBLIC cxx_std_14)
 target_include_directories(client_channel_test
   PRIVATE
@@ -9195,6 +10134,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(client_context_test_peer_test
   test/cpp/test/client_context_test_peer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_context_test_peer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_context_test_peer_test PUBLIC cxx_std_14)
 target_include_directories(client_context_test_peer_test
   PRIVATE
@@ -9249,6 +10198,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
     test/cpp/end2end/client_fork_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(client_fork_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(client_fork_test PUBLIC cxx_std_14)
   target_include_directories(client_fork_test
     PRIVATE
@@ -9303,6 +10262,16 @@ add_executable(client_interceptors_end2end_test
   test/cpp/end2end/interceptors_util.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_interceptors_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_interceptors_end2end_test PUBLIC cxx_std_14)
 target_include_directories(client_interceptors_end2end_test
   PRIVATE
@@ -9365,6 +10334,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/connection_attempt_injector.cc
     test/cpp/end2end/test_service_impl.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(client_lb_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(client_lb_end2end_test PUBLIC cxx_std_14)
   target_include_directories(client_lb_end2end_test
     PRIVATE
@@ -9400,6 +10379,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(client_ssl_test
     test/core/handshake/client_ssl.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(client_ssl_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(client_ssl_test PUBLIC cxx_std_14)
   target_include_directories(client_ssl_test
     PRIVATE
@@ -9443,6 +10431,15 @@ add_executable(client_streaming_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_streaming_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_streaming_test PUBLIC cxx_std_14)
 target_include_directories(client_streaming_test
   PRIVATE
@@ -9487,6 +10484,15 @@ add_executable(client_transport_error_test
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   test/core/transport/chaotic_good/client_transport_error_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_transport_error_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_transport_error_test PUBLIC cxx_std_14)
 target_include_directories(client_transport_error_test
   PRIVATE
@@ -9530,6 +10536,15 @@ add_executable(client_transport_test
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   test/core/transport/chaotic_good/client_transport_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(client_transport_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(client_transport_test PUBLIC cxx_std_14)
 target_include_directories(client_transport_test
   PRIVATE
@@ -9574,6 +10589,15 @@ add_executable(cmdline_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cmdline_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cmdline_test PUBLIC cxx_std_14)
 target_include_directories(cmdline_test
   PRIVATE
@@ -9607,6 +10631,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(codegen_test_full
   test/cpp/codegen/codegen_test_full.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(codegen_test_full
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(codegen_test_full PUBLIC cxx_std_14)
 target_include_directories(codegen_test_full
   PRIVATE
@@ -9641,6 +10675,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(codegen_test_minimal
   test/cpp/codegen/codegen_test_minimal.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(codegen_test_minimal
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(codegen_test_minimal PUBLIC cxx_std_14)
 target_include_directories(codegen_test_minimal
   PRIVATE
@@ -9686,6 +10730,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(combiner_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(combiner_test PUBLIC cxx_std_14)
   target_include_directories(combiner_test
     PRIVATE
@@ -9720,6 +10773,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(common_closures_test
   test/core/event_engine/common_closures_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(common_closures_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(common_closures_test PUBLIC cxx_std_14)
 target_include_directories(common_closures_test
   PRIVATE
@@ -9754,6 +10815,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(completion_queue_threading_test
   test/core/surface/completion_queue_threading_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(completion_queue_threading_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(completion_queue_threading_test PUBLIC cxx_std_14)
 target_include_directories(completion_queue_threading_test
   PRIVATE
@@ -9796,6 +10866,15 @@ add_executable(compressed_payload_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(compressed_payload_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(compressed_payload_test PUBLIC cxx_std_14)
 target_include_directories(compressed_payload_test
   PRIVATE
@@ -9831,6 +10910,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(compression_test
   test/core/compression/compression_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(compression_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(compression_test PUBLIC cxx_std_14)
 target_include_directories(compression_test
   PRIVATE
@@ -9864,6 +10952,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(concurrent_connectivity_test
   test/core/surface/concurrent_connectivity_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(concurrent_connectivity_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(concurrent_connectivity_test PUBLIC cxx_std_14)
 target_include_directories(concurrent_connectivity_test
   PRIVATE
@@ -9899,6 +10996,15 @@ add_executable(connection_prefix_bad_client_test
   test/core/bad_client/tests/connection_prefix.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(connection_prefix_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(connection_prefix_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(connection_prefix_bad_client_test
   PRIVATE
@@ -9933,6 +11039,15 @@ add_executable(connection_refused_test
   test/core/end2end/connection_refused_test.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(connection_refused_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(connection_refused_test PUBLIC cxx_std_14)
 target_include_directories(connection_refused_test
   PRIVATE
@@ -9976,6 +11091,15 @@ add_executable(connectivity_state_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(connectivity_state_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(connectivity_state_test PUBLIC cxx_std_14)
 target_include_directories(connectivity_state_test
   PRIVATE
@@ -10018,6 +11142,15 @@ add_executable(connectivity_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(connectivity_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(connectivity_test PUBLIC cxx_std_14)
 target_include_directories(connectivity_test
   PRIVATE
@@ -10070,6 +11203,16 @@ add_executable(context_allocator_end2end_test
   test/cpp/end2end/context_allocator_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(context_allocator_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(context_allocator_end2end_test PUBLIC cxx_std_14)
 target_include_directories(context_allocator_end2end_test
   PRIVATE
@@ -10103,6 +11246,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(context_test
   test/core/promise/context_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(context_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(context_test PUBLIC cxx_std_14)
 target_include_directories(context_test
   PRIVATE
@@ -10136,6 +11287,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(core_configuration_test
   test/core/config/core_configuration_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(core_configuration_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(core_configuration_test PUBLIC cxx_std_14)
 target_include_directories(core_configuration_test
   PRIVATE
@@ -10201,6 +11361,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(cpu_test
   test/core/gpr/cpu_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(cpu_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(cpu_test PUBLIC cxx_std_14)
 target_include_directories(cpu_test
   PRIVATE
@@ -10251,6 +11420,16 @@ add_executable(crl_provider_test
   test/cpp/end2end/crl_provider_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(crl_provider_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(crl_provider_test PUBLIC cxx_std_14)
 target_include_directories(crl_provider_test
   PRIVATE
@@ -10286,6 +11465,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/tsi/crl_ssl_transport_security_test.cc
     test/core/tsi/transport_security_test_lib.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(crl_ssl_transport_security_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(crl_ssl_transport_security_test PUBLIC cxx_std_14)
   target_include_directories(crl_ssl_transport_security_test
     PRIVATE
@@ -10320,6 +11508,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(default_engine_methods_test
   test/core/event_engine/default_engine_methods_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(default_engine_methods_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(default_engine_methods_test PUBLIC cxx_std_14)
 target_include_directories(default_engine_methods_test
   PRIVATE
@@ -10362,6 +11559,15 @@ add_executable(default_host_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(default_host_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(default_host_test PUBLIC cxx_std_14)
 target_include_directories(default_host_test
   PRIVATE
@@ -10414,6 +11620,16 @@ add_executable(delegating_channel_test
   test/cpp/end2end/delegating_channel_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(delegating_channel_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(delegating_channel_test PUBLIC cxx_std_14)
 target_include_directories(delegating_channel_test
   PRIVATE
@@ -10447,6 +11663,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(destroy_grpclb_channel_with_active_connect_stress_test
   test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(destroy_grpclb_channel_with_active_connect_stress_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(destroy_grpclb_channel_with_active_connect_stress_test PUBLIC cxx_std_14)
 target_include_directories(destroy_grpclb_channel_with_active_connect_stress_test
   PRIVATE
@@ -10480,6 +11706,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(directory_reader_test
   test/core/gprpp/directory_reader_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(directory_reader_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(directory_reader_test PUBLIC cxx_std_14)
 target_include_directories(directory_reader_test
   PRIVATE
@@ -10522,6 +11757,15 @@ add_executable(disappearing_server_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(disappearing_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(disappearing_server_test PUBLIC cxx_std_14)
 target_include_directories(disappearing_server_test
   PRIVATE
@@ -10557,6 +11801,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(dns_resolver_cooldown_test
   test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(dns_resolver_cooldown_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(dns_resolver_cooldown_test PUBLIC cxx_std_14)
 target_include_directories(dns_resolver_cooldown_test
   PRIVATE
@@ -10590,6 +11843,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(dns_resolver_test
   test/core/client_channel/resolvers/dns_resolver_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(dns_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(dns_resolver_test PUBLIC cxx_std_14)
 target_include_directories(dns_resolver_test
   PRIVATE
@@ -10623,6 +11885,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(dual_ref_counted_test
   test/core/gprpp/dual_ref_counted_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(dual_ref_counted_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(dual_ref_counted_test PUBLIC cxx_std_14)
 target_include_directories(dual_ref_counted_test
   PRIVATE
@@ -10658,6 +11929,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/end2end/cq_verifier.cc
     test/core/end2end/dualstack_socket_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(dualstack_socket_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(dualstack_socket_test PUBLIC cxx_std_14)
   target_include_directories(dualstack_socket_test
     PRIVATE
@@ -10694,6 +11974,15 @@ add_executable(duplicate_header_bad_client_test
   test/core/bad_client/tests/duplicate_header.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(duplicate_header_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(duplicate_header_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(duplicate_header_bad_client_test
   PRIVATE
@@ -10736,6 +12025,15 @@ add_executable(empty_batch_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(empty_batch_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(empty_batch_test PUBLIC cxx_std_14)
 target_include_directories(empty_batch_test
   PRIVATE
@@ -10791,6 +12089,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/core/transport/binder/end2end/testing_channel_create.cc
     test/cpp/end2end/test_service_impl.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(end2end_binder_transport_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(end2end_binder_transport_test PUBLIC cxx_std_14)
   target_include_directories(end2end_binder_transport_test
     PRIVATE
@@ -10847,6 +12155,16 @@ add_executable(end2end_test
   test/cpp/end2end/interceptors_util.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(end2end_test PUBLIC cxx_std_14)
 target_include_directories(end2end_test
   PRIVATE
@@ -10880,6 +12198,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(endpoint_addresses_test
   test/core/resolver/endpoint_addresses_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(endpoint_addresses_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(endpoint_addresses_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_addresses_test
   PRIVATE
@@ -10975,7 +12302,17 @@ add_executable(endpoint_binder_pool_test
   src/cpp/util/time_cc.cc
   test/core/transport/binder/endpoint_binder_pool_test.cc
   test/core/transport/binder/mock_objects.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(endpoint_binder_pool_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(endpoint_binder_pool_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_binder_pool_test
   PRIVATE
@@ -11015,6 +12352,14 @@ add_executable(endpoint_config_test
   src/core/lib/surface/channel_stack_type.cc
   test/core/event_engine/endpoint_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(endpoint_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(endpoint_config_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_config_test
   PRIVATE
@@ -11062,6 +12407,15 @@ add_executable(endpoint_pair_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(endpoint_pair_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(endpoint_pair_test PUBLIC cxx_std_14)
 target_include_directories(endpoint_pair_test
   PRIVATE
@@ -11095,6 +12449,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(env_test
   test/core/gpr/env_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(env_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(env_test PUBLIC cxx_std_14)
 target_include_directories(env_test
   PRIVATE
@@ -11140,6 +12503,16 @@ add_executable(error_details_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/util/error_details_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(error_details_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(error_details_test PUBLIC cxx_std_14)
 target_include_directories(error_details_test
   PRIVATE
@@ -11185,6 +12558,15 @@ add_executable(error_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(error_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(error_test PUBLIC cxx_std_14)
 target_include_directories(error_test
   PRIVATE
@@ -11228,6 +12610,15 @@ add_executable(error_utils_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(error_utils_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(error_utils_test PUBLIC cxx_std_14)
 target_include_directories(error_utils_test
   PRIVATE
@@ -11271,6 +12662,15 @@ add_executable(evaluate_args_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(evaluate_args_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(evaluate_args_test PUBLIC cxx_std_14)
 target_include_directories(evaluate_args_test
   PRIVATE
@@ -11304,6 +12704,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(event_engine_wakeup_scheduler_test
   test/core/promise/event_engine_wakeup_scheduler_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(event_engine_wakeup_scheduler_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(event_engine_wakeup_scheduler_test PUBLIC cxx_std_14)
 target_include_directories(event_engine_wakeup_scheduler_test
   PRIVATE
@@ -11339,6 +12748,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/posix/event_poller_posix_test.cc
     test/core/event_engine/posix/posix_engine_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(event_poller_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(event_poller_posix_test PUBLIC cxx_std_14)
   target_include_directories(event_poller_posix_test
     PRIVATE
@@ -11374,6 +12792,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(examine_stack_test
     test/core/gprpp/examine_stack_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(examine_stack_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(examine_stack_test PUBLIC cxx_std_14)
   target_include_directories(examine_stack_test
     PRIVATE
@@ -11424,6 +12851,16 @@ add_executable(exception_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/exception_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(exception_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(exception_test PUBLIC cxx_std_14)
 target_include_directories(exception_test
   PRIVATE
@@ -11495,6 +12932,14 @@ add_executable(exec_ctx_wakeup_scheduler_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(exec_ctx_wakeup_scheduler_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(exec_ctx_wakeup_scheduler_test PUBLIC cxx_std_14)
 target_include_directories(exec_ctx_wakeup_scheduler_test
   PRIVATE
@@ -11536,6 +12981,14 @@ add_executable(experiments_tag_test
   test/core/experiments/experiments_tag_test.cc
   test/core/experiments/fixtures/experiments.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(experiments_tag_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(experiments_tag_test PUBLIC cxx_std_14)
 target_include_directories(experiments_tag_test
   PRIVATE
@@ -11573,6 +13026,14 @@ add_executable(experiments_test
   test/core/experiments/experiments_test.cc
   test/core/experiments/fixtures/experiments.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(experiments_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(experiments_test PUBLIC cxx_std_14)
 target_include_directories(experiments_test
   PRIVATE
@@ -11606,6 +13067,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(factory_test
   test/core/event_engine/factory_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(factory_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(factory_test PUBLIC cxx_std_14)
 target_include_directories(factory_test
   PRIVATE
@@ -11701,7 +13171,17 @@ add_executable(fake_binder_test
   src/cpp/util/time_cc.cc
   test/core/transport/binder/end2end/fake_binder.cc
   test/core/transport/binder/end2end/fake_binder_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(fake_binder_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(fake_binder_test PUBLIC cxx_std_14)
 target_include_directories(fake_binder_test
   PRIVATE
@@ -11736,6 +13216,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(fake_resolver_test
   test/core/client_channel/resolvers/fake_resolver_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(fake_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(fake_resolver_test PUBLIC cxx_std_14)
 target_include_directories(fake_resolver_test
   PRIVATE
@@ -11770,6 +13259,15 @@ add_executable(fake_transport_security_test
   test/core/tsi/fake_transport_security_test.cc
   test/core/tsi/transport_security_test_lib.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(fake_transport_security_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(fake_transport_security_test PUBLIC cxx_std_14)
 target_include_directories(fake_transport_security_test
   PRIVATE
@@ -11814,6 +13312,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(fd_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(fd_posix_test PUBLIC cxx_std_14)
   target_include_directories(fd_posix_test
     PRIVATE
@@ -11848,6 +13355,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(file_watcher_certificate_provider_factory_test
   test/core/xds/file_watcher_certificate_provider_factory_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(file_watcher_certificate_provider_factory_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(file_watcher_certificate_provider_factory_test PUBLIC cxx_std_14)
 target_include_directories(file_watcher_certificate_provider_factory_test
   PRIVATE
@@ -11890,6 +13406,15 @@ add_executable(filter_causes_close_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(filter_causes_close_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(filter_causes_close_test PUBLIC cxx_std_14)
 target_include_directories(filter_causes_close_test
   PRIVATE
@@ -11934,6 +13459,15 @@ add_executable(filter_context_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(filter_context_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(filter_context_test PUBLIC cxx_std_14)
 target_include_directories(filter_context_test
   PRIVATE
@@ -11978,6 +13512,15 @@ add_executable(filter_init_fails_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(filter_init_fails_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(filter_init_fails_test PUBLIC cxx_std_14)
 target_include_directories(filter_init_fails_test
   PRIVATE
@@ -12019,6 +13562,15 @@ add_executable(filter_test_test
   test/core/filters/filter_test.cc
   test/core/filters/filter_test_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(filter_test_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(filter_test_test PUBLIC cxx_std_14)
 target_include_directories(filter_test_test
   PRIVATE
@@ -12063,6 +13615,15 @@ add_executable(filtered_metadata_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(filtered_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(filtered_metadata_test PUBLIC cxx_std_14)
 target_include_directories(filtered_metadata_test
   PRIVATE
@@ -12115,6 +13676,16 @@ add_executable(flaky_network_test
   test/cpp/end2end/flaky_network_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(flaky_network_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(flaky_network_test PUBLIC cxx_std_14)
 target_include_directories(flaky_network_test
   PRIVATE
@@ -12197,6 +13768,14 @@ add_executable(flow_control_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(flow_control_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(flow_control_test PUBLIC cxx_std_14)
 target_include_directories(flow_control_test
   PRIVATE
@@ -12282,6 +13861,14 @@ add_executable(for_each_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(for_each_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(for_each_test PUBLIC cxx_std_14)
 target_include_directories(for_each_test
   PRIVATE
@@ -12322,6 +13909,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(fork_test
     test/core/gprpp/fork_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(fork_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(fork_test PUBLIC cxx_std_14)
   target_include_directories(fork_test
     PRIVATE
@@ -12358,6 +13954,14 @@ add_executable(forkable_test
   src/core/lib/event_engine/forkable.cc
   test/core/event_engine/forkable_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(forkable_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(forkable_test PUBLIC cxx_std_14)
 target_include_directories(forkable_test
   PRIVATE
@@ -12406,6 +14010,15 @@ add_executable(format_request_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(format_request_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(format_request_test PUBLIC cxx_std_14)
 target_include_directories(format_request_test
   PRIVATE
@@ -12440,6 +14053,15 @@ add_executable(frame_handler_test
   test/core/tsi/alts/crypt/gsec_test_util.cc
   test/core/tsi/alts/frame_protector/frame_handler_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(frame_handler_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(frame_handler_test PUBLIC cxx_std_14)
 target_include_directories(frame_handler_test
   PRIVATE
@@ -12519,6 +14141,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/test_suite/tests/server_test.cc
     test/core/event_engine/test_suite/tests/timer_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(fuzzing_event_engine_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(fuzzing_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(fuzzing_event_engine_test
     PRIVATE
@@ -12559,6 +14190,15 @@ add_executable(fuzzing_event_engine_unittest
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine_unittest.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(fuzzing_event_engine_unittest
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(fuzzing_event_engine_unittest PUBLIC cxx_std_14)
 target_include_directories(fuzzing_event_engine_unittest
   PRIVATE
@@ -12613,6 +14253,16 @@ add_executable(generic_end2end_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/generic_end2end_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(generic_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(generic_end2end_test PUBLIC cxx_std_14)
 target_include_directories(generic_end2end_test
   PRIVATE
@@ -12647,6 +14297,15 @@ add_executable(goaway_server_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/goaway_server_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(goaway_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(goaway_server_test PUBLIC cxx_std_14)
 target_include_directories(goaway_server_test
   PRIVATE
@@ -12681,6 +14340,16 @@ add_executable(google_c2p_resolver_test
   test/core/client_channel/resolvers/google_c2p_resolver_test.cc
   test/core/util/fake_udp_and_tcp_server.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(google_c2p_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(google_c2p_resolver_test PUBLIC cxx_std_14)
 target_include_directories(google_c2p_resolver_test
   PRIVATE
@@ -12723,6 +14392,15 @@ add_executable(graceful_server_shutdown_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(graceful_server_shutdown_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(graceful_server_shutdown_test PUBLIC cxx_std_14)
 target_include_directories(graceful_server_shutdown_test
   PRIVATE
@@ -12759,6 +14437,15 @@ add_executable(graceful_shutdown_test
   test/core/end2end/cq_verifier.cc
   test/core/transport/chttp2/graceful_shutdown_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(graceful_shutdown_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(graceful_shutdown_test PUBLIC cxx_std_14)
 target_include_directories(graceful_shutdown_test
   PRIVATE
@@ -12802,6 +14489,15 @@ add_executable(grpc_alts_credentials_options_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_alts_credentials_options_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_alts_credentials_options_test PUBLIC cxx_std_14)
 target_include_directories(grpc_alts_credentials_options_test
   PRIVATE
@@ -12835,6 +14531,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(grpc_audit_logging_test
   test/core/security/grpc_audit_logging_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_audit_logging_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_audit_logging_test PUBLIC cxx_std_14)
 target_include_directories(grpc_audit_logging_test
   PRIVATE
@@ -12879,6 +14584,15 @@ add_executable(grpc_authorization_engine_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_authorization_engine_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_authorization_engine_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authorization_engine_test
   PRIVATE
@@ -12922,6 +14636,15 @@ add_executable(grpc_authorization_policy_provider_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_authorization_policy_provider_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_authorization_policy_provider_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authorization_policy_provider_test
   PRIVATE
@@ -12975,6 +14698,16 @@ add_executable(grpc_authz_end2end_test
   test/cpp/end2end/grpc_authz_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_authz_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_authz_end2end_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authz_end2end_test
   PRIVATE
@@ -13018,6 +14751,15 @@ add_executable(grpc_authz_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_authz_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_authz_test PUBLIC cxx_std_14)
 target_include_directories(grpc_authz_test
   PRIVATE
@@ -13053,6 +14795,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(grpc_byte_buffer_reader_test
   test/core/surface/byte_buffer_reader_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_byte_buffer_reader_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_byte_buffer_reader_test PUBLIC cxx_std_14)
 target_include_directories(grpc_byte_buffer_reader_test
   PRIVATE
@@ -13096,6 +14847,16 @@ add_executable(grpc_cli
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_cli
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_cli PUBLIC cxx_std_14)
 target_include_directories(grpc_cli
   PRIVATE
@@ -13126,6 +14887,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(grpc_completion_queue_test
   test/core/surface/completion_queue_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_completion_queue_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_completion_queue_test PUBLIC cxx_std_14)
 target_include_directories(grpc_completion_queue_test
   PRIVATE
@@ -13245,6 +15015,15 @@ add_executable(grpc_ipv6_loopback_available_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_ipv6_loopback_available_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_ipv6_loopback_available_test PUBLIC cxx_std_14)
 target_include_directories(grpc_ipv6_loopback_available_test
   PRIVATE
@@ -13478,6 +15257,15 @@ add_executable(grpc_tls_certificate_distributor_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_tls_certificate_distributor_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_tls_certificate_distributor_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_certificate_distributor_test
   PRIVATE
@@ -13521,6 +15309,15 @@ add_executable(grpc_tls_certificate_provider_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_tls_certificate_provider_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_tls_certificate_provider_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_certificate_provider_test
   PRIVATE
@@ -13564,6 +15361,15 @@ add_executable(grpc_tls_certificate_verifier_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_tls_certificate_verifier_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_tls_certificate_verifier_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_certificate_verifier_test
   PRIVATE
@@ -13607,6 +15413,15 @@ add_executable(grpc_tls_credentials_options_comparator_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_tls_credentials_options_comparator_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_tls_credentials_options_comparator_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_credentials_options_comparator_test
   PRIVATE
@@ -13650,6 +15465,15 @@ add_executable(grpc_tls_credentials_options_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_tls_credentials_options_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_tls_credentials_options_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_credentials_options_test
   PRIVATE
@@ -13693,6 +15517,15 @@ add_executable(grpc_tls_crl_provider_test
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   test/core/security/grpc_tls_crl_provider_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc_tls_crl_provider_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpc_tls_crl_provider_test PUBLIC cxx_std_14)
 target_include_directories(grpc_tls_crl_provider_test
   PRIVATE
@@ -13750,6 +15583,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/cpp/util/proto_reflection_descriptor_database.cc
     test/cpp/util/service_describer.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(grpc_tool_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(grpc_tool_test PUBLIC cxx_std_14)
   target_include_directories(grpc_tool_test
     PRIVATE
@@ -13791,6 +15634,16 @@ add_executable(grpclb_api_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/lb/v1/load_balancer.grpc.pb.h
   test/cpp/grpclb/grpclb_api_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpclb_api_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(grpclb_api_test PUBLIC cxx_std_14)
 target_include_directories(grpclb_api_test
   PRIVATE
@@ -13850,6 +15703,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/grpclb_end2end_test.cc
     test/cpp/end2end/test_service_impl.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(grpclb_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(grpclb_end2end_test PUBLIC cxx_std_14)
   target_include_directories(grpclb_end2end_test
     PRIVATE
@@ -13893,6 +15756,15 @@ add_executable(h2_ssl_cert_test
   test/core/end2end/h2_ssl_cert_test.cc
   test/core/event_engine/event_engine_test_utils.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(h2_ssl_cert_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(h2_ssl_cert_test PUBLIC cxx_std_14)
 target_include_directories(h2_ssl_cert_test
   PRIVATE
@@ -13927,6 +15799,15 @@ add_executable(h2_ssl_session_reuse_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/h2_ssl_session_reuse_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(h2_ssl_session_reuse_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(h2_ssl_session_reuse_test PUBLIC cxx_std_14)
 target_include_directories(h2_ssl_session_reuse_test
   PRIVATE
@@ -13961,6 +15842,15 @@ add_executable(h2_tls_peer_property_external_verifier_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/h2_tls_peer_property_external_verifier_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(h2_tls_peer_property_external_verifier_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(h2_tls_peer_property_external_verifier_test PUBLIC cxx_std_14)
 target_include_directories(h2_tls_peer_property_external_verifier_test
   PRIVATE
@@ -13994,6 +15884,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(handle_tests
   test/core/event_engine/handle_tests.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(handle_tests
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(handle_tests PUBLIC cxx_std_14)
 target_include_directories(handle_tests
   PRIVATE
@@ -14029,6 +15928,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/handshake/readahead_handshaker_server_ssl.cc
     test/core/handshake/server_ssl_common.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(handshake_server_with_readahead_handshaker_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(handshake_server_with_readahead_handshaker_test PUBLIC cxx_std_14)
   target_include_directories(handshake_server_with_readahead_handshaker_test
     PRIVATE
@@ -14065,6 +15973,15 @@ add_executable(head_of_line_blocking_bad_client_test
   test/core/bad_client/tests/head_of_line_blocking.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(head_of_line_blocking_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(head_of_line_blocking_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(head_of_line_blocking_bad_client_test
   PRIVATE
@@ -14100,6 +16017,15 @@ add_executable(headers_bad_client_test
   test/core/bad_client/tests/headers.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(headers_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(headers_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(headers_bad_client_test
   PRIVATE
@@ -14159,6 +16085,16 @@ add_executable(health_service_end2end_test
   test/cpp/end2end/test_health_check_service_impl.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(health_service_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(health_service_end2end_test PUBLIC cxx_std_14)
 target_include_directories(health_service_end2end_test
   PRIVATE
@@ -14201,6 +16137,15 @@ add_executable(high_initial_seqno_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(high_initial_seqno_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(high_initial_seqno_test PUBLIC cxx_std_14)
 target_include_directories(high_initial_seqno_test
   PRIVATE
@@ -14246,6 +16191,15 @@ add_executable(histogram_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(histogram_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(histogram_test PUBLIC cxx_std_14)
 target_include_directories(histogram_test
   PRIVATE
@@ -14279,6 +16233,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(host_port_test
   test/core/gprpp/host_port_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(host_port_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(host_port_test PUBLIC cxx_std_14)
 target_include_directories(host_port_test
   PRIVATE
@@ -14322,6 +16285,15 @@ add_executable(hpack_encoder_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(hpack_encoder_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(hpack_encoder_test PUBLIC cxx_std_14)
 target_include_directories(hpack_encoder_test
   PRIVATE
@@ -14365,6 +16337,15 @@ add_executable(hpack_parser_table_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(hpack_parser_table_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(hpack_parser_table_test PUBLIC cxx_std_14)
 target_include_directories(hpack_parser_table_test
   PRIVATE
@@ -14408,6 +16389,15 @@ add_executable(hpack_parser_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(hpack_parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(hpack_parser_test PUBLIC cxx_std_14)
 target_include_directories(hpack_parser_test
   PRIVATE
@@ -14450,6 +16440,15 @@ add_executable(hpack_size_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(hpack_size_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(hpack_size_test PUBLIC cxx_std_14)
 target_include_directories(hpack_size_test
   PRIVATE
@@ -14497,6 +16496,16 @@ add_executable(http2_client
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.grpc.pb.h
   test/cpp/interop/http2_client.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(http2_client
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(http2_client PUBLIC cxx_std_14)
 target_include_directories(http2_client
   PRIVATE
@@ -14535,6 +16544,15 @@ add_executable(http2_stats_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(http2_stats_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(http2_stats_test PUBLIC cxx_std_14)
 target_include_directories(http2_stats_test
   PRIVATE
@@ -14570,6 +16588,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(http_proxy_mapper_test
   test/core/client_channel/http_proxy_mapper_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(http_proxy_mapper_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(http_proxy_mapper_test PUBLIC cxx_std_14)
 target_include_directories(http_proxy_mapper_test
   PRIVATE
@@ -14606,6 +16633,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/http/httpcli_test_util.cc
     test/core/util/fake_udp_and_tcp_server.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(httpcli_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(httpcli_test PUBLIC cxx_std_14)
   target_include_directories(httpcli_test
     PRIVATE
@@ -14643,6 +16680,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/http/httpscli_test.cc
     test/core/util/fake_udp_and_tcp_server.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(httpscli_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(httpscli_test PUBLIC cxx_std_14)
   target_include_directories(httpscli_test
     PRIVATE
@@ -14698,6 +16745,16 @@ add_executable(hybrid_end2end_test
   test/cpp/end2end/hybrid_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(hybrid_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(hybrid_end2end_test PUBLIC cxx_std_14)
 target_include_directories(hybrid_end2end_test
   PRIVATE
@@ -14796,6 +16853,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(if_test
   test/core/promise/if_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(if_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(if_test PUBLIC cxx_std_14)
 target_include_directories(if_test
   PRIVATE
@@ -14831,6 +16896,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(init_test
   test/core/surface/init_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(init_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(init_test PUBLIC cxx_std_14)
 target_include_directories(init_test
   PRIVATE
@@ -14866,6 +16940,15 @@ add_executable(initial_settings_frame_bad_client_test
   test/core/bad_client/tests/initial_settings_frame.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(initial_settings_frame_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(initial_settings_frame_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(initial_settings_frame_bad_client_test
   PRIVATE
@@ -14909,6 +16992,15 @@ add_executable(insecure_security_connector_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(insecure_security_connector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(insecure_security_connector_test PUBLIC cxx_std_14)
 target_include_directories(insecure_security_connector_test
   PRIVATE
@@ -14945,6 +17037,14 @@ add_executable(inter_activity_pipe_test
   src/core/lib/promise/trace.cc
   test/core/promise/inter_activity_pipe_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(inter_activity_pipe_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(inter_activity_pipe_test PUBLIC cxx_std_14)
 target_include_directories(inter_activity_pipe_test
   PRIVATE
@@ -15027,6 +17127,14 @@ add_executable(interceptor_list_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(interceptor_list_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(interceptor_list_test PUBLIC cxx_std_14)
 target_include_directories(interceptor_list_test
   PRIVATE
@@ -15082,6 +17190,16 @@ add_executable(interop_client
   test/cpp/interop/client_helper.cc
   test/cpp/interop/interop_client.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(interop_client
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(interop_client PUBLIC cxx_std_14)
 target_include_directories(interop_client
   PRIVATE
@@ -15125,7 +17243,18 @@ add_executable(interop_server
   test/cpp/interop/interop_server.cc
   test/cpp/interop/interop_server_bootstrap.cc
   test/cpp/interop/server_helper.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(interop_server
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(interop_server PUBLIC cxx_std_14)
 target_include_directories(interop_server
   PRIVATE
@@ -15156,6 +17285,15 @@ add_executable(invalid_call_argument_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/invalid_call_argument_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(invalid_call_argument_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(invalid_call_argument_test PUBLIC cxx_std_14)
 target_include_directories(invalid_call_argument_test
   PRIVATE
@@ -15198,6 +17336,15 @@ add_executable(invoke_large_request_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(invoke_large_request_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(invoke_large_request_test PUBLIC cxx_std_14)
 target_include_directories(invoke_large_request_test
   PRIVATE
@@ -15235,6 +17382,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
     test/core/event_engine/windows/create_sockpair.cc
     test/core/event_engine/windows/iocp_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(iocp_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(iocp_test PUBLIC cxx_std_14)
   target_include_directories(iocp_test
     PRIVATE
@@ -15274,6 +17430,16 @@ add_executable(istio_echo_server_test
   test/cpp/interop/istio_echo_server_lib.cc
   test/cpp/interop/istio_echo_server_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(istio_echo_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(istio_echo_server_test PUBLIC cxx_std_14)
 target_include_directories(istio_echo_server_test
   PRIVATE
@@ -15311,6 +17477,14 @@ add_executable(join_test
   src/core/lib/promise/trace.cc
   test/core/promise/join_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(join_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(join_test PUBLIC cxx_std_14)
 target_include_directories(join_test
   PRIVATE
@@ -15346,6 +17520,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(json_object_loader_test
   test/core/json/json_object_loader_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(json_object_loader_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(json_object_loader_test PUBLIC cxx_std_14)
 target_include_directories(json_object_loader_test
   PRIVATE
@@ -15379,6 +17562,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(json_test
   test/core/json/json_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(json_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(json_test PUBLIC cxx_std_14)
 target_include_directories(json_test
   PRIVATE
@@ -15422,6 +17614,15 @@ add_executable(json_token_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(json_token_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(json_token_test PUBLIC cxx_std_14)
 target_include_directories(json_token_test
   PRIVATE
@@ -15465,6 +17666,15 @@ add_executable(jwt_verifier_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(jwt_verifier_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(jwt_verifier_test PUBLIC cxx_std_14)
 target_include_directories(jwt_verifier_test
   PRIVATE
@@ -15507,6 +17717,15 @@ add_executable(keepalive_timeout_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(keepalive_timeout_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(keepalive_timeout_test PUBLIC cxx_std_14)
 target_include_directories(keepalive_timeout_test
   PRIVATE
@@ -15543,6 +17762,15 @@ add_executable(lame_client_test
   test/core/end2end/cq_verifier.cc
   test/core/surface/lame_client_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(lame_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(lame_client_test PUBLIC cxx_std_14)
 target_include_directories(lame_client_test
   PRIVATE
@@ -15585,6 +17813,15 @@ add_executable(large_metadata_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(large_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(large_metadata_test PUBLIC cxx_std_14)
 target_include_directories(large_metadata_test
   PRIVATE
@@ -15623,6 +17860,14 @@ add_executable(latch_test
   src/core/lib/promise/trace.cc
   test/core/promise/latch_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(latch_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(latch_test PUBLIC cxx_std_14)
 target_include_directories(latch_test
   PRIVATE
@@ -15663,6 +17908,15 @@ add_executable(lb_get_cpu_stats_test
   src/cpp/server/load_reporter/get_cpu_stats_windows.cc
   test/cpp/server/load_reporter/get_cpu_stats_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(lb_get_cpu_stats_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(lb_get_cpu_stats_test PUBLIC cxx_std_14)
 target_include_directories(lb_get_cpu_stats_test
   PRIVATE
@@ -15697,6 +17951,16 @@ add_executable(lb_load_data_store_test
   src/cpp/server/load_reporter/load_data_store.cc
   test/cpp/server/load_reporter/load_data_store_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(lb_load_data_store_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(lb_load_data_store_test PUBLIC cxx_std_14)
 target_include_directories(lb_load_data_store_test
   PRIVATE
@@ -15731,6 +17995,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(load_config_test
   test/core/config/load_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(load_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(load_config_test PUBLIC cxx_std_14)
 target_include_directories(load_config_test
   PRIVATE
@@ -15765,6 +18038,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   add_executable(lock_free_event_test
     test/core/event_engine/posix/lock_free_event_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(lock_free_event_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(lock_free_event_test PUBLIC cxx_std_14)
   target_include_directories(lock_free_event_test
     PRIVATE
@@ -15800,6 +18082,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(log_test
   test/core/gpr/log_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(log_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(log_test PUBLIC cxx_std_14)
 target_include_directories(log_test
   PRIVATE
@@ -15834,6 +18125,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(log_too_many_open_files_test
     test/core/event_engine/posix/log_too_many_open_files_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(log_too_many_open_files_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(log_too_many_open_files_test PUBLIC cxx_std_14)
   target_include_directories(log_too_many_open_files_test
     PRIVATE
@@ -15870,6 +18170,14 @@ add_executable(loop_test
   src/core/lib/promise/trace.cc
   test/core/promise/loop_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(loop_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(loop_test PUBLIC cxx_std_14)
 target_include_directories(loop_test
   PRIVATE
@@ -15951,6 +18259,14 @@ add_executable(map_pipe_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(map_pipe_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(map_pipe_test PUBLIC cxx_std_14)
 target_include_directories(map_pipe_test
   PRIVATE
@@ -16032,6 +18348,15 @@ add_executable(matchers_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(matchers_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(matchers_test PUBLIC cxx_std_14)
 target_include_directories(matchers_test
   PRIVATE
@@ -16066,6 +18391,14 @@ add_executable(max_concurrent_streams_policy_test
   src/core/ext/transport/chttp2/transport/max_concurrent_streams_policy.cc
   test/core/transport/chttp2/max_concurrent_streams_policy_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(max_concurrent_streams_policy_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(max_concurrent_streams_policy_test PUBLIC cxx_std_14)
 target_include_directories(max_concurrent_streams_policy_test
   PRIVATE
@@ -16108,6 +18441,15 @@ add_executable(max_concurrent_streams_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(max_concurrent_streams_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(max_concurrent_streams_test PUBLIC cxx_std_14)
 target_include_directories(max_concurrent_streams_test
   PRIVATE
@@ -16152,6 +18494,15 @@ add_executable(max_connection_age_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(max_connection_age_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(max_connection_age_test PUBLIC cxx_std_14)
 target_include_directories(max_connection_age_test
   PRIVATE
@@ -16196,6 +18547,15 @@ add_executable(max_connection_idle_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(max_connection_idle_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(max_connection_idle_test PUBLIC cxx_std_14)
 target_include_directories(max_connection_idle_test
   PRIVATE
@@ -16240,6 +18600,15 @@ add_executable(max_message_length_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(max_message_length_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(max_message_length_test PUBLIC cxx_std_14)
 target_include_directories(max_message_length_test
   PRIVATE
@@ -16276,6 +18645,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   add_executable(memory_quota_stress_test
     test/core/resource_quota/memory_quota_stress_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(memory_quota_stress_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(memory_quota_stress_test PUBLIC cxx_std_14)
   target_include_directories(memory_quota_stress_test
     PRIVATE
@@ -16310,6 +18688,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(memory_quota_test
   test/core/resource_quota/memory_quota_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(memory_quota_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(memory_quota_test PUBLIC cxx_std_14)
 target_include_directories(memory_quota_test
   PRIVATE
@@ -16360,6 +18747,16 @@ add_executable(message_allocator_end2end_test
   test/cpp/end2end/message_allocator_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(message_allocator_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(message_allocator_end2end_test PUBLIC cxx_std_14)
 target_include_directories(message_allocator_end2end_test
   PRIVATE
@@ -16403,6 +18800,15 @@ add_executable(message_compress_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(message_compress_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(message_compress_test PUBLIC cxx_std_14)
 target_include_directories(message_compress_test
   PRIVATE
@@ -16436,6 +18842,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(message_size_service_config_test
   test/core/message_size/message_size_service_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(message_size_service_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(message_size_service_config_test PUBLIC cxx_std_14)
 target_include_directories(message_size_service_config_test
   PRIVATE
@@ -16479,6 +18894,15 @@ add_executable(metadata_map_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(metadata_map_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(metadata_map_test PUBLIC cxx_std_14)
 target_include_directories(metadata_map_test
   PRIVATE
@@ -16512,6 +18936,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(minimal_stack_is_minimal_test
   test/core/channel/minimal_stack_is_minimal_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(minimal_stack_is_minimal_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(minimal_stack_is_minimal_test PUBLIC cxx_std_14)
 target_include_directories(minimal_stack_is_minimal_test
   PRIVATE
@@ -16593,6 +19026,16 @@ add_executable(mock_stream_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/test/mock_stream_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(mock_stream_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(mock_stream_test PUBLIC cxx_std_14)
 target_include_directories(mock_stream_test
   PRIVATE
@@ -16646,6 +19089,16 @@ add_executable(mock_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/mock_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(mock_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(mock_test PUBLIC cxx_std_14)
 target_include_directories(mock_test
   PRIVATE
@@ -16680,6 +19133,14 @@ add_executable(mpsc_test
   src/core/lib/promise/activity.cc
   test/core/promise/mpsc_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(mpsc_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(mpsc_test PUBLIC cxx_std_14)
 target_include_directories(mpsc_test
   PRIVATE
@@ -16717,6 +19178,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(mpscq_test
     test/core/gprpp/mpscq_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(mpscq_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(mpscq_test PUBLIC cxx_std_14)
   target_include_directories(mpscq_test
     PRIVATE
@@ -16760,6 +19230,15 @@ add_executable(negative_deadline_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(negative_deadline_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(negative_deadline_test PUBLIC cxx_std_14)
 target_include_directories(negative_deadline_test
   PRIVATE
@@ -16836,6 +19315,15 @@ add_executable(no_logging_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(no_logging_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(no_logging_test PUBLIC cxx_std_14)
 target_include_directories(no_logging_test
   PRIVATE
@@ -16880,6 +19368,15 @@ add_executable(no_op_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(no_op_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(no_op_test PUBLIC cxx_std_14)
 target_include_directories(no_op_test
   PRIVATE
@@ -16916,6 +19413,15 @@ add_executable(no_server_test
   test/core/end2end/cq_verifier.cc
   test/core/end2end/no_server_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(no_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(no_server_test PUBLIC cxx_std_14)
 target_include_directories(no_server_test
   PRIVATE
@@ -16965,6 +19471,16 @@ add_executable(nonblocking_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/nonblocking_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(nonblocking_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(nonblocking_test PUBLIC cxx_std_14)
 target_include_directories(nonblocking_test
   PRIVATE
@@ -16998,6 +19514,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(notification_test
   test/core/gprpp/notification_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(notification_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(notification_test PUBLIC cxx_std_14)
 target_include_directories(notification_test
   PRIVATE
@@ -17031,6 +19555,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(num_external_connectivity_watchers_test
   test/core/surface/num_external_connectivity_watchers_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(num_external_connectivity_watchers_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(num_external_connectivity_watchers_test PUBLIC cxx_std_14)
 target_include_directories(num_external_connectivity_watchers_test
   PRIVATE
@@ -17070,6 +19603,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/test_suite/tests/client_test.cc
     test/core/event_engine/test_suite/tests/server_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(oracle_event_engine_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(oracle_event_engine_posix_test PUBLIC cxx_std_14)
   target_include_directories(oracle_event_engine_posix_test
     PRIVATE
@@ -17112,7 +19654,18 @@ add_executable(orca_service_end2end_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_service.grpc.pb.h
   src/cpp/server/orca/orca_service.cc
   test/cpp/end2end/orca_service_end2end_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(orca_service_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(orca_service_end2end_test PUBLIC cxx_std_14)
 target_include_directories(orca_service_end2end_test
   PRIVATE
@@ -17146,6 +19699,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(orphanable_test
   test/core/gprpp/orphanable_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(orphanable_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(orphanable_test PUBLIC cxx_std_14)
 target_include_directories(orphanable_test
   PRIVATE
@@ -17214,6 +19776,15 @@ add_executable(out_of_bounds_bad_client_test
   test/core/bad_client/tests/out_of_bounds.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(out_of_bounds_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(out_of_bounds_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(out_of_bounds_bad_client_test
   PRIVATE
@@ -17247,6 +19818,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(outlier_detection_lb_config_parser_test
   test/core/client_channel/lb_policy/outlier_detection_lb_config_parser_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(outlier_detection_lb_config_parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(outlier_detection_lb_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(outlier_detection_lb_config_parser_test
   PRIVATE
@@ -17286,6 +19866,15 @@ add_executable(outlier_detection_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(outlier_detection_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(outlier_detection_test PUBLIC cxx_std_14)
 target_include_directories(outlier_detection_test
   PRIVATE
@@ -17352,6 +19941,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(parse_address_test
   test/core/address_utils/parse_address_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(parse_address_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(parse_address_test PUBLIC cxx_std_14)
 target_include_directories(parse_address_test
   PRIVATE
@@ -17386,6 +19984,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(parse_address_with_named_scope_id_test
     test/core/address_utils/parse_address_with_named_scope_id_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(parse_address_with_named_scope_id_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(parse_address_with_named_scope_id_test PUBLIC cxx_std_14)
   target_include_directories(parse_address_with_named_scope_id_test
     PRIVATE
@@ -17420,6 +20027,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(parsed_metadata_test
   test/core/transport/parsed_metadata_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(parsed_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(parsed_metadata_test PUBLIC cxx_std_14)
 target_include_directories(parsed_metadata_test
   PRIVATE
@@ -17467,6 +20083,15 @@ add_executable(parser_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(parser_test PUBLIC cxx_std_14)
 target_include_directories(parser_test
   PRIVATE
@@ -17500,6 +20125,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(party_test
   test/core/promise/party_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(party_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(party_test PUBLIC cxx_std_14)
 target_include_directories(party_test
   PRIVATE
@@ -17542,6 +20176,15 @@ add_executable(payload_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(payload_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(payload_test PUBLIC cxx_std_14)
 target_include_directories(payload_test
   PRIVATE
@@ -17577,6 +20220,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(percent_encoding_test
   test/core/slice/percent_encoding_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(percent_encoding_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(percent_encoding_test PUBLIC cxx_std_14)
 target_include_directories(percent_encoding_test
   PRIVATE
@@ -17648,6 +20300,14 @@ add_executable(periodic_update_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(periodic_update_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(periodic_update_test PUBLIC cxx_std_14)
 target_include_directories(periodic_update_test
   PRIVATE
@@ -17692,6 +20352,15 @@ add_executable(pick_first_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(pick_first_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(pick_first_test PUBLIC cxx_std_14)
 target_include_directories(pick_first_test
   PRIVATE
@@ -17736,6 +20405,15 @@ add_executable(pid_controller_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(pid_controller_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(pid_controller_test PUBLIC cxx_std_14)
 target_include_directories(pid_controller_test
   PRIVATE
@@ -17779,6 +20457,15 @@ add_executable(ping_abuse_policy_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ping_abuse_policy_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ping_abuse_policy_test PUBLIC cxx_std_14)
 target_include_directories(ping_abuse_policy_test
   PRIVATE
@@ -17812,6 +20499,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(ping_callbacks_test
   test/core/transport/chttp2/ping_callbacks_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ping_callbacks_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ping_callbacks_test PUBLIC cxx_std_14)
 target_include_directories(ping_callbacks_test
   PRIVATE
@@ -17855,6 +20551,15 @@ add_executable(ping_configuration_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ping_configuration_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ping_configuration_test PUBLIC cxx_std_14)
 target_include_directories(ping_configuration_test
   PRIVATE
@@ -17897,6 +20602,15 @@ add_executable(ping_pong_streaming_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ping_pong_streaming_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ping_pong_streaming_test PUBLIC cxx_std_14)
 target_include_directories(ping_pong_streaming_test
   PRIVATE
@@ -17942,6 +20656,15 @@ add_executable(ping_rate_policy_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ping_rate_policy_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ping_rate_policy_test PUBLIC cxx_std_14)
 target_include_directories(ping_rate_policy_test
   PRIVATE
@@ -17984,6 +20707,15 @@ add_executable(ping_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ping_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ping_test PUBLIC cxx_std_14)
 target_include_directories(ping_test
   PRIVATE
@@ -18019,6 +20751,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(pipe_test
   test/core/promise/pipe_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(pipe_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(pipe_test PUBLIC cxx_std_14)
 target_include_directories(pipe_test
   PRIVATE
@@ -18052,6 +20793,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(poll_test
   test/core/promise/poll_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(poll_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(poll_test PUBLIC cxx_std_14)
 target_include_directories(poll_test
   PRIVATE
@@ -18102,6 +20851,16 @@ add_executable(port_sharing_end2end_test
   test/cpp/end2end/port_sharing_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(port_sharing_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(port_sharing_end2end_test PUBLIC cxx_std_14)
 target_include_directories(port_sharing_end2end_test
   PRIVATE
@@ -18140,6 +20899,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/test_suite/event_engine_test_framework.cc
     test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(posix_endpoint_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(posix_endpoint_test PUBLIC cxx_std_14)
   target_include_directories(posix_endpoint_test
     PRIVATE
@@ -18175,6 +20943,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(posix_engine_listener_utils_test
     test/core/event_engine/posix/posix_engine_listener_utils_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(posix_engine_listener_utils_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(posix_engine_listener_utils_test PUBLIC cxx_std_14)
   target_include_directories(posix_engine_listener_utils_test
     PRIVATE
@@ -18213,6 +20990,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/test_suite/event_engine_test_framework.cc
     test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(posix_event_engine_connect_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(posix_event_engine_connect_test PUBLIC cxx_std_14)
   target_include_directories(posix_event_engine_connect_test
     PRIVATE
@@ -18258,6 +21044,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/cpp/util/get_grpc_test_runfile_dir.cc
     test/cpp/util/windows/manifest_file.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(posix_event_engine_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(posix_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(posix_event_engine_test
     PRIVATE
@@ -18333,6 +21129,16 @@ add_executable(pre_stop_hook_server_test
   test/cpp/interop/pre_stop_hook_server_test.cc
   test/cpp/interop/xds_interop_server_lib.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(pre_stop_hook_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(pre_stop_hook_server_test PUBLIC cxx_std_14)
 target_include_directories(pre_stop_hook_server_test
   PRIVATE
@@ -18369,6 +21175,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(prioritized_race_test
   test/core/promise/prioritized_race_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(prioritized_race_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(prioritized_race_test PUBLIC cxx_std_14)
 target_include_directories(prioritized_race_test
   PRIVATE
@@ -18403,6 +21217,15 @@ add_executable(promise_endpoint_test
   src/core/lib/transport/promise_endpoint.cc
   test/core/transport/promise_endpoint_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(promise_endpoint_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(promise_endpoint_test PUBLIC cxx_std_14)
 target_include_directories(promise_endpoint_test
   PRIVATE
@@ -18436,6 +21259,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(promise_factory_test
   test/core/promise/promise_factory_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(promise_factory_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(promise_factory_test PUBLIC cxx_std_14)
 target_include_directories(promise_factory_test
   PRIVATE
@@ -18471,6 +21302,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(promise_map_test
   test/core/promise/map_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(promise_map_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(promise_map_test PUBLIC cxx_std_14)
 target_include_directories(promise_map_test
   PRIVATE
@@ -18508,6 +21347,14 @@ add_executable(promise_mutex_test
   src/core/lib/promise/trace.cc
   test/core/promise/promise_mutex_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(promise_mutex_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(promise_mutex_test PUBLIC cxx_std_14)
 target_include_directories(promise_mutex_test
   PRIVATE
@@ -18544,6 +21391,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(promise_test
   test/core/promise/promise_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(promise_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(promise_test PUBLIC cxx_std_14)
 target_include_directories(promise_test
   PRIVATE
@@ -18578,6 +21433,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(proto_buffer_reader_test
   test/cpp/util/proto_buffer_reader_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(proto_buffer_reader_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(proto_buffer_reader_test PUBLIC cxx_std_14)
 target_include_directories(proto_buffer_reader_test
   PRIVATE
@@ -18611,6 +21476,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(proto_buffer_writer_test
   test/cpp/util/proto_buffer_writer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(proto_buffer_writer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(proto_buffer_writer_test PUBLIC cxx_std_14)
 target_include_directories(proto_buffer_writer_test
   PRIVATE
@@ -18666,6 +21541,16 @@ add_executable(proto_server_reflection_test
   test/cpp/end2end/test_service_impl.cc
   test/cpp/util/proto_reflection_descriptor_database.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(proto_server_reflection_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(proto_server_reflection_test PUBLIC cxx_std_14)
 target_include_directories(proto_server_reflection_test
   PRIVATE
@@ -18700,6 +21585,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(proto_utils_test
   test/cpp/codegen/proto_utils_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(proto_utils_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(proto_utils_test PUBLIC cxx_std_14)
 target_include_directories(proto_utils_test
   PRIVATE
@@ -18743,6 +21638,15 @@ add_executable(proxy_auth_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(proxy_auth_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(proxy_auth_test PUBLIC cxx_std_14)
 target_include_directories(proxy_auth_test
   PRIVATE
@@ -18819,6 +21723,16 @@ add_executable(qps_json_driver
   test/cpp/qps/server_sync.cc
   test/cpp/qps/usage_timer.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(qps_json_driver
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(qps_json_driver PUBLIC cxx_std_14)
 target_include_directories(qps_json_driver
   PRIVATE
@@ -18881,6 +21795,16 @@ add_executable(qps_worker
   test/cpp/qps/usage_timer.cc
   test/cpp/qps/worker.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(qps_worker
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(qps_worker PUBLIC cxx_std_14)
 target_include_directories(qps_worker
   PRIVATE
@@ -18910,6 +21834,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(race_test
   test/core/promise/race_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(race_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(race_test PUBLIC cxx_std_14)
 target_include_directories(race_test
   PRIVATE
@@ -19000,6 +21932,16 @@ add_executable(raw_end2end_test
   test/cpp/end2end/raw_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(raw_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(raw_end2end_test PUBLIC cxx_std_14)
 target_include_directories(raw_end2end_test
   PRIVATE
@@ -19033,6 +21975,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(rbac_service_config_parser_test
   test/core/ext/filters/rbac/rbac_service_config_parser_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(rbac_service_config_parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(rbac_service_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(rbac_service_config_parser_test
   PRIVATE
@@ -19076,6 +22027,15 @@ add_executable(rbac_translator_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(rbac_translator_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(rbac_translator_test PUBLIC cxx_std_14)
 target_include_directories(rbac_translator_test
   PRIVATE
@@ -19110,6 +22070,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(ref_counted_ptr_test
   test/core/gprpp/ref_counted_ptr_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ref_counted_ptr_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ref_counted_ptr_test PUBLIC cxx_std_14)
 target_include_directories(ref_counted_ptr_test
   PRIVATE
@@ -19143,6 +22112,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(ref_counted_test
   test/core/gprpp/ref_counted_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ref_counted_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ref_counted_test PUBLIC cxx_std_14)
 target_include_directories(ref_counted_test
   PRIVATE
@@ -19185,6 +22163,15 @@ add_executable(registered_call_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(registered_call_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(registered_call_test PUBLIC cxx_std_14)
 target_include_directories(registered_call_test
   PRIVATE
@@ -19221,6 +22208,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(remove_stream_from_stalled_lists_test
     test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(remove_stream_from_stalled_lists_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(remove_stream_from_stalled_lists_test PUBLIC cxx_std_14)
   target_include_directories(remove_stream_from_stalled_lists_test
     PRIVATE
@@ -19264,6 +22260,15 @@ add_executable(request_with_flags_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(request_with_flags_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(request_with_flags_test PUBLIC cxx_std_14)
 target_include_directories(request_with_flags_test
   PRIVATE
@@ -19308,6 +22313,15 @@ add_executable(request_with_payload_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(request_with_payload_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(request_with_payload_test PUBLIC cxx_std_14)
 target_include_directories(request_with_payload_test
   PRIVATE
@@ -19354,6 +22368,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(resolve_address_using_ares_resolver_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(resolve_address_using_ares_resolver_posix_test PUBLIC cxx_std_14)
   target_include_directories(resolve_address_using_ares_resolver_posix_test
     PRIVATE
@@ -19399,6 +22422,15 @@ add_executable(resolve_address_using_ares_resolver_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(resolve_address_using_ares_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(resolve_address_using_ares_resolver_test PUBLIC cxx_std_14)
 target_include_directories(resolve_address_using_ares_resolver_test
   PRIVATE
@@ -19444,6 +22476,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(resolve_address_using_native_resolver_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(resolve_address_using_native_resolver_posix_test PUBLIC cxx_std_14)
   target_include_directories(resolve_address_using_native_resolver_posix_test
     PRIVATE
@@ -19489,6 +22530,15 @@ add_executable(resolve_address_using_native_resolver_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(resolve_address_using_native_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(resolve_address_using_native_resolver_test PUBLIC cxx_std_14)
 target_include_directories(resolve_address_using_native_resolver_test
   PRIVATE
@@ -19539,6 +22589,16 @@ add_executable(resource_quota_end2end_stress_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/resource_quota_end2end_stress_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(resource_quota_end2end_stress_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(resource_quota_end2end_stress_test PUBLIC cxx_std_14)
 target_include_directories(resource_quota_end2end_stress_test
   PRIVATE
@@ -19581,6 +22641,15 @@ add_executable(resource_quota_server_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(resource_quota_server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(resource_quota_server_test PUBLIC cxx_std_14)
 target_include_directories(resource_quota_server_test
   PRIVATE
@@ -19616,6 +22685,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(resource_quota_test
   test/core/resource_quota/resource_quota_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(resource_quota_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(resource_quota_test PUBLIC cxx_std_14)
 target_include_directories(resource_quota_test
   PRIVATE
@@ -19658,6 +22736,15 @@ add_executable(retry_cancel_after_first_attempt_starts_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_cancel_after_first_attempt_starts_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_cancel_after_first_attempt_starts_test PUBLIC cxx_std_14)
 target_include_directories(retry_cancel_after_first_attempt_starts_test
   PRIVATE
@@ -19702,6 +22789,15 @@ add_executable(retry_cancel_during_delay_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_cancel_during_delay_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_cancel_during_delay_test PUBLIC cxx_std_14)
 target_include_directories(retry_cancel_during_delay_test
   PRIVATE
@@ -19746,6 +22842,15 @@ add_executable(retry_cancel_with_multiple_send_batches_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_cancel_with_multiple_send_batches_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_cancel_with_multiple_send_batches_test PUBLIC cxx_std_14)
 target_include_directories(retry_cancel_with_multiple_send_batches_test
   PRIVATE
@@ -19790,6 +22895,15 @@ add_executable(retry_cancellation_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_cancellation_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_cancellation_test PUBLIC cxx_std_14)
 target_include_directories(retry_cancellation_test
   PRIVATE
@@ -19834,6 +22948,15 @@ add_executable(retry_disabled_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_disabled_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_disabled_test PUBLIC cxx_std_14)
 target_include_directories(retry_disabled_test
   PRIVATE
@@ -19878,6 +23001,15 @@ add_executable(retry_exceeds_buffer_size_in_delay_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_exceeds_buffer_size_in_delay_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_exceeds_buffer_size_in_delay_test PUBLIC cxx_std_14)
 target_include_directories(retry_exceeds_buffer_size_in_delay_test
   PRIVATE
@@ -19922,6 +23054,15 @@ add_executable(retry_exceeds_buffer_size_in_initial_batch_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_exceeds_buffer_size_in_initial_batch_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_exceeds_buffer_size_in_initial_batch_test PUBLIC cxx_std_14)
 target_include_directories(retry_exceeds_buffer_size_in_initial_batch_test
   PRIVATE
@@ -19966,6 +23107,15 @@ add_executable(retry_exceeds_buffer_size_in_subsequent_batch_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_exceeds_buffer_size_in_subsequent_batch_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_exceeds_buffer_size_in_subsequent_batch_test PUBLIC cxx_std_14)
 target_include_directories(retry_exceeds_buffer_size_in_subsequent_batch_test
   PRIVATE
@@ -20010,6 +23160,15 @@ add_executable(retry_lb_drop_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_lb_drop_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_lb_drop_test PUBLIC cxx_std_14)
 target_include_directories(retry_lb_drop_test
   PRIVATE
@@ -20054,6 +23213,15 @@ add_executable(retry_lb_fail_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_lb_fail_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_lb_fail_test PUBLIC cxx_std_14)
 target_include_directories(retry_lb_fail_test
   PRIVATE
@@ -20098,6 +23266,15 @@ add_executable(retry_non_retriable_status_before_trailers_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_non_retriable_status_before_trailers_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_non_retriable_status_before_trailers_test PUBLIC cxx_std_14)
 target_include_directories(retry_non_retriable_status_before_trailers_test
   PRIVATE
@@ -20142,6 +23319,15 @@ add_executable(retry_non_retriable_status_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_non_retriable_status_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_non_retriable_status_test PUBLIC cxx_std_14)
 target_include_directories(retry_non_retriable_status_test
   PRIVATE
@@ -20186,6 +23372,15 @@ add_executable(retry_per_attempt_recv_timeout_on_last_attempt_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_per_attempt_recv_timeout_on_last_attempt_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_per_attempt_recv_timeout_on_last_attempt_test PUBLIC cxx_std_14)
 target_include_directories(retry_per_attempt_recv_timeout_on_last_attempt_test
   PRIVATE
@@ -20230,6 +23425,15 @@ add_executable(retry_per_attempt_recv_timeout_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_per_attempt_recv_timeout_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_per_attempt_recv_timeout_test PUBLIC cxx_std_14)
 target_include_directories(retry_per_attempt_recv_timeout_test
   PRIVATE
@@ -20274,6 +23478,15 @@ add_executable(retry_recv_initial_metadata_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_recv_initial_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_recv_initial_metadata_test PUBLIC cxx_std_14)
 target_include_directories(retry_recv_initial_metadata_test
   PRIVATE
@@ -20318,6 +23531,15 @@ add_executable(retry_recv_message_replay_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_recv_message_replay_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_recv_message_replay_test PUBLIC cxx_std_14)
 target_include_directories(retry_recv_message_replay_test
   PRIVATE
@@ -20362,6 +23584,15 @@ add_executable(retry_recv_message_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_recv_message_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_recv_message_test PUBLIC cxx_std_14)
 target_include_directories(retry_recv_message_test
   PRIVATE
@@ -20406,6 +23637,15 @@ add_executable(retry_recv_trailing_metadata_error_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_recv_trailing_metadata_error_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_recv_trailing_metadata_error_test PUBLIC cxx_std_14)
 target_include_directories(retry_recv_trailing_metadata_error_test
   PRIVATE
@@ -20450,6 +23690,15 @@ add_executable(retry_send_initial_metadata_refs_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_send_initial_metadata_refs_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_send_initial_metadata_refs_test PUBLIC cxx_std_14)
 target_include_directories(retry_send_initial_metadata_refs_test
   PRIVATE
@@ -20494,6 +23743,15 @@ add_executable(retry_send_op_fails_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_send_op_fails_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_send_op_fails_test PUBLIC cxx_std_14)
 target_include_directories(retry_send_op_fails_test
   PRIVATE
@@ -20538,6 +23796,15 @@ add_executable(retry_send_recv_batch_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_send_recv_batch_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_send_recv_batch_test PUBLIC cxx_std_14)
 target_include_directories(retry_send_recv_batch_test
   PRIVATE
@@ -20582,6 +23849,15 @@ add_executable(retry_server_pushback_delay_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_server_pushback_delay_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_server_pushback_delay_test PUBLIC cxx_std_14)
 target_include_directories(retry_server_pushback_delay_test
   PRIVATE
@@ -20626,6 +23902,15 @@ add_executable(retry_server_pushback_disabled_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_server_pushback_disabled_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_server_pushback_disabled_test PUBLIC cxx_std_14)
 target_include_directories(retry_server_pushback_disabled_test
   PRIVATE
@@ -20661,6 +23946,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(retry_service_config_test
   test/core/client_channel/retry_service_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_service_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_service_config_test PUBLIC cxx_std_14)
 target_include_directories(retry_service_config_test
   PRIVATE
@@ -20703,6 +23997,15 @@ add_executable(retry_streaming_after_commit_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_streaming_after_commit_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_streaming_after_commit_test PUBLIC cxx_std_14)
 target_include_directories(retry_streaming_after_commit_test
   PRIVATE
@@ -20747,6 +24050,15 @@ add_executable(retry_streaming_succeeds_before_replay_finished_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_streaming_succeeds_before_replay_finished_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_streaming_succeeds_before_replay_finished_test PUBLIC cxx_std_14)
 target_include_directories(retry_streaming_succeeds_before_replay_finished_test
   PRIVATE
@@ -20791,6 +24103,15 @@ add_executable(retry_streaming_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_streaming_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_streaming_test PUBLIC cxx_std_14)
 target_include_directories(retry_streaming_test
   PRIVATE
@@ -20835,6 +24156,15 @@ add_executable(retry_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_test PUBLIC cxx_std_14)
 target_include_directories(retry_test
   PRIVATE
@@ -20870,6 +24200,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(retry_throttle_test
   test/core/client_channel/retry_throttle_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_throttle_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_throttle_test PUBLIC cxx_std_14)
 target_include_directories(retry_throttle_test
   PRIVATE
@@ -20912,6 +24251,15 @@ add_executable(retry_throttled_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_throttled_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_throttled_test PUBLIC cxx_std_14)
 target_include_directories(retry_throttled_test
   PRIVATE
@@ -20956,6 +24304,15 @@ add_executable(retry_too_many_attempts_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_too_many_attempts_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_too_many_attempts_test PUBLIC cxx_std_14)
 target_include_directories(retry_too_many_attempts_test
   PRIVATE
@@ -21000,6 +24357,15 @@ add_executable(retry_transparent_goaway_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_transparent_goaway_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_transparent_goaway_test PUBLIC cxx_std_14)
 target_include_directories(retry_transparent_goaway_test
   PRIVATE
@@ -21044,6 +24410,15 @@ add_executable(retry_transparent_max_concurrent_streams_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_transparent_max_concurrent_streams_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_transparent_max_concurrent_streams_test PUBLIC cxx_std_14)
 target_include_directories(retry_transparent_max_concurrent_streams_test
   PRIVATE
@@ -21088,6 +24463,15 @@ add_executable(retry_transparent_not_sent_on_wire_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_transparent_not_sent_on_wire_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_transparent_not_sent_on_wire_test PUBLIC cxx_std_14)
 target_include_directories(retry_transparent_not_sent_on_wire_test
   PRIVATE
@@ -21132,6 +24516,15 @@ add_executable(retry_unref_before_finish_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_unref_before_finish_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_unref_before_finish_test PUBLIC cxx_std_14)
 target_include_directories(retry_unref_before_finish_test
   PRIVATE
@@ -21176,6 +24569,15 @@ add_executable(retry_unref_before_recv_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(retry_unref_before_recv_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(retry_unref_before_recv_test PUBLIC cxx_std_14)
 target_include_directories(retry_unref_before_recv_test
   PRIVATE
@@ -21217,6 +24619,15 @@ add_executable(ring_hash_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(ring_hash_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(ring_hash_test PUBLIC cxx_std_14)
 target_include_directories(ring_hash_test
   PRIVATE
@@ -21278,6 +24689,16 @@ add_executable(rls_end2end_test
   test/cpp/end2end/rls_server.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(rls_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(rls_end2end_test PUBLIC cxx_std_14)
 target_include_directories(rls_end2end_test
   PRIVATE
@@ -21312,6 +24733,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(rls_lb_config_parser_test
   test/core/client_channel/lb_policy/rls_lb_config_parser_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(rls_lb_config_parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(rls_lb_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(rls_lb_config_parser_test
   PRIVATE
@@ -21351,6 +24781,15 @@ add_executable(round_robin_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(round_robin_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(round_robin_test PUBLIC cxx_std_14)
 target_include_directories(round_robin_test
   PRIVATE
@@ -21385,6 +24824,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(secure_auth_context_test
   test/cpp/common/secure_auth_context_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(secure_auth_context_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(secure_auth_context_test PUBLIC cxx_std_14)
 target_include_directories(secure_auth_context_test
   PRIVATE
@@ -21418,6 +24867,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(secure_channel_create_test
   test/core/surface/secure_channel_create_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(secure_channel_create_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(secure_channel_create_test PUBLIC cxx_std_14)
 target_include_directories(secure_channel_create_test
   PRIVATE
@@ -21462,6 +24920,15 @@ add_executable(secure_endpoint_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(secure_endpoint_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(secure_endpoint_test PUBLIC cxx_std_14)
 target_include_directories(secure_endpoint_test
   PRIVATE
@@ -21505,6 +24972,15 @@ add_executable(security_connector_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(security_connector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(security_connector_test PUBLIC cxx_std_14)
 target_include_directories(security_connector_test
   PRIVATE
@@ -21540,6 +25016,14 @@ add_executable(seq_test
   src/core/lib/promise/trace.cc
   test/core/promise/seq_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(seq_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(seq_test PUBLIC cxx_std_14)
 target_include_directories(seq_test
   PRIVATE
@@ -21575,6 +25059,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(sequential_connectivity_test
   test/core/surface/sequential_connectivity_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(sequential_connectivity_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(sequential_connectivity_test PUBLIC cxx_std_14)
 target_include_directories(sequential_connectivity_test
   PRIVATE
@@ -21629,6 +25122,16 @@ add_executable(server_builder_plugin_test
   test/cpp/end2end/server_builder_plugin_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_builder_plugin_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_builder_plugin_test PUBLIC cxx_std_14)
 target_include_directories(server_builder_plugin_test
   PRIVATE
@@ -21689,6 +25192,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/tracer_util.cc
     test/cpp/server/server_builder_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(server_builder_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(server_builder_test PUBLIC cxx_std_14)
   target_include_directories(server_builder_test
     PRIVATE
@@ -21751,6 +25264,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/tracer_util.cc
     test/cpp/server/server_builder_with_socket_mutator_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(server_builder_with_socket_mutator_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(server_builder_with_socket_mutator_test PUBLIC cxx_std_14)
   target_include_directories(server_builder_with_socket_mutator_test
     PRIVATE
@@ -21786,6 +25309,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(server_call_tracer_factory_test
   test/core/channel/server_call_tracer_factory_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_call_tracer_factory_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_call_tracer_factory_test PUBLIC cxx_std_14)
 target_include_directories(server_call_tracer_factory_test
   PRIVATE
@@ -21819,6 +25351,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(server_chttp2_test
   test/core/surface/server_chttp2_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_chttp2_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_chttp2_test PUBLIC cxx_std_14)
 target_include_directories(server_chttp2_test
   PRIVATE
@@ -21852,6 +25393,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(server_config_selector_test
   test/core/server_config_selector/server_config_selector_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_config_selector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_config_selector_test PUBLIC cxx_std_14)
 target_include_directories(server_config_selector_test
   PRIVATE
@@ -21885,6 +25435,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(server_context_test_spouse_test
   test/cpp/test/server_context_test_spouse_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_context_test_spouse_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_context_test_spouse_test PUBLIC cxx_std_14)
 target_include_directories(server_context_test_spouse_test
   PRIVATE
@@ -21934,6 +25494,16 @@ add_executable(server_early_return_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/server_early_return_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_early_return_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_early_return_test PUBLIC cxx_std_14)
 target_include_directories(server_early_return_test
   PRIVATE
@@ -21976,6 +25546,15 @@ add_executable(server_finishes_request_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_finishes_request_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_finishes_request_test PUBLIC cxx_std_14)
 target_include_directories(server_finishes_request_test
   PRIVATE
@@ -22029,6 +25608,16 @@ add_executable(server_interceptors_end2end_test
   test/cpp/end2end/server_interceptors_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_interceptors_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_interceptors_end2end_test PUBLIC cxx_std_14)
 target_include_directories(server_interceptors_end2end_test
   PRIVATE
@@ -22064,6 +25653,15 @@ add_executable(server_registered_method_bad_client_test
   test/core/bad_client/tests/server_registered_method.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_registered_method_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_registered_method_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(server_registered_method_bad_client_test
   PRIVATE
@@ -22124,6 +25722,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/tracer_util.cc
     test/cpp/server/server_request_call_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(server_request_call_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(server_request_call_test PUBLIC cxx_std_14)
   target_include_directories(server_request_call_test
     PRIVATE
@@ -22161,6 +25769,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/handshake/server_ssl.cc
     test/core/handshake/server_ssl_common.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(server_ssl_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(server_ssl_test PUBLIC cxx_std_14)
   target_include_directories(server_ssl_test
     PRIVATE
@@ -22204,6 +25821,15 @@ add_executable(server_streaming_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_streaming_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_streaming_test PUBLIC cxx_std_14)
 target_include_directories(server_streaming_test
   PRIVATE
@@ -22239,6 +25865,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(server_test
   test/core/surface/server_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(server_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(server_test PUBLIC cxx_std_14)
 target_include_directories(server_test
   PRIVATE
@@ -22293,6 +25928,16 @@ add_executable(service_config_end2end_test
   test/cpp/end2end/service_config_end2end_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(service_config_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(service_config_end2end_test PUBLIC cxx_std_14)
 target_include_directories(service_config_end2end_test
   PRIVATE
@@ -22326,6 +25971,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(service_config_test
   test/core/service_config/service_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(service_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(service_config_test PUBLIC cxx_std_14)
 target_include_directories(service_config_test
   PRIVATE
@@ -22369,6 +26023,15 @@ add_executable(settings_timeout_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(settings_timeout_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(settings_timeout_test PUBLIC cxx_std_14)
 target_include_directories(settings_timeout_test
   PRIVATE
@@ -22411,6 +26074,15 @@ add_executable(shutdown_finishes_calls_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(shutdown_finishes_calls_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(shutdown_finishes_calls_test PUBLIC cxx_std_14)
 target_include_directories(shutdown_finishes_calls_test
   PRIVATE
@@ -22455,6 +26127,15 @@ add_executable(shutdown_finishes_tags_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(shutdown_finishes_tags_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(shutdown_finishes_tags_test PUBLIC cxx_std_14)
 target_include_directories(shutdown_finishes_tags_test
   PRIVATE
@@ -22510,6 +26191,16 @@ add_executable(shutdown_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/shutdown_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(shutdown_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(shutdown_test PUBLIC cxx_std_14)
 target_include_directories(shutdown_test
   PRIVATE
@@ -22552,6 +26243,15 @@ add_executable(simple_delayed_request_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(simple_delayed_request_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(simple_delayed_request_test PUBLIC cxx_std_14)
 target_include_directories(simple_delayed_request_test
   PRIVATE
@@ -22596,6 +26296,15 @@ add_executable(simple_metadata_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(simple_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(simple_metadata_test PUBLIC cxx_std_14)
 target_include_directories(simple_metadata_test
   PRIVATE
@@ -22633,6 +26342,15 @@ add_executable(simple_request_bad_client_test
   test/core/bad_client/tests/simple_request.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(simple_request_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(simple_request_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(simple_request_bad_client_test
   PRIVATE
@@ -22675,6 +26393,15 @@ add_executable(simple_request_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(simple_request_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(simple_request_test PUBLIC cxx_std_14)
 target_include_directories(simple_request_test
   PRIVATE
@@ -22710,6 +26437,14 @@ if(gRPC_BUILD_TESTS)
 add_executable(single_set_ptr_test
   test/core/gprpp/single_set_ptr_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(single_set_ptr_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(single_set_ptr_test PUBLIC cxx_std_14)
 target_include_directories(single_set_ptr_test
   PRIVATE
@@ -22743,6 +26478,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(sleep_test
   test/core/promise/sleep_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(sleep_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(sleep_test PUBLIC cxx_std_14)
 target_include_directories(sleep_test
   PRIVATE
@@ -22780,6 +26524,14 @@ add_executable(slice_string_helpers_test
   src/core/lib/slice/slice_string_helpers.cc
   test/core/slice/slice_string_helpers_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(slice_string_helpers_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(slice_string_helpers_test PUBLIC cxx_std_14)
 target_include_directories(slice_string_helpers_test
   PRIVATE
@@ -22815,6 +26567,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(smoke_test
   test/core/event_engine/smoke_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(smoke_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(smoke_test PUBLIC cxx_std_14)
 target_include_directories(smoke_test
   PRIVATE
@@ -22848,6 +26609,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(sockaddr_resolver_test
   test/core/client_channel/resolvers/sockaddr_resolver_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(sockaddr_resolver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(sockaddr_resolver_test PUBLIC cxx_std_14)
 target_include_directories(sockaddr_resolver_test
   PRIVATE
@@ -22881,6 +26651,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(sockaddr_utils_test
   test/core/address_utils/sockaddr_utils_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(sockaddr_utils_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(sockaddr_utils_test PUBLIC cxx_std_14)
 target_include_directories(sockaddr_utils_test
   PRIVATE
@@ -22925,6 +26704,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(socket_utils_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(socket_utils_test PUBLIC cxx_std_14)
   target_include_directories(socket_utils_test
     PRIVATE
@@ -22991,6 +26779,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(spinlock_test
   test/core/gpr/spinlock_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(spinlock_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(spinlock_test PUBLIC cxx_std_14)
 target_include_directories(spinlock_test
   PRIVATE
@@ -23026,6 +26823,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/tsi/ssl_transport_security_test.cc
     test/core/tsi/transport_security_test_lib.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(ssl_transport_security_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(ssl_transport_security_test PUBLIC cxx_std_14)
   target_include_directories(ssl_transport_security_test
     PRIVATE
@@ -23061,6 +26867,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(ssl_transport_security_utils_test
     test/core/tsi/ssl_transport_security_utils_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(ssl_transport_security_utils_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(ssl_transport_security_utils_test PUBLIC cxx_std_14)
   target_include_directories(ssl_transport_security_utils_test
     PRIVATE
@@ -23096,6 +26911,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(stack_tracer_test
     test/core/util/stack_tracer_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(stack_tracer_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(stack_tracer_test PUBLIC cxx_std_14)
   target_include_directories(stack_tracer_test
     PRIVATE
@@ -23130,6 +26954,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(stat_test
   test/core/gprpp/stat_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(stat_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(stat_test PUBLIC cxx_std_14)
 target_include_directories(stat_test
   PRIVATE
@@ -23164,6 +26997,14 @@ add_executable(static_stride_scheduler_test
   src/core/ext/filters/client_channel/lb_policy/weighted_round_robin/static_stride_scheduler.cc
   test/core/client_channel/lb_policy/static_stride_scheduler_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(static_stride_scheduler_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(static_stride_scheduler_test PUBLIC cxx_std_14)
 target_include_directories(static_stride_scheduler_test
   PRIVATE
@@ -23198,6 +27039,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(stats_test
   test/core/debug/stats_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(stats_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(stats_test PUBLIC cxx_std_14)
 target_include_directories(stats_test
   PRIVATE
@@ -23241,6 +27091,15 @@ add_executable(status_conversion_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(status_conversion_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(status_conversion_test PUBLIC cxx_std_14)
 target_include_directories(status_conversion_test
   PRIVATE
@@ -23307,7 +27166,17 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(status_helper_test
   test/core/gprpp/status_helper_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(status_helper_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(status_helper_test PUBLIC cxx_std_14)
 target_include_directories(status_helper_test
   PRIVATE
@@ -23341,6 +27210,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(status_util_test
   test/core/channel/status_util_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(status_util_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(status_util_test PUBLIC cxx_std_14)
 target_include_directories(status_util_test
   PRIVATE
@@ -23374,6 +27252,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(stream_leak_with_queued_flow_control_update_test
   test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(stream_leak_with_queued_flow_control_update_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(stream_leak_with_queued_flow_control_update_test PUBLIC cxx_std_14)
 target_include_directories(stream_leak_with_queued_flow_control_update_test
   PRIVATE
@@ -23416,6 +27303,15 @@ add_executable(streaming_error_response_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(streaming_error_response_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(streaming_error_response_test PUBLIC cxx_std_14)
 target_include_directories(streaming_error_response_test
   PRIVATE
@@ -23472,6 +27368,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
     test/cpp/end2end/streaming_throughput_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(streaming_throughput_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(streaming_throughput_test PUBLIC cxx_std_14)
   target_include_directories(streaming_throughput_test
     PRIVATE
@@ -23517,6 +27423,15 @@ add_executable(streams_not_seen_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(streams_not_seen_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(streams_not_seen_test PUBLIC cxx_std_14)
 target_include_directories(streams_not_seen_test
   PRIVATE
@@ -23550,6 +27465,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(string_ref_test
   test/cpp/util/string_ref_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(string_ref_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(string_ref_test PUBLIC cxx_std_14)
 target_include_directories(string_ref_test
   PRIVATE
@@ -23584,6 +27509,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(string_test
   test/core/gpr/string_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(string_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(string_test PUBLIC cxx_std_14)
 target_include_directories(string_test
   PRIVATE
@@ -23617,6 +27551,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(sync_test
   test/core/gpr/sync_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(sync_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(sync_test PUBLIC cxx_std_14)
 target_include_directories(sync_test
   PRIVATE
@@ -23660,6 +27603,15 @@ add_executable(system_roots_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(system_roots_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(system_roots_test PUBLIC cxx_std_14)
 target_include_directories(system_roots_test
   PRIVATE
@@ -23738,6 +27690,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(tcp_client_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(tcp_client_posix_test PUBLIC cxx_std_14)
   target_include_directories(tcp_client_posix_test
     PRIVATE
@@ -23773,6 +27734,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(tcp_posix_socket_utils_test
     test/core/event_engine/posix/tcp_posix_socket_utils_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(tcp_posix_socket_utils_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(tcp_posix_socket_utils_test PUBLIC cxx_std_14)
   target_include_directories(tcp_posix_socket_utils_test
     PRIVATE
@@ -23819,6 +27789,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(tcp_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(tcp_posix_test PUBLIC cxx_std_14)
   target_include_directories(tcp_posix_test
     PRIVATE
@@ -23864,6 +27843,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/slice_splitter.cc
     test/core/util/tracer_util.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(tcp_server_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(tcp_server_posix_test PUBLIC cxx_std_14)
   target_include_directories(tcp_server_posix_test
     PRIVATE
@@ -23898,6 +27886,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(tcp_socket_utils_test
   test/core/event_engine/tcp_socket_utils_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(tcp_socket_utils_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(tcp_socket_utils_test PUBLIC cxx_std_14)
 target_include_directories(tcp_socket_utils_test
   PRIVATE
@@ -23937,6 +27934,16 @@ add_executable(test_core_channel_channelz_test
   test/core/event_engine/event_engine_test_utils.cc
   test/cpp/util/channel_trace_proto_helper.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_channel_channelz_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_channel_channelz_test PUBLIC cxx_std_14)
 target_include_directories(test_core_channel_channelz_test
   PRIVATE
@@ -23980,6 +27987,15 @@ add_executable(test_core_end2end_channelz_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_end2end_channelz_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_end2end_channelz_test PUBLIC cxx_std_14)
 target_include_directories(test_core_end2end_channelz_test
   PRIVATE
@@ -24019,6 +28035,14 @@ add_executable(test_core_event_engine_posix_timer_heap_test
   src/core/lib/gprpp/time_averaged_stats.cc
   test/core/event_engine/posix/timer_heap_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_event_engine_posix_timer_heap_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_event_engine_posix_timer_heap_test PUBLIC cxx_std_14)
 target_include_directories(test_core_event_engine_posix_timer_heap_test
   PRIVATE
@@ -24057,6 +28081,14 @@ add_executable(test_core_event_engine_posix_timer_list_test
   src/core/lib/gprpp/time_averaged_stats.cc
   test/core/event_engine/posix/timer_list_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_event_engine_posix_timer_list_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_event_engine_posix_timer_list_test PUBLIC cxx_std_14)
 target_include_directories(test_core_event_engine_posix_timer_list_test
   PRIVATE
@@ -24100,6 +28132,14 @@ add_executable(test_core_event_engine_slice_buffer_test
   src/core/lib/slice/slice_string_helpers.cc
   test/core/event_engine/slice_buffer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_event_engine_slice_buffer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_event_engine_slice_buffer_test PUBLIC cxx_std_14)
 target_include_directories(test_core_event_engine_slice_buffer_test
   PRIVATE
@@ -24136,6 +28176,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(test_core_gpr_time_test
   test/core/gpr/time_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_gpr_time_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_gpr_time_test PUBLIC cxx_std_14)
 target_include_directories(test_core_gpr_time_test
   PRIVATE
@@ -24169,6 +28218,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(test_core_gprpp_load_file_test
   test/core/gprpp/load_file_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_gprpp_load_file_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_gprpp_load_file_test PUBLIC cxx_std_14)
 target_include_directories(test_core_gprpp_load_file_test
   PRIVATE
@@ -24203,6 +28261,14 @@ add_executable(test_core_gprpp_time_test
   src/core/lib/gprpp/time.cc
   test/core/gprpp/time_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_gprpp_time_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_gprpp_time_test PUBLIC cxx_std_14)
 target_include_directories(test_core_gprpp_time_test
   PRIVATE
@@ -24247,6 +28313,15 @@ add_executable(test_core_iomgr_load_file_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_iomgr_load_file_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_iomgr_load_file_test PUBLIC cxx_std_14)
 target_include_directories(test_core_iomgr_load_file_test
   PRIVATE
@@ -24290,6 +28365,15 @@ add_executable(test_core_iomgr_timer_heap_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_iomgr_timer_heap_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_iomgr_timer_heap_test PUBLIC cxx_std_14)
 target_include_directories(test_core_iomgr_timer_heap_test
   PRIVATE
@@ -24333,6 +28417,15 @@ add_executable(test_core_security_credentials_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_security_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_security_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_core_security_credentials_test
   PRIVATE
@@ -24376,6 +28469,15 @@ add_executable(test_core_security_ssl_credentials_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_security_ssl_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_security_ssl_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_core_security_ssl_credentials_test
   PRIVATE
@@ -24409,6 +28511,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(test_core_slice_slice_buffer_test
   test/core/slice/slice_buffer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_slice_slice_buffer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_slice_slice_buffer_test PUBLIC cxx_std_14)
 target_include_directories(test_core_slice_slice_buffer_test
   PRIVATE
@@ -24443,6 +28554,15 @@ add_executable(test_core_slice_slice_test
   test/core/slice/slice_test.cc
   test/core/util/build.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_slice_slice_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_slice_slice_test PUBLIC cxx_std_14)
 target_include_directories(test_core_slice_slice_test
   PRIVATE
@@ -24739,6 +28859,14 @@ add_executable(test_core_transport_chaotic_good_frame_test
   third_party/upb/upb/wire/eps_copy_input_stream.c
   third_party/upb/upb/wire/reader.c
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_transport_chaotic_good_frame_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_transport_chaotic_good_frame_test PUBLIC cxx_std_14)
 target_include_directories(test_core_transport_chaotic_good_frame_test
   PRIVATE
@@ -24793,6 +28921,14 @@ add_executable(test_core_transport_chttp2_frame_test
   src/core/lib/slice/slice_string_helpers.cc
   test/core/transport/chttp2/frame_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_core_transport_chttp2_frame_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_core_transport_chttp2_frame_test PUBLIC cxx_std_14)
 target_include_directories(test_core_transport_chttp2_frame_test
   PRIVATE
@@ -24830,6 +28966,16 @@ add_executable(test_cpp_client_credentials_test
   test/cpp/client/credentials_test.cc
   test/cpp/util/tls_test_utils.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_cpp_client_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_cpp_client_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_client_credentials_test
   PRIVATE
@@ -24881,6 +29027,16 @@ add_executable(test_cpp_end2end_ssl_credentials_test
   test/cpp/end2end/ssl_credentials_test.cc
   test/cpp/end2end/test_service_impl.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_cpp_end2end_ssl_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_cpp_end2end_ssl_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_end2end_ssl_credentials_test
   PRIVATE
@@ -24915,6 +29071,16 @@ add_executable(test_cpp_server_credentials_test
   test/cpp/server/credentials_test.cc
   test/cpp/util/tls_test_utils.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_cpp_server_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_cpp_server_credentials_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_server_credentials_test
   PRIVATE
@@ -24949,6 +29115,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(test_cpp_util_slice_test
   test/cpp/util/slice_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_cpp_util_slice_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_cpp_util_slice_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_util_slice_test
   PRIVATE
@@ -24982,6 +29158,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(test_cpp_util_time_test
   test/cpp/util/time_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(test_cpp_util_time_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(test_cpp_util_time_test PUBLIC cxx_std_14)
 target_include_directories(test_cpp_util_time_test
   PRIVATE
@@ -25015,6 +29201,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(thd_test
   test/core/gprpp/thd_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(thd_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(thd_test PUBLIC cxx_std_14)
 target_include_directories(thd_test
   PRIVATE
@@ -25048,6 +29243,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(thread_manager_test
   test/cpp/thread_manager/thread_manager_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(thread_manager_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(thread_manager_test PUBLIC cxx_std_14)
 target_include_directories(thread_manager_test
   PRIVATE
@@ -25082,6 +29287,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(thread_pool_test
   test/core/event_engine/thread_pool_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(thread_pool_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(thread_pool_test PUBLIC cxx_std_14)
 target_include_directories(thread_pool_test
   PRIVATE
@@ -25117,6 +29331,14 @@ add_executable(thread_quota_test
   src/core/lib/resource_quota/thread_quota.cc
   test/core/resource_quota/thread_quota_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(thread_quota_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(thread_quota_test PUBLIC cxx_std_14)
 target_include_directories(thread_quota_test
   PRIVATE
@@ -25172,6 +29394,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
     test/cpp/end2end/thread_stress_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(thread_stress_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(thread_stress_test PUBLIC cxx_std_14)
   target_include_directories(thread_stress_test
     PRIVATE
@@ -25213,6 +29445,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/test_suite/tests/timer_test.cc
     test/core/event_engine/test_suite/thready_posix_event_engine_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(thready_posix_event_engine_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(thready_posix_event_engine_test PUBLIC cxx_std_14)
   target_include_directories(thready_posix_event_engine_test
     PRIVATE
@@ -25248,6 +29489,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(time_jump_test
     test/cpp/common/time_jump_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(time_jump_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(time_jump_test PUBLIC cxx_std_14)
   target_include_directories(time_jump_test
     PRIVATE
@@ -25283,6 +29534,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(time_util_test
   test/core/gprpp/time_util_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(time_util_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(time_util_test PUBLIC cxx_std_14)
 target_include_directories(time_util_test
   PRIVATE
@@ -25325,6 +29585,15 @@ add_executable(timeout_before_request_call_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(timeout_before_request_call_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(timeout_before_request_call_test PUBLIC cxx_std_14)
 target_include_directories(timeout_before_request_call_test
   PRIVATE
@@ -25370,6 +29639,15 @@ add_executable(timeout_encoding_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(timeout_encoding_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(timeout_encoding_test PUBLIC cxx_std_14)
 target_include_directories(timeout_encoding_test
   PRIVATE
@@ -25403,6 +29681,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(timer_manager_test
   test/core/event_engine/posix/timer_manager_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(timer_manager_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(timer_manager_test PUBLIC cxx_std_14)
 target_include_directories(timer_manager_test
   PRIVATE
@@ -25436,6 +29723,16 @@ if(gRPC_BUILD_TESTS)
 add_executable(timer_test
   test/cpp/common/timer_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(timer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(timer_test PUBLIC cxx_std_14)
 target_include_directories(timer_test
   PRIVATE
@@ -25471,6 +29768,16 @@ add_executable(tls_certificate_verifier_test
   test/cpp/security/tls_certificate_verifier_test.cc
   test/cpp/util/tls_test_utils.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(tls_certificate_verifier_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(tls_certificate_verifier_test PUBLIC cxx_std_14)
 target_include_directories(tls_certificate_verifier_test
   PRIVATE
@@ -25522,6 +29829,16 @@ add_executable(tls_credentials_test
   test/cpp/end2end/test_service_impl.cc
   test/cpp/end2end/tls_credentials_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(tls_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(tls_credentials_test PUBLIC cxx_std_14)
 target_include_directories(tls_credentials_test
   PRIVATE
@@ -25571,6 +29888,16 @@ add_executable(tls_key_export_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
   test/cpp/end2end/tls_key_export_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(tls_key_export_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(tls_key_export_test PUBLIC cxx_std_14)
 target_include_directories(tls_key_export_test
   PRIVATE
@@ -25614,6 +29941,15 @@ add_executable(tls_security_connector_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(tls_security_connector_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(tls_security_connector_test PUBLIC cxx_std_14)
 target_include_directories(tls_security_connector_test
   PRIVATE
@@ -25648,6 +29984,16 @@ add_executable(too_many_pings_test
   test/core/end2end/cq_verifier.cc
   test/core/transport/chttp2/too_many_pings_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(too_many_pings_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(too_many_pings_test PUBLIC cxx_std_14)
 target_include_directories(too_many_pings_test
   PRIVATE
@@ -25683,6 +30029,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(traced_buffer_list_test
     test/core/event_engine/posix/traced_buffer_list_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(traced_buffer_list_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(traced_buffer_list_test PUBLIC cxx_std_14)
   target_include_directories(traced_buffer_list_test
     PRIVATE
@@ -25726,6 +30081,15 @@ add_executable(trailing_metadata_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(trailing_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(trailing_metadata_test PUBLIC cxx_std_14)
 target_include_directories(trailing_metadata_test
   PRIVATE
@@ -25761,6 +30125,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(transport_security_common_api_test
   test/core/tsi/alts/handshaker/transport_security_common_api_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(transport_security_common_api_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(transport_security_common_api_test PUBLIC cxx_std_14)
 target_include_directories(transport_security_common_api_test
   PRIVATE
@@ -25794,6 +30167,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(transport_security_test
   test/core/tsi/transport_security_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(transport_security_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(transport_security_test PUBLIC cxx_std_14)
 target_include_directories(transport_security_test
   PRIVATE
@@ -25888,7 +30270,17 @@ add_executable(transport_stream_receiver_test
   src/cpp/util/string_ref.cc
   src/cpp/util/time_cc.cc
   test/core/transport/binder/transport_stream_receiver_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(transport_stream_receiver_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(transport_stream_receiver_test PUBLIC cxx_std_14)
 target_include_directories(transport_stream_receiver_test
   PRIVATE
@@ -25925,6 +30317,14 @@ add_executable(try_join_test
   src/core/lib/promise/trace.cc
   test/core/promise/try_join_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(try_join_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(try_join_test PUBLIC cxx_std_14)
 target_include_directories(try_join_test
   PRIVATE
@@ -25961,6 +30361,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(try_seq_metadata_test
   test/core/promise/try_seq_metadata_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(try_seq_metadata_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(try_seq_metadata_test PUBLIC cxx_std_14)
 target_include_directories(try_seq_metadata_test
   PRIVATE
@@ -25996,6 +30405,14 @@ add_executable(try_seq_test
   src/core/lib/promise/trace.cc
   test/core/promise/try_seq_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(try_seq_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(try_seq_test PUBLIC cxx_std_14)
 target_include_directories(try_seq_test
   PRIVATE
@@ -26066,6 +30483,15 @@ add_executable(unknown_frame_bad_client_test
   test/core/bad_client/tests/unknown_frame.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(unknown_frame_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(unknown_frame_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(unknown_frame_bad_client_test
   PRIVATE
@@ -26099,6 +30525,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(uri_parser_test
   test/core/uri/uri_parser_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(uri_parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(uri_parser_test PUBLIC cxx_std_14)
 target_include_directories(uri_parser_test
   PRIVATE
@@ -26165,6 +30600,15 @@ add_executable(uuid_v4_test
   src/core/lib/gprpp/uuid_v4.cc
   test/core/gprpp/uuid_v4_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(uuid_v4_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(uuid_v4_test PUBLIC cxx_std_14)
 target_include_directories(uuid_v4_test
   PRIVATE
@@ -26198,6 +30642,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(validation_errors_test
   test/core/gprpp/validation_errors_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(validation_errors_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(validation_errors_test PUBLIC cxx_std_14)
 target_include_directories(validation_errors_test
   PRIVATE
@@ -26231,6 +30684,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(varint_test
   test/core/transport/chttp2/varint_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(varint_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(varint_test PUBLIC cxx_std_14)
 target_include_directories(varint_test
   PRIVATE
@@ -26265,6 +30727,14 @@ add_executable(wait_for_callback_test
   src/core/lib/promise/activity.cc
   test/core/promise/wait_for_callback_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(wait_for_callback_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(wait_for_callback_test PUBLIC cxx_std_14)
 target_include_directories(wait_for_callback_test
   PRIVATE
@@ -26302,6 +30772,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(wakeup_fd_posix_test
     test/core/event_engine/posix/wakeup_fd_posix_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(wakeup_fd_posix_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(wakeup_fd_posix_test PUBLIC cxx_std_14)
   target_include_directories(wakeup_fd_posix_test
     PRIVATE
@@ -26336,6 +30815,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(weighted_round_robin_config_test
   test/core/client_channel/lb_policy/weighted_round_robin_config_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(weighted_round_robin_config_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(weighted_round_robin_config_test PUBLIC cxx_std_14)
 target_include_directories(weighted_round_robin_config_test
   PRIVATE
@@ -26375,6 +30863,15 @@ add_executable(weighted_round_robin_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(weighted_round_robin_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(weighted_round_robin_test PUBLIC cxx_std_14)
 target_include_directories(weighted_round_robin_test
   PRIVATE
@@ -26411,6 +30908,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
     test/core/event_engine/windows/create_sockpair.cc
     test/core/event_engine/windows/win_socket_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(win_socket_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(win_socket_test PUBLIC cxx_std_14)
   target_include_directories(win_socket_test
     PRIVATE
@@ -26447,6 +30953,15 @@ add_executable(window_overflow_bad_client_test
   test/core/bad_client/tests/window_overflow.cc
   test/core/end2end/cq_verifier.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(window_overflow_bad_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(window_overflow_bad_client_test PUBLIC cxx_std_14)
 target_include_directories(window_overflow_bad_client_test
   PRIVATE
@@ -26482,6 +30997,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
     test/core/event_engine/windows/create_sockpair.cc
     test/core/event_engine/windows/windows_endpoint_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(windows_endpoint_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(windows_endpoint_test PUBLIC cxx_std_14)
   target_include_directories(windows_endpoint_test
     PRIVATE
@@ -26578,7 +31102,17 @@ add_executable(wire_reader_test
   src/cpp/util/time_cc.cc
   test/core/transport/binder/mock_objects.cc
   test/core/transport/binder/wire_reader_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(wire_reader_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(wire_reader_test PUBLIC cxx_std_14)
 target_include_directories(wire_reader_test
   PRIVATE
@@ -26675,7 +31209,17 @@ add_executable(wire_writer_test
   src/cpp/util/time_cc.cc
   test/core/transport/binder/mock_objects.cc
   test/core/transport/binder/wire_writer_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(wire_writer_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(wire_writer_test PUBLIC cxx_std_14)
 target_include_directories(wire_writer_test
   PRIVATE
@@ -26712,6 +31256,15 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/event_engine/event_engine_test_utils.cc
     test/core/gprpp/work_serializer_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(work_serializer_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(work_serializer_test PUBLIC cxx_std_14)
   target_include_directories(work_serializer_test
     PRIVATE
@@ -26755,6 +31308,15 @@ add_executable(write_buffering_at_end_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(write_buffering_at_end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(write_buffering_at_end_test PUBLIC cxx_std_14)
 target_include_directories(write_buffering_at_end_test
   PRIVATE
@@ -26799,6 +31361,15 @@ add_executable(write_buffering_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/util/test_lb_policies.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(write_buffering_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(write_buffering_test PUBLIC cxx_std_14)
 target_include_directories(write_buffering_test
   PRIVATE
@@ -26836,6 +31407,14 @@ add_executable(write_size_policy_test
   src/core/lib/gprpp/time.cc
   test/core/transport/chttp2/write_size_policy_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(write_size_policy_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(write_size_policy_test PUBLIC cxx_std_14)
 target_include_directories(write_size_policy_test
   PRIVATE
@@ -26897,6 +31476,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/core/util/tracer_util.cc
     test/cpp/performance/writes_per_rpc_test.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(writes_per_rpc_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(writes_per_rpc_test PUBLIC cxx_std_14)
   target_include_directories(writes_per_rpc_test
     PRIVATE
@@ -26996,7 +31585,18 @@ add_executable(xds_audit_logger_registry_test
   test/cpp/util/proto_file_parser.cc
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_audit_logger_registry_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_audit_logger_registry_test PUBLIC cxx_std_14)
 target_include_directories(xds_audit_logger_registry_test
   PRIVATE
@@ -27032,6 +31632,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(xds_bootstrap_test
   test/core/xds/xds_bootstrap_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_bootstrap_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_bootstrap_test PUBLIC cxx_std_14)
 target_include_directories(xds_bootstrap_test
   PRIVATE
@@ -27065,6 +31674,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(xds_certificate_provider_test
   test/core/xds/xds_certificate_provider_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_certificate_provider_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_certificate_provider_test PUBLIC cxx_std_14)
 target_include_directories(xds_certificate_provider_test
   PRIVATE
@@ -27112,6 +31730,15 @@ add_executable(xds_client_test
   test/core/xds/xds_client_test.cc
   test/core/xds/xds_transport_fake.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_client_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_client_test PUBLIC cxx_std_14)
 target_include_directories(xds_client_test
   PRIVATE
@@ -27277,6 +31904,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_cluster_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_cluster_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_cluster_end2end_test
     PRIVATE
@@ -27375,7 +32012,17 @@ add_executable(xds_cluster_resource_type_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/wrr_locality.grpc.pb.h
   src/cpp/util/status.cc
   test/core/xds/xds_cluster_resource_type_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_cluster_resource_type_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_cluster_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_cluster_resource_type_test
   PRIVATE
@@ -27545,6 +32192,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_cluster_type_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_cluster_type_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_cluster_type_end2end_test
     PRIVATE
@@ -27619,7 +32276,18 @@ add_executable(xds_common_types_test
   test/cpp/util/proto_file_parser.cc
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_common_types_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_common_types_test PUBLIC cxx_std_14)
 target_include_directories(xds_common_types_test
   PRIVATE
@@ -27785,6 +32453,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_core_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_core_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_core_end2end_test
     PRIVATE
@@ -27836,6 +32514,16 @@ add_executable(xds_credentials_end2end_test
   test/cpp/end2end/test_service_impl.cc
   test/cpp/end2end/xds/xds_credentials_end2end_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_credentials_end2end_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_credentials_end2end_test PUBLIC cxx_std_14)
 target_include_directories(xds_credentials_end2end_test
   PRIVATE
@@ -27879,6 +32567,15 @@ add_executable(xds_credentials_test
   test/core/util/slice_splitter.cc
   test/core/util/tracer_util.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_credentials_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_credentials_test PUBLIC cxx_std_14)
 target_include_directories(xds_credentials_test
   PRIVATE
@@ -28051,6 +32748,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_csds_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_csds_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_csds_end2end_test
     PRIVATE
@@ -28236,6 +32943,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_end2end_test
     PRIVATE
@@ -28291,7 +33008,17 @@ add_executable(xds_endpoint_resource_type_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.grpc.pb.h
   src/cpp/util/status.cc
   test/core/xds/xds_endpoint_resource_type_test.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_endpoint_resource_type_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_endpoint_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_endpoint_resource_type_test
   PRIVATE
@@ -28464,6 +33191,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_fault_injection_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_fault_injection_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_fault_injection_end2end_test
     PRIVATE
@@ -28587,6 +33324,16 @@ add_executable(xds_http_filters_test
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_http_filters_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_http_filters_test PUBLIC cxx_std_14)
 target_include_directories(xds_http_filters_test
   PRIVATE
@@ -28694,7 +33441,18 @@ add_executable(xds_lb_policy_registry_test
   test/cpp/util/proto_file_parser.cc
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_lb_policy_registry_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_lb_policy_registry_test PUBLIC cxx_std_14)
 target_include_directories(xds_lb_policy_registry_test
   PRIVATE
@@ -28826,7 +33584,18 @@ add_executable(xds_listener_resource_type_test
   test/cpp/util/proto_file_parser.cc
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_listener_resource_type_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_listener_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_listener_resource_type_test
   PRIVATE
@@ -29000,6 +33769,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_outlier_detection_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_outlier_detection_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_outlier_detection_end2end_test
     PRIVATE
@@ -29176,6 +33955,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_override_host_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_override_host_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_override_host_end2end_test
     PRIVATE
@@ -29210,6 +33999,15 @@ if(gRPC_BUILD_TESTS)
 add_executable(xds_override_host_lb_config_parser_test
   test/core/client_channel/lb_policy/xds_override_host_lb_config_parser_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_override_host_lb_config_parser_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_override_host_lb_config_parser_test PUBLIC cxx_std_14)
 target_include_directories(xds_override_host_lb_config_parser_test
   PRIVATE
@@ -29249,6 +34047,15 @@ add_executable(xds_override_host_test
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_override_host_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_override_host_test PUBLIC cxx_std_14)
 target_include_directories(xds_override_host_test
   PRIVATE
@@ -29422,6 +34229,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_pick_first_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_pick_first_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_pick_first_end2end_test
     PRIVATE
@@ -29591,6 +34408,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_ring_hash_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_ring_hash_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_ring_hash_end2end_test
     PRIVATE
@@ -29764,6 +34591,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_rls_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_rls_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_rls_end2end_test
     PRIVATE
@@ -29874,7 +34711,18 @@ add_executable(xds_route_config_resource_type_test
   test/cpp/util/proto_file_parser.cc
   test/cpp/util/proto_reflection_descriptor_database.cc
   test/cpp/util/service_describer.cc
+  ${gRPC_UPB_GEN_DUPL_TEST_SRC}
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_route_config_resource_type_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_route_config_resource_type_test PUBLIC cxx_std_14)
 target_include_directories(xds_route_config_resource_type_test
   PRIVATE
@@ -30048,6 +34896,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_utils.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_routing_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_routing_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_routing_end2end_test
     PRIVATE
@@ -30114,6 +34972,16 @@ add_executable(xds_stats_watcher_test
   test/cpp/interop/xds_stats_watcher.cc
   test/cpp/interop/xds_stats_watcher_test.cc
 )
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_stats_watcher_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+endif()
 target_compile_features(xds_stats_watcher_test PUBLIC cxx_std_14)
 target_include_directories(xds_stats_watcher_test
   PRIVATE
@@ -30288,6 +35156,16 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     test/cpp/end2end/xds/xds_wrr_end2end_test.cc
     test/cpp/util/tls_test_utils.cc
   )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(xds_wrr_end2end_test
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+        "GRPCXX_DLL_IMPORTS"
+      )
+    endif()
+  endif()
   target_compile_features(xds_wrr_end2end_test PUBLIC cxx_std_14)
   target_include_directories(xds_wrr_end2end_test
     PRIVATE

--- a/include/grpcpp/support/string_ref.h
+++ b/include/grpcpp/support/string_ref.h
@@ -19,6 +19,8 @@
 #ifndef GRPCPP_SUPPORT_STRING_REF_H
 #define GRPCPP_SUPPORT_STRING_REF_H
 
+#include <grpc/support/port_platform.h>
+
 #include <string.h>
 
 #include <algorithm>
@@ -45,7 +47,7 @@ class string_ref {
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
   /// constants
-  const static size_t npos;
+  const static GRPCXX_DLL size_t npos;
 
   /// construct/copy.
   string_ref() : data_(nullptr), length_(0) {}

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -89,7 +89,7 @@ struct grpc_ares_request {
 // synchronized by the caller. TODO(apolcyn): we should remove this requirement
 // by changing this API to use two phase initialization - one API to create
 // the grpc_ares_request* and another to start the async work.
-extern grpc_ares_request* (*grpc_dns_lookup_hostname_ares)(
+extern GRPC_DLL grpc_ares_request* (*grpc_dns_lookup_hostname_ares)(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     std::unique_ptr<grpc_core::EndpointAddressesList>* addresses,
@@ -97,7 +97,7 @@ extern grpc_ares_request* (*grpc_dns_lookup_hostname_ares)(
 
 // Asynchronously resolve a SRV record.
 // See \a grpc_dns_lookup_hostname_ares for usage details and caveats.
-extern grpc_ares_request* (*grpc_dns_lookup_srv_ares)(
+extern GRPC_DLL grpc_ares_request* (*grpc_dns_lookup_srv_ares)(
     const char* dns_server, const char* name,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     std::unique_ptr<grpc_core::EndpointAddressesList>* balancer_addresses,
@@ -105,13 +105,13 @@ extern grpc_ares_request* (*grpc_dns_lookup_srv_ares)(
 
 // Asynchronously resolve a TXT record.
 // See \a grpc_dns_lookup_hostname_ares for usage details and caveats.
-extern grpc_ares_request* (*grpc_dns_lookup_txt_ares)(
+extern GRPC_DLL grpc_ares_request* (*grpc_dns_lookup_txt_ares)(
     const char* dns_server, const char* name,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     char** service_config_json, int query_timeout_ms);
 
 // Cancel the pending grpc_ares_request \a request
-extern void (*grpc_cancel_ares_request)(grpc_ares_request* request);
+extern GRPC_DLL void (*grpc_cancel_ares_request)(grpc_ares_request* request);
 
 // Initialize gRPC ares wrapper. Must be called at least once before
 // grpc_resolve_address_ares().
@@ -132,9 +132,10 @@ void grpc_cares_wrapper_address_sorting_sort(
     grpc_core::EndpointAddressesList* addresses);
 
 // Exposed in this header for C-core tests only
-extern void (*grpc_ares_test_only_inject_config)(ares_channel* channel);
+extern GRPC_DLL void (*grpc_ares_test_only_inject_config)(
+    ares_channel* channel);
 
 // Exposed in this header for C-core tests only
-extern bool g_grpc_ares_test_only_force_tcp;
+extern GRPC_DLL bool g_grpc_ares_test_only_force_tcp;
 
 #endif  // GRPC_SRC_CORE_EXT_FILTERS_CLIENT_CHANNEL_RESOLVER_DNS_C_ARES_GRPC_ARES_WRAPPER_H

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.h
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.h
@@ -40,7 +40,7 @@ namespace grpc_core {
 // of the ordinary channel stack. The fault injection filter fetches fault
 // injection policy from the method config of service config returned by the
 // resolver, and enforces the fault injection policy.
-class FaultInjectionFilter : public ChannelFilter {
+class GRPC_DLL FaultInjectionFilter : public ChannelFilter {
  public:
   static const grpc_channel_filter kFilter;
 

--- a/src/core/ext/filters/rbac/rbac_filter.h
+++ b/src/core/ext/filters/rbac/rbac_filter.h
@@ -34,7 +34,7 @@ namespace grpc_core {
 
 // Filter used when xDS server config fetcher provides a configuration with an
 // HTTP RBAC filter. Also serves as the type for channel data for the filter.
-class RbacFilter : public ChannelFilter {
+class GRPC_DLL RbacFilter : public ChannelFilter {
  public:
   // This channel filter is intended to be used by connections on xDS enabled
   // servers configured with RBAC. The RBAC filter fetches the RBAC policy from

--- a/src/core/ext/filters/stateful_session/stateful_session_filter.h
+++ b/src/core/ext/filters/stateful_session/stateful_session_filter.h
@@ -68,7 +68,7 @@ class XdsOverrideHostAttribute
 };
 
 // A filter to provide cookie-based stateful session affinity.
-class StatefulSessionFilter : public ChannelFilter {
+class GRPC_DLL StatefulSessionFilter : public ChannelFilter {
  public:
   static const grpc_channel_filter kFilter;
 

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -317,8 +317,8 @@ class ChannelArgs {
     }
 
    private:
-    static const grpc_arg_pointer_vtable int_vtable_;
-    static const grpc_arg_pointer_vtable string_vtable_;
+    static const GRPC_DLL grpc_arg_pointer_vtable int_vtable_;
+    static const GRPC_DLL grpc_arg_pointer_vtable string_vtable_;
 
     Pointer rep_;
   };

--- a/src/core/lib/debug/stats_data.h
+++ b/src/core/lib/debug/stats_data.h
@@ -188,11 +188,13 @@ struct GlobalStats {
     COUNT
   };
   GlobalStats();
-  static const absl::string_view counter_name[static_cast<int>(Counter::COUNT)];
-  static const absl::string_view
+  static GRPC_DLL const absl::string_view
+      counter_name[static_cast<int>(Counter::COUNT)];
+  static GRPC_DLL const absl::string_view
       histogram_name[static_cast<int>(Histogram::COUNT)];
-  static const absl::string_view counter_doc[static_cast<int>(Counter::COUNT)];
-  static const absl::string_view
+  static GRPC_DLL const absl::string_view
+      counter_doc[static_cast<int>(Counter::COUNT)];
+  static GRPC_DLL const absl::string_view
       histogram_doc[static_cast<int>(Histogram::COUNT)];
   union {
     struct {

--- a/src/core/lib/event_engine/ares_resolver.h
+++ b/src/core/lib/event_engine/ares_resolver.h
@@ -45,7 +45,7 @@
 namespace grpc_event_engine {
 namespace experimental {
 
-extern grpc_core::TraceFlag grpc_trace_ares_resolver;
+extern GRPC_DLL grpc_core::TraceFlag grpc_trace_ares_resolver;
 
 #define GRPC_ARES_RESOLVER_TRACE_LOG(format, ...)                              \
   do {                                                                         \
@@ -142,11 +142,11 @@ class AresResolver : public grpc_core::InternallyRefCounted<AresResolver> {
 }  // namespace grpc_event_engine
 
 // Exposed in this header for C-core tests only
-extern void (*event_engine_grpc_ares_test_only_inject_config)(
+extern GRPC_DLL void (*event_engine_grpc_ares_test_only_inject_config)(
     ares_channel* channel);
 
 // Exposed in this header for C-core tests only
-extern bool g_event_engine_grpc_ares_test_only_force_tcp;
+extern GRPC_DLL bool g_event_engine_grpc_ares_test_only_force_tcp;
 
 #endif  // GRPC_ARES == 1
 #endif  // GRPC_SRC_CORE_LIB_EVENT_ENGINE_ARES_RESOLVER_H

--- a/src/core/lib/gpr/windows/time.cc
+++ b/src/core/lib/gpr/windows/time.cc
@@ -75,7 +75,7 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
   return now_tv;
 }
 
-gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type) = now_impl;
+gpr_timespec GPR_DLL (*gpr_now_impl)(gpr_clock_type clock_type) = now_impl;
 
 gpr_timespec gpr_now(gpr_clock_type clock_type) {
   return gpr_now_impl(clock_type);

--- a/src/core/lib/gprpp/time.h
+++ b/src/core/lib/gprpp/time.h
@@ -100,7 +100,7 @@ class Timestamp {
 
   class ScopedSource : public Source {
    public:
-    ScopedSource() : previous_(thread_local_time_source_) {
+    GRPC_DLL ScopedSource() : previous_(thread_local_time_source_) {
       thread_local_time_source_ = this;
     }
     ScopedSource(const ScopedSource&) = delete;
@@ -108,7 +108,7 @@ class Timestamp {
     void InvalidateCache() override { previous_->InvalidateCache(); }
 
    protected:
-    ~ScopedSource() { thread_local_time_source_ = previous_; }
+    GRPC_DLL ~ScopedSource() { thread_local_time_source_ = previous_; }
     Source* previous() const { return previous_; }
 
    private:
@@ -124,7 +124,7 @@ class Timestamp {
   static Timestamp FromCycleCounterRoundUp(gpr_cycle_counter c);
   static Timestamp FromCycleCounterRoundDown(gpr_cycle_counter c);
 
-  static Timestamp Now() { return thread_local_time_source_->Now(); }
+  static GRPC_DLL Timestamp Now() { return thread_local_time_source_->Now(); }
 
   static constexpr Timestamp FromMillisecondsAfterProcessEpoch(int64_t millis) {
     return Timestamp(millis);

--- a/src/core/lib/iomgr/resolve_address.h
+++ b/src/core/lib/iomgr/resolve_address.h
@@ -59,11 +59,11 @@ class DNSResolver {
       TaskHandle,
       grpc_event_engine::experimental::TaskHandleComparator<TaskHandle>::Hash>;
 
-  static const TaskHandle kNullHandle;
+  static const GRPC_DLL TaskHandle kNullHandle;
 
   virtual ~DNSResolver() {}
 
-  static std::string HandleToString(TaskHandle handle);
+  static GRPC_DLL std::string HandleToString(TaskHandle handle);
 
   // Asynchronously resolve name. Use \a default_port if a port isn't designated
   // in \a name, otherwise use the port in \a name. On completion, \a on_done is

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -48,8 +48,8 @@
 #define MIN_QUEUE_WINDOW_DURATION 0.01
 #define MAX_QUEUE_WINDOW_DURATION 1.0
 
-grpc_core::TraceFlag grpc_timer_trace(false, "timer");
-grpc_core::TraceFlag grpc_timer_check_trace(false, "timer_check");
+grpc_core::TraceFlag GRPC_DLL grpc_timer_trace(false, "timer");
+grpc_core::TraceFlag GRPC_DLL grpc_timer_check_trace(false, "timer_check");
 
 // A "timer shard". Contains a 'heap' and a 'list' of timers. All timers with
 // deadlines earlier than 'queue_deadline_cap' are maintained in the heap and

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -200,7 +200,7 @@ class Activity : public Orphanable {
   //   locked
   // - back up that assertation with a runtime check in debug builds (it's
   //   prohibitively expensive in non-debug builds)
-  static Activity* current() { return g_current_activity_; }
+  static GRPC_DLL Activity* current() { return g_current_activity_; }
 
   // Produce an activity-owning Waker. The produced waker will keep the activity
   // alive until it's awoken or dropped.
@@ -217,17 +217,17 @@ class Activity : public Orphanable {
  protected:
   // Check if this activity is the current activity executing on the current
   // thread.
-  bool is_current() const { return this == g_current_activity_; }
+  GRPC_DLL bool is_current() const { return this == g_current_activity_; }
   // Check if there is an activity executing on the current thread.
-  static bool have_current() { return g_current_activity_ != nullptr; }
+  static GRPC_DLL bool have_current() { return g_current_activity_ != nullptr; }
   // Set the current activity at construction, clean it up at destruction.
   class ScopedActivity {
    public:
-    explicit ScopedActivity(Activity* activity)
+    explicit GRPC_DLL ScopedActivity(Activity* activity)
         : prior_activity_(g_current_activity_) {
       g_current_activity_ = activity;
     }
-    ~ScopedActivity() { g_current_activity_ = prior_activity_; }
+    GRPC_DLL ~ScopedActivity() { g_current_activity_ = prior_activity_; }
     ScopedActivity(const ScopedActivity&) = delete;
     ScopedActivity& operator=(const ScopedActivity&) = delete;
 

--- a/src/core/lib/promise/trace.h
+++ b/src/core/lib/promise/trace.h
@@ -19,6 +19,6 @@
 
 #include "src/core/lib/debug/trace.h"
 
-extern grpc_core::DebugOnlyTraceFlag grpc_trace_promise_primitives;
+extern GRPC_DLL grpc_core::DebugOnlyTraceFlag grpc_trace_promise_primitives;
 
 #endif  // GRPC_SRC_CORE_LIB_PROMISE_TRACE_H

--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -40,7 +40,7 @@
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/security/credentials/credentials.h"  // IWYU pragma: keep
 
-extern grpc_core::DebugOnlyTraceFlag grpc_trace_auth_context_refcount;
+extern GRPC_DLL grpc_core::DebugOnlyTraceFlag grpc_trace_auth_context_refcount;
 
 // --- grpc_auth_context ---
 

--- a/src/core/lib/security/security_connector/insecure/insecure_security_connector.h
+++ b/src/core/lib/security/security_connector/insecure/insecure_security_connector.h
@@ -43,7 +43,7 @@
 
 namespace grpc_core {
 
-extern const char kInsecureTransportSecurityType[];
+extern GRPC_DLL const char kInsecureTransportSecurityType[];
 
 // Exposed for testing purposes only.
 // Create an auth context which is necessary to pass the santiy check in

--- a/src/core/lib/transport/connectivity_state.h
+++ b/src/core/lib/transport/connectivity_state.h
@@ -36,7 +36,7 @@
 
 namespace grpc_core {
 
-extern TraceFlag grpc_connectivity_state_trace;
+extern GRPC_DLL TraceFlag grpc_connectivity_state_trace;
 
 // Enum to string conversion.
 const char* ConnectivityStateName(grpc_connectivity_state state);

--- a/src/cpp/server/health/default_health_check_service.h
+++ b/src/cpp/server/health/default_health_check_service.h
@@ -88,9 +88,10 @@ class DefaultHealthCheckService final : public HealthCheckServiceInterface {
         const ByteBuffer* request, ByteBuffer* response);
 
     // Returns true on success.
-    static bool DecodeRequest(const ByteBuffer& request,
-                              std::string* service_name);
-    static bool EncodeResponse(ServingStatus status, ByteBuffer* response);
+    static GRPCXX_DLL bool DecodeRequest(const ByteBuffer& request,
+                                         std::string* service_name);
+    static GRPCXX_DLL bool EncodeResponse(ServingStatus status,
+                                          ByteBuffer* response);
 
     DefaultHealthCheckService* database_;
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -25,6 +25,7 @@
   import re
 
   proto_re = re.compile('(.*)\\.proto')
+  upb_gen_re = re.compile('^src/core/ext/upb(defs)?-generated/.*$')
   lib_map = {lib.name: lib for lib in libs}
 
   third_party_proto_prefixes = {lib.proto_prefix for lib in external_proto_libraries}
@@ -157,8 +158,8 @@
     if lib_name in ['grpc_csharp_ext']:
       return ' SHARED'
 
-    # upb always compiles as a static library on Windows
-    elif lib_name in ['upb','upb_collections_lib','upb_json_lib','upb_textformat_lib']:
+    # upb gtest always compile as a static library on Windows
+    elif lib_name in ['upb','upb_collections_lib','upb_json_lib','upb_textformat_lib','gtest'] + protoc_libs:
       return ' ${_gRPC_STATIC_WIN32}'
 
     else:
@@ -191,6 +192,19 @@
       else:
         deps.append(d)
     return deps
+
+  def get_all_deps(target_dict, all_libs):
+    ret = set()
+    get_all_deps_recurse(target_dict, all_libs, ret)
+    return ret
+
+  def get_all_deps_recurse(target_dict, all_libs, all_deps):
+    for d in target_dict.get('deps', []):
+      if not d in all_deps:
+        all_deps.add(d)
+        for other_lib in all_libs:
+          if other_lib.name == d:
+            get_all_deps_recurse(other_lib,all_libs,all_deps)
 
   def is_generate_cmake_target(lib_or_target):
     """Returns True if a cmake target should be generated for given library/target."""
@@ -250,12 +264,6 @@
       return '\n'.join(lines)
     return _func
 
-  def add_dll_annotation_macros(lib, prefix):
-    return """set_target_properties(%s PROPERTIES DEFINE_SYMBOL "%s_DLL_EXPORTS")
-    if(BUILD_SHARED_LIBS)
-      target_compile_definitions(%s INTERFACE %s_DLL_IMPORTS)
-    endif()""" % (lib, prefix, lib, prefix)
-
   %>
   <%
   # These files are added to a set so that they are not duplicated if multiple
@@ -285,6 +293,10 @@
   set(PACKAGE_TARNAME       "<%text>${PACKAGE_NAME}-${PACKAGE_VERSION}</%text>")
   set(PACKAGE_BUGREPORT     "https://github.com/grpc/grpc/issues/")
   project(<%text>${PACKAGE_NAME}</%text> LANGUAGES C CXX)
+
+  if(BUILD_SHARED_LIBS AND MSVC)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
 
   set(gRPC_INSTALL_BINDIR "bin" CACHE STRING "Installation directory for executables")
   set(gRPC_INSTALL_LIBDIR "lib" CACHE STRING "Installation directory for libraries")
@@ -410,6 +422,8 @@
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /wd4503")
     # Tell MSVC to build grpc using utf-8
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /utf-8")
+    # Inconsistent object sizes can cause stack corruption and should be treated as an error
+    set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /we4789")
   endif()
   if (MINGW)
     add_definitions(-D_WIN32_WINNT=0x600)
@@ -525,14 +539,66 @@
   # include redundant duplicate code. Hence, the duplication is only activated
   # for DLL builds - and should be completely removed when source files are
   # generated with the necessary __declspec annotations.
+  # TODO (@dawidcha) remove this when DLL export macros available for upb-generated code.
   set(gRPC_UPB_GEN_DUPL_SRC
     src/core/ext/upb-gen/src/proto/grpc/gcp/altscontext.upb_minitable.c
     src/core/ext/upb-gen/src/proto/grpc/health/v1/health.upb_minitable.c
     src/core/ext/upb-gen/src/proto/grpc/gcp/transport_security_common.upb_minitable.c
   )
+  <%
+  # Build a list of all upb-generated code as a bunch of tests depend on various parts of
+  # this code. Yes, adding all upb code to all affected tests is overkill, but these are
+  # only tests, and doing so will likely prove more resilient to future changes.
+  # TODO (@dawidcha) remove this when DLL export macros available for upb-generated code.
+  upb_gen_srcs = []
+  for lib in libs:
+    if lib.name == 'grpc':
+      for src in lib.src:
+        if upb_gen_re.match(src):
+          upb_gen_srcs.append(src)
+
+  # This is the list of tests with some dependency on upb-generated code. This list has
+  # been compiled through trial and error - it may need extending as new tests are added.
+  # TODO (@dawidcha) remove this when DLL export macros available for upb-generated code.
+  tests_needing_upb = [
+    'alts_handshaker_client_test',
+    'alts_tsi_handshaker_test',
+    'alts_tsi_utils_test',
+    'alts_util_test',
+    'binder_transport_test',
+    'cel_authoriztion_engine_test',
+    'endpoint_binder_pool_test',
+    'fake_binder_test',
+    'interop_server',
+    'orca_service_end2end_test',
+    'status_helper_test',
+    'transport_stream_receiver_test',
+    'wire_reader_test',
+    'wire_writer_test',
+    'xds_audit_logger_registry_test',
+    'xds_cluster_resource_type_test',
+    'xds_common_types_test',
+    'xds_endpoint_resource_type_test',
+    'xds_lb_policy_registry_test',
+    'xds_listener_resource_type_test',
+    'xds_route_config_resource_type_test',
+  ]
+
+  gpr_libs = ['gpr']
+  grpc_libs = ['grpc', 'grpc_unsecure']
+  grpcxx_libs = ['grpc++', 'grpc++_unsecure']
+  protoc_libs = ['benchmark_helpers','grpc++_reflection','grpcpp_channelz']
+  %>
+  # All upb sources for inclusion in tests that depend on them
+  set(gRPC_UPB_GEN_DUPL_TEST_SRC
+  % for upb_gen_src in upb_gen_srcs:
+    ${upb_gen_src}
+  % endfor
+  )
   set(gRPC_ADDITIONAL_DLL_SRC
     src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.cc
     src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+    src/cpp/common/tls_certificate_provider.cc
   )
 
   endif() # BUILD_SHARED_LIBS AND WIN32
@@ -792,10 +858,10 @@
   % endif
   % endfor
   % if lib.name in ['grpc++_alts', 'grpc++_unsecure', 'grpc++']:
-    ${'${gRPC_UPB_GEN_DUPL_SRC}'}
+    <%text>${gRPC_UPB_GEN_DUPL_SRC}</%text>
   % endif
   % if lib.name in ['grpc_unsecure']:
-    ${'${gRPC_ADDITIONAL_DLL_SRC}'}
+    <%text>${gRPC_ADDITIONAL_DLL_SRC}</%text>
   % endif
   )
 
@@ -814,17 +880,30 @@
   if(WIN32 AND MSVC)
     set_target_properties(${lib.name} PROPERTIES COMPILE_PDB_NAME "${lib.name}"
       COMPILE_PDB_OUTPUT_DIRECTORY <%text>"${CMAKE_BINARY_DIR}</%text>"
-    )
-    % if lib.name == 'gpr':
-    ${add_dll_annotation_macros(lib.name, 'GPR')}
-    % elif lib.name == 'grpc':
-    ${add_dll_annotation_macros(lib.name, 'GRPC')}
-    % elif lib.name == 'grpc_unsecure':
-    ${add_dll_annotation_macros(lib.name, 'GRPC')}
-    % elif lib.name == 'grpc++':
-    ${add_dll_annotation_macros(lib.name, 'GRPCXX')}
-    % elif lib.name == 'grpc++_unsecure':
-    ${add_dll_annotation_macros(lib.name, 'GRPCXX')}
+    )<%
+    dll_annotations = []
+    if lib.name in gpr_libs:
+      dll_annotations.append("GPR_DLL_EXPORTS")
+    if lib.name in grpc_libs:
+      dll_annotations.append("GRPC_DLL_EXPORTS")
+    if lib.name in grpcxx_libs:
+      dll_annotations.append("GRPCXX_DLL_EXPORTS")
+    if set(gpr_libs) & set(get_all_deps(lib,libs)):
+      dll_annotations.append("GPR_DLL_IMPORTS")
+    if set(grpc_libs) & set(get_all_deps(lib,libs)):
+      dll_annotations.append("GRPC_DLL_IMPORTS")
+    if set(grpcxx_libs) & set(get_all_deps(lib,libs)):
+      dll_annotations.append("GRPCXX_DLL_IMPORTS")
+    %>
+    % if dll_annotations:
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(${lib.name}
+      PRIVATE
+    % for definition in dll_annotations:
+        "${definition}"
+    % endfor
+      )
+    endif()
     % endif
     if(gRPC_INSTALL)
       install(FILES <%text>${CMAKE_CURRENT_BINARY_DIR}/</%text>${lib.name}.pdb
@@ -908,7 +987,30 @@
     ${proto_replace_ext(src, '.grpc.pb.h')}
   % endif
   % endfor
-  )
+  % if tgt.name in tests_needing_upb:
+    <%text>${gRPC_UPB_GEN_DUPL_TEST_SRC}</%text>
+  % endif
+  )<%
+  dll_annotations = []
+  if set(gpr_libs) & set(get_all_deps(tgt,libs)):
+    dll_annotations.append("GPR_DLL_IMPORTS")
+  if set(grpc_libs) & set(get_all_deps(tgt,libs)):
+    dll_annotations.append("GRPC_DLL_IMPORTS")
+  if set(grpcxx_libs) & set(get_all_deps(tgt,libs)):
+    dll_annotations.append("GRPCXX_DLL_IMPORTS")
+  %>
+  % if dll_annotations:
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(${tgt.name}
+      PRIVATE
+    % for definition in dll_annotations:
+        "${definition}"
+    % endfor
+      )
+    endif()
+  endif()
+  % endif
   target_compile_features(${tgt.name} PUBLIC cxx_std_14)
   target_include_directories(${tgt.name}
     PRIVATE

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -40,7 +40,7 @@
 
 // IWYU pragma: no_include <sys/socket.h>
 
-extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+extern GPR_DLL gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
 static grpc_core::TraceFlag trace_writes(false, "fuzzing_ee_writes");
 static grpc_core::TraceFlag trace_timers(false, "fuzzing_ee_timers");

--- a/test/core/iomgr/timer_list_test.cc
+++ b/test/core/iomgr/timer_list_test.cc
@@ -35,8 +35,8 @@
 
 #define MAX_CB 30
 
-extern grpc_core::TraceFlag grpc_timer_trace;
-extern grpc_core::TraceFlag grpc_timer_check_trace;
+extern GRPC_DLL grpc_core::TraceFlag grpc_timer_trace;
+extern GRPC_DLL grpc_core::TraceFlag grpc_timer_check_trace;
 
 static int cb_called[MAX_CB][2];
 static const int64_t kHoursIn25Days = 25 * 24;

--- a/test/core/transport/bdp_estimator_test.cc
+++ b/test/core/transport/bdp_estimator_test.cc
@@ -31,7 +31,7 @@
 #include "src/core/lib/iomgr/timer_manager.h"
 #include "test/core/util/test_config.h"
 
-extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+extern GPR_DLL gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
 namespace grpc_core {
 namespace testing {

--- a/test/core/transport/chttp2/flow_control_fuzzer.cc
+++ b/test/core/transport/chttp2/flow_control_fuzzer.cc
@@ -49,7 +49,7 @@
 
 bool squelch = true;
 
-extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+extern GPR_DLL gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
 namespace grpc_core {
 namespace chttp2 {

--- a/test/core/transport/chttp2/flow_control_test.cc
+++ b/test/core/transport/chttp2/flow_control_test.cc
@@ -29,7 +29,7 @@
 #include "src/core/lib/resource_quota/resource_quota.h"
 #include "src/core/lib/transport/bdp_estimator.h"
 
-extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+extern GPR_DLL gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
 namespace grpc_core {
 namespace chttp2 {

--- a/test/core/transport/chttp2/hpack_parser_input_size_fuzzer.cc
+++ b/test/core/transport/chttp2/hpack_parser_input_size_fuzzer.cc
@@ -141,7 +141,7 @@ std::string Stringify(absl::StatusOr<std::string> result) {
 }  // namespace
 }  // namespace grpc_core
 
-extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+extern GPR_DLL gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   gpr_now_impl = [](gpr_clock_type clock_type) {

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -45,7 +45,7 @@
 static std::string g_root;
 
 static gpr_mu g_mu;
-extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+extern GPR_DLL gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
 gpr_timespec (*gpr_now_impl_orig)(gpr_clock_type clock_type) = gpr_now_impl;
 static int g_time_shift_sec = 0;
 static int g_time_shift_nsec = 0;

--- a/tools/codegen/core/gen_stats_data.py
+++ b/tools/codegen/core/gen_stats_data.py
@@ -359,28 +359,28 @@ with open("src/core/lib/debug/stats_data.h", "w") as H:
     print("  GlobalStats();", file=H)
     print(
         (
-            "  static const absl::string_view"
+            "  static GRPC_DLL const absl::string_view"
             " counter_name[static_cast<int>(Counter::COUNT)];"
         ),
         file=H,
     )
     print(
         (
-            "  static const absl::string_view"
+            "  static GRPC_DLL const absl::string_view"
             " histogram_name[static_cast<int>(Histogram::COUNT)];"
         ),
         file=H,
     )
     print(
         (
-            "  static const absl::string_view"
+            "  static GRPC_DLL const absl::string_view"
             " counter_doc[static_cast<int>(Counter::COUNT)];"
         ),
         file=H,
     )
     print(
         (
-            "  static const absl::string_view"
+            "  static GRPC_DLL const absl::string_view"
             " histogram_doc[static_cast<int>(Histogram::COUNT)];"
         ),
         file=H,


### PR DESCRIPTION
This is a follow up from https://github.com/grpc/grpc/pull/34327

The goal of this PR is to annotate the API with dllimport/export annotations to a sufficient extent that the gRPC package successfully compiles with gRPC_BUILD_TESTS=ON

As such, the bulk of the changes are to headers and c/c++ source to provide these annotations, this being done largely through trial and error.

A few other changes were needed to get this to work:
* A blanket application of the XXX_DLL_IMPORT macro for all compilation units caused conflicts for some test compilations. As a result, a more targeted approach was adopted such that these macros were only applied if the corresponding libraries were actually a dependency.
* A few of the tests had a dependency on one or more upb-generated files which as noted before can no longer be accessed from the grpc library. The approach taken was to include *all* upb-generated source files for those tests. I'm working on code for protobuf/upb which would permit dllimport/export annotations for upb-generated source and when/if that is accepted/merged we can dispense with all these duplications
* I added a new test: [test/distrib/cpp/run_distrib_test_dll_cmake.bat](https://github.com/grpc/grpc/compare/master...dawidcha:win_shared_tests?expand=1#diff-be63ff29b5644ed404b8a08db994400c553b28cbc545b4503a149880ae35a115) to confirm that the Windows DLL build is working - I'm not sure where I would need to add this in order to have it run as a validation?


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

