### PR TITLE
[ObjC] Remove grpc core podspec module map

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -65,9 +65,6 @@ Pod::Spec.new do |s|
   # following lets users write `#include <grpc/grpc.h>`.
   s.header_dir = name
 
-  # The module map created automatically by Cocoapods doesn't work for C libraries like gRPC-Core.
-  s.module_map = 'include/grpc/module.modulemap'
-
   # To compile the library, we need the user headers search path (quoted includes) to point to the
   # root of the repo, third_party/** and two upb generated directories, and the system headers
   # search path (angled includes) to point to `include/`.

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -141,9 +141,6 @@
     # following lets users write `#include <grpc/grpc.h>`.
     s.header_dir = name
 
-    # The module map created automatically by Cocoapods doesn't work for C libraries like gRPC-Core.
-    s.module_map = 'include/grpc/module.modulemap'
-
     # To compile the library, we need the user headers search path (quoted includes) to point to the
     # root of the repo, third_party/** and two upb generated directories, and the system headers
     # search path (angled includes) to point to `include/`.


### PR DESCRIPTION
Not really needed, this should help the firestore upgrade issue

Tested with 
https://github.com/wu-hui/ReproGrpcCyclic