### PR TITLE
[bazelify tests] make grpc_distribtests_standalone and grpc_bazel_distribtest presubmit jobs a noop

### DIFF
--- a/test/distrib/cpp/run_distrib_test_dummy.sh
+++ b/test/distrib/cpp/run_distrib_test_dummy.sh
@@ -15,6 +15,6 @@
 
 set -ex
 
-echo "This is a dummy C++ distribtest. It acts as a tools/run_tests/task_runner.py"
+echo "This is an empty C++ distribtest. It acts as a tools/run_tests/task_runner.py"
 echo "placeholder, since the C++ distribtests are now run by tools/bazelify_tests"
 echo "and task_runner.py reports an error when no task match the filter."

--- a/test/distrib/cpp/run_distrib_test_dummy.sh
+++ b/test/distrib/cpp/run_distrib_test_dummy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+echo "This is a dummy C++ distribtest. It acts as a tools/run_tests/task_runner.py"
+echo "placeholder, since the C++ distribtests are now run by tools/bazelify_tests"
+echo "and task_runner.py reports an error when no task match the filter."

--- a/tools/internal_ci/linux/grpc_bazel_distribtest.sh
+++ b/tools/internal_ci/linux/grpc_bazel_distribtest.sh
@@ -22,6 +22,22 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
+# Since grpc_bazel_distribtest kokoro job does not have different
+# configuration files for master/PR, use a workaround to detect when running
+# on pull request.
+# TODO(jtattermusch): Once the grpc_bazel_distribtest.cfg kokoro
+# is fully retired on both presubmit and master, simply get rid
+# of the job configuration and this script.
+if [ "${KOKORO_GITHUB_PULL_REQUEST_NUMBER}" != "" ]
+then
+  echo "Bazel distribtests have been migrated to tools/bazelify_tests"
+  echo "and are running on bazel RBE. It is no longer necessary"
+  echo "to run them on presubmit in a dedicated kokoro job."
+  echo ""
+  echo "Exiting the kokoro job since there is nothing to do."
+  exit 0
+fi
+
 export DOCKERFILE_DIR=tools/dockerfile/test/bazel
 export DOCKER_RUN_SCRIPT=test/distrib/bazel/run_bazel_distrib_test.sh
 exec tools/run_tests/dockerize/build_and_run_docker.sh

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -380,32 +380,35 @@ def targets():
     """Gets list of supported targets"""
     return [
         # C++
-        CppDistribTest("linux", "x64", "debian10", "cmake", presubmit=True),
+        # The "dummy" C++ distribtest so that the set of tasks to run isn't empty
+        # when grpc_distribtest_standalone runs on PRs.
+        CppDistribTest("linux", "x64", "debian10", "dummy", presubmit=True),
+        CppDistribTest("linux", "x64", "debian10", "cmake", presubmit=False),
         CppDistribTest(
-            "linux", "x64", "debian10", "cmake_as_submodule", presubmit=True
+            "linux", "x64", "debian10", "cmake_as_submodule", presubmit=False
         ),
         CppDistribTest(
             "linux",
             "x64",
             "debian10",
             "cmake_as_externalproject",
-            presubmit=True,
+            presubmit=False,
         ),
         CppDistribTest(
-            "linux", "x64", "debian10", "cmake_fetchcontent", presubmit=True
+            "linux", "x64", "debian10", "cmake_fetchcontent", presubmit=False
         ),
         CppDistribTest(
-            "linux", "x64", "debian10", "cmake_module_install", presubmit=True
+            "linux", "x64", "debian10", "cmake_module_install", presubmit=False
         ),
         CppDistribTest(
-            "linux", "x64", "debian10", "cmake_pkgconfig", presubmit=True
+            "linux", "x64", "debian10", "cmake_pkgconfig", presubmit=False
         ),
         CppDistribTest(
             "linux",
             "x64",
             "debian10_aarch64_cross",
             "cmake_aarch64_cross",
-            presubmit=True,
+            presubmit=False,
         ),
         CppDistribTest("windows", "x86", testcase="cmake", presubmit=True),
         CppDistribTest(


### PR DESCRIPTION
Since many tests now run reliably as bazelified tests on RBE, we can remove them from presubmit runs
to speedup testing of PRs.
(for now, these jobs will still run on master, they can be removed from master as a followup).

- linux/grpc_distribtests_standalone is now fully covered by bazel test suite https://github.com/grpc/grpc/blob/a3b4c797a7c6c4a37efb711dd7cff6988049c1b7/tools/bazelify_tests/test/BUILD#L202, setting them to `presubmit=False` will stop tests from running on PRs.

- stop running tests from grpc_bazel_distribtest on PR, instead rely on bazel distribtests running as bazelified tests.
