### PR TITLE
[work-serializer] Fix synchronous test assumption

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -1729,7 +1729,7 @@ TEST_F(RoundRobinTest, FailsEmptyResolverUpdate) {
   EXPECT_TRUE(
       WaitForChannelState(channel.get(), predicate, /*try_to_connect=*/true));
   // Callback should have been run.
-  ASSERT_TRUE(notification.HasBeenNotified());
+  notification.WaitForNotification();
   // Return a valid address.
   gpr_log(GPR_INFO, "****** SENDING NEXT RESOLVER RESULT *******");
   StartServers(1);


### PR DESCRIPTION
This test assumed synchronous work serializer execution (or at least faster async than we always get)... make a trivial change to keep the test semantics but allow for the implementation to be more async.