### PR TITLE
[Python dist] Explicitly link Core Foundation framework for MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -292,6 +292,11 @@ if EXTRA_ENV_LINK_ARGS is None:
     if "linux" in sys.platform:
         EXTRA_ENV_LINK_ARGS += " -static-libgcc"
 
+# Explicitly link Core Foundation framework for MacOS to ensure no symbol is
+# missing when compiled using package managers like Conda.
+if "darwin" in sys.platform:
+    EXTRA_ENV_LINK_ARGS += " -framework CoreFoundation"
+
 EXTRA_COMPILE_ARGS = shlex.split(EXTRA_ENV_COMPILE_ARGS)
 EXTRA_LINK_ARGS = shlex.split(EXTRA_ENV_LINK_ARGS)
 

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -190,6 +190,11 @@ if EXTRA_ENV_LINK_ARGS is None:
         if check_linker_need_libatomic():
             EXTRA_ENV_LINK_ARGS += " -latomic"
 
+# Explicitly link Core Foundation framework for MacOS to ensure no symbol is
+# missing when compiled using package managers like Conda.
+if "darwin" in sys.platform:
+    EXTRA_ENV_LINK_ARGS += " -framework CoreFoundation"
+
 EXTRA_COMPILE_ARGS = shlex.split(EXTRA_ENV_COMPILE_ARGS)
 EXTRA_LINK_ARGS = shlex.split(EXTRA_ENV_LINK_ARGS)
 


### PR DESCRIPTION
Some user reported an issue that symbols from CoreFoundation are missing when install grpc/grpc-tools inside Conda:
* https://github.com/grpc/grpc/issues/33714
* https://github.com/grpc/grpc/issues/34135

This PR adds the `-framework CoreFoundation` flag so no workarounds are required from user.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

