### PR TITLE
[client_channel] don't unref picker while holding the LB mutex

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2868,6 +2868,7 @@ absl::optional<absl::Status> ClientChannel::LoadBalancedCall::PickSubchannel(
     grpc_error_handle error;
     bool pick_complete = PickSubchannelImpl(pickers.back().get(), &error);
     if (!pick_complete) {
+      RefCountedPtr<LoadBalancingPolicy::SubchannelPicker> old_picker;
       MutexLock lock(&chand_->lb_mu_);
       // If picker has been swapped out since we grabbed it, try again.
       if (pickers.back() != chand_->picker_) {
@@ -2875,6 +2876,10 @@ absl::optional<absl::Status> ClientChannel::LoadBalancedCall::PickSubchannel(
           gpr_log(GPR_INFO,
                   "chand=%p lb_call=%p: pick not complete, but picker changed",
                   chand_, this);
+        }
+        if (IsClientChannelSubchannelWrapperWorkSerializerOrphanEnabled()) {
+          // Don't unref until after we release the mutex.
+          old_picker = std::move(pickers.back());
         }
         set_picker(chand_->picker_);
         continue;


### PR DESCRIPTION
This fixes a deadlock seen when both the `round_robin_delegate_to_pick_first` and `client_channel_subchannel_wrapper_work_serializer_orphan` experiments are enabled -- although I think the bug really has to do only with the latter.

The problem here was that we were unreffing the picker while holding the channel's LB mutex.  Destroying the picker was triggering a `SubchannelWrapper` to be orphaned, which triggered a hop into the `WorkSerializer`.  Once there, we were also running a queued subchannel connectivity state notification, which triggered an update to the LB policy, which triggered returning a new picker to the channel, which tried to acquire the channel's LB mutex again.

Note that the `work_serializer_dispatch` experiment would have avoided this problem.