### PR TITLE
[CSM] Update labels

### DIFF
--- a/src/cpp/ext/csm/metadata_exchange.cc
+++ b/src/cpp/ext/csm/metadata_exchange.cc
@@ -69,7 +69,7 @@ constexpr absl::string_view kMetadataExchangeCanonicalServiceKey =
     "canonical_service";
 // The keys that will be used for the local attributes when recording metrics.
 constexpr absl::string_view kCanonicalServiceAttribute =
-    "csm.canonical_service";
+    "csm.workload_canonical_service";
 constexpr absl::string_view kMeshIdAttribute = "csm.mesh_id";
 // The keys that will be used for the peer attributes when recording metrics.
 constexpr absl::string_view kPeerTypeAttribute = "csm.remote_workload_type";

--- a/src/cpp/ext/csm/metadata_exchange.cc
+++ b/src/cpp/ext/csm/metadata_exchange.cc
@@ -59,9 +59,7 @@ namespace {
 
 // The keys that will be used in the Metadata Exchange between local and remote.
 constexpr absl::string_view kMetadataExchangeTypeKey = "type";
-constexpr absl::string_view kMetadataExchangePodNameKey = "pod_name";
-constexpr absl::string_view kMetadataExchangeContainerNameKey =
-    "container_name";
+constexpr absl::string_view kMetadataExchangeWorkloadNameKey = "workload_name";
 constexpr absl::string_view kMetadataExchangeNamespaceNameKey =
     "namespace_name";
 constexpr absl::string_view kMetadataExchangeClusterNameKey = "cluster_name";
@@ -70,13 +68,13 @@ constexpr absl::string_view kMetadataExchangeProjectIdKey = "project_id";
 constexpr absl::string_view kMetadataExchangeCanonicalServiceKey =
     "canonical_service";
 // The keys that will be used for the local attributes when recording metrics.
+constexpr absl::string_view kCanonicalServiceAttribute =
+    "csm.canonical_service";
 constexpr absl::string_view kMeshIdAttribute = "csm.mesh_id";
 // The keys that will be used for the peer attributes when recording metrics.
 constexpr absl::string_view kPeerTypeAttribute = "csm.remote_workload_type";
-constexpr absl::string_view kPeerPodNameAttribute =
-    "csm.remote_workload_pod_name";
-constexpr absl::string_view kPeerContainerNameAttribute =
-    "csm.remote_workload_container_name";
+constexpr absl::string_view kPeerWorkloadNameAttribute =
+    "csm.remote_workload_name";
 constexpr absl::string_view kPeerNamespaceNameAttribute =
     "csm.remote_workload_namespace_name";
 constexpr absl::string_view kPeerClusterNameAttribute =
@@ -270,10 +268,9 @@ class MeshLabelsIterable : public LabelsIterable {
     google_protobuf_Struct* struct_pb = nullptr;
   };
 
-  static constexpr std::array<GkeAttribute, 7> kGkeAttributeList = {
-      GkeAttribute{kPeerPodNameAttribute, kMetadataExchangePodNameKey},
-      GkeAttribute{kPeerContainerNameAttribute,
-                   kMetadataExchangeContainerNameKey},
+  static constexpr std::array<GkeAttribute, 6> kGkeAttributeList = {
+      GkeAttribute{kPeerWorkloadNameAttribute,
+                   kMetadataExchangeWorkloadNameKey},
       GkeAttribute{kPeerNamespaceNameAttribute,
                    kMetadataExchangeNamespaceNameKey},
       GkeAttribute{kPeerClusterNameAttribute, kMetadataExchangeClusterNameKey},
@@ -311,7 +308,7 @@ class MeshLabelsIterable : public LabelsIterable {
   uint32_t pos_ = 0;
 };
 
-constexpr std::array<MeshLabelsIterable::GkeAttribute, 7>
+constexpr std::array<MeshLabelsIterable::GkeAttribute, 6>
     MeshLabelsIterable::kGkeAttributeList;
 
 }  // namespace
@@ -348,11 +345,8 @@ ServiceMeshLabelsInjector::ServiceMeshLabelsInjector(
   // Assume kubernetes for now
   absl::string_view type_value = GetStringValueFromAttributeMap(
       map, opentelemetry::sdk::resource::SemanticConventions::kCloudPlatform);
-  absl::string_view pod_name_value = GetStringValueFromAttributeMap(
-      map, opentelemetry::sdk::resource::SemanticConventions::kK8sPodName);
-  absl::string_view container_name_value = GetStringValueFromAttributeMap(
-      map,
-      opentelemetry::sdk::resource::SemanticConventions::kK8sContainerName);
+  std::string workload_name_value =
+      grpc_core::GetEnv("CSM_WORKLOAD_NAME").value_or("unknown");
   absl::string_view namespace_value = GetStringValueFromAttributeMap(
       map,
       opentelemetry::sdk::resource::SemanticConventions::kK8sNamespaceName);
@@ -369,16 +363,14 @@ ServiceMeshLabelsInjector::ServiceMeshLabelsInjector(
   absl::string_view project_id_value = GetStringValueFromAttributeMap(
       map, opentelemetry::sdk::resource::SemanticConventions::kCloudAccountId);
   std::string canonical_service_value =
-      grpc_core::GetEnv("GSM_CANONICAL_SERVICE_NAME").value_or("unknown");
+      grpc_core::GetEnv("CSM_CANONICAL_SERVICE_NAME").value_or("unknown");
   // Create metadata to be sent over wire.
   AddStringKeyValueToStructProto(metadata, kMetadataExchangeTypeKey, type_value,
                                  arena.ptr());
   // Only handle GKE for now
   if (type_value == kGkeType) {
-    AddStringKeyValueToStructProto(metadata, kMetadataExchangePodNameKey,
-                                   pod_name_value, arena.ptr());
-    AddStringKeyValueToStructProto(metadata, kMetadataExchangeContainerNameKey,
-                                   container_name_value, arena.ptr());
+    AddStringKeyValueToStructProto(metadata, kMetadataExchangeWorkloadNameKey,
+                                   workload_name_value, arena.ptr());
     AddStringKeyValueToStructProto(metadata, kMetadataExchangeNamespaceNameKey,
                                    namespace_value, arena.ptr());
     AddStringKeyValueToStructProto(metadata, kMetadataExchangeClusterNameKey,
@@ -399,6 +391,8 @@ ServiceMeshLabelsInjector::ServiceMeshLabelsInjector(
       absl::Base64Escape(absl::string_view(output, output_length)));
   // Fill up local labels map. The rest we get from the detected Resource and
   // from the peer.
+  local_labels_.emplace_back(kCanonicalServiceAttribute,
+                             canonical_service_value);
   local_labels_.emplace_back(kMeshIdAttribute, GetMeshId());
 }
 

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -150,8 +150,9 @@ class MetadataExchangeTest
       const std::map<std::string,
                      opentelemetry::sdk::common::OwnedAttributeValue>&
           attributes) {
-    EXPECT_EQ(absl::get<std::string>(attributes.at("csm.canonical_service")),
-              "canonical_service");
+    EXPECT_EQ(
+        absl::get<std::string>(attributes.at("csm.workload_canonical_service")),
+        "canonical_service");
     EXPECT_EQ(absl::get<std::string>(attributes.at("csm.mesh_id")), "mesh-id");
     switch (GetParam().type()) {
       case TestScenario::ResourceType::kGke:

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -150,6 +150,8 @@ class MetadataExchangeTest
       const std::map<std::string,
                      opentelemetry::sdk::common::OwnedAttributeValue>&
           attributes) {
+    EXPECT_EQ(absl::get<std::string>(attributes.at("csm.canonical_service")),
+              "canonical_service");
     EXPECT_EQ(absl::get<std::string>(attributes.at("csm.mesh_id")), "mesh-id");
     switch (GetParam().type()) {
       case TestScenario::ResourceType::kGke:

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -156,12 +156,9 @@ class MetadataExchangeTest
         EXPECT_EQ(
             absl::get<std::string>(attributes.at("csm.remote_workload_type")),
             "gcp_kubernetes_engine");
-        EXPECT_EQ(absl::get<std::string>(
-                      attributes.at("csm.remote_workload_pod_name")),
-                  "pod");
-        EXPECT_EQ(absl::get<std::string>(
-                      attributes.at("csm.remote_workload_container_name")),
-                  "container");
+        EXPECT_EQ(
+            absl::get<std::string>(attributes.at("csm.remote_workload_name")),
+            "workload");
         EXPECT_EQ(absl::get<std::string>(
                       attributes.at("csm.remote_workload_namespace_name")),
                   "namespace");
@@ -307,6 +304,7 @@ INSTANTIATE_TEST_SUITE_P(
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_core::SetEnv("GSM_CANONICAL_SERVICE_NAME", "canonical_service");
+  grpc_core::SetEnv("CSM_WORKLOAD_NAME", "workload");
+  grpc_core::SetEnv("CSM_CANONICAL_SERVICE_NAME", "canonical_service");
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Changes - 
* Remove `csm.remote_workload_pod_name` and `csm.remote_workload_container_name`.
* Add `csm.remote_workload_name`, the value for which is sent through MetadataExchange, from the `CSM_WORKLOAD_NAME` env var. (Note that this is not added in local labels.)
* Add a local `csm.canonical_service` (@markdroth, please verify the key that we want here) that is read from `CSM_CANONICAL_SERVICE_NAME` env var, and we continue to send it over via MetadataExchange
