### PR TITLE
[Testing] Added windows/grpc_distribtests_cpp_dll

### DIFF
--- a/test/distrib/cpp/run_distrib_test_cmake_for_dll.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_for_dll.bat
@@ -1,0 +1,122 @@
+@rem Copyright 2023 gRPC authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+@rem enter this directory
+cd /d %~dp0\..\..\..
+
+@rem TODO(jtattermusch): Kokoro has pre-installed protoc.exe in C:\Program Files\ProtoC and that directory
+@rem is on PATH. To avoid picking up the older version protoc.exe, we change the path to something non-existent.
+set PATH=%PATH:ProtoC=DontPickupProtoC%
+
+@rem Install into ./testinstall, but use absolute path and foward slashes
+set INSTALL_DIR=%cd:\=/%/testinstall
+
+@rem Download OpenSSL-Win32 originally installed from https://slproweb.com/products/Win32OpenSSL.html
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://storage.googleapis.com/grpc-testing.appspot.com/OpenSSL-Win32-1_1_0g.zip', 'OpenSSL-Win32.zip')"
+powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::ExtractToDirectory('OpenSSL-Win32.zip', '.');"
+
+@rem set absolute path to OpenSSL with forward slashes
+set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
+
+@rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
+
+set VS_GENERATOR="Visual Studio 16 2019"
+@rem TODO(jtattermusch): switch to x64 build (will require pulling a x64 build of openssl)
+set VS_ARCHITECTURE="Win32"
+
+@rem Install absl
+mkdir third_party\abseil-cpp\cmake\build
+pushd third_party\abseil-cpp\cmake\build
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake --build . --config Release --target install || goto :error
+popd
+
+@rem Install c-ares
+mkdir third_party\cares\cares\cmake\build
+pushd third_party\cares\cares\cmake\build
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake --build . --config Release --target install || goto :error
+popd
+
+@rem Install protobuf
+mkdir third_party\protobuf\cmake\build
+pushd third_party\protobuf\cmake\build
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -Dprotobuf_ABSL_PROVIDER=package -DZLIB_ROOT=%INSTALL_DIR% -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF ..\..
+cmake --build . --config Release --target install || goto :error
+popd
+
+@rem Install re2
+mkdir third_party\re2\cmake\build
+pushd third_party\re2\cmake\build
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake --build . --config Release --target install || goto :error
+popd
+
+@rem Install zlib
+mkdir third_party\zlib\cmake\build
+pushd third_party\zlib\cmake\build
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..\..
+cmake --build . --config Release --target install || goto :error
+popd
+
+@rem Just before installing gRPC, wipe out contents of all the submodules to simulate
+@rem a standalone build from an archive
+@rem NOTE(lidiz) We used to use "git submodule deinit", but it leaves an empty
+@rem folder for deinit-ed submodules, blocking the CMake download. For users
+@rem downloaded gRPC code as an archive, they won't have submodule residual
+@rem folders, like the following command trying to imitate.
+git submodule foreach bash -c "cd $toplevel; rm -rf $name"
+
+@rem Install gRPC
+@rem NOTE(jtattermusch): The -DProtobuf_USE_STATIC_LIBS=ON is necessary on cmake3.16+
+@rem since by default "find_package(Protobuf ...)" uses the cmake's builtin
+@rem FindProtobuf.cmake module, which now requires the info whether protobuf
+@rem is to be linked statically.
+@rem See https://github.com/Kitware/CMake/commit/3bbd85d5fffe66181cf16c81b23b2ba50f5387ba
+@rem See https://gitlab.kitware.com/cmake/cmake/-/merge_requests/3555#note_660390
+mkdir cmake\build
+pushd cmake\build
+cmake ^
+  -G %VS_GENERATOR% ^
+  -A %VS_ARCHITECTURE% ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ^
+  -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% ^
+  -DZLIB_ROOT=%INSTALL_DIR% ^
+  -DgRPC_INSTALL=ON ^
+  -DgRPC_BUILD_TESTS=OFF ^
+  -DgRPC_BUILD_MSVC_MP_COUNT=-1 ^
+  -DgRPC_ABSL_PROVIDER=package ^
+  -DgRPC_CARES_PROVIDER=package ^
+  -DgRPC_PROTOBUF_PROVIDER=package ^
+  -DProtobuf_USE_STATIC_LIBS=ON ^
+  -DgRPC_RE2_PROVIDER=package ^
+  -DgRPC_SSL_PROVIDER=package ^
+  -DgRPC_ZLIB_PROVIDER=package ^
+  ../.. || goto :error
+cmake --build . --config Release --target install || goto :error
+popd
+
+@rem Build helloworld example using cmake
+mkdir examples\cpp\helloworld\cmake\build
+pushd examples\cpp\helloworld\cmake\build
+cmake -G %VS_GENERATOR% -A %VS_ARCHITECTURE% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% -DZLIB_ROOT=%INSTALL_DIR% ../.. || goto :error
+cmake --build . --config Release || goto :error
+popd
+
+goto :EOF
+
+:error
+echo Failed!
+exit /b %errorlevel%

--- a/tools/internal_ci/windows/grpc_distribtests_cpp_dll.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_cpp_dll.bat
@@ -27,7 +27,7 @@ cd /d %~dp0\..\..\..
 
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
-python tools/run_tests/task_runner.py -b cpp_windows_x86_cmake cpp_windows_x86_cmake_as_externalproject -f %TASK_RUNNER_EXTRA_FILTERS% -j 4
+python tools/run_tests/task_runner.py -b cpp_windows_x86_cmake_for_dll %TASK_RUNNER_EXTRA_FILTERS% -j 4
 set RUNTESTS_EXITCODE=%errorlevel%
 
 exit /b %RUNTESTS_EXITCODE%

--- a/tools/internal_ci/windows/grpc_distribtests_cpp_dll.cfg
+++ b/tools/internal_ci/windows/grpc_distribtests_cpp_dll.cfg
@@ -1,0 +1,26 @@
+# Copyright 2023 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_cpp_dll.bat"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}

--- a/tools/internal_ci/windows/pull_request/grpc_distribtests_cpp_dll.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_distribtests_cpp_dll.cfg
@@ -1,0 +1,31 @@
+# Copyright 2021 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_standalone.bat"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}
+
+env_vars {
+  key: "TASK_RUNNER_EXTRA_FILTERS"
+  value: "presubmit"
+}

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -417,6 +417,12 @@ def targets():
             testcase="cmake_as_externalproject",
             presubmit=True,
         ),
+        CppDistribTest(
+            "windows",
+            "x86",
+            testcase="cmake_for_dll",
+            presubmit=True,
+        ),
         # C#
         CSharpDistribTest(
             "linux", "x64", "debian10", use_dotnet_cli=True, presubmit=True


### PR DESCRIPTION
Added a separate distribtests for gRPC C++ DLL build on Windows. This DLL build is a community support so it should be independently run from the existing Windows distribtests. Actual DLL test will be added.