### PR TITLE
[bazelified tests] Make bazelified C basictests build only

### DIFF
--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -27,19 +27,19 @@ generate_bazel_distribtests(name = "bazel_distribtests_linux")
 
 # C/C++
 grpc_run_tests_harness_test(
-    name = "runtests_c_linux_dbg",
+    name = "runtests_c_linux_dbg_build_only",
     size = "enormous",
     args = [
-        "-l c -c dbg",
+        "-l c -c dbg --build_only",
     ],
     docker_image_version = "tools/dockerfile/test/cxx_debian11_x64.current_version",
 )
 
 grpc_run_tests_harness_test(
-    name = "runtests_c_linux_opt",
+    name = "runtests_c_linux_opt_build_only",
     size = "enormous",
     args = [
-        "-l c -c opt",
+        "-l c -c opt --build_only",
     ],
     docker_image_version = "tools/dockerfile/test/cxx_debian11_x64.current_version",
 )
@@ -136,8 +136,8 @@ grpc_run_tests_harness_test(
 test_suite(
     name = "basic_tests_linux",
     tests = [
-        ":runtests_c_linux_dbg",
-        ":runtests_c_linux_opt",
+        ":runtests_c_linux_dbg_build_only",
+        ":runtests_c_linux_opt_build_only",
         ":runtests_cpp_linux_dbg_build_only",
         ":runtests_cpp_linux_opt_build_only",
         ":runtests_csharp_linux_dbg",

--- a/tools/bazelify_tests/test/portability_tests.bzl
+++ b/tools/bazelify_tests/test/portability_tests.bzl
@@ -32,12 +32,12 @@ def generate_run_tests_portability_tests(name):
 
     # portability C x86
     grpc_run_tests_harness_test(
-        name = "runtests_c_linux_dbg_x86",
-        args = ["-l c -c dbg"],
+        name = "runtests_c_linux_dbg_x86_build_only",
+        args = ["-l c -c dbg --build_only"],
         docker_image_version = "tools/dockerfile/test/cxx_debian11_x86.current_version",
         size = "enormous",
     )
-    test_names.append("runtests_c_linux_dbg_x86")
+    test_names.append("runtests_c_linux_dbg_x86_build_only")
 
     # C and C++ with no-exceptions on Linux
     for language in ["c", "c++"]:

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.cfg
@@ -15,16 +15,11 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.sh"
 timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
   }
-}
-
-env_vars {
-  key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux corelang --inner_jobs 16 -j 1 --internal_ci --build_only"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# avoid slow finalization after the script has exited.
+source $(dirname $0)/../../../../tools/internal_ci/helper_scripts/move_src_tree_and_respawn_itself_rc
+
+# change to grpc repo root
+cd $(dirname $0)/../../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
+
+echo "The grpc_basictests_c_cpp_build_only job on linux has been deprecated and is now a no-op."
+echo "The tests are running as bazelified tests under tools/bazelify_tests."
+echo "Note that the grpc_basictests_c_cpp job still runs on master (but not on PRs)."


### PR DESCRIPTION
- make C-core basictests use `--build_only` when running as bazelified tests. This is because the volume of C core tests is expected to grow very significantly after https://github.com/grpc/grpc/pull/34419 and  currently the non-bazelified counterpart of the tests (the presubmit grpc_basictests_c_cpp_build_only job) is also "build only".
- make the linux presubmit job `grpc_basictests_c_cpp_build_only` a noop, since the bazelified tests already give the same coverage on presubmit.