### PR TITLE
[bazelified tests] Bazelify tests from "linux/grpc_bazel_build" and make the original test job a noop.

### DIFF
--- a/tools/bazelify_tests/BUILD
+++ b/tools/bazelify_tests/BUILD
@@ -26,6 +26,7 @@ exports_files([
     "grpc_run_tests_harness_test.sh",
     "grpc_run_bazel_distribtest_test.sh",
     "grpc_run_cpp_distribtest_test.sh",
+    "grpc_run_simple_command_test.sh",
 ])
 
 genrule(

--- a/tools/bazelify_tests/build_defs.bzl
+++ b/tools/bazelify_tests/build_defs.bzl
@@ -173,3 +173,34 @@ def grpc_run_cpp_distribtest_test(name, args = [], data = [], size = "medium", t
     # TODO(jtattermusch): revisit running docker as root (but currently some distribtests need to install stuff inside the docker container)
     env = {}
     _dockerized_sh_test(name = name, srcs = srcs, args = args, data = data, size = size, timeout = timeout, tags = tags, exec_compatible_with = exec_compatible_with, flaky = flaky, docker_image_version = docker_image_version, env = env, docker_run_as_root = True)
+
+def grpc_run_simple_command_test(name, args = [], data = [], size = "medium", timeout = None, tags = [], exec_compatible_with = [], flaky = None, docker_image_version = None):
+    """Execute the specified test command under grpc workspace (and under a docker container)
+
+    Args:
+        name: The name of the test.
+        args: The command to run.
+        data: Data dependencies.
+        size: The size of the test.
+        timeout: The test timeout.
+        tags: The tags for the test.
+        exec_compatible_with: A list of constraint values that must be
+            satisifed for the platform.
+        flaky: Whether this test is flaky.
+        docker_image_version: The docker .current_version file to use for docker containerization.
+    """
+
+    data = [
+        "//tools/bazelify_tests:grpc_repo_archive_with_submodules.tar.gz",
+    ] + data
+
+    args = [
+        "$(location //tools/bazelify_tests:grpc_repo_archive_with_submodules.tar.gz)",
+    ] + args
+
+    srcs = [
+        "//tools/bazelify_tests:grpc_run_simple_command_test.sh",
+    ]
+
+    env = {}
+    _dockerized_sh_test(name = name, srcs = srcs, args = args, data = data, size = size, timeout = timeout, tags = tags, exec_compatible_with = exec_compatible_with, flaky = flaky, docker_image_version = docker_image_version, env = env, docker_run_as_root = False)

--- a/tools/bazelify_tests/grpc_run_bazel_distribtest_test.sh
+++ b/tools/bazelify_tests/grpc_run_bazel_distribtest_test.sh
@@ -28,8 +28,8 @@ REPORT_SUITE_NAME="$(echo ${TEST_TARGET} | sed 's|^.*[:/]||')"
 tar -xopf ${ARCHIVE_WITH_SUBMODULES}
 cd grpc
 
-# Remove the override the "do not detect toolchain" setting that was set
-# by the from .bazelrc configuration for the remote build.
+# Override the "do not detect toolchain" setting that was set
+# by the .bazelrc configuration for the remote build.
 # TODO(jtattermusch): find a better solution to avoid breaking toolchain detection.
 export BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0
 

--- a/tools/bazelify_tests/grpc_run_simple_command_test.sh
+++ b/tools/bazelify_tests/grpc_run_simple_command_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+ARCHIVE_WITH_SUBMODULES="$1"
+shift
+
+# Extract grpc repo archive
+tar -xopf ${ARCHIVE_WITH_SUBMODULES}
+cd grpc
+
+# Remove the override the "do not detect toolchain" setting that was set
+# by the from .bazelrc configuration for the remote build.
+# TODO(jtattermusch): find a better solution to avoid breaking toolchain detection.
+export BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0
+
+# Run command passed as args
+"$@"

--- a/tools/bazelify_tests/grpc_run_simple_command_test.sh
+++ b/tools/bazelify_tests/grpc_run_simple_command_test.sh
@@ -22,8 +22,8 @@ shift
 tar -xopf ${ARCHIVE_WITH_SUBMODULES}
 cd grpc
 
-# Remove the override the "do not detect toolchain" setting that was set
-# by the from .bazelrc configuration for the remote build.
+# Override the "do not detect toolchain" setting that was set
+# by the .bazelrc configuration for the remote build.
 # TODO(jtattermusch): find a better solution to avoid breaking toolchain detection.
 export BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0
 

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_package")
-load("//tools/bazelify_tests:build_defs.bzl", "grpc_run_cpp_distribtest_test", "grpc_run_tests_harness_test")
+load("//tools/bazelify_tests:build_defs.bzl", "grpc_run_cpp_distribtest_test", "grpc_run_simple_command_test", "grpc_run_tests_harness_test")
 load(":portability_tests.bzl", "generate_run_tests_portability_tests")
 load(":bazel_distribtests.bzl", "generate_bazel_distribtests")
 
@@ -212,10 +212,42 @@ test_suite(
     ],
 )
 
+# "Bazel build" tests
+grpc_run_simple_command_test(
+    name = "bazel_build_with_strict_warnings_linux",
+    size = "enormous",
+    args = ["tools/bazelify_tests/test/bazel_build_with_strict_warnings_linux.sh"],
+    docker_image_version = "tools/dockerfile/test/bazel.current_version",
+)
+
+grpc_run_simple_command_test(
+    name = "bazel_build_with_grpc_no_xds_linux",
+    size = "enormous",
+    args = ["tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_linux.sh"],
+    docker_image_version = "tools/dockerfile/test/bazel.current_version",
+)
+
+grpc_run_simple_command_test(
+    name = "bazel_build_with_grpc_no_xds_negative_test_linux",
+    size = "enormous",
+    args = ["tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_negative_test_linux.sh"],
+    docker_image_version = "tools/dockerfile/test/bazel.current_version",
+)
+
+test_suite(
+    name = "bazel_build_tests_linux",
+    tests = [
+        ":bazel_build_with_grpc_no_xds_linux",
+        ":bazel_build_with_grpc_no_xds_negative_test_linux",
+        ":bazel_build_with_strict_warnings_linux",
+    ],
+)
+
 test_suite(
     name = "all_tests_linux",
     tests = [
         ":basic_tests_linux",
+        ":bazel_build_tests_linux",
         ":bazel_distribtests_linux",
         ":cpp_distribtests_linux",
         ":portability_tests_linux",

--- a/tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_linux.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Test that builds with --define=grpc_no_xds=true work.
+tools/bazel build //test/cpp/end2end:end2end_test --define=grpc_no_xds=true

--- a/tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_negative_test_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_negative_test_linux.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Test that builds that need xDS do not build with --define=grpc_no_xds=true
+EXIT_CODE=0
+bazel build //test/cpp/end2end/xds:xds_end2end_test --define=grpc_no_xds=true || EXIT_CODE=$?
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "Building xds_end2end_test succeeded even with --define=grpc_no_xds=true"
+  exit 1
+fi

--- a/tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_negative_test_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_negative_test_linux.sh
@@ -15,10 +15,10 @@
 
 set -ex
 
-# Test that builds that need xDS do not build with --define=grpc_no_xds=true
+# Ensure that tests that require XDS do not build with --define=grpc_no_xds=true
 EXIT_CODE=0
 bazel build //test/cpp/end2end/xds:xds_end2end_test --define=grpc_no_xds=true || EXIT_CODE=$?
 if [ $EXIT_CODE -eq 0 ]; then
-  echo "Building xds_end2end_test succeeded even with --define=grpc_no_xds=true"
+  echo "FAILED: Building xds_end2end_test succeeded even with --define=grpc_no_xds=true"
   exit 1
 fi

--- a/tools/bazelify_tests/test/bazel_build_with_strict_warnings_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_strict_warnings_linux.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+tools/bazel \
+  build \
+  --define=use_strict_warning=true \
+  -- \
+  :all \
+  //src/core/... \
+  //src/compiler/... \
+  //test/... \
+  //examples/... \
+  -//examples/android/binder/...
+

--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -20,30 +20,5 @@
 
 set -ex
 
-python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_build_with_strict_warnings
-bazel_build_with_strict_warnings/bazel_wrapper \
-  --bazelrc=tools/remote_build/include/test_locally_with_resultstore_results.bazelrc \
-  build \
-  --define=use_strict_warning=true \
-  -- \
-  :all \
-  //src/core/... \
-  //src/compiler/... \
-  //test/... \
-  //examples/... \
-  -//examples/android/binder/...
-
-# TODO(jtattersmusch): Adding a build here for --define=grpc_no_xds is not ideal
-# and we should find a better place for this. Refer
-# https://github.com/grpc/grpc/pull/24536#pullrequestreview-517466531 for more
-# details.
-# Test that builds with --define=grpc_no_xds=true work.
-bazel build //test/cpp/end2end:end2end_test --define=grpc_no_xds=true
-
-# Test that builds that need xDS do not build with --define=grpc_no_xds=true
-EXIT_CODE=0
-bazel build //test/cpp/end2end/xds:xds_end2end_test --define=grpc_no_xds=true || EXIT_CODE=$?
-if [ $EXIT_CODE -eq 0 ]; then
-  echo "Building xds_end2end_test succeeded even with --define=grpc_no_xds=true"
-  exit 1
-fi
+echo "The "bazel build C/C++" tests have been migrated to bazelified tests under tools/bazelify_tests."
+echo "This job is now a no-op".


### PR DESCRIPTION
Bazelify tests from "linux/grpc_bazel_build" kokoro job by creating 3 bazelified tests - "build with strict warning", "build with no_xds=True" and "build with no_xds=True negative test".

- also make the original "linux/grpc_bazel_build" kokoro job a no-op (since bazelified tests now provide the same coverage).
