### PR TITLE
[RegisteredMethod] Set information on initial metadata about whether method is registered or not

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -73,6 +73,9 @@ EXPERIMENTS = {
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
             ],
+            "surface_registered_method_lookup": [
+                "registered_method_lookup_in_transport",
+            ],
             "xds_end2end_test": [
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
@@ -134,6 +137,9 @@ EXPERIMENTS = {
             "lb_unit_test": [
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
+            ],
+            "surface_registered_method_lookup": [
+                "registered_method_lookup_in_transport",
             ],
             "xds_end2end_test": [
                 "round_robin_delegate_to_pick_first",
@@ -206,6 +212,9 @@ EXPERIMENTS = {
             "lb_unit_test": [
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
+            ],
+            "surface_registered_method_lookup": [
+                "registered_method_lookup_in_transport",
             ],
             "xds_end2end_test": [
                 "round_robin_delegate_to_pick_first",

--- a/src/core/ext/transport/binder/transport/binder_transport.cc
+++ b/src/core/ext/transport/binder/transport/binder_transport.cc
@@ -221,7 +221,10 @@ static void recv_initial_metadata_locked(void* arg,
       AssignMetadata(gbs->recv_initial_metadata, *args->initial_metadata);
       return absl::OkStatus();
     }();
-
+    if (gbs->t->registered_method_matcher_cb != nullptr) {
+      gbs->t->registered_method_matcher_cb(gbs->t->accept_stream_user_data,
+                                           gbs->recv_initial_metadata);
+    }
     grpc_closure* cb = gbs->recv_initial_metadata_ready;
     gbs->recv_initial_metadata_ready = nullptr;
     gbs->recv_initial_metadata = nullptr;
@@ -615,6 +618,7 @@ static void perform_transport_op_locked(void* transport_op,
   if (op->set_accept_stream) {
     gbt->accept_stream_user_data = op->set_accept_stream_user_data;
     gbt->accept_stream_fn = op->set_accept_stream_fn;
+    gbt->registered_method_matcher_cb = op->set_registered_method_matcher_fn;
     gpr_log(GPR_DEBUG, "accept_stream_fn_called_count_ = %d",
             gbt->accept_stream_fn_called_count_);
     while (gbt->accept_stream_fn_called_count_ > 0) {

--- a/src/core/ext/transport/binder/transport/binder_transport.h
+++ b/src/core/ext/transport/binder/transport/binder_transport.h
@@ -71,9 +71,12 @@ struct grpc_binder_transport {
   grpc_core::Combiner* combiner;
 
   // The callback and the data for the callback when the stream is connected
-  // between client and server.
+  // between client and server. registered_method_matcher_cb is called before
+  // invoking the recv initial metadata callback.
   void (*accept_stream_fn)(void* user_data, grpc_transport* transport,
                            const void* server_data) = nullptr;
+  void (*registered_method_matcher_cb)(
+      void* user_data, grpc_core::ServerMetadata* metadata) = nullptr;
   void* accept_stream_user_data = nullptr;
   // `accept_stream_locked()` could be called before `accept_stream_fn` has been
   // set, we need to remember those requests that comes too early and call them

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1875,6 +1875,7 @@ static void perform_transport_op_locked(void* stream_op,
   if (op->set_accept_stream) {
     t->accept_stream_cb = op->set_accept_stream_fn;
     t->accept_stream_cb_user_data = op->set_accept_stream_user_data;
+    t->registered_method_matcher_cb = op->set_registered_method_matcher_fn;
   }
 
   if (op->bind_pollset) {
@@ -1943,6 +1944,10 @@ void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_chttp2_transport* t,
         s->published_metadata[1] == GRPC_METADATA_SYNTHESIZED_FROM_FAKE) {
       *s->trailing_metadata_available = true;
       s->trailing_metadata_available = nullptr;
+    }
+    if (t->registered_method_matcher_cb != nullptr) {
+      t->registered_method_matcher_cb(t->accept_stream_cb_user_data,
+                                      s->recv_initial_metadata);
     }
     null_then_sched_closure(&s->recv_initial_metadata_ready);
   }

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -307,6 +307,10 @@ struct grpc_chttp2_transport : public grpc_core::KeepsGrpcInitialized {
   // accept stream callback
   void (*accept_stream_cb)(void* user_data, grpc_transport* transport,
                            const void* server_data);
+  // registered_method_matcher_cb is called before invoking the recv initial
+  // metadata callback.
+  void (*registered_method_matcher_cb)(
+      void* user_data, grpc_core::ServerMetadata* metadata) = nullptr;
   void* accept_stream_cb_user_data;
 
   /// connectivity tracking

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -118,9 +118,10 @@ const char* const description_combiner_offload_to_event_engine =
     "Offload Combiner work onto the EventEngine instead of the Executor.";
 const char* const additional_constraints_combiner_offload_to_event_engine =
     "{}";
-const char* const description_rm_lookup_point_transport =
+const char* const description_registered_method_lookup_in_transport =
     "Change registered method's lookup point to transport";
-const char* const additional_constraints_rm_lookup_point_transport = "{}";
+const char* const additional_constraints_registered_method_lookup_in_transport =
+    "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -182,8 +183,9 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"combiner_offload_to_event_engine",
      description_combiner_offload_to_event_engine,
      additional_constraints_combiner_offload_to_event_engine, true, true},
-    {"rm_lookup_point_transport", description_rm_lookup_point_transport,
-     additional_constraints_rm_lookup_point_transport, true, true},
+    {"registered_method_lookup_in_transport",
+     description_registered_method_lookup_in_transport,
+     additional_constraints_registered_method_lookup_in_transport, true, true},
 };
 
 }  // namespace grpc_core
@@ -286,9 +288,10 @@ const char* const description_combiner_offload_to_event_engine =
     "Offload Combiner work onto the EventEngine instead of the Executor.";
 const char* const additional_constraints_combiner_offload_to_event_engine =
     "{}";
-const char* const description_rm_lookup_point_transport =
+const char* const description_registered_method_lookup_in_transport =
     "Change registered method's lookup point to transport";
-const char* const additional_constraints_rm_lookup_point_transport = "{}";
+const char* const additional_constraints_registered_method_lookup_in_transport =
+    "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -350,8 +353,9 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"combiner_offload_to_event_engine",
      description_combiner_offload_to_event_engine,
      additional_constraints_combiner_offload_to_event_engine, true, true},
-    {"rm_lookup_point_transport", description_rm_lookup_point_transport,
-     additional_constraints_rm_lookup_point_transport, true, true},
+    {"registered_method_lookup_in_transport",
+     description_registered_method_lookup_in_transport,
+     additional_constraints_registered_method_lookup_in_transport, true, true},
 };
 
 }  // namespace grpc_core
@@ -454,9 +458,10 @@ const char* const description_combiner_offload_to_event_engine =
     "Offload Combiner work onto the EventEngine instead of the Executor.";
 const char* const additional_constraints_combiner_offload_to_event_engine =
     "{}";
-const char* const description_rm_lookup_point_transport =
+const char* const description_registered_method_lookup_in_transport =
     "Change registered method's lookup point to transport";
-const char* const additional_constraints_rm_lookup_point_transport = "{}";
+const char* const additional_constraints_registered_method_lookup_in_transport =
+    "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -518,8 +523,9 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"combiner_offload_to_event_engine",
      description_combiner_offload_to_event_engine,
      additional_constraints_combiner_offload_to_event_engine, true, true},
-    {"rm_lookup_point_transport", description_rm_lookup_point_transport,
-     additional_constraints_rm_lookup_point_transport, true, true},
+    {"registered_method_lookup_in_transport",
+     description_registered_method_lookup_in_transport,
+     additional_constraints_registered_method_lookup_in_transport, true, true},
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -118,6 +118,9 @@ const char* const description_combiner_offload_to_event_engine =
     "Offload Combiner work onto the EventEngine instead of the Executor.";
 const char* const additional_constraints_combiner_offload_to_event_engine =
     "{}";
+const char* const description_rm_lookup_point_transport =
+    "Change registered method's lookup point to transport";
+const char* const additional_constraints_rm_lookup_point_transport = "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -179,6 +182,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"combiner_offload_to_event_engine",
      description_combiner_offload_to_event_engine,
      additional_constraints_combiner_offload_to_event_engine, true, true},
+    {"rm_lookup_point_transport", description_rm_lookup_point_transport,
+     additional_constraints_rm_lookup_point_transport, true, true},
 };
 
 }  // namespace grpc_core
@@ -281,6 +286,9 @@ const char* const description_combiner_offload_to_event_engine =
     "Offload Combiner work onto the EventEngine instead of the Executor.";
 const char* const additional_constraints_combiner_offload_to_event_engine =
     "{}";
+const char* const description_rm_lookup_point_transport =
+    "Change registered method's lookup point to transport";
+const char* const additional_constraints_rm_lookup_point_transport = "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -342,6 +350,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"combiner_offload_to_event_engine",
      description_combiner_offload_to_event_engine,
      additional_constraints_combiner_offload_to_event_engine, true, true},
+    {"rm_lookup_point_transport", description_rm_lookup_point_transport,
+     additional_constraints_rm_lookup_point_transport, true, true},
 };
 
 }  // namespace grpc_core
@@ -444,6 +454,9 @@ const char* const description_combiner_offload_to_event_engine =
     "Offload Combiner work onto the EventEngine instead of the Executor.";
 const char* const additional_constraints_combiner_offload_to_event_engine =
     "{}";
+const char* const description_rm_lookup_point_transport =
+    "Change registered method's lookup point to transport";
+const char* const additional_constraints_rm_lookup_point_transport = "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -505,6 +518,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"combiner_offload_to_event_engine",
      description_combiner_offload_to_event_engine,
      additional_constraints_combiner_offload_to_event_engine, true, true},
+    {"rm_lookup_point_transport", description_rm_lookup_point_transport,
+     additional_constraints_rm_lookup_point_transport, true, true},
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -90,6 +90,8 @@ inline bool IsRoundRobinDelegateToPickFirstEnabled() { return true; }
 inline bool IsWrrDelegateToPickFirstEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
+inline bool IsRmLookupPointTransportEnabled() { return true; }
 
 #elif defined(GPR_WINDOWS)
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
@@ -125,6 +127,8 @@ inline bool IsRoundRobinDelegateToPickFirstEnabled() { return true; }
 inline bool IsWrrDelegateToPickFirstEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
+inline bool IsRmLookupPointTransportEnabled() { return true; }
 
 #else
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
@@ -160,6 +164,8 @@ inline bool IsRoundRobinDelegateToPickFirstEnabled() { return true; }
 inline bool IsWrrDelegateToPickFirstEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
+inline bool IsRmLookupPointTransportEnabled() { return true; }
 #endif
 
 #else
@@ -190,6 +196,7 @@ enum ExperimentIds {
   kExperimentIdRoundRobinDelegateToPickFirst,
   kExperimentIdWrrDelegateToPickFirst,
   kExperimentIdCombinerOffloadToEventEngine,
+  kExperimentIdRmLookupPointTransport,
   kNumExperiments
 };
 #define GRPC_EXPERIMENT_IS_INCLUDED_TCP_FRAME_SIZE_TUNING
@@ -295,6 +302,10 @@ inline bool IsWrrDelegateToPickFirstEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() {
   return IsExperimentEnabled(kExperimentIdCombinerOffloadToEventEngine);
+}
+#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
+inline bool IsRmLookupPointTransportEnabled() {
+  return IsExperimentEnabled(kExperimentIdRmLookupPointTransport);
 }
 
 extern const ExperimentMetadata g_experiment_metadata[kNumExperiments];

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -90,8 +90,8 @@ inline bool IsRoundRobinDelegateToPickFirstEnabled() { return true; }
 inline bool IsWrrDelegateToPickFirstEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
-inline bool IsRmLookupPointTransportEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_REGISTERED_METHOD_LOOKUP_IN_TRANSPORT
+inline bool IsRegisteredMethodLookupInTransportEnabled() { return true; }
 
 #elif defined(GPR_WINDOWS)
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
@@ -127,8 +127,8 @@ inline bool IsRoundRobinDelegateToPickFirstEnabled() { return true; }
 inline bool IsWrrDelegateToPickFirstEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
-inline bool IsRmLookupPointTransportEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_REGISTERED_METHOD_LOOKUP_IN_TRANSPORT
+inline bool IsRegisteredMethodLookupInTransportEnabled() { return true; }
 
 #else
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
@@ -164,8 +164,8 @@ inline bool IsRoundRobinDelegateToPickFirstEnabled() { return true; }
 inline bool IsWrrDelegateToPickFirstEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_COMBINER_OFFLOAD_TO_EVENT_ENGINE
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
-inline bool IsRmLookupPointTransportEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_REGISTERED_METHOD_LOOKUP_IN_TRANSPORT
+inline bool IsRegisteredMethodLookupInTransportEnabled() { return true; }
 #endif
 
 #else
@@ -196,7 +196,7 @@ enum ExperimentIds {
   kExperimentIdRoundRobinDelegateToPickFirst,
   kExperimentIdWrrDelegateToPickFirst,
   kExperimentIdCombinerOffloadToEventEngine,
-  kExperimentIdRmLookupPointTransport,
+  kExperimentIdRegisteredMethodLookupInTransport,
   kNumExperiments
 };
 #define GRPC_EXPERIMENT_IS_INCLUDED_TCP_FRAME_SIZE_TUNING
@@ -303,9 +303,9 @@ inline bool IsWrrDelegateToPickFirstEnabled() {
 inline bool IsCombinerOffloadToEventEngineEnabled() {
   return IsExperimentEnabled(kExperimentIdCombinerOffloadToEventEngine);
 }
-#define GRPC_EXPERIMENT_IS_INCLUDED_RM_LOOKUP_POINT_TRANSPORT
-inline bool IsRmLookupPointTransportEnabled() {
-  return IsExperimentEnabled(kExperimentIdRmLookupPointTransport);
+#define GRPC_EXPERIMENT_IS_INCLUDED_REGISTERED_METHOD_LOOKUP_IN_TRANSPORT
+inline bool IsRegisteredMethodLookupInTransportEnabled() {
+  return IsExperimentEnabled(kExperimentIdRegisteredMethodLookupInTransport);
 }
 
 extern const ExperimentMetadata g_experiment_metadata[kNumExperiments];

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -206,7 +206,7 @@
   expiry: 2024/01/15
   owner: hork@google.com
   test_tags: []
-- name: rm_lookup_point_transport
+- name: registered_method_lookup_in_transport
   description:
     Change registered method's lookup point to transport
   expiry: 2024/03/31

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -206,3 +206,9 @@
   expiry: 2024/01/15
   owner: hork@google.com
   test_tags: []
+- name: rm_lookup_point_transport
+  description:
+    Change registered method's lookup point to transport
+  expiry: 2024/03/31
+  owner: yashkt@google.com
+  test_tags: []

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -211,4 +211,4 @@
     Change registered method's lookup point to transport
   expiry: 2024/03/31
   owner: yashkt@google.com
-  test_tags: []
+  test_tags: ["surface_registered_method_lookup"]

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -100,5 +100,5 @@
   default: true
 - name: combiner_offload_to_event_engine
   default: true
-- name: rm_lookup_point_transport
+- name: registered_method_lookup_in_transport
   default: true

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -100,3 +100,5 @@
   default: true
 - name: combiner_offload_to_event_engine
   default: true
+- name: rm_lookup_point_transport
+  default: true

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -835,6 +835,9 @@ grpc_error_handle FilterStackCall::Create(grpc_call_create_args* args,
       call->send_initial_metadata_.Set(HttpAuthorityMetadata(),
                                        std::move(*args->authority));
     }
+    call->send_initial_metadata_.Set(
+        GrpcRegisteredMethod(), reinterpret_cast<void*>(static_cast<uintptr_t>(
+                                    args->registered_method)));
   } else {
     global_stats().IncrementServerCallsCreated();
     call->final_op_.server.cancelled = nullptr;
@@ -2720,6 +2723,9 @@ class ClientPromiseBasedCall final : public PromiseBasedCall {
       send_initial_metadata_->Set(HttpAuthorityMetadata(),
                                   std::move(*args->authority));
     }
+    send_initial_metadata_->Set(GrpcRegisteredMethod(),
+                                reinterpret_cast<void*>(static_cast<uintptr_t>(
+                                    args->registered_method)));
     if (auto* channelz_channel = channel()->channelz_node()) {
       channelz_channel->RecordCallStarted();
     }

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -73,6 +73,7 @@ typedef struct grpc_call_create_args {
   absl::optional<grpc_core::Slice> authority;
 
   grpc_core::Timestamp send_deadline;
+  bool registered_method;  // client_only
 } grpc_call_create_args;
 
 namespace grpc_core {

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1204,7 +1204,6 @@ void Server::ChannelData::InitTransport(RefCountedPtr<Server> server,
   op->set_accept_stream = true;
   op->set_accept_stream_fn = AcceptStream;
   if (IsRmLookupPointTransportEnabled()) {
-    gpr_log(GPR_ERROR, "setting");
     op->set_registered_method_matcher_fn = SetRegisteredMethodOnMetadata;
   }
   // op->set_registered_method_matcher_fn = Registered
@@ -1246,7 +1245,6 @@ Server::ChannelRegisteredMethod* Server::ChannelData::GetRegisteredMethod(
 
 void Server::ChannelData::SetRegisteredMethodOnMetadata(
     void* arg, ServerMetadata* metadata) {
-  gpr_log(GPR_ERROR, "here");
   auto* chand = static_cast<Server::ChannelData*>(arg);
   auto* authority = metadata->get_pointer(HttpAuthorityMetadata());
   if (authority == nullptr) {

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1203,6 +1203,11 @@ void Server::ChannelData::InitTransport(RefCountedPtr<Server> server,
   grpc_transport_op* op = grpc_make_transport_op(nullptr);
   op->set_accept_stream = true;
   op->set_accept_stream_fn = AcceptStream;
+  if (IsRmLookupPointTransportEnabled()) {
+    gpr_log(GPR_ERROR, "setting");
+    op->set_registered_method_matcher_fn = SetRegisteredMethodOnMetadata;
+  }
+  // op->set_registered_method_matcher_fn = Registered
   op->set_accept_stream_user_data = this;
   op->start_connectivity_watch = MakeOrphanable<ConnectivityWatcher>(this);
   if (server_->ShutdownCalled()) {
@@ -1237,6 +1242,29 @@ Server::ChannelRegisteredMethod* Server::ChannelData::GetRegisteredMethod(
     return rm;
   }
   return nullptr;
+}
+
+void Server::ChannelData::SetRegisteredMethodOnMetadata(
+    void* arg, ServerMetadata* metadata) {
+  gpr_log(GPR_ERROR, "here");
+  auto* chand = static_cast<Server::ChannelData*>(arg);
+  auto* authority = metadata->get_pointer(HttpAuthorityMetadata());
+  if (authority == nullptr) {
+    authority = metadata->get_pointer(HostMetadata());
+    if (authority == nullptr) {
+      // Authority not being set is an RPC error.
+      return;
+    }
+  }
+  auto* path = metadata->get_pointer(HttpPathMetadata());
+  if (path == nullptr) {
+    // Path not being set would result in an RPC error.
+    return;
+  }
+  ChannelRegisteredMethod* method =
+      chand->GetRegisteredMethod(authority->c_slice(), path->c_slice());
+  // insert in metadata
+  metadata->Set(GrpcRegisteredMethod(), method);
 }
 
 void Server::ChannelData::AcceptStream(void* arg, grpc_transport* /*transport*/,
@@ -1305,8 +1333,14 @@ ArenaPromise<ServerMetadataHandle> Server::ChannelData::MakeCallPromise(
   Timestamp deadline = GetContext<CallContext>()->deadline();
   // Find request matcher.
   RequestMatcherInterface* matcher;
-  ChannelRegisteredMethod* rm =
-      chand->GetRegisteredMethod(host_ptr->c_slice(), path->c_slice());
+  ChannelRegisteredMethod* rm = nullptr;
+  if (IsRmLookupPointTransportEnabled()) {
+    rm = static_cast<ChannelRegisteredMethod*>(
+        call_args.client_initial_metadata->get(GrpcRegisteredMethod())
+            .value_or(nullptr));
+  } else {
+    rm = chand->GetRegisteredMethod(host_ptr->c_slice(), path->c_slice());
+  }
   ArenaPromise<absl::StatusOr<NextResult<MessageHandle>>>
       maybe_read_first_message([] { return NextResult<MessageHandle>(); });
   if (rm != nullptr) {
@@ -1565,8 +1599,14 @@ void Server::CallData::StartNewRpc(grpc_call_element* elem) {
   grpc_server_register_method_payload_handling payload_handling =
       GRPC_SRM_PAYLOAD_NONE;
   if (path_.has_value() && host_.has_value()) {
-    ChannelRegisteredMethod* rm =
-        chand->GetRegisteredMethod(host_->c_slice(), path_->c_slice());
+    ChannelRegisteredMethod* rm;
+    if (IsRmLookupPointTransportEnabled()) {
+      rm = static_cast<ChannelRegisteredMethod*>(
+          recv_initial_metadata_->get(GrpcRegisteredMethod())
+              .value_or(nullptr));
+    } else {
+      rm = chand->GetRegisteredMethod(host_->c_slice(), path_->c_slice());
+    }
     if (rm != nullptr) {
       matcher_ = rm->server_registered_method->matcher.get();
       payload_handling = rm->server_registered_method->payload_handling;

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1203,7 +1203,7 @@ void Server::ChannelData::InitTransport(RefCountedPtr<Server> server,
   grpc_transport_op* op = grpc_make_transport_op(nullptr);
   op->set_accept_stream = true;
   op->set_accept_stream_fn = AcceptStream;
-  if (IsRmLookupPointTransportEnabled()) {
+  if (IsRegisteredMethodLookupInTransportEnabled()) {
     op->set_registered_method_matcher_fn = SetRegisteredMethodOnMetadata;
   }
   // op->set_registered_method_matcher_fn = Registered
@@ -1332,7 +1332,7 @@ ArenaPromise<ServerMetadataHandle> Server::ChannelData::MakeCallPromise(
   // Find request matcher.
   RequestMatcherInterface* matcher;
   ChannelRegisteredMethod* rm = nullptr;
-  if (IsRmLookupPointTransportEnabled()) {
+  if (IsRegisteredMethodLookupInTransportEnabled()) {
     rm = static_cast<ChannelRegisteredMethod*>(
         call_args.client_initial_metadata->get(GrpcRegisteredMethod())
             .value_or(nullptr));
@@ -1598,7 +1598,7 @@ void Server::CallData::StartNewRpc(grpc_call_element* elem) {
       GRPC_SRM_PAYLOAD_NONE;
   if (path_.has_value() && host_.has_value()) {
     ChannelRegisteredMethod* rm;
-    if (IsRmLookupPointTransportEnabled()) {
+    if (IsRegisteredMethodLookupInTransportEnabled()) {
       rm = static_cast<ChannelRegisteredMethod*>(
           recv_initial_metadata_->get(GrpcRegisteredMethod())
               .value_or(nullptr));

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -231,7 +231,6 @@ class Server : public InternallyRefCounted<Server>,
 
     ChannelRegisteredMethod* GetRegisteredMethod(const grpc_slice& host,
                                                  const grpc_slice& path);
-
     // Filter vtable functions.
     static grpc_error_handle InitChannelElement(
         grpc_channel_element* elem, grpc_channel_element_args* args);
@@ -244,6 +243,8 @@ class Server : public InternallyRefCounted<Server>,
 
     static void AcceptStream(void* arg, grpc_transport* /*transport*/,
                              const void* transport_server_data);
+    static void SetRegisteredMethodOnMetadata(void* arg,
+                                              ServerMetadata* metadata);
 
     void Destroy() ABSL_EXCLUSIVE_LOCKS_REQUIRED(server_->mu_global_);
 

--- a/src/core/lib/transport/metadata_batch.cc
+++ b/src/core/lib/transport/metadata_batch.cc
@@ -19,10 +19,12 @@
 #include <string.h>
 
 #include <algorithm>
+#include <initializer_list>
 
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 
 #include "src/core/lib/transport/timeout_encoding.h"
 
@@ -290,6 +292,10 @@ std::string GrpcStreamNetworkState::DisplayValue(ValueType x) {
       return "not seen by server";
   }
   GPR_UNREACHABLE_CODE(return "unknown value");
+}
+
+std::string GrpcRegisteredMethod::DisplayValue(void* x) {
+  return absl::StrFormat("%p", x);
 }
 
 std::string PeerString::DisplayValue(const ValueType& x) {

--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -509,6 +509,16 @@ struct GrpcTrailersOnly {
   static absl::string_view DisplayValue(bool x) { return x ? "true" : "false"; }
 };
 
+// On the client-side, the value is a uintptr_t with a value of 1 if the call
+// has a registered/known method, or 0, if it's not known. On the server side,
+// the value is a (ChannelRegisteredMethod*).
+struct GrpcRegisteredMethod {
+  static absl::string_view DebugKey() { return "GrpcRegisteredMethod"; }
+  static constexpr bool kRepeatable = false;
+  using ValueType = void*;
+  static std::string DisplayValue(void* x);
+};
+
 namespace metadata_detail {
 
 // Build a key/value formatted debug string.
@@ -1486,7 +1496,8 @@ using grpc_metadata_batch_base = grpc_core::MetadataMap<
     grpc_core::GrpcStreamNetworkState, grpc_core::PeerString,
     grpc_core::GrpcStatusContext, grpc_core::GrpcStatusFromWire,
     grpc_core::GrpcCallWasCancelled, grpc_core::WaitForReady,
-    grpc_core::GrpcTrailersOnly GRPC_CUSTOM_CLIENT_METADATA
+    grpc_core::GrpcTrailersOnly,
+    grpc_core::GrpcRegisteredMethod GRPC_CUSTOM_CLIENT_METADATA
         GRPC_CUSTOM_SERVER_METADATA>;
 
 struct grpc_metadata_batch : public grpc_metadata_batch_base {

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -526,6 +526,8 @@ typedef struct grpc_transport_op {
   bool set_accept_stream = false;
   void (*set_accept_stream_fn)(void* user_data, grpc_transport* transport,
                                const void* server_data) = nullptr;
+  void (*set_registered_method_matcher_fn)(
+      void* user_data, grpc_core::ServerMetadata* metadata) = nullptr;
   void* set_accept_stream_user_data = nullptr;
   /// set the callback for accepting new streams based upon promises;
   /// this is a permanent callback, unlike the other one-shot closures.

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -522,7 +522,13 @@ typedef struct grpc_transport_op {
   /// set the callback for accepting new streams;
   /// this is a permanent callback, unlike the other one-shot closures.
   /// If true, the callback is set to set_accept_stream_fn, with its
-  /// user_data argument set to set_accept_stream_user_data
+  /// user_data argument set to set_accept_stream_user_data.
+  /// `set_registered_method_matcher_fn` is also set with its user_data argument
+  /// set to set_accept_stream_user_data. The transport should invoke
+  /// `set_registered_method_matcher_fn` after initial metadata is received but
+  /// before recv_initial_metadata_ready callback is invoked. If the transport
+  /// detects an error in the stream, invoking
+  /// `set_registered_method_matcher_fn` can be skipped.
   bool set_accept_stream = false;
   void (*set_accept_stream_fn)(void* user_data, grpc_transport* transport,
                                const void* server_data) = nullptr;

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -340,6 +340,7 @@ grpc_cc_test(
     tags = [
         "cpp_end2end_test",
         "no_test_ios",
+        "surface_registered_method_lookup",
     ],
     deps = [
         ":end2end_test_lib",

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -2337,8 +2337,12 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  grpc::testing::TestEnvironment env(&argc, argv);
+  // Use this test as a canary to make sure that method lookup in the surface
+  // layer still works when this experiment is off.
+  grpc_core::ForceEnableExperiment("registered_method_lookup_in_transport",
+                                   false);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc::testing::TestEnvironment env(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;
 }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -2337,12 +2337,8 @@ INSTANTIATE_TEST_SUITE_P(
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  // Use this test as a canary to make sure that method lookup in the surface
-  // layer still works when this experiment is off.
-  grpc_core::ForceEnableExperiment("registered_method_lookup_in_transport",
-                                   false);
-  ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;
 }


### PR DESCRIPTION
Summary - 
On the server-side, we are changing the point at which we decide whether a method is registered or not from the surface to the transport at the point where we are done receiving initial metadata and before we invoke the recv_initial_metadata_ready closures from the filters. The main motivation for this is to allow filters to check whether the incoming method is a registered or not. The exact use-case is for observability where we only want to record the method if it is registered. We store the information about the registered method in the initial metadata.

On the client-side, we also set information about whether the method is registered or not in the outgoing initial metadata.

Since we are effectively changing the lookup point of the registered method, there are slight concerns of this being a potentially breaking change, so we are guarding this with an experiment to be safe.

Changes - 
* Transport API changes -
  * Along with `accept_stream_fn`, a new callback `registered_method_matcher_cb` will be sent down as a transport op on the server side. When initial metadata is received on the server side, this callback is invoked. This happens before invoking the `recv_initial_metadata_ready` closure.
* Metadata changes -
  * We add a new non-serializable metadata trait `GrpcRegisteredMethod()`. On the client-side, the value is a uintptr_t with a value of 1 if the call has a registered/known method, or 0, if it's not known. On the server side, the value is a (ChannelRegisteredMethod*). This metadata information can be used throughout the stack to check whether a call is registered or not.
* Server Changes -
  * When a new transport connection is accepted, the server sets `registered_method_matcher_cb` along with `accept_stream_fn`. This function checks whether the method is registered or not and sets the RegisteredMethod matcher in the metadata for use later.
* Client Changes -
  * Set the metadata on call creation on whether the  method is registered or not.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

