### PR TITLE
[test scripts] fix GRPC_VERBOSITY setting for run_tests jobs on CI

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1851,10 +1851,6 @@ jobset.measure_cpu_costs = args.measure_cpu_costs
 run_config = _CONFIGS[args.config]
 build_config = run_config.build_config
 
-# TODO(jtattermusch): is this setting applied/being used?
-if args.travis:
-    _FORCE_ENVIRON_FOR_WRAPPERS = {"GRPC_TRACE": "api"}
-
 languages = set(_LANGUAGES[l] for l in args.language)
 for l in languages:
     l.configure(run_config, args)


### PR DESCRIPTION
The deleted code here was overriding the [intended](https://github.com/grpc/grpc/blob/866fc41067eb1a5ddd232093b9e2a95d19349354/tools/run_tests/run_tests.py#L62) default test env of `GRPC_VERBOSITY=DEBUG`.

I'm just deleting it because it looks like`GRPC_TRACE=api` is not having any affect anyways, since it relies on `GRPC_VERBOSITY=DEBUG` which it happens to be unsetting.
