### PR TITLE
Revert "[ObjC] Remove grpc core podspec module map"

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -65,6 +65,9 @@ Pod::Spec.new do |s|
   # following lets users write `#include <grpc/grpc.h>`.
   s.header_dir = name
 
+  # The module map created automatically by Cocoapods doesn't work for C libraries like gRPC-Core.
+  s.module_map = 'include/grpc/module.modulemap'
+
   # To compile the library, we need the user headers search path (quoted includes) to point to the
   # root of the repo, third_party/** and two upb generated directories, and the system headers
   # search path (angled includes) to point to `include/`.

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -141,6 +141,9 @@
     # following lets users write `#include <grpc/grpc.h>`.
     s.header_dir = name
 
+    # The module map created automatically by Cocoapods doesn't work for C libraries like gRPC-Core.
+    s.module_map = 'include/grpc/module.modulemap'
+
     # To compile the library, we need the user headers search path (quoted includes) to point to the
     # root of the repo, third_party/** and two upb generated directories, and the system headers
     # search path (angled includes) to point to `include/`.


### PR DESCRIPTION
Reverts grpc/grpc#34361

Not sure why CI didn't capture it and why my previous test works, but looks like it broke at least src/objective-c/examples/SwiftSample build.
Will see how CI goes in this PR.