### PR TITLE
[CSM] Plumbing fixes

### DIFF
--- a/include/grpcpp/ext/csm_observability.h
+++ b/include/grpcpp/ext/csm_observability.h
@@ -55,11 +55,6 @@ class CsmObservabilityBuilder {
   CsmObservabilityBuilder& EnableMetric(absl::string_view metric_name);
   CsmObservabilityBuilder& DisableMetric(absl::string_view metric_name);
   CsmObservabilityBuilder& DisableAllMetrics();
-  // If set, \a target_selector is called per channel to decide whether to
-  // collect metrics on that target or not.
-  CsmObservabilityBuilder& SetTargetSelector(
-      absl::AnyInvocable<bool(absl::string_view /*target*/) const>
-          target_selector);
   // If set, \a target_attribute_filter is called per channel to decide whether
   // to record the target attribute on client or to replace it with "other".
   // This helps reduce the cardinality on metrics in cases where many channels

--- a/src/cpp/ext/csm/BUILD
+++ b/src/cpp/ext/csm/BUILD
@@ -23,9 +23,10 @@ licenses(["reciprocal"])
 
 package(
     default_visibility = ["//visibility:public"],
-    features = [
-        "layering_check",
-    ],
+    # TODO(yashykt): Google Cloud C++ does not explicitly export the headers. Remove this once that is fixed.
+    #features = [
+    #    "layering_check",
+    #],
 )
 
 grpc_cc_library(
@@ -46,6 +47,7 @@ grpc_cc_library(
         "absl/strings",
         "absl/types:optional",
         "absl/types:variant",
+        "google_cloud_cpp:experimental-opentelemetry",
         "otel/sdk/src/metrics",
         "otel/sdk:headers",
         "upb_lib",

--- a/src/cpp/ext/csm/csm_observability.cc
+++ b/src/cpp/ext/csm/csm_observability.cc
@@ -16,11 +16,10 @@
 //
 //
 
+#include <grpc/support/port_platform.h>
+
 #include "src/cpp/ext/csm/csm_observability.h"
 
-#include <grpc/support/port_platform.h>
-#include <grpc/support/log.h>
-#include <grpcpp/ext/csm_observability.h>
 #include <memory>
 #include <string>
 #include <utility>
@@ -30,13 +29,17 @@
 #include "absl/types/optional.h"
 #include "google/cloud/opentelemetry/resource_detector.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+
+#include <grpc/support/log.h>
+#include <grpcpp/ext/csm_observability.h>
+
 #include "src/core/ext/xds/xds_enabled_server.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/uri/uri_parser.h"
 #include "src/cpp/ext/csm/metadata_exchange.h"
 #include "src/cpp/ext/otel/otel_plugin.h"
-#include "opentelemetry/sdk/resource/resource.h"
-#include "opentelemetry/sdk/resource/resource_detector.h"
 
 namespace grpc {
 namespace experimental {

--- a/tools/distrib/fix_build_deps.py
+++ b/tools/distrib/fix_build_deps.py
@@ -107,6 +107,8 @@ EXTERNAL_DEPS = {
     "opentelemetry/nostd/unique_ptr.h": "otel/api",
     "opentelemetry/sdk/metrics/meter_provider.h": "otel/sdk/src/metrics",
     "opentelemetry/sdk/common/attribute_utils.h": "otel/sdk:headers",
+    "opentelemetry/sdk/resource/resource.h": "otel/sdk:headers",
+    "opentelemetry/sdk/resource/resource_detector.h": "otel/sdk:headers",
     "opentelemetry/sdk/resource/semantic_conventions.h": "otel/sdk:headers",
     "ares.h": "cares",
     "fuzztest/fuzztest.h": ["fuzztest", "fuzztest_main"],


### PR DESCRIPTION
Changes -
* CsmObservability doesn't need `SetTargetSelector`. Removed it.
* Added missing plumbing of `ServiceMeshLabelsInjector` in `CsmObservability` to actually do the metadata exchange.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

