### PR TITLE
[OTel C++] OTel plugin improvements

### DIFF
--- a/src/cpp/ext/otel/BUILD
+++ b/src/cpp/ext/otel/BUILD
@@ -62,6 +62,7 @@ grpc_cc_library(
         "//:config",
         "//:gpr",
         "//:gpr_platform",
+        "//:grpc++",
         "//:grpc_base",
         "//:grpc_client_channel",
         "//:grpc_public_hdrs",

--- a/src/cpp/ext/otel/otel_plugin.cc
+++ b/src/cpp/ext/otel/otel_plugin.cc
@@ -180,13 +180,13 @@ void OpenTelemetryPluginBuilder::BuildAndRegisterGlobal() {
   if (metrics_.contains(OTelClientAttemptStartedInstrumentName())) {
     g_otel_plugin_state_->client.attempt.started = meter->CreateUInt64Counter(
         std::string(OTelClientAttemptStartedInstrumentName()),
-        "Number of call attempts started", "{attempt}");
+        "Number of client call attempts started", "{attempt}");
   }
   if (metrics_.contains(OTelClientAttemptDurationInstrumentName())) {
     g_otel_plugin_state_->client.attempt.duration =
         meter->CreateDoubleHistogram(
             std::string(OTelClientAttemptDurationInstrumentName()),
-            "End-to-end time taken to complete a call attempt", "s");
+            "End-to-end time taken to complete a client call attempt", "s");
   }
   if (metrics_.contains(
           OTelClientAttemptSentTotalCompressedMessageSizeInstrumentName())) {
@@ -194,7 +194,7 @@ void OpenTelemetryPluginBuilder::BuildAndRegisterGlobal() {
         .sent_total_compressed_message_size = meter->CreateUInt64Histogram(
         std::string(
             OTelClientAttemptSentTotalCompressedMessageSizeInstrumentName()),
-        "Compressed message bytes sent per call attempt", "By");
+        "Compressed message bytes sent per client call attempt", "By");
   }
   if (metrics_.contains(
           OTelClientAttemptRcvdTotalCompressedMessageSizeInstrumentName())) {
@@ -230,7 +230,7 @@ void OpenTelemetryPluginBuilder::BuildAndRegisterGlobal() {
         meter->CreateUInt64Histogram(
             std::string(
                 OTelServerCallRcvdTotalCompressedMessageSizeInstrumentName()),
-            "Compressed message bytes sent per server call", "By");
+            "Compressed message bytes received per server call", "By");
   }
   g_otel_plugin_state_->labels_injector = std::move(labels_injector_);
   g_otel_plugin_state_->target_attribute_filter =

--- a/src/cpp/ext/otel/otel_plugin.cc
+++ b/src/cpp/ext/otel/otel_plugin.cc
@@ -31,6 +31,7 @@
 #include "opentelemetry/nostd/unique_ptr.h"
 
 #include <grpc/support/log.h>
+#include <grpcpp/version_info.h>
 
 #include "src/core/ext/filters/client_channel/client_channel.h"
 #include "src/core/lib/channel/call_tracer.h"
@@ -175,47 +176,61 @@ void OpenTelemetryPluginBuilder::BuildAndRegisterGlobal() {
   if (meter_provider == nullptr) {
     return;
   }
-  auto meter = meter_provider->GetMeter("grpc");
+  auto meter = meter_provider->GetMeter("grpc-c++", GRPC_CPP_VERSION_STRING);
   if (metrics_.contains(OTelClientAttemptStartedInstrumentName())) {
     g_otel_plugin_state_->client.attempt.started = meter->CreateUInt64Counter(
-        std::string(OTelClientAttemptStartedInstrumentName()));
+        std::string(OTelClientAttemptStartedInstrumentName()),
+        "Number of call attempts started", "{attempt}");
   }
   if (metrics_.contains(OTelClientAttemptDurationInstrumentName())) {
     g_otel_plugin_state_->client.attempt.duration =
         meter->CreateDoubleHistogram(
-            std::string(OTelClientAttemptDurationInstrumentName()));
+            std::string(OTelClientAttemptDurationInstrumentName()),
+            "End-to-end time taken to complete a call attempt", "s");
   }
   if (metrics_.contains(
           OTelClientAttemptSentTotalCompressedMessageSizeInstrumentName())) {
-    g_otel_plugin_state_->client.attempt.sent_total_compressed_message_size =
-        meter->CreateUInt64Histogram(std::string(
-            OTelClientAttemptSentTotalCompressedMessageSizeInstrumentName()));
+    g_otel_plugin_state_->client.attempt
+        .sent_total_compressed_message_size = meter->CreateUInt64Histogram(
+        std::string(
+            OTelClientAttemptSentTotalCompressedMessageSizeInstrumentName()),
+        "Compressed message bytes sent per call attempt", "By");
   }
   if (metrics_.contains(
           OTelClientAttemptRcvdTotalCompressedMessageSizeInstrumentName())) {
-    g_otel_plugin_state_->client.attempt.rcvd_total_compressed_message_size =
-        meter->CreateUInt64Histogram(std::string(
-            OTelClientAttemptRcvdTotalCompressedMessageSizeInstrumentName()));
+    g_otel_plugin_state_->client.attempt
+        .rcvd_total_compressed_message_size = meter->CreateUInt64Histogram(
+        std::string(
+            OTelClientAttemptRcvdTotalCompressedMessageSizeInstrumentName()),
+        "Compressed message bytes received per call attempt", "By");
   }
   if (metrics_.contains(OTelServerCallStartedInstrumentName())) {
     g_otel_plugin_state_->server.call.started = meter->CreateUInt64Counter(
-        std::string(OTelServerCallStartedInstrumentName()));
+        std::string(OTelServerCallStartedInstrumentName()),
+        "Number of server calls started", "{call}");
   }
   if (metrics_.contains(OTelServerCallDurationInstrumentName())) {
     g_otel_plugin_state_->server.call.duration = meter->CreateDoubleHistogram(
-        std::string(OTelServerCallDurationInstrumentName()));
+        std::string(OTelServerCallDurationInstrumentName()),
+        "End-to-end time taken to complete a call from server transport's "
+        "perspective",
+        "s");
   }
   if (metrics_.contains(
           OTelServerCallSentTotalCompressedMessageSizeInstrumentName())) {
     g_otel_plugin_state_->server.call.sent_total_compressed_message_size =
-        meter->CreateUInt64Histogram(std::string(
-            OTelServerCallSentTotalCompressedMessageSizeInstrumentName()));
+        meter->CreateUInt64Histogram(
+            std::string(
+                OTelServerCallSentTotalCompressedMessageSizeInstrumentName()),
+            "Compressed message bytes sent per server call", "By");
   }
   if (metrics_.contains(
           OTelServerCallRcvdTotalCompressedMessageSizeInstrumentName())) {
     g_otel_plugin_state_->server.call.rcvd_total_compressed_message_size =
-        meter->CreateUInt64Histogram(std::string(
-            OTelServerCallRcvdTotalCompressedMessageSizeInstrumentName()));
+        meter->CreateUInt64Histogram(
+            std::string(
+                OTelServerCallRcvdTotalCompressedMessageSizeInstrumentName()),
+            "Compressed message bytes sent per server call", "By");
   }
   g_otel_plugin_state_->labels_injector = std::move(labels_injector_);
   g_otel_plugin_state_->target_attribute_filter =


### PR DESCRIPTION
Changes -
* Use `grpc-c++` as the meter name and the proper version string when creating the meter for OTel
* setting metric description and unit. (Pointed out by @DNVindhya )

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

