### PR TITLE
[DO NOT SUBMIT] Repro access violation when a WinSocket is Shutdown and destroyed before its pending callback is called

### DIFF
--- a/test/core/event_engine/windows/iocp_test.cc
+++ b/test/core/event_engine/windows/iocp_test.cc
@@ -138,6 +138,57 @@ TEST_F(IOCPTest, ClientReceivesNotificationOfServerSend) {
   thread_pool->Quiesce();
 }
 
+TEST_F(IOCPTest, SocketShutdownWhenPendingOperation) {
+  auto thread_pool = grpc_event_engine::experimental::MakeThreadPool(8);
+  IOCP iocp(thread_pool.get());
+  SOCKET sockpair[2];
+  CreateSockpair(sockpair, iocp.GetDefaultSocketFlags());
+  AnyInvocableClosure* on_read;
+  grpc_core::Notification read_called;
+  {
+    auto wrapped_client_socket = iocp.Watch(sockpair[0]);
+    DWORD flags = 0;
+    {
+      // When the client gets some data, ensure it matches what we expect.
+      WSABUF read_wsabuf;
+      read_wsabuf.len = 2048;
+      char read_char_buffer[2048];
+      read_wsabuf.buf = read_char_buffer;
+      DWORD bytes_rcvd;
+      int status = WSARecv(
+          wrapped_client_socket->raw_socket(), &read_wsabuf, 1, &bytes_rcvd,
+          &flags, wrapped_client_socket->read_info()->overlapped(), NULL);
+      // Expecting error 997, WSA_IO_PENDING
+      EXPECT_EQ(status, -1);
+      int last_error = WSAGetLastError();
+      EXPECT_EQ(last_error, WSA_IO_PENDING);
+      if (last_error != WSA_IO_PENDING) {
+        LogErrorMessage(last_error, "WSARecv");
+      }
+      on_read = new AnyInvocableClosure(
+          [win_socket = wrapped_client_socket.get(), &read_called]() {
+            gpr_log(GPR_DEBUG, "Notified on read");
+            EXPECT_EQ(win_socket->read_info()->result().wsa_error,
+                      WSA_OPERATION_ABORTED);
+            read_called.Notify();
+          });
+      wrapped_client_socket->NotifyOnRead(on_read);
+    }
+    wrapped_client_socket->Shutdown();
+  }
+  bool cb_invoked = false;
+  auto work_result = iocp.Work(std::chrono::seconds(10),
+                               [&cb_invoked]() { cb_invoked = true; });
+  ASSERT_TRUE(work_result == Poller::WorkResult::kOk);
+  ASSERT_TRUE(cb_invoked);
+  // wait for the callbacks to run
+  read_called.WaitForNotification();
+
+  delete on_read;
+  iocp.Shutdown();
+  thread_pool->Quiesce();
+}
+
 TEST_F(IOCPTest, IocpWorkTimeoutDueToNoNotificationRegistered) {
   auto thread_pool = grpc_event_engine::experimental::MakeThreadPool(8);
   IOCP iocp(thread_pool.get());


### PR DESCRIPTION
```
(4c48.444c): Access violation - code c0000005 (first chance)
First chance exceptions are reported before any exception handling.
This exception may be expected and handled.
*** WARNING: Unable to verify checksum for iocp_test.exe
iocp_test!grpc_event_engine::experimental::WinSocket::raw_socket+0xa:
00007ff6`e6f3a0fa 488b00          mov     rax,qword ptr [rax] ds:feeefeee`feeefeee=????????????????
0:000> k
 # Child-SP          RetAddr               Call Site
00 00000096`65afe508 00007ff6`e6f39b17     iocp_test!grpc_event_engine::experimental::WinSocket::raw_socket+0xa [C:\bazel6\execroot\com_github_grpc_grpc\src\core\lib\event_engine\windows\win_socket.cc @ 52] 
01 00000096`65afe510 00007ff6`e6f3afa5     iocp_test!grpc_event_engine::experimental::WinSocket::OpState::GetOverlappedResult+0x17 [C:\bazel6\execroot\com_github_grpc_grpc\src\core\lib\event_engine\windows\win_socket.cc @ 138] 
02 00000096`65afe540 00007ff6`e68287a2     iocp_test!grpc_event_engine::experimental::IOCP::Work+0x305 [C:\bazel6\execroot\com_github_grpc_grpc\src\core\lib\event_engine\windows\iocp.cc @ 105] 
03 00000096`65afe660 00007ff6`e71fe3cc     iocp_test!IOCPTest_SocketShutdownWhenPendingOperation_Test::TestBody+0x542 [C:\bazel6\execroot\com_github_grpc_grpc\test\core\event_engine\windows\iocp_test.cc @ 180] 
04 00000096`65aff210 00007ff6`e71fe169     iocp_test!testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test,void>+0x1c [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 2639] 
05 00000096`65aff270 00007ff6`e71e59ba     iocp_test!testing::internal::HandleExceptionsInMethodIfSupported<testing::Test,void>+0x59 [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 2690] 
06 00000096`65aff320 00007ff6`e71e6453     iocp_test!testing::Test::Run+0xaa [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 2736] 
07 00000096`65aff370 00007ff6`e71e6c52     iocp_test!testing::TestInfo::Run+0x113 [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 2911] 
08 00000096`65aff3d0 00007ff6`e71ec98c     iocp_test!testing::TestSuite::Run+0x142 [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 3069] 
09 00000096`65aff440 00007ff6`e71fe54c     iocp_test!testing::internal::UnitTestImpl::RunAllTests+0x41c [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 5938] 
0a 00000096`65aff550 00007ff6`e71fe359     iocp_test!testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl,bool>+0x1c [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 2639] 
0b 00000096`65aff5b0 00007ff6`e71e73e1     iocp_test!testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl,bool>+0x59 [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 2690] 
0c 00000096`65aff670 00007ff6`e68370c1     iocp_test!testing::UnitTest::Run+0x131 [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\src\gtest.cc @ 5506] 
0d 00000096`65aff6f0 00007ff6`e682c426     iocp_test!RUN_ALL_TESTS+0x11 [C:\bazel6\execroot\com_github_grpc_grpc\external\com_google_googletest\googletest\include\gtest\gtest.h @ 2312] 
0e 00000096`65aff720 00007ff6`e7235679     iocp_test!main+0x26 [C:\bazel6\execroot\com_github_grpc_grpc\test\core\event_engine\windows\iocp_test.cc @ 419] 
0f 00000096`65aff760 00007ff6`e72355ce     iocp_test!invoke_main+0x39 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 79] 
10 00000096`65aff7b0 00007ff6`e723548e     iocp_test!__scrt_common_main_seh+0x12e [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 288] 
11 00000096`65aff820 00007ff6`e72356ee     iocp_test!__scrt_common_main+0xe [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl @ 331] 
12 00000096`65aff850 00007ffa`ea2a7344     iocp_test!mainCRTStartup+0xe [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp @ 17] 
13 00000096`65aff880 00007ffa`ebd226b1     KERNEL32!BaseThreadInitThunk+0x14
14 00000096`65aff8b0 00000000`00000000     ntdll!RtlUserThreadStart+0x21
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

