### PR TITLE
[PSM Interop] Rename GAMMA tests to CSM tests

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_install_test_driver.sh
@@ -50,6 +50,10 @@ activate_gke_cluster() {
       GKE_CLUSTER_NAME="psm-interop-security"
       GKE_CLUSTER_ZONE="us-central1-a"
       ;;
+    GKE_CLUSTER_PSM_CSM)
+      GKE_CLUSTER_NAME="psm-interop-csm"
+      GKE_CLUSTER_ZONE="us-east7-c"
+      ;;
     GKE_CLUSTER_PSM_GAMMA)
       GKE_CLUSTER_NAME="psm-interop-gamma"
       GKE_CLUSTER_ZONE="us-central1-a"

--- a/tools/internal_ci/linux/psm-csm.cfg
+++ b/tools/internal_ci/linux/psm-csm.cfg
@@ -15,7 +15,6 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-# TODO(sergiitk): delete when the job is renamed
 build_file: "grpc/tools/internal_ci/linux/psm-csm.sh"
 timeout_mins: 60
 action {

--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -160,7 +160,8 @@ main() {
   local failed_tests=0
   test_suites=(
     "gamma.gamma_baseline_test"
-    # "gamma.session_affinity_test"
+    "gamma.affinity_test"
+    "app_net_ssa_test"
   )
   for test in "${test_suites[@]}"; do
     run_test $test || (( ++failed_tests ))

--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -106,7 +106,7 @@ run_test() {
   set -x
   python3 -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
-    --flagfile="config/gamma.cfg" \
+    --flagfile="config/csm.cfg" \
     --kube_context="${KUBE_CONTEXT}" \
     --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \
@@ -146,7 +146,7 @@ main() {
   echo "Sourcing test driver install script from: ${TEST_DRIVER_INSTALL_SCRIPT_URL}"
   source /dev/stdin <<< "$(curl -s "${TEST_DRIVER_INSTALL_SCRIPT_URL}")"
 
-  activate_gke_cluster GKE_CLUSTER_PSM_GAMMA
+  activate_gke_cluster GKE_CLUSTER_PSM_CSM
 
   set -x
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then

--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -106,7 +106,7 @@ run_test() {
   set -x
   python3 -m "tests.${test_name}" \
     --flagfile="${TEST_DRIVER_FLAGFILE}" \
-    --flagfile="config/csm.cfg" \
+    --flagfile="config/common-csm.cfg" \
     --kube_context="${KUBE_CONTEXT}" \
     --server_image="${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
     --client_image="${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" \

--- a/tools/run_tests/xds_k8s_test_driver/config/common-csm.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common-csm.cfg
@@ -1,2 +1,3 @@
 # Common config file for PSM CSM tests.
 --resource_prefix=psm-csm
+--noenable_workload_identity

--- a/tools/run_tests/xds_k8s_test_driver/config/csm.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/csm.cfg
@@ -1,0 +1,2 @@
+# Common config file for PSM CSM tests.
+--resource_prefix=psm-csm

--- a/tools/run_tests/xds_k8s_test_driver/config/gamma.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/gamma.cfg
@@ -1,3 +1,4 @@
 # Common config file for GAMMA PSM tests.
 # TODO(sergiitk): delete when confirmed it's not used
 --resource_prefix=psm-gamma
+--noenable_workload_identity

--- a/tools/run_tests/xds_k8s_test_driver/config/gamma.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/gamma.cfg
@@ -1,2 +1,3 @@
 # Common config file for GAMMA PSM tests.
+# TODO(sergiitk): delete when confirmed it's not used
 --resource_prefix=psm-gamma


### PR DESCRIPTION
Notes:
- GAMMA tests are now a subset of a wider CSM scope
- Some "gamma" files to ensure graceful renames
- Should be safe to merge as is