### PR TITLE
[CSM] Remove enable/disable metrics API

### DIFF
--- a/include/grpcpp/ext/csm_observability.h
+++ b/include/grpcpp/ext/csm_observability.h
@@ -57,7 +57,8 @@ class CsmObservabilityBuilder {
   //
   // The most common way to use this API is -
   //
-  // CsmObservabilityBuilder().SetMeterProvider(provider).BuildAndRegister();
+  // auto observability =
+  //    CsmObservabilityBuilder().SetMeterProvider(provider).BuildAndRegister();
   //
   // The set of instruments available are -
   // grpc.client.attempt.started

--- a/include/grpcpp/ext/csm_observability.h
+++ b/include/grpcpp/ext/csm_observability.h
@@ -37,24 +37,13 @@ namespace experimental {
 // for performing cleanup.
 class CsmObservability {};
 
+// CsmObservabilityBuilder configures observability for all service mesh traffic
+// for a binary running on CSM.
 class CsmObservabilityBuilder {
  public:
   CsmObservabilityBuilder& SetMeterProvider(
       std::shared_ptr<opentelemetry::sdk::metrics::MeterProvider>
           meter_provider);
-  // Methods to manipulate which instruments are enabled in the OTel Stats
-  // Plugin. The default set of instruments are -
-  // grpc.client.attempt.started
-  // grpc.client.attempt.duration
-  // grpc.client.attempt.sent_total_compressed_message_size
-  // grpc.client.attempt.rcvd_total_compressed_message_size
-  // grpc.server.call.started
-  // grpc.server.call.duration
-  // grpc.server.call.sent_total_compressed_message_size
-  // grpc.server.call.rcvd_total_compressed_message_size
-  CsmObservabilityBuilder& EnableMetric(absl::string_view metric_name);
-  CsmObservabilityBuilder& DisableMetric(absl::string_view metric_name);
-  CsmObservabilityBuilder& DisableAllMetrics();
   // If set, \a target_attribute_filter is called per channel to decide whether
   // to record the target attribute on client or to replace it with "other".
   // This helps reduce the cardinality on metrics in cases where many channels
@@ -65,6 +54,20 @@ class CsmObservabilityBuilder {
           target_attribute_filter);
   // Builds the CsmObservability plugin. The return status shows whether
   // CsmObservability was successfully enabled or not.
+  //
+  // The most common way to use this API is -
+  //
+  // CsmObservabilityBuilder().SetMeterProvider(provider).BuildAndRegister();
+  //
+  // The set of instruments available are -
+  // grpc.client.attempt.started
+  // grpc.client.attempt.duration
+  // grpc.client.attempt.sent_total_compressed_message_size
+  // grpc.client.attempt.rcvd_total_compressed_message_size
+  // grpc.server.call.started
+  // grpc.server.call.duration
+  // grpc.server.call.sent_total_compressed_message_size
+  // grpc.server.call.rcvd_total_compressed_message_size
   absl::StatusOr<CsmObservability> BuildAndRegister();
 
  private:

--- a/src/cpp/ext/csm/csm_observability.cc
+++ b/src/cpp/ext/csm/csm_observability.cc
@@ -55,23 +55,6 @@ CsmObservabilityBuilder& CsmObservabilityBuilder::SetMeterProvider(
   return *this;
 }
 
-CsmObservabilityBuilder& CsmObservabilityBuilder::EnableMetric(
-    absl::string_view metric_name) {
-  builder_.EnableMetric(metric_name);
-  return *this;
-}
-
-CsmObservabilityBuilder& CsmObservabilityBuilder::DisableMetric(
-    absl::string_view metric_name) {
-  builder_.DisableMetric(metric_name);
-  return *this;
-}
-
-CsmObservabilityBuilder& CsmObservabilityBuilder::DisableAllMetrics() {
-  builder_.DisableAllMetrics();
-  return *this;
-}
-
 CsmObservabilityBuilder& CsmObservabilityBuilder::SetTargetAttributeFilter(
     absl::AnyInvocable<bool(absl::string_view /*target*/) const>
         target_attribute_filter) {


### PR DESCRIPTION
There's an ongoing discussion on whether we should have API to disable default metrics. Removing this API till we have a decision on that.

I'm keeping the internal API  for enabling/disabling metrics on the OTel plugin for now, just not exposing it publicly.

