### PR TITLE
[PSM Interop] update td bootstrap generator image for prod test

### DIFF
--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -336,6 +336,7 @@ def maybe_apply_patches_on_git_tag(stack_base, lang, release):
 def checkout_grpc_stack(lang, release):
     """Invokes 'git check' for the lang/release and returns directory created."""
     assert args.git_checkout and args.git_checkout_root
+
     if not os.path.exists(args.git_checkout_root):
         os.makedirs(args.git_checkout_root)
 

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -336,7 +336,7 @@ def maybe_apply_patches_on_git_tag(stack_base, lang, release):
 def checkout_grpc_stack(lang, release):
     """Invokes 'git check' for the lang/release and returns directory created."""
     assert args.git_checkout and args.git_checkout_root
-
+    print(args.git_checkout_root)
     if not os.path.exists(args.git_checkout_root):
         os.makedirs(args.git_checkout_root)
 

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -336,7 +336,6 @@ def maybe_apply_patches_on_git_tag(stack_base, lang, release):
 def checkout_grpc_stack(lang, release):
     """Invokes 'git check' for the lang/release and returns directory created."""
     assert args.git_checkout and args.git_checkout_root
-    print(args.git_checkout_root)
     if not os.path.exists(args.git_checkout_root):
         os.makedirs(args.git_checkout_root)
 

--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,6 +1,4 @@
 --resource_prefix=psm-interop
-
-# https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.15.0
 --td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:7d8d90477792e2e1bfe3a3da20b3dc9ef01d326c
 
 # The canonical implementation of the xDS test server.

--- a/tools/run_tests/xds_k8s_test_driver/config/common.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common.cfg
@@ -1,5 +1,7 @@
 --resource_prefix=psm-interop
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:d47f36f78aef8fe9d67303be1aba480f2fe9a77c
+
+# https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.15.0
+--td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:7d8d90477792e2e1bfe3a3da20b3dc9ef01d326c
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,


### PR DESCRIPTION
This change is to update the TD bootstrap generator for prod tests. This is part of the TD release process. The new image has already been merged to staging and tested locally in google3.

cc: @sergiitk PTAL.
