### PR TITLE
fix examples/cpp/keepalive/CMakeLists.txt  Parse error

### DIFF
--- a/examples/cpp/keepalive/CMakeLists.txt
+++ b/examples/cpp/keepalive/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(hw_grpc_proto
 
 # Targets greeter_[async_](client|server)
 foreach(_target
-  greeter_callback_client greeter_callback_server
+  greeter_callback_client greeter_callback_server)
   add_executable(${_target} "${_target}.cc")
   target_link_libraries(${_target}
     hw_grpc_proto


### PR DESCRIPTION
The lack of  ')' in the CMakeLists.txt file leads to parsing failure




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

