### PR TITLE
[bazelified tests] First attempt at bazelified rules for building artifacts/packages

### DIFF
--- a/tools/bazelify_tests/BUILD
+++ b/tools/bazelify_tests/BUILD
@@ -26,6 +26,7 @@ exports_files([
     "grpc_run_tests_harness_test.sh",
     "grpc_run_bazel_distribtest_test.sh",
     "grpc_run_cpp_distribtest_test.sh",
+    "grpc_run_distribtest_test.sh",
     "grpc_run_simple_command_test.sh",
     "grpc_build_artifact_task.sh",
     "grpc_build_artifact_task_build_test.sh",

--- a/tools/bazelify_tests/BUILD
+++ b/tools/bazelify_tests/BUILD
@@ -27,6 +27,8 @@ exports_files([
     "grpc_run_bazel_distribtest_test.sh",
     "grpc_run_cpp_distribtest_test.sh",
     "grpc_run_simple_command_test.sh",
+    "grpc_build_artifact_task.sh",
+    "grpc_build_artifact_task_build_test.sh",
 ])
 
 genrule(

--- a/tools/bazelify_tests/grpc_build_artifact_task.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task.sh
@@ -27,6 +27,7 @@ tar -xopf ${ARCHIVE_WITH_SUBMODULES}
 cd grpc
 
 # Extract all input archives with artifacts into input_artifacts directory
+# TODO(jtattermusch): Deduplicate the snippet below (it appears in multiple files).
 mkdir -p input_artifacts
 pushd input_artifacts >/dev/null
 # all remaining args are .tar.gz archives with input artifacts

--- a/tools/bazelify_tests/grpc_build_artifact_task.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+ARCHIVE_WITH_SUBMODULES="$1"
+BUILD_SCRIPT="$2"
+EXIT_CODE_FILE="$3"
+SCRIPT_LOG_FILE="$4"
+ARTIFACTS_OUT_FILE="$5"
+shift 5
+
+# Extract grpc repo archive
+tar -xopf ${ARCHIVE_WITH_SUBMODULES}
+cd grpc
+
+mkdir -p artifacts
+
+# Run the build script with args, storing its stdout and stderr
+# in a log file.
+SCRIPT_EXIT_CODE=0
+../"${BUILD_SCRIPT}" "$@" >"../${SCRIPT_LOG_FILE}" 2>&1  || SCRIPT_EXIT_CODE="$?"
+
+# Store build script's exitcode in a file.
+# Note that the build atifacts task will terminate with success even when
+# there was an error building the artifacts.
+# The error status (an associated log) will be reported by an associated
+# bazel test.
+echo "${SCRIPT_EXIT_CODE}" >"../${EXIT_CODE_FILE}"
+
+# collect the artifacts
+# TODO(jtattermusch): add tar flags to create deterministic tar archive
+tar -czvf ../"${ARTIFACTS_OUT_FILE}" artifacts

--- a/tools/bazelify_tests/grpc_build_artifact_task.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task.sh
@@ -37,7 +37,11 @@ do
   # Note that input artifacts from different dependencies can have files
   # with the same name, so disambiguating through the name of the archive
   # is important.
-  tar --strip-components=1 --one-top-level -xopf ../../${input_artifact_archive}
+  archive_extract_dir="$(basename ${input_artifact_archive} .tar.gz)"
+  mkdir -p "${archive_extract_dir}"
+  pushd "${archive_extract_dir}" >/dev/null
+  tar --strip-components=1 -xopf ../../../${input_artifact_archive}
+  popd >/dev/null
 done
 popd >/dev/null
 

--- a/tools/bazelify_tests/grpc_build_artifact_task.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task.sh
@@ -26,12 +26,27 @@ shift 5
 tar -xopf ${ARCHIVE_WITH_SUBMODULES}
 cd grpc
 
+# Extract all input archives with artifacts into input_artifacts directory
+mkdir -p input_artifacts
+pushd input_artifacts >/dev/null
+# all remaining args are .tar.gz archives with input artifacts
+for input_artifact_archive in "$@"
+do
+  # extract the .tar.gz with artifacts into a directory named after a basename
+  # of the archive itself (and strip the "artifact/" prefix)
+  # Note that input artifacts from different dependencies can have files
+  # with the same name, so disambiguating through the name of the archive
+  # is important.
+  tar --strip-components=1 --one-top-level -xopf ../../${input_artifact_archive}
+done
+popd >/dev/null
+
 mkdir -p artifacts
 
 # Run the build script with args, storing its stdout and stderr
 # in a log file.
 SCRIPT_EXIT_CODE=0
-../"${BUILD_SCRIPT}" "$@" >"../${SCRIPT_LOG_FILE}" 2>&1  || SCRIPT_EXIT_CODE="$?"
+../"${BUILD_SCRIPT}" >"../${SCRIPT_LOG_FILE}" 2>&1  || SCRIPT_EXIT_CODE="$?"
 
 # Store build script's exitcode in a file.
 # Note that the build atifacts task will terminate with success even when

--- a/tools/bazelify_tests/grpc_build_artifact_task_build_test.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task_build_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+EXIT_CODE_FILE="$1"
+SCRIPT_LOG_FILE="$2"
+ARTIFACTS_ARCHIVE="$3"
+shift 3
+
+BUILD_ARTIFACT_EXITCODE="$(cat ${EXIT_CODE_FILE})"
+
+echo "Build artifact task for '${ARTIFACTS_ARCHIVE}' has finished with exitcode ${BUILD_ARTIFACT_EXITCODE}."
+
+echo "BUILD LOG"
+echo "--------------"
+cat "${SCRIPT_LOG_FILE}"
+echo "--------------"
+echo
+
+# Try extracting the archive with artifacts (and list the files)
+mkdir -p input_artifacts
+pushd input_artifacts >/dev/null
+echo "Artifacts that were built by the build artifact task:"
+echo "--------------"
+tar -xopvf ../${ARTIFACTS_ARCHIVE}
+echo "--------------"
+popd >/dev/null
+
+# TODO(jtattermusch): consider adding the contents of artifacts archive
+# to bazel "undeclared test outputs" directory to make them available in the resultstore UI
+# easily. See docs for TEST_UNDECLARED_OUTPUTS_DIR for details.
+
+if [ "${BUILD_ARTIFACT_EXITCODE}" -eq "0" ]
+then
+  echo "SUCCESS: Artifact build task for '${ARTIFACTS_ARCHIVE}' to build 'ran successfully."
+else
+  echo "FAIL: Artifact build task for '${ARTIFACTS_ARCHIVE}' failed with exitcode ${BUILD_ARTIFACT_EXITCODE}."
+  exit 1
+fi

--- a/tools/bazelify_tests/grpc_build_artifact_task_build_test.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task_build_test.sh
@@ -22,7 +22,7 @@ shift 3
 
 BUILD_ARTIFACT_EXITCODE="$(cat ${EXIT_CODE_FILE})"
 
-echo "Build artifact task for '${ARTIFACTS_ARCHIVE}' has finished with exitcode ${BUILD_ARTIFACT_EXITCODE}."
+echo "Build artifact/package task for '${ARTIFACTS_ARCHIVE}' has finished with exitcode ${BUILD_ARTIFACT_EXITCODE}."
 
 echo "BUILD LOG"
 echo "--------------"
@@ -35,18 +35,21 @@ mkdir -p input_artifacts
 pushd input_artifacts >/dev/null
 echo "Artifacts that were built by the build artifact task:"
 echo "--------------"
+# TODO(jtattermusch): strip top level artifacts/ directory from the archive?
 tar -xopvf ../${ARTIFACTS_ARCHIVE}
 echo "--------------"
 popd >/dev/null
 
-# TODO(jtattermusch): consider adding the contents of artifacts archive
-# to bazel "undeclared test outputs" directory to make them available in the resultstore UI
-# easily. See docs for TEST_UNDECLARED_OUTPUTS_DIR for details.
+# Add artifact archive to the "undeclared test outputs" directory
+# to make it readily available in the resultstore UI.
+# See bazel docs for TEST_UNDECLARED_OUTPUTS_DIR.
+mkdir -p "${TEST_UNDECLARED_OUTPUTS_DIR}"
+cp "${ARTIFACTS_ARCHIVE}" "${TEST_UNDECLARED_OUTPUTS_DIR}" || true
 
 if [ "${BUILD_ARTIFACT_EXITCODE}" -eq "0" ]
 then
-  echo "SUCCESS: Artifact build task for '${ARTIFACTS_ARCHIVE}' to build 'ran successfully."
+  echo "SUCCESS: Build artifact/package task for '${ARTIFACTS_ARCHIVE}' ran successfully."
 else
-  echo "FAIL: Artifact build task for '${ARTIFACTS_ARCHIVE}' failed with exitcode ${BUILD_ARTIFACT_EXITCODE}."
+  echo "FAIL: Build artifact/package task for '${ARTIFACTS_ARCHIVE}' failed with exitcode ${BUILD_ARTIFACT_EXITCODE}."
   exit 1
 fi

--- a/tools/bazelify_tests/grpc_build_artifact_task_build_test.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task_build_test.sh
@@ -33,7 +33,7 @@ echo
 # Try extracting the archive with artifacts (and list the files)
 mkdir -p input_artifacts
 pushd input_artifacts >/dev/null
-echo "Artifacts that were built by the build artifact task:"
+echo "Artifacts that were built by the build artifact/package task:"
 echo "--------------"
 # TODO(jtattermusch): strip top level artifacts/ directory from the archive?
 tar -xopvf ../${ARTIFACTS_ARCHIVE}

--- a/tools/bazelify_tests/grpc_run_distribtest_test.sh
+++ b/tools/bazelify_tests/grpc_run_distribtest_test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+ARCHIVE_WITH_SUBMODULES="$1"
+BUILD_SCRIPT="$2"
+shift 2
+
+# Extract grpc repo archive
+tar -xopf ${ARCHIVE_WITH_SUBMODULES}
+cd grpc
+
+# Extract all input archives with artifacts into input_artifacts directory
+mkdir -p input_artifacts
+pushd input_artifacts >/dev/null
+# all remaining args are .tar.gz archives with input artifacts
+for input_artifact_archive in "$@"
+do
+  # extract the .tar.gz with artifacts into a directory named after a basename
+  # of the archive itself (and strip the "artifact/" prefix)
+  # Note that input artifacts from different dependencies can have files
+  # with the same name, so disambiguating through the name of the archive
+  # is important.
+  tar --strip-components=1 --one-top-level -xopf ../../${input_artifact_archive}
+done
+popd >/dev/null
+
+ls -lR input_artifacts
+
+# Run build script passed as arg.
+"${BUILD_SCRIPT}"

--- a/tools/bazelify_tests/grpc_run_distribtest_test.sh
+++ b/tools/bazelify_tests/grpc_run_distribtest_test.sh
@@ -34,7 +34,11 @@ do
   # Note that input artifacts from different dependencies can have files
   # with the same name, so disambiguating through the name of the archive
   # is important.
-  tar --strip-components=1 --one-top-level -xopf ../../${input_artifact_archive}
+  archive_extract_dir="$(basename ${input_artifact_archive} .tar.gz)"
+  mkdir -p "${archive_extract_dir}"
+  pushd "${archive_extract_dir}" >/dev/null
+  tar --strip-components=1 -xopf ../../../${input_artifact_archive}
+  popd >/dev/null
 done
 popd >/dev/null
 

--- a/tools/bazelify_tests/grpc_run_distribtest_test.sh
+++ b/tools/bazelify_tests/grpc_run_distribtest_test.sh
@@ -24,6 +24,7 @@ tar -xopf ${ARCHIVE_WITH_SUBMODULES}
 cd grpc
 
 # Extract all input archives with artifacts into input_artifacts directory
+# TODO(jtattermusch): Deduplicate the snippet below (it appears in multiple files).
 mkdir -p input_artifacts
 pushd input_artifacts >/dev/null
 # all remaining args are .tar.gz archives with input artifacts

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_package")
-load("//tools/bazelify_tests:build_defs.bzl", "grpc_run_cpp_distribtest_test", "grpc_run_simple_command_test", "grpc_run_tests_harness_test")
+load("//tools/bazelify_tests:build_defs.bzl", "grpc_build_artifact_task", "grpc_run_cpp_distribtest_test", "grpc_run_simple_command_test", "grpc_run_tests_harness_test")
 load(":portability_tests.bzl", "generate_run_tests_portability_tests")
 load(":bazel_distribtests.bzl", "generate_bazel_distribtests")
 
@@ -243,9 +243,50 @@ test_suite(
     ],
 )
 
+# protoc artifact build tasks
+grpc_build_artifact_task(
+    name = "artifact_protoc_linux_x64",
+    build_script = "build_artifact_protoc_linux.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_centos6_x64.current_version",
+)
+
+grpc_build_artifact_task(
+    name = "artifact_protoc_linux_x86",
+    build_script = "build_artifact_protoc_linux.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_centos6_x86.current_version",
+)
+
+grpc_build_artifact_task(
+    name = "artifact_protoc_linux_aarch64",
+    build_script = "build_artifact_protoc_linux.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_protoc_aarch64.current_version",
+)
+
+# PHP artifact build tasks
+
+grpc_build_artifact_task(
+    name = "artifact_php_linux_x64",
+    build_script = "build_artifact_php_linux.sh",
+    docker_image_version = "tools/dockerfile/test/php73_zts_debian11_x64.current_version",
+)
+
+# TODO(jtattermusch): add grpc_build_artifact_task targets for python artifacts (but they would require ability to set env)
+# TODO(jtattermusch): add grpc_build_artifact_task targets for ruby artifacts (which is tricky, since ruby artifact builds do not run under docker since they invoke docker themselves)
+
+test_suite(
+    name = "artifact_build_tests_linux",
+    tests = [
+        ":artifact_protoc_linux_aarch64_build_test",
+        ":artifact_protoc_linux_x64_build_test",
+        ":artifact_protoc_linux_x86_build_test",
+        ":artifact_php_linux_x64_build_test",
+    ],
+)
+
 test_suite(
     name = "all_tests_linux",
     tests = [
+        ":artifact_build_tests_linux",
         ":basic_tests_linux",
         ":bazel_build_tests_linux",
         ":bazel_distribtests_linux",

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -278,6 +278,12 @@ grpc_build_artifact_task(
     docker_image_version = "tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version",
 )
 
+grpc_build_artifact_task(
+    name = "artifact_python_linux_x64_manylinux2014_cp37",
+    build_script = "build_artifact_python_linux_x64_cp37.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version",
+)
+
 # TODO(jtattermusch): add more grpc_build_artifact_task targets for existing python artifacts from artifact_targets.py
 
 grpc_build_artifact_task(
@@ -285,6 +291,7 @@ grpc_build_artifact_task(
     # TODO(jtattermusch): add more python artifacts once they are migrated from artifact_targets.py
     artifact_deps = [
         "artifact_python_linux_x64_manylinux2014_cp311",
+        "artifact_python_linux_x64_manylinux2014_cp37",
     ],
     build_script = "build_package_python_linux.sh",
     docker_image_version = "tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version",
@@ -397,67 +404,21 @@ grpc_run_distribtest_test(
     docker_image_version = "tools/dockerfile/distribtest/python_buster_x64.current_version",
 )
 
-
-test_suite(
-    name = "python_distribtests_linux",
-    tests = [
-        ":distribtest_python_linux_x64_buster",
-    ],
-)
-
-#PythonDistribTest("linux", "x64", "buster", presubmit=True),
-#PythonDistribTest("linux", "x86", "buster", presubmit=True),
-#PythonDistribTest("linux", "x64", "fedora36"),
-#PythonDistribTest("linux", "x64", "arch"),
-#PythonDistribTest("linux", "x64", "alpine"),
-#PythonDistribTest("linux", "x64", "ubuntu2204"),
-#PythonDistribTest(
-#    "linux", "aarch64", "python38_buster", presubmit=True
-#),
-#PythonDistribTest(
-#    "linux", "x64", "alpine3.7", source=True, presubmit=True
-#),
-#PythonDistribTest(
-#    "linux", "x64", "buster", source=True, presubmit=True
-#),
-#PythonDistribTest(
-#    "linux", "x86", "buster", source=True, presubmit=True
-#),
-#PythonDistribTest("linux", "x64", "fedora36", source=True),
-#PythonDistribTest("linux", "x64", "arch", source=True),
-#PythonDistribTest("linux", "x64", "ubuntu2204", source=True),
-
-# source vs binary
-# if self.source:
-#return create_docker_jobspec(
-#    self.name,
-#    "tools/dockerfile/distribtest/python_dev_%s_%s"
-#    % (self.docker_suffix, self.arch),
-#    "test/distrib/python/run_source_distrib_test.sh",
-#    copy_rel_path="test/distrib",
-#    timeout_seconds=45 * 60,
-#)
-#else:
-#return create_docker_jobspec(
-#    self.name,
-#    "tools/dockerfile/distribtest/python_%s_%s"
-#    % (self.docker_suffix, self.arch),
-#    "test/distrib/python/run_binary_distrib_test.sh",
-#    copy_rel_path="test/distrib",
-#    timeout_seconds=45 * 60,
+# TODO(jtattermusch): add more grpc_run_distribtest_test targets for existing python distribtests from distribtest_targets.py
+# Note that there a two flavors of python distribtests - "binary" (which uses pre-built wheels) and "source" (which compiles python extension for sources)
 
 # TODO(jtattermusch): add grpc_build_artifact_task targets for ruby artifacts (which is tricky, since ruby artifact builds do not run under docker since they invoke docker themselves)
 
 test_suite(
     name = "artifact_build_tests_linux",
     tests = [
+        ":ackage_python_linux_build_test",
         ":artifact_php_linux_x64_build_test",
         ":artifact_protoc_linux_aarch64_build_test",
         ":artifact_protoc_linux_x64_build_test",
         ":artifact_protoc_linux_x86_build_test",
         ":artifact_python_linux_x64_manylinux2014_cp311_build_test",
         ":package_csharp_linux_build_test",
-        ":ackage_python_linux_build_test",
     ],
 )
 
@@ -471,7 +432,7 @@ test_suite(
         ":cpp_distribtests_linux",
         ":csharp_distribtests_linux",
         ":php_distribtests_linux",
-        ":python_distribtests_linux",
         ":portability_tests_linux",
+        ":python_distribtests_linux",
     ],
 )

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -285,10 +285,10 @@ grpc_build_artifact_task(
 test_suite(
     name = "artifact_build_tests_linux",
     tests = [
+        ":artifact_php_linux_x64_build_test",
         ":artifact_protoc_linux_aarch64_build_test",
         ":artifact_protoc_linux_x64_build_test",
         ":artifact_protoc_linux_x86_build_test",
-        ":artifact_php_linux_x64_build_test",
         ":artifact_python_linux_x64_manylinux2014_cp311_build_test",
     ],
 )

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -280,6 +280,20 @@ grpc_build_artifact_task(
 
 # TODO(jtattermusch): add more grpc_build_artifact_task targets for existing python artifacts from artifact_targets.py
 
+# C# package build tasks
+
+grpc_build_artifact_task(
+    name = "package_csharp_linux",
+    # csharp package needs pre-built protoc and protoc plugin binaries
+    artifact_deps = [
+        "artifact_protoc_linux_x64",
+        "artifact_protoc_linux_x86",
+        "artifact_protoc_linux_aarch64",
+    ],
+    build_script = "build_package_csharp_linux.sh",
+    docker_image_version = "tools/dockerfile/test/csharp_debian11_x64.current_version",
+)
+
 # TODO(jtattermusch): add grpc_build_artifact_task targets for ruby artifacts (which is tricky, since ruby artifact builds do not run under docker since they invoke docker themselves)
 
 test_suite(
@@ -290,6 +304,7 @@ test_suite(
         ":artifact_protoc_linux_x64_build_test",
         ":artifact_protoc_linux_x86_build_test",
         ":artifact_python_linux_x64_manylinux2014_cp311_build_test",
+        ":package_csharp_linux_build_test",
     ],
 )
 

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -280,6 +280,16 @@ grpc_build_artifact_task(
 
 # TODO(jtattermusch): add more grpc_build_artifact_task targets for existing python artifacts from artifact_targets.py
 
+grpc_build_artifact_task(
+    name = "package_python_linux",
+    # TODO(jtattermusch): add more python artifacts once they are migrated from artifact_targets.py
+    artifact_deps = [
+        "artifact_python_linux_x64_manylinux2014_cp311",
+    ],
+    build_script = "build_package_python_linux.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version",
+)
+
 # C# package build tasks
 
 grpc_build_artifact_task(
@@ -376,6 +386,66 @@ test_suite(
     ],
 )
 
+# Python distribtests
+
+grpc_run_distribtest_test(
+    name = "distribtest_python_linux_x64_buster",
+    artifact_deps = [
+        "package_python_linux",
+    ],
+    build_script = "run_distribtest_python_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/python_buster_x64.current_version",
+)
+
+
+test_suite(
+    name = "python_distribtests_linux",
+    tests = [
+        ":distribtest_python_linux_x64_buster",
+    ],
+)
+
+#PythonDistribTest("linux", "x64", "buster", presubmit=True),
+#PythonDistribTest("linux", "x86", "buster", presubmit=True),
+#PythonDistribTest("linux", "x64", "fedora36"),
+#PythonDistribTest("linux", "x64", "arch"),
+#PythonDistribTest("linux", "x64", "alpine"),
+#PythonDistribTest("linux", "x64", "ubuntu2204"),
+#PythonDistribTest(
+#    "linux", "aarch64", "python38_buster", presubmit=True
+#),
+#PythonDistribTest(
+#    "linux", "x64", "alpine3.7", source=True, presubmit=True
+#),
+#PythonDistribTest(
+#    "linux", "x64", "buster", source=True, presubmit=True
+#),
+#PythonDistribTest(
+#    "linux", "x86", "buster", source=True, presubmit=True
+#),
+#PythonDistribTest("linux", "x64", "fedora36", source=True),
+#PythonDistribTest("linux", "x64", "arch", source=True),
+#PythonDistribTest("linux", "x64", "ubuntu2204", source=True),
+
+# source vs binary
+# if self.source:
+#return create_docker_jobspec(
+#    self.name,
+#    "tools/dockerfile/distribtest/python_dev_%s_%s"
+#    % (self.docker_suffix, self.arch),
+#    "test/distrib/python/run_source_distrib_test.sh",
+#    copy_rel_path="test/distrib",
+#    timeout_seconds=45 * 60,
+#)
+#else:
+#return create_docker_jobspec(
+#    self.name,
+#    "tools/dockerfile/distribtest/python_%s_%s"
+#    % (self.docker_suffix, self.arch),
+#    "test/distrib/python/run_binary_distrib_test.sh",
+#    copy_rel_path="test/distrib",
+#    timeout_seconds=45 * 60,
+
 # TODO(jtattermusch): add grpc_build_artifact_task targets for ruby artifacts (which is tricky, since ruby artifact builds do not run under docker since they invoke docker themselves)
 
 test_suite(
@@ -387,6 +457,7 @@ test_suite(
         ":artifact_protoc_linux_x86_build_test",
         ":artifact_python_linux_x64_manylinux2014_cp311_build_test",
         ":package_csharp_linux_build_test",
+        ":ackage_python_linux_build_test",
     ],
 )
 
@@ -400,6 +471,7 @@ test_suite(
         ":cpp_distribtests_linux",
         ":csharp_distribtests_linux",
         ":php_distribtests_linux",
+        ":python_distribtests_linux",
         ":portability_tests_linux",
     ],
 )

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -404,6 +404,13 @@ grpc_run_distribtest_test(
     docker_image_version = "tools/dockerfile/distribtest/python_buster_x64.current_version",
 )
 
+test_suite(
+    name = "python_distribtests_linux",
+    tests = [
+        ":distribtest_python_linux_x64_buster",
+    ],
+)
+
 # TODO(jtattermusch): add more grpc_run_distribtest_test targets for existing python distribtests from distribtest_targets.py
 # Note that there a two flavors of python distribtests - "binary" (which uses pre-built wheels) and "source" (which compiles python extension for sources)
 
@@ -412,13 +419,14 @@ grpc_run_distribtest_test(
 test_suite(
     name = "artifact_build_tests_linux",
     tests = [
-        ":ackage_python_linux_build_test",
         ":artifact_php_linux_x64_build_test",
         ":artifact_protoc_linux_aarch64_build_test",
         ":artifact_protoc_linux_x64_build_test",
         ":artifact_protoc_linux_x86_build_test",
         ":artifact_python_linux_x64_manylinux2014_cp311_build_test",
+        ":artifact_python_linux_x64_manylinux2014_cp37_build_test",
         ":package_csharp_linux_build_test",
+        ":package_python_linux_build_test",
     ],
 )
 

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_package")
-load("//tools/bazelify_tests:build_defs.bzl", "grpc_build_artifact_task", "grpc_run_cpp_distribtest_test", "grpc_run_simple_command_test", "grpc_run_tests_harness_test")
+load("//tools/bazelify_tests:build_defs.bzl", "grpc_build_artifact_task", "grpc_run_cpp_distribtest_test", "grpc_run_distribtest_test", "grpc_run_simple_command_test", "grpc_run_tests_harness_test")
 load(":portability_tests.bzl", "generate_run_tests_portability_tests")
 load(":bazel_distribtests.bzl", "generate_bazel_distribtests")
 
@@ -294,6 +294,88 @@ grpc_build_artifact_task(
     docker_image_version = "tools/dockerfile/test/csharp_debian11_x64.current_version",
 )
 
+# C# distribtests
+
+grpc_run_distribtest_test(
+    name = "distribtest_csharp_linux_x64_debian10",
+    # depend on the C# packages
+    artifact_deps = [
+        "package_csharp_linux",
+    ],
+    build_script = "run_distribtest_csharp_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/csharp_debian10_x64.current_version",
+)
+
+grpc_run_distribtest_test(
+    name = "distribtest_csharp_linux_x64_ubuntu2204",
+    # depend on the C# packages
+    artifact_deps = [
+        "package_csharp_linux",
+    ],
+    build_script = "run_distribtest_csharp_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/csharp_ubuntu2204_x64.current_version",
+)
+
+grpc_run_distribtest_test(
+    name = "distribtest_csharp_linux_x64_alpine",
+    # depend on the C# packages
+    artifact_deps = [
+        "package_csharp_linux",
+    ],
+    build_script = "run_distribtest_csharp_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/csharp_alpine_x64.current_version",
+)
+
+grpc_run_distribtest_test(
+    name = "distribtest_csharp_linux_x64_dotnet31",
+    # depend on the C# packages
+    artifact_deps = [
+        "package_csharp_linux",
+    ],
+    build_script = "run_distribtest_csharp_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/csharp_dotnet31_x64.current_version",
+)
+
+grpc_run_distribtest_test(
+    name = "distribtest_csharp_linux_x64_dotnet5",
+    # depend on the C# packages
+    artifact_deps = [
+        "package_csharp_linux",
+    ],
+    build_script = "run_distribtest_csharp_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/csharp_dotnet5_x64.current_version",
+)
+
+test_suite(
+    name = "csharp_distribtests_linux",
+    tests = [
+        ":distribtest_csharp_linux_x64_alpine",
+        ":distribtest_csharp_linux_x64_debian10",
+        ":distribtest_csharp_linux_x64_dotnet31",
+        ":distribtest_csharp_linux_x64_dotnet5",
+        ":distribtest_csharp_linux_x64_ubuntu2204",
+    ],
+)
+
+# PHP distribtests
+
+grpc_run_distribtest_test(
+    name = "distribtest_php_linux_x64_debian10",
+    artifact_deps = [
+        "artifact_php_linux_x64",
+    ],
+    build_script = "run_distribtest_php_linux.sh",
+    docker_image_version = "tools/dockerfile/distribtest/php7_debian10_x64.current_version",
+    docker_run_as_root = True,
+)
+
+test_suite(
+    name = "php_distribtests_linux",
+    tests = [
+        ":distribtest_php_linux_x64_debian10",
+    ],
+)
+
 # TODO(jtattermusch): add grpc_build_artifact_task targets for ruby artifacts (which is tricky, since ruby artifact builds do not run under docker since they invoke docker themselves)
 
 test_suite(
@@ -316,6 +398,8 @@ test_suite(
         ":bazel_build_tests_linux",
         ":bazel_distribtests_linux",
         ":cpp_distribtests_linux",
+        ":csharp_distribtests_linux",
+        ":php_distribtests_linux",
         ":portability_tests_linux",
     ],
 )

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -270,7 +270,16 @@ grpc_build_artifact_task(
     docker_image_version = "tools/dockerfile/test/php73_zts_debian11_x64.current_version",
 )
 
-# TODO(jtattermusch): add grpc_build_artifact_task targets for python artifacts (but they would require ability to set env)
+# Python artifact build tasks
+
+grpc_build_artifact_task(
+    name = "artifact_python_linux_x64_manylinux2014_cp311",
+    build_script = "build_artifact_python_linux_x64_cp311.sh",
+    docker_image_version = "tools/dockerfile/grpc_artifact_python_manylinux2014_x64.current_version",
+)
+
+# TODO(jtattermusch): add more grpc_build_artifact_task targets for existing python artifacts from artifact_targets.py
+
 # TODO(jtattermusch): add grpc_build_artifact_task targets for ruby artifacts (which is tricky, since ruby artifact builds do not run under docker since they invoke docker themselves)
 
 test_suite(
@@ -280,6 +289,7 @@ test_suite(
         ":artifact_protoc_linux_x64_build_test",
         ":artifact_protoc_linux_x86_build_test",
         ":artifact_php_linux_x64_build_test",
+        ":artifact_python_linux_x64_manylinux2014_cp311_build_test",
     ],
 )
 

--- a/tools/bazelify_tests/test/build_artifact_php_linux.sh
+++ b/tools/bazelify_tests/test/build_artifact_php_linux.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+mkdir -p artifacts
+
+ARTIFACTS_OUT=artifacts tools/run_tests/artifacts/build_artifact_php.sh

--- a/tools/bazelify_tests/test/build_artifact_protoc_linux.sh
+++ b/tools/bazelify_tests/test/build_artifact_protoc_linux.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# compile/link options extracted from ProtocArtifact in tools/run_tests/artifacts/artifact_targets.py
+export LDFLAGS="${LDFLAGS} -static-libgcc -static-libstdc++ -s"
+# set build parallelism to fit the machine configuration of bazelified tests RBE pool.
+export GRPC_PROTOC_BUILD_COMPILER_JOBS=8
+
+mkdir -p artifacts
+
+ARTIFACTS_OUT=artifacts tools/run_tests/artifacts/build_artifact_protoc.sh

--- a/tools/bazelify_tests/test/build_artifact_python_linux_x64_cp311.sh
+++ b/tools/bazelify_tests/test/build_artifact_python_linux_x64_cp311.sh
@@ -23,6 +23,11 @@ export GRPC_SKIP_PIP_CYTHON_UPGRADE=TRUE
 export GRPC_RUN_AUDITWHEEL_REPAIR=TRUE
 export GRPC_BUILD_GRPCIO_TOOLS_DEPENDENTS=TRUE
 
+# Without this python cannot find the c++ compiler
+# TODO(jtattermusch): find better solution to prevent bazel from
+# restricting path contents
+export PATH="/opt/rh/devtoolset-10/root/usr/bin:$PATH"
+
 # set build parallelism to fit the machine configuration of bazelified tests RBE pool.
 export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=8
 

--- a/tools/bazelify_tests/test/build_artifact_python_linux_x64_cp311.sh
+++ b/tools/bazelify_tests/test/build_artifact_python_linux_x64_cp311.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# env variable values extracted from PythonArtifact in tools/run_tests/artifacts/artifact_targets.py
+# TODO(jtattermusch): find a better way of configuring the python artifact build (the current approach mostly serves as a demonstration)
+export PYTHON=/opt/python/cp311-cp311/bin/python
+export PIP=/opt/python/cp311-cp311/bin/pip
+export GRPC_SKIP_PIP_CYTHON_UPGRADE=TRUE
+export GRPC_RUN_AUDITWHEEL_REPAIR=TRUE
+export GRPC_BUILD_GRPCIO_TOOLS_DEPENDENTS=TRUE
+
+# set build parallelism to fit the machine configuration of bazelified tests RBE pool.
+export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=8
+
+mkdir -p artifacts
+
+ARTIFACTS_OUT=artifacts tools/run_tests/artifacts/build_artifact_python.sh

--- a/tools/bazelify_tests/test/build_artifact_python_linux_x64_cp37.sh
+++ b/tools/bazelify_tests/test/build_artifact_python_linux_x64_cp37.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# env variable values extracted from PythonArtifact in tools/run_tests/artifacts/artifact_targets.py
+# TODO(jtattermusch): find a better way of configuring the python artifact build (the current approach mostly serves as a demonstration)
+export PYTHON=/opt/python/cp37-cp37m/bin/python
+export PIP=/opt/python/cp37-cp37m/bin/pip
+export GRPC_SKIP_PIP_CYTHON_UPGRADE=TRUE
+export GRPC_RUN_AUDITWHEEL_REPAIR=TRUE
+export GRPC_BUILD_GRPCIO_TOOLS_DEPENDENTS=TRUE
+
+# Without this python cannot find the c++ compiler
+# TODO(jtattermusch): find better solution to prevent bazel from
+# restricting path contents
+export PATH="/opt/rh/devtoolset-10/root/usr/bin:$PATH"
+
+# set build parallelism to fit the machine configuration of bazelified tests RBE pool.
+export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=8
+
+mkdir -p artifacts
+
+ARTIFACTS_OUT=artifacts tools/run_tests/artifacts/build_artifact_python.sh

--- a/tools/bazelify_tests/test/build_package_csharp_linux.sh
+++ b/tools/bazelify_tests/test/build_package_csharp_linux.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+mkdir -p artifacts
+
+# List all input artifacts we obtained for easier troubleshooting.
+ls -lR input_artifacts
+
+# Put the input artifacts where the legacy logic for building
+# C# package expects to find them.
+# See artifact_targets.py and package_targets.py for details.
+# TODO(jtattermusch): get rid of the manual renames of artifact directories.
+export EXTERNAL_GIT_ROOT="$(pwd)"
+mv input_artifacts/artifact_protoc_linux_aarch64 input_artifacts/protoc_linux_aarch64 || true
+mv input_artifacts/artifact_protoc_linux_x64 input_artifacts/protoc_linux_x64 || true
+mv input_artifacts/artifact_protoc_linux_x86 input_artifacts/protoc_linux_x86 || true
+
+# In the bazel workflow, we only have linux protoc artifact at hand,
+# so we can only build a "singleplatform" version of the C# package.
+export GRPC_CSHARP_BUILD_SINGLE_PLATFORM_NUGET=1
+
+# TODO(jtattermusch): when building the C# nugets, the current git commit SHA
+# is retrieved and stored as package metadata. But when running
+# as bazelified test, this is not possible since we're not in a git
+# workspace when running the build. This is ok for testing purposes
+# but would be a problem if building a production package
+# for the end users.
+
+src/csharp/build_nuget.sh

--- a/tools/bazelify_tests/test/build_package_python_linux.sh
+++ b/tools/bazelify_tests/test/build_package_python_linux.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+mkdir -p artifacts
+
+# List all input artifacts we obtained for easier troubleshooting.
+ls -lR input_artifacts
+
+# All the python packages have been built in the artifact phase already
+# and we only collect them here to deliver them to the distribtest phase.
+# This is the same logic as in "tools/run_tests/artifacts/build_package_python.sh",
+# but expects different layout under input_artifacts.
+cp -r input_artifacts/artifact_python_*/* artifacts/ || true

--- a/tools/bazelify_tests/test/run_distribtest_csharp_linux.sh
+++ b/tools/bazelify_tests/test/run_distribtest_csharp_linux.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# List all input artifacts we obtained for easier troubleshooting.
+ls -lR input_artifacts
+
+# Put the input packages where the legacy logic for running
+# C# distribtest expects to find them.
+# See distribtest_targets.py for details.
+# TODO(jtattermusch): get rid of the manual renames of artifact files.
+export EXTERNAL_GIT_ROOT="$(pwd)"
+mv input_artifacts/package_csharp_linux/* input_artifacts/ || true
+
+test/distrib/csharp/run_distrib_test_dotnetcli.sh

--- a/tools/bazelify_tests/test/run_distribtest_php_linux.sh
+++ b/tools/bazelify_tests/test/run_distribtest_php_linux.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# List all input artifacts we obtained for easier troubleshooting.
+ls -lR input_artifacts
+
+# Put the input packages where the legacy logic for running
+# PHP distribtest expects to find them.
+# See distribtest_targets.py for details.
+# TODO(jtattermusch): get rid of the manual renames of artifact files.
+export EXTERNAL_GIT_ROOT="$(pwd)"
+mv input_artifacts/artifact_php_linux_x64/* input_artifacts/ || true
+
+test/distrib/php/run_distrib_test.sh

--- a/tools/bazelify_tests/test/run_distribtest_python_linux.sh
+++ b/tools/bazelify_tests/test/run_distribtest_python_linux.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2023 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# List all input artifacts we obtained for easier troubleshooting.
+ls -lR input_artifacts
+
+# Put the input packages where the legacy logic for running
+# Python distribtest expects to find them.
+# See distribtest_targets.py for details.
+# TODO(jtattermusch): get rid of the manual renames of artifact files.
+export EXTERNAL_GIT_ROOT="$(pwd)"
+mv input_artifacts/package_python_linux/* input_artifacts/ || true
+
+test/distrib/python/run_binary_distrib_test.sh


### PR DESCRIPTION
Foundation for being able to bazelify the build artifact -> build package -> distribtest workflow tests.

Main ideas:
- "build artifact" and "build packages" will be represented by a custom genrule (that runs the build on RBE under a docker container).
- since genrule doesn't support displaying logs for each target as a separate "target log" (in the same way that bazel tests do), and we generally want readable per-target logs for the bazelified test, a pair of targets will be created for each "build artifact task":
      - a genrule that actually performs the build, creates an archive with artifacts and stores the exitcode and build log as rule outputs
      - a corresponding "build_test" sh_test that simply looks at the result of the genrule and presents the build log and build result a "target log" for this test.
 

