### PR TITLE
[promises] Re-enable CI for promise-based-client-call

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -23,6 +23,7 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "event_engine_listener",
+                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -41,6 +42,9 @@ EXPERIMENTS = {
                 "peer_state_based_framing",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
+            ],
+            "lame_client_test": [
+                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",
@@ -88,6 +92,7 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "event_engine_listener",
+                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -106,6 +111,9 @@ EXPERIMENTS = {
                 "peer_state_based_framing",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
+            ],
+            "lame_client_test": [
+                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",
@@ -157,6 +165,7 @@ EXPERIMENTS = {
             "core_end2end_test": [
                 "event_engine_client",
                 "event_engine_listener",
+                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -178,6 +187,9 @@ EXPERIMENTS = {
                 "peer_state_based_framing",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
+            ],
+            "lame_client_test": [
+                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -81,9 +81,7 @@
     (ie when all filters in a stack are promise based)
   expiry: 2023/11/01
   owner: ctiller@google.com
-  # TODO(ctiller): re-enable once we've got some more CI bandwidth
-  # test_tags: ["core_end2end_test", "lame_client_test"]
-  test_tags: []
+  test_tags: ["core_end2end_test", "lame_client_test"]
 - name: free_large_allocator
   description: If set, return all free bytes from a "big" allocator
   expiry: 2023/11/01


### PR DESCRIPTION
We disabled this a little while ago for lack of CI bandwidth, but #34404 ought to have freed up enough capacity that we can keep running this.