### PR TITLE
[PSM Interop] SSA: Remove failfast=True

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/tests/app_net_ssa_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/app_net_ssa_test.py
@@ -129,4 +129,4 @@ class AppNetSsaTest(xds_k8s_testcase.AppNetXdsKubernetesTestCase):
 
 
 if __name__ == "__main__":
-    absltest.main(failfast=True)
+    absltest.main()

--- a/tools/run_tests/xds_k8s_test_driver/tests/gamma/affinity_test.py
+++ b/tools/run_tests/xds_k8s_test_driver/tests/gamma/affinity_test.py
@@ -167,4 +167,4 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
 
 
 if __name__ == "__main__":
-    absltest.main(failfast=True)
+    absltest.main()


### PR DESCRIPTION
Was never needed in the first place.




