### PR TITLE
[python] fix empty rpc error

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -154,7 +154,7 @@ class _RPCState(object):
 
 
 def _raise_rpc_error(state: _RPCState) -> None:
-    rpc_error = grpc.RpcError()
+    rpc_error = grpc.RpcError(state.client)
     state.rpc_errors.append(rpc_error)
     raise rpc_error
 


### PR DESCRIPTION
Currently, the bidirectional stream exception show empty error.

```
def YourBidirectionalStreamingRPCMethod(self, request_iterator, context):
    try:
        for request in request_iterator:
            # Your logic to process the incoming request and generate responses
            response = your_response_generator(request)
            yield response
    except grpc.RpcError as rpc_error:
        print(f"Error: {rpc_error}")  # no error will be shown now, after the change, if cancelled, we will see `cancelled`
```
No error message in `grpc.RpcError()`
```
class RpcError(Exception):
    """Raised by the gRPC library to indicate non-OK-status RPC termination."""
```
```
def _raise_rpc_error(state: _RPCState) -> None:
    rpc_error = grpc.RpcError() # no error message here
    state.rpc_errors.append(rpc_error)
    raise rpc_error
```

