### PR TITLE
[EventEngine] Fix WinSocket/IOCP notification race

### DIFF
--- a/src/core/lib/event_engine/windows/win_socket.cc
+++ b/src/core/lib/event_engine/windows/win_socket.cc
@@ -100,7 +100,7 @@ void WinSocket::NotifyOnReady(OpState& info, EventEngine::Closure* closure) {
       // there is no notification callback yet, set the notification callback,
       // and return.
       EventEngine::Closure* prev = nullptr;
-      GPR_ASSERT(info.closure_.compare_exchange_strong(prev, closure));
+      GPR_ASSERT(std::exchange(info.closure_, closure) == nullptr);
       return;
     }
   }
@@ -129,7 +129,7 @@ void WinSocket::OpState::SetReady() {
   {
     grpc_core::MutexLock lock(&ready_mu_);
     GPR_ASSERT(!has_pending_iocp_);
-    closure = closure_.exchange(nullptr);
+    closure = std::exchange(closure_, nullptr);
     if (!closure) {
       has_pending_iocp_ = true;
     }

--- a/src/core/lib/event_engine/windows/win_socket.h
+++ b/src/core/lib/event_engine/windows/win_socket.h
@@ -67,10 +67,10 @@ class WinSocket {
 
     OVERLAPPED overlapped_;
     WinSocket* win_socket_ = nullptr;
-    std::atomic<EventEngine::Closure*> closure_{nullptr};
+    grpc_core::Mutex ready_mu_;
+    EventEngine::Closure* closure_ ABSL_GUARDED_BY(ready_mu_) = nullptr;
     bool has_pending_iocp_ = false;
     OverlappedResult result_;
-    grpc_core::Mutex ready_mu_;
   };
 
   WinSocket(SOCKET socket, ThreadPool* thread_pool) noexcept;

--- a/src/core/lib/event_engine/windows/win_socket.h
+++ b/src/core/lib/event_engine/windows/win_socket.h
@@ -80,9 +80,9 @@ class WinSocket {
   //    the callback now.
   //  - The IOCP hasn't completed yet, and we're queuing it for later.
   void NotifyOnRead(EventEngine::Closure* on_read)
-      ABSL_LOCKS_EXCLUDED(info.ready_mu_);
+      ABSL_LOCKS_EXCLUDED(read_info_.ready_mu_);
   void NotifyOnWrite(EventEngine::Closure* on_write)
-      ABSL_LOCKS_EXCLUDED(info.ready_mu_);
+      ABSL_LOCKS_EXCLUDED(write_info_.ready_mu_);
   bool IsShutdown();
   // Shutdown socket operations, but do not delete the WinSocket.
   // Connections will be disconnected, and the socket will be closed.

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -886,12 +886,6 @@ void grpc_cq_end_op(grpc_completion_queue* cq, void* tag,
                     void (*done)(void* done_arg, grpc_cq_completion* storage),
                     void* done_arg, grpc_cq_completion* storage,
                     bool internal) {
-// TODO(hork): remove when the listener flake is identified
-#ifdef GPR_WINDOWS
-  if (grpc_core::IsEventEngineListenerEnabled()) {
-    gpr_log(GPR_ERROR, "cq_end_op called for tag %d (0x%p)", tag, tag);
-  }
-#endif
   cq->vtable->end_op(cq, tag, error, done, done_arg, storage, internal);
 }
 


### PR DESCRIPTION
It was possible for threads that call `WinSocket::NotifyOnRead` and `WinSocket::NotifyOnWrite` to race against IOCP poller threads, causing poller events to be missed.

In the most common usage, in some thread (E), the Endpoint would make an async (overlapped) read or write using `WSARecv` or `WSASend` respectively, then use the socket's `NotifyOn*` methods to have callbacks executed when data was ready. If data was already available, those callbacks would be scheduled for execution immediately. Meanwhile, if overlapped events came in for some socket, some IOCP poller thread (P) would inform the socket that data was ready, and if notification callbacks were already present, they would be scheduled for execution immediately. It was possible for thread (E) to see no data available, and thread (P) to not see any notification callbacks registered. This resulted in registered callbacks that would never be called, for data that had already been received.