### PR TITLE
[PSM Interop] Remove --td_bootstrap_image override from csm config

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/config/common-csm.cfg
+++ b/tools/run_tests/xds_k8s_test_driver/config/common-csm.cfg
@@ -1,4 +1,3 @@
 # Common config file for PSM CSM tests.
 --resource_prefix=psm-csm
 --noenable_workload_identity
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:7d8d90477792e2e1bfe3a3da20b3dc9ef01d326c


### PR DESCRIPTION
Since we have released `7d8d90477792e2e1bfe3a3da20b3dc9ef01d326c` in https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/releases/tag/v0.15.0. So we dont need the csm tests to use an overridden version. This diff nixes the override flag. 

@sergiitk PTAL. (unfortunately, i don't have permissions to assign/ slap labels on the PR) 
