### PR TITLE
[PSM Interop] Double the active channel timeout for GAMMA tests

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -129,7 +129,12 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
             timeout_sec=timeout_sec
         )
 
-    def wait_for_active_server_channel(self) -> _ChannelzChannel:
+    def wait_for_active_server_channel(
+        self,
+        *,
+        timeout: Optional[_timedelta] = None,
+        rpc_deadline: Optional[_timedelta] = None,
+    ) -> _ChannelzChannel:
         """Wait for the channel to the server to transition to READY.
 
         Raises:
@@ -137,7 +142,9 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
         """
         try:
             return self.wait_for_server_channel_state(
-                _ChannelzChannelState.READY
+                _ChannelzChannelState.READY,
+                timeout=timeout,
+                rpc_deadline=rpc_deadline,
             )
         except retryers.RetryError as retry_err:
             if isinstance(retry_err.exception(), self.ChannelNotFound):

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -827,7 +827,7 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             server_target=server_target, **kwargs
         )
         test_client.wait_for_active_server_channel(
-            timeout=wait_for_active_channel_timeout
+            timeout=wait_for_active_channel_timeout,
         )
         return test_client
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -816,11 +816,19 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
     ) -> XdsTestClient:
         return self._start_test_client(test_server.xds_uri, **kwargs)
 
-    def _start_test_client(self, server_target: str, **kwargs) -> XdsTestClient:
+    def _start_test_client(
+        self,
+        server_target: str,
+        *,
+        wait_for_active_channel_timeout: Optional[_timedelta] = None,
+        **kwargs,
+    ) -> XdsTestClient:
         test_client = self.client_runner.run(
             server_target=server_target, **kwargs
         )
-        test_client.wait_for_active_server_channel()
+        test_client.wait_for_active_server_channel(
+            timeout=wait_for_active_channel_timeout
+        )
         return test_client
 
 


### PR DESCRIPTION
Waiting for an active channel takes less time in non-gamma test suites because they only start waiting after already waited for the TD backends to be created and report healthy.

In GAMMA, these resources are created asynchronously by Kubernetes. To compensate for this, we double the timeout for GAMMA tests.