### PR TITLE
[csharp] Grpc.Tools documentation for sharing proto files between projects and nuget packages

### DIFF
--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -79,6 +79,23 @@ For `.proto` files that are outside of the project directory a link can be added
 
 For more examples see the example project files in GitHub: https://github.com/grpc/grpc-dotnet/tree/master/examples
 
+## Sharing `.proto` files between projects
+
+As an alternative to each project generating their own code from a set of `.proto` files, you can have a shared .NET project that generates the code once, and then other projects reference the shared project.
+
+Here are a couple of examples:
+- for *gRPC for .NET* see the [Liber example](https://github.com/grpc/grpc-dotnet/tree/master/examples#liber)
+- for *gRPC C#* (legacy library) see the [RouteGuide example](https://github.com/grpc/grpc/tree/v1.46.x/examples/csharp/RouteGuide)
+
+Looking at the *Libre* example, it has three projects:
+- *Common.csproj* uses Grpc.Tools to generate messages contained in `common.proto`.
+- *Client.csproj* uses Grpc.Tools to generate the gRPC client for `greet.proto`. There is no `<Protobuf>` reference for `common.proto` because we don't want its messages generated in this project. Instead the .NET types for its messages are referenced from the common project.
+- *Server.csproj* uses Grpc.Tools to generate the gRPC service for `greet.proto`. It also references the common project.
+
+Another approach could be to have all the `.proto` files handled in the common project,
+generating the gRPC client and server code in that project, and not having any `.proto` files
+in the client and server projects. This is the approach taken by the *RouteGuide* example.
+
 # Reference
 
 ## Protobuf item metadata reference
@@ -252,6 +269,7 @@ Quick links to the examples below:
 * [Visual Studio: setting per-file `.proto` file options](#visualstudio)
 * [Bypassing Grpc.Tools to run the protocol buffers compiler explicitly](#compiler)
 * [Using Grpc.Tools with unsupported architectures](#unsupported-arch)
+* [Referencing `.proto` files that are in NuGet packages](#proto-only-nuget)
 
 ---
 ## <a name="ProtoRoot"></a>ProtoRoot - Common root for one or more `.proto` files
@@ -562,6 +580,18 @@ export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
 # use the binaries pointed to by the environment variables
 dotnet build
 ```
+
+---
+
+## <a name="proto-only-nuget"></a>Referencing `.proto` files that are in NuGet packages
+
+There might be occassions when you are given a NuGet package that contains `.proto` and you want to 
+generate the code from these files, or you wish to package your own `.proto` files in NuGet package.
+
+Note: This is not the same as a NuGet package providing a library built from the code already
+generated from the `.proto` files. It is just providing the `.proto` files themselves.
+
+
 
 ---
 

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -635,7 +635,8 @@ when creating NuGet packages that contain `.proto` files.
 
 __Note:__ This is not the same as a NuGet package providing a library built from
 the code generated from the `.proto` files. Below just describes how to provide
-the uncompiled `.proto` files in a NuGet package.
+the uncompiled `.proto` files in a NuGet package and have `Grpc.Tools` automatically
+use them.
 
 ### Creating the NuGet package
 

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -81,10 +81,34 @@ For more examples see the example project files in GitHub: https://github.com/gr
 
 ## Sharing `.proto` files between multiple projects (in the same VS solution)
 
-If you have one or more `.proto` files that you want to use in multiple project then
-you may create a shared class library that compiled the generated the code.
-The other projects in the solution then can reference this shared class library instead of each project having to compile
-the same `.proto` files.
+It's common to want to share `.proto` files between projects. For example, a gRPC client
+and gRPC server share the same contract. It is preferable to share contracts without
+copying `.proto` files because copies can go out of sync over time.
+
+There are a couple of ways to use `.proto` files in multiple projects without duplication:
+
+* Sharing `.proto` files between projects with MSBuild links.
+* Generating code in a class library and sharing the library.
+
+### Sharing `.proto` with MSBuild links
+
+`.proto` files can be placed in a shared location and referenced by multiple projects
+using MSBuild's [`Link` or `LinkBase` settings](https://learn.microsoft.com/visualstudio/msbuild/common-msbuild-item-metadata).
+
+```xml
+<ItemGroup>
+   <Protobuf Include="..\Protos\greet.proto" GrpcServices="None" Link="Protos\greet.proto"/>
+</ItemGroup>
+```
+
+In the example above, `greet.proto` is in a shared `Protos` directory outside 
+the project directory. Multiple projects can reference the proto file.
+
+### Generating code in a class library
+
+Create a class library that references `.proto` files and contains generated code. The other
+projects in the solution can then reference this shared class library instead of each project
+having to compile the same `.proto` files.
 
 The advantages of this are:
 - The `.proto` only need to be compiled once.

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -723,7 +723,7 @@ then all it needs to do is add the `<Protobuf>` items using the property defined
 in the package for the path to the files. For example, if the NuGet package contained
 the file `greet.proto`, then the project should add:
 
-```XML
+```xml
 <Protobuf Include="$(MyExampleProtos_ProtosPath)/greet.proto" />
 ```
 

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -734,7 +734,7 @@ used in the package. For example, if the project has the local `.proto` file
 `my_services.proto` and it imported a file from the package `common_message.proto`,
 then:
 
-```XML
+```xml
 <PropertyGroup>
   <!-- Update the Protobuf_StandardImportsPath -->
   <IncludeMyExampleProtosProtos>true</IncludeMyExampleProtosProtos>

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -79,19 +79,26 @@ For `.proto` files that are outside of the project directory a link can be added
 
 For more examples see the example project files in GitHub: https://github.com/grpc/grpc-dotnet/tree/master/examples
 
-## Sharing `.proto` files between projects
+## Sharing `.proto` files between multiple projects (in the same VS solution)
 
-Instead of each project generating their own code from a set of `.proto` files, you may have a shared .NET project that generates the code once, and then have other projects in the solution reference the shared project.
+If you have one or more `.proto` files that you want to use in multiple project then
+you may create a shared class library that compiled the generated the code.
+The other projects in the solution then can reference this shared class library instead of each project having to compile
+the same `.proto` files.
+
+The advantages of this are:
+- The `.proto` only need to be compiled once.
+- It prevents some projects getting multiple definitions of the same generated code, which can in turn break the build.
 
 There are a couple of examples in GitHub:
 - The [Liber example](https://github.com/grpc/grpc-dotnet/tree/master/examples#liber)
   demonstrates how common protocol buffers messages can be compiled once and used in other projects:
-  - The *Common* project generates messages contained in `common.proto`
+  - The *Common* project creates a class library that includes the generates messages contained in `common.proto`
   - The *Client* and *Server* projects reference the *Common* project.
   - They do not need to recompile `common.proto` as those .NET types are already in
-    the *Common* project.
+    the *Common* class library.
   - They do however each generate their own gRPC client or server code as both have a 
-    `<Protobuf>` reference for `greet.proto`
+    `<Protobuf>` reference for `greet.proto`.  The *Client* and *Server* projects each having their own version of `greet.proto` is OK since they don't reference each other - they only reference the shared *Common* class library.
 
 - The [RouteGuide example](https://github.com/grpc/grpc/tree/v1.46.x/examples/csharp/RouteGuide)
   demonstrates how the gRPC client and server code can be generated once and used in other
@@ -672,7 +679,7 @@ My.Example.Protos.targets:
       <Protobuf_StandardImportsPath>$(Protobuf_StandardImportsPath);$(MyPackage_ProtosPath)</Protobuf_StandardImportsPath>
     </PropertyGroup>
 
-    <!-- These message are unnecessary but included here for diagnostics -->
+    <!-- These message are not required but included here for diagnostics -->
     <Message Text="Included proto files at $(MyExampleProtos_ProtosPath) in import path." Importance="high" />
     <Message Text="Updated proto imports path: $(Protobuf_StandardImportsPath)" Importance="high" />
   </Target>

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -653,7 +653,7 @@ The NuGet package should:
 For example, for the package `My.Example.Protos`:
 
 My.Example.Protos.nuspec:
-```XML
+```xml
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -714,7 +714,7 @@ My.Example.Protos.targets:
 ### Using the NuGet package
 
 The project needs to add the package containing the `.proto` files:
-```XML
+```xml
 <PackageReference Include="My.Example.Protos" Version="1.0.0" />
 ```
 

--- a/src/csharp/BUILD-INTEGRATION.md
+++ b/src/csharp/BUILD-INTEGRATION.md
@@ -680,7 +680,7 @@ My.Example.Protos.nuspec:
 ```
 
 My.Example.Protos.targets:
-```XML
+```xml
 <?xml version="1.0"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- This targets file allows .proto files bundled in package, 


### PR DESCRIPTION
Added documented for Grpc.Tools for sharing proto files

- between projects in a solution
- in NuGet packages to be used by other projects

This addresses the questions raised in:
- https://github.com/grpc/grpc-dotnet/issues/1458
- https://github.com/grpc/grpc-dotnet/issues/183

@jtattermusch @JamesNK 