### PR TITLE
[Python][Callable] Fixing `_InterceptedStreamRequestMixin` to avoid deadlocking in client intereceptors

### DIFF
--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -520,8 +520,6 @@ class _InterceptedStreamRequestMixin:
         return request_iterator
 
     async def _proxy_writes_as_request_iterator(self):
-        await self._interceptors_task
-
         while True:
             value = await self._write_to_iterator_queue.get()
             if (


### PR DESCRIPTION
Issue is detailed https://github.com/grpc/grpc/issues/34530

Changes:

 - Removing awaiting on the interceptors task to allow `stream.write` invocations to channel requests into the async generator writing them out into the channel