### PR TITLE
[test infra] Bump Python Windows distribtest timeout

### DIFF
--- a/tools/internal_ci/windows/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Bump Python windows distribtest timeout. With the addition of 3.12 artifacts, we've been hitting this timeout pretty frequently recently. Once [https://github.com/grpc/grpc/pull/34450](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fgrpc%2Fgrpc%2Fpull%2F34450) is merged, we'll have a reduction in total time, but even before 3.12 was introduced, we were already hitting the timeout pretty frequently.