### PR TITLE
[PSM Interop] Increase CSM NEG annotation timeout; improve wording

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py
@@ -771,7 +771,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         )
         retryer(self.get)
 
-    def wait_for_service_neg(
+    def wait_for_service_neg_annotation(
         self,
         name: str,
         timeout_sec: int = WAIT_SHORT_TIMEOUT_SEC,
@@ -788,10 +788,12 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         except retryers.RetryError as retry_err:
             result = retry_err.result()
             note = framework.errors.FrameworkError.note_blanket_error_info_below(
-                "A k8s service wasn't assigned a NEG (Network Endpoint Group).",
+                "A Kubernetes Service wasn't assigned a NEG (Network Endpoint"
+                " Group) annotation.",
                 info_below=(
-                    f"Timeout {timeout} (h:mm:ss) waiting for service {name}"
-                    f" to report NEG status. Last service status:\n"
+                    f"Timeout {timeout} (h:mm:ss) waiting for Kubernetes"
+                    f" service {name} to report a NEG annotation."
+                    f" Last service status:\n"
                     f"{self._pretty_format_status(result, highlight=False)}"
                 ),
             )

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -14,6 +14,7 @@
 """
 Run xDS Test Client on Kubernetes using Gamma
 """
+import datetime
 import logging
 from typing import List, Optional
 
@@ -217,7 +218,13 @@ class GammaServerRunner(KubernetesServerRunner):
 
         # The controller will not populate the NEGs until there are
         # endpoint slices.
-        self._wait_service_neg(self.service_name, test_port)
+        # For this reason, we run this check after the servers were created,
+        # and increase the wait time from 1 minute to 3.
+        self._wait_service_neg_annotation(
+            self.service_name,
+            test_port,
+            timeout_sec=datetime.timedelta(minutes=3),
+        )
 
         return servers
 

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -769,14 +769,33 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         self.pod_log_collectors.append(pod_log_collector)
         return pod_log_collector
 
-    def _wait_service_neg(self, name, service_port, **kwargs):
-        logger.info("Waiting for NEG for service %s", name)
-        self.k8s_namespace.wait_for_service_neg(name, **kwargs)
+    def _wait_service_neg_annotation(
+        self,
+        service_name: str,
+        service_port: int,
+        **kwargs,
+    ) -> None:
+        logger.info(
+            "Waiting for the NEG annotation to be assigned "
+            "to Kubernetes Service %s, with service port %s, namespace %s",
+            service_name,
+            service_port,
+            self.k8s_namespace.name,
+        )
+        self.k8s_namespace.wait_for_service_neg_annotation(
+            service_name, **kwargs
+        )
         neg_name, neg_zones = self.k8s_namespace.get_service_neg(
-            name, service_port
+            service_name, service_port
         )
         logger.info(
-            "Service %s: detected NEG=%s in zones=%s", name, neg_name, neg_zones
+            "Kubernetes Service %s port %s namespace %s:"
+            " detected NEG annotation neg_name=%s, zones=%s",
+            service_name,
+            service_port,
+            self.k8s_namespace.name,
+            neg_name,
+            neg_zones,
         )
 
     def logs_explorer_link(self):

--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -170,7 +170,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
                 neg_name=self.gcp_neg_name,
                 test_port=test_port,
             )
-        self._wait_service_neg(self.service_name, test_port)
+        self._wait_service_neg_annotation(self.service_name, test_port)
 
         if self.enable_workload_identity:
             # Allow Kubernetes service account to use the GCP service account


### PR DESCRIPTION
- GAMMA server runner: increase the wait time for the NEG annotation from 1 minute to 3.
- Improve the wording around the wait for NEG methods to make it clear this is the annotation we're waiting for - so it's not confused with getting the NEG health from the GCP APIs.

ref b/298501683, b/302723651