### PR TITLE
[Cord] Backport-1.57: Fix MakeCordFromSlice memory bug

### DIFF
--- a/include/grpcpp/support/proto_buffer_reader.h
+++ b/include/grpcpp/support/proto_buffer_reader.h
@@ -185,10 +185,17 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
   // This function takes ownership of slice and return a newly created Cord off
   // of it.
   static absl::Cord MakeCordFromSlice(grpc_slice slice) {
+    // slice_for_cord is created to keep inlined data of the given slice
+    grpc_slice* slice_for_cord = new grpc_slice;
+    *slice_for_cord = slice;
     return absl::MakeCordFromExternal(
-        absl::string_view(reinterpret_cast<char*>(GRPC_SLICE_START_PTR(slice)),
-                          GRPC_SLICE_LENGTH(slice)),
-        [slice](absl::string_view /* view */) { grpc_slice_unref(slice); });
+        absl::string_view(
+            reinterpret_cast<char*>(GRPC_SLICE_START_PTR(*slice_for_cord)),
+            GRPC_SLICE_LENGTH(*slice_for_cord)),
+        [slice_for_cord](absl::string_view /* view */) {
+          grpc_slice_unref(*slice_for_cord);
+          delete slice_for_cord;
+        });
   }
 #endif  // GRPC_PROTOBUF_CORD_SUPPORT_ENABLED
 


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc/pull/34549
