### PR TITLE
[test] Enforce hygene between tests that require it

### DIFF
--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -730,6 +730,7 @@ void PerformCallWithResponsePayload(grpc_channel* channel, grpc_server* server,
 }
 
 TEST(TooManyPings, BdpPingNotSentWithoutReceiveSideActivity) {
+  TransportCounter::WaitForTransportsToBeDestroyed();
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   // create the server
   std::string server_address =
@@ -805,6 +806,7 @@ TEST(TooManyPings, BdpPingNotSentWithoutReceiveSideActivity) {
 }
 
 TEST(TooManyPings, TransportsGetCleanedUpOnDisconnect) {
+  TransportCounter::WaitForTransportsToBeDestroyed();
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   // create the client and server
   std::string server_address =


### PR DESCRIPTION
Looks like we've got a thread race on shutdown with some of these tests... adding a barrier at the head of tests that require precise transport counts in order to stabilize.