### PR TITLE
[chttp2] Refine ping logic

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -871,7 +871,7 @@ static const char* write_state_name(grpc_chttp2_write_state st) {
 
 static void set_write_state(grpc_chttp2_transport* t,
                             grpc_chttp2_write_state st, const char* reason) {
-  (gpr_log(GPR_INFO, "W:%p %s [%s] state %s -> %s [%s]", t,
+  (gpr_log(GPR_ERROR, "W:%p %s [%s] state %s -> %s [%s]", t,
            t->is_client ? "CLIENT" : "SERVER",
            std::string(t->peer_string.as_string_view()).c_str(),
            write_state_name(t->write_state), write_state_name(st), reason));

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1684,6 +1684,7 @@ static void retry_initiate_ping_locked(
 }
 
 void grpc_chttp2_ack_ping(grpc_chttp2_transport* t, uint64_t id) {
+  gpr_log(GPR_ERROR, "t=%p ack ping %" PRId64, t, id);
   if (!t->ping_callbacks.AckPing(id, t->event_engine.get())) {
     gpr_log(GPR_DEBUG, "Unknown ping response from %s: %" PRIx64,
             std::string(t->peer_string.as_string_view()).c_str(), id);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -871,11 +871,10 @@ static const char* write_state_name(grpc_chttp2_write_state st) {
 
 static void set_write_state(grpc_chttp2_transport* t,
                             grpc_chttp2_write_state st, const char* reason) {
-  GRPC_CHTTP2_IF_TRACING(
-      gpr_log(GPR_INFO, "W:%p %s [%s] state %s -> %s [%s]", t,
-              t->is_client ? "CLIENT" : "SERVER",
-              std::string(t->peer_string.as_string_view()).c_str(),
-              write_state_name(t->write_state), write_state_name(st), reason));
+  (gpr_log(GPR_INFO, "W:%p %s [%s] state %s -> %s [%s]", t,
+           t->is_client ? "CLIENT" : "SERVER",
+           std::string(t->peer_string.as_string_view()).c_str(),
+           write_state_name(t->write_state), write_state_name(st), reason));
   t->write_state = st;
   // If the state is being reset back to idle, it means a write was just
   // finished. Make sure all the run_after_write closures are scheduled.

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -100,9 +100,10 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
     } else {
       const bool transport_idle =
           t->keepalive_permit_without_calls == 0 && t->stream_map.empty();
-      gpr_log(GPR_ERROR, "t=%p received ping %" PRId64 ": %s", t,
+      gpr_log(GPR_ERROR, "t=%p received ping %" PRId64 ": %s ack_pings=%d", t,
               p->opaque_8bytes,
-              t->ping_abuse_policy.GetDebugString(transport_idle).c_str());
+              t->ping_abuse_policy.GetDebugString(transport_idle).c_str(),
+              t->ack_pings);
       if (!t->is_client) {
         if (true || grpc_keepalive_trace.enabled() ||
             grpc_http_trace.enabled()) {

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -98,12 +98,14 @@ grpc_error_handle grpc_chttp2_ping_parser_parse(void* parser,
     if (p->is_ack) {
       grpc_chttp2_ack_ping(t, p->opaque_8bytes);
     } else {
+      const bool transport_idle =
+          t->keepalive_permit_without_calls == 0 && t->stream_map.empty();
+      gpr_log(GPR_ERROR, "t=%p received ping %" PRId64 ": %s", t,
+              p->opaque_8bytes,
+              t->ping_abuse_policy.GetDebugString(transport_idle).c_str());
       if (!t->is_client) {
-        const bool transport_idle =
-            t->keepalive_permit_without_calls == 0 && t->stream_map.empty();
-        if (grpc_keepalive_trace.enabled() || grpc_http_trace.enabled()) {
-          gpr_log(GPR_INFO, "t=%p received ping: %s", t,
-                  t->ping_abuse_policy.GetDebugString(transport_idle).c_str());
+        if (true || grpc_keepalive_trace.enabled() ||
+            grpc_http_trace.enabled()) {
         }
         if (t->ping_abuse_policy.ReceivedOnePing(transport_idle)) {
           grpc_chttp2_exceeded_ping_strikes(t);

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -316,6 +316,7 @@ class WriteContext {
 
   void FlushPingAcks() {
     for (size_t i = 0; i < t_->ping_ack_count; i++) {
+      gpr_log(GPR_ERROR, "Write ping ack %" PRId64, t_->ping_acks[i]);
       grpc_slice_buffer_add(t_->outbuf.c_slice_buffer(),
                             grpc_chttp2_ping_create(true, t_->ping_acks[i]));
     }


### PR DESCRIPTION
Possible solution to the recent uptick in ping timeouts: if the write output buffer is very large, delay writing the ping for a little bit and try again later.

This means that the timer for the ping more likely matches when the ping was sent, and so leaves us less likely to spuriously timeout.