### PR TITLE
[Ruby] do not use static thread local member in scoped activity

### DIFF
--- a/src/core/lib/promise/activity.cc
+++ b/src/core/lib/promise/activity.cc
@@ -30,7 +30,9 @@ namespace grpc_core {
 ///////////////////////////////////////////////////////////////////////////////
 // GLOBALS
 
+#if !defined(_WIN32) || !defined(_DLL)
 thread_local Activity* Activity::g_current_activity_{nullptr};
+#endif
 
 namespace promise_detail {
 


### PR DESCRIPTION
This is to fix #34297
PR #34103 removed the use of `static threada_local` as class member (not supported on windows) in ExecCtx, now it crashes at a later time in ScopedActivity accessing another static thread_local class memeber.
This PR made a similar change by moving it into a function, with this PR, script in the original issue stopped crashing.
```
$ ruby test.rb
Never gets here
```

There are still static threada_local class member usages in the following classes:
[Context](https://github.com/grpc/grpc/blob/v1.59.0/src/core/lib/promise/context.h#L48)
[ScopedSource](https://github.com/grpc/grpc/blob/v1.59.0/src/core/lib/gprpp/time.h#L175)
[PerCpuShardingHelper](https://github.com/grpc/grpc/blob/v1.59.0/src/core/lib/gprpp/per_cpu.h#L79)
[WorkSerializer::DispatchingWorkSerializer](https://github.com/grpc/grpc/blob/v1.59.0/src/core/lib/gprpp/work_serializer.cc#L387), DEBUG only

I'll run more tests to see if they cause crashes as well.



--
New crashes with the ExecCtx fix (#34103 ):
```
(gdb) s
grpc_core::Activity::ScopedActivity::ScopedActivity (activity=0x1c01d0c7280,
    this=<synthetic pointer>) at ./src/core/lib/promise/activity.h:241
241       static thread_local Activity* g_current_activity_;
(gdb) s
0xffffffff93d10000 in ?? ()
(gdb) bt
#0  0xffffffff93d10000 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
```
crash log:
```
-- C level backtrace information -------------------------------------------
C:\Windows\SYSTEM32\ntdll.dll(ZwWaitForSingleObject+0x14) [0x00007ff9dc0a00c4]
C:\Windows\System32\KERNELBASE.dll(WaitForSingleObjectEx+0x8e) [0x00007ff9d9a5d77e]
C:\Ruby31-x64\bin\x64-ucrt-ruby310.dll(rb_vm_bugreport+0x2b6) [0x00007ff9c184d086]
C:\Ruby31-x64\bin\x64-ucrt-ruby310.dll(rb_bug_for_fatal_signal+0x84) [0x00007ff9c163f354]
C:\Ruby31-x64\bin\x64-ucrt-ruby310.dll(rb_fiber_scheduler_address_resolve+0x68b) [0x00007ff9c179e7fb]
 [0x00007ff6d3671e22]
C:\Windows\System32\ucrtbase.dll(_C_specific_handler+0xa0) [0x00007ff9d99555f0]
C:\Windows\SYSTEM32\ntdll.dll(_chkstk+0x12f) [0x00007ff9dc0a4faf]
C:\Windows\SYSTEM32\ntdll.dll(RtlVirtualUnwind2+0x35e) [0x00007ff9dc0318fe]
C:\Windows\SYSTEM32\ntdll.dll(KiUserExceptionDispatcher+0x2e) [0x00007ff9dc0a3f9e]
 [0xffffffff944c0000]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(ZN9grpc_core16BasicMemoryQuota5StartEv+0x6f0) [0x0000000000d280f0]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(ZN9grpc_core13ResourceQuotaC2ENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x1a2) [0
x0000000000d2b612]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(ZN9grpc_core13ResourceQuota7DefaultEv+0x121) [0x0000000000d2b801]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(ZN9grpc_core32EnsureResourceQuotaInChannelArgsERKNS_11ChannelArgsE+0x6a) [0x0000000000d2408a
]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(ZNSt17_Function_handlerIFN9grpc_core11ChannelArgsES1_EPFS1_RKS1_EE9_M_invokeERKSt9_Any_dataO
S1_+0x12) [0x0000000001092302]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(ZNK9grpc_core26ChannelArgsPreconditioning23PreconditionChannelArgsEPK17grpc_channel_args+0x4
e) [0x0000000000c9680e]
C:\Users\hannahshisfb\.local\share\gem\ruby\3.1.0\gems\grpc-1.60.0.dev-x64-mingw-ucrt\grpc_c.64-ucrt.ruby(grpc_channel_create+0x16f) [0x0000000000bd7d5f]
 [0x0000000071046591]
```