### PR TITLE
[test] Move random number generation before main test

### DIFF
--- a/test/core/end2end/tests/invoke_large_request.cc
+++ b/test/core/end2end/tests/invoke_large_request.cc
@@ -33,13 +33,13 @@ namespace {
 
 CORE_END2END_TEST(Http2SingleHopTest, InvokeLargeRequest) {
   const size_t kMessageSize = 10 * 1024 * 1024;
+  auto send_from_client = RandomSlice(kMessageSize);
+  auto send_from_server = RandomSlice(kMessageSize);
   InitServer(
       ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, kMessageSize));
   InitClient(
       ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, kMessageSize));
   auto c = NewClientCall("/foo").Timeout(Duration::Minutes(5)).Create();
-  auto send_from_client = RandomSlice(kMessageSize);
-  auto send_from_server = RandomSlice(kMessageSize);
   CoreEnd2endTest::IncomingStatusOnClient server_status;
   CoreEnd2endTest::IncomingMetadata server_initial_metadata;
   CoreEnd2endTest::IncomingMessage server_message;


### PR DESCRIPTION
My expectation is that generating 20 megabytes of random numbers with MSAN was taking some time..