### PR TITLE
[chttp2] Dont double-close closed streams

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2060,7 +2060,8 @@ static void remove_stream(grpc_chttp2_transport* t, uint32_t id,
 void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                                grpc_error_handle due_to_error) {
   if (!t->is_client && !s->sent_trailing_metadata &&
-      grpc_error_has_clear_grpc_status(due_to_error)) {
+      grpc_error_has_clear_grpc_status(due_to_error) &&
+      !(s->read_closed && s->write_closed)) {
     close_from_api(t, s, due_to_error);
     return;
   }


### PR DESCRIPTION
Noted internally: sometimes we close streams twice via `close_from_api`, in which case we send two trailers frames.