### PR TITLE
[PSM Interop] README.md typo fix

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/README.md
+++ b/tools/run_tests/xds_k8s_test_driver/README.md
@@ -53,7 +53,7 @@ sudo apt-get install python3-venv
    ```
 
 #### Configure GKE cluster
-This is an example outlining minimal requirements to run the [baseline tests](xds-baseline-tests).
+This is an example outlining minimal requirements to run the [baseline tests](#xds-baseline-tests).
 Update gloud sdk:
 ```shell
 gcloud -q components update


### PR DESCRIPTION
`baseline tests` should've been an anchor, not a directory.

