### PR TITLE
[csharp] Try and fix macos minimum deployment target for protoc

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -103,6 +103,7 @@ def create_jobspec(
 
 
 _MACOS_COMPAT_FLAG = "-mmacosx-version-min=10.10"
+_MACOS_COMPAT_ENV = "10.10"
 
 _ARCH_FLAG_MAP = {"x86": "-m32", "x64": "-m64"}
 
@@ -348,8 +349,9 @@ class ProtocArtifact:
                 )
             else:
                 environ["CXXFLAGS"] += (
-                    " -std=c++14 -stdlib=libc++ %s" % _MACOS_COMPAT_FLAG
+                    " -std=c++14 -stdlib=libc++ -Wunguarded-availability %s" % _MACOS_COMPAT_FLAG
                 )
+                environ["MACOSX_DEPLOYMENT_TARGET"] = _MACOS_COMPAT_ENV
                 return create_jobspec(
                     self.name,
                     ["tools/run_tests/artifacts/build_artifact_protoc.sh"],

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -349,7 +349,8 @@ class ProtocArtifact:
                 )
             else:
                 environ["CXXFLAGS"] += (
-                    " -std=c++14 -stdlib=libc++ -Wunguarded-availability %s" % _MACOS_COMPAT_FLAG
+                    " -std=c++14 -stdlib=libc++ -Wunguarded-availability %s" 
+                    % _MACOS_COMPAT_FLAG
                 )
                 environ["MACOSX_DEPLOYMENT_TARGET"] = _MACOS_COMPAT_ENV
                 return create_jobspec(


### PR DESCRIPTION
Speculative fix for https://github.com/grpc/grpc/issues/32558
Using environment variable MACOSX_DEPLOYMENT_TARGET to set minimum deployment target.
Also add `-Wunguarded-availability` flag to warn if using unavailable APIs.
