### PR TITLE
[Test] Bump the timeout for bazelify distribtest_php_linux_x64_debian10

### DIFF
--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -378,6 +378,7 @@ test_suite(
 
 grpc_run_distribtest_test(
     name = "distribtest_php_linux_x64_debian10",
+    size = "enormous",
     artifact_deps = [
         "artifact_php_linux_x64",
     ],


### PR DESCRIPTION
Bump the timeout as distribtest_php_linux_x64_debian10 takes longer while building core.