### PR TITLE
[Fix] new clang -Wthread-safety-analysis warnings

### DIFF
--- a/src/core/lib/security/security_connector/tls/tls_security_connector.h
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.h
@@ -205,12 +205,12 @@ class TlsServerSecurityConnector final : public grpc_server_security_connector {
     return server_handshaker_factory_;
   };
 
-  const absl::optional<absl::string_view>& RootCertsForTesting() {
+  const absl::optional<absl::string_view> RootCertsForTesting() {
     MutexLock lock(&mu_);
     return pem_root_certs_;
   }
 
-  const absl::optional<PemKeyCertPairList>& KeyCertPairListForTesting() {
+  const absl::optional<PemKeyCertPairList> KeyCertPairListForTesting() {
     MutexLock lock(&mu_);
     return pem_key_cert_pair_list_;
   }

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.h
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.h
@@ -205,12 +205,12 @@ class TlsServerSecurityConnector final : public grpc_server_security_connector {
     return server_handshaker_factory_;
   };
 
-  const absl::optional<absl::string_view> RootCertsForTesting() {
+  absl::optional<absl::string_view> RootCertsForTesting() {
     MutexLock lock(&mu_);
     return pem_root_certs_;
   }
 
-  const absl::optional<PemKeyCertPairList> KeyCertPairListForTesting() {
+  absl::optional<PemKeyCertPairList> KeyCertPairListForTesting() {
     MutexLock lock(&mu_);
     return pem_key_cert_pair_list_;
   }


### PR DESCRIPTION
Returning a reference to a GUARDED_BY variable while only holding the lock in the getter lets callers access the variable without holding the lock.

See https://github.com/llvm/llvm-project/pull/67776.

This is only used for testing, so just return a copy for simplicity.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

