### PR TITLE
[PSM Interop] Support --noenable_workload_identity in helper scripts

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/bin/lib/common.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/lib/common.py
@@ -52,8 +52,10 @@ def make_client_namespace(
 def make_client_runner(
     namespace: k8s.KubernetesNamespace,
     gcp_api_manager: gcp.api.GcpApiManager,
+    *,
     port_forwarding: bool = False,
     reuse_namespace: bool = True,
+    enable_workload_identity: bool = True,
     mode: str = "default",
 ) -> KubernetesClientRunner:
     # KubernetesClientRunner arguments.
@@ -69,6 +71,7 @@ def make_client_runner(
         stats_port=xds_flags.CLIENT_PORT.value,
         reuse_namespace=reuse_namespace,
         debug_use_port_forwarding=port_forwarding,
+        enable_workload_identity=enable_workload_identity,
     )
 
     if mode == "secure":
@@ -91,9 +94,11 @@ def make_server_namespace(
 def make_server_runner(
     namespace: k8s.KubernetesNamespace,
     gcp_api_manager: gcp.api.GcpApiManager,
+    *,
     port_forwarding: bool = False,
     reuse_namespace: bool = True,
     reuse_service: bool = False,
+    enable_workload_identity: bool = True,
     mode: str = "default",
 ) -> KubernetesServerRunner:
     # KubernetesServerRunner arguments.
@@ -109,6 +114,7 @@ def make_server_runner(
         reuse_namespace=reuse_namespace,
         reuse_service=reuse_service,
         debug_use_port_forwarding=port_forwarding,
+        enable_workload_identity=enable_workload_identity,
     )
 
     server_runner = KubernetesServerRunner

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_channelz.py
@@ -200,6 +200,9 @@ def main(argv):
 
     # Flags.
     should_port_forward: bool = xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
+    enable_workload_identity: bool = (
+        xds_k8s_flags.ENABLE_WORKLOAD_IDENTITY.value
+    )
     is_secure: bool = bool(_SECURITY.value)
 
     # Setup.
@@ -212,6 +215,7 @@ def main(argv):
         server_namespace,
         gcp_api_manager,
         port_forwarding=should_port_forward,
+        enable_workload_identity=enable_workload_identity,
         mode="secure",
     )
     # Find server pod.
@@ -225,6 +229,7 @@ def main(argv):
         client_namespace,
         gcp_api_manager,
         port_forwarding=should_port_forward,
+        enable_workload_identity=enable_workload_identity,
         mode="secure",
     )
     # Find client pod.

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_ping_pong.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_ping_pong.py
@@ -103,6 +103,9 @@ def main(argv):
 
     # Flags.
     should_port_forward: bool = xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
+    enable_workload_identity: bool = (
+        xds_k8s_flags.ENABLE_WORKLOAD_IDENTITY.value
+    )
 
     # Setup.
     gcp_api_manager = gcp.api.GcpApiManager()
@@ -114,6 +117,7 @@ def main(argv):
         server_namespace,
         gcp_api_manager,
         port_forwarding=should_port_forward,
+        enable_workload_identity=enable_workload_identity,
         mode=_MODE.value,
     )
     # Find server pod.
@@ -127,6 +131,7 @@ def main(argv):
         client_namespace,
         gcp_api_manager,
         port_forwarding=should_port_forward,
+        enable_workload_identity=enable_workload_identity,
         mode=_MODE.value,
     )
     # Find client pod.

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_client.py
@@ -114,6 +114,9 @@ def main(argv):
     should_port_forward = (
         should_follow_logs and xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
     )
+    enable_workload_identity: bool = (
+        xds_k8s_flags.ENABLE_WORKLOAD_IDENTITY.value
+    )
 
     # Setup.
     gcp_api_manager = gcp.api.GcpApiManager()
@@ -125,6 +128,7 @@ def main(argv):
         reuse_namespace=_REUSE_NAMESPACE.value,
         mode=_MODE.value,
         port_forwarding=should_port_forward,
+        enable_workload_identity=enable_workload_identity,
     )
 
     # Server target

--- a/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
+++ b/tools/run_tests/xds_k8s_test_driver/bin/run_test_server.py
@@ -80,6 +80,9 @@ def main(argv):
     should_port_forward = (
         should_follow_logs and xds_k8s_flags.DEBUG_USE_PORT_FORWARDING.value
     )
+    enable_workload_identity: bool = (
+        xds_k8s_flags.ENABLE_WORKLOAD_IDENTITY.value
+    )
 
     # Setup.
     gcp_api_manager = gcp.api.GcpApiManager()
@@ -93,6 +96,7 @@ def main(argv):
         reuse_service=_REUSE_SERVICE.value,
         mode=_MODE.value,
         port_forwarding=should_port_forward,
+        enable_workload_identity=enable_workload_identity,
     )
 
     if _CMD.value == "run":

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -832,10 +832,6 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
         test_client = self.client_runner.run(
             server_target=server_target, **kwargs
         )
-        test_client.wait_for_active_ads_channel(
-            target=self.xds_server_uri,
-            timeout=wait_for_active_ads_channel_timeout,
-        )
         test_client.wait_for_active_server_channel(
             timeout=wait_for_active_channel_timeout,
         )

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py
@@ -832,6 +832,10 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
         test_client = self.client_runner.run(
             server_target=server_target, **kwargs
         )
+        test_client.wait_for_active_ads_channel(
+            target=self.xds_server_uri,
+            timeout=wait_for_active_ads_channel_timeout,
+        )
         test_client.wait_for_active_server_channel(
             timeout=wait_for_active_channel_timeout,
         )


### PR DESCRIPTION
Example:

```
./run.sh bin/run_test_client.py --noenable_workload_identity
```

