### PR TITLE
[C++] Use GOOGLE_PROTOBUF_VERSION instead of PROTOBUF_VERSION.

### DIFF
--- a/include/grpcpp/support/proto_buffer_reader.h
+++ b/include/grpcpp/support/proto_buffer_reader.h
@@ -128,7 +128,7 @@ class ProtoBufferReader : public grpc::protobuf::io::ZeroCopyInputStream {
   //  doesn't have ReadCord method)
   // NOLINTNEXTLINE(modernize-use-override)
   virtual bool ReadCord(absl::Cord* cord, int count)
-#if PROTOBUF_VERSION >= 4022000
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
       override
 #endif
   {

--- a/include/grpcpp/support/proto_buffer_writer.h
+++ b/include/grpcpp/support/proto_buffer_writer.h
@@ -158,7 +158,7 @@ class ProtoBufferWriter : public grpc::protobuf::io::ZeroCopyOutputStream {
   //  doesn't have ReadCord method)
   // NOLINTNEXTLINE(modernize-use-override)
   virtual bool WriteCord(const absl::Cord& cord)
-#if PROTOBUF_VERSION >= 4022000
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
       override
 #endif
   {


### PR DESCRIPTION
Indeed it seems that on Protobuf side, PROTOBUF_VERSION is defined in port_def.inc which always comes with a matching include of port_undef.inc which explicitly undef all macros, among them PROTOBUF_VERSION. GOOGLE_PROTOBUF_VERSION doesn't suffer from this issue.

This is a followup of #33646.