### PR TITLE
[ping] Potential solution to timeout problems

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -415,8 +415,6 @@ struct grpc_chttp2_transport : public grpc_core::KeepsGrpcInitialized {
       keepalive_ping_timer_handle;
   /// time duration in between pings
   grpc_core::Duration keepalive_time;
-  /// grace period for a ping to complete before watchdog kicks in
-  grpc_core::Duration keepalive_timeout;
   /// keep-alive state machine state
   grpc_chttp2_keepalive_state keepalive_state;
   // Soft limit on max header size.

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -203,6 +203,8 @@ grpc_error_handle grpc_chttp2_perform_read(grpc_chttp2_transport* t,
 
   if (cur == end) return absl::OkStatus();
 
+  t->ping_callbacks.ReceivedData();
+
   switch (t->deframe_state) {
     case GRPC_DTS_CLIENT_PREFIX_0:
     case GRPC_DTS_CLIENT_PREFIX_1:

--- a/src/core/ext/transport/chttp2/transport/ping_callbacks.h
+++ b/src/core/ext/transport/chttp2/transport/ping_callbacks.h
@@ -84,9 +84,17 @@ class Chttp2PingCallbacks {
   // Add a ping timeout for the most recently started ping.
   // started_new_ping_without_setting_timeout must be set.
   // Clears started_new_ping_without_setting_timeout.
-  void OnPingTimeout(Duration ping_timeout,
-                     grpc_event_engine::experimental::EventEngine* event_engine,
+  void OnPingTimeout(grpc_event_engine::experimental::EventEngine* event_engine,
                      Callback callback);
+
+  // Received some data, so next ping needn't be a keepalive
+  void ReceivedData() { next_ping_is_keepalive_ = false; }
+
+  // Set timeouts
+  void SetTimeouts(Duration keepalive_timeout, Duration ping_timeout) {
+    keepalive_timeout_ = keepalive_timeout;
+    ping_timeout_ = ping_timeout;
+  }
 
  private:
   using CallbackVec = std::vector<Callback>;
@@ -99,6 +107,9 @@ class Chttp2PingCallbacks {
   uint64_t most_recent_inflight_ = 0;
   bool ping_requested_ = false;
   bool started_new_ping_without_setting_timeout_ = false;
+  bool next_ping_is_keepalive_ = false;
+  Duration keepalive_timeout_ = Duration::Seconds(20);
+  Duration ping_timeout_ = Duration::Minutes(1);
   CallbackVec on_start_;
   CallbackVec on_ack_;
 };


### PR DESCRIPTION
Allow non-keepalive pings to have a different timeout to pings that are trying to establish liveness of a very idle channel