### PR TITLE
[fuzzing] Avoid referencing an uninitialized fork_fd_list.

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -266,20 +266,18 @@ struct grpc_pollset_set {
 //
 
 static void fork_fd_list_remove_node(grpc_fork_fd_list* node) {
-  if (track_fds_for_fork) {
-    gpr_mu_lock(&fork_fd_list_mu);
-    if (fork_fd_list_head == node) {
-      fork_fd_list_head = node->next;
-    }
-    if (node->prev != nullptr) {
-      node->prev->next = node->next;
-    }
-    if (node->next != nullptr) {
-      node->next->prev = node->prev;
-    }
-    gpr_free(node);
-    gpr_mu_unlock(&fork_fd_list_mu);
+  gpr_mu_lock(&fork_fd_list_mu);
+  if (fork_fd_list_head == node) {
+    fork_fd_list_head = node->next;
   }
+  if (node->prev != nullptr) {
+    node->prev->next = node->next;
+  }
+  if (node->next != nullptr) {
+    node->next->prev = node->prev;
+  }
+  gpr_free(node);
+  gpr_mu_unlock(&fork_fd_list_mu);
 }
 
 static void fork_fd_list_add_node(grpc_fork_fd_list* node) {
@@ -360,7 +358,9 @@ static void unref_by(grpc_fd* fd, int n) {
   if (old == n) {
     gpr_mu_destroy(&fd->mu);
     grpc_iomgr_unregister_object(&fd->iomgr_object);
-    fork_fd_list_remove_node(fd->fork_fd_list);
+    if (track_fds_for_fork) {
+      fork_fd_list_remove_node(fd->fork_fd_list);
+    }
     if (fd->shutdown) {
     }
     fd->shutdown_error.~Status();
@@ -859,7 +859,9 @@ static void pollset_destroy(grpc_pollset* pollset) {
   GPR_ASSERT(!pollset_has_workers(pollset));
   while (pollset->local_wakeup_cache) {
     grpc_cached_wakeup_fd* next = pollset->local_wakeup_cache->next;
-    fork_fd_list_remove_node(pollset->local_wakeup_cache->fork_fd_list);
+    if (track_fds_for_fork) {
+      fork_fd_list_remove_node(pollset->local_wakeup_cache->fork_fd_list);
+    }
     grpc_wakeup_fd_destroy(&pollset->local_wakeup_cache->fd);
     gpr_free(pollset->local_wakeup_cache);
     pollset->local_wakeup_cache = next;


### PR DESCRIPTION
This avoids MSAN violations when fuzzing.