### PR TITLE
[Bazel] Fix some build deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1112,6 +1112,7 @@ grpc_cc_library(
         "//src/core:default_event_engine",
         "//src/core:iomgr_fwd",
         "//src/core:iomgr_port",
+        "//src/core:notification",
         "//src/core:slice",
         "//src/core:slice_refcount",
         "//src/core:status_helper",
@@ -1842,6 +1843,7 @@ grpc_cc_library(
     visibility = ["@grpc:tsi_interface"],
     deps = [
         "gpr",
+        "grpc_public_hdrs",
         "grpc_trace",
     ],
 )
@@ -2763,6 +2765,7 @@ grpc_cc_library(
     external_deps = [
         "absl/strings",
         "absl/strings:str_format",
+        "absl/types:optional",
     ],
     tags = ["nofixdeps"],
     visibility = ["@grpc:iomgr_buffer_list"],
@@ -3679,6 +3682,7 @@ grpc_cc_library(
     deps = [
         "backoff",
         "debug_location",
+        "endpoint_addresses",
         "envoy_admin_upb",
         "envoy_config_core_upb",
         "envoy_config_endpoint_upb",


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/34482.

But this is only a bandaid, there is a bigger issue with build dependencies. AFAICT, https://github.com/grpc/grpc/blob/master/tools/distrib/fix_build_deps.py does not work on many targets, e.g. if the target has specified the `nofixdeps` tag or if a field is set to a variable, e.g.

```
GRPCXX_SRCS = [
  "a",
  "b",
  "c",
]
...
srcs = GRPCXX_SRCS,
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

