### PR TITLE
[Build] Add str_cat header dependency.

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2212,6 +2212,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/container:flat_hash_map",
+        "absl/strings",
         "absl/strings:str_format",
     ],
     deps = [

--- a/src/core/lib/event_engine/cf_engine/dns_service_resolver.cc
+++ b/src/core/lib/event_engine/cf_engine/dns_service_resolver.cc
@@ -18,6 +18,7 @@
 #include <AvailabilityMacros.h>
 #ifdef AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER
 
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
 #include "src/core/lib/address_utils/parse_address.h"


### PR DESCRIPTION
Afaict the Abseil change that causes failures is https://github.com/abseil/abseil-cpp/commit/143e983739333ce4b30320d26bce8594bd24b5f3