### PR TITLE
[CSM] Google Cloud C++ libraries now allow bazel layering checks

### DIFF
--- a/src/cpp/ext/csm/BUILD
+++ b/src/cpp/ext/csm/BUILD
@@ -23,10 +23,9 @@ licenses(["reciprocal"])
 
 package(
     default_visibility = ["//visibility:public"],
-    # TODO(yashykt): Google Cloud C++ does not explicitly export the headers. Remove this once that is fixed.
-    #features = [
-    #    "layering_check",
-    #],
+    features = [
+        "layering_check",
+    ],
 )
 
 grpc_cc_library(
@@ -47,7 +46,7 @@ grpc_cc_library(
         "absl/strings",
         "absl/types:optional",
         "absl/types:variant",
-        "google_cloud_cpp:experimental-opentelemetry",
+        "google_cloud_cpp:opentelemetry",
         "otel/sdk/src/metrics",
         "otel/sdk:headers",
         "upb_lib",

--- a/test/cpp/ext/csm/BUILD
+++ b/test/cpp/ext/csm/BUILD
@@ -27,7 +27,7 @@ grpc_cc_test(
         "csm_observability_test.cc",
     ],
     external_deps = [
-        "google_cloud_cpp:experimental-opentelemetry",
+        "google_cloud_cpp:opentelemetry",
         "gtest",
         "otel/sdk/src/metrics",
     ],
@@ -47,7 +47,7 @@ grpc_cc_test(
         "metadata_exchange_test.cc",
     ],
     external_deps = [
-        "google_cloud_cpp:experimental-opentelemetry",
+        "google_cloud_cpp:opentelemetry",
         "gtest",
         "otel/sdk/src/metrics",
     ],

--- a/tools/distrib/fix_build_deps.py
+++ b/tools/distrib/fix_build_deps.py
@@ -95,7 +95,7 @@ EXTERNAL_DEPS = {
     "absl/types/variant.h": "absl/types:variant",
     "absl/utility/utility.h": "absl/utility",
     "address_sorting/address_sorting.h": "address_sorting",
-    "google/cloud/opentelemetry/resource_detector.h": "google_cloud_cpp:experimental-opentelemetry",
+    "google/cloud/opentelemetry/resource_detector.h": "google_cloud_cpp:opentelemetry",
     "opentelemetry/common/attribute_value.h": "otel/api",
     "opentelemetry/common/key_value_iterable.h": "otel/api",
     "opentelemetry/nostd/function_ref.h": "otel/api",


### PR DESCRIPTION
Changes - 
Use the following features from the new google cloud C++ release - 
1) The opentelemetry bazel target is no longer experimental.
2) layering checks now work with bazel

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

