### PR TITLE
[interop] Add absl dependency to interop clients

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -202,7 +202,8 @@ class RunInterop(test.test):
         from tests.interop import client
 
         sys.argv[1:] = self.args.split()
-        client.test_interoperability()
+        client.test_interoperability(
+            client.parse_interop_client_args(sys.argv))
 
 
 class RunFork(test.test):

--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -202,8 +202,7 @@ class RunInterop(test.test):
         from tests.interop import client
 
         sys.argv[1:] = self.args.split()
-        client.test_interoperability(
-            client.parse_interop_client_args(sys.argv))
+        client.test_interoperability(client.parse_interop_client_args(sys.argv))
 
 
 class RunFork(test.test):

--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -33,6 +33,7 @@ py_library(
         ":resources",
         "//src/proto/grpc/testing:py_test_proto",
         "//src/python/grpcio/grpc:grpcio",
+        requirement("absl-py"),
         requirement("google-auth"),
     ],
 )

--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -216,7 +216,6 @@ def _test_case_from_arg(test_case_arg):
 
 
 def test_interoperability(args):
-    args = parse_interop_client_args()
     channel = _create_channel(args)
     stub = create_stub(channel, args)
     test_case = _test_case_from_arg(args.test_case)

--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 """The Python implementation of the GRPC interoperability test client."""
 
-import argparse
 import os
 
+from absl import app
+from absl.flags import argparse_flags
 from google import auth as google_auth
 from google.auth import jwt as google_auth_jwt
 import grpc
@@ -25,8 +26,8 @@ from tests.interop import methods
 from tests.interop import resources
 
 
-def parse_interop_client_args():
-    parser = argparse.ArgumentParser()
+def parse_interop_client_args(argv):
+    parser = argparse_flags.ArgumentParser()
     parser.add_argument(
         "--server_host",
         default="localhost",
@@ -92,7 +93,7 @@ def parse_interop_client_args():
             " round_robin " + "or pick_first)."
         ),
     )
-    return parser.parse_args()
+    return parser.parse_args(argv[1:])
 
 
 def _create_call_credentials(args):
@@ -214,7 +215,7 @@ def _test_case_from_arg(test_case_arg):
         raise ValueError('No test case "%s"!' % test_case_arg)
 
 
-def test_interoperability():
+def test_interoperability(args):
     args = parse_interop_client_args()
     channel = _create_channel(args)
     stub = create_stub(channel, args)
@@ -223,4 +224,4 @@ def test_interoperability():
 
 
 if __name__ == "__main__":
-    test_interoperability()
+    app.run(test_interoperability, flags_parser=parse_interop_client_args)

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 """Entry point for running stress tests."""
 
-import argparse
 from concurrent import futures
 import queue
 import threading
 
 import grpc
 
+from absl import app
+from absl.flags import argparse_flags
 from src.proto.grpc.testing import metrics_pb2_grpc
 from src.proto.grpc.testing import test_pb2_grpc
 from tests.interop import methods
@@ -30,9 +31,7 @@ from tests.stress import test_runner
 
 
 def _args():
-    parser = argparse.ArgumentParser(
-        description="gRPC Python stress test client"
-    )
+    parser = argparse_flags.ArgumentParser()
     parser.add_argument(
         "--server_addresses",
         help="comma separated list of hostname:port to run servers on",
@@ -83,7 +82,7 @@ def _args():
         help="the server host to which to claim to connect",
         type=str,
     )
-    return parser.parse_args()
+    return parser.parse_args(argv[1:])
 
 
 def _test_case_from_arg(test_case_arg):
@@ -174,4 +173,4 @@ def run_test(args):
 
 
 if __name__ == "__main__":
-    run_test(_args())
+    app.run(run_test, flags_parser=_args)

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -17,10 +17,10 @@ from concurrent import futures
 import queue
 import threading
 
-import grpc
-
 from absl import app
 from absl.flags import argparse_flags
+import grpc
+
 from src.proto.grpc.testing import metrics_pb2_grpc
 from src.proto.grpc.testing import test_pb2_grpc
 from tests.interop import methods
@@ -30,7 +30,7 @@ from tests.stress import metrics_server
 from tests.stress import test_runner
 
 
-def _args():
+def _args(argv):
     parser = argparse_flags.ArgumentParser()
     parser.add_argument(
         "--server_addresses",

--- a/src/python/grpcio_tests/tests_aio/interop/client.py
+++ b/src/python/grpcio_tests/tests_aio/interop/client.py
@@ -16,6 +16,7 @@ import argparse
 import asyncio
 import logging
 import os
+import sys
 
 import grpc
 from grpc.experimental import aio
@@ -53,7 +54,7 @@ def _test_case_from_arg(test_case_arg):
 
 
 async def test_interoperability():
-    args = interop_client_lib.parse_interop_client_args()
+    args = interop_client_lib.parse_interop_client_args(sys.argv)
     channel = _create_channel(args)
     stub = interop_client_lib.create_stub(channel, args)
     test_case = _test_case_from_arg(args.test_case)


### PR DESCRIPTION
Similar to https://github.com/grpc/grpc/pull/33830 but adds the absl dependency on the client side.

Requires a cherrypick

