### PR TITLE
[xds_override_host] fix vector initialization bug

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -793,7 +793,8 @@ void XdsOverrideHostLb::SubchannelWrapper::UpdateConnectivityState(
   // Sending connectivity state notifications to the watchers may cause the set
   // of watchers to change, so we can't be iterating over the set of watchers
   // while we send the notifications
-  std::vector<ConnectivityStateWatcherInterface*> watchers(watchers_.size());
+  std::vector<ConnectivityStateWatcherInterface*> watchers;
+  watchers.reserve(watchers_.size());
   for (const auto& watcher : watchers_) {
     watchers.push_back(watcher.get());
   }


### PR DESCRIPTION
Instead of initializing the vector to N elements whose values are all null, we should be reserving N elements before populating the vector.

This bug didn't actually break anything, but it did cause us to allocate twice the amount of space that we should have.