### PR TITLE
[test infra] Bump Python Windows distribtest timeout part 2

### DIFF
--- a/tools/internal_ci/windows/pull_request/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/release/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/release/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Since we added support for Python 3.12, our tests have been taking longer to complete and we've been seeing an increase in timeout errors.

We already increased timeout in #34550, this PR increase timeout for release and pull_request jobs.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

