### PR TITLE
[CSM C++] Fix behavior when peer does not send metadata

### DIFF
--- a/src/cpp/ext/csm/metadata_exchange.h
+++ b/src/cpp/ext/csm/metadata_exchange.h
@@ -43,12 +43,12 @@ class ServiceMeshLabelsInjector : public LabelsInjector {
   // Read the incoming initial metadata to get the set of labels to be added to
   // metrics.
   std::unique_ptr<LabelsIterable> GetLabels(
-      grpc_metadata_batch* incoming_initial_metadata,
-      bool* received_peer_metadata) override;
+      grpc_metadata_batch* incoming_initial_metadata) override;
 
   // Modify the outgoing initial metadata with metadata information to be sent
   // to the peer.
-  void AddLabels(grpc_metadata_batch* outgoing_initial_metadata) override;
+  void AddLabels(grpc_metadata_batch* outgoing_initial_metadata,
+                 LabelsIterable* labels_from_incoming_metadata) override;
 
  private:
   std::vector<std::pair<absl::string_view, std::string>> local_labels_;

--- a/src/cpp/ext/csm/metadata_exchange.h
+++ b/src/cpp/ext/csm/metadata_exchange.h
@@ -43,7 +43,8 @@ class ServiceMeshLabelsInjector : public LabelsInjector {
   // Read the incoming initial metadata to get the set of labels to be added to
   // metrics.
   std::unique_ptr<LabelsIterable> GetLabels(
-      grpc_metadata_batch* incoming_initial_metadata) override;
+      grpc_metadata_batch* incoming_initial_metadata,
+      bool* received_peer_metadata) override;
 
   // Modify the outgoing initial metadata with metadata information to be sent
   // to the peer.

--- a/src/cpp/ext/otel/otel_client_filter.cc
+++ b/src/cpp/ext/otel/otel_client_filter.cc
@@ -130,8 +130,8 @@ OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
 void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
     RecordReceivedInitialMetadata(grpc_metadata_batch* recv_initial_metadata) {
   if (OTelPluginState().labels_injector != nullptr) {
-    injected_labels_ =
-        OTelPluginState().labels_injector->GetLabels(recv_initial_metadata);
+    injected_labels_ = OTelPluginState().labels_injector->GetLabels(
+        recv_initial_metadata, nullptr);
   }
 }
 

--- a/src/cpp/ext/otel/otel_client_filter.cc
+++ b/src/cpp/ext/otel/otel_client_filter.cc
@@ -130,15 +130,16 @@ OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
 void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
     RecordReceivedInitialMetadata(grpc_metadata_batch* recv_initial_metadata) {
   if (OTelPluginState().labels_injector != nullptr) {
-    injected_labels_ = OTelPluginState().labels_injector->GetLabels(
-        recv_initial_metadata, nullptr);
+    injected_labels_ =
+        OTelPluginState().labels_injector->GetLabels(recv_initial_metadata);
   }
 }
 
 void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
     RecordSendInitialMetadata(grpc_metadata_batch* send_initial_metadata) {
   if (OTelPluginState().labels_injector != nullptr) {
-    OTelPluginState().labels_injector->AddLabels(send_initial_metadata);
+    OTelPluginState().labels_injector->AddLabels(send_initial_metadata,
+                                                 nullptr);
   }
 }
 

--- a/src/cpp/ext/otel/otel_plugin.h
+++ b/src/cpp/ext/otel/otel_plugin.h
@@ -65,15 +65,16 @@ class LabelsInjector {
  public:
   virtual ~LabelsInjector() {}
   // Read the incoming initial metadata to get the set of labels to be added to
-  // metrics. If \a received_peer_metadata is not nullptr, it is set to true if
-  // peer's metadata was received on the wire, false otherwise.
+  // metrics.
   virtual std::unique_ptr<LabelsIterable> GetLabels(
-      grpc_metadata_batch* incoming_initial_metadata,
-      bool* received_peer_metadata) = 0;
+      grpc_metadata_batch* incoming_initial_metadata) = 0;
 
   // Modify the outgoing initial metadata with metadata information to be sent
-  // to the peer.
-  virtual void AddLabels(grpc_metadata_batch* outgoing_initial_metadata) = 0;
+  // to the peer. On the server side, \a labels_from_incoming_metadata returned
+  // from `GetLabels` should be provided as input here. On the client side, this
+  // should be nullptr.
+  virtual void AddLabels(grpc_metadata_batch* outgoing_initial_metadata,
+                         LabelsIterable* labels_from_incoming_metadata) = 0;
 };
 
 struct OTelPluginState {

--- a/src/cpp/ext/otel/otel_plugin.h
+++ b/src/cpp/ext/otel/otel_plugin.h
@@ -65,9 +65,11 @@ class LabelsInjector {
  public:
   virtual ~LabelsInjector() {}
   // Read the incoming initial metadata to get the set of labels to be added to
-  // metrics.
+  // metrics. If \a received_peer_metadata is not nullptr, it is set to true if
+  // peer's metadata was received on the wire, false otherwise.
   virtual std::unique_ptr<LabelsIterable> GetLabels(
-      grpc_metadata_batch* incoming_initial_metadata) = 0;
+      grpc_metadata_batch* incoming_initial_metadata,
+      bool* received_peer_metadata) = 0;
 
   // Modify the outgoing initial metadata with metadata information to be sent
   // to the peer.

--- a/src/cpp/ext/otel/otel_server_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_server_call_tracer.cc
@@ -77,8 +77,7 @@ class OpenTelemetryServerCallTracer : public grpc_core::ServerCallTracer {
   void RecordSendInitialMetadata(
       grpc_metadata_batch* send_initial_metadata) override {
     // Only add labels to outgoing metadata if labels were received from peer.
-    if (OTelPluginState().labels_injector != nullptr &&
-        injected_labels_ != nullptr) {
+    if (OTelPluginState().labels_injector != nullptr && received_peer_labels_) {
       OTelPluginState().labels_injector->AddLabels(send_initial_metadata);
     }
   }
@@ -142,6 +141,7 @@ class OpenTelemetryServerCallTracer : public grpc_core::ServerCallTracer {
   absl::Duration elapsed_time_;
   grpc_core::Slice path_;
   std::unique_ptr<LabelsIterable> injected_labels_;
+  bool received_peer_labels_ = false;
   bool registered_method_;
 };
 
@@ -150,8 +150,8 @@ void OpenTelemetryServerCallTracer::RecordReceivedInitialMetadata(
   path_ =
       recv_initial_metadata->get_pointer(grpc_core::HttpPathMetadata())->Ref();
   if (OTelPluginState().labels_injector != nullptr) {
-    injected_labels_ =
-        OTelPluginState().labels_injector->GetLabels(recv_initial_metadata);
+    injected_labels_ = OTelPluginState().labels_injector->GetLabels(
+        recv_initial_metadata, &received_peer_labels_);
   }
   registered_method_ =
       recv_initial_metadata->get(grpc_core::GrpcRegisteredMethod())

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -111,7 +111,8 @@ class MetadataExchangeTest
     : public OTelPluginEnd2EndTest,
       public ::testing::WithParamInterface<TestScenario> {
  protected:
-  void Init(const absl::flat_hash_set<absl::string_view>& metric_names) {
+  void Init(const absl::flat_hash_set<absl::string_view>& metric_names,
+            bool enable_client_side_injector = true) {
     const char* kBootstrap =
         "{\"node\": {\"id\": "
         "\"projects/1234567890/networks/mesh:mesh-id/nodes/"
@@ -134,7 +135,12 @@ class MetadataExchangeTest
         metric_names, /*resource=*/GetParam().GetTestResource(),
         /*labels_injector=*/
         std::make_unique<grpc::internal::ServiceMeshLabelsInjector>(
-            GetParam().GetTestResource().GetAttributes()));
+            GetParam().GetTestResource().GetAttributes()),
+        /*test_no_meter_provider=*/false,
+        /*target_selector=*/
+        [enable_client_side_injector](absl::string_view /*target*/) {
+          return enable_client_side_injector;
+        });
   }
 
   ~MetadataExchangeTest() override {
@@ -197,6 +203,7 @@ class MetadataExchangeTest
   char* bootstrap_file_name_ = nullptr;
 };
 
+// Verify that grpc.client.attempt.started does not get service mesh attributes
 TEST_P(MetadataExchangeTest, ClientAttemptStarted) {
   Init(/*metric_names=*/{
       grpc::internal::OTelClientAttemptStartedInstrumentName()});
@@ -245,6 +252,7 @@ TEST_P(MetadataExchangeTest, ClientAttemptDuration) {
   VerifyServiceMeshAttributes(attributes);
 }
 
+// Verify that grpc.server.call.started does not get service mesh attributes
 TEST_P(MetadataExchangeTest, ServerCallStarted) {
   Init(
       /*metric_names=*/{grpc::internal::OTelServerCallStartedInstrumentName()});
@@ -285,6 +293,35 @@ TEST_P(MetadataExchangeTest, ServerCallDuration) {
   EXPECT_EQ(absl::get<std::string>(attributes.at("grpc.method")), kMethodName);
   EXPECT_EQ(absl::get<std::string>(attributes.at("grpc.status")), "OK");
   VerifyServiceMeshAttributes(attributes);
+}
+
+// Test that the server records unknown when the client does not send metadata
+TEST_P(MetadataExchangeTest, ClientDoesNotSendMetadata) {
+  Init(
+      /*metric_names=*/{grpc::internal::OTelServerCallDurationInstrumentName()},
+      /*enable_client_side_injector=*/false);
+  SendRPC();
+  const char* kMetricName = "grpc.server.call.duration";
+  auto data = ReadCurrentMetricsData(
+      [&](const absl::flat_hash_map<
+          std::string,
+          std::vector<opentelemetry::sdk::metrics::PointDataAttributes>>&
+              data) { return !data.contains(kMetricName); });
+  ASSERT_EQ(data[kMetricName].size(), 1);
+  auto point_data =
+      absl::get_if<opentelemetry::sdk::metrics::HistogramPointData>(
+          &data[kMetricName][0].point_data);
+  ASSERT_NE(point_data, nullptr);
+  ASSERT_EQ(point_data->count_, 1);
+  const auto& attributes = data[kMetricName][0].attributes.GetAttributes();
+  EXPECT_EQ(absl::get<std::string>(attributes.at("grpc.method")), kMethodName);
+  EXPECT_EQ(absl::get<std::string>(attributes.at("grpc.status")), "OK");
+  EXPECT_EQ(
+      absl::get<std::string>(attributes.at("csm.workload_canonical_service")),
+      "canonical_service");
+  EXPECT_EQ(absl::get<std::string>(attributes.at("csm.mesh_id")), "mesh-id");
+  EXPECT_EQ(absl::get<std::string>(attributes.at("csm.remote_workload_type")),
+            "unknown");
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
@stanley-cheung noticed a bug where CSM labels were not being added on metrics if the peer was not also CSM Observability enabled.

This PR fixes the behavior to add in the local labels in this case, as well as add the remote workload type label with the value of unknown.