### PR TITLE
[time-cache] Remove experimentally from ExecCtx

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -23,11 +23,13 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "event_engine_listener",
+                "no_exec_ctx_time_cache",
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
             "cpp_end2end_test": [
+                "no_exec_ctx_time_cache",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -50,6 +52,7 @@ EXPERIMENTS = {
                 "promise_based_client_call",
             ],
             "lb_unit_test": [
+                "no_exec_ctx_time_cache",
                 "work_serializer_dispatch",
             ],
             "logging_test": [
@@ -61,6 +64,7 @@ EXPERIMENTS = {
                 "unconstrained_max_quota_buffer_size",
             ],
             "xds_end2end_test": [
+                "no_exec_ctx_time_cache",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -107,11 +111,13 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "event_engine_listener",
+                "no_exec_ctx_time_cache",
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
             "cpp_end2end_test": [
+                "no_exec_ctx_time_cache",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -134,6 +140,7 @@ EXPERIMENTS = {
                 "promise_based_client_call",
             ],
             "lb_unit_test": [
+                "no_exec_ctx_time_cache",
                 "work_serializer_dispatch",
             ],
             "logging_test": [
@@ -145,6 +152,7 @@ EXPERIMENTS = {
                 "unconstrained_max_quota_buffer_size",
             ],
             "xds_end2end_test": [
+                "no_exec_ctx_time_cache",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -195,11 +203,13 @@ EXPERIMENTS = {
             "core_end2end_test": [
                 "event_engine_client",
                 "event_engine_listener",
+                "no_exec_ctx_time_cache",
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
             "cpp_end2end_test": [
+                "no_exec_ctx_time_cache",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -225,6 +235,7 @@ EXPERIMENTS = {
                 "promise_based_client_call",
             ],
             "lb_unit_test": [
+                "no_exec_ctx_time_cache",
                 "work_serializer_dispatch",
             ],
             "logging_test": [
@@ -239,6 +250,7 @@ EXPERIMENTS = {
                 "unconstrained_max_quota_buffer_size",
             ],
             "xds_end2end_test": [
+                "no_exec_ctx_time_cache",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -439,6 +439,7 @@ grpc_cc_library(
         "promise_factory",
         "promise_trace",
         "ref_counted",
+        "time",
         "//:event_engine_base_hdrs",
         "//:exec_ctx",
         "//:gpr",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -83,6 +83,9 @@ const char* const additional_constraints_monitoring_experiment = "{}";
 const char* const description_multiping =
     "Allow more than one ping to be in flight at a time by default.";
 const char* const additional_constraints_multiping = "{}";
+const char* const description_no_exec_ctx_time_cache =
+    "Eliminate time caching from the exec_ctx.";
+const char* const additional_constraints_no_exec_ctx_time_cache = "{}";
 const char* const description_peer_state_based_framing =
     "If set, the max sizes of frames sent to lower layers is controlled based "
     "on the peer's memory pressure which is reflected in its max http2 frame "
@@ -230,6 +233,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_monitoring_experiment, true, true},
     {"multiping", description_multiping, additional_constraints_multiping,
      false, true},
+    {"no_exec_ctx_time_cache", description_no_exec_ctx_time_cache,
+     additional_constraints_no_exec_ctx_time_cache, false, true},
     {"peer_state_based_framing", description_peer_state_based_framing,
      additional_constraints_peer_state_based_framing, false, true},
     {"pick_first_happy_eyeballs", description_pick_first_happy_eyeballs,
@@ -351,6 +356,9 @@ const char* const additional_constraints_monitoring_experiment = "{}";
 const char* const description_multiping =
     "Allow more than one ping to be in flight at a time by default.";
 const char* const additional_constraints_multiping = "{}";
+const char* const description_no_exec_ctx_time_cache =
+    "Eliminate time caching from the exec_ctx.";
+const char* const additional_constraints_no_exec_ctx_time_cache = "{}";
 const char* const description_peer_state_based_framing =
     "If set, the max sizes of frames sent to lower layers is controlled based "
     "on the peer's memory pressure which is reflected in its max http2 frame "
@@ -498,6 +506,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_monitoring_experiment, true, true},
     {"multiping", description_multiping, additional_constraints_multiping,
      false, true},
+    {"no_exec_ctx_time_cache", description_no_exec_ctx_time_cache,
+     additional_constraints_no_exec_ctx_time_cache, false, true},
     {"peer_state_based_framing", description_peer_state_based_framing,
      additional_constraints_peer_state_based_framing, false, true},
     {"pick_first_happy_eyeballs", description_pick_first_happy_eyeballs,
@@ -619,6 +629,9 @@ const char* const additional_constraints_monitoring_experiment = "{}";
 const char* const description_multiping =
     "Allow more than one ping to be in flight at a time by default.";
 const char* const additional_constraints_multiping = "{}";
+const char* const description_no_exec_ctx_time_cache =
+    "Eliminate time caching from the exec_ctx.";
+const char* const additional_constraints_no_exec_ctx_time_cache = "{}";
 const char* const description_peer_state_based_framing =
     "If set, the max sizes of frames sent to lower layers is controlled based "
     "on the peer's memory pressure which is reflected in its max http2 frame "
@@ -766,6 +779,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_monitoring_experiment, true, true},
     {"multiping", description_multiping, additional_constraints_multiping,
      false, true},
+    {"no_exec_ctx_time_cache", description_no_exec_ctx_time_cache,
+     additional_constraints_no_exec_ctx_time_cache, false, true},
     {"peer_state_based_framing", description_peer_state_based_framing,
      additional_constraints_peer_state_based_framing, false, true},
     {"pick_first_happy_eyeballs", description_pick_first_happy_eyeballs,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -91,6 +91,7 @@ inline bool IsMemoryPressureControllerEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_MONITORING_EXPERIMENT
 inline bool IsMonitoringExperimentEnabled() { return true; }
 inline bool IsMultipingEnabled() { return false; }
+inline bool IsNoExecCtxTimeCacheEnabled() { return false; }
 inline bool IsPeerStateBasedFramingEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PICK_FIRST_HAPPY_EYEBALLS
 inline bool IsPickFirstHappyEyeballsEnabled() { return true; }
@@ -163,6 +164,7 @@ inline bool IsMemoryPressureControllerEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_MONITORING_EXPERIMENT
 inline bool IsMonitoringExperimentEnabled() { return true; }
 inline bool IsMultipingEnabled() { return false; }
+inline bool IsNoExecCtxTimeCacheEnabled() { return false; }
 inline bool IsPeerStateBasedFramingEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PICK_FIRST_HAPPY_EYEBALLS
 inline bool IsPickFirstHappyEyeballsEnabled() { return true; }
@@ -235,6 +237,7 @@ inline bool IsMemoryPressureControllerEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_MONITORING_EXPERIMENT
 inline bool IsMonitoringExperimentEnabled() { return true; }
 inline bool IsMultipingEnabled() { return false; }
+inline bool IsNoExecCtxTimeCacheEnabled() { return false; }
 inline bool IsPeerStateBasedFramingEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PICK_FIRST_HAPPY_EYEBALLS
 inline bool IsPickFirstHappyEyeballsEnabled() { return true; }
@@ -293,6 +296,7 @@ enum ExperimentIds {
   kExperimentIdMemoryPressureController,
   kExperimentIdMonitoringExperiment,
   kExperimentIdMultiping,
+  kExperimentIdNoExecCtxTimeCache,
   kExperimentIdPeerStateBasedFraming,
   kExperimentIdPickFirstHappyEyeballs,
   kExperimentIdPingOnRstStream,
@@ -392,6 +396,10 @@ inline bool IsMonitoringExperimentEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_MULTIPING
 inline bool IsMultipingEnabled() {
   return IsExperimentEnabled(kExperimentIdMultiping);
+}
+#define GRPC_EXPERIMENT_IS_INCLUDED_NO_EXEC_CTX_TIME_CACHE
+inline bool IsNoExecCtxTimeCacheEnabled() {
+  return IsExperimentEnabled(kExperimentIdNoExecCtxTimeCache);
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PEER_STATE_BASED_FRAMING
 inline bool IsPeerStateBasedFramingEnabled() {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -144,6 +144,12 @@
   expiry: 2024/01/15
   owner: ctiller@google.com
   test_tags: [flow_control_test]
+- name: no_exec_ctx_time_cache
+  description:
+    Eliminate time caching from the exec_ctx.
+  expiry: 2024/03/03
+  owner: ctiller@google.com
+  test_tags: ["core_end2end_test", "cpp_end2end_test", "xds_end2end_test", "lb_unit_test"]
 - name: peer_state_based_framing
   description:
     If set, the max sizes of frames sent to lower layers is controlled based

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -228,6 +228,9 @@ bool Party::RunParty() {
   ScopedActivity activity(this);
   promise_detail::Context<Arena> arena_ctx(arena_);
   return sync_.RunParty([this](int i) {
+    // One poll of one participate gets a cached time, so if we query time
+    // repeatedly (say on the outbound path of a write) we get the same value.
+    ScopedTimeCache time_cache;
     // If the participant is null, skip.
     // This allows participants to complete whilst wakers still exist
     // somewhere.

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -24,6 +24,7 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/sync.h"
+#include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/promise/activity.h"
 #include "src/core/lib/promise/trace.h"


### PR DESCRIPTION
- always include it in Party::RunParty when polling one promise (this is very short lived - must be - and gets us the benefits we want for promises, without the risks we see elsewhere)
- we can do this now as a test, and have the new caching behavior held under test with the promise client & server code paths
