### PR TITLE
[EventEngine] Re-enable skipped core/end2end EventEngine client tests

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -117,8 +117,6 @@ constexpr grpc_core::Duration kLifeguardMinSleepBetweenChecks{
 // Maximum time the lifeguard thread should sleep between checking for new work.
 constexpr grpc_core::Duration kLifeguardMaxSleepBetweenChecks{
     grpc_core::Duration::Seconds(1)};
-// Maximum size of local queue before enqueueing new work onto the global queue
-constexpr size_t kLocalQueueMaxSize{10};
 }  // namespace
 
 thread_local WorkQueue* g_local_queue = nullptr;
@@ -188,7 +186,7 @@ void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Start() {
 void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Run(
     EventEngine::Closure* closure) {
   GPR_DEBUG_ASSERT(quiesced_.load(std::memory_order_relaxed) == false);
-  if (g_local_queue != nullptr && g_local_queue->Size() < kLocalQueueMaxSize) {
+  if (g_local_queue != nullptr) {
     g_local_queue->Add(closure);
   } else {
     queue_.Add(closure);

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -117,6 +117,8 @@ constexpr grpc_core::Duration kLifeguardMinSleepBetweenChecks{
 // Maximum time the lifeguard thread should sleep between checking for new work.
 constexpr grpc_core::Duration kLifeguardMaxSleepBetweenChecks{
     grpc_core::Duration::Seconds(1)};
+// Maximum size of local queue before enqueueing new work onto the global queue
+constexpr size_t kLocalQueueMaxSize{10};
 }  // namespace
 
 thread_local WorkQueue* g_local_queue = nullptr;
@@ -186,7 +188,7 @@ void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Start() {
 void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Run(
     EventEngine::Closure* closure) {
   GPR_DEBUG_ASSERT(quiesced_.load(std::memory_order_relaxed) == false);
-  if (g_local_queue != nullptr) {
+  if (g_local_queue != nullptr && g_local_queue->Size() < kLocalQueueMaxSize) {
     g_local_queue->Add(closure);
   } else {
     queue_.Add(closure);

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -868,10 +868,6 @@ class CoreEnd2endTestRegistry {
   if (GetParam()->feature_mask & FEATURE_MASK_IS_MINSTACK) \
   GTEST_SKIP() << "Skipping test for minstack"
 
-#define SKIP_IF_USES_EVENT_ENGINE_CLIENT()                                     \
-  if (!g_is_fuzzing_core_e2e_tests && grpc_core::IsEventEngineClientEnabled()) \
-  GTEST_SKIP() << "Skipping test to prevent it from using EventEngine client"
-
 #define SKIP_IF_FUZZING() \
   if (g_is_fuzzing_core_e2e_tests) GTEST_SKIP() << "Skipping test for fuzzing"
 

--- a/test/core/end2end/tests/binary_metadata.cc
+++ b/test/core/end2end/tests/binary_metadata.cc
@@ -119,8 +119,6 @@ CORE_END2END_TEST(CoreEnd2endTest,
 
 CORE_END2END_TEST(CoreEnd2endTest,
                   BinaryMetadataServerHttp2FallbackClientHttp2Fallback) {
-  // TODO(vigneshbabu): re-enable these before release
-  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   BinaryMetadata(*this, false, false);
 }
 

--- a/test/core/end2end/tests/call_creds.cc
+++ b/test/core/end2end/tests/call_creds.cc
@@ -288,8 +288,6 @@ CORE_END2END_TEST(PerCallCredsTest,
 
 CORE_END2END_TEST(PerCallCredsTest,
                   RequestResponseWithPayloadAndDeletedInsecureCallCreds) {
-  // TODO(vigneshbabu): re-enable these before release
-  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   TestRequestResponseWithPayloadAndDeletedCallCreds(*this, false);
 }
 
@@ -305,8 +303,6 @@ CORE_END2END_TEST(PerCallCredsOnInsecureTest,
 
 CORE_END2END_TEST(PerCallCredsOnInsecureTest,
                   RequestResponseWithPayloadAndDeletedInsecureCallCreds) {
-  // TODO(vigneshbabu): re-enable these before release
-  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   TestRequestResponseWithPayloadAndDeletedCallCreds(*this, false);
 }
 

--- a/test/core/end2end/tests/cancel_after_accept.cc
+++ b/test/core/end2end/tests/cancel_after_accept.cc
@@ -78,8 +78,6 @@ CORE_END2END_TEST(CoreDeadlineTest, DeadlineAfterAccept) {
 }
 
 CORE_END2END_TEST(CoreClientChannelTest, DeadlineAfterAcceptWithServiceConfig) {
-  // TODO(vigneshbabu): re-enable these before release
-  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/cancel_after_invoke.cc
+++ b/test/core/end2end/tests/cancel_after_invoke.cc
@@ -109,25 +109,21 @@ void CancelAfterInvoke3(CoreEnd2endTest& test,
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke6) {
-  // TODO(vigneshbabu): re-enable these before release
   CancelAfterInvoke6(*this, std::make_unique<CancelCancellationMode>(),
                      kCancelTimeout);
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke5) {
-  // TODO(vigneshbabu): re-enable these before release
   CancelAfterInvoke5(*this, std::make_unique<CancelCancellationMode>(),
                      kCancelTimeout);
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke4) {
-  // TODO(vigneshbabu): re-enable these before release
   CancelAfterInvoke4(*this, std::make_unique<CancelCancellationMode>(),
                      kCancelTimeout);
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelAfterInvoke3) {
-  // TODO(vigneshbabu): re-enable these before release
   CancelAfterInvoke3(*this, std::make_unique<CancelCancellationMode>(),
                      kCancelTimeout);
 }

--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -83,7 +83,6 @@ CORE_END2END_TEST(CoreEnd2endTest, CancelWithStatus3) {
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, CancelWithStatus4) {
-  // TODO(vigneshbabu): re-enable these before release
   auto c = NewClientCall("/foo").Timeout(Duration::Seconds(5)).Create();
   CoreEnd2endTest::IncomingMetadata server_initial_metadata;
   CoreEnd2endTest::IncomingStatusOnClient server_status;

--- a/test/core/end2end/tests/filtered_metadata.cc
+++ b/test/core/end2end/tests/filtered_metadata.cc
@@ -74,8 +74,6 @@ void TestRequestResponseWithMetadataToBeFiltered(
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, ContentLengthIsFiltered) {
-  // TODO(vigneshbabu): re-enable these before release
-  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   TestRequestResponseWithMetadataToBeFiltered(*this, "content-length", "45");
 }
 

--- a/test/core/end2end/tests/retry_recv_initial_metadata.cc
+++ b/test/core/end2end/tests/retry_recv_initial_metadata.cc
@@ -36,8 +36,6 @@ namespace {
 // - first attempt receives initial metadata before trailing metadata,
 //   so no retry is done even though status was ABORTED
 CORE_END2END_TEST(RetryTest, RetryRecvInitialMetadata) {
-  // TODO(vigneshbabu): re-enable these before release
-  SKIP_IF_USES_EVENT_ENGINE_CLIENT();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/simple_request.cc
+++ b/test/core/end2end/tests/simple_request.cc
@@ -98,9 +98,7 @@ void SimpleRequestBody(CoreEnd2endTest& test) {
             expected_calls);
 }
 
-CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest) {
-  SimpleRequestBody(*this);
-}
+CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest) { SimpleRequestBody(*this); }
 
 CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest10) {
   for (int i = 0; i < 10; i++) {

--- a/test/core/end2end/tests/simple_request.cc
+++ b/test/core/end2end/tests/simple_request.cc
@@ -99,7 +99,6 @@ void SimpleRequestBody(CoreEnd2endTest& test) {
 }
 
 CORE_END2END_TEST(CoreEnd2endTest, SimpleRequest) {
-  // TODO(vigneshbabu): re-enable these before release
   SimpleRequestBody(*this);
 }
 


### PR DESCRIPTION
Let's not merge this PR this week, maybe 2023-10-23 at the earliest. This will allow time for flakes to shake out of the listener experiments (enabled in https://github.com/grpc/grpc/pull/34700) in isolation of client problems.