### PR TITLE
[interop] Add v1.59.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -291,6 +291,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.56.3", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.57.1", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.58.3", ReleaseInfo(runtimes=["go1.19"])),
+            ("v1.59.0", ReleaseInfo(runtimes=["go1.19"])),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
Add new release to interop matrix https://github.com/grpc/grpc-go/releases/tag/v1.59.0