### PR TITLE
[ruby] upgrade and pin rake compiler dock

### DIFF
--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -41,7 +41,7 @@
     s.add_development_dependency 'simplecov',          '~> 0.22'
     s.add_development_dependency 'rake',               '~> 13.0'
     s.add_development_dependency 'rake-compiler',      '~> 1.2.1'
-    s.add_development_dependency 'rake-compiler-dock', '~> 1.3'
+    s.add_development_dependency 'rake-compiler-dock', '== 1.3.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 1.41.0'
     s.add_development_dependency 'signet',             '~> 0.7'


### PR DESCRIPTION
Follow up to https://github.com/grpc/grpc/pull/34632 which upgraded rake compiler dock images to 1.3.1

It doesn't make sense to pull a rake compiler dock gem different from the version of our rake compiler dock docker images, so let's pin the version.
