### PR TITLE
[Fix Python Deadlock] Guard grpc_ssl_credentials_create with nogil (v1.59.x backport)

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -153,8 +153,9 @@ cdef class SSLChannelCredentials(ChannelCredentials):
     else:
       c_pem_root_certificates = self._pem_root_certificates
     if self._private_key is None and self._certificate_chain is None:
-      return grpc_ssl_credentials_create(
-          c_pem_root_certificates, NULL, NULL, NULL)
+      with nogil:
+        return grpc_ssl_credentials_create(
+            c_pem_root_certificates, NULL, NULL, NULL)
     else:
       if self._private_key:
         c_pem_key_certificate_pair.private_key = self._private_key
@@ -164,8 +165,9 @@ cdef class SSLChannelCredentials(ChannelCredentials):
         c_pem_key_certificate_pair.certificate_chain = self._certificate_chain
       else:
         c_pem_key_certificate_pair.certificate_chain = NULL
-      return grpc_ssl_credentials_create(
-          c_pem_root_certificates, &c_pem_key_certificate_pair, NULL, NULL)
+      with nogil:
+        return grpc_ssl_credentials_create(
+            c_pem_root_certificates, &c_pem_key_certificate_pair, NULL, NULL)
 
 
 cdef class CompositeChannelCredentials(ChannelCredentials):


### PR DESCRIPTION
Backport of #34712 to v1.59.x.
---
Fix: https://github.com/grpc/grpc/issues/34672
With some recent changes in core, now `grpc_ssl_credentials_create` is guarded by `gpr_once_init`. In our current implementation, The thread got `gpr_once_init` lock might require GIL lock during the execution of `grpc_ssl_credentials_create`, which might cause a deadlock if another thread is holding GIL lock and waiting for `gpr_once_init` lock.

This change adds `with nogil` to calls to native function `grpc_ssl_credentials_create` to make sure GIL is released before calling `grpc_ssl_credentials_create`.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

