### PR TITLE
[Lint] Fixed clang-tidy error

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -127,9 +127,10 @@ struct grpc_cronet_transport final : public grpc_core::Transport,
   grpc_core::ServerTransport* server_transport() override { return nullptr; }
 
   absl::string_view GetTransportName() const override { return "cronet_http"; }
-  void SetPollset(grpc_stream* stream, grpc_pollset* pollset) override {}
-  void SetPollsetSet(grpc_stream* stream,
-                     grpc_pollset_set* pollset_set) override {}
+  void SetPollset(grpc_stream* /*stream*/, grpc_pollset* /*pollset*/) override {
+  }
+  void SetPollsetSet(grpc_stream* /*stream*/,
+                     grpc_pollset_set* /*pollset_set*/) override {}
   void PerformOp(grpc_transport_op* op) override;
   grpc_endpoint* GetEndpoint() override { return nullptr; }
   size_t SizeOfStream() const override;


### PR DESCRIPTION
Fixed the followings.

```
src/core/ext/transport/cronet/transport/cronet_transport.cc:130:32: error: unused parameter 'stream' [-Werror,-Wunused-parameter]
  void SetPollset(grpc_stream* stream, grpc_pollset* pollset) override {}
                               ^
src/core/ext/transport/cronet/transport/cronet_transport.cc:130:54: error: unused parameter 'pollset' [-Werror,-Wunused-parameter]
  void SetPollset(grpc_stream* stream, grpc_pollset* pollset) override {}
                                                     ^
src/core/ext/transport/cronet/transport/cronet_transport.cc:131:35: error: unused parameter 'stream' [-Werror,-Wunused-parameter]
  void SetPollsetSet(grpc_stream* stream,
                                  ^
src/core/ext/transport/cronet/transport/cronet_transport.cc:132:40: error: unused parameter 'pollset_set' [-Werror,-Wunused-parameter]
                     grpc_pollset_set* pollset_set) override {}
                                       ^
```