### PR TITLE
[Doc] Updated gRPC C++ supported platform 

### DIFF
--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -30,11 +30,11 @@ Therefore, gRPC supports several major build systems, which should satisfy most 
 
 | Operating System | Architectures | Versions | Support Level |
 |------------------|---------------|----------|---------------|
-| Linux - Debian, Ubuntu, CentOS | x86, x64      | clang 6+, GCC 7.3+     | Officially Supported |
+| Linux - Debian, Ubuntu, CentOS | x86, x64      | clang 7+, GCC 7.3+     | Officially Supported |
 | Windows 10+                    | x86, x64      | Visual Studio 2019+    | Officially Supported |
-| MacOS                          | x86, x64      | XCode 12+              | Officially Supported |
-| Linux - Others                 | x86, x64      | clang 6+, GCC 7.3+     | Best Effort          |
-| Linux                          | ARM           |                        | Best Effort          |
+| MacOS                          | x64, ARM64    | XCode 12+              | Officially Supported |
+| Linux - Others                 | x86, x64      | clang 7+, GCC 7.3+     | Best Effort          |
+| Linux                          | ARM64         |                        | Best Effort          |
 | iOS                            |               |                        | Best Effort          |
 | Android                        |               |                        | Best Effort          |
 | AIX                            |               |                        | Community Supported  |


### PR DESCRIPTION
- Added ARM64 to MacOS to be clear about the recent Apple Silicon support.
- Removed x86 from MacOS as x86 is no longer used for Apple.
- Changed ARM to ARM64 for Linux as Foundational-cxx-support only support ARM64 although gRPC is still working on ARM32.