### PR TITLE
[PSM Interop] Log Google Cloud API debug header part 3

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -585,7 +585,11 @@ class ComputeV1(
 
     @staticmethod
     def _log_debug_header(resp: httplib2.Response):
-        if DEBUG_HEADER_IN_RESPONSE in resp and resp.status >= 300:
+        if (
+            DEBUG_HEADER_IN_RESPONSE in resp
+            and resp.status >= 300
+            and resp.status != 404
+        ):
             logger.info(
                 "Received GCP debug headers: %s",
                 resp[DEBUG_HEADER_IN_RESPONSE],
@@ -595,7 +599,9 @@ class ComputeV1(
         self, request, *, timeout_sec=_WAIT_FOR_OPERATION_SEC
     ):
         if self.gfe_debug_header:
-            logger.info("Adding debug headers for method: %s", request.methodId)
+            logger.debug(
+                "Adding debug headers for method: %s", request.methodId
+            )
             request.headers[DEBUG_HEADER_KEY] = self.gfe_debug_header
             request.add_response_callback(self._log_debug_header)
         operation = request.execute(num_retries=self._GCP_API_RETRIES)


### PR DESCRIPTION
In case of test fails, the clean up script will try delete some resource we didn't create and resulting lots of 404 errors, we should exclude those status code since we have specific handling for 404.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

