### PR TITLE
[doc] Update glossary link to grpc_arg_keys

### DIFF
--- a/doc/python/sphinx/conf.py
+++ b/doc/python/sphinx/conf.py
@@ -107,4 +107,4 @@ todo_include_todos = True
 
 # -- Options for substitutions -----------------------------------------------
 
-rst_epilog = '.. |grpc_types_link| replace:: https://github.com/grpc/grpc/blob/%s/include/grpc/impl/codegen/grpc_types.h' % branch
+rst_epilog = '.. |channel_arg_names_link| replace:: https://github.com/grpc/grpc/blob/%s/include/grpc/impl/channel_arg_names.h' % branch

--- a/doc/python/sphinx/glossary.rst
+++ b/doc/python/sphinx/glossary.rst
@@ -45,6 +45,7 @@ Glossary
     server object. Channel arguments are meant for advanced usages and contain
     experimental API (some may not labeled as experimental). Full list of
     available channel arguments and documentation can be found under the
-    "grpc_arg_keys" section of "grpc_types.h" header file (|grpc_types_link|).
-    For example, if you want to disable TCP port reuse, you may construct
-    channel arguments like: ``options = (('grpc.so_reuseport', 0),)``.
+    "grpc_arg_keys" section of "channel_arg_names.h" header file
+    (|channel_arg_names_link|). For example, if you want to disable TCP port
+    reuse, you may construct channel arguments like:
+    ``options = (('grpc.so_reuseport', 0),)``.


### PR DESCRIPTION
I have created an [issue on grpc.io repository](https://github.com/grpc/grpc.io/issues/1212), and they have pointed me towards this repository.

Currently, in the Python documentation glossary, the [channel arguments](https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments) section contains a link to [header file grpc_types.h](https://github.com/grpc/grpc/blob/v1.58.x/include/grpc/impl/codegen/grpc_types.h) which is almost empty, and doesn't contain relevant information.

This PR fixes the invalid link in the Python glossary of gRPC documentation, by replacing it with [channel_arg_names.h](https://github.com/grpc/grpc/blob/v1.58.x/include/grpc/impl/channel_arg_names.h) which contains the relevant information.
