### PR TITLE
[Fix] safe cast int to void*

### DIFF
--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -284,7 +284,7 @@ class ChannelArgs {
 
   class Value {
    public:
-    explicit Value(int n) : rep_(reinterpret_cast<void*>(n), &int_vtable_) {}
+    explicit Value(int n) : rep_(reinterpret_cast<void*>(static_cast<intptr_t>(n)), &int_vtable_) {}
     explicit Value(std::string s)
         : rep_(RefCountedString::Make(s).release(), &string_vtable_) {}
     explicit Value(Pointer p) : rep_(std::move(p)) {}


### PR DESCRIPTION
**Brief summary**

Current direct reinterpret cast from `int` to `void*` is getting flagged by compiler and is breaking build in Windows.
```
external\com_github_grpc_grpc\src/core/lib/channel/channel_args.h(287): error C2220: the following warning is treated as an error
external\com_github_grpc_grpc\src/core/lib/channel/channel_args.h(287): warning C4312: 'reinterpret_cast': conversion from 'int' to 'void *' of greater size
```

Fixes https://github.com/envoyproxy/envoy/issues/30403

