### PR TITLE
[http2] Fix framing_bytes stat

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -35,7 +35,7 @@ grpc_slice grpc_chttp2_window_update_create(
     uint32_t id, uint32_t window_delta, grpc_transport_one_way_stats* stats) {
   static const size_t frame_size = 13;
   grpc_slice slice = GRPC_SLICE_MALLOC(frame_size);
-  stats->header_bytes += frame_size;
+  stats->framing_bytes += frame_size;
   uint8_t* p = GRPC_SLICE_START_PTR(slice);
 
   GPR_ASSERT(window_delta);

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -42,12 +42,12 @@ namespace grpc_core {
 
 namespace {
 
-constexpr size_t kDataFrameHeaderSize = 9;
+constexpr size_t kHeadersFrameHeaderSize = 9;
 
 }  // namespace
 
-// fills p (which is expected to be kDataFrameHeaderSize bytes long)
-// with a data frame header
+// fills p (which is expected to be kHeadersFrameHeaderSize bytes long)
+// with a headers frame header
 static void FillHeader(uint8_t* p, uint8_t type, uint32_t id, size_t len,
                        uint8_t flags) {
   // len is the current frame size (i.e. for the frame we're finishing).
@@ -99,9 +99,9 @@ void HPackCompressor::Frame(const EncodeHeaderOptions& options,
     } else {
       len = options.max_frame_size;
     }
-    FillHeader(grpc_slice_buffer_tiny_add(output, kDataFrameHeaderSize),
+    FillHeader(grpc_slice_buffer_tiny_add(output, kHeadersFrameHeaderSize),
                frame_type, options.stream_id, len, flags);
-    options.stats->framing_bytes += kDataFrameHeaderSize;
+    options.stats->framing_bytes += kHeadersFrameHeaderSize;
     grpc_slice_buffer_move_first(raw.c_slice_buffer(), len, output);
 
     frame_type = GRPC_CHTTP2_FRAME_CONTINUATION;


### PR DESCRIPTION
This stat is unused at present, so no need to protect it by an experiment.