### PR TITLE
[ssl] Remove unnecessary log in SSL security connector.

### DIFF
--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -294,7 +294,6 @@ class grpc_ssl_server_security_connector
     grpc_ssl_certificate_config_reload_status cb_result =
         server_creds->FetchCertConfig(&certificate_config);
     if (cb_result == GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_UNCHANGED) {
-      gpr_log(GPR_DEBUG, "No change in SSL server credentials.");
       status = false;
     } else if (cb_result == GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_NEW) {
       status = try_replace_server_handshaker_factory(certificate_config);


### PR DESCRIPTION
This log is unnecessary and it is causing a failure in `//test/core/end2end:no_logging_fuzzer`.
