### PR TITLE
[pick_first] fix happy eyeballs address interleaving bug

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -22,12 +22,12 @@
 #include <string.h>
 
 #include <algorithm>
-#include <map>
 #include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <set>
 
 #include "absl/algorithm/container.h"
 #include "absl/random/random.h"
@@ -526,8 +526,8 @@ absl::Status PickFirst::UpdateLocked(UpdateArgs args) {
       for (size_t i = 0; i < endpoints.size(); ++i) {
         EndpointAddresses* endpoint;
         do {
-          auto& iterator = address_family_order[
-              scheme_index++ % address_family_order.size()];
+          auto& iterator = address_family_order[scheme_index++ %
+                                                address_family_order.size()];
           endpoint = iterator.Next(endpoints, &endpoints_moved);
         } while (endpoint == nullptr);
         interleaved_endpoints.emplace_back(std::move(*endpoint));

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -23,11 +23,11 @@
 
 #include <algorithm>
 #include <memory>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
-#include <set>
 
 #include "absl/algorithm/container.h"
 #include "absl/random/random.h"


### PR DESCRIPTION
The original logic from #34615 was incorrect in cases where one address family has a different number of addresses than the other(s).

Fixes b/307937051.