### PR TITLE
[PSM Interop] Remove default backend maxRatePerEndpoint=5

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py
@@ -190,15 +190,15 @@ class ComputeV1(
         backends,
         max_rate_per_endpoint: Optional[int] = None,
     ):
-        if max_rate_per_endpoint is None:
-            max_rate_per_endpoint = 5
+        backend_attrs = {
+            "balancingMode": "RATE",
+        }
+        if max_rate_per_endpoint is not None:
+            backend_attrs["maxRatePerEndpoint"] = max_rate_per_endpoint
+
+        # Note that the backend_attrs dict is copied per backend.
         backend_list = [
-            {
-                "group": backend.url,
-                "balancingMode": "RATE",
-                "maxRatePerEndpoint": max_rate_per_endpoint,
-            }
-            for backend in backends
+            backend_attrs | {"group": backend.url} for backend in backends
         ]
 
         self._patch_resource(


### PR DESCRIPTION
- The default value `5` for the backend setting `maxRatePerEndpoint` was never needed, but existed from the very first commit of the PSM Interop test driver: https://github.com/grpc/grpc/blame/ee17927fce645c8c2a0ab767ea90d9311aad2b89/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/gcp/compute.py#L149
- It was later made configurable in #26360, which is needed for the failover test
- This PR removes the default value of `maxRatePerEndpoint` for all tests that doesn't specify it explicitly, i.e. the failover test.