### PR TITLE
[promises] Add an intra-activity mutex type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1208,6 +1208,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx promise_endpoint_test)
   add_dependencies(buildtests_cxx promise_factory_test)
   add_dependencies(buildtests_cxx promise_map_test)
+  add_dependencies(buildtests_cxx promise_mutex_test)
   add_dependencies(buildtests_cxx promise_test)
   add_dependencies(buildtests_cxx proto_buffer_reader_test)
   add_dependencies(buildtests_cxx proto_buffer_writer_test)
@@ -18182,6 +18183,45 @@ target_link_libraries(promise_map_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
   absl::type_traits
+  gpr
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(promise_mutex_test
+  src/core/lib/debug/trace.cc
+  src/core/lib/promise/activity.cc
+  src/core/lib/promise/trace.cc
+  test/core/promise/promise_mutex_test.cc
+)
+target_compile_features(promise_mutex_test PUBLIC cxx_std_14)
+target_include_directories(promise_mutex_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(promise_mutex_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  gtest
+  absl::hash
+  absl::type_traits
+  absl::statusor
   gpr
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -12168,6 +12168,44 @@ targets:
   - absl/meta:type_traits
   - gpr
   uses_polling: false
+- name: promise_mutex_test
+  gtest: true
+  build: test
+  language: c++
+  headers:
+  - src/core/lib/debug/trace.h
+  - src/core/lib/gprpp/atomic_utils.h
+  - src/core/lib/gprpp/bitset.h
+  - src/core/lib/gprpp/orphanable.h
+  - src/core/lib/gprpp/ref_counted.h
+  - src/core/lib/gprpp/ref_counted_ptr.h
+  - src/core/lib/promise/activity.h
+  - src/core/lib/promise/context.h
+  - src/core/lib/promise/detail/basic_seq.h
+  - src/core/lib/promise/detail/join_state.h
+  - src/core/lib/promise/detail/promise_factory.h
+  - src/core/lib/promise/detail/promise_like.h
+  - src/core/lib/promise/detail/seq_state.h
+  - src/core/lib/promise/detail/status.h
+  - src/core/lib/promise/join.h
+  - src/core/lib/promise/map.h
+  - src/core/lib/promise/poll.h
+  - src/core/lib/promise/promise.h
+  - src/core/lib/promise/promise_mutex.h
+  - src/core/lib/promise/seq.h
+  - src/core/lib/promise/trace.h
+  - test/core/promise/test_wakeup_schedulers.h
+  src:
+  - src/core/lib/debug/trace.cc
+  - src/core/lib/promise/activity.cc
+  - src/core/lib/promise/trace.cc
+  - test/core/promise/promise_mutex_test.cc
+  deps:
+  - gtest
+  - absl/hash:hash
+  - absl/meta:type_traits
+  - absl/status:statusor
+  - gpr
 - name: promise_test
   gtest: true
   build: test

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -889,6 +889,7 @@ grpc_cc_library(
     language = "c++",
     deps = [
         "activity",
+        "poll",
         "//:gpr",
     ],
 )

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -882,6 +882,18 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "promise_mutex",
+    hdrs = [
+        "lib/promise/promise_mutex.h",
+    ],
+    language = "c++",
+    deps = [
+        "activity",
+        "//:gpr",
+    ],
+)
+
+grpc_cc_library(
     name = "inter_activity_pipe",
     hdrs = [
         "lib/promise/inter_activity_pipe.h",

--- a/src/core/lib/promise/promise_mutex.h
+++ b/src/core/lib/promise/promise_mutex.h
@@ -12,12 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GRPC_SRC_CORE_LIB_PROMISE_MUTEX_H
-#define GRPC_SRC_CORE_LIB_PROMISE_MUTEX_H
+#ifndef GRPC_SRC_CORE_LIB_PROMISE_PROMISE_MUTEX_H
+#define GRPC_SRC_CORE_LIB_PROMISE_PROMISE_MUTEX_H
 
 #include <grpc/support/port_platform.h>
 
+#include <utility>
+
+#include <grpc/support/log.h>
+
 #include "src/core/lib/promise/activity.h"
+#include "src/core/lib/promise/poll.h"
 
 namespace grpc_core {
 
@@ -84,4 +89,4 @@ class PromiseMutex {
 
 }  // namespace grpc_core
 
-#endif
+#endif  // GRPC_SRC_CORE_LIB_PROMISE_PROMISE_MUTEX_H

--- a/src/core/lib/promise/promise_mutex.h
+++ b/src/core/lib/promise/promise_mutex.h
@@ -1,0 +1,87 @@
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_SRC_CORE_LIB_PROMISE_MUTEX_H
+#define GRPC_SRC_CORE_LIB_PROMISE_MUTEX_H
+
+#include <grpc/support/port_platform.h>
+
+#include "src/core/lib/promise/activity.h"
+
+namespace grpc_core {
+
+// A mutex that can be used to synchronize access to a value within one
+// activity.
+template <typename T>
+class PromiseMutex {
+ public:
+  class Lock {
+   public:
+    Lock() {}
+    ~Lock() {
+      if (mutex_ != nullptr) {
+        GPR_ASSERT(mutex_->locked_);
+        mutex_->locked_ = false;
+        mutex_->waiter_.Wake();
+      }
+    }
+
+    Lock(Lock&& other) noexcept
+        : mutex_(std::exchange(other.mutex_, nullptr)) {}
+    Lock& operator=(Lock&& other) noexcept {
+      std::swap(mutex_, other.mutex_);
+      return *this;
+    }
+
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) noexcept = delete;
+
+    T* operator->() {
+      GPR_DEBUG_ASSERT(mutex_ != nullptr);
+      return &mutex_->value_;
+    }
+    T& operator*() {
+      GPR_DEBUG_ASSERT(mutex_ != nullptr);
+      return mutex_->value_;
+    }
+
+   private:
+    friend class PromiseMutex;
+    explicit Lock(PromiseMutex* mutex) : mutex_(mutex) {
+      GPR_DEBUG_ASSERT(!mutex_->locked_);
+      mutex_->locked_ = true;
+    }
+    PromiseMutex* mutex_ = nullptr;
+  };
+
+  PromiseMutex() = default;
+  explicit PromiseMutex(T value) : value_(std::move(value)) {}
+  ~PromiseMutex() { GPR_DEBUG_ASSERT(!locked_); }
+
+  auto Acquire() {
+    return [this]() -> Poll<Lock> {
+      if (locked_) return waiter_.pending();
+      return Lock(this);
+    };
+  }
+
+ private:
+  bool locked_ = false;
+  IntraActivityWaiter waiter_;
+  GPR_NO_UNIQUE_ADDRESS T value_;
+};
+
+}  // namespace grpc_core
+
+#endif

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -546,7 +546,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "promise_mutex_test",
     srcs = ["promise_mutex_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/status",
+        "gtest",
+    ],
     deps = [
         "test_wakeup_schedulers",
         "//:promise",

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -544,6 +544,20 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "promise_mutex_test",
+    srcs = ["promise_mutex_test.cc"],
+    external_deps = ["gtest"],
+    deps = [
+        "test_wakeup_schedulers",
+        "//:promise",
+        "//src/core:activity",
+        "//src/core:join",
+        "//src/core:promise_mutex",
+        "//src/core:seq",
+    ],
+)
+
+grpc_cc_test(
     name = "party_test",
     srcs = ["party_test.cc"],
     external_deps = [

--- a/test/core/promise/promise_mutex_test.cc
+++ b/test/core/promise/promise_mutex_test.cc
@@ -14,6 +14,10 @@
 
 #include "src/core/lib/promise/promise_mutex.h"
 
+#include <memory>
+#include <optional>
+
+#include "absl/status/status.h"
 #include "gtest/gtest.h"
 
 #include "src/core/lib/promise/activity.h"

--- a/test/core/promise/promise_mutex_test.cc
+++ b/test/core/promise/promise_mutex_test.cc
@@ -1,0 +1,67 @@
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/lib/promise/promise_mutex.h"
+
+#include "gtest/gtest.h"
+
+#include "src/core/lib/promise/activity.h"
+#include "src/core/lib/promise/join.h"
+#include "src/core/lib/promise/promise.h"
+#include "src/core/lib/promise/seq.h"
+#include "test/core/promise/test_wakeup_schedulers.h"
+
+namespace grpc_core {
+namespace {
+
+TEST(PromiseMutexTest, Basic) {
+  PromiseMutex<int> mutex{1};
+  bool done = false;
+  MakeActivity(
+      [&]() {
+        return Seq(Join(Seq(mutex.Acquire(),
+                            [](PromiseMutex<int>::Lock l) {
+                              EXPECT_EQ(*l, 1);
+                              *l = 2;
+                              return Empty{};
+                            }),
+                        Seq(mutex.Acquire(),
+                            [](PromiseMutex<int>::Lock l) {
+                              EXPECT_EQ(*l, 2);
+                              *l = 3;
+                              return Empty{};
+                            }),
+                        Seq(mutex.Acquire(),
+                            [](PromiseMutex<int>::Lock l) {
+                              EXPECT_EQ(*l, 3);
+                              return Empty{};
+                            })),
+                   []() { return absl::OkStatus(); });
+      },
+      InlineWakeupScheduler(),
+      [&done](absl::Status status) {
+        EXPECT_TRUE(status.ok());
+        done = true;
+      });
+  EXPECT_TRUE(done);
+  EXPECT_EQ(**NowOrNever(mutex.Acquire()), 3);
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -6942,6 +6942,30 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "promise_mutex_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "promise_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
Modeled after mutexes in the Rust ecosystem: the mutex owns the data provided, and acquisition of the mutex returns a handle with which to manipulate that data.

This fits in nicely with the execution environment we've established whereby we may want to pass the lock from lambda to lambda for some time.