### PR TITLE
Backport #34550 and #34685 to v1.59.x

### DIFF
--- a/tools/internal_ci/windows/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/pull_request/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/release/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/release/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
These two PRs bump the Python Windows distribtest timeout, which has been causing several artifact builds and distribtests to fail.