### PR TITLE
[observability] Switch from datetime.utcnow to time.perf_counter

### DIFF
--- a/src/python/grpcio/grpc/_observability.py
+++ b/src/python/grpcio/grpc/_observability.py
@@ -278,6 +278,6 @@ def maybe_record_rpc_latency(state: "_channel._RPCState") -> None:
     with get_plugin() as plugin:
         if not (plugin and plugin.stats_enabled):
             return
-        rpc_latency = state.rpc_end_time - state.rpc_start_time
-        rpc_latency_ms = rpc_latency.total_seconds() * 1000
+        rpc_latency_s = state.rpc_end_time - state.rpc_start_time
+        rpc_latency_ms = rpc_latency_s * 1000
         plugin.record_rpc_latency(state.method, rpc_latency_ms, state.code)


### PR DESCRIPTION
datetime.utcnow() raises a deprecation warning on Python 3.12, so this change prevents that deprecation warning while also switching to a monotonic clock for calculating RPC latency

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

cc @XuanWang-Amos 