### PR TITLE
[PSM Interop] Add flag to enable CSM Observability in c++ image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,6 +819,45 @@ protobuf_generate_grpc_cpp_with_import_path_correction(
 protobuf_generate_grpc_cpp_with_import_path_correction(
   test/core/tsi/alts/fake_handshaker/transport_security_common.proto test/core/tsi/alts/fake_handshaker/transport_security_common.proto
 )
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/api/annotations.proto google/api/annotations.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/api/client.proto google/api/client.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/api/field_behavior.proto google/api/field_behavior.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/api/http.proto google/api/http.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/api/resource.proto google/api/resource.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/devtools/cloudtrace/v1/trace.proto google/devtools/cloudtrace/v1/trace.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/devtools/cloudtrace/v2/trace.proto google/devtools/cloudtrace/v2/trace.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/devtools/cloudtrace/v2/tracing.proto google/devtools/cloudtrace/v2/tracing.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/iam/credentials/v1/common.proto google/iam/credentials/v1/common.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/iam/credentials/v1/iamcredentials.proto google/iam/credentials/v1/iamcredentials.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/longrunning/operations.proto google/longrunning/operations.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/rpc/error_details.proto google/rpc/error_details.proto
+)
+protobuf_generate_grpc_cpp_with_import_path_correction(
+  third_party/googleapis/google/rpc/status.proto google/rpc/status.proto
+)
 
 if(gRPC_BUILD_TESTS)
   add_custom_target(buildtests_c)
@@ -28196,6 +28235,63 @@ add_executable(xds_interop_client
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.grpc.pb.h
+  src/cpp/ext/csm/csm_observability.cc
+  src/cpp/ext/csm/metadata_exchange.cc
+  src/cpp/ext/otel/otel_client_filter.cc
+  src/cpp/ext/otel/otel_plugin.cc
+  src/cpp/ext/otel/otel_server_call_tracer.cc
   src/cpp/server/admin/admin_services.cc
   src/cpp/server/csds/csds.cc
   test/cpp/interop/rpc_behavior_lb_policy.cc
@@ -28263,6 +28359,63 @@ add_executable(xds_interop_server
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/percent.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/annotations.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/client.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/field_behavior.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/http.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/api/resource.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v1/trace.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/trace.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/devtools/cloudtrace/v2/tracing.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/common.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/iam/credentials/v1/iamcredentials.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/longrunning/operations.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/error_details.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/google/rpc/status.grpc.pb.h
+  src/cpp/ext/csm/csm_observability.cc
+  src/cpp/ext/csm/metadata_exchange.cc
+  src/cpp/ext/otel/otel_client_filter.cc
+  src/cpp/ext/otel/otel_plugin.cc
+  src/cpp/ext/otel/otel_server_call_tracer.cc
   src/cpp/server/admin/admin_services.cc
   src/cpp/server/csds/csds.cc
   test/cpp/end2end/test_health_check_service_impl.cc

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -18096,6 +18096,13 @@ targets:
   run: false
   language: c++
   headers:
+  - src/cpp/ext/csm/csm_observability.h
+  - src/cpp/ext/csm/metadata_exchange.h
+  - src/cpp/ext/otel/key_value_iterable.h
+  - src/cpp/ext/otel/otel_call_tracer.h
+  - src/cpp/ext/otel/otel_client_filter.h
+  - src/cpp/ext/otel/otel_plugin.h
+  - src/cpp/ext/otel/otel_server_call_tracer.h
   - src/cpp/server/csds/csds.h
   - test/cpp/interop/rpc_behavior_lb_policy.h
   - test/cpp/interop/xds_stats_watcher.h
@@ -18107,6 +18114,24 @@ targets:
   - src/proto/grpc/testing/xds/v3/config_dump.proto
   - src/proto/grpc/testing/xds/v3/csds.proto
   - src/proto/grpc/testing/xds/v3/percent.proto
+  - third_party/googleapis/google/api/annotations.proto
+  - third_party/googleapis/google/api/client.proto
+  - third_party/googleapis/google/api/field_behavior.proto
+  - third_party/googleapis/google/api/http.proto
+  - third_party/googleapis/google/api/resource.proto
+  - third_party/googleapis/google/devtools/cloudtrace/v1/trace.proto
+  - third_party/googleapis/google/devtools/cloudtrace/v2/trace.proto
+  - third_party/googleapis/google/devtools/cloudtrace/v2/tracing.proto
+  - third_party/googleapis/google/iam/credentials/v1/common.proto
+  - third_party/googleapis/google/iam/credentials/v1/iamcredentials.proto
+  - third_party/googleapis/google/longrunning/operations.proto
+  - third_party/googleapis/google/rpc/error_details.proto
+  - third_party/googleapis/google/rpc/status.proto
+  - src/cpp/ext/csm/csm_observability.cc
+  - src/cpp/ext/csm/metadata_exchange.cc
+  - src/cpp/ext/otel/otel_client_filter.cc
+  - src/cpp/ext/otel/otel_plugin.cc
+  - src/cpp/ext/otel/otel_server_call_tracer.cc
   - src/cpp/server/admin/admin_services.cc
   - src/cpp/server/csds/csds.cc
   - test/cpp/interop/rpc_behavior_lb_policy.cc
@@ -18122,6 +18147,13 @@ targets:
   run: false
   language: c++
   headers:
+  - src/cpp/ext/csm/csm_observability.h
+  - src/cpp/ext/csm/metadata_exchange.h
+  - src/cpp/ext/otel/key_value_iterable.h
+  - src/cpp/ext/otel/otel_call_tracer.h
+  - src/cpp/ext/otel/otel_client_filter.h
+  - src/cpp/ext/otel/otel_plugin.h
+  - src/cpp/ext/otel/otel_server_call_tracer.h
   - src/cpp/server/csds/csds.h
   - test/cpp/end2end/test_health_check_service_impl.h
   - test/cpp/interop/pre_stop_hook_server.h
@@ -18135,6 +18167,24 @@ targets:
   - src/proto/grpc/testing/xds/v3/config_dump.proto
   - src/proto/grpc/testing/xds/v3/csds.proto
   - src/proto/grpc/testing/xds/v3/percent.proto
+  - third_party/googleapis/google/api/annotations.proto
+  - third_party/googleapis/google/api/client.proto
+  - third_party/googleapis/google/api/field_behavior.proto
+  - third_party/googleapis/google/api/http.proto
+  - third_party/googleapis/google/api/resource.proto
+  - third_party/googleapis/google/devtools/cloudtrace/v1/trace.proto
+  - third_party/googleapis/google/devtools/cloudtrace/v2/trace.proto
+  - third_party/googleapis/google/devtools/cloudtrace/v2/tracing.proto
+  - third_party/googleapis/google/iam/credentials/v1/common.proto
+  - third_party/googleapis/google/iam/credentials/v1/iamcredentials.proto
+  - third_party/googleapis/google/longrunning/operations.proto
+  - third_party/googleapis/google/rpc/error_details.proto
+  - third_party/googleapis/google/rpc/status.proto
+  - src/cpp/ext/csm/csm_observability.cc
+  - src/cpp/ext/csm/metadata_exchange.cc
+  - src/cpp/ext/otel/otel_client_filter.cc
+  - src/cpp/ext/otel/otel_plugin.cc
+  - src/cpp/ext/otel/otel_server_call_tracer.cc
   - src/cpp/server/admin/admin_services.cc
   - src/cpp/server/csds/csds.cc
   - test/cpp/end2end/test_health_check_service_impl.cc

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -268,6 +268,8 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "otel/exporters/prometheus:prometheus_exporter",
+        "otel/sdk/src/metrics",
     ],
     deps = [
         ":rpc_behavior_lb_policy",
@@ -275,6 +277,7 @@ grpc_cc_binary(
         "//:grpc++",
         "//:grpc++_reflection",
         "//:grpcpp_admin",
+        "//:grpcpp_csm_observability",
         "//src/proto/grpc/testing:empty_proto",
         "//src/proto/grpc/testing:messages_proto",
         "//src/proto/grpc/testing:test_proto",
@@ -313,10 +316,13 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "otel/exporters/prometheus:prometheus_exporter",
+        "otel/sdk/src/metrics",
     ],
     deps = [
         ":xds_interop_server_lib",
         "//:grpc++",
+        "//:grpcpp_csm_observability",
         "//test/core/util:grpc_test_util",
         "//test/cpp/end2end:test_health_check_service_impl",
         "//test/cpp/util:test_config",

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -405,7 +405,7 @@ void EnableCsmObservability() {
   meter_provider->AddMetricReader(std::move(prometheus_exporter));
   auto observability = grpc::experimental::CsmObservabilityBuilder();
   observability.SetMeterProvider(std::move(meter_provider));
-  observability.BuildAndRegister();
+  auto status = observability.BuildAndRegister();
 }
 
 void RunServer(const int port, StatsWatchers* stats_watchers,

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -33,8 +33,12 @@
 #include "absl/algorithm/container.h"
 #include "absl/flags/flag.h"
 #include "absl/strings/str_split.h"
+#include "opentelemetry/exporters/prometheus/exporter_factory.h"
+#include "opentelemetry/exporters/prometheus/exporter_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
 
 #include <grpcpp/ext/admin_services.h>
+#include <grpcpp/ext/csm_observability.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/server.h>
@@ -69,6 +73,8 @@ ABSL_FLAG(std::string, expect_status, "OK",
 ABSL_FLAG(
     bool, secure_mode, false,
     "If true, XdsCredentials are used, InsecureChannelCredentials otherwise");
+ABSL_FLAG(bool, enable_csm_observability, false,
+          "Whether to enable CSM Observability");
 
 using grpc::Channel;
 using grpc::ClientAsyncResponseReader;
@@ -386,6 +392,23 @@ void RunTestLoop(std::chrono::duration<double> duration_per_query,
   GPR_UNREACHABLE_CODE(thread.join());
 }
 
+void EnableCsmObservability() {
+  gpr_log(GPR_DEBUG, "Registering Prometheus exporter");
+  opentelemetry::exporter::metrics::PrometheusExporterOptions opts;
+  // default was "localhost:9464" which causes connection issue across GKE
+  // pods
+  opts.url = "0.0.0.0:9464";
+  auto prometheus_exporter =
+      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(
+          opts);
+  auto meter_provider =
+      std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
+  meter_provider->AddMetricReader(std::move(prometheus_exporter));
+  auto observability = grpc::experimental::CsmObservabilityBuilder();
+  observability.SetMeterProvider(std::move(meter_provider));
+  observability.BuildAndRegister();
+}
+
 void RunServer(const int port, StatsWatchers* stats_watchers,
                RpcConfigurationsQueue* rpc_configs_queue) {
   GPR_ASSERT(port != 0);
@@ -474,6 +497,9 @@ int main(int argc, char** argv) {
   }
 
   BuildRpcConfigsFromFlags(&rpc_config_queue);
+  if (absl::GetFlag(FLAGS_enable_csm_observability)) {
+    EnableCsmObservability();
+  }
 
   std::chrono::duration<double> duration_per_query =
       std::chrono::nanoseconds(std::chrono::seconds(1)) /

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -399,8 +399,7 @@ void EnableCsmObservability() {
   // pods
   opts.url = "0.0.0.0:9464";
   auto prometheus_exporter =
-      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(
-          opts);
+      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(opts);
   auto meter_provider =
       std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
   meter_provider->AddMetricReader(std::move(prometheus_exporter));

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -56,7 +56,7 @@ void EnableCsmObservability() {
   meter_provider->AddMetricReader(std::move(prometheus_exporter));
   auto observability = grpc::experimental::CsmObservabilityBuilder();
   observability.SetMeterProvider(std::move(meter_provider));
-  observability.BuildAndRegister();
+  auto status = observability.BuildAndRegister();
 }
 
 int main(int argc, char** argv) {

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -50,8 +50,7 @@ void EnableCsmObservability() {
   // pods
   opts.url = "0.0.0.0:9464";
   auto prometheus_exporter =
-      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(
-          opts);
+      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(opts);
   auto meter_provider =
       std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
   meter_provider->AddMetricReader(std::move(prometheus_exporter));

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -19,8 +19,12 @@
 #include <iostream>
 
 #include "absl/flags/flag.h"
+#include "opentelemetry/exporters/prometheus/exporter_factory.h"
+#include "opentelemetry/exporters/prometheus/exporter_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
 
 #include <grpc/grpc.h>
+#include <grpcpp/ext/csm_observability.h>
 #include <grpcpp/health_check_service_interface.h>
 
 #include "src/core/lib/iomgr/gethostname.h"
@@ -36,6 +40,25 @@ ABSL_FLAG(std::string, server_id, "cpp_server",
 ABSL_FLAG(bool, secure_mode, false,
           "If true, XdsServerCredentials are used, InsecureServerCredentials "
           "otherwise");
+ABSL_FLAG(bool, enable_csm_observability, false,
+          "Whether to enable CSM Observability");
+
+void EnableCsmObservability() {
+  gpr_log(GPR_DEBUG, "Registering Prometheus exporter");
+  opentelemetry::exporter::metrics::PrometheusExporterOptions opts;
+  // default was "localhost:9464" which causes connection issue across GKE
+  // pods
+  opts.url = "0.0.0.0:9464";
+  auto prometheus_exporter =
+      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(
+          opts);
+  auto meter_provider =
+      std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
+  meter_provider->AddMetricReader(std::move(prometheus_exporter));
+  auto observability = grpc::experimental::CsmObservabilityBuilder();
+  observability.SetMeterProvider(std::move(meter_provider));
+  observability.BuildAndRegister();
+}
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
@@ -56,6 +79,9 @@ int main(int argc, char** argv) {
     return 1;
   }
   grpc::EnableDefaultHealthCheckService(false);
+  if (absl::GetFlag(FLAGS_enable_csm_observability)) {
+    EnableCsmObservability();
+  }
   grpc::testing::RunServer(
       absl::GetFlag(FLAGS_secure_mode), port, maintenance_port, hostname,
       absl::GetFlag(FLAGS_server_id), [](grpc::Server* /* unused */) {});


### PR DESCRIPTION
Add the flag `enable_csm_observability` to the c++ PSM interop testing image, such that when enabled from the PSM interop testing framework, the C++ client/server app will enable the CSM Observability plugin.