### PR TITLE
[EventEngine] Enable EventEngine Listener experiment for Posix builds

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -203,7 +203,6 @@ EXPERIMENTS = {
             ],
             "core_end2end_test": [
                 "event_engine_client",
-                "event_engine_listener",
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
@@ -218,9 +217,6 @@ EXPERIMENTS = {
             ],
             "event_engine_client_test": [
                 "event_engine_client",
-            ],
-            "event_engine_listener_test": [
-                "event_engine_listener",
             ],
             "flow_control_test": [
                 "multiping",
@@ -257,6 +253,9 @@ EXPERIMENTS = {
                 "block_excessive_requests_before_settings_ack",
                 "tarpit",
             ],
+            "core_end2end_test": [
+                "event_engine_listener",
+            ],
             "cpp_end2end_test": [
                 "chttp2_batch_requests",
                 "chttp2_offload_on_rst_stream",
@@ -265,6 +264,9 @@ EXPERIMENTS = {
                 "pick_first_happy_eyeballs",
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
+            ],
+            "event_engine_listener_test": [
+                "event_engine_listener",
             ],
             "flow_control_test": [
                 "chttp2_batch_requests",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -827,7 +827,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, false, false},
     {"event_engine_listener", description_event_engine_listener,
-     additional_constraints_event_engine_listener, false, true},
+     additional_constraints_event_engine_listener, true, true},
     {"free_large_allocator", description_free_large_allocator,
      additional_constraints_free_large_allocator, false, true},
     {"http2_stats_fix", description_http2_stats_fix,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -240,7 +240,8 @@ inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsCombinerOffloadToEventEngineEnabled() { return true; }
 inline bool IsEventEngineClientEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
-inline bool IsEventEngineListenerEnabled() { return false; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
+inline bool IsEventEngineListenerEnabled() { return true; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_HTTP2_STATS_FIX
 inline bool IsHttp2StatsFixEnabled() { return true; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -72,7 +72,7 @@
   default:
     # not tested on iOS at all
     ios: broken
-    posix: false
+    posix: true
     windows: true
 - name: free_large_allocator
   default: false


### PR DESCRIPTION
Previously disabled due to

* a problem in the core/end2end http_proxy_fixture (fixed in https://github.com/grpc/grpc/pull/34838)
* a race with the EventEngine in the bad_server_response test (fixed in https://github.com/grpc/grpc/pull/34816)