### PR TITLE
[build] Exclude experiments from RBE Build Tests PR job

### DIFF
--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_build.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_build.cfg
@@ -37,7 +37,7 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation
   key: "BAZEL_FLAGS"
-  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --build_tag_filters='-experiment_variation' --test_tag_filters='-experiment_variation'"
+  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --build_tag_filters=\"-experiment_variation\" --test_tag_filters=\"-experiment_variation\""
 }
 
 env_vars {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_build.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_build.cfg
@@ -37,7 +37,7 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation
   key: "BAZEL_FLAGS"
-  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --build_tag_filter='-experiment_variation' --test_tag_filter='-experiment_variation'"
+  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --build_tag_filters='-experiment_variation' --test_tag_filters='-experiment_variation'"
 }
 
 env_vars {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_build.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_build.cfg
@@ -37,7 +37,7 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation
   key: "BAZEL_FLAGS"
-  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh"
+  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --build_tag_filter='-experiment_variation' --test_tag_filter='-experiment_variation'"
 }
 
 env_vars {


### PR DESCRIPTION
This only affects pull requests for the `Bazel RBE Build Tests` job. The equivalent master CI job will still build all end2end tests, including experiments.