### PR TITLE
[csharp] Attempt to fix download flakes in C# distrib tests

### DIFF
--- a/test/distrib/csharp/run_distrib_test_dotnetcli.sh
+++ b/test/distrib/csharp/run_distrib_test_dotnetcli.sh
@@ -25,7 +25,7 @@ cd DistribTest
 
 # TODO(jtattermusch): make sure we don't pollute the global nuget cache with
 # the nugets being tested.
-dotnet restore DistribTestDotNet.csproj
+CLR_OPENSSL_VERSION_OVERRIDE=1.1 dotnet restore DistribTestDotNet.csproj
 
 dotnet build DistribTestDotNet.csproj
 


### PR DESCRIPTION
Attempt to fix https://source.cloud.google.com/results/invocations/46cb13f1-7532-4c37-af5d-40e013dafc4c/targets/%2F%2Ftools%2Fbazelify_tests%2Ftest:distribtest_csharp_linux_x64_ubuntu2204/log flakes

Fix taken from https://github.com/dotnet/runtime/issues/27792

