### PR TITLE
[Python] Do not call PyEval_InitThreads

### DIFF
--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -80,14 +80,7 @@ include "_cygrpc/aio/server.pyx.pxi"
 #
 # initialize gRPC
 #
-cdef extern from "Python.h":
-
-  int PyEval_InitThreads()
-
 cdef _initialize():
-  # We have Python callbacks called by c-core threads, this ensures the GIL
-  # is initialized.
-  PyEval_InitThreads()
   grpc_set_ssl_roots_override_callback(
           <grpc_ssl_roots_override_callback>ssl_roots_override_callback)
 


### PR DESCRIPTION
Since Python 3.7, it’s called by [`Py_Initialize`](https://docs.python.org/3/c-api/init.html#c.Py_Initialize) and doesn’t need to be called manually, so this removal has no effect.

Since Python 3.9, it does nothing, and in [Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html), it [will be removed](https://github.com/python/cpython/issues/105182), which makes this change necessary.

References:

https://docs.python.org/3/c-api/init.html#c.PyEval_InitThreads

https://github.com/python/cpython/issues/105182

----

Together with the changes discussed in https://github.com/grpc/grpc/issues/33918 and with a [Cython fix](https://github.com/cython/cython/pull/5791) to be released in 3.0.5, this allowed us to build and test our `grpc` package with Python 3.13.0a1 and Cython 3.0.4.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

