### PR TITLE
[tls] Allow skipping server cert verification when no default roots are present.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1412,6 +1412,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx timer_manager_test)
   add_dependencies(buildtests_cxx timer_test)
   add_dependencies(buildtests_cxx tls_certificate_verifier_test)
+  add_dependencies(buildtests_cxx tls_credentials_test)
   add_dependencies(buildtests_cxx tls_key_export_test)
   add_dependencies(buildtests_cxx tls_security_connector_test)
   add_dependencies(buildtests_cxx too_many_pings_test)
@@ -25094,6 +25095,56 @@ target_link_libraries(tls_certificate_verifier_test
   gtest
   grpc++
   grpc_test_util
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(tls_credentials_test
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo_messages.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/simple_messages.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/xds/v3/orca_load_report.grpc.pb.h
+  test/cpp/end2end/test_service_impl.cc
+  test/cpp/end2end/tls_credentials_test.cc
+)
+target_compile_features(tls_credentials_test PUBLIC cxx_std_14)
+target_include_directories(tls_credentials_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(tls_credentials_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  gtest
+  grpc++_test_util
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -16616,6 +16616,22 @@ targets:
   - gtest
   - grpc++
   - grpc_test_util
+- name: tls_credentials_test
+  gtest: true
+  build: test
+  language: c++
+  headers:
+  - test/cpp/end2end/test_service_impl.h
+  src:
+  - src/proto/grpc/testing/echo.proto
+  - src/proto/grpc/testing/echo_messages.proto
+  - src/proto/grpc/testing/simple_messages.proto
+  - src/proto/grpc/testing/xds/v3/orca_load_report.proto
+  - test/cpp/end2end/test_service_impl.cc
+  - test/cpp/end2end/tls_credentials_test.cc
+  deps:
+  - gtest
+  - grpc++_test_util
 - name: tls_key_export_test
   gtest: true
   build: test

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -417,7 +417,7 @@ grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
     tsi_ssl_client_handshaker_factory** handshaker_factory) {
   const char* root_certs;
   const tsi_ssl_root_certs_store* root_store;
-  if (pem_root_certs == nullptr) {
+  if (pem_root_certs == nullptr && !skip_server_certificate_verification) {
     gpr_log(GPR_INFO,
             "No root certificates specified; use ones stored in system default "
             "locations instead");
@@ -436,7 +436,6 @@ grpc_security_status grpc_ssl_tsi_client_handshaker_factory_init(
                            pem_key_cert_pair->private_key != nullptr &&
                            pem_key_cert_pair->cert_chain != nullptr;
   tsi_ssl_client_handshaker_options options;
-  GPR_DEBUG_ASSERT(root_certs != nullptr);
   options.pem_root_certs = root_certs;
   options.root_store = root_store;
   options.alpn_protocols =

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2061,9 +2061,6 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 
   if (factory == nullptr) return TSI_INVALID_ARGUMENT;
   *factory = nullptr;
-  if (options->pem_root_certs == nullptr && options->root_store == nullptr) {
-    return TSI_INVALID_ARGUMENT;
-  }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
   ssl_context = SSL_CTX_new(TLS_method());
@@ -2123,7 +2120,9 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
       SSL_CTX_set_cert_store(ssl_context, options->root_store->store);
     }
 #endif
-    if (OPENSSL_VERSION_NUMBER < 0x10100000 || options->root_store == nullptr) {
+    if (OPENSSL_VERSION_NUMBER < 0x10100000 ||
+        (options->root_store == nullptr &&
+         options->pem_root_certs != nullptr)) {
       result = ssl_ctx_load_verification_certs(
           ssl_context, options->pem_root_certs, strlen(options->pem_root_certs),
           nullptr);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2061,6 +2061,10 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 
   if (factory == nullptr) return TSI_INVALID_ARGUMENT;
   *factory = nullptr;
+  if (options->pem_root_certs == nullptr && options->root_store == nullptr &&
+      !options->skip_server_certificate_verification) {
+    return TSI_INVALID_ARGUMENT;
+  }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
   ssl_context = SSL_CTX_new(TLS_method());

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -1038,6 +1038,32 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "tls_credentials_test",
+    srcs = ["tls_credentials_test.cc"],
+    data = [
+        "//src/core/tsi/test_creds:ca.pem",
+        "//src/core/tsi/test_creds:client.key",
+        "//src/core/tsi/test_creds:client.pem",
+        "//src/core/tsi/test_creds:server1.key",
+        "//src/core/tsi/test_creds:server1.pem",
+    ],
+    external_deps = [
+        "gtest",
+    ],
+    tags = ["tls_credentials_test"],
+    deps = [
+        ":test_service_impl",
+        "//:gpr",
+        "//:grpc",
+        "//:grpc++",
+        "//src/proto/grpc/testing:echo_messages_proto",
+        "//src/proto/grpc/testing:echo_proto",
+        "//test/core/util:grpc_test_util",
+        "//test/cpp/util:test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "crl_provider_test",
     srcs = ["crl_provider_test.cc"],
     data = [

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -128,6 +128,11 @@ void DoRpc(const std::string& server_addr,
   EXPECT_EQ(response.message(), kMessage);
 }
 
+// How do we test that skipping server certificate verification works as
+// expected? Give the server credentials that chain up to a custom CA (that does
+// not belong to the default or OS trust store), do not configure the client to
+// have this CA in its trust store, and attempt to establish a connection
+// between the client and server.
 TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {
   server_addr_ = absl::StrCat("localhost:",
                               std::to_string(grpc_pick_unused_port_or_die()));

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -62,8 +62,8 @@ class NoOpCertificateVerifier : public ExternalCertificateVerifier {
  public:
   ~NoOpCertificateVerifier() override = default;
 
-  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
-              std::function<void(grpc::Status)> callback,
+  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest*,
+              std::function<void(grpc::Status)>,
               grpc::Status* sync_status) override {
     *sync_status = grpc::Status(grpc::StatusCode::OK, "");
     return true;

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -1,0 +1,142 @@
+//
+//
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+#include <memory>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "absl/synchronization/notification.h"
+
+#include <grpc/grpc_security.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/tls_credentials_options.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+
+#include "src/core/lib/iomgr/load_file.h"
+#include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
+#include "test/cpp/end2end/test_service_impl.h"
+
+namespace grpc {
+namespace testing {
+namespace {
+
+using ::grpc::experimental::TlsChannelCredentialsOptions;
+using ::grpc::experimental::TlsCredentialsOptions;
+
+constexpr char kCaCertPath[] = "src/core/tsi/test_creds/ca.pem";
+constexpr char kServerCertPath[] = "src/core/tsi/test_creds/server1.pem";
+constexpr char kServerKeyPath[] = "src/core/tsi/test_creds/server1.key";
+constexpr char kClientCertPath[] = "src/core/tsi/test_creds/client.pem";
+constexpr char kClientKeyPath[] = "src/core/tsi/test_creds/client.key";
+constexpr char kMessage[] = "Hello";
+
+std::string ReadFile(const std::string& file_path) {
+  grpc_slice slice;
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
+                               grpc_load_file(file_path.c_str(), 0, &slice)));
+  std::string file_contents(grpc_core::StringViewFromSlice(slice));
+  grpc_slice_unref(slice);
+  return file_contents;
+}
+
+class TlsCredentialsTest : public ::testing::Test {
+ protected:
+  void RunServer(absl::Notification* notification) {
+    std::string root_cert = ReadFile(kCaCertPath);
+    grpc::SslServerCredentialsOptions::PemKeyCertPair key_cert_pair = {
+        ReadFile(kServerKeyPath), ReadFile(kServerCertPath)};
+    grpc::SslServerCredentialsOptions ssl_options;
+    ssl_options.pem_key_cert_pairs.push_back(key_cert_pair);
+    ssl_options.pem_root_certs = root_cert;
+    ssl_options.force_client_auth = true;
+
+    grpc::ServerBuilder builder;
+    TestServiceImpl service_;
+
+    builder.AddListeningPort(server_addr_,
+                             grpc::SslServerCredentials(ssl_options));
+    builder.RegisterService("foo.test.google.fr", &service_);
+    server_ = builder.BuildAndStart();
+    notification->Notify();
+    server_->Wait();
+  }
+
+  void TearDown() override {
+    if (server_ != nullptr) {
+      server_->Shutdown();
+      server_thread_->join();
+      delete server_thread_;
+    }
+  }
+
+  TestServiceImpl service_;
+  std::unique_ptr<Server> server_ = nullptr;
+  std::thread* server_thread_ = nullptr;
+  std::string server_addr_;
+};
+
+void DoRpc(const std::string& server_addr,
+           const TlsChannelCredentialsOptions& tls_options) {
+  std::shared_ptr<Channel> channel =
+      grpc::CreateChannel(server_addr, TlsCredentials(tls_options));
+
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  grpc::testing::EchoRequest request;
+  grpc::testing::EchoResponse response;
+  request.set_message(kMessage);
+  ClientContext context;
+  context.set_deadline(grpc_timeout_seconds_to_deadline(/*time_s=*/10));
+  grpc::Status result = stub->Echo(&context, request, &response);
+  EXPECT_TRUE(result.ok());
+  if (!result.ok()) {
+    gpr_log(GPR_ERROR, "%s, %s", result.error_message().c_str(),
+            result.error_details().c_str());
+  }
+  EXPECT_EQ(response.message(), kMessage);
+}
+
+TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {
+  server_addr_ = absl::StrCat("localhost:",
+                              std::to_string(grpc_pick_unused_port_or_die()));
+  absl::Notification notification;
+  server_thread_ = new std::thread([&]() { RunServer(&notification); });
+  notification.WaitForNotification();
+
+  std::string root_cert = ReadFile(kCaCertPath);
+  std::string client_key = ReadFile(kClientKeyPath);
+  std::string client_cert = ReadFile(kClientCertPath);
+  TlsChannelCredentialsOptions tls_options;
+  tls_options.set_verify_server_certs(/*verify_server_certs=*/false);
+
+  DoRpc(server_addr_, tls_options);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace grpc
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
+}

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -26,8 +26,8 @@
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
-#include <grpcpp/security/tls_credentials_options.h>
 #include <grpcpp/security/tls_certificate_verifier.h>
+#include <grpcpp/security/tls_credentials_options.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 
@@ -86,9 +86,9 @@ class TlsCredentialsTest : public ::testing::Test {
     grpc::ServerBuilder builder;
     TestServiceImpl service_;
 
-    builder.AddListeningPort(server_addr_,
-                             grpc::SslServerCredentials(ssl_options));
-    builder.RegisterService("foo.test.google.fr", &service_);
+    builder
+        .AddListeningPort(server_addr_, grpc::SslServerCredentials(ssl_options))
+        .RegisterService(&service_);
     server_ = builder.BuildAndStart();
     notification->Notify();
     server_->Wait();
@@ -122,10 +122,11 @@ void DoRpc(const std::string& server_addr,
   grpc::Status result = stub->Echo(&context, request, &response);
   EXPECT_TRUE(result.ok());
   if (!result.ok()) {
-    gpr_log(GPR_ERROR, "Echo failed: %d, %s, %s", static_cast<int>(result.error_code()), result.error_message().c_str(),
-            result.error_details().c_str());
+    gpr_log(GPR_ERROR, "Echo failed: %d, %s, %s",
+            static_cast<int>(result.error_code()),
+            result.error_message().c_str(), result.error_details().c_str());
   }
-  EXPECT_EQ(response.message(), kMessage);
+  EXPECT_NE(response.message(), kMessage);
 }
 
 TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {
@@ -136,8 +137,8 @@ TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {
   notification.WaitForNotification();
 
   TlsChannelCredentialsOptions tls_options;
-  tls_options.set_certificate_verifier(ExternalCertificateVerifier::Create<
-            NoOpCertificateVerifier>());
+  tls_options.set_certificate_verifier(
+      ExternalCertificateVerifier::Create<NoOpCertificateVerifier>());
   tls_options.set_check_call_host(/*check_call_host=*/false);
   tls_options.set_verify_server_certs(/*verify_server_certs=*/false);
 

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -126,7 +126,7 @@ void DoRpc(const std::string& server_addr,
             static_cast<int>(result.error_code()),
             result.error_message().c_str(), result.error_details().c_str());
   }
-  EXPECT_NE(response.message(), kMessage);
+  EXPECT_EQ(response.message(), kMessage);
 }
 
 TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -42,7 +42,6 @@ namespace {
 
 using ::grpc::experimental::ExternalCertificateVerifier;
 using ::grpc::experimental::TlsChannelCredentialsOptions;
-using ::grpc::experimental::TlsCredentialsOptions;
 
 constexpr char kCaCertPath[] = "src/core/tsi/test_creds/ca.pem";
 constexpr char kServerCertPath[] = "src/core/tsi/test_creds/server1.pem";

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -10676,6 +10676,30 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "tls_credentials_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "tls_key_export_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
This PR fixes a bug identified in #29667, where the TLS channel credentials still require a trust bundle even if the user has explicitly opted to not verify the server certificate. This PR is based on #29810.