### PR TITLE
[Security] Fix bug for layered composite creds

### DIFF
--- a/src/core/lib/security/credentials/composite/composite_credentials.h
+++ b/src/core/lib/security/credentials/composite/composite_credentials.h
@@ -55,7 +55,7 @@ class grpc_composite_channel_credentials : public grpc_channel_credentials {
 
   grpc_core::RefCountedPtr<grpc_channel_credentials>
   duplicate_without_call_credentials() override {
-    return inner_creds_;
+    return inner_creds_->duplicate_without_call_credentials();
   }
 
   grpc_core::RefCountedPtr<grpc_channel_security_connector>

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -3878,7 +3878,7 @@ TEST(CredentialsTest, TestCompositeChannelCredsCompareSuccess) {
   grpc_channel_credentials_release(composite_creds_2);
 }
 
-TEST(CredentialsTest, RecursiveCompositeCredsCompareSuccess) {
+TEST(CredentialsTest, RecursiveCompositeCredsDuplicateWithoutCallCreds) {
   auto* insecure_creds = grpc_insecure_credentials_create();
   auto inner_fake_creds = MakeRefCounted<fake_call_creds>();
   auto outer_fake_creds = MakeRefCounted<fake_call_creds>();

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -3888,8 +3888,7 @@ TEST(CredentialsTest, RecursiveCompositeCredsDuplicateWithoutCallCreds) {
       inner_composite_creds, outer_fake_creds.get(), nullptr);
   auto duplicate_without_call_creds =
       outer_composite_creds->duplicate_without_call_credentials();
-  auto type = duplicate_without_call_creds->type();
-  ASSERT_NE(type, inner_composite_creds->type());
+  EXPECT_EQ(duplicate_without_call_creds.get(), insecure_creds);
   grpc_channel_credentials_release(insecure_creds);
   grpc_channel_credentials_release(inner_composite_creds);
   grpc_channel_credentials_release(outer_composite_creds);


### PR DESCRIPTION
Address https://github.com/grpc/grpc/issues/12554

The API for `duplicate_without_call_credentials` says 
```
// Creates a version of the channel credentials without any attached call
// credentials. This can be used in order to open a channel to a non-trusted
// gRPC load balancer.
```

As the impl stands right now, because of that description, in the case of layered composite creds, I think the right behavior would be to call down until you get the base cred with no call cred.

In discussing with the team, we do wonder if the use-case of layered composite creds is really something that should be a feature, or if we should be checking during the creation of composite creds to make sure we aren't layering composite creds? @markdroth can you give your thoughts?
