### PR TITLE
[PSM Interop] Add flag to enable CSM Observability in c++ image

### DIFF
--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -268,6 +268,8 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "otel/exporters/prometheus:prometheus_exporter",
+        "otel/sdk/src/metrics",
     ],
     deps = [
         ":rpc_behavior_lb_policy",
@@ -275,6 +277,7 @@ grpc_cc_binary(
         "//:grpc++",
         "//:grpc++_reflection",
         "//:grpcpp_admin",
+        "//:grpcpp_csm_observability",
         "//src/proto/grpc/testing:empty_proto",
         "//src/proto/grpc/testing:messages_proto",
         "//src/proto/grpc/testing:test_proto",
@@ -313,10 +316,13 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "otel/exporters/prometheus:prometheus_exporter",
+        "otel/sdk/src/metrics",
     ],
     deps = [
         ":xds_interop_server_lib",
         "//:grpc++",
+        "//:grpcpp_csm_observability",
         "//test/core/util:grpc_test_util",
         "//test/cpp/end2end:test_health_check_service_impl",
         "//test/cpp/util:test_config",

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -19,8 +19,12 @@
 #include <iostream>
 
 #include "absl/flags/flag.h"
+#include "opentelemetry/exporters/prometheus/exporter_factory.h"
+#include "opentelemetry/exporters/prometheus/exporter_options.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
 
 #include <grpc/grpc.h>
+#include <grpcpp/ext/csm_observability.h>
 #include <grpcpp/health_check_service_interface.h>
 
 #include "src/core/lib/iomgr/gethostname.h"
@@ -36,6 +40,24 @@ ABSL_FLAG(std::string, server_id, "cpp_server",
 ABSL_FLAG(bool, secure_mode, false,
           "If true, XdsServerCredentials are used, InsecureServerCredentials "
           "otherwise");
+ABSL_FLAG(bool, enable_csm_observability, false,
+          "Whether to enable CSM Observability");
+
+void EnableCsmObservability() {
+  gpr_log(GPR_DEBUG, "Registering Prometheus exporter");
+  opentelemetry::exporter::metrics::PrometheusExporterOptions opts;
+  // default was "localhost:9464" which causes connection issue across GKE
+  // pods
+  opts.url = "0.0.0.0:9464";
+  auto prometheus_exporter =
+      opentelemetry::exporter::metrics::PrometheusExporterFactory::Create(opts);
+  auto meter_provider =
+      std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
+  meter_provider->AddMetricReader(std::move(prometheus_exporter));
+  auto observability = grpc::experimental::CsmObservabilityBuilder();
+  observability.SetMeterProvider(std::move(meter_provider));
+  auto status = observability.BuildAndRegister();
+}
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
@@ -56,6 +78,9 @@ int main(int argc, char** argv) {
     return 1;
   }
   grpc::EnableDefaultHealthCheckService(false);
+  if (absl::GetFlag(FLAGS_enable_csm_observability)) {
+    EnableCsmObservability();
+  }
   grpc::testing::RunServer(
       absl::GetFlag(FLAGS_secure_mode), port, maintenance_port, hostname,
       absl::GetFlag(FLAGS_server_id), [](grpc::Server* /* unused */) {});


### PR DESCRIPTION
Roll forward of #34832, 3rd attempt. Will run a grpc import cherry-pick to make sure the next import is going to be clean.