### PR TITLE
[clang-format] spam cleanup

### DIFF
--- a/tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
+++ b/tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -e
 
 # directories to run against
 DIRS="examples/cpp examples/android/binder src/core/lib src/core/tsi src/core/ext src/cpp test/core test/cpp include src/compiler src/ruby src/objective-c tools/distrib/python src/python/grpcio_observability"
@@ -60,11 +60,13 @@ if [ -n "$CHANGED_FILES" ]; then
   files=$(comm -12 <(echo $files | tr ' ' '\n' | sort -u) <(echo $CHANGED_FILES | tr ' ' '\n' | sort -u))
 fi
 
+files=`echo $files | sort -R`
+
 FILES_PER_PROCESS="$(expr $(echo "$files" | grep -o '\n' | wc -l) / $CPU_COUNT + 1)"
 
 if [ "$TEST" == "" ]
 then
-  echo $files | xargs -P $CPU_COUNT -n $FILES_PER_PROCESS $CLANG_FORMAT -i --verbose
+  echo $files | xargs -P $CPU_COUNT -n $FILES_PER_PROCESS $CLANG_FORMAT -i
 else
   ok=yes
   for file in $files


### PR DESCRIPTION
Eliminate spam from clang-format script.
Also add a shuffle to the file list - saves about a second of runtime on my machine by making sure clusters of hard files are distributed evenly amongst CPUs.