### PR TITLE
[event-engine] Fix channelz test to be sound against callback leakage

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -308,6 +308,7 @@ grpc_cc_test(
         "//src/proto/grpc/channelz:channelz_proto",
         "//src/proto/grpc/testing:echo_messages_proto",
         "//src/proto/grpc/testing:echo_proto",
+        "//test/core/event_engine:event_engine_test_utils",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],


### PR DESCRIPTION
EventEngine experiments, especially with `work_serializer_dispatch` tend to cause callbacks to occur later than we've previously seen, so tests that verify global data structures tend to become flakier when these are introduced.

Here, the fix is waiting for EventEngine to be closed before starting the new test.

Whilst here, make some adjustments to the test for better readability on what's going on:
- if we fail a request to an echo service, we do not actually expect the messages to match, so don't report that
- if we expect a value of 1 or 2, AnyOf is a better tool: it will report the actual value too