### PR TITLE
[PMS Interop] ADS detection: minor wording change

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py
@@ -318,11 +318,13 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
                     channel, **rpc_params
                 )
                 logger.info(
-                    "[%s] Detected successful calls to xDS control plane: %s",
+                    "[%s] Detected successful calls to xDS control plane %s,"
+                    " channel: %s",
                     self.hostname,
                     xds_server_uri,
+                    _ChannelzServiceClient.channel_repr(channel),
                 )
-            except self.NotFound as e:
+            except self.NotFound:
                 # Otherwise, keep searching.
                 continue
 


### PR DESCRIPTION
Now we log pretty much identical message:

```
client_app.py:320] [psm-grpc-client-7768f6597-nvtgl] Detected successful calls to xDS control plane: trafficdirector.googleapis.com:443
client_app.py:292] [psm-grpc-client-7768f6597-nvtgl] ADS: Detected successful calls to xDS control plane trafficdirector.googleapis.com:443
```

This PR will log the latest channel state in the first message, similar to what we do in `find_server_channel_with_state`:

https://github.com/grpc/grpc/blob/52c08f44982fe34df389267a9901d8652caca2ee/tools/run_tests/xds_k8s_test_driver/framework/test_app/client_app.py#L367-L371

After the change:

```
client_app.py:320] [psm-grpc-client-6566595cff-8wrfd] Detected successful calls to xDS control plane trafficdirector.googleapis.com:443, channel: <Channel channel_id=4 target=trafficdirector.googleapis.com:443 call_started=9 calls_failed=8 state=READY>
client_app.py:292] [psm-grpc-client-6566595cff-8wrfd] ADS: Detected successful calls to xDS control plane trafficdirector.googleapis.com:443
```