### PR TITLE
[channelz] Remove unused objects from channelz socket node

### DIFF
--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -364,10 +364,6 @@ Json SocketNode::Security::Tls::RenderJson() {
   } else if (type == NameType::kOtherName) {
     data["other_name"] = Json::FromString(name);
   }
-  if (!local_certificate.empty()) {
-    data["local_certificate"] =
-        Json::FromString(absl::Base64Escape(local_certificate));
-  }
   if (!remote_certificate.empty()) {
     data["remote_certificate"] =
         Json::FromString(absl::Base64Escape(remote_certificate));
@@ -387,11 +383,6 @@ Json SocketNode::Security::RenderJson() {
     case ModelType::kTls:
       if (tls) {
         data["tls"] = tls->RenderJson();
-      }
-      break;
-    case ModelType::kOther:
-      if (other.has_value()) {
-        data["other"] = *other;
       }
       break;
   }

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -299,15 +299,13 @@ class SocketNode : public BaseNode {
       NameType type = NameType::kUnset;
       // Holds the value of standard_name or other_names if type is not kUnset.
       std::string name;
-      std::string local_certificate;
       std::string remote_certificate;
 
       Json RenderJson();
     };
-    enum class ModelType { kUnset = 0, kTls = 1, kOther = 2 };
+    enum class ModelType { kUnset = 0, kTls = 1 };
     ModelType type = ModelType::kUnset;
     absl::optional<Tls> tls;
-    absl::optional<Json> other;
 
     Json RenderJson();
 


### PR DESCRIPTION
Based on [this comment](https://github.com/grpc/grpc/blob/master/src/core/lib/security/transport/security_handshaker.cc#L231), we only support TLS right now, meaning we don't populate local cert or the `other` object. We can save 96 bytes per node by removing these until we do support non-TLS.

