### PR TITLE
[tracing] Add member getters to HttpAnnotation (#34592)

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.h
@@ -119,6 +119,15 @@ class HttpAnnotation : public CallTracerAnnotationInterface::Annotation {
 
   std::string ToString() const override;
 
+  Type http_type() const { return type_; }
+  Timestamp time() const { return time_; }
+  absl::optional<chttp2::TransportFlowControl::Stats> transport_stats() const {
+    return transport_stats_;
+  }
+  absl::optional<chttp2::StreamFlowControl::Stats> stream_stats() const {
+    return stream_stats_;
+  }
+
  private:
   const Type type_;
   const Timestamp time_;


### PR DESCRIPTION
So that users can process annotations other than calling ToString().




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

