### PR TITLE
[Build] Shortened python_build to pyb

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 plugins = Cython.Coverage
 
 [build]
-build_base=python_build
+build_base=pyb
 
 [build_ext]
 inplace=1


### PR DESCRIPTION
To mitigate windows long path issue found in https://github.com/grpc/grpc/pull/34513