### PR TITLE
[Build] Shortened python_build to pyb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ cython_debug/
 dist/
 htmlcov/
 py3*/
-python_build/
+pyb/
 python_pylint_venv/
 src/python/grpcio_*/=*
 src/python/grpcio_*/build/

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 plugins = Cython.Coverage
 
 [build]
-build_base=python_build
+build_base=pyb
 
 [build_ext]
 inplace=1

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -349,7 +349,7 @@ class Clean(setuptools.Command):
     ]
 
     _FILE_PATTERNS = (
-        "python_build",
+        "pyb",
         "src/python/grpcio/__pycache__/",
         "src/python/grpcio/grpc/_cython/cygrpc.cpp",
         "src/python/grpcio/grpc/_cython/*.so",


### PR DESCRIPTION
To mitigate the following windows long path issue found in https://github.com/grpc/grpc/pull/34513. Using `pyb` instead of `python_build` saves 9 characters.

---

`Distribution Tests Python Windows` failed because of 
`T:\altsrc\github\grpc\workspace_python_windows_x86_Python38_32bit\python_build\\temp.win-amd64-cpython-312\\Release\\src\core\ext\upb-gen\envoy\extensions\load_balancing_policies\client_side_weighted_round_robin\v3\client_side_weighted_round_robin.upb_minitable.obj`

