### PR TITLE
[Python Test] Increase Python Windows build artifact timeout

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -223,7 +223,7 @@ class PythonArtifact:
                     "32" if self.arch == "x86" else "64",
                 ],
                 environ=environ,
-                timeout_seconds=45 * 60,
+                timeout_seconds=60 * 60 * 2,
                 use_workspace=True,
             )
         else:


### PR DESCRIPTION
We're seeing timeout errors in our distribution test: https://fusion2.corp.google.com/invocations/dfa9aaa9-e94b-479e-8c28-a39d98d277bc/targets/github%2Fgrpc%2Fbuild_artifacts_python;config=default/tests.

Sample error:
`2023-11-10 09:12:19,512 TIMEOUT: build_artifact.python_windows_x86_Python39_32bit [pid=2320, time=2700.1sec]`

This change increases timeout for windows build artifact jobs from 2700s to 7200s, which aligns with all other jobs (except `linux_extra`, which is 3600s).

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

