### PR TITLE
[ci/cd] Hash-pin GitHub Actions, set up dependabot to keep them updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -12,17 +12,17 @@ jobs:
     steps:
       # Cache bazel build
       - name: Get current time
-        uses: srfrnk/current-time@master
+        uses: srfrnk/current-time@5a4163ad035ccd9a407ec9e519c3b6ba1b633d1e # v1.1.0
         id: current-time
         with:
           format: YYYYWW
       - name: Get current time
-        uses: srfrnk/current-time@master
+        uses: srfrnk/current-time@5a4163ad035ccd9a407ec9e519c3b6ba1b633d1e # v1.1.0
         id: current-time-with-day
         with:
           format: YYYYWWd
       - name: Cache bazel
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         env:
           cache-name: bazel-cache
         with:
@@ -38,12 +38,12 @@ jobs:
       # Cancel current runs if they're still running
       # (saves processing on fast pushes)
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432 # 0.12.0
         with:
           access_token: ${{ github.token }}
       # Allow opt-out for some users
       - name: Should I Stay Or Should I Go
-        uses: actions/github-script@v4
+        uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7.0.0
         id: check
         with:
           script: |
@@ -65,7 +65,7 @@ jobs:
         run: test "${{ steps.check.outputs.result }}" = "stay"
       # Setup to run sanity suite
       - name: Install Python Interpreter
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: 3.8
       - name: Install Python Packages
@@ -74,7 +74,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install python3-dev
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: True
       - name: Get the upstream code
@@ -89,7 +89,7 @@ jobs:
         run: ANDROID_NDK_HOME= ${{ github.workspace }}/tools/distrib/sanitize.sh
       # Report back with a PR if things are broken
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
           delete-branch: true
           branch-suffix: short-commit-hash

--- a/.github/workflows/pr-auto-tag.yaml
+++ b/.github/workflows/pr-auto-tag.yaml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: ""

--- a/.github/workflows/psm-interop.yaml
+++ b/.github/workflows/psm-interop.yaml
@@ -26,14 +26,14 @@ jobs:
         working-directory: 'tools/run_tests/xds_k8s_test_driver'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # To add this job to required GitHub checks, it's not enough to use
       # the on.pull_request.paths filter. For required checks, the job needs to
       # return the success status, and not be skipped.
       # Using paths-filter action, we skip the setup/test steps when psm interop
       # files are unchanged, and the job returns success.
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: paths_filter
         with:
           filters:  |
@@ -43,7 +43,7 @@ jobs:
               - 'src/proto/grpc/testing/messages.proto'
               - 'src/proto/grpc/testing/test.proto'
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         if: ${{ steps.paths_filter.outputs.psm_interop_src == 'true' }}
         with:
           python-version: "${{ matrix.python_version }}"


### PR DESCRIPTION
Fixes #34929.

This PR hash-pins all Actions used in workflows and sets up dependabot to keep them up-to-date.

Dependabot will send at most one PR per month. That PR will update the hashes and version comments of all Actions with new versions.

I also suggest you enable Dependabot Security Updates in the repo's [Code security & analysis](https://github.com/grpc/grpc/settings/security_analysis) settings (if you haven't already). This will make Dependabot send a PR as soon as a dependency is found to have a vulnerability.