### PR TITLE
Fix Python DeprecationWarning: 'pipes'

### DIFF
--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -21,8 +21,8 @@ import collections
 import itertools
 import json
 import os
-import pipes
 import re
+import shlex
 import sys
 import time
 
@@ -121,7 +121,7 @@ def create_scenario_jobspec(
     if bq_result_table:
         cmd += 'BQ_RESULT_TABLE="%s" ' % bq_result_table
     cmd += "tools/run_tests/performance/run_qps_driver.sh "
-    cmd += "--scenarios_json=%s " % pipes.quote(
+    cmd += "--scenarios_json=%s " % shlex.quote(
         json.dumps({"scenarios": [scenario_json]})
     )
     cmd += "--scenario_result_file=scenario_result.json "
@@ -135,7 +135,7 @@ def create_scenario_jobspec(
         user_at_host = "%s@%s" % (_REMOTE_HOST_USERNAME, remote_host)
         cmd = 'ssh %s "cd ~/performance_workspace/grpc/ && "%s' % (
             user_at_host,
-            pipes.quote(cmd),
+            shlex.quote(cmd),
         )
 
     return jobset.JobSpec(
@@ -157,7 +157,7 @@ def create_quit_jobspec(workers, remote_host=None):
         user_at_host = "%s@%s" % (_REMOTE_HOST_USERNAME, remote_host)
         cmd = 'ssh %s "cd ~/performance_workspace/grpc/ && "%s' % (
             user_at_host,
-            pipes.quote(cmd),
+            shlex.quote(cmd),
         )
 
     return jobset.JobSpec(
@@ -192,7 +192,7 @@ def create_netperf_jobspec(
         user_at_host = "%s@%s" % (_REMOTE_HOST_USERNAME, client_host)
         cmd = 'ssh %s "cd ~/performance_workspace/grpc/ && "%s' % (
             user_at_host,
-            pipes.quote(cmd),
+            shlex.quote(cmd),
         )
 
     return jobset.JobSpec(

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -26,10 +26,10 @@ import logging
 import multiprocessing
 import os
 import os.path
-import pipes
 import platform
 import random
 import re
+import shlex
 import socket
 import subprocess
 import sys
@@ -479,7 +479,7 @@ class CLanguage(object):
                         cmdline = [binary] + target["args"]
                         shortname = target.get(
                             "shortname",
-                            " ".join(pipes.quote(arg) for arg in cmdline),
+                            " ".join(shlex.quote(arg) for arg in cmdline),
                         )
                         shortname += shortname_ext
                         out.append(


### PR DESCRIPTION
Starting from Python 3.11, the pipes module produces this warning:

DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13

Turns out that in this repo the pipes module is only used for the
"quote" function which is turn directly taken from the shlex module [1].

The shlex module is not deprecated as of today and is already used in
other places in this repo. The function shlex.quote has been around
since the ancient Python 3.3.

[1] https://github.com/python/cpython/blob/3.11/Lib/pipes.py#L64-L66




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

