### PR TITLE
[PSM Interop] Check for active ADS in Security and URL Map tests

### DIFF
--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_gamma_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_gamma_testcase.py
@@ -130,6 +130,8 @@ class GammaXdsKubernetesTestCase(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         # To compensate for this, we double the timeout for GAMMA tests.
         return self._start_test_client(
             server_target,
-            wait_for_active_channel_timeout=datetime.timedelta(minutes=10),
+            wait_for_server_channel_ready_timeout=datetime.timedelta(
+                minutes=10
+            ),
             **kwargs,
         )

--- a/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
+++ b/tools/run_tests/xds_k8s_test_driver/framework/xds_url_map_testcase.py
@@ -479,6 +479,9 @@ class XdsUrlMapTestCase(
             super().run(result)
 
     def test_client_config(self):
+        self.test_client.wait_for_active_xds_channel(
+            xds_server_uri=GcpResourceManager().xds_server_uri,
+        )
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(
                 seconds=_URL_MAP_PROPAGATE_CHECK_INTERVAL_SEC


### PR DESCRIPTION
`test_client.wait_for_server_channel_ready` was not called in `SecurityXdsKubernetesTestCase` and `XdsUrlMapTestCase`.
Initial PR: https://github.com/grpc/grpc/pull/34631.