### PR TITLE
[EventEngine] Produce better error logs on `bind` failures

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
@@ -46,8 +46,6 @@
 #include <netinet/in.h>  // IWYU pragma: keep
 #include <sys/socket.h>  // IWYU pragma: keep
 #include <unistd.h>      // IWYU pragma: keep
-
-#include "absl/strings/str_cat.h"
 #endif
 
 namespace grpc_event_engine {

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
@@ -186,8 +186,8 @@ absl::Status PrepareSocket(const PosixTcpOptions& options,
     }
     sockaddr_str = absl::StrReplaceAll(*sockaddr_str, {{"\0", "@"}});
     return absl::FailedPreconditionError(
-        absl::StrCat("Error in bind for address '%s': ", *sockaddr_str,
-                     std::strerror(errno)));
+        absl::StrCat("Error in bind for address '", *sockaddr_str,
+                     "': ", std::strerror(errno)));
   }
 
   if (listen(fd, GetMaxAcceptQueueSize()) < 0) {

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.cc
@@ -25,6 +25,8 @@
 
 #include "absl/cleanup/cleanup.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/support/log.h>
@@ -182,8 +184,9 @@ absl::Status PrepareSocket(const PosixTcpOptions& options,
               sockaddr_str.status().ToString().c_str());
       sockaddr_str = "<unparsable>";
     }
+    sockaddr_str = absl::StrReplaceAll(*sockaddr_str, {{"\0", "@"}});
     return absl::FailedPreconditionError(
-        absl::StrCat("Error in bind for address '%s': ", sockaddr_str.value(),
+        absl::StrCat("Error in bind for address '%s': ", *sockaddr_str,
                      std::strerror(errno)));
   }
 


### PR DESCRIPTION
Seeing a rare flake where a fixture address is already in use. This PR adds sockaddr->string conversion for the address, in case some of this address is being truncated before attempting to bind. It's very odd to see this exact-time-based address string generated twice in succession.

`E1116 21:34:56.431768483      17 chttp2_server.cc:1051]                UNKNOWN:No address added out of total 1 resolved for 'unix-abstract:grpc_fullstack_test.%00.17.974.661825339.14468088171934000544.7442035989947845277' {created_time:"2023-11-16T21:34:56.431729283+00:00", children:[FAILED_PRECONDITION:Error in bind: Address already in use]}
`

https://source.cloud.google.com/results/invocations/48ee2e26-9341-46ec-9761-35939b73f3f8/targets/%2F%2Ftest%2Fcore%2Fend2end:retry_transparent_max_concurrent_streams_test@poller%3Dpoll/log