### PR TITLE
Return Qnil from grpc_rb_fork_unsafe_begin/end_api

### DIFF
--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -450,9 +450,9 @@ void grpc_rb_fork_unsafe_begin() { g_grpc_rb_num_fork_unsafe_threads++; }
 void grpc_rb_fork_unsafe_end() { g_grpc_rb_num_fork_unsafe_threads--; }
 
 // APIs to mark fork-unsafe sections from ruby code
-static VALUE grpc_rb_fork_unsafe_begin_api() { grpc_rb_fork_unsafe_begin(); }
+static VALUE grpc_rb_fork_unsafe_begin_api() { grpc_rb_fork_unsafe_begin(); return Qnil; }
 
-static VALUE grpc_rb_fork_unsafe_end_api() { grpc_rb_fork_unsafe_end(); }
+static VALUE grpc_rb_fork_unsafe_end_api() { grpc_rb_fork_unsafe_end(); return Qnil; }
 
 // One-time initialization
 void Init_grpc_c() {


### PR DESCRIPTION

`grpc_rb_fork_unsafe_begin_api` and `grpc_rb_fork_unsafe_end_api` are returning nothing but they are declared as returning `VALUE`. Hence if the return value is used, this results in undefined behavior.