### PR TITLE
[test] Do not return empty values if there's no metadata

### DIFF
--- a/test/cpp/interop/xds_stats_watcher.cc
+++ b/test/cpp/interop/xds_stats_watcher.cc
@@ -56,10 +56,8 @@ bool HasNonEmptyMetadata(
         metadata_by_peer) {
   for (const auto& entry : metadata_by_peer) {
     for (const auto& rpc_metadata : entry.second.rpc_metadata()) {
-      for (const auto& metadata : rpc_metadata.metadata()) {
-        if (!metadata.key().empty() || !metadata.value().empty()) {
-          return true;
-        }
+      if (rpc_metadata.metadata_size() > 0) {
+        return true;
       }
     }
   }

--- a/test/cpp/interop/xds_stats_watcher.cc
+++ b/test/cpp/interop/xds_stats_watcher.cc
@@ -127,7 +127,7 @@ LoadBalancerStatsResponse XdsStatsWatcher::WaitForRpcStatsResponse(
   response.mutable_rpcs_by_peer()->insert(rpcs_by_peer_.begin(),
                                           rpcs_by_peer_.end());
   // Return metadata if at least one RPC had relevant metadata. Note that empty
-  // entries would be returned for RCPs with no relevant metadata in this case.
+  // entries would be returned for RPCs with no relevant metadata in this case.
   if (HasNonEmptyMetadata(metadata_by_peer_)) {
     response.mutable_metadatas_by_peer()->insert(metadata_by_peer_.begin(),
                                                  metadata_by_peer_.end());

--- a/test/cpp/interop/xds_stats_watcher.cc
+++ b/test/cpp/interop/xds_stats_watcher.cc
@@ -51,6 +51,21 @@ std::unordered_set<std::string> ToLowerCase(
   return result;
 }
 
+bool HasNonEmptyMetadata(
+    const std::map<std::string, LoadBalancerStatsResponse::MetadataByPeer>&
+        metadata_by_peer) {
+  for (const auto& entry : metadata_by_peer) {
+    for (const auto& rpc_metadata : entry.second.rpc_metadata()) {
+      for (const auto& metadata : rpc_metadata.metadata()) {
+        if (!metadata.key().empty() || !metadata.value().empty()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 XdsStatsWatcher::XdsStatsWatcher(int start_id, int end_id,
@@ -113,8 +128,12 @@ LoadBalancerStatsResponse XdsStatsWatcher::WaitForRpcStatsResponse(
                [this] { return rpcs_needed_ == 0; });
   response.mutable_rpcs_by_peer()->insert(rpcs_by_peer_.begin(),
                                           rpcs_by_peer_.end());
-  response.mutable_metadatas_by_peer()->insert(metadata_by_peer_.begin(),
-                                               metadata_by_peer_.end());
+  // Return metadata if at least one RPC had relevant metadata. Note that empty
+  // entries would be returned for RCPs with no relevant metadata in this case.
+  if (HasNonEmptyMetadata(metadata_by_peer_)) {
+    response.mutable_metadatas_by_peer()->insert(metadata_by_peer_.begin(),
+                                                 metadata_by_peer_.end());
+  }
   auto& response_rpcs_by_method = *response.mutable_rpcs_by_method();
   for (const auto& rpc_by_type : rpcs_by_type_) {
     std::string method_name;

--- a/test/cpp/interop/xds_stats_watcher_test.cc
+++ b/test/cpp/interop/xds_stats_watcher_test.cc
@@ -152,7 +152,7 @@ TEST(XdsStatsWatcherTest, WaitForRpcStatsResponseReturnsAll) {
             watcher.WaitForRpcStatsResponse(0).DebugString());
 }
 
-TEST(XdsStatsWatcherTest, WaitForRpcStatsResponseIgnoresMetadata) {
+TEST(XdsStatsWatcherTest, WaitForRpcStatsResponseExcludesMetadata) {
   XdsStatsWatcher watcher(0, 3, {});
   // RPC had metadata - but watcher should ignore it
   watcher.RpcCompleted(BuildCallResult(0), "peer1",
@@ -163,11 +163,6 @@ TEST(XdsStatsWatcherTest, WaitForRpcStatsResponseIgnoresMetadata) {
                        {{"k1", "v5"}, {"k2", "v6"}, {"k3", "v7"}});
   LoadBalancerStatsResponse expected;
   expected.mutable_rpcs_by_peer()->insert({{"peer1", 2}, {"peer2", 1}});
-  // There will still be an empty metadata collection for each RPC
-  expected.mutable_metadatas_by_peer()->insert({
-      {"peer1", BuildMetadatas({{}, {}})},
-      {"peer2", BuildMetadatas({{}})},
-  });
   (*expected.mutable_rpcs_by_method())["UnaryCall"]
       .mutable_rpcs_by_peer()
       ->insert({{"peer1", 2}, {"peer2", 1}});


### PR DESCRIPTION
Changes C++ Xds server to only return metadata when there is at least one non-empty entry.

Fixes: #34872 