### PR TITLE
Remove backslash at the end of comment

### DIFF
--- a/src/core/lib/gpr/posix/sync.cc
+++ b/src/core/lib/gpr/posix/sync.cc
@@ -155,5 +155,5 @@ void gpr_once_init(gpr_once* once, void (*init_function)(void)) {
   GPR_ASSERT(pthread_once(once, init_function) == 0);
 }
 
-#endif  // defined(GPR_POSIX_SYNC) && !defined(GPR_ABSEIL_SYNC) && \
+#endif  // defined(GPR_POSIX_SYNC) && !defined(GPR_ABSEIL_SYNC) && 
        // !defined(GPR_CUSTOM_SYNC)

--- a/src/core/lib/gpr/windows/sync.cc
+++ b/src/core/lib/gpr/windows/sync.cc
@@ -118,5 +118,5 @@ void gpr_once_init(gpr_once* once, void (*init_function)(void)) {
   InitOnceExecuteOnce(once, run_once_func, &arg, &phony);
 }
 
-#endif  // defined(GPR_WINDOWS) && !defined(GPR_ABSEIL_SYNC) && \
+#endif  // defined(GPR_WINDOWS) && !defined(GPR_ABSEIL_SYNC) && 
        // !defined(GPR_CUSTOM_SYNC)

--- a/src/core/lib/iomgr/grpc_if_nametoindex_posix.cc
+++ b/src/core/lib/iomgr/grpc_if_nametoindex_posix.cc
@@ -39,5 +39,5 @@ uint32_t grpc_if_nametoindex(char* name) {
   return out;
 }
 
-#endif  // GRPC_IF_NAMETOINDEX == 1 && \
+#endif  // GRPC_IF_NAMETOINDEX == 1 && 
        // defined(GRPC_POSIX_SOCKET_IF_NAMETOINDEX)


### PR DESCRIPTION
the backslash cause a compile error: multi-line comment

```
external/com_github_grpc_grpc/src/core/lib/gpr/posix/sync.cc:158:9: error: multi-line comment [-Werror=comment]
  158 | #endif  // defined(GPR_POSIX_SYNC) && !defined(GPR_ABSEIL_SYNC) && \
      |         ^
cc1plus: all warnings being treated as errors
```

