### PR TITLE
[Ruby] fix incompatible function pointer type error calling rb_thread_create

### DIFF
--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -726,7 +726,7 @@ static void run_poll_channels_loop_unblocking_func(void* arg) {
 }
 
 // Poll channel connectivity states in background thread without the GIL.
-static VALUE run_poll_channels_loop(VALUE arg) {
+static VALUE run_poll_channels_loop(void* arg) {
   (void)arg;
   gpr_log(
       GPR_DEBUG,

--- a/src/ruby/ext/grpc/rb_event_thread.c
+++ b/src/ruby/ext/grpc/rb_event_thread.c
@@ -116,7 +116,7 @@ static void grpc_rb_event_unblocking_func(void* arg) {
 
 /* This is the implementation of the thread that handles auth metadata plugin
  * events */
-static VALUE grpc_rb_event_thread(VALUE arg) {
+static VALUE grpc_rb_event_thread(void* arg) {
   grpc_rb_event* event;
   (void)arg;
   while (true) {


### PR DESCRIPTION
rb_thread_create accept VALUE (*f)(void *g) for its first arg: https://github.com/ruby/ruby/blob/ruby_3_2/include/ruby/internal/intern/thread.h#L190

fixes #35148