### PR TITLE
binder: skip all tests on ios

### DIFF
--- a/test/core/transport/binder/BUILD
+++ b/test/core/transport/binder/BUILD
@@ -44,7 +44,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
-    tags = [ "no_test_ios", ],
+    tags = ["no_test_ios"],
     uses_event_engine = False,
     uses_polling = False,
     deps = [
@@ -62,7 +62,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
-    tags = [ "no_test_ios", ],
+    tags = ["no_test_ios"],
     uses_event_engine = False,
     uses_polling = False,
     deps = [
@@ -80,7 +80,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
-    tags = [ "no_test_ios", ],
+    tags = ["no_test_ios"],
     uses_event_engine = False,
     uses_polling = False,
     deps = [
@@ -121,7 +121,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
-    tags = [ "no_test_ios", ],
+    tags = ["no_test_ios"],
     uses_event_engine = False,
     uses_polling = False,
     deps = [

--- a/test/core/transport/binder/BUILD
+++ b/test/core/transport/binder/BUILD
@@ -44,6 +44,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = [ "no_test_ios", ],
     uses_event_engine = False,
     uses_polling = False,
     deps = [
@@ -61,6 +62,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = [ "no_test_ios", ],
     uses_event_engine = False,
     uses_polling = False,
     deps = [
@@ -78,6 +80,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = [ "no_test_ios", ],
     uses_event_engine = False,
     uses_polling = False,
     deps = [
@@ -98,6 +101,7 @@ grpc_cc_test(
     tags = [
         # To avoid `symbolizer buffer too small` warning of UBSAN
         "noubsan",
+        "no_test_ios",
     ],
     uses_event_engine = False,
     uses_polling = False,
@@ -117,6 +121,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = [ "no_test_ios", ],
     uses_event_engine = False,
     uses_polling = False,
     deps = [

--- a/test/core/transport/binder/end2end/BUILD
+++ b/test/core/transport/binder/end2end/BUILD
@@ -34,7 +34,6 @@ grpc_cc_library(
         "absl/time",
         "absl/types:variant",
     ],
-    tags = ["no_test_ios"],
     deps = [
         "//:gpr",
         "//:grpc++_binder",

--- a/test/core/transport/binder/end2end/BUILD
+++ b/test/core/transport/binder/end2end/BUILD
@@ -34,7 +34,7 @@ grpc_cc_library(
         "absl/time",
         "absl/types:variant",
     ],
-    tags = [ "no_test_ios", ],
+    tags = ["no_test_ios"],
     deps = [
         "//:gpr",
         "//:grpc++_binder",
@@ -50,9 +50,9 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = ["no_test_ios"],
     uses_event_engine = False,
     uses_polling = False,
-    tags = [ "no_test_ios", ],
     deps = [
         ":fake_binder",
         "//test/core/util:grpc_test_util",
@@ -108,7 +108,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
-    tags = [ "no_test_ios", ],
+    tags = ["no_test_ios"],
     deps = [
         "//:grpc++",
         "//:grpc++_binder",

--- a/test/core/transport/binder/end2end/BUILD
+++ b/test/core/transport/binder/end2end/BUILD
@@ -34,6 +34,7 @@ grpc_cc_library(
         "absl/time",
         "absl/types:variant",
     ],
+    tags = [ "no_test_ios", ],
     deps = [
         "//:gpr",
         "//:grpc++_binder",
@@ -51,6 +52,7 @@ grpc_cc_test(
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
+    tags = [ "no_test_ios", ],
     deps = [
         ":fake_binder",
         "//test/core/util:grpc_test_util",
@@ -106,6 +108,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    tags = [ "no_test_ios", ],
     deps = [
         "//:grpc++",
         "//:grpc++_binder",


### PR DESCRIPTION
They don't build due to -DNO_GRPC_BINDER.