### PR TITLE
[XdsCertificateProvider] clean up some cruft

### DIFF
--- a/src/core/ext/xds/xds_certificate_provider.cc
+++ b/src/core/ext/xds/xds_certificate_provider.cc
@@ -374,43 +374,4 @@ void XdsCertificateProvider::WatchStatusCallback(std::string cert_name,
   if (it->second->IsSafeToRemove()) certificate_state_map_.erase(it);
 }
 
-namespace {
-
-void* XdsCertificateProviderArgCopy(void* p) {
-  XdsCertificateProvider* xds_certificate_provider =
-      static_cast<XdsCertificateProvider*>(p);
-  return xds_certificate_provider->Ref().release();
-}
-
-void XdsCertificateProviderArgDestroy(void* p) {
-  XdsCertificateProvider* xds_certificate_provider =
-      static_cast<XdsCertificateProvider*>(p);
-  xds_certificate_provider->Unref();
-}
-
-int XdsCertificateProviderArgCmp(void* p, void* q) {
-  return QsortCompare(p, q);
-}
-
-const grpc_arg_pointer_vtable kChannelArgVtable = {
-    XdsCertificateProviderArgCopy, XdsCertificateProviderArgDestroy,
-    XdsCertificateProviderArgCmp};
-
-}  // namespace
-
-grpc_arg XdsCertificateProvider::MakeChannelArg() const {
-  return grpc_channel_arg_pointer_create(
-      const_cast<char*>(GRPC_ARG_XDS_CERTIFICATE_PROVIDER),
-      const_cast<XdsCertificateProvider*>(this), &kChannelArgVtable);
-}
-
-RefCountedPtr<XdsCertificateProvider>
-XdsCertificateProvider::GetFromChannelArgs(const grpc_channel_args* args) {
-  XdsCertificateProvider* xds_certificate_provider =
-      grpc_channel_args_find_pointer<XdsCertificateProvider>(
-          args, GRPC_ARG_XDS_CERTIFICATE_PROVIDER);
-  return xds_certificate_provider != nullptr ? xds_certificate_provider->Ref()
-                                             : nullptr;
-}
-
 }  // namespace grpc_core

--- a/src/core/ext/xds/xds_certificate_provider.h
+++ b/src/core/ext/xds/xds_certificate_provider.h
@@ -40,24 +40,12 @@
 #include "src/core/lib/security/credentials/tls/grpc_tls_certificate_distributor.h"
 #include "src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.h"
 
-#define GRPC_ARG_XDS_CERTIFICATE_PROVIDER \
-  "grpc.internal.xds_certificate_provider"
-
 namespace grpc_core {
 
 class XdsCertificateProvider : public grpc_tls_certificate_provider {
  public:
   XdsCertificateProvider();
   ~XdsCertificateProvider() override;
-
-  static absl::string_view ChannelArgName() {
-    return GRPC_ARG_XDS_CERTIFICATE_PROVIDER;
-  }
-
-  static int ChannelArgsCompare(const XdsCertificateProvider* a,
-                                const XdsCertificateProvider* b) {
-    return QsortCompare(a, b);
-  }
 
   RefCountedPtr<grpc_tls_certificate_distributor> distributor() const override {
     return distributor_;
@@ -86,10 +74,13 @@ class XdsCertificateProvider : public grpc_tls_certificate_provider {
   void UpdateSubjectAlternativeNameMatchers(
       const std::string& cluster, std::vector<StringMatcher> matchers);
 
-  grpc_arg MakeChannelArg() const;
-
-  static RefCountedPtr<XdsCertificateProvider> GetFromChannelArgs(
-      const grpc_channel_args* args);
+  static absl::string_view ChannelArgName() {
+    return "grpc.internal.xds_certificate_provider";
+  }
+  static int ChannelArgsCompare(const XdsCertificateProvider* a,
+                                const XdsCertificateProvider* b) {
+    return a->Compare(b);
+  }
 
  private:
   class ClusterCertificateState {


### PR DESCRIPTION
- Remove old-style channel args utility methods, which are unused.
- Change `ChannelArgsCompare()` to delegate to the `Compare()` method.