### PR TITLE
[server] Remove per-channel registered methods map

### DIFF
--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -211,26 +211,6 @@ class Server : public InternallyRefCounted<Server>,
  private:
   struct RequestedCall;
 
-  struct ChannelRegisteredMethod {
-    ChannelRegisteredMethod() = default;
-    ChannelRegisteredMethod(RegisteredMethod* server_registered_method_arg,
-                            uint32_t flags_arg, bool has_host_arg,
-                            Slice method_arg, Slice host_arg)
-        : server_registered_method(server_registered_method_arg),
-          flags(flags_arg),
-          has_host(has_host_arg),
-          method(std::move(method_arg)),
-          host(std::move(host_arg)) {}
-
-    ~ChannelRegisteredMethod() = default;
-
-    RegisteredMethod* server_registered_method = nullptr;
-    uint32_t flags;
-    bool has_host;
-    Slice method;
-    Slice host;
-  };
-
   class RequestMatcherInterface;
   class RealRequestMatcherFilterStack;
   class RealRequestMatcherPromises;
@@ -251,11 +231,8 @@ class Server : public InternallyRefCounted<Server>,
     Channel* channel() const { return channel_.get(); }
     size_t cq_idx() const { return cq_idx_; }
 
-    ChannelRegisteredMethod* GetRegisteredMethod(const grpc_slice& host,
-                                                 const grpc_slice& path);
-
-    ChannelRegisteredMethod* GetRegisteredMethod(const absl::string_view& host,
-                                                 const absl::string_view& path);
+    RegisteredMethod* GetRegisteredMethod(const absl::string_view& host,
+                                          const absl::string_view& path);
     // Filter vtable functions.
     static grpc_error_handle InitChannelElement(
         grpc_channel_element* elem, grpc_channel_element_args* args);
@@ -274,36 +251,12 @@ class Server : public InternallyRefCounted<Server>,
 
     static void FinishDestroy(void* arg, grpc_error_handle error);
 
-    struct StringViewStringViewPairHash
-        : absl::flat_hash_set<
-              std::pair<absl::string_view, absl::string_view>>::hasher {
-      using is_transparent = void;
-    };
-
-    struct StringViewStringViewPairEq
-        : std::equal_to<std::pair<absl::string_view, absl::string_view>> {
-      using is_transparent = void;
-    };
-
     RefCountedPtr<Server> server_;
     RefCountedPtr<Channel> channel_;
     // The index into Server::cqs_ of the CQ used as a starting point for
     // where to publish new incoming calls.
     size_t cq_idx_;
     absl::optional<std::list<ChannelData*>::iterator> list_position_;
-    // A hash-table of the methods and hosts of the registered methods.
-    // TODO(vjpai): Convert this to an STL map type as opposed to a direct
-    // bucket implementation. (Consider performance impact, hash function to
-    // use, etc.)
-    std::unique_ptr<std::vector<ChannelRegisteredMethod>>
-        old_registered_methods_;
-    // Map of registered methods.
-    absl::flat_hash_map<std::pair<std::string, std::string> /*host, method*/,
-                        std::unique_ptr<ChannelRegisteredMethod>,
-                        StringViewStringViewPairHash,
-                        StringViewStringViewPairEq>
-        registered_methods_;
-    uint32_t registered_method_max_probes_;
     grpc_closure finish_destroy_channel_closure_;
     intptr_t channelz_socket_uuid_;
   };
@@ -412,6 +365,17 @@ class Server : public InternallyRefCounted<Server>,
     grpc_cq_completion completion;
   };
 
+  struct StringViewStringViewPairHash
+      : absl::flat_hash_set<
+            std::pair<absl::string_view, absl::string_view>>::hasher {
+    using is_transparent = void;
+  };
+
+  struct StringViewStringViewPairEq
+      : std::equal_to<std::pair<absl::string_view, absl::string_view>> {
+    using is_transparent = void;
+  };
+
   static void ListenerDestroyDone(void* arg, grpc_error_handle error);
 
   static void DoneShutdownEvent(void* server,
@@ -497,7 +461,11 @@ class Server : public InternallyRefCounted<Server>,
   bool starting_ ABSL_GUARDED_BY(mu_global_) = false;
   CondVar starting_cv_;
 
-  std::vector<std::unique_ptr<RegisteredMethod>> registered_methods_;
+  // Map of registered methods.
+  absl::flat_hash_map<std::pair<std::string, std::string> /*host, method*/,
+                      std::unique_ptr<RegisteredMethod>,
+                      StringViewStringViewPairHash, StringViewStringViewPairEq>
+      registered_methods_;
 
   // Request matcher for unregistered methods.
   std::unique_ptr<RequestMatcherInterface> unregistered_request_matcher_;


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/34286 was split into two parts - the first part was submitted in https://github.com/grpc/grpc/pull/34612, to move to absl::flat_hash_map for per-channel registered methods map, and this is the second part to remove the per-channel map and switch to using per-server.