### PR TITLE
[upb] cast to (upb_Message*) when calling upb functions

### DIFF
--- a/src/core/ext/xds/xds_api.cc
+++ b/src/core/ext/xds/xds_api.cc
@@ -185,7 +185,8 @@ void MaybeLogDiscoveryRequest(
     const upb_MessageDef* msg_type =
         envoy_service_discovery_v3_DiscoveryRequest_getmsgdef(context.def_pool);
     char buf[10240];
-    upb_TextEncode(request, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)request, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] constructed ADS request: %s",
             context.client, buf);
   }
@@ -274,7 +275,8 @@ void MaybeLogDiscoveryResponse(
         envoy_service_discovery_v3_DiscoveryResponse_getmsgdef(
             context.def_pool);
     char buf[10240];
-    upb_TextEncode(response, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)response, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] received response: %s", context.client,
             buf);
   }
@@ -362,7 +364,8 @@ void MaybeLogLrsRequest(
         envoy_service_load_stats_v3_LoadStatsRequest_getmsgdef(
             context.def_pool);
     char buf[10240];
-    upb_TextEncode(request, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)request, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] constructed LRS request: %s",
             context.client, buf);
   }
@@ -523,7 +526,8 @@ void MaybeLogLrsResponse(
         envoy_service_load_stats_v3_LoadStatsResponse_getmsgdef(
             context.def_pool);
     char buf[10240];
-    upb_TextEncode(response, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)response, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] received LRS response: %s",
             context.client, buf);
   }

--- a/src/core/ext/xds/xds_cluster.cc
+++ b/src/core/ext/xds/xds_cluster.cc
@@ -658,7 +658,8 @@ void MaybeLogCluster(const XdsResourceType::DecodeContext& context,
     const upb_MessageDef* msg_type =
         envoy_config_cluster_v3_Cluster_getmsgdef(context.symtab);
     char buf[10240];
-    upb_TextEncode(cluster, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)cluster, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] Cluster: %s", context.client, buf);
   }
 }

--- a/src/core/ext/xds/xds_cluster_specifier_plugin.cc
+++ b/src/core/ext/xds/xds_cluster_specifier_plugin.cc
@@ -70,7 +70,7 @@ Json XdsRouteLookupClusterSpecifierPlugin::GenerateLoadBalancingPolicyConfig(
     errors->AddError("could not parse plugin config");
     return {};
   }
-  const auto* plugin_config =
+  const upb_Message* plugin_config = (upb_Message*)
       grpc_lookup_v1_RouteLookupClusterSpecifier_route_lookup_config(specifier);
   if (plugin_config == nullptr) {
     ValidationErrors::ScopedField field(errors, ".route_lookup_config");

--- a/src/core/ext/xds/xds_common_types.cc
+++ b/src/core/ext/xds/xds_common_types.cc
@@ -422,15 +422,16 @@ absl::StatusOr<Json> ParseProtobufStructToJson(
     const google_protobuf_Struct* resource) {
   upb::Status status;
   const auto* msg_def = google_protobuf_Struct_getmsgdef(context.symtab);
-  size_t json_size = upb_JsonEncode(resource, msg_def, context.symtab, 0,
-                                    nullptr, 0, status.ptr());
+  size_t json_size =
+      upb_JsonEncode((upb_Message*)resource, msg_def, context.symtab, 0,
+                     nullptr, 0, status.ptr());
   if (json_size == static_cast<size_t>(-1)) {
     return absl::InvalidArgumentError(
         absl::StrCat("error encoding google::Protobuf::Struct as JSON: ",
                      upb_Status_ErrorMessage(status.ptr())));
   }
   void* buf = upb_Arena_Malloc(context.arena, json_size + 1);
-  upb_JsonEncode(resource, msg_def, context.symtab, 0,
+  upb_JsonEncode((upb_Message*)resource, msg_def, context.symtab, 0,
                  reinterpret_cast<char*>(buf), json_size + 1, status.ptr());
   auto json = JsonParse(reinterpret_cast<char*>(buf));
   if (!json.ok()) {

--- a/src/core/ext/xds/xds_endpoint.cc
+++ b/src/core/ext/xds/xds_endpoint.cc
@@ -161,7 +161,7 @@ void MaybeLogClusterLoadAssignment(
         envoy_config_endpoint_v3_ClusterLoadAssignment_getmsgdef(
             context.symtab);
     char buf[10240];
-    upb_TextEncode(cla, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)cla, msg_type, nullptr, 0, buf, sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] ClusterLoadAssignment: %s",
             context.client, buf);
   }

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -291,8 +291,8 @@ void MaybeLogHttpConnectionManager(
         envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_getmsgdef(
             context.symtab);
     char buf[10240];
-    upb_TextEncode(http_connection_manager_config, msg_type, nullptr, 0, buf,
-                   sizeof(buf));
+    upb_TextEncode((upb_Message*)http_connection_manager_config, msg_type,
+                   nullptr, 0, buf, sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] HttpConnectionManager: %s",
             context.client, buf);
   }
@@ -1091,7 +1091,8 @@ void MaybeLogListener(const XdsResourceType::DecodeContext& context,
     const upb_MessageDef* msg_type =
         envoy_config_listener_v3_Listener_getmsgdef(context.symtab);
     char buf[10240];
-    upb_TextEncode(listener, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)listener, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] Listener: %s", context.client, buf);
   }
 }

--- a/src/core/ext/xds/xds_route_config.cc
+++ b/src/core/ext/xds/xds_route_config.cc
@@ -1137,7 +1137,8 @@ void MaybeLogRouteConfiguration(
     const upb_MessageDef* msg_type =
         envoy_config_route_v3_RouteConfiguration_getmsgdef(context.symtab);
     char buf[10240];
-    upb_TextEncode(route_config, msg_type, nullptr, 0, buf, sizeof(buf));
+    upb_TextEncode((upb_Message*)route_config, msg_type, nullptr, 0, buf,
+                   sizeof(buf));
     gpr_log(GPR_DEBUG, "[xds_client %p] RouteConfiguration: %s", context.client,
             buf);
   }


### PR DESCRIPTION
upb currently defines upb_Message to be void, which has allowed us to be lax with the types when calling upb functions that take a (upb_Message*) as an arg.

If that ever changes (which may happen quite soon) things will break, so this is a pre-emptive patch to protect against such a change.
