### PR TITLE
[EventEngine] Skip `dns_resolver_cooldown_test` for `event_engine_dns` experiment

### DIFF
--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -42,6 +42,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/config/core_configuration.h"
 #include "src/core/lib/event_engine/default_event_engine.h"
+#include "src/core/lib/experiments/experiments.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/no_destruct.h"
 #include "src/core/lib/gprpp/notification.h"
@@ -409,6 +410,14 @@ static void test_cooldown() {
 }
 
 TEST(DnsResolverCooldownTest, MainTest) {
+  // TODO(yijiem): This test tests the cooldown behavior of the PollingResolver
+  // interface. To do that, it overrides the grpc_dns_lookup_hostname_ares
+  // function and iomgr's g_dns_resolver system. We would need to rewrite this
+  // test for EventEngine using a custom EE DNSResolver or adding to the
+  // resolver_fuzzer.
+  if (grpc_core::IsEventEngineDnsEnabled()) {
+    GTEST_SKIP() << "Not with event engine dns";
+  }
   grpc_init();
 
   auto work_serializer = std::make_shared<grpc_core::WorkSerializer>(

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -412,9 +412,9 @@ static void test_cooldown() {
 TEST(DnsResolverCooldownTest, MainTest) {
   // TODO(yijiem): This test tests the cooldown behavior of the PollingResolver
   // interface. To do that, it overrides the grpc_dns_lookup_hostname_ares
-  // function and iomgr's g_dns_resolver system. We would need to rewrite this
-  // test for EventEngine using a custom EE DNSResolver or adding to the
-  // resolver_fuzzer.
+  // function and overrides the iomgr's g_dns_resolver system. We would need to
+  // rewrite this test for EventEngine using a custom EE DNSResolver or adding
+  // to the resolver_fuzzer.
   if (grpc_core::IsEventEngineDnsEnabled()) {
     GTEST_SKIP() << "Not with event engine dns";
   }


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

