### PR TITLE
[PSM Interop] Configure CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 /src/core/lib/resolver/** @markdroth
 /src/core/lib/service_config/** @markdroth
 /tools/dockerfile/** @jtattermusch @apolcyn
+/tools/run_tests/xds_k8s_test_driver/** @sergiitk @XuanWang-Amos @gnossen


### PR DESCRIPTION
Configures CODEOWNERS for the PSM Interop framework `/tools/run_tests/xds_k8s_test_driver/` to be @sergiitk, @XuanWang-Amos, @gnossen.

We need this change to be able to prevent unexpected changes to the the framework while it's being moved to the dedicated grpc/psm-interop repo. 