### PR TITLE
Change outdated cfg = "host" to cfg = "exec"

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -175,7 +175,7 @@ _generate_cc = rule(
         "plugin": attr.label(
             executable = True,
             providers = ["files_to_run"],
-            cfg = "host",
+            cfg = "exec",
         ),
         "flags": attr.string_list(
             mandatory = False,
@@ -189,7 +189,7 @@ _generate_cc = rule(
         "_protoc": attr.label(
             default = Label("//external:protocol_compiler"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     # We generate .h files, so we need to output to genfiles.

--- a/bazel/generate_objc.bzl
+++ b/bazel/generate_objc.bzl
@@ -166,7 +166,7 @@ generate_objc = rule(
             default = "@com_github_grpc_grpc//src/compiler:grpc_objective_c_plugin",
             executable = True,
             providers = ["files_to_run"],
-            cfg = "host",
+            cfg = "exec",
         ),
         "srcs": attr.string_list(
             mandatory = False,
@@ -182,7 +182,7 @@ generate_objc = rule(
         "_protoc": attr.label(
             default = Label("//external:protocol_compiler"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     output_to_genfiles = True,

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -113,7 +113,7 @@ _gen_py_aspect = aspect(
             default = Label("//external:protocol_compiler"),
             providers = ["files_to_run"],
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_protobuf_library": attr.label(
             default = Label("@com_google_protobuf//:protobuf_python"),
@@ -169,7 +169,7 @@ py_proto_library = rule(
             default = Label("//external:protocol_compiler"),
             providers = ["files_to_run"],
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_protobuf_library": attr.label(
             default = Label("@com_google_protobuf//:protobuf_python"),
@@ -252,13 +252,13 @@ _generate_pb2_grpc_src = rule(
         "_grpc_plugin": attr.label(
             executable = True,
             providers = ["files_to_run"],
-            cfg = "host",
+            cfg = "exec",
             default = Label("//src/compiler:grpc_python_plugin"),
         ),
         "_protoc": attr.label(
             executable = True,
             providers = ["files_to_run"],
-            cfg = "host",
+            cfg = "exec",
             default = Label("//external:protocol_compiler"),
         ),
         "_grpc_library": attr.label(


### PR DESCRIPTION
Preserves future Bazel compatibility:https://github.com/bazelbuild/bazel/issues/17032

Extension of https://github.com/grpc/grpc/pull/32021 which missed review.

release notes: no
