### PR TITLE
Replace bind() targets with alias() ones

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -128,6 +128,12 @@ load("@com_github_google_benchmark//:bazel/benchmark_deps.bzl", "benchmark_deps"
 
 benchmark_deps()
 
+# This is a transitive dependency from google_cloud_cpp
+bind(
+    name = "cares",
+    actual = "@com_github_cares_cares//:ares",
+)
+
 load("@io_opentelemetry_cpp//bazel:repository.bzl", "opentelemetry_cpp_deps")
 
 opentelemetry_cpp_deps()
@@ -135,6 +141,12 @@ opentelemetry_cpp_deps()
 load("@io_opentelemetry_cpp//bazel:extra_deps.bzl", "opentelemetry_extra_deps")
 
 opentelemetry_extra_deps()
+
+# Transitive dependency of opentelemetry_extra_deps()
+bind(
+    name = "madler_zlib",
+    actual = "@zlib//:zlib",
+)
 
 # TODO: Enable below once https://github.com/bazel-xcode/PodToBUILD/issues/232 is resolved
 #

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -69,7 +69,7 @@ def _get_external_deps(external_deps):
         elif dep == "cares":
             ret += select({
                 "//:grpc_no_ares": [],
-                "//conditions:default": ["//external:cares"],
+                "//conditions:default": ["//third_party:cares"],
             })
         elif dep == "cronet_c_for_grpc":
             ret.append("//third_party/objective_c/Cronet:cronet_c_for_grpc")
@@ -84,7 +84,7 @@ def _get_external_deps(external_deps):
         elif dep == "libprotobuf_mutator":
             ret.append("@com_google_libprotobuf_mutator//:libprotobuf_mutator")
         else:
-            ret.append("//external:" + dep)
+            ret.append("//third_party:" + dep)
     return ret
 
 def _update_visibility(visibility):

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -14,166 +14,11 @@
 """Load dependencies needed to compile and test the grpc library as a 3rd-party consumer."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@com_github_grpc_grpc//bazel:grpc_python_deps.bzl", "grpc_python_deps")
+load("//bazel:grpc_python_deps.bzl", "grpc_python_deps")
 
 # buildifier: disable=unnamed-macro
 def grpc_deps():
     """Loads dependencies need to compile and test the grpc library."""
-
-    native.bind(
-        name = "libssl",
-        actual = "@boringssl//:ssl",
-    )
-
-    native.bind(
-        name = "libcrypto",
-        actual = "@boringssl//:crypto",
-    )
-
-    native.bind(
-        name = "madler_zlib",
-        actual = "@zlib//:zlib",
-    )
-
-    native.bind(
-        name = "protobuf",
-        actual = "@com_google_protobuf//:protobuf",
-    )
-
-    native.bind(
-        name = "protobuf_clib",
-        actual = "@com_google_protobuf//:protoc_lib",
-    )
-
-    native.bind(
-        name = "protobuf_headers",
-        actual = "@com_google_protobuf//:protobuf_headers",
-    )
-
-    native.bind(
-        name = "protocol_compiler",
-        actual = "@com_google_protobuf//:protoc",
-    )
-
-    native.bind(
-        name = "cares",
-        actual = "@com_github_cares_cares//:ares",
-    )
-
-    native.bind(
-        name = "gtest",
-        actual = "@com_google_googletest//:gtest",
-    )
-
-    native.bind(
-        name = "fuzztest",
-        actual = "@com_google_fuzztest//fuzztest",
-    )
-
-    native.bind(
-        name = "fuzztest_main",
-        actual = "@com_google_fuzztest//fuzztest:fuzztest_gtest_main",
-    )
-
-    native.bind(
-        name = "benchmark",
-        actual = "@com_github_google_benchmark//:benchmark",
-    )
-
-    native.bind(
-        name = "re2",
-        actual = "@com_googlesource_code_re2//:re2",
-    )
-
-    native.bind(
-        name = "grpc_cpp_plugin",
-        actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
-    )
-
-    native.bind(
-        name = "grpc++_codegen_proto",
-        actual = "@com_github_grpc_grpc//:grpc++_codegen_proto",
-    )
-
-    native.bind(
-        name = "opencensus-context",
-        actual = "@io_opencensus_cpp//opencensus/context:context",
-    )
-
-    native.bind(
-        name = "opencensus-trace",
-        actual = "@io_opencensus_cpp//opencensus/trace:trace",
-    )
-
-    native.bind(
-        name = "opencensus-trace-context_util",
-        actual = "@io_opencensus_cpp//opencensus/trace:context_util",
-    )
-
-    native.bind(
-        name = "opencensus-trace-propagation",
-        actual = "@io_opencensus_cpp//opencensus/trace:grpc_trace_bin",
-    )
-
-    native.bind(
-        name = "opencensus-trace-span_context",
-        actual = "@io_opencensus_cpp//opencensus/trace:span_context",
-    )
-
-    native.bind(
-        name = "opencensus-stats",
-        actual = "@io_opencensus_cpp//opencensus/stats:stats",
-    )
-
-    native.bind(
-        name = "opencensus-stats-test",
-        actual = "@io_opencensus_cpp//opencensus/stats:test_utils",
-    )
-
-    native.bind(
-        name = "opencensus-with-tag-map",
-        actual = "@io_opencensus_cpp//opencensus/tags:with_tag_map",
-    )
-
-    native.bind(
-        name = "opencensus-tags",
-        actual = "@io_opencensus_cpp//opencensus/tags:tags",
-    )
-
-    native.bind(
-        name = "opencensus-tags-context_util",
-        actual = "@io_opencensus_cpp//opencensus/tags:context_util",
-    )
-
-    native.bind(
-        name = "opencensus-trace-stackdriver_exporter",
-        actual = "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
-    )
-
-    native.bind(
-        name = "opencensus-stats-stackdriver_exporter",
-        actual = "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
-    )
-
-    native.bind(
-        name = "googleapis_trace_grpc_service",
-        actual = "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_grpc",
-    )
-
-    native.bind(
-        name = "googleapis_monitoring_grpc_service",
-        actual = "@com_google_googleapis//google/monitoring/v3:monitoring_cc_grpc",
-    )
-
-    native.bind(
-        name = "googleapis_logging_grpc_service",
-        actual = "@com_google_googleapis//google/logging/v2:logging_cc_grpc",
-    )
-
-    native.bind(
-        name = "googleapis_logging_cc_proto",
-        actual = "@com_google_googleapis//google/logging/v2:logging_cc_proto",
-    )
 
     if "platforms" not in native.existing_rules():
         http_archive(
@@ -496,15 +341,6 @@ def grpc_test_only_deps():
 
     Loads dependencies that are only needed to run grpc library's tests.
     """
-    native.bind(
-        name = "twisted",
-        actual = "@com_github_twisted_twisted//:twisted",
-    )
-
-    native.bind(
-        name = "yaml",
-        actual = "@com_github_yaml_pyyaml//:yaml",
-    )
 
     if "com_github_twisted_twisted" not in native.existing_rules():
         http_archive(

--- a/examples/objective-c/BUILD
+++ b/examples/objective-c/BUILD
@@ -27,10 +27,10 @@ objc_grpc_library(
     deps = ["//examples/protos:helloworld_proto"],
 )
 
-# This one works with import "external/com_github_grpc_grpc/examples/protos/Keyvaluestore.pbrpc.h"
+# This one works with import "third_party/com_github_grpc_grpc/examples/protos/Keyvaluestore.pbrpc.h"
 objc_grpc_library(
     name = "Keyvaluestore_grpc_proto_external",
-    srcs = ["//external/com_github_grpc_grpc/examples/protos:keyvaluestore.proto"],
+    srcs = ["//third_party/com_github_grpc_grpc/examples/protos:keyvaluestore.proto"],
     tags = ["manual"],
     deps = ["@com_github_grpc_grpc//examples/protos:keyvaluestore_proto"],
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -13,3 +13,170 @@ exports_files([
     "protobuf.patch",
     "protoc-gen-validate.patch",
 ])
+
+package(default_visibility = ["//:__subpackages__"])
+
+alias(
+    name = "libssl",
+    actual = "@boringssl//:ssl",
+)
+
+alias(
+    name = "libcrypto",
+    actual = "@boringssl//:crypto",
+)
+
+alias(
+    name = "madler_zlib",
+    actual = "@zlib//:zlib",
+)
+
+alias(
+    name = "protobuf",
+    actual = "@com_google_protobuf//:protobuf",
+)
+
+alias(
+    name = "protobuf_clib",
+    actual = "@com_google_protobuf//:protoc_lib",
+)
+
+alias(
+    name = "protobuf_headers",
+    actual = "@com_google_protobuf//:protobuf_headers",
+)
+
+alias(
+    name = "protocol_compiler",
+    actual = "@com_google_protobuf//:protoc",
+)
+
+alias(
+    name = "cares",
+    actual = "@com_github_cares_cares//:ares",
+)
+
+alias(
+    name = "gtest",
+    actual = "@com_google_googletest//:gtest",
+)
+
+alias(
+    name = "fuzztest",
+    actual = "@com_google_fuzztest//fuzztest",
+)
+
+alias(
+    name = "fuzztest_main",
+    actual = "@com_google_fuzztest//fuzztest:fuzztest_gtest_main",
+)
+
+alias(
+    name = "benchmark",
+    actual = "@com_github_google_benchmark//:benchmark",
+)
+
+alias(
+    name = "re2",
+    actual = "@com_googlesource_code_re2//:re2",
+)
+
+alias(
+    name = "grpc_cpp_plugin",
+    actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+)
+
+alias(
+    name = "grpc++_codegen_proto",
+    actual = "@com_github_grpc_grpc//:grpc++_codegen_proto",
+)
+
+alias(
+    name = "opencensus-context",
+    actual = "@io_opencensus_cpp//opencensus/context:context",
+)
+
+alias(
+    name = "opencensus-trace",
+    actual = "@io_opencensus_cpp//opencensus/trace:trace",
+)
+
+alias(
+    name = "opencensus-trace-context_util",
+    actual = "@io_opencensus_cpp//opencensus/trace:context_util",
+)
+
+alias(
+    name = "opencensus-trace-propagation",
+    actual = "@io_opencensus_cpp//opencensus/trace:grpc_trace_bin",
+)
+
+alias(
+    name = "opencensus-trace-span_context",
+    actual = "@io_opencensus_cpp//opencensus/trace:span_context",
+)
+
+alias(
+    name = "opencensus-stats",
+    actual = "@io_opencensus_cpp//opencensus/stats:stats",
+)
+
+alias(
+    name = "opencensus-stats-test",
+    actual = "@io_opencensus_cpp//opencensus/stats:test_utils",
+)
+
+alias(
+    name = "opencensus-with-tag-map",
+    actual = "@io_opencensus_cpp//opencensus/tags:with_tag_map",
+)
+
+alias(
+    name = "opencensus-tags",
+    actual = "@io_opencensus_cpp//opencensus/tags:tags",
+)
+
+alias(
+    name = "opencensus-tags-context_util",
+    actual = "@io_opencensus_cpp//opencensus/tags:context_util",
+)
+
+alias(
+    name = "opencensus-trace-stackdriver_exporter",
+    actual = "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
+)
+
+alias(
+    name = "opencensus-stats-stackdriver_exporter",
+    actual = "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
+)
+
+alias(
+    name = "googleapis_trace_grpc_service",
+    actual = "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_grpc",
+)
+
+alias(
+    name = "googleapis_monitoring_grpc_service",
+    actual = "@com_google_googleapis//google/monitoring/v3:monitoring_cc_grpc",
+)
+
+alias(
+    name = "googleapis_logging_grpc_service",
+    actual = "@com_google_googleapis//google/logging/v2:logging_cc_grpc",
+)
+
+alias(
+    name = "googleapis_logging_cc_proto",
+    actual = "@com_google_googleapis//google/logging/v2:logging_cc_proto",
+)
+
+alias(
+    name = "twisted",
+    actual = "@com_github_twisted_twisted//:twisted",
+)
+
+alias(
+    name = "yaml",
+    actual = "@com_github_yaml_pyyaml//:yaml",
+)

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -19,164 +19,198 @@ package(default_visibility = ["//:__subpackages__"])
 alias(
     name = "libssl",
     actual = "@boringssl//:ssl",
+    tags = ["manual"],
 )
 
 alias(
     name = "libcrypto",
     actual = "@boringssl//:crypto",
+    tags = ["manual"],
 )
 
 alias(
     name = "madler_zlib",
     actual = "@zlib//:zlib",
+    tags = ["manual"],
 )
 
 alias(
     name = "protobuf",
     actual = "@com_google_protobuf//:protobuf",
+    tags = ["manual"],
 )
 
 alias(
     name = "protobuf_clib",
     actual = "@com_google_protobuf//:protoc_lib",
+    tags = ["manual"],
 )
 
 alias(
     name = "protobuf_headers",
     actual = "@com_google_protobuf//:protobuf_headers",
+    tags = ["manual"],
 )
 
 alias(
     name = "protocol_compiler",
     actual = "@com_google_protobuf//:protoc",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "cares",
     actual = "@com_github_cares_cares//:ares",
+    tags = ["manual"],
 )
 
 alias(
     name = "gtest",
     actual = "@com_google_googletest//:gtest",
+    tags = ["manual"],
 )
 
 alias(
     name = "fuzztest",
     actual = "@com_google_fuzztest//fuzztest",
+    tags = ["manual"],
 )
 
 alias(
     name = "fuzztest_main",
     actual = "@com_google_fuzztest//fuzztest:fuzztest_gtest_main",
+    tags = ["manual"],
 )
 
 alias(
     name = "benchmark",
     actual = "@com_github_google_benchmark//:benchmark",
+    tags = ["manual"],
 )
 
 alias(
     name = "re2",
     actual = "@com_googlesource_code_re2//:re2",
+    tags = ["manual"],
 )
 
 alias(
     name = "grpc_cpp_plugin",
     actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+    tags = ["manual"],
 )
 
 alias(
     name = "grpc++_codegen_proto",
     actual = "@com_github_grpc_grpc//:grpc++_codegen_proto",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-context",
     actual = "@io_opencensus_cpp//opencensus/context:context",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-trace",
     actual = "@io_opencensus_cpp//opencensus/trace:trace",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-trace-context_util",
     actual = "@io_opencensus_cpp//opencensus/trace:context_util",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-trace-propagation",
     actual = "@io_opencensus_cpp//opencensus/trace:grpc_trace_bin",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-trace-span_context",
     actual = "@io_opencensus_cpp//opencensus/trace:span_context",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-stats",
     actual = "@io_opencensus_cpp//opencensus/stats:stats",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-stats-test",
     actual = "@io_opencensus_cpp//opencensus/stats:test_utils",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-with-tag-map",
     actual = "@io_opencensus_cpp//opencensus/tags:with_tag_map",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-tags",
     actual = "@io_opencensus_cpp//opencensus/tags:tags",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-tags-context_util",
     actual = "@io_opencensus_cpp//opencensus/tags:context_util",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-trace-stackdriver_exporter",
     actual = "@io_opencensus_cpp//opencensus/exporters/trace/stackdriver:stackdriver_exporter",
+    tags = ["manual"],
 )
 
 alias(
     name = "opencensus-stats-stackdriver_exporter",
     actual = "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
+    tags = ["manual"],
 )
 
 alias(
     name = "googleapis_trace_grpc_service",
     actual = "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_grpc",
+    tags = ["manual"],
 )
 
 alias(
     name = "googleapis_monitoring_grpc_service",
     actual = "@com_google_googleapis//google/monitoring/v3:monitoring_cc_grpc",
+    tags = ["manual"],
 )
 
 alias(
     name = "googleapis_logging_grpc_service",
     actual = "@com_google_googleapis//google/logging/v2:logging_cc_grpc",
+    tags = ["manual"],
 )
 
 alias(
     name = "googleapis_logging_cc_proto",
     actual = "@com_google_googleapis//google/logging/v2:logging_cc_proto",
+    tags = ["manual"],
 )
 
 alias(
     name = "twisted",
     actual = "@com_github_twisted_twisted//:twisted",
+    tags = ["manual"],
 )
 
 alias(
     name = "yaml",
     actual = "@com_github_yaml_pyyaml//:yaml",
+    tags = ["manual"],
 )

--- a/third_party/objective_c/google_toolbox_for_mac/BUILD
+++ b/third_party/objective_c/google_toolbox_for_mac/BUILD
@@ -24,6 +24,6 @@ objc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//external:gtest",
+        "//third_party:gtest",
     ],
 )

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -544,11 +544,11 @@ def update_test_metadata_with_transitive_metadata(
 
         bazel_rule = bazel_rules[_get_bazel_label(lib_name)]
 
-        if "//external:benchmark" in bazel_rule["_TRANSITIVE_DEPS"]:
+        if "//third_party:benchmark" in bazel_rule["_TRANSITIVE_DEPS"]:
             lib_dict["benchmark"] = True
             lib_dict["defaults"] = "benchmark"
 
-        if "//external:gtest" in bazel_rule["_TRANSITIVE_DEPS"]:
+        if "//third_party:gtest" in bazel_rule["_TRANSITIVE_DEPS"]:
             # run_tests.py checks the "gtest" property to see if test should be run via gtest.
             lib_dict["gtest"] = True
             # TODO: this might be incorrect categorization of the test...
@@ -672,7 +672,7 @@ def _patch_grpc_proto_library_rules(bazel_rules):
             and generator_func == "grpc_proto_library"
         ):
             # Add explicit protobuf dependency for internal c++ proto targets.
-            bazel_rule["deps"].append("//external:protobuf")
+            bazel_rule["deps"].append("//third_party:protobuf")
 
 
 def _patch_descriptor_upb_proto_library(bazel_rules):
@@ -1333,8 +1333,8 @@ _BAZEL_DEPS_QUERIES = [
     'deps("//test/...")',
     'deps("//:all")',
     'deps("//src/compiler/...")',
-    # allow resolving bind() workspace rules to the actual targets they point to
-    'kind(bind, "//external:*")',
+    # allow resolving alias() targets to the actual targets they point to
+    'kind(alias, "//third_party:*")',
     # The ^ is needed to differentiate proto_library from go_proto_library
     'deps(kind("^proto_library", @envoy_api//envoy/...))',
     # Make sure we have source info for all the targets that _expand_upb_proto_library_rules artificially adds

--- a/tools/run_tests/sanity/check_bad_dependencies.sh
+++ b/tools/run_tests/sanity/check_bad_dependencies.sh
@@ -18,10 +18,10 @@ set -ex
 # Make sure that there is no path from known unsecure libraries and targets
 # to an SSL library. Any failure among these will make the script fail.
 
-test "$(bazel query 'somepath("//:grpc_unsecure", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
-test "$(bazel query 'somepath("//:grpc++_unsecure", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
-test "$(bazel query 'somepath("//:grpc++_codegen_proto", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
-test "$(bazel query 'somepath("//test/cpp/microbenchmarks:helpers", "//external:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//:grpc_unsecure", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//:grpc++_unsecure", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//:grpc++_codegen_proto", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
+test "$(bazel query 'somepath("//test/cpp/microbenchmarks:helpers", "//third_party:libssl")' 2>/dev/null | wc -l)" -eq 0 || exit 1
 
 # Make sure that core doesn't depend on anything in C++ library
 


### PR DESCRIPTION
Usage of `bind()` is [deprecated in WORKSPACE](https://bazel.build/reference/be/workspace#bind) and [not supported in Bzlmod](https://bazel.build/external/migration#bind-targets).

This is a required preparatory step for #35271.

An alternative would be to use the target names directly and completely get rid of `bind()` and `alias()`.

Fixes #13902, #20193.