### PR TITLE
[upb] stop calling hazzers for repeated fields

### DIFF
--- a/src/core/ext/xds/xds_common_types.cc
+++ b/src/core/ext/xds/xds_common_types.cc
@@ -385,13 +385,16 @@ CommonTlsContext CommonTlsContext::Parse(
           CertificateProviderInstanceParse(
               context, tls_certificate_certificate_provider_instance, errors);
     } else {
-      if (envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_tls_certificates(
-              common_tls_context_proto)) {
+      size_t size;
+      envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_tls_certificates(
+          common_tls_context_proto, &size);
+      if (size != 0) {
         ValidationErrors::ScopedField field(errors, ".tls_certificates");
         errors->AddError("feature unsupported");
       }
-      if (envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_has_tls_certificate_sds_secret_configs(
-              common_tls_context_proto)) {
+      envoy_extensions_transport_sockets_tls_v3_CommonTlsContext_tls_certificate_sds_secret_configs(
+          common_tls_context_proto, &size);
+      if (size != 0) {
         ValidationErrors::ScopedField field(
             errors, ".tls_certificate_sds_secret_configs");
         errors->AddError("feature unsupported");

--- a/src/core/ext/xds/xds_http_rbac_filter.cc
+++ b/src/core/ext/xds/xds_http_rbac_filter.cc
@@ -486,8 +486,10 @@ Json ParseHttpRbacToJson(const XdsResourceType::DecodeContext& context,
           ValidationErrors::ScopedField field(errors, ".audit_condition");
           errors->AddError("invalid audit condition");
       }
-      if (envoy_config_rbac_v3_RBAC_AuditLoggingOptions_has_logger_configs(
-              audit_logging_options)) {
+      size_t size;
+      envoy_config_rbac_v3_RBAC_AuditLoggingOptions_logger_configs(
+          audit_logging_options, &size);
+      if (size != 0) {
         inner_rbac_json.emplace("audit_loggers",
                                 ParseAuditLoggerConfigsToJson(
                                     context, audit_logging_options, errors));

--- a/src/core/ext/xds/xds_listener.cc
+++ b/src/core/ext/xds/xds_listener.cc
@@ -332,11 +332,15 @@ XdsListenerResource::HttpConnectionManager HttpConnectionManagerParse(
   }
   // original_ip_detection_extensions -- must be empty as per
   // https://github.com/grpc/proposal/blob/master/A41-xds-rbac.md
-  if (envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_has_original_ip_detection_extensions(
-          http_connection_manager_proto)) {
-    ValidationErrors::ScopedField field(errors,
-                                        ".original_ip_detection_extensions");
-    errors->AddError("must be empty");
+  {
+    size_t size;
+    envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_original_ip_detection_extensions(
+        http_connection_manager_proto, &size);
+    if (size != 0) {
+      ValidationErrors::ScopedField field(errors,
+                                          ".original_ip_detection_extensions");
+      errors->AddError("must be empty");
+    }
   }
   // common_http_protocol_options
   const envoy_config_core_v3_HttpProtocolOptions* options =


### PR DESCRIPTION
The upb gencode is being changed to no longer generate _has_() functions for repeated fields as they are redundant and really only intended for scalar fields with presence. So instead of calling foo_has_bar(msg), one now calls foo_bar(msg, &size) to get the number of elements in the repeated field.