### PR TITLE
Disable failing openssl102 tests

### DIFF
--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1278,7 +1278,6 @@ TEST(SslTransportSecurityTest, MainTest) {
       ssl_tsi_test_do_handshake_small_handshake_buffer();
       ssl_tsi_test_do_handshake();
       ssl_tsi_test_do_handshake_with_root_store();
-      ssl_tsi_test_do_handshake_skipping_server_certificate_verification();
       ssl_tsi_test_do_handshake_with_large_server_handshake_messages(
           trust_bundle);
       ssl_tsi_test_do_handshake_with_client_authentication();
@@ -1289,6 +1288,11 @@ TEST(SslTransportSecurityTest, MainTest) {
       ssl_tsi_test_do_handshake_with_wrong_server_name_indication();
       ssl_tsi_test_do_handshake_with_bad_server_cert();
       ssl_tsi_test_do_handshake_with_bad_client_cert();
+// TODO(gregorycooke) - failing with OpenSSL1.0.2
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
+      ssl_tsi_test_do_handshake_skipping_server_certificate_verification();
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
+
 #ifdef OPENSSL_IS_BORINGSSL
       // BoringSSL and OpenSSL have different behaviors on mismatched ALPN.
       ssl_tsi_test_do_handshake_alpn_client_no_server();

--- a/test/cpp/end2end/crl_provider_test.cc
+++ b/test/cpp/end2end/crl_provider_test.cc
@@ -282,11 +282,11 @@ TEST_F(CrlProviderTest, CrlProviderValidReloaderProvider) {
 }  // namespace testing
 }  // namespace grpc
 
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();
   return ret;
 }
-
-#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000

--- a/test/cpp/end2end/crl_provider_test.cc
+++ b/test/cpp/end2end/crl_provider_test.cc
@@ -49,6 +49,8 @@
 #include "test/core/util/tls_utils.h"
 #include "test/cpp/end2end/test_service_impl.h"
 
+// CRL Providers not supported for <1.1
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
 namespace grpc {
 namespace testing {
 namespace {
@@ -286,3 +288,5 @@ int main(int argc, char** argv) {
   int ret = RUN_ALL_TESTS();
   return ret;
 }
+
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -128,6 +128,8 @@ void DoRpc(const std::string& server_addr,
   EXPECT_EQ(response.message(), kMessage);
 }
 
+// TODO(gregorycooke) - failing with OpenSSL1.0.2
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
 // How do we test that skipping server certificate verification works as
 // expected? Give the server credentials that chain up to a custom CA (that does
 // not belong to the default or OS trust store), do not configure the client to
@@ -148,6 +150,7 @@ TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {
 
   DoRpc(server_addr_, tls_options);
 }
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -107,6 +107,7 @@ class TlsCredentialsTest : public ::testing::Test {
   std::string server_addr_;
 };
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 void DoRpc(const std::string& server_addr,
            const TlsChannelCredentialsOptions& tls_options) {
   std::shared_ptr<Channel> channel =
@@ -128,8 +129,6 @@ void DoRpc(const std::string& server_addr,
   EXPECT_EQ(response.message(), kMessage);
 }
 
-// TODO(gregorycooke) - failing with OpenSSL1.0.2
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
 // How do we test that skipping server certificate verification works as
 // expected? Give the server credentials that chain up to a custom CA (that does
 // not belong to the default or OS trust store), do not configure the client to
@@ -150,7 +149,6 @@ TEST_F(TlsCredentialsTest, SkipServerCertificateVerification) {
 
   DoRpc(server_addr_, tls_options);
 }
-#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
 
 }  // namespace
 }  // namespace testing


### PR DESCRIPTION
There are a select few tests that are failing when building with OpenSSL102 - disable them until we can fix.