### PR TITLE
[Python AIO] Raise resource_exhausted error in case of concurrent RPC limit exceeded

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -74,6 +74,7 @@ cdef class _ConcurrentRpcLimiter:
     cdef int _active_rpcs
     cdef object _active_rpcs_condition # asyncio.Condition
     cdef object _loop  # asyncio.EventLoop
+    cdef bint _concurrency_exceeded
 
 
 cdef class AioServer:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -72,9 +72,7 @@ cdef enum AioServerStatus:
 cdef class _ConcurrentRpcLimiter:
     cdef int _maximum_concurrent_rpcs
     cdef int _active_rpcs
-    cdef object _active_rpcs_condition # asyncio.Condition
-    cdef object _loop  # asyncio.EventLoop
-    cdef bint _concurrency_exceeded
+    cdef bint limiter_concurrency_exceeded
 
 
 cdef class AioServer:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -871,8 +871,6 @@ cdef class _ConcurrentRpcLimiter:
     async def check_before_request_call(self):
         await self._active_rpcs_condition.acquire()
         try:
-            # predicate = lambda: self._active_rpcs < self._maximum_concurrent_rpcs
-            # await self._active_rpcs_condition.wait_for(predicate)
             if self._active_rpcs >= self._maximum_concurrent_rpcs:
                 self._concurrency_exceeded = True
             else:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -977,8 +977,10 @@ cdef class AioServer:
             if self._status != AIO_SERVER_STATUS_RUNNING:
                 break
 
+            concurrency_exceeded = False
             if self._limiter is not None:
                 await self._limiter.check_before_request_call()
+                concurrency_exceeded = self._limiter._concurrency_exceeded
 
             # Accepts new request from Core
             rpc_state = await self._request_call()
@@ -992,7 +994,7 @@ cdef class AioServer:
                                    self._interceptors,
                                    rpc_state,
                                    self._loop,
-                                   self._limiter._concurrency_exceeded)
+                                   concurrency_exceeded)
 
             # Fires off a task that listens on the cancellation from client.
             rpc_task = self._loop.create_task(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -783,7 +783,7 @@ async def _schedule_rpc_coro(object rpc_coro,
 
 
 async def _handle_rpc(list generic_handlers, tuple interceptors,
-                      RPCState rpc_state, object loop):
+                      RPCState rpc_state, object loop, bint concurrency_exceeded):
     cdef object method_handler
     # Finds the method handler (application logic)
     method_handler = await _find_method_handler(
@@ -798,6 +798,18 @@ async def _handle_rpc(list generic_handlers, tuple interceptors,
             rpc_state,
             StatusCode.unimplemented,
             'Method not found!',
+            _IMMUTABLE_EMPTY_METADATA,
+            rpc_state.create_send_initial_metadata_op_if_not_sent(),
+            loop
+        )
+        return
+
+    if concurrency_exceeded:
+        rpc_state.status_sent = True
+        await _send_error_status_from_server(
+            rpc_state,
+            StatusCode.resource_exhausted,
+            'Concurrent RPC limit exceeded!',
             _IMMUTABLE_EMPTY_METADATA,
             rpc_state.create_send_initial_metadata_op_if_not_sent(),
             loop
@@ -854,13 +866,17 @@ cdef class _ConcurrentRpcLimiter:
         self._active_rpcs = 0
         self._active_rpcs_condition = asyncio.Condition()
         self._loop = loop
+        self._concurrency_exceeded = False
 
     async def check_before_request_call(self):
         await self._active_rpcs_condition.acquire()
         try:
-            predicate = lambda: self._active_rpcs < self._maximum_concurrent_rpcs
-            await self._active_rpcs_condition.wait_for(predicate)
-            self._active_rpcs += 1
+            # predicate = lambda: self._active_rpcs < self._maximum_concurrent_rpcs
+            # await self._active_rpcs_condition.wait_for(predicate)
+            if self._active_rpcs >= self._maximum_concurrent_rpcs:
+                self._concurrency_exceeded = True
+            else:
+                self._active_rpcs += 1
         finally:
             self._active_rpcs_condition.release()
 
@@ -868,6 +884,8 @@ cdef class _ConcurrentRpcLimiter:
         await self._active_rpcs_condition.acquire()
         try:
             self._active_rpcs -= 1
+            if self._active_rpcs < self._maximum_concurrent_rpcs:
+                self._concurrency_exceeded = False
             self._active_rpcs_condition.notify()
         finally:
             self._active_rpcs_condition.release()
@@ -973,7 +991,8 @@ cdef class AioServer:
             rpc_coro = _handle_rpc(self._generic_handlers,
                                    self._interceptors,
                                    rpc_state,
-                                   self._loop)
+                                   self._loop,
+                                   self._limiter._concurrency_exceeded)
 
             # Fires off a task that listens on the cancellation from client.
             rpc_task = self._loop.create_task(

--- a/src/python/grpcio_tests/tests_aio/unit/server_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/server_test.py
@@ -588,18 +588,19 @@ class TestServer(AioTestBase):
                 coro_wrapper(channel.unary_unary(_BLOCK_BRIEFLY)(_REQUEST))
             )
             rpc_tasks.append(task)
-        await_tasks = asyncio.wait(
-            rpc_tasks, return_when=asyncio.ALL_COMPLETED
-        )
+        await_tasks = asyncio.wait(rpc_tasks, return_when=asyncio.ALL_COMPLETED)
 
         done, _ = await await_tasks
         for task in done:
             exception = task.exception()
             if exception:
                 self.assertTrue(isinstance(exception, aio.AioRpcError))
-                self.assertEqual(grpc.StatusCode.RESOURCE_EXHAUSTED, exception.code())
-                self.assertIn("Concurrent RPC limit exceeded", exception.details())
-
+                self.assertEqual(
+                    grpc.StatusCode.RESOURCE_EXHAUSTED, exception.code()
+                )
+                self.assertIn(
+                    "Concurrent RPC limit exceeded", exception.details()
+                )
 
         # Clean-up
         await channel.close()


### PR DESCRIPTION
Fix: https://github.com/grpc/grpc/issues/30424

Currently the implementation of `maximum_concurrent_rpcs` flag in AIO is different with docstring, in implementation, we're waiting for RPCs to finish and continue execution instead of raising `resource_exhausted` as mentioned in docstring.

This PR changes the implementation of `maximum_concurrent_rpcs` flag in AIO stack to match the docstring.



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

