### PR TITLE
[SSA] improve lifetime management of subchannel map

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -183,7 +183,7 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
     std::set<std::unique_ptr<ConnectivityStateWatcherInterface>,
              PtrLessThan<ConnectivityStateWatcherInterface>>
         watchers_;
-    // FIXME: move to SubchannelEntry
+// FIXME: move to SubchannelEntry
     std::atomic<grpc_connectivity_state> connectivity_state_ = {
         GRPC_CHANNEL_IDLE};
   };
@@ -245,6 +245,7 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
 
    private:
     RefCountedPtr<XdsOverrideHostLb> policy_;
+// FIXME: add lock annotations for all three!
     absl::variant<WeakRefCountedPtr<SubchannelWrapper>,
                   RefCountedPtr<SubchannelWrapper>>
         subchannel_;
@@ -463,6 +464,7 @@ LoadBalancingPolicy::PickResult XdsOverrideHostLb::Picker::Pick(PickArgs args) {
     // Populate the address list in the override host attribute so that
     // the StatefulSession filter can set the cookie.
     if (override_host_attr != nullptr) {
+// FIXME: this needs the lock!
       override_host_attr->set_actual_address_list(wrapper->address_list());
     }
     // Unwrap the subchannel.
@@ -698,6 +700,7 @@ void XdsOverrideHostLb::UpdateAddressMap(
         }
         it = subchannel_map_
                  .emplace(address, MakeOrphanable<SubchannelEntry>(
+                                       RefAsSubclass<XdsOverrideHostLb>(),
                                        address_info.eds_health_status))
                  .first;
       } else {
@@ -724,8 +727,7 @@ RefCountedPtr<XdsOverrideHostLb::SubchannelWrapper>
 XdsOverrideHostLb::AdoptSubchannel(
     const grpc_resolved_address& address,
     RefCountedPtr<SubchannelInterface> subchannel) {
-  auto wrapper = MakeRefCounted<SubchannelWrapper>(
-      std::move(subchannel), RefAsSubclass<XdsOverrideHostLb>());
+  auto wrapper = MakeRefCounted<SubchannelWrapper>(std::move(subchannel));
   auto key = grpc_sockaddr_to_string(&address, /*normalize=*/false);
   if (key.ok()) {
     MutexLock lock(&subchannel_map_mu_);

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -147,7 +147,7 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
       return subchannel_entry_->address_list();
     }
 
-    XdsOverrideHostLb* policy() { return subchannel_entry_->policy_.get(); }
+    XdsOverrideHostLb* policy() const { return subchannel_entry_->policy(); }
 
    private:
     class ConnectivityStateWatcher : public ConnectivityStateWatcherInterface {
@@ -191,6 +191,8 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
       subchannel_ = WeakRefCountedPtr<SubchannelWrapper>(nullptr);
       Unref();
     }
+
+    XdsOverrideHostLb* policy() const { return policy_.get(); }
 
     grpc_connectivity_state connectivity_state() const {
       return connectivity_state_.load();

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -464,7 +464,7 @@ LoadBalancingPolicy::PickResult XdsOverrideHostLb::Picker::Pick(PickArgs args) {
     // Populate the address list in the override host attribute so that
     // the StatefulSession filter can set the cookie.
     if (override_host_attr != nullptr) {
-// FIXME: this needs the lock!
+      MutexLock lock(&wrapper->policy()->subchannel_map_mu_);
       override_host_attr->set_actual_address_list(wrapper->address_list());
     }
     // Unwrap the subchannel.

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -356,11 +356,6 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
       const grpc_resolved_address& address,
       RefCountedPtr<SubchannelInterface> subchannel);
 
-  void OnSubchannelConnectivityStateChange(absl::string_view subchannel_key)
-      ABSL_NO_THREAD_SAFETY_ANALYSIS;  // Called from within the
-                                       // WorkSerializer and does not require
-                                       // additional synchronization
-
   // Current config from the resolver.
   RefCountedPtr<XdsOverrideHostLbConfig> config_;
 

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_override_host.cc
@@ -183,9 +183,8 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
 
   class SubchannelEntry : public RefCounted<SubchannelEntry> {
    public:
-    using SubchannelRef =
-        absl::variant<WeakRefCountedPtr<SubchannelWrapper>,
-                      RefCountedPtr<SubchannelWrapper>>;
+    using SubchannelRef = absl::variant<WeakRefCountedPtr<SubchannelWrapper>,
+                                        RefCountedPtr<SubchannelWrapper>>;
 
     SubchannelEntry(RefCountedPtr<XdsOverrideHostLb> policy,
                     XdsHealthStatus eds_health_status)
@@ -276,11 +275,9 @@ class XdsOverrideHostLb : public LoadBalancingPolicy {
 
    private:
     RefCountedPtr<XdsOverrideHostLb> policy_;
-    std::atomic<grpc_connectivity_state> connectivity_state_{
-        GRPC_CHANNEL_IDLE};
+    std::atomic<grpc_connectivity_state> connectivity_state_{GRPC_CHANNEL_IDLE};
     SubchannelRef subchannel_ ABSL_GUARDED_BY(&XdsOverrideHostLb::mu_);
-    XdsHealthStatus eds_health_status_
-        ABSL_GUARDED_BY(&XdsOverrideHostLb::mu_);
+    XdsHealthStatus eds_health_status_ ABSL_GUARDED_BY(&XdsOverrideHostLb::mu_);
     RefCountedStringValue address_list_
         ABSL_GUARDED_BY(&XdsOverrideHostLb::mu_);
   };


### PR DESCRIPTION
Currently, each subchannel wrapper stores a ref to the policy and its key in the policy's subchannel map, and it looks up its entry in the map whenever it needs to modify that entry.  There's some complexity due to the need to avoid deadlocks in the case where we remove the last strong ref to a subchannel wrapper from a map entry.  This approach has a number of problems:
- The subchannel wrapper is dropping its key when it gets orphaned, meaning that it will *never* actually remove itself from the map entry when it is destroyed, which is not what we want.  (This isn't actually causing a bug, but it does mean that we'll never delete the subchannel wrapper, even when it is really unused.)
- Having the subchannel wrapper look up its key in the map every time it needs to modfy its entry is fairly inefficient, especially if there are a large number of endpoints.
- There is a race condition that was accidentally introduced in #34472.  The subchannel wrapper's key is being modified when the subchannel wrapper is orphaned, but that PR changed the picker to read the same value without any synchronization between the two, and we didn't notice the bug or catch it in any tests.
- The code is fairly hard to understand, with a bunch of special cases that are not obvious to the reader.

This PR addresses those problems by making the entries in the subchannel map be ref-counted, where a ref is held both by the map and by each subchannel wrapper.  Specific changes:
- Because the wrapper holds a ref directly to the map entry, there is no longer any need for a map lookup every time the subchannel wrapper needs to access its map entry.
- We now avoid deadlocks by waiting until after we've released the lock to drop refs to subchannel wrappers, so there is no more need to modify the internal state of a subchannel wrapper.
- We now remove subchannel wrappers from the map entry when they are orphaned, so there is no longer any need to hold a weak ref in the map entry; instead, we now just use a raw pointer.
- The connectivity state is now stored in the map entry instead of in each individual subchannel wrapper.  And we no longer need to use an atomic for it, since we are always holding the lock when it is accessed.
- All state guarded by the mutex (other than the subchannel map itself) is now in the subchannel entry, and I have added lock annotations so that the compiler can enforce the lock semantics.

This PR paves the way for subsequent work that will make SSA work across priorities (see in-progress [gRFC A75](https://github.com/grpc/proposal/pull/405)), where we will need to generalize the behavior such that we hold strong refs to subchannels in any state (not just DRAINING) when the child policy is not holding its own refs.