### PR TITLE
[Python Deps] Deprecate pkg_resources in grpc_tools

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_dynamic_stubs_test.py
+++ b/src/python/grpcio_tests/tests/unit/_dynamic_stubs_test.py
@@ -29,7 +29,7 @@ _DATA_DIR = os.path.join("tests", "unit", "data")
 @contextlib.contextmanager
 def _grpc_tools_unimportable():
     original_sys_path = sys.path
-    sys.path = [path for path in sys.path if "grpcio_tools" not in path]
+    sys.path = [path for path in sys.path if "grpcio_tools" not in str(path)]
     try:
         import grpc_tools
     except ImportError:

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -41,6 +41,13 @@ def main(command_arguments):
     return _protoc_compiler.run_main(command_arguments)
 
 
+def _get_resource_file_name(package_or_requirement: str, resource_name: str) -> str:
+  """Obtain the filename for a resource on the file system."""
+  if sys.version_info >= (3, 9, 0):
+    return (resources.files(package_or_requirement) / resource_name).resolve()
+  else:
+    return pkg_resources.resource_filename(package_or_requirement, resource_name)
+
 # NOTE(rbellevi): importlib.abc is not supported on 3.4.
 if sys.version_info >= (3, 5, 0):
     import contextlib
@@ -68,18 +75,8 @@ if sys.version_info >= (3, 5, 0):
                     ]
                 )
 
-                if sys.version_info >= (3, 9, 0):
-                    proto_include = (
-                        resources.files("grpc_tools") / "_proto"
-                    ).resolve()
-                    sys.path.append(proto_include)
-                else:
-                    proto_include = pkg_resources.resource_filename(
-                        "grpc_tools", "_proto"
-                    )
-                    sys.path.append(
-                        pkg_resources.resource_filename("grpc_tools", "_proto")
-                    )
+                proto_include = _get_resource_file_name("grpc_tools", "_proto")
+                sys.path.append(proto_include)
 
                 _FINDERS_INSTALLED = True
 
@@ -200,8 +197,5 @@ if sys.version_info >= (3, 5, 0):
         _maybe_install_proto_finders()
 
 if __name__ == "__main__":
-    if sys.version_info >= (3, 9, 0):
-        proto_include = (resources.files("grpc_tools") / "_proto").resolve()
-    else:
-        proto_include = pkg_resources.resource_filename("grpc_tools", "_proto")
+    proto_include = _get_resource_file_name("grpc_tools", "_proto")
     sys.exit(main(sys.argv + ["-I{}".format(proto_include)]))

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -41,12 +41,19 @@ def main(command_arguments):
     return _protoc_compiler.run_main(command_arguments)
 
 
-def _get_resource_file_name(package_or_requirement: str, resource_name: str) -> str:
-  """Obtain the filename for a resource on the file system."""
-  if sys.version_info >= (3, 9, 0):
-    return (resources.files(package_or_requirement) / resource_name).resolve()
-  else:
-    return pkg_resources.resource_filename(package_or_requirement, resource_name)
+def _get_resource_file_name(
+    package_or_requirement: str, resource_name: str
+) -> str:
+    """Obtain the filename for a resource on the file system."""
+    if sys.version_info >= (3, 9, 0):
+        return (
+            resources.files(package_or_requirement) / resource_name
+        ).resolve()
+    else:
+        return pkg_resources.resource_filename(
+            package_or_requirement, resource_name
+        )
+
 
 # NOTE(rbellevi): importlib.abc is not supported on 3.4.
 if sys.version_info >= (3, 5, 0):

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -19,8 +19,8 @@ import sys
 
 from grpc_tools import _protoc_compiler
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 9:
-    from importlib.resources import files
+if sys.version_info >= (3, 9, 0):
+    from importlib import resources
 else:
     import pkg_resources
 
@@ -68,12 +68,15 @@ if sys.version_info >= (3, 5, 0):
                     ]
                 )
 
-                if sys.version_info.major == 3 and sys.version_info.minor >= 9:
-                    proto_include = (files("grpc_tools") / "_proto").resolve()
+                if sys.version_info >= (3, 9, 0):
+                    proto_include = (
+                        resources.files("grpc_tools") / "_proto"
+                    ).resolve()
                     sys.path.append(proto_include)
                 else:
                     proto_include = pkg_resources.resource_filename(
-                        "grpc_tools", "_proto")
+                        "grpc_tools", "_proto"
+                    )
                     sys.path.append(
                         pkg_resources.resource_filename("grpc_tools", "_proto")
                     )
@@ -197,8 +200,8 @@ if sys.version_info >= (3, 5, 0):
         _maybe_install_proto_finders()
 
 if __name__ == "__main__":
-    if sys.version_info.major == 3 and sys.version_info.minor >= 9:
-        proto_include = (files("grpc_tools") / "_proto").resolve()
+    if sys.version_info >= (3, 9, 0):
+        proto_include = (resources.files("grpc_tools") / "_proto").resolve()
     else:
         proto_include = pkg_resources.resource_filename("grpc_tools", "_proto")
     sys.exit(main(sys.argv + ["-I{}".format(proto_include)]))

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 from grpc_tools import _protoc_compiler
-import pkg_resources
+from importlib.resources import files
 
 _PROTO_MODULE_SUFFIX = "_pb2"
 _SERVICE_MODULE_SUFFIX = "_pb2_grpc"
@@ -63,9 +63,8 @@ if sys.version_info >= (3, 5, 0):
                         ),
                     ]
                 )
-                sys.path.append(
-                    pkg_resources.resource_filename("grpc_tools", "_proto")
-                )
+                proto_include = (files("grpc_tools") / "_proto").resolve()
+                sys.path.append(proto_include)
                 _FINDERS_INSTALLED = True
 
     def _module_name_to_proto_file(suffix, module_name):
@@ -185,5 +184,5 @@ if sys.version_info >= (3, 5, 0):
         _maybe_install_proto_finders()
 
 if __name__ == "__main__":
-    proto_include = pkg_resources.resource_filename("grpc_tools", "_proto")
+    proto_include = (files("grpc_tools") / "_proto").resolve()
     sys.exit(main(sys.argv + ["-I{}".format(proto_include)]))

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -18,7 +18,11 @@ import os
 import sys
 
 from grpc_tools import _protoc_compiler
-from importlib.resources import files
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+    from importlib.resources import files
+else:
+    import pkg_resources
 
 _PROTO_MODULE_SUFFIX = "_pb2"
 _SERVICE_MODULE_SUFFIX = "_pb2_grpc"
@@ -63,8 +67,17 @@ if sys.version_info >= (3, 5, 0):
                         ),
                     ]
                 )
-                proto_include = (files("grpc_tools") / "_proto").resolve()
-                sys.path.append(proto_include)
+
+                if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+                    proto_include = (files("grpc_tools") / "_proto").resolve()
+                    sys.path.append(proto_include)
+                else:
+                    proto_include = pkg_resources.resource_filename(
+                        "grpc_tools", "_proto")
+                    sys.path.append(
+                        pkg_resources.resource_filename("grpc_tools", "_proto")
+                    )
+
                 _FINDERS_INSTALLED = True
 
     def _module_name_to_proto_file(suffix, module_name):
@@ -184,5 +197,8 @@ if sys.version_info >= (3, 5, 0):
         _maybe_install_proto_finders()
 
 if __name__ == "__main__":
-    proto_include = (files("grpc_tools") / "_proto").resolve()
+    if sys.version_info.major == 3 and sys.version_info.minor >= 9:
+        proto_include = (files("grpc_tools") / "_proto").resolve()
+    else:
+        proto_include = pkg_resources.resource_filename("grpc_tools", "_proto")
     sys.exit(main(sys.argv + ["-I{}".format(proto_include)]))


### PR DESCRIPTION
…/protoc.py

pkg_resources deprecated in grpc_tools/protoc.py

.venv/lib/python3.11/site-packages/grpc_tools/protoc.py:21: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources



Fix for [https://github.com/grpc/grpc/issues/33570](https://github.com/grpc/grpc/issues/33570)

