### PR TITLE
Fixed bazel tests for 7

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -112,6 +112,9 @@ $ bazel build :all
 $ bazel test --config=dbg //test/...
 ```
 
+NOTE: If you're using Bazel 7 or newer and working with gRPC, you'll need to turn off bzlmod.
+This is because gRPC isn't fully compatible with bzlmod yet. To do this, add --enable_bzlmod=false to your Bazel commands.
+
 NOTE: If you are a gRPC maintainer and you have access to our test cluster, you should use our [gRPC's Remote Execution environment](tools/remote_build/README.md)
 to get significant improvement to the build and test speed (and a bunch of other very useful features).
 

--- a/doc/bazel_support.md
+++ b/doc/bazel_support.md
@@ -45,3 +45,5 @@ following list:
 
 - [`6.4.0`](https://github.com/bazelbuild/bazel/releases/tag/6.4.0)
 - [`7.0.0`](https://github.com/bazelbuild/bazel/releases/tag/7.0.0)
+
+NOTE: gRPC doesn't support bzlmod yet.

--- a/templates/doc/bazel_support.md.template
+++ b/templates/doc/bazel_support.md.template
@@ -48,3 +48,5 @@
   % for version in supported_bazel_versions:
   - [`${version}`](https://github.com/bazelbuild/bazel/releases/tag/${version})
   % endfor
+
+  NOTE: gRPC doesn't support bzlmod yet.

--- a/test/distrib/bazel/cpp/.bazelrc
+++ b/test/distrib/bazel/cpp/.bazelrc
@@ -1,4 +1,8 @@
 # bazelrc file
 
+# Bazel 7 begins to enable module by default which breaks gRPC build.
+# Therefore, this option is disabled until gRPC works with bzlmod.
+common --enable_bzlmod=false
+
 build --cxxopt='-std=c++14'
 build --host_cxxopt='-std=c++14'

--- a/test/distrib/bazel/python/.bazelrc
+++ b/test/distrib/bazel/python/.bazelrc
@@ -1,4 +1,8 @@
 # bazelrc file
 
+# Bazel 7 begins to enable module by default which breaks gRPC build.
+# Therefore, this option is disabled until gRPC works with bzlmod.
+common --enable_bzlmod=false
+
 build --cxxopt='-std=c++14'
 build --host_cxxopt='-std=c++14'

--- a/test/distrib/bazel/python_second_test_repo/.bazelrc
+++ b/test/distrib/bazel/python_second_test_repo/.bazelrc
@@ -1,4 +1,8 @@
 # bazelrc file
 
+# Bazel 7 begins to enable module by default which breaks gRPC build.
+# Therefore, this option is disabled until gRPC works with bzlmod.
+common --enable_bzlmod=false
+
 build --cxxopt='-std=c++14'
 build --host_cxxopt='-std=c++14'


### PR DESCRIPTION
- Fixed the bazel distrib tests with Bazel 7 by disabling bzlmod option.
- Added a new note for bzlmod to the doc.