### PR TITLE
Read roots.pem from any bundle.

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCore/GRPCSecureChannelFactory.mm
+++ b/src/objective-c/GRPCClient/private/GRPCCore/GRPCSecureChannelFactory.mm
@@ -67,6 +67,18 @@
     if (utf8Str != NULL) {
       setenv("GRPC_DEFAULT_SSL_ROOTS_FILE_PATH", utf8Str, 1);
     } else {
+      // Swift Package Manager puts the resources under PACKAGENAME_TARGETNAME.bundle
+      NSArray *bundleURLs = [[NSBundle mainBundle] URLsForResourcesWithExtension:@"bundle"
+                                                                    subdirectory:nil];
+      for (NSURL *bundleURL in bundleURLs) {
+        NSBundle *resourceBundle = [NSBundle bundleWithURL:[bundleURL URLByAppendingPathComponent: resourceBundlePath]];
+        _sslRootPathStr = [resourceBundle pathForResource:rootsPEM ofType:@"pem"];
+        utf8Str = [_sslRootPathStr cStringUsingEncoding:NSUTF8StringEncoding];
+        if (utf8Str != NULL) {
+          setenv("GRPC_DEFAULT_SSL_ROOTS_FILE_PATH", utf8Str, 1);
+          return;
+        }
+      }
       if (errorPtr) {
         *errorPtr = [NSError
             errorWithDomain:kGRPCErrorDomain


### PR DESCRIPTION
Currently the file roots.pem is only read correctly if gRPCCertificates.bundle is at the top level directory of the Framework. When using Swift Package Manager and attempting to add gRPCCertificates.bundle as resources within the Swift package, gRPCCertificates.bundle is not put at the top level directory of the Framework but rather in a directory called PACKAGENAME_TARGETNAME.bundle. Therefore this code change will fix an issue where gRPCCertificates.bundle is not found if the framework requiring gRPC is released through Swift Package Manager.