### PR TITLE
Fix building v1.46.x branch - turn off NuGet checks

### DIFF
--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NuGetAudit>false</NuGetAudit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
The C# builds in the v1.46.x branch are failing because NuGet reports an error for the Newtonsoft.Json package:
```
grpc\src\csharp\Grpc.Core.Tests\Grpc.Core.Tests.csproj : error NU1903: Warning As Error: Package 'Newtonsoft.Json' 9.0.1 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
```

This is only for the test project `Grpc.Core.Tests`.

Rather than update to a later version of Newtonsoft.Json which might have other consequences in the build environment, I've disabled the NuGet checks _for that project only_ by including `<NuGetAudit>false</NuGetAudit>`. As this is a test project the risk is minimal.