### PR TITLE
[Python Misc] Revert change to print backtrace in server (v1.60.x backport)

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -579,7 +579,7 @@ def _call_behavior(
                                 exception.__traceback__,
                             )
                         )
-                    traceback.print_exc()
+                        traceback.print_exc()
                     _LOGGER.exception(details)
                     _abort(
                         state,


### PR DESCRIPTION
Backport of #34877 to v1.60.x.
---
Fix: https://github.com/grpc/grpc/issues/34853

In order to make debugging easier, we have begun printing backtraces in servers. However, this change has the unintended consequence of printing errors to stderr by default, which may not be expected by some users.

This PR reverts the change. We recommend that users set up a logging sink if they want to see errors. We will add this to our documentation later.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

