### PR TITLE
Avoid warnings due to trailing backslash

### DIFF
--- a/src/core/lib/channel/call_tracer.h
+++ b/src/core/lib/channel/call_tracer.h
@@ -44,9 +44,9 @@ namespace grpc_core {
 
 // The interface hierarchy is as follows -
 //                 CallTracerAnnotationInterface
-//                      /          \
+//                    |                  |
 //        ClientCallTracer       CallTracerInterface
-//                                /             \
+//                                |              |
 //                      CallAttemptTracer    ServerCallTracer
 
 // The base class for all tracer implementations.


### PR DESCRIPTION
I appreciate the elegance of using `\` and `/` to create ASCII art, but trailing backslashes in a `//` comment generates a lot of warnings with some compilers:

```
INFO: From Compiling src/core/lib/channel/promise_based_filter.cc:
In file included from external/com_github_grpc_grpc/src/core/lib/surface/server.h:48,
                 from external/com_github_grpc_grpc/src/core/lib/surface/call.h:53,
                 from external/com_github_grpc_grpc/src/core/lib/channel/promise_based_filter.h:65,
                 from external/com_github_grpc_grpc/src/core/lib/channel/promise_based_filter.cc:17:
external/com_github_grpc_grpc/src/core/lib/channel/call_tracer.h:47:1: warning: multi-line comment [-Wcomment]
   47 | //                      /          \
      | ^
external/com_github_grpc_grpc/src/core/lib/channel/call_tracer.h:49:1: warning: multi-line comment [-Wcomment]
   49 | //                                /             \
      | ^
```




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

