### PR TITLE
[channel] Remove test only feature

### DIFF
--- a/include/grpcpp/test/channel_test_peer.h
+++ b/include/grpcpp/test/channel_test_peer.h
@@ -32,7 +32,6 @@ class ChannelTestPeer {
   /// Provide the gRPC Core channel
   grpc_channel* channel() const { return channel_->c_channel_; }
   int registered_calls() const;
-  int registration_attempts() const;
 
  private:
   Channel* channel_;  // not owned

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -376,7 +376,6 @@ namespace grpc_core {
 
 RegisteredCall* Channel::RegisterCall(const char* method, const char* host) {
   MutexLock lock(&registration_table_.mu);
-  registration_table_.method_registration_attempts++;
   auto key = std::make_pair(std::string(host != nullptr ? host : ""),
                             std::string(method != nullptr ? method : ""));
   auto rc_posn = registration_table_.map.find(key);

--- a/src/core/lib/surface/channel.h
+++ b/src/core/lib/surface/channel.h
@@ -103,7 +103,6 @@ struct CallRegistrationTable {
   // C++ or other wrapped language Channel that registered these calls).
   std::map<std::pair<std::string, std::string>, RegisteredCall> map
       ABSL_GUARDED_BY(mu);
-  int method_registration_attempts ABSL_GUARDED_BY(mu) = 0;
 };
 
 class Channel : public RefCounted<Channel>,
@@ -148,11 +147,6 @@ class Channel : public RefCounted<Channel>,
   int TestOnlyRegisteredCalls() {
     MutexLock lock(&registration_table_.mu);
     return registration_table_.map.size();
-  }
-
-  int TestOnlyRegistrationAttempts() {
-    MutexLock lock(&registration_table_.mu);
-    return registration_table_.method_registration_attempts;
   }
 
   grpc_event_engine::experimental::EventEngine* event_engine() const {

--- a/src/cpp/client/channel_test_peer.cc
+++ b/src/cpp/client/channel_test_peer.cc
@@ -29,10 +29,5 @@ int ChannelTestPeer::registered_calls() const {
       ->TestOnlyRegisteredCalls();
 }
 
-int ChannelTestPeer::registration_attempts() const {
-  return grpc_core::Channel::FromC(channel_->c_channel_)
-      ->TestOnlyRegistrationAttempts();
-}
-
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -862,12 +862,10 @@ TEST_P(End2endTest, ManyStubs) {
   ResetStub();
   ChannelTestPeer peer(channel_.get());
   int registered_calls_pre = peer.registered_calls();
-  int registration_attempts_pre = peer.registration_attempts();
   for (int i = 0; i < 1000; ++i) {
     grpc::testing::EchoTestService::NewStub(channel_);
   }
   EXPECT_EQ(peer.registered_calls(), registered_calls_pre);
-  EXPECT_GT(peer.registration_attempts(), registration_attempts_pre);
 }
 
 TEST_P(End2endTest, EmptyBinaryMetadata) {


### PR DESCRIPTION
It's not clear to me that this one unit test of very marginal importance warrants 8 bytes per channel.