### PR TITLE
[Cleanup] Fix abseil include error

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -6237,6 +6237,7 @@ grpc_cc_library(
     external_deps = [
         "absl/status",
         "absl/status:statusor",
+        "absl/strings",
     ],
     deps = [
         "bitset",

--- a/src/core/ext/transport/chaotic_good/frame_header.cc
+++ b/src/core/ext/transport/chaotic_good/frame_header.cc
@@ -19,6 +19,7 @@
 #include <cstdint>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 
 #include <grpc/support/log.h>
 


### PR DESCRIPTION
Fixed 

```
/var/local/git/grpc/src/core/ext/transport/chaotic_good/frame_header.cc:69:15: error: no member named 'StrCat' in namespace 'absl'
        absl::StrCat("Invalid header length: ", header.header_length));
        ~~~~~~^
```