### PR TITLE
Suppress event loop warnning

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -181,7 +181,9 @@ if PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
         try:
             return asyncio.get_running_loop()
         except RuntimeError:
-            return asyncio.get_event_loop_policy().get_event_loop()
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                return asyncio.get_event_loop_policy().get_event_loop()
 else:
     def get_working_loop():
         """Returns a running event loop."""

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -183,9 +183,7 @@ if PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 7:
         try:
             return asyncio.get_running_loop()
         except RuntimeError:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                return asyncio.get_event_loop_policy().get_event_loop()
+            return asyncio.get_event_loop_policy().new_event_loop()
 else:
     def get_working_loop():
         """Returns a running event loop."""

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
-
 from cpython.version cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
 
 TYPE_METADATA_STRING = "Tuple[Tuple[str, Union[str, bytes]]...]"

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/common.pyx.pxi
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 from cpython.version cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
 
 TYPE_METADATA_STRING = "Tuple[Tuple[str, Union[str, bytes]]...]"


### PR DESCRIPTION
Starting Python 3.12, `asyncio.get_event_loop()` will emit deprecation warning if there is no current event loop.

Since we're calling `get_event_loop()` if there is no running loop, it make sense to use `new_event_loop()` instead.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

