### PR TITLE
[Test] Removed openssl tests from the at-head tests

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -79,4 +79,4 @@ fi
 # commit so that changes are passed to Docker
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 --inner_jobs 16 -j 2 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl --inner_jobs 16 -j 2 --internal_ci --build_only

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -370,7 +370,8 @@ def _create_portability_test_jobs(
             platforms=["linux"],
             arch="x64",
             compiler=compiler,
-            labels=["portability", "corelang"],
+            labels=["portability", "corelang"]
+            + (["openssl"] if "openssl" in compiler else []),
             extra_args=extra_args,
             inner_jobs=inner_jobs,
             timeout_seconds=_CPP_RUNTESTS_TIMEOUT,


### PR DESCRIPTION
Recently two more openssl tests were added to the portability test suite. At-head tests are using the same set, having an unintended big surge in the test time, causing timeout. So I've changed at-head tests not to run openssl tests.