### PR TITLE
Use MSBuildProjectExtension to detect language in Google.Protobuf.Tools.targets

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <!-- We allow a non-C# generator be set by the user, but skip adding outputs to Compile in this case. -->
-    <Protobuf_Generator Condition=" '$(Protobuf_Generator)' == '' and '$(Language)' == 'C#' ">CSharp</Protobuf_Generator>
+    <Protobuf_Generator Condition=" '$(Protobuf_Generator)' == '' and '$(MSBuildProjectExtension)' == 'csproj' ">CSharp</Protobuf_Generator>
     <!-- Configuration is passing the smoke test. -->
     <Protobuf_ProjectSupported Condition=" '$(Protobuf_Generator)' != '' ">true</Protobuf_ProjectSupported>
     <!-- Allow assembly file to be specified externally for testing by setting property _Protobuf_MsBuildAssembly -->
@@ -22,7 +22,7 @@
     <Protobuf_DepFilesPath Condition=" '$(Protobuf_DepFilesPath)' == '' ">$(Protobuf_IntermediatePath)</Protobuf_DepFilesPath>
   </PropertyGroup>
 
-  <ItemDefinitionGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(Language)' == 'C#' ">
+  <ItemDefinitionGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(MSBuildProjectExtension)' == 'csproj' ">
     <Protobuf>
       <Access Condition="'%(Protobuf.Access)' == '' ">Public</Access>
       <ProtoCompile Condition="'%(Protobuf.ProtoCompile)' == '' ">True</ProtoCompile>
@@ -33,7 +33,7 @@
     </Protobuf>
   </ItemDefinitionGroup>
 
-  <ItemGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(Language)' == 'C#' ">
+  <ItemGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(MSBuildProjectExtension)' == 'csproj' ">
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Protobuf.CSharp.xml">
       <Context>File;BrowseObject</Context>
     </PropertyPageSchema>


### PR DESCRIPTION
Prior to this commit, $(Language) is used in Google.Protobuf.Tools.targets to identify whether a project is C# or not. The issue with this approach is that $(Language) is not set by default in MSBUILD. It is set in the Microsoft.CSharp.targets file here: https://github.com/dotnet/msbuild/blob/45f3aed1944548f123ce928d1253e38b5008dccf/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L38 . This causes the Google.Protobuf.Tools.targets to have a dependency on Microsoft.CSharp.targets file to be called first.

To improve on this situation, this PR seeks to remove this dependency by using the well-defined MSBUILD properties that are available at any time during the build process. Specifically, we can identify whether or not a project is a C# project by checking the project extension with the $(MSBuildProjectExtension) property. If $(MSBuildProjectExtension) == 'csproj', then we can say that this is a C# project.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

