### PR TITLE
[CocoaPods] Re-work how privacy manifests are exposed

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -80,6 +80,14 @@ Pod::Spec.new do |s|
 
   s.header_mappings_dir = 'include/grpcpp'
 
+  # Exposes the privacy manifest. Depended on by any subspecs containing
+  # non-interface files.
+  s.subspec 'Privacy' do |ss|
+    ss.resource_bundles = {
+      s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+    }
+  end
+
   s.subspec 'Interface' do |ss|
     ss.header_mappings_dir = 'include/grpcpp'
 
@@ -214,6 +222,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Implementation' do |ss|
     ss.header_mappings_dir = '.'
+    ss.dependency "#{s.name}/Privacy", version
     ss.dependency "#{s.name}/Interface", version
     ss.dependency 'gRPC-Core', version
     abseil_version = '1.20230802.0'
@@ -2733,6 +2742,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     ss.dependency "#{s.name}/Cronet-Interface", version
     ss.dependency "#{s.name}/Implementation", version
+    ss.dependency "#{s.name}/Privacy", version
 
     ss.dependency 'gRPC-Core/Cronet-Implementation', version
 

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -94,6 +94,14 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DGRPC_ARES=0 -Wno-comma'
   s.libraries = 'c++'
 
+  # Exposes the privacy manifest. Depended on by any subspecs containing
+  # non-interface files.
+  s.subspec 'Privacy' do |ss|
+    ss.resource_bundles = {
+      s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+    }
+  end
+
   # Like many other C libraries, gRPC-Core has its public headers under `include/<libname>/` and its
   # sources and private headers in other directories outside `include/`. Cocoapods' linter doesn't
   # allow any header to be listed outside the `header_mappings_dir` (even though doing so works in
@@ -185,6 +193,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     ss.libraries = 'z'
     ss.dependency "#{s.name}/Interface", version
+    ss.dependency "#{s.name}/Privacy", version
     ss.dependency 'BoringSSL-GRPC', '0.0.31'
     ss.dependency 'abseil/algorithm/container', abseil_version
     ss.dependency 'abseil/base/base', abseil_version
@@ -3485,6 +3494,7 @@ Pod::Spec.new do |s|
 
     ss.dependency "#{s.name}/Interface", version
     ss.dependency "#{s.name}/Implementation", version
+    ss.dependency "#{s.name}/Privacy", version
     ss.dependency "#{s.name}/Cronet-Interface", version
 
     ss.source_files = 'src/core/ext/transport/cronet/client/secure/cronet_channel_create.cc',

--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -32,8 +32,6 @@ Pod::Spec.new do |s|
     :tag => "v#{version}",
   }
 
-  s.resource = 'src/objective-c/PrivacyInfo.xcprivacy'
-
   name = 'GRPCClient'
   s.module_name = name
   s.header_dir = name
@@ -51,6 +49,14 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '6.0'
+
+  # Exposes the privacy manifest. Depended on by any subspecs containing
+  # non-interface files.
+  s.subspec 'Privacy' do |ss|
+    ss.resource_bundles = {
+      s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+    }
+  end
 
   s.subspec 'Interface-Legacy' do |ss|
     ss.header_mappings_dir = 'src/objective-c/GRPCClient'
@@ -72,7 +78,7 @@ Pod::Spec.new do |s|
                       "src/objective-c/GRPCClient/GRPCTypes.h",
                       "src/objective-c/GRPCClient/GRPCTypes.mm"
     ss.dependency "gRPC-RxLibrary/Interface", version
-
+    ss.dependency "#{s.name}/Privacy", version
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '12.0'
@@ -107,7 +113,7 @@ Pod::Spec.new do |s|
                       'src/objective-c/GRPCClient/version.h'
 
     ss.dependency "#{s.name}/Interface-Legacy", version
-
+    ss.dependency "#{s.name}/Privacy", version
     s.ios.deployment_target = '10.0'
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '12.0'
@@ -141,6 +147,7 @@ Pod::Spec.new do |s|
 
     ss.dependency "#{s.name}/Interface-Legacy", version
     ss.dependency "#{s.name}/Interface", version
+    ss.dependency "#{s.name}/Privacy", version
     ss.dependency 'gRPC-Core', version
     ss.dependency 'gRPC-RxLibrary', version
 
@@ -157,6 +164,7 @@ Pod::Spec.new do |s|
                       'src/objective-c/GRPCClient/GRPCCall+Cronet.mm',
                       'src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreCronet/*.{h,mm}'
     ss.dependency "#{s.name}/GRPCCore", version
+    ss.dependency "#{s.name}/Privacy", version
     ss.dependency 'gRPC-Core/Cronet-Implementation', version
     ss.dependency 'CronetFramework'
 

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -122,6 +122,11 @@ Pod::Spec.new do |s|
   end
   s.subspec 'Implementation' do |ss|
     ss.header_mappings_dir = 'src'
+
+    ss.resource_bundles = {
+      s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+    }
+
     ss.source_files = 'src/ssl/*.{h,c,cc}',
                       'src/ssl/**/*.{h,c,cc}',
                       'src/crypto/*.{h,c,cc}',

--- a/src/objective-c/PrivacyInfo.xcprivacy
+++ b/src/objective-c/PrivacyInfo.xcprivacy
@@ -18,7 +18,7 @@
 				<string>C617.1</string>
 			</array>
 		</dict>
-    <dict>
+		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>

--- a/src/objective-c/PrivacyInfo.xcprivacy
+++ b/src/objective-c/PrivacyInfo.xcprivacy
@@ -18,6 +18,14 @@
 				<string>C617.1</string>
 			</array>
 		</dict>
+    <dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -164,6 +164,14 @@
 
     s.header_mappings_dir = 'include/grpcpp'
 
+    # Exposes the privacy manifest. Depended on by any subspecs containing
+    # non-interface files.
+    s.subspec 'Privacy' do |ss|
+      ss.resource_bundles = {
+        s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+      }
+    end
+
     s.subspec 'Interface' do |ss|
       ss.header_mappings_dir = 'include/grpcpp'
 
@@ -172,6 +180,7 @@
 
     s.subspec 'Implementation' do |ss|
       ss.header_mappings_dir = '.'
+      ss.dependency "#{s.name}/Privacy", version
       ss.dependency "#{s.name}/Interface", version
       ss.dependency 'gRPC-Core', version
       abseil_version = '1.20230802.0'
@@ -203,6 +212,7 @@
       ss.header_mappings_dir = '.'
       ss.dependency "#{s.name}/Cronet-Interface", version
       ss.dependency "#{s.name}/Implementation", version
+      ss.dependency "#{s.name}/Privacy", version
 
       ss.dependency 'gRPC-Core/Cronet-Implementation', version
 

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -170,6 +170,14 @@
     s.compiler_flags = '-DGRPC_ARES=0 -Wno-comma'
     s.libraries = 'c++'
 
+    # Exposes the privacy manifest. Depended on by any subspecs containing
+    # non-interface files.
+    s.subspec 'Privacy' do |ss|
+      ss.resource_bundles = {
+        s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+      }
+    end
+
     # Like many other C libraries, gRPC-Core has its public headers under `include/<libname>/` and its
     # sources and private headers in other directories outside `include/`. Cocoapods' linter doesn't
     # allow any header to be listed outside the `header_mappings_dir` (even though doing so works in
@@ -189,6 +197,7 @@
       ss.header_mappings_dir = '.'
       ss.libraries = 'z'
       ss.dependency "#{s.name}/Interface", version
+      ss.dependency "#{s.name}/Privacy", version
       ss.dependency 'BoringSSL-GRPC', '0.0.31'
       % for abseil_spec in grpc_abseil_specs:
       ss.dependency '${abseil_spec}', abseil_version
@@ -214,6 +223,7 @@
 
       ss.dependency "#{s.name}/Interface", version
       ss.dependency "#{s.name}/Implementation", version
+      ss.dependency "#{s.name}/Privacy", version
       ss.dependency "#{s.name}/Cronet-Interface", version
 
       ss.source_files = ${ruby_multiline_list(grpc_cronet_files, 22)}

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -34,8 +34,6 @@
       :tag => "v#{version}",
     }
 
-    s.resource = 'src/objective-c/PrivacyInfo.xcprivacy'
-
     name = 'GRPCClient'
     s.module_name = name
     s.header_dir = name
@@ -53,6 +51,14 @@
     s.osx.deployment_target = '10.12'
     s.tvos.deployment_target = '12.0'
     s.watchos.deployment_target = '6.0'
+
+    # Exposes the privacy manifest. Depended on by any subspecs containing
+    # non-interface files.
+    s.subspec 'Privacy' do |ss|
+      ss.resource_bundles = {
+        s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+      }
+    end
 
     s.subspec 'Interface-Legacy' do |ss|
       ss.header_mappings_dir = 'src/objective-c/GRPCClient'
@@ -74,7 +80,7 @@
                         "src/objective-c/GRPCClient/GRPCTypes.h",
                         "src/objective-c/GRPCClient/GRPCTypes.mm"
       ss.dependency "gRPC-RxLibrary/Interface", version
-
+      ss.dependency "#{s.name}/Privacy", version
       s.ios.deployment_target = '10.0'
       s.osx.deployment_target = '10.12'
       s.tvos.deployment_target = '12.0'
@@ -109,7 +115,7 @@
                         'src/objective-c/GRPCClient/version.h'
 
       ss.dependency "#{s.name}/Interface-Legacy", version
-
+      ss.dependency "#{s.name}/Privacy", version
       s.ios.deployment_target = '10.0'
       s.osx.deployment_target = '10.12'
       s.tvos.deployment_target = '12.0'
@@ -143,6 +149,7 @@
 
       ss.dependency "#{s.name}/Interface-Legacy", version
       ss.dependency "#{s.name}/Interface", version
+      ss.dependency "#{s.name}/Privacy", version
       ss.dependency 'gRPC-Core', version
       ss.dependency 'gRPC-RxLibrary', version
 
@@ -159,6 +166,7 @@
                         'src/objective-c/GRPCClient/GRPCCall+Cronet.mm',
                         'src/objective-c/GRPCClient/private/GRPCCore/GRPCCoreCronet/*.{h,mm}'
       ss.dependency "#{s.name}/GRPCCore", version
+      ss.dependency "#{s.name}/Privacy", version
       ss.dependency 'gRPC-Core/Cronet-Implementation', version
       ss.dependency 'CronetFramework'
 

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -152,6 +152,11 @@
     end
     s.subspec 'Implementation' do |ss|
       ss.header_mappings_dir = 'src'
+
+      ss.resource_bundles = {
+        s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+      }
+
       ss.source_files = 'src/ssl/*.{h,c,cc}',
                         'src/ssl/**/*.{h,c,cc}',
                         'src/crypto/*.{h,c,cc}',


### PR DESCRIPTION
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

Follow-up to add privacy manifests to #35042

- [x] Update podspec template files
- [x] Align on manifest update:
```
git grep mach_absolute_time
src/core/lib/gpr/posix/time.cc:static uint64_t g_time_start = mach_absolute_time();
src/core/lib/gpr/posix/time.cc:                ((double)(mach_absolute_time() - g_time_start)) * g_time_scale;
```

cc: @paulb777 
