### PR TITLE
[PSM Interop] Add a payload to xds interop client when sending RPCs

### DIFF
--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -67,8 +67,10 @@ ABSL_FLAG(int32_t, stats_port, 50052,
           "Port to expose peer distribution stats service.");
 ABSL_FLAG(std::string, rpc, "UnaryCall",
           "a comma separated list of rpc methods.");
-ABSL_FLAG(int32_t, request_payload_size, 0, "request payload size in bytes.");
-ABSL_FLAG(int32_t, response_payload_size, 0, "response payload size in bytes.");
+ABSL_FLAG(int32_t, request_payload_size, 0,
+          "request payload size in bytes of zeros.");
+ABSL_FLAG(int32_t, response_payload_size, 0,
+          "response payload size in bytes of zeros.");
 ABSL_FLAG(std::string, metadata, "", "metadata to send with the RPC.");
 ABSL_FLAG(std::string, expect_status, "OK",
           "RPC status for the test RPC to be considered successful");
@@ -157,10 +159,14 @@ class TestClient {
       }
     }
     SimpleRequest request;
-    request.set_response_size(absl::GetFlag(FLAGS_response_payload_size));
-    std::string payload(absl::GetFlag(FLAGS_request_payload_size), '\0');
-    request.mutable_payload()->set_body(
-        payload.c_str(), absl::GetFlag(FLAGS_request_payload_size));
+    if (absl::GetFlag(FLAGS_response_payload_size) > 0) {
+      request.set_response_size(absl::GetFlag(FLAGS_response_payload_size));
+    }
+    if (absl::GetFlag(FLAGS_request_payload_size) > 0) {
+      std::string payload(absl::GetFlag(FLAGS_request_payload_size), '\0');
+      request.mutable_payload()->set_body(
+          payload.c_str(), absl::GetFlag(FLAGS_request_payload_size));
+    }
     call->context.set_deadline(deadline);
     call->result.saved_request_id = saved_request_id;
     call->result.rpc_type = ClientConfigureRequest::UNARY_CALL;

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -68,9 +68,11 @@ ABSL_FLAG(int32_t, stats_port, 50052,
 ABSL_FLAG(std::string, rpc, "UnaryCall",
           "a comma separated list of rpc methods.");
 ABSL_FLAG(int32_t, request_payload_size, 0,
-          "Set the SimpleRequest.payload.body to a string of repeated 0 (zero) ASCII characters of the given size in bytes.");
+          "Set the SimpleRequest.payload.body to a string of repeated 0 (zero) "
+          "ASCII characters of the given size in bytes.");
 ABSL_FLAG(int32_t, response_payload_size, 0,
-          "Ask the server to respond with SimpleResponse.payload.body of the given length (may not be implemented on the server).");
+          "Ask the server to respond with SimpleResponse.payload.body of the "
+          "given length (may not be implemented on the server).");
 ABSL_FLAG(std::string, metadata, "", "metadata to send with the RPC.");
 ABSL_FLAG(std::string, expect_status, "OK",
           "RPC status for the test RPC to be considered successful");

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -349,7 +349,7 @@ class XdsUpdateClientConfigureServiceImpl
       }
       if (absl::GetFlag(FLAGS_request_payload_size) > 0) {
         config.request_payload_size = absl::GetFlag(FLAGS_request_payload_size);
-        std::string payload(config.request_payload_size, '\0');
+        std::string payload(config.request_payload_size, '0');
         config.request_payload = payload;
       }
       if (absl::GetFlag(FLAGS_response_payload_size) > 0) {
@@ -496,7 +496,7 @@ void BuildRpcConfigsFromFlags(RpcConfigurationsQueue* rpc_configs_queue) {
     }
     if (absl::GetFlag(FLAGS_request_payload_size) > 0) {
       config.request_payload_size = absl::GetFlag(FLAGS_request_payload_size);
-      std::string payload(config.request_payload_size, '\0');
+      std::string payload(config.request_payload_size, '0');
       config.request_payload = payload;
     }
     if (absl::GetFlag(FLAGS_response_payload_size) > 0) {

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -164,8 +164,8 @@ class TestClient {
     call->context.set_deadline(deadline);
     call->result.saved_request_id = saved_request_id;
     call->result.rpc_type = ClientConfigureRequest::UNARY_CALL;
-    call->simple_response_reader = stub_->PrepareAsyncUnaryCall(
-        &call->context, request, &cq_);
+    call->simple_response_reader =
+        stub_->PrepareAsyncUnaryCall(&call->context, request, &cq_);
     call->simple_response_reader->StartCall();
     call->simple_response_reader->Finish(&call->result.simple_response,
                                          &call->result.status, call);

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -67,6 +67,8 @@ ABSL_FLAG(int32_t, stats_port, 50052,
           "Port to expose peer distribution stats service.");
 ABSL_FLAG(std::string, rpc, "UnaryCall",
           "a comma separated list of rpc methods.");
+ABSL_FLAG(int32_t, request_payload_size, 0, "request payload size in bytes.");
+ABSL_FLAG(int32_t, response_payload_size, 0, "response payload size in bytes.");
 ABSL_FLAG(std::string, metadata, "", "metadata to send with the RPC.");
 ABSL_FLAG(std::string, expect_status, "OK",
           "RPC status for the test RPC to be considered successful");
@@ -131,9 +133,6 @@ class TestClient {
              StatsWatchers* stats_watchers)
       : stub_(TestService::NewStub(channel)), stats_watchers_(stats_watchers) {}
 
-  const int kLargeRequestSize = 271828;
-  const int kLargeResponseSize = 314159;
-
   void AsyncUnaryCall(const RpcConfig& config) {
     SimpleResponse response;
     int saved_request_id;
@@ -158,9 +157,10 @@ class TestClient {
       }
     }
     SimpleRequest request;
-    request.set_response_size(kLargeResponseSize);
-    std::string payload(kLargeRequestSize, '\0');
-    request.mutable_payload()->set_body(payload.c_str(), kLargeRequestSize);
+    request.set_response_size(absl::GetFlag(FLAGS_response_payload_size));
+    std::string payload(absl::GetFlag(FLAGS_request_payload_size), '\0');
+    request.mutable_payload()->set_body(
+        payload.c_str(), absl::GetFlag(FLAGS_request_payload_size));
     call->context.set_deadline(deadline);
     call->result.saved_request_id = saved_request_id;
     call->result.rpc_type = ClientConfigureRequest::UNARY_CALL;

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -68,7 +68,7 @@ ABSL_FLAG(int32_t, stats_port, 50052,
 ABSL_FLAG(std::string, rpc, "UnaryCall",
           "a comma separated list of rpc methods.");
 ABSL_FLAG(int32_t, request_payload_size, 0,
-          "request payload size in bytes of zeros.");
+          "Set the SimpleRequest.payload.body to a string of repeated 0 (zero) ASCII characters of the given size in bytes.");
 ABSL_FLAG(int32_t, response_payload_size, 0,
           "response payload size in bytes of zeros.");
 ABSL_FLAG(std::string, metadata, "", "metadata to send with the RPC.");

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -131,6 +131,9 @@ class TestClient {
              StatsWatchers* stats_watchers)
       : stub_(TestService::NewStub(channel)), stats_watchers_(stats_watchers) {}
 
+  const int kLargeRequestSize = 271828;
+  const int kLargeResponseSize = 314159;
+
   void AsyncUnaryCall(const RpcConfig& config) {
     SimpleResponse response;
     int saved_request_id;
@@ -154,11 +157,15 @@ class TestClient {
             std::chrono::system_clock::now() + std::chrono::seconds(INT_MAX);
       }
     }
+    SimpleRequest request;
+    request.set_response_size(kLargeResponseSize);
+    std::string payload(kLargeRequestSize, '\0');
+    request.mutable_payload()->set_body(payload.c_str(), kLargeRequestSize);
     call->context.set_deadline(deadline);
     call->result.saved_request_id = saved_request_id;
     call->result.rpc_type = ClientConfigureRequest::UNARY_CALL;
     call->simple_response_reader = stub_->PrepareAsyncUnaryCall(
-        &call->context, SimpleRequest::default_instance(), &cq_);
+        &call->context, request, &cq_);
     call->simple_response_reader->StartCall();
     call->simple_response_reader->Finish(&call->result.simple_response,
                                          &call->result.status, call);

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -500,8 +500,7 @@ void BuildRpcConfigsFromFlags(RpcConfigurationsQueue* rpc_configs_queue) {
       config.request_payload = payload;
     }
     if (absl::GetFlag(FLAGS_response_payload_size) > 0) {
-      config.response_payload_size =
-          absl::GetFlag(FLAGS_response_payload_size);
+      config.response_payload_size = absl::GetFlag(FLAGS_response_payload_size);
     }
     configs.push_back(std::move(config));
   }

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -353,13 +353,13 @@ class XdsUpdateClientConfigureServiceImpl
       }
       if (request_payload_size > 0 &&
           config.type == ClientConfigureRequest::EMPTY_CALL) {
-        gpr_log(GPR_DEBUG,
+        gpr_log(GPR_ERROR,
                 "request_payload_size should not be set "
                 "for EMPTY_CALL");
       }
       if (response_payload_size > 0 &&
           config.type == ClientConfigureRequest::EMPTY_CALL) {
-        gpr_log(GPR_DEBUG,
+        gpr_log(GPR_ERROR,
                 "response_payload_size should not be set "
                 "for EMPTY_CALL");
       }
@@ -511,13 +511,13 @@ void BuildRpcConfigsFromFlags(RpcConfigurationsQueue* rpc_configs_queue) {
     }
     if (request_payload_size > 0 &&
         config.type == ClientConfigureRequest::EMPTY_CALL) {
-      gpr_log(GPR_DEBUG,
+      gpr_log(GPR_ERROR,
               "request_payload_size should not be set "
               "for EMPTY_CALL");
     }
     if (response_payload_size > 0 &&
         config.type == ClientConfigureRequest::EMPTY_CALL) {
-      gpr_log(GPR_DEBUG,
+      gpr_log(GPR_ERROR,
               "response_payload_size should not be set "
               "for EMPTY_CALL");
     }

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -351,13 +351,13 @@ class XdsUpdateClientConfigureServiceImpl
       }
       if (request_payload_size > 0 &&
           config.type == ClientConfigureRequest::EMPTY_CALL) {
-        gpr_log(GPR_WARNING,
+        gpr_log(GPR_DEBUG,
                 "request_payload_size should not be set "
                 "for EMPTY_CALL");
       }
       if (response_payload_size > 0 &&
           config.type == ClientConfigureRequest::EMPTY_CALL) {
-        gpr_log(GPR_WARNING,
+        gpr_log(GPR_DEBUG,
                 "response_payload_size should not be set "
                 "for EMPTY_CALL");
       }
@@ -509,13 +509,13 @@ void BuildRpcConfigsFromFlags(RpcConfigurationsQueue* rpc_configs_queue) {
     }
     if (request_payload_size > 0 &&
         config.type == ClientConfigureRequest::EMPTY_CALL) {
-      gpr_log(GPR_WARNING,
+      gpr_log(GPR_DEBUG,
               "request_payload_size should not be set "
               "for EMPTY_CALL");
     }
     if (response_payload_size > 0 &&
         config.type == ClientConfigureRequest::EMPTY_CALL) {
-      gpr_log(GPR_WARNING,
+      gpr_log(GPR_DEBUG,
               "response_payload_size should not be set "
               "for EMPTY_CALL");
     }

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -70,7 +70,7 @@ ABSL_FLAG(std::string, rpc, "UnaryCall",
 ABSL_FLAG(int32_t, request_payload_size, 0,
           "Set the SimpleRequest.payload.body to a string of repeated 0 (zero) ASCII characters of the given size in bytes.");
 ABSL_FLAG(int32_t, response_payload_size, 0,
-          "response payload size in bytes of zeros.");
+          "Ask the server to respond with SimpleResponse.payload.body of the given length (may not be implemented on the server).");
 ABSL_FLAG(std::string, metadata, "", "metadata to send with the RPC.");
 ABSL_FLAG(std::string, expect_status, "OK",
           "RPC status for the test RPC to be considered successful");

--- a/test/cpp/interop/xds_interop_server_lib.cc
+++ b/test/cpp/interop/xds_interop_server_lib.cc
@@ -81,7 +81,7 @@ class TestServiceImpl : public TestService::Service {
                            absl::string_view server_id)
       : hostname_(hostname), server_id_(server_id) {}
 
-  Status UnaryCall(ServerContext* context, const SimpleRequest* /*request*/,
+  Status UnaryCall(ServerContext* context, const SimpleRequest* request,
                    SimpleResponse* response) override {
     response->set_server_id(server_id_);
     for (const auto& rpc_behavior : GetRpcBehaviorMetadata(context)) {
@@ -90,6 +90,11 @@ class TestServiceImpl : public TestService::Service {
       if (maybe_status.has_value()) {
         return *maybe_status;
       }
+    }
+    if (request->response_size() > 0) {
+      std::unique_ptr<char[]> body(new char[request->response_size()]());
+      response->mutable_payload()->set_body(body.get(),
+                                            request->response_size());
     }
     response->set_hostname(hostname_);
     context->AddInitialMetadata("hostname", hostname_);

--- a/test/cpp/interop/xds_interop_server_lib.cc
+++ b/test/cpp/interop/xds_interop_server_lib.cc
@@ -92,8 +92,8 @@ class TestServiceImpl : public TestService::Service {
       }
     }
     if (request->response_size() > 0) {
-      std::unique_ptr<char[]> body(new char[request->response_size()]());
-      response->mutable_payload()->set_body(body.get(),
+      std::string payload(request->response_size(), '0');
+      response->mutable_payload()->set_body(payload.c_str(),
                                             request->response_size());
     }
     response->set_hostname(hostname_);


### PR DESCRIPTION
When testing CSM Observability, we discovered that the c++ xds interop client is not sending any payload with the `UnaryCall` RPCs so most of the metrics will have a value of 0.

Adding a payload to the xds interop client here.

We need this fix so that we can verify that the metrics are recording the right number of bytes being sent / received. So we need a non-trivial payload to be sent with the `UnaryCall` RPC between the xds interop client and server.