### PR TITLE
Fix sync-labels

### DIFF
--- a/.github/workflows/pr-auto-tag.yaml
+++ b/.github/workflows/pr-auto-tag.yaml
@@ -16,4 +16,4 @@ jobs:
     - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: ""
+        sync-labels: false


### PR DESCRIPTION
Fixes the following error found in https://github.com/grpc/grpc/actions/runs/7545482012/job/20541188443?pr=34523

```
Run actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
Error: TypeError: Input does not meet YAML 1.2 "Core Schema" specification: sync-labels
Support boolean input list: `true | True | TRUE | false | False | FALSE`
Error: Input does not meet YAML 1.2 "Core Schema" specification: sync-labels
Support boolean input list: `true | True | TRUE | false | False | FALSE`
```

