### PR TITLE
[ruby] Fix SEGV after fork due to use-after-free

### DIFF
--- a/src/ruby/end2end/fork_test_repro_35489.rb
+++ b/src/ruby/end2end/fork_test_repro_35489.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
+fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+
+this_dir = File.expand_path(File.dirname(__FILE__))
+protos_lib_dir = File.join(this_dir, 'lib')
+grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
+$LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
+$LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
+$LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
+
+require 'grpc'
+require 'end2end_common'
+
+def do_rpc(stub)
+  stub.echo(Echo::EchoRequest.new(request: 'hello'), deadline: Time.now + 1)
+rescue GRPC::Unavailable => e
+  STDERR.puts "RPC terminated with expected error: #{e}"
+rescue GRPC::DeadlineExceeded => e
+  STDERR.puts "RPC terminated with expected error: #{e}"
+end
+
+def main
+  key = "testkey" * 100000 # large enough to malloc backing storage
+  value = "testvalue" * 100000
+  # TODO(apolcyn): point this to a guaranteed-non-listening port
+  stub = Echo::EchoServer::Stub.new("localhost:443", :this_channel_is_insecure, channel_args: { key => value })
+  do_rpc(stub)
+  with_logging("GRPC.pre_fork") { GRPC.prefork }
+  pid = fork do
+    with_logging("child: GRPC.postfork_child") { GRPC.postfork_child }
+    key.clear
+    value.clear
+    GC.compact # free backing memory for the old key
+    with_logging("child: post-fork RPC") { do_rpc(stub) }
+    STDERR.puts "child: done"
+  end
+  with_logging("parent: GRPC.postfork_parent") { GRPC.postfork_parent }
+  with_logging("parent: post-fork RPC") { do_rpc(stub) }
+  Process.wait pid
+  STDERR.puts "parent: done"
+end
+
+main

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -45,16 +45,16 @@ static rb_data_type_t grpc_rb_channel_args_data_type = {
 static int grpc_rb_channel_create_in_process_add_args_hash_cb(VALUE key,
                                                               VALUE val,
                                                               VALUE args_obj) {
-  const char* the_key;
+  const char* key_cstr;
   grpc_channel_args* args;
 
   switch (TYPE(key)) {
     case T_STRING:
-      the_key = StringValuePtr(key);
+      key_cstr = StringValuePtr(key);
       break;
 
     case T_SYMBOL:
-      the_key = rb_id2name(SYM2ID(key));
+      key_cstr = rb_id2name(SYM2ID(key));
       break;
 
     default:
@@ -71,7 +71,7 @@ static int grpc_rb_channel_create_in_process_add_args_hash_cb(VALUE key,
     return ST_STOP;
   }
 
-  args->args[args->num_args - 1].key = (char*)the_key;
+  args->args[args->num_args - 1].key = gpr_strdup(key_cstr);
   switch (TYPE(val)) {
     case T_SYMBOL:
       args->args[args->num_args - 1].type = GRPC_ARG_STRING;
@@ -163,8 +163,8 @@ void grpc_rb_channel_args_destroy(grpc_channel_args* args) {
   GPR_ASSERT(args != NULL);
   if (args->args == NULL) return;
   for (int i = 0; i < args->num_args; i++) {
+    gpr_free(args->args[i].key);
     if (args->args[i].type == GRPC_ARG_STRING) {
-      // we own string pointers, which were created with gpr_strdup
       gpr_free(args->args[i].value.string);
     }
   }

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -45,16 +45,16 @@ static rb_data_type_t grpc_rb_channel_args_data_type = {
 static int grpc_rb_channel_create_in_process_add_args_hash_cb(VALUE key,
                                                               VALUE val,
                                                               VALUE args_obj) {
-  const char* key_cstr;
+  const char* the_key;
   grpc_channel_args* args;
 
   switch (TYPE(key)) {
     case T_STRING:
-      key_cstr = StringValuePtr(key);
+      the_key = StringValuePtr(key);
       break;
 
     case T_SYMBOL:
-      key_cstr = rb_id2name(SYM2ID(key));
+      the_key = rb_id2name(SYM2ID(key));
       break;
 
     default:
@@ -71,7 +71,7 @@ static int grpc_rb_channel_create_in_process_add_args_hash_cb(VALUE key,
     return ST_STOP;
   }
 
-  args->args[args->num_args - 1].key = gpr_strdup(key_cstr);
+  args->args[args->num_args - 1].key = (char*)the_key;
   switch (TYPE(val)) {
     case T_SYMBOL:
       args->args[args->num_args - 1].type = GRPC_ARG_STRING;
@@ -163,8 +163,8 @@ void grpc_rb_channel_args_destroy(grpc_channel_args* args) {
   GPR_ASSERT(args != NULL);
   if (args->args == NULL) return;
   for (int i = 0; i < args->num_args; i++) {
-    gpr_free(args->args[i].key);
     if (args->args[i].type == GRPC_ARG_STRING) {
+      // we own string pointers, which were created with gpr_strdup
       gpr_free(args->args[i].value.string);
     }
   }

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1026,6 +1026,7 @@ class RubyLanguage(object):
                 "src/ruby/end2end/bad_usage_fork_test.rb",
                 "src/ruby/end2end/prefork_without_using_grpc_test.rb",
                 "src/ruby/end2end/prefork_postfork_loop_test.rb",
+                "src/ruby/end2end/fork_test_repro_35489.rb",
             ]:
                 # Skip fork tests in general until https://github.com/grpc/grpc/issues/34442
                 # is fixed. Otherwise we see too many flakes.


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/35489

Channel args are re-created when using a channel post-fork. So we need to maintain ownership of keys too.

