### PR TITLE
[Build] Bump the required CMake version to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13)
 
 set(PACKAGE_NAME          "grpc")
 set(PACKAGE_VERSION       "1.62.0-dev")

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -31,6 +31,7 @@ android {
                 arguments '-Dhelloworld_GRPC_CPP_PLUGIN_EXECUTABLE=' + grpc_cpp_plugin
                 arguments '-Dprotobuf_INSTALL=OFF'
                 arguments '-Dutf8_range_ENABLE_INSTALL=OFF'
+                version "3.22.1"
             }
         }
         ndk.abiFilters 'x86'
@@ -47,6 +48,7 @@ android {
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
+            version "3.22.1"
         }
     }
 }

--- a/src/android/test/interop/app/build.gradle
+++ b/src/android/test/interop/app/build.gradle
@@ -31,6 +31,7 @@ android {
                 arguments '-DgRPC_CPP_PLUGIN_EXECUTABLE=' + grpc_cpp_plugin
                 arguments '-Dprotobuf_INSTALL=OFF'
                 arguments '-Dutf8_range_ENABLE_INSTALL=OFF'
+                version "3.22.1"
             }
         }
         ndk {
@@ -49,6 +50,7 @@ android {
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
+            version "3.22.1"
         }
     }
 }

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -285,7 +285,7 @@
         protobuf_gen_files.add(src)
   %>
 
-  cmake_minimum_required(VERSION 3.8)
+  cmake_minimum_required(VERSION 3.13)
 
   set(PACKAGE_NAME          "grpc")
   set(PACKAGE_VERSION       "${settings.cpp_version}")

--- a/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
+++ b/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
@@ -45,7 +45,7 @@
   # Install Android NDK & CMake
   # This is not required but desirable to reduce the time to download and the chance of download failure.
   RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
-  RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.18.1'
+  RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.22.1'
 
   # Install gcloud
   RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && ${'\\'}

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -86,7 +86,7 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/interoptest/grpc_interop_pythonasyncio.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_pythonasyncio@sha256:47127a7863097b436613885a8866a2ef055470452838ceebb31f692ac88ac1d1",
     "tools/dockerfile/interoptest/grpc_interop_ruby.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_ruby@sha256:7b044d6848f82234dba81b38d8eca220b608f830f93b42932df59ed6fe20b24d",
     "tools/dockerfile/interoptest/lb_interop_fake_servers.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/lb_interop_fake_servers@sha256:b89a51dd9147e1293f50ee64dd719fce5929ca7894d3770a3d80dbdecb99fd52",
-    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:64ffc5d1e117172ca4dda89720087616830996181192de25fe10e03a88f0b3e5",
+    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:2866e815ceaf7407a9017842b86c1bf1efc96abe77ecff88e932aa1b1ddf727e",
     "tools/dockerfile/test/bazel.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf",
     "tools/dockerfile/test/bazel_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel_arm64@sha256:3b087387c44dee405c1b80d6ff50994e6d8e90a4ef67cc94b4291f1a29c0ef41",
     "tools/dockerfile/test/binder_transport_apk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/binder_transport_apk@sha256:bf60a187cd2ce1abe8b4f32ae6479040a72ca6aa789cd5ab509f60ceb37a41f9",

--- a/tools/dockerfile/test/android_ndk.current_version
+++ b/tools/dockerfile/test/android_ndk.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:61b1d3a9fbbf58be10bb86f024193c069d126c8c@sha256:64ffc5d1e117172ca4dda89720087616830996181192de25fe10e03a88f0b3e5
+us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:7642d2e940a8b14b0f3b63798642869e544d8e01@sha256:2866e815ceaf7407a9017842b86c1bf1efc96abe77ecff88e932aa1b1ddf727e

--- a/tools/dockerfile/test/android_ndk/Dockerfile
+++ b/tools/dockerfile/test/android_ndk/Dockerfile
@@ -121,7 +121,7 @@ RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licens
 # Install Android NDK & CMake
 # This is not required but desirable to reduce the time to download and the chance of download failure.
 RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
-RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.18.1'
+RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.22.1'
 
 # Install gcloud
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && \


### PR DESCRIPTION
We've been trying to upgrade Cmake to 3.13 or later as OSS policy bumped it. But we couldn't as Android has a weird linker error with Cmake 3.18 (you can see the error from https://github.com/grpc/grpc/pull/34331) This PR instead upgrades it to use 3.22 for Android test.