### PR TITLE
[PSM Interop] Add gamma.csm_observability_test to psm-csm Kokoro job

### DIFF
--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -161,6 +161,7 @@ main() {
   test_suites=(
     "gamma.gamma_baseline_test"
     "gamma.affinity_test"
+    "gamma.csm_observability_test"
     "app_net_ssa_test"
   )
   for test in "${test_suites[@]}"; do


### PR DESCRIPTION
Add `gamma.csm_observability_test` test suite to `grpc/core/master/linux/psm-csm` Kokoro job.
