### PR TITLE
[grpc] Helping to keep the maintainer list sorted

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIB
 for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)
+<!-- go/keep-sorted start case=no -->
 - [a11r](https://github.com/a11r), Google LLC
 - [apolcyn](https://github.com/apolcyn), Google LLC
 - [arjunroy](https://github.com/arjunroy), Google LLC
@@ -40,6 +41,7 @@ for general contribution guidelines.
 - [wenbozhu](https://github.com/wenbozhu), Google LLC
 - [yashykt](https://github.com/yashykt), Google LLC
 - [ZhouyihaiDing](https://github.com/ZhouyihaiDing), Google LLC
+<!-- go/keep-sorted end -->
 
 ## Emeritus Maintainers (in alphabetical order)
 - [adelez](https://github.com/adelez), Google LLC


### PR DESCRIPTION
My Google Enterprise Id : https://github.com/tjagtap 

I am making these commits from my personal id because I need to properly document the process for submission to grpc repo by non-googlers.

If safe review and approval are the same thing - Please grant both.

If Safe Review is different from approval - Please only grant the safe review for now,
I need to take a few screenshots before I get the approval. @veblush 

Just adding the # go/keep-sorted to keep this list sorted.

releasenotes:no

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

