### PR TITLE
[ruby] [v1.61.x] Build/test ruby 3.3 and build native gems with Ruby 3.3 support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ task 'gem:native', [:plat] do |t, args|
   verbose = ENV['V'] || '0'
 
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
-  ruby_cc_versions = ['3.2.0', '3.1.0', '3.0.0', '2.7.0'].join(':')
+  ruby_cc_versions = ['3.3.0', '3.2.0', '3.1.0', '3.0.0', '2.7.0'].join(':')
   selected_plat = "#{args[:plat]}"
 
   # use env variable to set artifact build paralellism

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov',          '~> 0.22'
   s.add_development_dependency 'rake',               '~> 13.0'
   s.add_development_dependency 'rake-compiler',      '~> 1.2.1'
-  s.add_development_dependency 'rake-compiler-dock', '~> 1.3'
+  s.add_development_dependency 'rake-compiler-dock', '~> 1.4'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 1.41.0'
   s.add_development_dependency 'signet',             '~> 0.7'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -41,7 +41,7 @@
     s.add_development_dependency 'simplecov',          '~> 0.22'
     s.add_development_dependency 'rake',               '~> 13.0'
     s.add_development_dependency 'rake-compiler',      '~> 1.2.1'
-    s.add_development_dependency 'rake-compiler-dock', '~> 1.3'
+    s.add_development_dependency 'rake-compiler-dock', '~> 1.4'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 1.41.0'
     s.add_development_dependency 'signet',             '~> 0.7'

--- a/third_party/rake-compiler-dock/rake_aarch64-linux.current_version
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux:259a85e5196b3e77c33cb1537e21a295177a7016@sha256:a015b83950b891a61b43cbfcdac5bcdfd62d34ac58652302b3e25633274e942a
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux:b9951a211adf3534ac726c7575199423a543e317@sha256:2ab21c63fc49cd56e2d083d5219dc67134de0e1465edddb3f87e9efdc538910b

--- a/third_party/rake-compiler-dock/rake_aarch64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-aarch64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-aarch64-linux
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_arm64-darwin.current_version
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:842f0f8d43cc078ada34cb0331d589323aac133f@sha256:5e207456cc0cdd67f308023b5cbc6932a6db56e58a537862292e76c8ac2e5f90
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:38eb91d4ddd8567f91c2e04f373f0cccd3425e5e@sha256:16bb1a0746215557f5577e4cd289e10cec593d74b5a3033c9bb2ab4bc3c6662f

--- a/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-arm64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-arm64-darwin

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:0f80d5366a28f03bb836ba4e1b3cb6987bf90207@sha256:4b60f82c8425db2b8fb430833175538aa362cf61d7f88c9c68cbf5970bf8b92c
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:79dc5d2714b6fe06e330fd6f59d2d7124d619904@sha256:8392ae8ca347a6ce4a140ada7c24135de8744523282ad94eef389eafc9f4397e

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-x64-mingw-ucrt
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-x64-mingw-ucrt
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x64-mingw32.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32:6aa6aae6ef0aba70d140718a9f9c9fc8741ebf73@sha256:eab102dc22d88124c78444f35b3a24bb45bce379b147cca0c5b64662ca41a82c
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32:bbe2698a2ef8126b20ac051a3cf2e60349f4571b@sha256:b97c530e1f2b1bd793c743fc961d21b8a52b2dbb8c4d06b3dcf3fce5d8b99500

--- a/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-x64-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-x64-mingw32
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86-linux.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-linux.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux:66ad2a2893389ffe6235ed32b658d198b67ff7da@sha256:c1221bb41bb36ecc2b998431aabdffacec8bacea03dde2c6bf717a71a25975e2
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux:e040af5597a8005687afe45d8156247e598dad8c@sha256:facd2d03737e64f615335156c726b1284f44fff1ae83b1c06fa0c39c176df04a

--- a/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-x86-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-x86-linux
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_x86-mingw32.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:61b946da29a4f0c2829f948ff6afcbcf3ca27292@sha256:909ae31711de69a129bac3b2ed568ccc771f467ec3c712cf2cb142c3cdd6a154
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:aad1cd2120215e5cbe10d74f2148e2c2640af31c@sha256:41f92a60b2b8bec72f3772cb0644860d00c0475b6acdc7062abdd01e6667e3e6

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-x86-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-x86-mingw32
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:e35029584ce9636070e53e0044d29825412ad071@sha256:44865f928d61f97369903673785fcbe0f6a823a60efcd045c025ca9c5579bcee
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:e1be88a89f0500d0d43c7604625ef056d7bc7948@sha256:ba8e38140f69ae8febe01f8b168782ec1f15cd2e59dd61719fd1176404138062

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-x86_64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-x86_64-darwin

--- a/third_party/rake-compiler-dock/rake_x86_64-linux.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux:4d91e9b890dc074d1e185bd387efea18110cf5e6@sha256:91603592860c33da1773711b9422b7ffc8ecb69892d112082be17093f2995095
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux:cbdd9ab7c650280049ed107c95ac12e91e8143ec@sha256:149b949cfe4968963d86dca7e4bc425201efb6be912a996aff952b0003f25ad0

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.3.1-mri-x86_64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.4.0-mri-x86_64-linux
 
 #=================
 # Install ccache

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -19,14 +19,14 @@ accessible to bazel builds.
 """
 
 DOCKERIMAGE_CURRENT_VERSIONS = {
-    "third_party/rake-compiler-dock/rake_aarch64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux@sha256:a015b83950b891a61b43cbfcdac5bcdfd62d34ac58652302b3e25633274e942a",
-    "third_party/rake-compiler-dock/rake_arm64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin@sha256:5e207456cc0cdd67f308023b5cbc6932a6db56e58a537862292e76c8ac2e5f90",
-    "third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt@sha256:4b60f82c8425db2b8fb430833175538aa362cf61d7f88c9c68cbf5970bf8b92c",
-    "third_party/rake-compiler-dock/rake_x64-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32@sha256:eab102dc22d88124c78444f35b3a24bb45bce379b147cca0c5b64662ca41a82c",
-    "third_party/rake-compiler-dock/rake_x86-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux@sha256:c1221bb41bb36ecc2b998431aabdffacec8bacea03dde2c6bf717a71a25975e2",
-    "third_party/rake-compiler-dock/rake_x86-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32@sha256:909ae31711de69a129bac3b2ed568ccc771f467ec3c712cf2cb142c3cdd6a154",
-    "third_party/rake-compiler-dock/rake_x86_64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin@sha256:44865f928d61f97369903673785fcbe0f6a823a60efcd045c025ca9c5579bcee",
-    "third_party/rake-compiler-dock/rake_x86_64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux@sha256:91603592860c33da1773711b9422b7ffc8ecb69892d112082be17093f2995095",
+    "third_party/rake-compiler-dock/rake_aarch64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux@sha256:2ab21c63fc49cd56e2d083d5219dc67134de0e1465edddb3f87e9efdc538910b",
+    "third_party/rake-compiler-dock/rake_arm64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin@sha256:16bb1a0746215557f5577e4cd289e10cec593d74b5a3033c9bb2ab4bc3c6662f",
+    "third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt@sha256:8392ae8ca347a6ce4a140ada7c24135de8744523282ad94eef389eafc9f4397e",
+    "third_party/rake-compiler-dock/rake_x64-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32@sha256:b97c530e1f2b1bd793c743fc961d21b8a52b2dbb8c4d06b3dcf3fce5d8b99500",
+    "third_party/rake-compiler-dock/rake_x86-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux@sha256:facd2d03737e64f615335156c726b1284f44fff1ae83b1c06fa0c39c176df04a",
+    "third_party/rake-compiler-dock/rake_x86-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32@sha256:41f92a60b2b8bec72f3772cb0644860d00c0475b6acdc7062abdd01e6667e3e6",
+    "third_party/rake-compiler-dock/rake_x86_64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin@sha256:ba8e38140f69ae8febe01f8b168782ec1f15cd2e59dd61719fd1176404138062",
+    "third_party/rake-compiler-dock/rake_x86_64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux@sha256:149b949cfe4968963d86dca7e4bc425201efb6be912a996aff952b0003f25ad0",
     "tools/dockerfile/distribtest/cpp_debian10_aarch64_cross_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_debian10_aarch64_cross_x64@sha256:15eeafcd816cb32a0d44da22f654749352a92fec9626dc028b39948897d5bea3",
     "tools/dockerfile/distribtest/cpp_debian10_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_debian10_x64@sha256:904e3db8521697768f94aa08230063b474246184e126f74a41b98a6f4aaf6a49",
     "tools/dockerfile/distribtest/csharp_alpine_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_alpine_x64@sha256:d018105349fcabdc3aa0649c1381d840c613df6b442a53a751d7dc839a80d429",

--- a/tools/internal_ci/helper_scripts/prepare_build_linux_ruby_artifact_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_ruby_artifact_rc
@@ -28,7 +28,7 @@ set +ex
 # but we want to exit if there's a failure
 set -e
 
-RUBY_VERSION=3.2.0
+RUBY_VERSION=3.3.0
 echo "Installing ruby-${RUBY_VERSION}"
 time rvm install "ruby-${RUBY_VERSION}"
 echo "Setting default ruby version."
@@ -41,7 +41,7 @@ set -ex
 ruby --version
 
 # Bundler is required for grpc ruby artifact build.
-gem install bundler -v 2.4
+gem install bundler -v 2.5
 
 # log gem versions for easier debugging if things go wrong
 gem list || true


### PR DESCRIPTION
Cherry-pick of #35399 for `1.61` since release branch appears to have been cut for pre-release builds.

It'd be good to land this for `1.61` since Ruby 3.3 has been out for a few weeks and this is one of the most popular native gems which is blocking some testing/upgrades by users who can't/don't want to build from source.

I read `CONTRIBUTING.md` but not entirely sure if this is needed, or whether the team have a habit of merging from master selectively prior to release. Let me know if this PR is unnecessary for consideration for `1.61` release.

---
Updates ruby-compiler-dock to 1.4.0 which brings Ruby 3.3 final support per https://github.com/rake-compiler/rake-compiler-dock/releases/tag/1.4.0 and starts cross-compiling for ruby 3.3.

As noted in #31991 and https://github.com/grpc/grpc/pull/35399#issuecomment-1886117733 the tests currently don't run on all ruby versions, so this is still an existing gap which this PR does not close, but also doesn't appear to make worse.

FYI @alto-ruby @apolcyn 