### PR TITLE
[Python AIO] Add note for read/write APIs

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_call.py
+++ b/src/python/grpcio/grpc/aio/_base_call.py
@@ -169,6 +169,9 @@ class UnaryStreamCall(
         Read operations must be serialized when called from multiple
         coroutines.
 
+        Note that the iterator and read/write APIs may not be mixed on
+        a single RPC.
+
         Returns:
           A response message, or an `grpc.aio.EOF` to indicate the end of the
           stream.
@@ -181,6 +184,9 @@ class StreamUnaryCall(
     @abstractmethod
     async def write(self, request: RequestType) -> None:
         """Writes one message to the stream.
+
+        Note that the iterator and read/write APIs may not be mixed on
+        a single RPC.
 
         Raises:
           An RpcError exception if the write failed.
@@ -223,6 +229,9 @@ class StreamStreamCall(
         Read operations must be serialized when called from multiple
         coroutines.
 
+        Note that the iterator and read/write APIs may not be mixed on
+        a single RPC.
+
         Returns:
           A response message, or an `grpc.aio.EOF` to indicate the end of the
           stream.
@@ -231,6 +240,9 @@ class StreamStreamCall(
     @abstractmethod
     async def write(self, request: RequestType) -> None:
         """Writes one message to the stream.
+
+        Note that the iterator and read/write APIs may not be mixed on
+        a single RPC.
 
         Raises:
           An RpcError exception if the write failed.


### PR DESCRIPTION
Fix: https://github.com/grpc/grpc/issues/35061

Add note to indicate that iterator and read/write APIs can't be mixed in a single RPC.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

