### PR TITLE
[GPR] Removed GPR_BACKWARDS_COMPATIBILITY_MODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ set(gRPC_BUILD_MSVC_MP_COUNT 0 CACHE STRING "The maximum number of processes for
 # Options
 option(gRPC_BUILD_TESTS "Build tests" OFF)
 option(gRPC_BUILD_CODEGEN "Build codegen" ON)
-option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
 
 set(gRPC_INSTALL_default ON)
 if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -285,14 +284,6 @@ if(gRPC_USE_PROTO_LITE)
   add_definitions("-DGRPC_USE_PROTO_LITE")
 else()
   set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf")
-endif()
-
-if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
-  add_definitions(-DGPR_BACKWARDS_COMPATIBILITY_MODE)
-  if(_gRPC_PLATFORM_MAC)
-    # some C++11 constructs not supported before OS X 10.10
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
-  endif()
 endif()
 
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)

--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -19,14 +19,6 @@
 #ifndef GRPC_SUPPORT_PORT_PLATFORM_H
 #define GRPC_SUPPORT_PORT_PLATFORM_H
 
-/*
- * Define GPR_BACKWARDS_COMPATIBILITY_MODE to try harder to be ABI
- * compatible with older platforms (currently only on Linux)
- * Causes:
- *  - some libc calls to be gotten via dlsym
- *  - some syscalls to be made directly
- */
-
 // [[deprecated]] attribute is only available since C++14
 #if __cplusplus >= 201402L
 #define GRPC_DEPRECATED(reason) [[deprecated(reason)]]
@@ -524,18 +516,6 @@
 #error "Could not auto-detect platform"
 #endif
 #endif /* GPR_NO_AUTODETECT_PLATFORM */
-
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE)
-/*
- * For backward compatibility mode, reset _FORTIFY_SOURCE to prevent
- * a library from having non-standard symbols such as __asprintf_chk.
- * This helps non-glibc systems such as alpine using musl to find symbols.
- */
-#if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0
-#undef _FORTIFY_SOURCE
-#define _FORTIFY_SOURCE 0
-#endif
-#endif
 
 #if defined(__has_include)
 #if __has_include(<atomic>)

--- a/setup.py
+++ b/setup.py
@@ -194,12 +194,6 @@ USE_PREBUILT_GRPC_CORE = _env_bool_value(
     "GRPC_PYTHON_USE_PREBUILT_GRPC_CORE", "False"
 )
 
-# If this environmental variable is set, GRPC will not try to be compatible with
-# libc versions old than the one it was compiled against.
-DISABLE_LIBC_COMPATIBILITY = _env_bool_value(
-    "GRPC_PYTHON_DISABLE_LIBC_COMPATIBILITY", "False"
-)
-
 # Environment variable to determine whether or not to enable coverage analysis
 # in Cython modules.
 ENABLE_CYTHON_TRACING = _env_bool_value(
@@ -424,9 +418,6 @@ if asm_key:
     asm_files = grpc_core_dependencies.ASM_SOURCE_FILES[asm_key]
 else:
     DEFINE_MACROS += (("OPENSSL_NO_ASM", 1),)
-
-if not DISABLE_LIBC_COMPATIBILITY:
-    DEFINE_MACROS += (("GPR_BACKWARDS_COMPATIBILITY_MODE", 1),)
 
 if "win32" in sys.platform:
     # TODO(zyc): Re-enable c-ares on x64 and x86 windows after fixing the

--- a/src/core/lib/gpr/posix/time.cc
+++ b/src/core/lib/gpr/posix/time.cc
@@ -74,12 +74,7 @@ static gpr_timespec now_impl(gpr_clock_type clock_type) {
     gpr_precise_clock_now(&ret);
     return ret;
   } else {
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE) && defined(__linux__)
-    // avoid ABI problems by invoking syscalls directly
-    syscall(SYS_clock_gettime, clockid_for_gpr_clock[clock_type], &now);
-#else
     clock_gettime(clockid_for_gpr_clock[clock_type], &now);
-#endif
     if (clock_type == GPR_CLOCK_MONOTONIC) {
       // Add 5 seconds arbitrarily: avoids weird conditions in gprpp/time.cc
       // when there's a small number of seconds returned.

--- a/src/core/lib/gprpp/linux/env.cc
+++ b/src/core/lib/gprpp/linux/env.cc
@@ -29,10 +29,6 @@
 
 #ifdef GPR_LINUX_ENV
 
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE)
-#include <dlfcn.h>
-#endif
-
 #include <features.h>
 #include <stdlib.h>
 
@@ -42,21 +38,7 @@ namespace grpc_core {
 
 absl::optional<std::string> GetEnv(const char* name) {
   char* result = nullptr;
-#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE)
-  typedef char* (*getenv_type)(const char*);
-  static getenv_type getenv_func = nullptr;
-  // Check to see which getenv variant is supported (go from most
-  // to least secure)
-  if (getenv_func == nullptr) {
-    for (auto name : {"secure_getenv", "__secure_getenv", "getenv"}) {
-      getenv_func = reinterpret_cast<getenv_type>(dlsym(RTLD_DEFAULT, name));
-      if (getenv_func != nullptr) {
-        break;
-      }
-    }
-  }
-  result = getenv_func(name);
-#elif __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)
   result = secure_getenv(name);
 #else
   result = getenv(name);

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -111,7 +111,6 @@ if apple_toolchain && !cross_compiling
   end
 end
 
-env_append 'CPPFLAGS', '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_NAME_SUFFIX="\"RUBY\""'
 
 require_relative '../../lib/grpc/version'

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -312,7 +312,6 @@
   # Options
   option(gRPC_BUILD_TESTS "Build tests" OFF)
   option(gRPC_BUILD_CODEGEN "Build codegen" ON)
-  option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
 
   set(gRPC_INSTALL_default ON)
   if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -440,14 +439,6 @@
     add_definitions("-DGRPC_USE_PROTO_LITE")
   else()
     set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf")
-  endif()
-
-  if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
-    add_definitions(-DGPR_BACKWARDS_COMPATIBILITY_MODE)
-    if(_gRPC_PLATFORM_MAC)
-      # some C++11 constructs not supported before OS X 10.10
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.10)
-    endif()
   endif()
 
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)

--- a/third_party/cares/config_android/ares_config.h
+++ b/third_party/cares/config_android/ares_config.h
@@ -66,15 +66,8 @@
 /* Define to 1 if bool is an available type. */
 #define HAVE_BOOL_T
 
-/* Define HAVE_CLOCK_GETTIME_MONOTONIC if you have the clock_gettime
- * function and monotonic timer.
- *
- * IMPORTANT: gRPC MANUAL EDIT HERE!
- * Note: setting HAVE_CLOCK_GETTIME_MONOTONIC causes use of the clock_gettime
- * function from glibc, don't set it to support glibc < 2.17 */
-#ifndef GPR_BACKWARDS_COMPATIBILITY_MODE
-  #define HAVE_CLOCK_GETTIME_MONOTONIC
-#endif
+/* Define to 1 if you have the clock_gettime function and monotonic timer. */
+#define HAVE_CLOCK_GETTIME_MONOTONIC 1
 
 /* Define to 1 if you have the closesocket function. */
 /* #undef HAVE_CLOSESOCKET */
@@ -430,32 +423,3 @@
 
 /* Type to use in place of in_addr_t when system does not provide it. */
 #undef in_addr_t
-
-#ifdef GPR_BACKWARDS_COMPATIBILITY_MODE
-  /* IMPORTANT: gRPC MANUAL EDIT HERE!
-   * Redefine the fd_set macros for GLIBC < 2.15 support.
-   * This is a backwards compatibility hack. At version 2.15, GLIBC introduces
-   * the __fdelt_chk function, and starts using it within its fd_set macros
-   * (which c-ares uses). For compatibility with GLIBC < 2.15, we need to redefine
-   * the fd_set macros to not use __fdelt_chk. */
-  #include <sys/select.h>
-  #undef FD_SET
-  #undef FD_CLR
-  #undef FD_ISSET
-  /* 'FD_ZERO' doesn't use __fdelt_chk, no need to redefine. */
-
-  #ifdef __FDS_BITS
-    #define GRPC_CARES_FDS_BITS(set) __FDS_BITS(set)
-  #else
-    #define GRPC_CARES_FDS_BITS(set) ((set)->fds_bits)
-  #endif
-
-  #define GRPC_CARES_FD_MASK(d) ((long int)(1UL << (d) % NFDBITS))
-
-  #define FD_SET(d, set) \
-      ((void) (GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] |= GRPC_CARES_FD_MASK(d)))
-  #define FD_CLR(d, set) \
-      ((void) (GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] &= ~GRPC_CARES_FD_MASK(d)))
-  #define FD_ISSET(d, set) \
-      ((GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] & GRPC_CARES_FD_MASK(d)) != 0)
-#endif /* GPR_BACKWARDS_COMPATIBILITY_MODE */

--- a/third_party/cares/config_linux/ares_config.h
+++ b/third_party/cares/config_linux/ares_config.h
@@ -66,15 +66,8 @@
 /* Define to 1 if bool is an available type. */
 #define HAVE_BOOL_T
 
-/* Define HAVE_CLOCK_GETTIME_MONOTONIC if you have the clock_gettime
- * function and monotonic timer.
- *
- * IMPORTANT: gRPC MANUAL EDIT HERE!
- * Note: setting HAVE_CLOCK_GETTIME_MONOTONIC causes use of the clock_gettime
- * function from glibc, don't set it to support glibc < 2.17 */
-#ifndef GPR_BACKWARDS_COMPATIBILITY_MODE
-  #define HAVE_CLOCK_GETTIME_MONOTONIC
-#endif
+/* Define to 1 if you have the clock_gettime function and monotonic timer. */
+#define HAVE_CLOCK_GETTIME_MONOTONIC 1
 
 /* Define to 1 if you have the closesocket function. */
 /* #undef HAVE_CLOSESOCKET */
@@ -430,32 +423,3 @@
 
 /* Type to use in place of in_addr_t when system does not provide it. */
 #undef in_addr_t
-
-#ifdef GPR_BACKWARDS_COMPATIBILITY_MODE
-  /* IMPORTANT: gRPC MANUAL EDIT HERE!
-   * Redefine the fd_set macros for GLIBC < 2.15 support.
-   * This is a backwards compatibility hack. At version 2.15, GLIBC introduces
-   * the __fdelt_chk function, and starts using it within its fd_set macros
-   * (which c-ares uses). For compatibility with GLIBC < 2.15, we need to redefine
-   * the fd_set macros to not use __fdelt_chk. */
-  #include <sys/select.h>
-  #undef FD_SET
-  #undef FD_CLR
-  #undef FD_ISSET
-  /* 'FD_ZERO' doesn't use __fdelt_chk, no need to redefine. */
-
-  #ifdef __FDS_BITS
-    #define GRPC_CARES_FDS_BITS(set) __FDS_BITS(set)
-  #else
-    #define GRPC_CARES_FDS_BITS(set) ((set)->fds_bits)
-  #endif
-
-  #define GRPC_CARES_FD_MASK(d) ((long int)(1UL << (d) % NFDBITS))
-
-  #define FD_SET(d, set) \
-      ((void) (GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] |= GRPC_CARES_FD_MASK(d)))
-  #define FD_CLR(d, set) \
-      ((void) (GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] &= ~GRPC_CARES_FD_MASK(d)))
-  #define FD_ISSET(d, set) \
-      ((GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] & GRPC_CARES_FD_MASK(d)) != 0)
-#endif /* GPR_BACKWARDS_COMPATIBILITY_MODE */


### PR DESCRIPTION
`GPR_BACKWARDS_COMPATIBILITY_MODE` was devised to support old Linux kernel with old glibc but gRPC is now expected to support glibc 2.17 and later (2.17 is derived from the oldest but supported Linux distro, CentOS 7). Effectively, gRPC doesn't need `GPR_BACKWARDS_COMPATIBILITY_MODE` anymore. Hence, let's remove it.

gRPC Python and Ruby that distribute binary artifacts already began to use `manylinux` environment dealing with this issue in a better way so they don't need this flag anymore.