### PR TITLE
Enable service config resolution with c-ares by default

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -208,7 +208,7 @@ AresClientChannelDNSResolver::AresClientChannelDNSResolver(
       request_service_config_(
           !channel_args()
                .GetBool(GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION)
-               .value_or(true)),
+               .value_or(false)),
       enable_srv_queries_(channel_args()
                               .GetBool(GRPC_ARG_DNS_ENABLE_SRV_QUERIES)
                               .value_or(false)),


### PR DESCRIPTION
Currently, service configuration lookup in DNS TXT records is disabled by default and requires clients to set `GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION` to false, as introduced in commit 93b7acd.

Considering my understanding of service configuration and the merged [error handling proposal](https://github.com/grpc/proposal/pull/100), it may seem reasonable to make it the default now.
