### PR TITLE
ssl_transport_security.cc: Make it compile with libressl

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2082,7 +2082,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
 #else
   ssl_context = SSL_CTX_new(TLSv1_2_method());
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10101000
+#if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
   SSL_CTX_set_options(ssl_context, SSL_OP_NO_RENEGOTIATION);
 #endif
   if (ssl_context == nullptr) {
@@ -2185,7 +2185,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
                                      nullptr);
   }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
   if (options->crl_provider != nullptr) {
     SSL_CTX_set_ex_data(impl->ssl_context, g_ssl_ctx_ex_crl_provider_index,
                         options->crl_provider.get());
@@ -2302,7 +2302,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 #else
       impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10101000
+#if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
       SSL_CTX_set_options(impl->ssl_contexts[i], SSL_OP_NO_RENEGOTIATION);
 #endif
       if (impl->ssl_contexts[i] == nullptr) {
@@ -2389,7 +2389,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
           break;
       }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
+#if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
       if (options->crl_provider != nullptr) {
         SSL_CTX_set_ex_data(impl->ssl_contexts[i],
                             g_ssl_ctx_ex_crl_provider_index,


### PR DESCRIPTION
Compiling grpc latest master [1] on Windows 10 Pro using MSVC 2019 and using LibreSSL 3.8.2 as SSL provider (package) does currently not work, as the functions X509_STORE_set_get_crl/X509_STORE_set_check_crl and the define SSL_OP_NO_RENEGOTIATION are not present.

Employ a workaround seen in the surrounding code by making the code block only for openssl available.

[1]: 24f89637 ([Test] Removed obsolete node test from run_tests.py (#35525), 2024-01-19)
