### PR TITLE
[ObjC] add privacy manifests to boringssl grpc

### DIFF
--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -124,7 +124,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = 'src'
 
     ss.resource_bundles = {
-      s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+      s.module_name => 'src/PrivacyInfo.xcprivacy'
     }
 
     ss.source_files = 'src/ssl/*.{h,c,cc}',
@@ -689,6 +689,16 @@ Pod::Spec.new do |s|
       Wakc8+BjAUEM+xrF8G7bU4XRfSnBNUFNazq8w9xJ6nPNKHVW53WH3E4DXUQc74M63K56B6GuNOLa24gZ
       Jq0aVQND6Yw85rfNdhzPO5g1Sys4QKiPIuizghfbI6QRd9+2Lyrf1y9VXjbKHgOIJwh//9v/AXNDsFL5
       zwQA
+    EOF
+
+    # PrivacyInfo.xcprivacy is not part of BoringSSL repo, inject it during pod installation
+    base64 --decode $opts <<EOF | gunzip > src/PrivacyInfo.xcprivacy
+      H4sICAAAAAAC/1ByaXZhY3lJbmZvLnhjcHJpdmFjeQC1kl9PwjAUxZ/Hp6h9Z1di/JsxAhskJAQXGQ8+
+      Nt0VG7a1aRuw395OHUhE8UHflrNzzj2/pNHgpSrJBrURsu7TXnhOCdZcFqJe9ekyn3Rv6CDuRGfpfZI/
+      ZmOiSmEsyZaj2TQhtAswVKpEgDRPSTabLnLiOwDGc0ros7XqDmC73YascYVcVo3RQKalQm3dzJd1fSAs
+      bEH9mff2gzleLQS3cSeI1uji+SLTYsO4yzXja78ygkb2f59YaRC++BJZlsgtFimzLHcKzS7BtGYOvm1O
+      ZcVEfdI+5ByNwWKYTY/U+4+gBQh+TrZBbzNW+wFHnQmzuJLaTUSJuajQWFapCD4SJ488IDNyDxV8mrm/
+      m1z1rsPeYSnscaDl+RewhTMWq5GUtsH7Y7KLy8ntL8h2WqtE8PY0484rAb5xoDEDAAA=
     EOF
 
     # We are renaming openssl to openssl_grpc so that there is no conflict with openssl if it exists

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -17,13 +17,14 @@
     # bytes from this file, then delete the intermediate file.
     #
     # TODO(mxyan): move to python3 style gzip compression when possible
-    def compress_boringssl_prefix_header():
+    def compress_and_encode_file(filepath):
+      gzip_filepath = filepath + '.gz'
       import gzip, shutil, os, base64
-      with open('src/boringssl/boringssl_prefix_symbols.h', 'rb') as f_in, gzip.GzipFile('src/boringssl/boringssl_prefix_symbols.h.gz', 'w', mtime=0.0) as f_out:
+      with open(filepath, 'rb') as f_in, gzip.GzipFile(gzip_filepath, 'w', mtime=0.0) as f_out:
         shutil.copyfileobj(f_in, f_out)
-      with open('src/boringssl/boringssl_prefix_symbols.h.gz', 'rb') as f_in:
+      with open(gzip_filepath, 'rb') as f_in:
         prefix_gz = f_in.read()
-      os.remove('src/boringssl/boringssl_prefix_symbols.h.gz')
+      os.remove(gzip_filepath)
       prefix_gz_b64 = base64.b64encode(prefix_gz)
       WRAP_LENGTH=80
       prefix_gz_b64_wrapped = [prefix_gz_b64[i:i+WRAP_LENGTH] for i in range(0, len(prefix_gz_b64), WRAP_LENGTH)]
@@ -154,7 +155,7 @@
       ss.header_mappings_dir = 'src'
 
       ss.resource_bundles = {
-        s.module_name => 'src/objective-c/PrivacyInfo.xcprivacy'
+        s.module_name => 'src/PrivacyInfo.xcprivacy'
       }
 
       ss.source_files = 'src/ssl/*.{h,c,cc}',
@@ -205,7 +206,14 @@
              *) opts="--ignore-garbage" ;;
       esac
       base64 --decode $opts <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
-        % for line in compress_boringssl_prefix_header():
+        % for line in compress_and_encode_file('src/boringssl/boringssl_prefix_symbols.h'):
+        ${line.decode('utf-8')}
+        % endfor
+      EOF
+
+      # PrivacyInfo.xcprivacy is not part of BoringSSL repo, inject it during pod installation
+      base64 --decode $opts <<EOF | gunzip > src/PrivacyInfo.xcprivacy
+        % for line in compress_and_encode_file('src/objective-c/PrivacyInfo.xcprivacy'):
         ${line.decode('utf-8')}
         % endfor
       EOF


### PR DESCRIPTION
BoringSSL-GRPC uses sources from https://github.com/google/boringssl.git, which doesn't contain PrivacyInfo.xcprivacy file.
This PR embeds the manifest data into the podspec and extract during pod install, similar to file boringssl_prefix_symbols.h

--
Will need to regenerate the podspec after #35542 merged.