### PR TITLE
[cds LB] obtain dynamic subscription even if cluster is present in XdsConfig

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/cds.cc
@@ -298,14 +298,14 @@ absl::Status CdsLb::UpdateLocked(UpdateArgs args) {
   if (new_config->is_dynamic() && subscription_ == nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_cds_lb_trace)) {
       gpr_log(GPR_INFO,
-              "[cdslb %p] obtaining dynamic subscription for cluster %s",
-              this, cluster_name_.c_str());
+              "[cdslb %p] obtaining dynamic subscription for cluster %s", this,
+              cluster_name_.c_str());
     }
     auto* dependency_mgr = args.args.GetObject<XdsDependencyManager>();
     if (dependency_mgr == nullptr) {
       // Should never happen.
-      absl::Status status = absl::InternalError(
-          "xDS dependency mgr not passed to CDS LB policy");
+      absl::Status status =
+          absl::InternalError("xDS dependency mgr not passed to CDS LB policy");
       ReportTransientFailure(status);
       return status;
     }


### PR DESCRIPTION
This ensures that if a cluster is used both in the RouteConfig and via a ClusterSpecifierPlugin, and then the entry in the RouteConfig goes away, we won't unsubscribe and then resubscribe to the CDS resource.