### PR TITLE
Add error message when virtualenv is not installed and running on glinux

### DIFF
--- a/tools/buildgen/generate_projects.sh
+++ b/tools/buildgen/generate_projects.sh
@@ -36,7 +36,23 @@ tools/buildgen/build_cleaner.py build_handwritten.yaml
 
 # /usr/local/google/home/rbellevi/dev/tmp/grpc/venv/bin/python3: No module named virtualenv
 # Generate xds-protos
-[[ -d generate_projects_virtual_environment ]] || { python3 -m pip install virtualenv --upgrade && python3 -m virtualenv generate_projects_virtual_environment; }
+if [[ ! -d generate_projects_virtual_environment ]]; then
+  if ! python3 -m pip freeze | grep virtualenv &>/dev/null; then
+    echo "virtualenv Python module not installed. Attempting to install via pip." >/dev/stderr
+    if INSTALL_OUTPUT=$(! python3 -m pip install virtualenv --upgrade &>/dev/stdout); then
+      echo "$INSTALL_OUTPUT"
+      if echo "$INSTALL_OUTPUT" | grep "externally managed" &>/dev/null; then
+        echo >/dev/stderr
+        echo "############################" >/dev/stderr
+        echo  "Your administrator is _insisting_ on managing your packages themself. Try running \`sudo apt-get install python3-virtualenv\`" >/dev/stderr
+        echo "############################" >/dev/stderr
+      fi
+      exit 1
+    fi
+  fi 
+  python3 -m virtualenv generate_projects_virtual_environment
+fi
+
 generate_projects_virtual_environment/bin/pip install --upgrade --ignore-installed grpcio-tools==1.59.0
 generate_projects_virtual_environment/bin/python tools/distrib/python/xds_protos/build.py
 


### PR DESCRIPTION
Example:

```
virtualenv Python module not installed. Attempting to install via pip.                                                                                                                                              
error: externally-managed-environment                                                                                                                                                                               
                                                                                                                                                                                                                    
× This environment is externally managed                                                                                                                                                                            
╰─> To install Python packages system-wide, try apt install                                                                                                                                                         
    python3-xyz, where xyz is the package you are trying to                                                                                                                                                         
    install.                                                                                                                                                                                                        
                                                                                                                                                                                                                    
    If you wish to install a non-Debian-packaged Python package,                                                                                                                                                    
    create a virtual environment using python3 -m venv path/to/venv.                                                                                                                                                
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make                                                                                                                                                 
    sure you have python3-full installed.                                                                                                                                                                           
                                                                                                                                                                                                                    
    If you wish to install a non-Debian packaged Python application,                                                                                                                                                
    it may be easiest to use pipx install xyz, which will manage a                                                                                                                                                  
    virtual environment for you. Make sure you have pipx installed.                                                                                                                                                 
                                                                                                                                                                                                                    
    See /usr/share/doc/python3.11/README.venv for more information.                                                                                                                                                 
                                                                                                                                                                                                                    
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.                                                                                                                                                                                                         
hint: See PEP 668 for the detailed specification.                                                                                                                                                                   
                                                                                                                                                                                                                    
############################                                                                                                                                                                                        
Your administrator is _insisting_ on managing your packages themself. Try running `sudo apt-get install python3-virtualenv`                                                                                         
############################
```