### PR TITLE
[CI] Removed dbg test from at-head tests

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -71,8 +71,7 @@ fi
 
 tools/buildgen/generate_projects.sh
 
-
 # commit so that changes are passed to Docker
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl --inner_jobs 16 -j 2 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg --inner_jobs 16 -j 2 --internal_ci --build_only


### PR DESCRIPTION
Removing dbg test is helpful to cut back half the total test time and dbg test is not necessarily as opt test is included. 

