### PR TITLE
[CSM o11y] Re-experimentalize CSM OTel Plugin Option

### DIFF
--- a/include/grpcpp/ext/csm_observability.h
+++ b/include/grpcpp/ext/csm_observability.h
@@ -90,8 +90,6 @@ class CsmObservabilityBuilder {
   std::unique_ptr<grpc::internal::OpenTelemetryPluginBuilderImpl> builder_;
 };
 
-}  // namespace experimental
-
 /// Creates an OpenTelemetryPluginOption that would add additional labels on
 /// gRPC metrics to enhance observability for CSM users.
 ///
@@ -102,6 +100,7 @@ class CsmObservabilityBuilder {
 ///     .BuildAndRegisterGlobal();
 std::unique_ptr<OpenTelemetryPluginOption> MakeCsmOpenTelemetryPluginOption();
 
+}  // namespace experimental
 }  // namespace grpc
 
 #endif  // GRPCPP_EXT_CSM_OBSERVABILITY_H

--- a/src/cpp/ext/csm/csm_observability.cc
+++ b/src/cpp/ext/csm/csm_observability.cc
@@ -141,10 +141,9 @@ absl::StatusOr<CsmObservability> CsmObservabilityBuilder::BuildAndRegister() {
   return CsmObservability();
 }
 
-}  // namespace experimental
-
 std::unique_ptr<OpenTelemetryPluginOption> MakeCsmOpenTelemetryPluginOption() {
   return std::make_unique<grpc::internal::CsmOpenTelemetryPluginOption>();
 }
 
+}  // namespace experimental
 }  // namespace grpc

--- a/test/cpp/ext/csm/csm_observability_test.cc
+++ b/test/cpp/ext/csm/csm_observability_test.cc
@@ -65,7 +65,7 @@ TEST(CsmChannelTargetSelectorTest, XdsTargetsWithTDAuthority) {
 
 TEST(CsmPluginOptionTest, Basic) {
   OpenTelemetryPluginBuilder()
-      .AddPluginOption(MakeCsmOpenTelemetryPluginOption())
+      .AddPluginOption(experimental::MakeCsmOpenTelemetryPluginOption())
       .BuildAndRegisterGlobal();
 }
 

--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -404,7 +404,7 @@ void EnableCsmObservability() {
       std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
   meter_provider->AddMetricReader(std::move(prometheus_exporter));
   grpc::OpenTelemetryPluginBuilder()
-      .AddPluginOption(grpc::MakeCsmOpenTelemetryPluginOption())
+      .AddPluginOption(grpc::experimental::MakeCsmOpenTelemetryPluginOption())
       .SetMeterProvider(std::move(meter_provider))
       .BuildAndRegisterGlobal();
 }

--- a/test/cpp/interop/xds_interop_server.cc
+++ b/test/cpp/interop/xds_interop_server.cc
@@ -55,7 +55,7 @@ void EnableCsmObservability() {
       std::make_shared<opentelemetry::sdk::metrics::MeterProvider>();
   meter_provider->AddMetricReader(std::move(prometheus_exporter));
   grpc::OpenTelemetryPluginBuilder()
-      .AddPluginOption(grpc::MakeCsmOpenTelemetryPluginOption())
+      .AddPluginOption(grpc::experimental::MakeCsmOpenTelemetryPluginOption())
       .SetMeterProvider(std::move(meter_provider))
       .BuildAndRegisterGlobal();
 }


### PR DESCRIPTION
We are no longer sure about this API, so re-experimentalizing it.

This PR will be backported to 1.61 as well.