### PR TITLE
Revert "[EventEngine] Enable the EventEngine DNS Resolver on Posix (#35573)"

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -218,6 +218,9 @@ EXPERIMENTS = {
             "bad_client_test": [
                 "rfc_max_concurrent_streams",
             ],
+            "cancel_ares_query_test": [
+                "event_engine_dns",
+            ],
             "compression_test": [
                 "v3_compression_filter",
             ],
@@ -254,6 +257,9 @@ EXPERIMENTS = {
             "logging_test": [
                 "promise_based_server_call",
             ],
+            "resolver_component_tests_runner_invoker": [
+                "event_engine_dns",
+            ],
             "resource_quota_test": [
                 "free_large_allocator",
                 "unconstrained_max_quota_buffer_size",
@@ -264,9 +270,6 @@ EXPERIMENTS = {
             ],
         },
         "on": {
-            "cancel_ares_query_test": [
-                "event_engine_dns",
-            ],
             "core_end2end_test": [
                 "event_engine_listener",
             ],
@@ -286,9 +289,6 @@ EXPERIMENTS = {
                 "pick_first_happy_eyeballs",
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
-            ],
-            "resolver_component_tests_runner_invoker": [
-                "event_engine_dns",
             ],
             "surface_registered_method_lookup": [
                 "registered_method_lookup_in_transport",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -717,7 +717,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_client", description_event_engine_client,
      additional_constraints_event_engine_client, nullptr, 0, false, true},
     {"event_engine_dns", description_event_engine_dns,
-     additional_constraints_event_engine_dns, nullptr, 0, true, false},
+     additional_constraints_event_engine_dns, nullptr, 0, false, false},
     {"event_engine_listener", description_event_engine_listener,
      additional_constraints_event_engine_listener, nullptr, 0, true, true},
     {"free_large_allocator", description_free_large_allocator,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -195,8 +195,7 @@ inline bool IsCanaryClientPrivacyEnabled() { return false; }
 inline bool IsClientIdlenessEnabled() { return true; }
 inline bool IsClientPrivacyEnabled() { return false; }
 inline bool IsEventEngineClientEnabled() { return false; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
-inline bool IsEventEngineDnsEnabled() { return true; }
+inline bool IsEventEngineDnsEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
 inline bool IsEventEngineListenerEnabled() { return true; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -60,7 +60,7 @@
   default:
     # not tested on iOS at all
     ios: broken
-    posix: true
+    posix: false
     # TODO(yijiem): resolve when the WindowsEventEngine DNS Resolver is
     # implemented
     windows: broken

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -32,7 +32,6 @@
 #include <grpc++/grpc++.h>
 #include <grpcpp/opencensus.h>
 
-#include "src/core/lib/experiments/experiments.h"
 #include "src/cpp/ext/filters/census/context.h"
 #include "src/cpp/ext/filters/census/grpc_plugin.h"
 #include "src/cpp/ext/filters/census/open_census_call_tracer.h"
@@ -663,14 +662,8 @@ TEST_F(StatsPluginEnd2EndTest,
   auto sent_span_data =
       GetSpanByName(recorded_spans, absl::StrCat("Sent.", client_method_name_));
   ASSERT_NE(sent_span_data, recorded_spans.end());
-  // TODO(yijiem): the EventEngine DNS resolver might be faster in getting the
-  // result before TryCheckResolution and the call would not be queued:
-  // https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/client_channel.cc#L2340.
-  // We could use a FakeResolver and introduce a delay to deflake this test.
-  if (!grpc_core::IsEventEngineDnsEnabled()) {
-    EXPECT_TRUE(IsAnnotationPresent(sent_span_data,
-                                    "Delayed name resolution complete."));
-  }
+  EXPECT_TRUE(
+      IsAnnotationPresent(sent_span_data, "Delayed name resolution complete."));
   // Check presence of trace annotation for removal from channel's pending
   // lb pick queue.
   auto attempt_span_data = GetSpanByName(


### PR DESCRIPTION


This reverts commit 6318e9e7e98fa8076dfb78c4446073bc09221c30.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

