### PR TITLE
[experiment] Stop testing promise_based_client_call due to leak

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -70,7 +70,6 @@ EXPERIMENTS = {
                 "v3_compression_filter",
             ],
             "core_end2end_test": [
-                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -88,9 +87,6 @@ EXPERIMENTS = {
                 "rstpit",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "lame_client_test": [
-                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",
@@ -149,7 +145,6 @@ EXPERIMENTS = {
                 "v3_compression_filter",
             ],
             "core_end2end_test": [
-                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -167,9 +162,6 @@ EXPERIMENTS = {
                 "rstpit",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "lame_client_test": [
-                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",
@@ -226,7 +218,6 @@ EXPERIMENTS = {
             ],
             "core_end2end_test": [
                 "event_engine_client",
-                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -247,9 +238,6 @@ EXPERIMENTS = {
                 "rstpit",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "lame_client_test": [
-                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -87,7 +87,7 @@
 - name: pick_first_happy_eyeballs
   default: true
 - name: promise_based_client_call
-  default: false
+  default: broken
 - name: promise_based_server_call
   default: false
 - name: registered_method_lookup_in_transport


### PR DESCRIPTION
There's roughly a 25% flake of a leak, blocking PR submission due to ASAN failures. Example: https://source.cloud.google.com/results/invocations/5d9fc8b9-c64f-4aaa-bbe6-2fb5f8fd0b24/targets/%2F%2Ftest%2Fcore%2Fend2end:negative_deadline_test@poller%3Dpoll@experiment%3Dpromise_based_client_call/log

Reproducible via: `bazel test --config=asan --test_env=GRPC_VERBOSITY=debug --test_filter='**' --test_sharding_strategy=disabled --runs_per_test=100 -- //test/core/end2end:negative_deadline_test@poller=poll@experiment=promise_based_client_call`