### PR TITLE
[Build Reproducibility] Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -372,7 +372,8 @@ if BUILD_WITH_SYSTEM_RE2:
     EXTENSION_LIBRARIES += ("re2",)
 if BUILD_WITH_SYSTEM_ABSL:
     EXTENSION_LIBRARIES += tuple(
-        lib.stem[3:] for lib in sorted(pathlib.Path("/usr").glob("lib*/libabsl_*.so"))
+        lib.stem[3:]
+        for lib in sorted(pathlib.Path("/usr").glob("lib*/libabsl_*.so"))
     )
 
 DEFINE_MACROS = (("_WIN32_WINNT", 0x600),)

--- a/setup.py
+++ b/setup.py
@@ -372,7 +372,7 @@ if BUILD_WITH_SYSTEM_RE2:
     EXTENSION_LIBRARIES += ("re2",)
 if BUILD_WITH_SYSTEM_ABSL:
     EXTENSION_LIBRARIES += tuple(
-        lib.stem[3:] for lib in pathlib.Path("/usr").glob("lib*/libabsl_*.so")
+        lib.stem[3:] for lib in sorted(pathlib.Path("/usr").glob("lib*/libabsl_*.so"))
     )
 
 DEFINE_MACROS = (("_WIN32_WINNT", 0x600),)


### PR DESCRIPTION
Sort input file list
so that the `.so` file builds in a reproducible way
in spite of non-deterministic filesystem readdir order and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

