### PR TITLE
[EventEngine] Fix HttpCli test to deail with EventEngine async execution

### DIFF
--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -43,6 +43,7 @@
 
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"
 #include "src/core/lib/gpr/subprocess.h"
+#include "src/core/lib/gprpp/notification.h"
 #include "src/core/lib/gprpp/status_helper.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/gprpp/time_util.h"
@@ -147,6 +148,7 @@ struct RequestState {
   bool done = false;
   grpc_http_response response = {};
   grpc_pollset_set* pollset_set_to_destroy_eagerly = nullptr;
+  grpc_core::Notification callback_finished;
 };
 
 void OnFinish(void* arg, grpc_error_handle error) {
@@ -185,6 +187,12 @@ void OnFinishExpectFailure(void* arg, grpc_error_handle error) {
   GPR_ASSERT(!error.ok());
   request_state->test->RunAndKick(
       [request_state]() { request_state->done = true; });
+}
+
+void OnFinishExpectFailureWithNotification(void* arg, grpc_error_handle error) {
+  RequestState* request_state = static_cast<RequestState*>(arg);
+  OnFinishExpectFailure(arg, error);
+  request_state->callback_finished.Notify();
 }
 
 TEST_F(HttpRequestTest, Get) {
@@ -466,8 +474,8 @@ TEST_F(HttpRequestTest, CallerPollentsAreNotReferencedAfterCallbackIsRan) {
       grpc_core::HttpRequest::Get(
           std::move(*uri), nullptr /* channel args */,
           &wrapped_pollset_set_to_destroy_eagerly, &req, NSecondsTime(15),
-          GRPC_CLOSURE_CREATE(OnFinishExpectFailure, &request_state,
-                              grpc_schedule_on_exec_ctx),
+          GRPC_CLOSURE_CREATE(OnFinishExpectFailureWithNotification,
+                              &request_state, grpc_schedule_on_exec_ctx),
           &request_state.response,
           grpc_core::RefCountedPtr<grpc_channel_credentials>(
               grpc_insecure_credentials_create()));
@@ -475,13 +483,20 @@ TEST_F(HttpRequestTest, CallerPollentsAreNotReferencedAfterCallbackIsRan) {
   http_request->Start();
   exec_ctx.Flush();
   http_request.reset();  // cancel the request
-  // Since the request was cancelled, the on_done callback should be flushed
-  // out on the ExecCtx flush below. When the on_done callback is ran, it will
-  // eagerly destroy 'request_state.pollset_set_to_destroy_eagerly'. Thus, we
-  // can't poll on that pollset here.
-  exec_ctx.Flush();
-  PollUntil([&request_state]() { return request_state.done; },
-            AbslDeadlineSeconds(60));
+  if (!grpc_core::IsEventEngineClientEnabled()) {
+    // Since the request was cancelled, the on_done callback should be flushed
+    // out on the ExecCtx flush below. When the on_done callback is ran, it will
+    // eagerly destroy 'request_state.pollset_set_to_destroy_eagerly'. Thus, we
+    // can't poll on that pollset here.
+    exec_ctx.Flush();
+  } else {
+    // EventEngine threads will execute the `OnFinishExpectFailure` callback
+    // asynchronously. Since the pollset will be destroyed in another thread,
+    // this test can't poll on it here, so this uses a Notification to signal
+    // that the callback has been run to completion.
+    exec_ctx.Flush();
+    request_state.callback_finished.WaitForNotification();
+  }
 }
 
 void CancelRequest(grpc_core::HttpRequest* req) {

--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -480,6 +480,8 @@ TEST_F(HttpRequestTest, CallerPollentsAreNotReferencedAfterCallbackIsRan) {
   // eagerly destroy 'request_state.pollset_set_to_destroy_eagerly'. Thus, we
   // can't poll on that pollset here.
   exec_ctx.Flush();
+  PollUntil([&request_state]() { return request_state.done; },
+            AbslDeadlineSeconds(60));
 }
 
 void CancelRequest(grpc_core::HttpRequest* req) {

--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -475,12 +475,13 @@ TEST_F(HttpRequestTest, CallerPollentsAreNotReferencedAfterCallbackIsRan) {
   http_request->Start();
   exec_ctx.Flush();
   http_request.reset();  // cancel the request
+  // When the on_done callback is ran, it will eagerly destroy
+  // 'request_state.pollset_set_to_destroy_eagerly'. PollUntil's predicate
+  // should return true immediately.
+  //
   // With iomgr polling:
   // Since the request was cancelled, the on_done callback should be flushed
-  // out on the ExecCtx flush below. When the on_done callback is ran, it will
-  // eagerly destroy 'request_state.pollset_set_to_destroy_eagerly'. PollUntil's
-  // predicate should return true immediately.
-  //
+  // out on the ExecCtx flush below.
   // With EventEngine polling:
   // Since the callback will be run asynchronously in another thread, with an
   // independent ExecCtx, PollUntil is used here to ensure this test does not


### PR DESCRIPTION
One test (`CallerPollentsAreNotReferencedAfterCallbackIsRan`) was not waiting for a callback to be run before finishing when the EventEngine client is in use. With the iomgr implementation, `exec_ctx.Flush();` previously guaranteed that the callback would be executed before the test ended, but the EventEngine runs it in a separate thread, with the EventEngine shim providing its own isolated ExecCtx. This fix simply waits for the callback to be run before exiting, in the same way many other tests in this file wait on iomgr-based callback execution.