### PR TITLE
[CSM] Modify CsmObservability to CsmOpenTelemetryPluginOption internally

### DIFF
--- a/src/cpp/ext/csm/csm_observability.cc
+++ b/src/cpp/ext/csm/csm_observability.cc
@@ -130,13 +130,8 @@ CsmObservabilityBuilder::SetGenericMethodAttributeFilter(
 }
 
 absl::StatusOr<CsmObservability> CsmObservabilityBuilder::BuildAndRegister() {
-  builder_->SetServerSelector(internal::CsmServerSelector);
-  builder_->SetTargetSelector(internal::CsmChannelTargetSelector);
-  builder_->SetLabelsInjector(
-      std::make_unique<internal::ServiceMeshLabelsInjector>(
-          google::cloud::otel::MakeResourceDetector()
-              ->Detect()
-              .GetAttributes()));
+  builder_->AddPluginOption(
+      std::make_unique<grpc::internal::CsmOpenTelemetryPluginOption>());
   auto status = builder_->BuildAndRegisterGlobal();
   if (!status.ok()) {
     return status;

--- a/src/cpp/ext/otel/otel_client_filter.cc
+++ b/src/cpp/ext/otel/otel_client_filter.cc
@@ -131,19 +131,15 @@ OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
     // We might not have all the injected labels that we want at this point, so
     // avoid recording a subset of injected labels here.
     OpenTelemetryPluginState().client.attempt.started->Add(
-        1, KeyValueIterable(
-               /*injected_labels_iterable=*/nullptr, {}, additional_labels,
-               /*active_plugin_options_view=*/nullptr,
-               /*optional_labels_span=*/{}, /*is_client=*/true));
+        1, KeyValueIterable(/*injected_labels_from_plugin_options=*/{},
+                            additional_labels,
+                            /*active_plugin_options_view=*/nullptr,
+                            /*optional_labels_span=*/{}, /*is_client=*/true));
   }
 }
 
 void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
     RecordReceivedInitialMetadata(grpc_metadata_batch* recv_initial_metadata) {
-  if (OpenTelemetryPluginState().labels_injector != nullptr) {
-    injected_labels_ = OpenTelemetryPluginState().labels_injector->GetLabels(
-        recv_initial_metadata);
-  }
   parent_->parent_->active_plugin_options_view().ForEach(
       [&](const InternalOpenTelemetryPluginOption& plugin_option,
           size_t /*index*/) {
@@ -158,10 +154,6 @@ void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
 
 void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
     RecordSendInitialMetadata(grpc_metadata_batch* send_initial_metadata) {
-  if (OpenTelemetryPluginState().labels_injector != nullptr) {
-    OpenTelemetryPluginState().labels_injector->AddLabels(send_initial_metadata,
-                                                          nullptr);
-  }
   parent_->parent_->active_plugin_options_view().ForEach(
       [&](const InternalOpenTelemetryPluginOption& plugin_option,
           size_t /*index*/) {
@@ -210,10 +202,10 @@ void OpenTelemetryCallTracer::OpenTelemetryCallAttemptTracer::
            {OpenTelemetryStatusKey(),
             grpc_status_code_to_string(
                 static_cast<grpc_status_code>(status.code()))}}};
-  KeyValueIterable labels(
-      injected_labels_.get(), injected_labels_from_plugin_options_,
-      additional_labels, &parent_->parent_->active_plugin_options_view(),
-      optional_labels_array_, /*is_client=*/true);
+  KeyValueIterable labels(injected_labels_from_plugin_options_,
+                          additional_labels,
+                          &parent_->parent_->active_plugin_options_view(),
+                          optional_labels_array_, /*is_client=*/true);
   if (OpenTelemetryPluginState().client.attempt.duration != nullptr) {
     OpenTelemetryPluginState().client.attempt.duration->Record(
         absl::ToDoubleSeconds(absl::Now() - start_time_), labels,

--- a/src/cpp/ext/otel/otel_plugin.cc
+++ b/src/cpp/ext/otel/otel_plugin.cc
@@ -117,13 +117,6 @@ OpenTelemetryPluginBuilderImpl::DisableAllMetrics() {
 }
 
 OpenTelemetryPluginBuilderImpl&
-OpenTelemetryPluginBuilderImpl::SetLabelsInjector(
-    std::unique_ptr<LabelsInjector> labels_injector) {
-  labels_injector_ = std::move(labels_injector);
-  return *this;
-}
-
-OpenTelemetryPluginBuilderImpl&
 OpenTelemetryPluginBuilderImpl::SetTargetSelector(
     absl::AnyInvocable<bool(absl::string_view /*target*/) const>
         target_selector) {
@@ -243,7 +236,6 @@ absl::Status OpenTelemetryPluginBuilderImpl::BuildAndRegisterGlobal() {
                     kServerCallRcvdTotalCompressedMessageSizeInstrumentName),
             "Compressed message bytes received per server call", "By");
   }
-  g_otel_plugin_state_->labels_injector = std::move(labels_injector_);
   g_otel_plugin_state_->target_attribute_filter =
       std::move(target_attribute_filter_);
   g_otel_plugin_state_->server_selector = std::move(server_selector_);

--- a/src/cpp/ext/otel/otel_plugin.h
+++ b/src/cpp/ext/otel/otel_plugin.h
@@ -135,7 +135,6 @@ struct OpenTelemetryPluginState {
   } server;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::MeterProvider>
       meter_provider;
-  std::unique_ptr<LabelsInjector> labels_injector;
   absl::AnyInvocable<bool(absl::string_view /*target*/) const>
       target_attribute_filter;
   absl::AnyInvocable<bool(absl::string_view /*generic_method*/) const>
@@ -173,9 +172,6 @@ class OpenTelemetryPluginBuilderImpl {
   OpenTelemetryPluginBuilderImpl& EnableMetric(absl::string_view metric_name);
   OpenTelemetryPluginBuilderImpl& DisableMetric(absl::string_view metric_name);
   OpenTelemetryPluginBuilderImpl& DisableAllMetrics();
-  // Allows setting a labels injector on calls traced through this plugin.
-  OpenTelemetryPluginBuilderImpl& SetLabelsInjector(
-      std::unique_ptr<LabelsInjector> labels_injector);
   // If set, \a target_selector is called per channel to decide whether to
   // collect metrics on that target or not.
   OpenTelemetryPluginBuilderImpl& SetTargetSelector(

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -127,7 +127,8 @@ class TestScenario {
 class MeshLabelsPluginOption
     : public grpc::internal::InternalOpenTelemetryPluginOption {
  public:
-  MeshLabelsPluginOption(const opentelemetry::sdk::common::AttributeMap& map)
+  explicit MeshLabelsPluginOption(
+      const opentelemetry::sdk::common::AttributeMap& map)
       : labels_injector_(
             std::make_unique<grpc::internal::ServiceMeshLabelsInjector>(map)) {}
 

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -132,11 +132,11 @@ class MeshLabelsPluginOption
       : labels_injector_(
             std::make_unique<grpc::internal::ServiceMeshLabelsInjector>(map)) {}
 
-  bool IsActiveOnClientChannel(absl::string_view target) const override {
+  bool IsActiveOnClientChannel(absl::string_view /*target*/) const override {
     return true;
   }
 
-  bool IsActiveOnServer(const grpc_core::ChannelArgs& args) const override {
+  bool IsActiveOnServer(const grpc_core::ChannelArgs& /*args*/) const override {
     return true;
   }
 

--- a/test/cpp/ext/csm/metadata_exchange_test.cc
+++ b/test/cpp/ext/csm/metadata_exchange_test.cc
@@ -121,6 +121,32 @@ class TestScenario {
   XdsBootstrapSource bootstrap_source_;
 };
 
+// A PluginOption that injects `ServiceMeshLabelsInjector`. (This is different
+// from CsmOpenTelemetryPluginOption since it does not restrict itself to just
+// CSM channels and servers.)
+class MeshLabelsPluginOption
+    : public grpc::internal::InternalOpenTelemetryPluginOption {
+ public:
+  MeshLabelsPluginOption(const opentelemetry::sdk::common::AttributeMap& map)
+      : labels_injector_(
+            std::make_unique<grpc::internal::ServiceMeshLabelsInjector>(map)) {}
+
+  bool IsActiveOnClientChannel(absl::string_view target) const override {
+    return true;
+  }
+
+  bool IsActiveOnServer(const grpc_core::ChannelArgs& args) const override {
+    return true;
+  }
+
+  const grpc::internal::LabelsInjector* labels_injector() const override {
+    return labels_injector_.get();
+  }
+
+ private:
+  std::unique_ptr<grpc::internal::ServiceMeshLabelsInjector> labels_injector_;
+};
+
 class MetadataExchangeTest
     : public OpenTelemetryPluginEnd2EndTest,
       public ::testing::WithParamInterface<TestScenario> {
@@ -149,9 +175,8 @@ class MetadataExchangeTest
     OpenTelemetryPluginEnd2EndTest::Init(std::move(
         Options()
             .set_metric_names(std::move(metric_names))
-            .set_labels_injector(
-                std::make_unique<grpc::internal::ServiceMeshLabelsInjector>(
-                    GetParam().GetTestResource().GetAttributes()))
+            .add_plugin_option(std::make_unique<MeshLabelsPluginOption>(
+                GetParam().GetTestResource().GetAttributes()))
             .set_labels_to_inject(std::move(labels_to_inject))
             .set_target_selector(
                 [enable_client_side_injector](absl::string_view /*target*/) {

--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -775,19 +775,15 @@ class CustomPluginOption
 };
 
 TEST_F(OpenTelemetryPluginOptionEnd2EndTest, Basic) {
-  std::vector<
-      std::unique_ptr<grpc::internal::InternalOpenTelemetryPluginOption>>
-      plugin_option_list;
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ true, /*enabled_on_server*/ true,
-      std::make_pair("key", "value")));
   Init(
       std::move(Options()
                     .set_metric_names({grpc::OpenTelemetryPluginBuilder::
                                            kClientAttemptDurationInstrumentName,
                                        grpc::OpenTelemetryPluginBuilder::
                                            kServerCallDurationInstrumentName})
-                    .set_plugin_options(std::move(plugin_option_list))));
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ true, /*enabled_on_server*/ true,
+                        std::make_pair("key", "value")))));
   SendRPC();
   auto data = ReadCurrentMetricsData(
       [&](const absl::flat_hash_map<
@@ -812,19 +808,15 @@ TEST_F(OpenTelemetryPluginOptionEnd2EndTest, Basic) {
 }
 
 TEST_F(OpenTelemetryPluginOptionEnd2EndTest, ClientOnlyPluginOption) {
-  std::vector<
-      std::unique_ptr<grpc::internal::InternalOpenTelemetryPluginOption>>
-      plugin_option_list;
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ true, /*enabled_on_server*/ false,
-      std::make_pair("key", "value")));
   Init(
       std::move(Options()
                     .set_metric_names({grpc::OpenTelemetryPluginBuilder::
                                            kClientAttemptDurationInstrumentName,
                                        grpc::OpenTelemetryPluginBuilder::
                                            kServerCallDurationInstrumentName})
-                    .set_plugin_options(std::move(plugin_option_list))));
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ true, /*enabled_on_server*/ false,
+                        std::make_pair("key", "value")))));
   SendRPC();
   auto data = ReadCurrentMetricsData(
       [&](const absl::flat_hash_map<
@@ -850,19 +842,15 @@ TEST_F(OpenTelemetryPluginOptionEnd2EndTest, ClientOnlyPluginOption) {
 }
 
 TEST_F(OpenTelemetryPluginOptionEnd2EndTest, ServerOnlyPluginOption) {
-  std::vector<
-      std::unique_ptr<grpc::internal::InternalOpenTelemetryPluginOption>>
-      plugin_option_list;
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ false, /*enabled_on_server*/ true,
-      std::make_pair("key", "value")));
   Init(
       std::move(Options()
                     .set_metric_names({grpc::OpenTelemetryPluginBuilder::
                                            kClientAttemptDurationInstrumentName,
                                        grpc::OpenTelemetryPluginBuilder::
                                            kServerCallDurationInstrumentName})
-                    .set_plugin_options(std::move(plugin_option_list))));
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ false, /*enabled_on_server*/ true,
+                        std::make_pair("key", "value")))));
   SendRPC();
   auto data = ReadCurrentMetricsData(
       [&](const absl::flat_hash_map<
@@ -889,32 +877,27 @@ TEST_F(OpenTelemetryPluginOptionEnd2EndTest, ServerOnlyPluginOption) {
 
 TEST_F(OpenTelemetryPluginOptionEnd2EndTest,
        MultipleEnabledAndDisabledPluginOptions) {
-  std::vector<
-      std::unique_ptr<grpc::internal::InternalOpenTelemetryPluginOption>>
-      plugin_option_list;
-  plugin_option_list.reserve(5);
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ true, /*enabled_on_server*/ true,
-      std::make_pair("key1", "value1")));
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ true, /*enabled_on_server*/ false,
-      std::make_pair("key2", "value2")));
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ true, /*enabled_on_server*/ false,
-      std::make_pair("key3", "value3")));
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ false, /*enabled_on_server*/ true,
-      std::make_pair("key4", "value4")));
-  plugin_option_list.emplace_back(std::make_unique<CustomPluginOption>(
-      /*enabled_on_client*/ false, /*enabled_on_server*/ true,
-      std::make_pair("key5", "value5")));
   Init(
       std::move(Options()
                     .set_metric_names({grpc::OpenTelemetryPluginBuilder::
                                            kClientAttemptDurationInstrumentName,
                                        grpc::OpenTelemetryPluginBuilder::
                                            kServerCallDurationInstrumentName})
-                    .set_plugin_options(std::move(plugin_option_list))));
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ true, /*enabled_on_server*/ true,
+                        std::make_pair("key1", "value1")))
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ true, /*enabled_on_server*/ false,
+                        std::make_pair("key2", "value2")))
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ true, /*enabled_on_server*/ false,
+                        std::make_pair("key3", "value3")))
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ false, /*enabled_on_server*/ true,
+                        std::make_pair("key4", "value4")))
+                    .add_plugin_option(std::make_unique<CustomPluginOption>(
+                        /*enabled_on_client*/ false, /*enabled_on_server*/ true,
+                        std::make_pair("key5", "value5")))));
   SendRPC();
   auto data = ReadCurrentMetricsData(
       [&](const absl::flat_hash_map<

--- a/test/cpp/ext/otel/otel_test_library.cc
+++ b/test/cpp/ext/otel/otel_test_library.cc
@@ -105,7 +105,6 @@ void OpenTelemetryPluginEnd2EndTest::Init(Options config) {
     meter_provider->AddMetricReader(reader_);
     ot_builder.SetMeterProvider(std::move(meter_provider));
   }
-  ot_builder.SetLabelsInjector(std::move(config.labels_injector));
   ot_builder.SetTargetSelector(std::move(config.target_selector));
   ot_builder.SetServerSelector(std::move(config.server_selector));
   ot_builder.SetTargetAttributeFilter(

--- a/test/cpp/ext/otel/otel_test_library.h
+++ b/test/cpp/ext/otel/otel_test_library.h
@@ -68,12 +68,6 @@ class OpenTelemetryPluginEnd2EndTest : public ::testing::Test {
       return *this;
     }
 
-    Options& set_labels_injector(
-        std::unique_ptr<grpc::internal::LabelsInjector> injector) {
-      labels_injector = std::move(injector);
-      return *this;
-    }
-
     Options& set_use_meter_provider(bool flag) {
       use_meter_provider = flag;
       return *this;
@@ -111,11 +105,10 @@ class OpenTelemetryPluginEnd2EndTest : public ::testing::Test {
       return *this;
     }
 
-    Options& set_plugin_options(
-        std::vector<
-            std::unique_ptr<grpc::internal::InternalOpenTelemetryPluginOption>>
-            options) {
-      plugin_options = std::move(options);
+    Options& add_plugin_option(
+        std::unique_ptr<grpc::internal::InternalOpenTelemetryPluginOption>
+            option) {
+      plugin_options.push_back(std::move(option));
       return *this;
     }
 


### PR DESCRIPTION
Changes -
* `CsmObservability` API will now use the `CsmOpenTelemetryPluginOption` internally. After this change, `CsmObservability` will enable observability for all channels and servers. (Earlier, `CsmObservability` only enabled observability for CSM-enabled channels and servers.) CSM labels will still be added just for CSM-enabled channels and servers. 
* Also, we no longer need the ability to set `LabelInjector` on the `OpenTelemetryPluginBuilder` directly. Instead, we always use `PluginOption` to inject the `LabelInjector`. This simplifies the code as well.

Note that `SetTargetSelector` and `SetServerSelector` APIs on the `OpenTelemetryPluginBuilderImpl` are not being deleted yet since we might need them shortly. This is also why `OpenTelemetryPluginBuilderImpl` is not being deleted right now.