### PR TITLE
[Python Misc] Fix issue when deprecate pkg_resources.resource_filename

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -47,7 +47,7 @@ def _get_resource_file_name(
     """Obtain the filename for a resource on the file system."""
     file_name = None
     if sys.version_info >= (3, 9, 0):
-         file_name = (
+        file_name = (
             resources.files(package_or_requirement) / resource_name
         ).resolve()
     else:

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -45,14 +45,16 @@ def _get_resource_file_name(
     package_or_requirement: str, resource_name: str
 ) -> str:
     """Obtain the filename for a resource on the file system."""
+    file_name = None
     if sys.version_info >= (3, 9, 0):
-        return (
+         file_name = (
             resources.files(package_or_requirement) / resource_name
         ).resolve()
     else:
-        return pkg_resources.resource_filename(
+        file_name = pkg_resources.resource_filename(
             package_or_requirement, resource_name
         )
+    return str(file_name)
 
 
 # NOTE(rbellevi): importlib.abc is not supported on 3.4.


### PR DESCRIPTION
We changed `pkg_resources.resource_filename` to `importlib.resources.files`, but the return of `resources.files()` API is a traversable object implementing a subset of the [pathlib.Path](https://docs.python.org/3/library/pathlib.html#pathlib.Path) interface instead of string, thus we're seeing errors like `AttributeError: 'PosixPath' object has no attribute 'rstrip'`.

This PR converts the result of `files()` to str to prevent those kinds of errors.

Test run:
 * [x] [grpc/core/master/linux/grpc_interop_tocloud](http://sponge/ee5d493b-e23e-4358-8084-3dba1df1d42f)

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

