### PR TITLE
[experiment] Disable Posix EventEngine Client experiment

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -231,6 +231,7 @@ EXPERIMENTS = {
                 "v3_compression_filter",
             ],
             "core_end2end_test": [
+                "event_engine_client",
                 "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
@@ -242,6 +243,9 @@ EXPERIMENTS = {
             "endpoint_test": [
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
+            ],
+            "event_engine_client_test": [
+                "event_engine_client",
             ],
             "flow_control_test": [
                 "multiping",
@@ -273,16 +277,12 @@ EXPERIMENTS = {
         },
         "on": {
             "core_end2end_test": [
-                "event_engine_client",
                 "event_engine_listener",
             ],
             "cpp_lb_end2end_test": [
                 "pick_first_happy_eyeballs",
                 "round_robin_delegate_to_pick_first",
                 "wrr_delegate_to_pick_first",
-            ],
-            "event_engine_client_test": [
-                "event_engine_client",
             ],
             "event_engine_listener_test": [
                 "event_engine_listener",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -725,7 +725,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"client_privacy", description_client_privacy,
      additional_constraints_client_privacy, nullptr, 0, false, false},
     {"event_engine_client", description_event_engine_client,
-     additional_constraints_event_engine_client, nullptr, 0, true, true},
+     additional_constraints_event_engine_client, nullptr, 0, false, true},
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, nullptr, 0, false, false},
     {"event_engine_listener", description_event_engine_listener,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -195,8 +195,7 @@ inline bool IsCanaryClientPrivacyEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CLIENT_IDLENESS
 inline bool IsClientIdlenessEnabled() { return true; }
 inline bool IsClientPrivacyEnabled() { return false; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
-inline bool IsEventEngineClientEnabled() { return true; }
+inline bool IsEventEngineClientEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
 inline bool IsEventEngineListenerEnabled() { return true; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -54,7 +54,7 @@
   default:
     # not tested on iOS at all
     ios: broken
-    posix: true
+    posix: false
     # TODO(hork): resolve when the client end2end test flake rate reduces to
     # a tolerable amount.
     windows: broken


### PR DESCRIPTION
Disabling before the 1.62 branch cut.

There is a flake in one specific interop test: cloud_to_prod_auth:c++:*:oauth2_auth_token:tls, with * being default or gateway_v4. There is also an unresolved PHP crash on test shutdown, just debug builds on Mac (not Linux or Windows).