### PR TITLE
[server] Keep server running after failed UDS `getpeername`

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2188,6 +2188,7 @@ grpc_cc_library(
         "posix_event_engine_tcp_socket_utils",
         "socket_mutator",
         "status_helper",
+        "strerror",
         "time",
         "//:event_engine_base_hdrs",
         "//:exec_ctx",

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -429,13 +429,13 @@ static void on_read(void* arg, grpc_error_handle err) {
         auto listener_addr_uri = grpc_sockaddr_to_uri(&sp->addr);
         gpr_log(
             GPR_ERROR,
-            "Failed getpeername: %s. This is a critical failure, the "
-            "listener on %s:%d is shutting down.",
+            "Failed getpeername: %s. Dropping the connection, and continuing "
+            "to listen on %s:%d.",
             grpc_core::StrError(errno).c_str(),
             listener_addr_uri.ok() ? listener_addr_uri->c_str() : "<unknown>",
             sp->port);
         close(fd);
-        goto error;
+        continue;
       }
     }
 


### PR DESCRIPTION
Closes #35076. See discussion there for context.

Previously, if `getpeername` failed on a recently-accepted Unix domain socket, the server would shut down. It's unclear if there's any valid reason `getpeername` would fail here, we could be looking at system issues / data corruption, but it may be implementation-dependent. I did not find a man page that specified this behavior: getpeername on a server errors with `EBADF` when a client closes its end of a UDS connection; the server's fd should still be valid. I was not able to reproduce the failure on recent Linux/Mac systems where clients close their connection after a listener accepted (basic, non-gRPC test: listener accepts a connection and sleeps, client closes their end, then listener wakes up and calls getpeername).

If there are no valid reasons `getpeername` would fail in these spots, gRPC behavior is essentially undefined - we cannot defensively code around system failures in every place they may occur. If this _is_ a valid situation on some platforms, then this fix keeps the server alive as one would hope. There are arguments to be made for shutting down servers if the system is unstable, but I can't find an objectively correct behavior here. For those reasons, I think it may be best to keep the server running, which is what this PR does.