### PR TITLE
[CSM] Disable metrics recording when CsmObservability goes out of scope

### DIFF
--- a/include/grpcpp/ext/csm_observability.h
+++ b/include/grpcpp/ext/csm_observability.h
@@ -38,11 +38,13 @@ class OpenTelemetryPluginBuilderImpl;
 
 namespace experimental {
 
-// This is a no-op at present, but in the future, this object would be useful
-// for performing cleanup.
+// When this object goes out of scope, CsmObservability will stop recording
+// metrics for new channels and servers. Existing channels and servers may
+// continue exporting metrics (implementation-dependent).
 class CsmObservability {
  public:
   CsmObservability() = default;
+  ~CsmObservability();
   // Disable copy constructor and copy-assignment operator.
   CsmObservability(const CsmObservability&) = delete;
   CsmObservability& operator=(const CsmObservability&) = delete;

--- a/src/cpp/ext/csm/csm_observability.cc
+++ b/src/cpp/ext/csm/csm_observability.cc
@@ -97,6 +97,14 @@ class CsmOpenTelemetryPluginOption
 namespace experimental {
 
 //
+// CsmObservability
+//
+
+CsmObservability::~CsmObservability() {
+  grpc::internal::DisableOpenTelemetryPlugin();
+}
+
+//
 // CsmObservabilityBuilder
 //
 

--- a/src/cpp/ext/otel/otel_client_filter.h
+++ b/src/cpp/ext/otel/otel_client_filter.h
@@ -60,6 +60,7 @@ class OpenTelemetryClientFilter : public grpc_core::ChannelFilter {
 
   std::string filtered_target_;
   ActivePluginOptionsView active_plugin_options_view_;
+  bool plugin_enabled_;
 };
 
 }  // namespace internal

--- a/src/cpp/ext/otel/otel_plugin.h
+++ b/src/cpp/ext/otel/otel_plugin.h
@@ -147,6 +147,11 @@ struct OpenTelemetryPluginState {
 
 const struct OpenTelemetryPluginState& OpenTelemetryPluginState();
 
+// Returns whether the OpenTelemetry plugin is enabled.
+bool OpenTelemetryPluginEnabled();
+// Disables the OpenTelemetry plugin.
+void DisableOpenTelemetryPlugin();
+
 // Tags
 absl::string_view OpenTelemetryMethodKey();
 absl::string_view OpenTelemetryStatusKey();

--- a/src/cpp/ext/otel/otel_server_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_server_call_tracer.cc
@@ -252,8 +252,9 @@ bool OpenTelemetryServerCallTracerFactory::IsServerTraced(
     const grpc_core::ChannelArgs& args) {
   // Return true only if there is no server selector registered or if the server
   // selector returns true.
-  return OpenTelemetryPluginState().server_selector == nullptr ||
-         OpenTelemetryPluginState().server_selector(args);
+  return OpenTelemetryPluginEnabled() &&
+         (OpenTelemetryPluginState().server_selector == nullptr ||
+          OpenTelemetryPluginState().server_selector(args));
 }
 
 }  // namespace internal

--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -680,6 +680,23 @@ TEST_F(OpenTelemetryPluginEnd2EndTest,
   EXPECT_EQ(*status_value, "UNIMPLEMENTED");
 }
 
+TEST_F(OpenTelemetryPluginEnd2EndTest, DisableOTelPluginTest) {
+  Init(std::move(Options().set_metric_names(
+      {grpc::OpenTelemetryPluginBuilder::kClientAttemptDurationInstrumentName,
+       grpc::OpenTelemetryPluginBuilder::kServerCallDurationInstrumentName})));
+  grpc::internal::DisableOpenTelemetryPlugin();
+  // Re-create server and channel after disabling the plugin.
+  ResetServerAndStub();
+  SendRPC();
+  auto data = ReadCurrentMetricsData(
+      [&](const absl::flat_hash_map<
+          std::string,
+          std::vector<opentelemetry::sdk::metrics::PointDataAttributes>>&
+          /*data*/) { return false; });
+  // Since we've disabled the plugin, no metrics should be recorded.
+  ASSERT_TRUE(data.empty());
+}
+
 using OpenTelemetryPluginOptionEnd2EndTest = OpenTelemetryPluginEnd2EndTest;
 
 class SimpleLabelIterable : public grpc::internal::LabelsIterable {

--- a/test/cpp/ext/otel/otel_test_library.cc
+++ b/test/cpp/ext/otel/otel_test_library.cc
@@ -115,7 +115,6 @@ void OpenTelemetryPluginEnd2EndTest::Init(Options config) {
     ot_builder.AddPluginOption(std::move(option));
   }
   ASSERT_EQ(ot_builder.BuildAndRegisterGlobal(), absl::OkStatus());
-  ChannelArguments channel_args;
   if (!config.labels_to_inject.empty()) {
     labels_to_inject_ = config.labels_to_inject;
     grpc_core::CoreConfiguration::RegisterBuilder(
@@ -123,9 +122,19 @@ void OpenTelemetryPluginEnd2EndTest::Init(Options config) {
           builder->channel_init()->RegisterFilter(
               GRPC_CLIENT_SUBCHANNEL, &AddServiceLabelsFilter::kFilter);
         });
-    channel_args.SetPointer(GRPC_ARG_LABELS_TO_INJECT, &labels_to_inject_);
   }
   grpc_init();
+  // Create the server and channel stub.
+  ResetServerAndStub();
+}
+
+void OpenTelemetryPluginEnd2EndTest::TearDown() {
+  server_->Shutdown();
+  grpc_shutdown_blocking();
+  grpc_core::ServerCallTracerFactory::TestOnlyReset();
+}
+
+void OpenTelemetryPluginEnd2EndTest::ResetServerAndStub() {
   grpc::ServerBuilder builder;
   int port;
   // Use IPv4 here because it's less flaky than IPv6 ("[::]:0") on Travis.
@@ -138,16 +147,12 @@ void OpenTelemetryPluginEnd2EndTest::Init(Options config) {
   server_address_ = absl::StrCat("localhost:", port);
   canonical_server_address_ = absl::StrCat("dns:///", server_address_);
 
+  ChannelArguments channel_args;
+  channel_args.SetPointer(GRPC_ARG_LABELS_TO_INJECT, &labels_to_inject_);
   auto channel = grpc::CreateCustomChannel(
       server_address_, grpc::InsecureChannelCredentials(), channel_args);
   stub_ = EchoTestService::NewStub(channel);
   generic_stub_ = std::make_unique<GenericStub>(std::move(channel));
-}
-
-void OpenTelemetryPluginEnd2EndTest::TearDown() {
-  server_->Shutdown();
-  grpc_shutdown_blocking();
-  grpc_core::ServerCallTracerFactory::TestOnlyReset();
 }
 
 void OpenTelemetryPluginEnd2EndTest::ResetStub(

--- a/test/cpp/ext/otel/otel_test_library.h
+++ b/test/cpp/ext/otel/otel_test_library.h
@@ -140,6 +140,7 @@ class OpenTelemetryPluginEnd2EndTest : public ::testing::Test {
 
   void TearDown() override;
 
+  void ResetServerAndStub();
   void ResetStub(std::shared_ptr<Channel> channel);
 
   void SendRPC();


### PR DESCRIPTION
As discussed, this change adds scoping to `CsmObservability` such that when that object goes out of scope, new channels and servers don't record metrics. In the documentation, I've talked about how existing channels/servers are going to continue to record metrics but i've left room for us to change that behavior in the future.

The current way of doing this is through a global bool since there can only be one plugin right now, but we'll change this to use the global stats plugin registry in the future.