### PR TITLE
[http] allow empty te header

### DIFF
--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -96,10 +96,8 @@ ServerMetadataHandle HttpServerFilter::Call::OnClientInitialMetadata(
   }
 
   auto te = md.Take(TeMetadata());
-  if (te == TeMetadata::kTrailers) {
+  if (te == TeMetadata::kTrailers || !te.has_value()) {
     // Do nothing, ok.
-  } else if (!te.has_value()) {
-    return MalformedRequest("Missing :te header");
   } else {
     return MalformedRequest("Bad :te header");
   }


### PR DESCRIPTION
I stumbled upon errors when `:te` header wasn't set. It should be ok to have an empty `:te` header.

[As the RFC says](https://datatracker.ietf.org/doc/html/rfc9113#section-8.2.2-2):
> The only exception to this is the TE header field, which MAY be present in an HTTP/2 request; when it is, it MUST NOT contain any value other than "trailers".

This change allow empty `:te` header but we could also set the header to `trailers` if this causes issues further down in the code.
