### PR TITLE
[Python O11Y] Fix core header dependency issue

### DIFF
--- a/src/python/grpcio_observability/make_grpcio_observability.py
+++ b/src/python/grpcio_observability/make_grpcio_observability.py
@@ -66,11 +66,7 @@ GRPCIO_OBSERVABILITY_ROOT_PREFIX = "src/python/grpcio_observability/"
 COPY_FILES_SOURCE_TARGET_PAIRS = [
     ("include", "grpc_root/include"),
     ("third_party/abseil-cpp/absl", "third_party/abseil-cpp/absl"),
-    ("src/core/lib", "grpc_root/src/core/lib"),
-    (
-        "src/core/load_balancing",
-        "grpc_root/src/core/load_balancing",
-    ),
+    ("src/core", "grpc_root/src/core"),
 ]
 
 # grpc repo root


### PR DESCRIPTION
Core team [moved resolver code](https://github.com/grpc/grpc/pull/35804) to `src/core/resolver`, our build is failing because we have a dependency on it and the resolver folder is not copied to `observability/grpc_root`:
 * `call_tracer.h` -> `core_configuration.h` -> `lb_policy_registry.h` -> `lb_policy.h` -> `endpoint_addresses.h`

To fix this issue and to prevent such issues from happening again, instead of subfolders, we'll copy all files from `src/core` to `observability/grpc_root/src/core`.

Artifact Size:
 * Before this change, ~4.7MB: ([grpcio_observability-1.62.0.dev0-cp312-cp312-linux_x86_64.whl](https://storage.googleapis.com/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/grpc_distribtests_python/28184/20240205-220543/github/grpc/artifacts/grpcio_observability-1.62.0.dev0-cp312-cp312-linux_x86_64.whl))
 * After this change, ~4.7MB: ([grpcio_observability-1.62.0.dev0-cp312-cp312-linux_x86_64.whl](https://storage.googleapis.com/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/grpc_distribtests_python/28235/20240207-111833/github/grpc/artifacts/grpcio_observability-1.62.0.dev0-cp312-cp312-linux_x86_64.whl))

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

