### PR TITLE
[Security] add mutex lock to the file loading in FileExternalAccountCredentials

### DIFF
--- a/src/core/lib/iomgr/load_file.h
+++ b/src/core/lib/iomgr/load_file.h
@@ -21,14 +21,15 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <stdio.h>
-
 #include <grpc/slice.h>
 
 #include "src/core/lib/iomgr/error.h"
 
 // Loads the content of a file into a slice. add_null_terminator will add
 // a NULL terminator if non-zero.
+// This API is NOT thread-safe and requires proper synchronization when used by
+// multiple threads, especially when they can happen to be reading from the same
+// file.
 grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
                                  grpc_slice* output);
 

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.cc
@@ -95,6 +95,7 @@ FileExternalAccountCredentials::FileExternalAccountCredentials(
       format_subject_token_field_name_ = format_it->second.string();
     }
   }
+  gpr_mu_init(&mu_);
 }
 
 void FileExternalAccountCredentials::RetrieveSubjectToken(
@@ -105,10 +106,12 @@ void FileExternalAccountCredentials::RetrieveSubjectToken(
     grpc_slice slice = grpc_empty_slice();
   };
   SliceWrapper content_slice;
+  gpr_mu_lock(&mu_);
   // To retrieve the subject token, we read the file every time we make a
   // request because it may have changed since the last request.
   grpc_error_handle error =
       grpc_load_file(file_.c_str(), 0, &content_slice.slice);
+  gpr_mu_unlock(&mu_);
   if (!error.ok()) {
     cb("", error);
     return;

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.h
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.h
@@ -25,6 +25,8 @@
 
 #include "absl/strings/string_view.h"
 
+#include <grpc/support/sync.h>
+
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/credentials/external/external_account_credentials.h"
@@ -52,6 +54,8 @@ class FileExternalAccountCredentials final : public ExternalAccountCredentials {
   std::string file_;
   std::string format_type_;
   std::string format_subject_token_field_name_;
+  // Used to lock the file loading.
+  gpr_mu mu_;
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
I'm following the suggestions in #23503.

The FileExternalAccountCredentials is the only place I found that could potentially read the same file concurrently (if multiple requests are made simultaneously with the same call credentials).

However, I can't produce any errors without the lock so am not entirely certain whether this is a necessary fix.
