### PR TITLE
[ssl] Remove TSI_OPENSSL_ALPN_SUPPORT macro.

### DIFF
--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -62,10 +62,6 @@ static const char* installed_roots_path =
 static const char* installed_roots_path = "/usr/share/grpc/roots.pem";
 #endif
 
-#ifndef TSI_OPENSSL_ALPN_SUPPORT
-#define TSI_OPENSSL_ALPN_SUPPORT 1
-#endif
-
 // -- Overridden default roots. --
 
 static grpc_ssl_roots_override_callback ssl_roots_override_cb = nullptr;
@@ -128,7 +124,6 @@ tsi_tls_version grpc_get_tsi_tls_version(grpc_tls_version tls_version) {
 }
 
 grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer) {
-#if TSI_OPENSSL_ALPN_SUPPORT
   // Check the ALPN if ALPN is supported.
   const tsi_peer_property* p =
       tsi_peer_get_property_by_name(peer, TSI_SSL_ALPN_SELECTED_PROTOCOL);
@@ -139,7 +134,6 @@ grpc_error_handle grpc_ssl_check_alpn(const tsi_peer* peer) {
   if (!grpc_chttp2_is_alpn_version_supported(p->value.data, p->value.length)) {
     return GRPC_ERROR_CREATE("Cannot check peer: invalid ALPN value.");
   }
-#endif  // TSI_OPENSSL_ALPN_SUPPORT
   return absl::OkStatus();
 }
 

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -40,10 +40,6 @@
 #include "src/core/tsi/transport_security.h"
 #include "test/core/util/test_config.h"
 
-#ifndef TSI_OPENSSL_ALPN_SUPPORT
-#define TSI_OPENSSL_ALPN_SUPPORT 1
-#endif
-
 static int check_peer_property(const tsi_peer* peer,
                                const tsi_peer_property* expected) {
   size_t i;
@@ -716,7 +712,6 @@ static void test_default_ssl_roots(void) {
 }
 
 static void test_peer_alpn_check(void) {
-#if TSI_OPENSSL_ALPN_SUPPORT
   tsi_peer peer;
   const char* alpn = "h2";
   const char* wrong_alpn = "wrong";
@@ -748,9 +743,6 @@ static void test_peer_alpn_check(void) {
       TSI_OK);
   ASSERT_EQ(grpc_ssl_check_alpn(&peer), absl::OkStatus());
   tsi_peer_destruct(&peer);
-#else
-  ASSERT_EQ(grpc_ssl_check_alpn(nullptr), absl::OkStatus());
-#endif
 }
 
 TEST(SecurityConnectorTest, MainTest) {


### PR DESCRIPTION
This macro is no longer serving any purpose.