### PR TITLE
Remove assert that causes a crash

### DIFF
--- a/src/core/lib/iomgr/load_file.cc
+++ b/src/core/lib/iomgr/load_file.cc
@@ -56,7 +56,6 @@ grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
   if (bytes_read < contents_size) {
     gpr_free(contents);
     error = GRPC_OS_ERROR(errno, "fread");
-    GPR_ASSERT(ferror(file));
     goto end;
   }
   if (add_null_terminator) {


### PR DESCRIPTION
It's been noted that this assert causes a crash - really, when shouldn't crash. The function will already return an error that can be handled as needed during the `end` block. The only possible code path for this assert to crash would occur when an error is already being returned, so this should not result in any behavior change except _not_ crashing and returning that error.
b/262285099
b/262240495