### PR TITLE
[securit] Add status to the Cancel function of the TlsCertificateVerifier

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -1074,9 +1074,12 @@ typedef struct grpc_tls_certificate_verifier_external {
    * request: request information exposed to the function implementer. It will
    *          be the same request object that was passed to verify(), and it
    *          tells the cancel() which request to cancel.
+   * code: status code for the cancellation.
+   * error_details: status message for the cancellation.
    */
   void (*cancel)(void* user_data,
-                 grpc_tls_custom_verification_check_request* request);
+                 grpc_tls_custom_verification_check_request* request,
+                 grpc_status_code code, const char* error_details);
   /**
    * A function pointer that does some additional destruction work when the
    * verifier is destroyed. This is used when the caller wants to associate some
@@ -1186,7 +1189,8 @@ int grpc_tls_certificate_verifier_verify(
  */
 void grpc_tls_certificate_verifier_cancel(
     grpc_tls_certificate_verifier* verifier,
-    grpc_tls_custom_verification_check_request* request);
+    grpc_tls_custom_verification_check_request* request, grpc_status_code code,
+    const char* error_details);
 
 /**
  * EXPERIMENTAL API - Subject to change

--- a/include/grpcpp/security/tls_certificate_verifier.h
+++ b/include/grpcpp/security/tls_certificate_verifier.h
@@ -23,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc_security_constants.h>
 #include <grpc/status.h>
 #include <grpc/support/log.h>
@@ -116,7 +118,7 @@ class CertificateVerifier {
   // verification request is pending.
   //
   // request: the verification information associated with this request
-  void Cancel(TlsCustomVerificationCheckRequest* request);
+  void Cancel(TlsCustomVerificationCheckRequest* request, const absl::Status&);
 
   // Gets the core verifier used internally.
   grpc_tls_certificate_verifier* c_verifier() { return verifier_; }
@@ -181,7 +183,8 @@ class ExternalCertificateVerifier {
   // passed to Verify() with a status indicating the cancellation.
   //
   // request: the verification information associated with this request
-  virtual void Cancel(TlsCustomVerificationCheckRequest* request) = 0;
+  virtual void Cancel(TlsCustomVerificationCheckRequest* request,
+                      const absl::Status&) = 0;
 
  protected:
   ExternalCertificateVerifier();
@@ -207,7 +210,8 @@ class ExternalCertificateVerifier {
       char** sync_error_details);
 
   static void CancelInCoreExternalVerifier(
-      void* user_data, grpc_tls_custom_verification_check_request* request);
+      void* user_data, grpc_tls_custom_verification_check_request* request,
+      grpc_status_code code, const char* error_details);
 
   static void DestructInCoreExternalVerifier(void* user_data);
 

--- a/src/core/lib/iomgr/load_file.h
+++ b/src/core/lib/iomgr/load_file.h
@@ -21,14 +21,15 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <stdio.h>
-
 #include <grpc/slice.h>
 
 #include "src/core/lib/iomgr/error.h"
 
 // Loads the content of a file into a slice. add_null_terminator will add
 // a NULL terminator if non-zero.
+// This API is NOT thread-safe and requires proper synchronization when used by
+// multiple threads, especially when they can happen to be reading from the same
+// file.
 grpc_error_handle grpc_load_file(const char* filename, int add_null_terminator,
                                  grpc_slice* output);
 

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.cc
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.cc
@@ -95,6 +95,7 @@ FileExternalAccountCredentials::FileExternalAccountCredentials(
       format_subject_token_field_name_ = format_it->second.string();
     }
   }
+  gpr_mu_init(&mu_);
 }
 
 void FileExternalAccountCredentials::RetrieveSubjectToken(
@@ -105,10 +106,12 @@ void FileExternalAccountCredentials::RetrieveSubjectToken(
     grpc_slice slice = grpc_empty_slice();
   };
   SliceWrapper content_slice;
+  gpr_mu_lock(&mu_);
   // To retrieve the subject token, we read the file every time we make a
   // request because it may have changed since the last request.
   grpc_error_handle error =
       grpc_load_file(file_.c_str(), 0, &content_slice.slice);
+  gpr_mu_unlock(&mu_);
   if (!error.ok()) {
     cb("", error);
     return;

--- a/src/core/lib/security/credentials/external/file_external_account_credentials.h
+++ b/src/core/lib/security/credentials/external/file_external_account_credentials.h
@@ -25,6 +25,8 @@
 
 #include "absl/strings/string_view.h"
 
+#include <grpc/support/sync.h>
+
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/security/credentials/external/external_account_credentials.h"
@@ -52,6 +54,8 @@ class FileExternalAccountCredentials final : public ExternalAccountCredentials {
   std::string file_;
   std::string format_type_;
   std::string format_subject_token_field_name_;
+  // Used to lock the file loading.
+  gpr_mu mu_;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
@@ -23,13 +23,13 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
-#include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/security/credentials/tls/tls_utils.h"
@@ -210,9 +210,11 @@ int grpc_tls_certificate_verifier_verify(
 
 void grpc_tls_certificate_verifier_cancel(
     grpc_tls_certificate_verifier* verifier,
-    grpc_tls_custom_verification_check_request* request) {
+    grpc_tls_custom_verification_check_request* request, grpc_status_code code,
+    const char* error_details) {
   grpc_core::ExecCtx exec_ctx;
-  verifier->Cancel(request);
+  verifier->Cancel(request, absl::Status(static_cast<absl::StatusCode>(code),
+                                         error_details));
 }
 
 grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_external_create(

--- a/src/core/lib/security/credentials/xds/xds_credentials.cc
+++ b/src/core/lib/security/credentials/xds/xds_credentials.cc
@@ -100,8 +100,8 @@ bool XdsCertificateVerifier::Verify(
   return true;  // synchronous check
 }
 
-void XdsCertificateVerifier::Cancel(
-    grpc_tls_custom_verification_check_request*) {}
+void XdsCertificateVerifier::Cancel(grpc_tls_custom_verification_check_request*,
+                                    const absl::Status&) {}
 
 int XdsCertificateVerifier::CompareImpl(
     const grpc_tls_certificate_verifier* other) const {

--- a/src/core/lib/security/credentials/xds/xds_credentials.h
+++ b/src/core/lib/security/credentials/xds/xds_credentials.h
@@ -52,7 +52,8 @@ class XdsCertificateVerifier : public grpc_tls_certificate_verifier {
   bool Verify(grpc_tls_custom_verification_check_request* request,
               std::function<void(absl::Status)>,
               absl::Status* sync_status) override;
-  void Cancel(grpc_tls_custom_verification_check_request*) override;
+  void Cancel(grpc_tls_custom_verification_check_request*,
+              const absl::Status&) override;
 
   UniqueTypeName type() const override;
 

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -389,7 +389,7 @@ void TlsChannelSecurityConnector::check_peer(
 }
 
 void TlsChannelSecurityConnector::cancel_check_peer(
-    grpc_closure* on_peer_checked, grpc_error_handle /*error*/) {
+    grpc_closure* on_peer_checked, grpc_error_handle error) {
   auto* verifier = options_->certificate_verifier();
   if (verifier != nullptr) {
     grpc_tls_custom_verification_check_request* pending_verifier_request =
@@ -406,7 +406,7 @@ void TlsChannelSecurityConnector::cancel_check_peer(
       }
     }
     if (pending_verifier_request != nullptr) {
-      verifier->Cancel(pending_verifier_request);
+      verifier->Cancel(pending_verifier_request, error);
     }
   }
 }
@@ -668,7 +668,7 @@ void TlsServerSecurityConnector::check_peer(
 }
 
 void TlsServerSecurityConnector::cancel_check_peer(
-    grpc_closure* on_peer_checked, grpc_error_handle /*error*/) {
+    grpc_closure* on_peer_checked, grpc_error_handle error) {
   auto* verifier = options_->certificate_verifier();
   if (verifier != nullptr) {
     grpc_tls_custom_verification_check_request* pending_verifier_request =
@@ -685,7 +685,7 @@ void TlsServerSecurityConnector::cancel_check_peer(
       }
     }
     if (pending_verifier_request != nullptr) {
-      verifier->Cancel(pending_verifier_request);
+      verifier->Cancel(pending_verifier_request, error);
     }
   }
 }

--- a/src/cpp/common/tls_certificate_verifier.cc
+++ b/src/cpp/common/tls_certificate_verifier.cc
@@ -16,7 +16,6 @@
 
 #include <stddef.h>
 
-#include <algorithm>
 #include <functional>
 #include <map>
 #include <utility>
@@ -141,10 +140,16 @@ bool CertificateVerifier::Verify(TlsCustomVerificationCheckRequest* request,
   return is_done;
 }
 
-void CertificateVerifier::Cancel(TlsCustomVerificationCheckRequest* request) {
+void CertificateVerifier::Cancel(TlsCustomVerificationCheckRequest* request,
+                                 const absl::Status& status) {
   GPR_ASSERT(request != nullptr);
   GPR_ASSERT(request->c_request() != nullptr);
-  grpc_tls_certificate_verifier_cancel(verifier_, request->c_request());
+  // A copy of the status message has to be made since the API takes const
+  // char*.
+  grpc_tls_certificate_verifier_cancel(
+      verifier_, request->c_request(),
+      static_cast<grpc_status_code>(status.code()),
+      std::string(status.message()).c_str());
 }
 
 void CertificateVerifier::AsyncCheckDone(
@@ -229,7 +234,8 @@ int ExternalCertificateVerifier::VerifyInCoreExternalVerifier(
 }
 
 void ExternalCertificateVerifier::CancelInCoreExternalVerifier(
-    void* user_data, grpc_tls_custom_verification_check_request* request) {
+    void* user_data, grpc_tls_custom_verification_check_request* request,
+    grpc_status_code code, const char* error_details) {
   auto* self = static_cast<ExternalCertificateVerifier*>(user_data);
   TlsCustomVerificationCheckRequest* cpp_request = nullptr;
   {
@@ -240,7 +246,8 @@ void ExternalCertificateVerifier::CancelInCoreExternalVerifier(
     }
   }
   if (cpp_request != nullptr) {
-    self->Cancel(cpp_request);
+    self->Cancel(cpp_request, absl::Status(static_cast<absl::StatusCode>(code),
+                                           error_details));
   }
 }
 

--- a/test/core/util/tls_utils.h
+++ b/test/core/util/tls_utils.h
@@ -81,7 +81,8 @@ class SyncExternalVerifier {
                     void* callback_arg, grpc_status_code* sync_status,
                     char** sync_error_details);
 
-  static void Cancel(void*, grpc_tls_custom_verification_check_request*) {}
+  static void Cancel(void*, grpc_tls_custom_verification_check_request*,
+                     grpc_status_code, const char*) {}
 
   static void Destruct(void* user_data);
 
@@ -130,7 +131,8 @@ class AsyncExternalVerifier {
                     void* callback_arg, grpc_status_code* sync_status,
                     char** sync_error_details);
 
-  static void Cancel(void*, grpc_tls_custom_verification_check_request*) {}
+  static void Cancel(void*, grpc_tls_custom_verification_check_request*,
+                     grpc_status_code, const char*) {}
 
   static void Destruct(void* user_data);
 
@@ -168,7 +170,8 @@ class PeerPropertyExternalVerifier {
                     void* callback_arg, grpc_status_code* sync_status,
                     char** sync_error_details);
 
-  static void Cancel(void*, grpc_tls_custom_verification_check_request*) {}
+  static void Cancel(void*, grpc_tls_custom_verification_check_request*,
+                     grpc_status_code, const char*) {}
 
   static void Destruct(void* user_data);
 

--- a/test/cpp/util/tls_test_utils.cc
+++ b/test/cpp/util/tls_test_utils.cc
@@ -16,10 +16,7 @@
 
 #include "test/cpp/util/tls_test_utils.h"
 
-#include <memory>
-
 #include "src/core/lib/gprpp/thd.h"
-#include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
 using ::grpc::experimental::TlsCustomVerificationCheckRequest;
@@ -43,6 +40,7 @@ AsyncCertificateVerifier::AsyncCertificateVerifier(bool success)
     : success_(success),
       thread_("AsyncCertificateVerifierWorkerThread", WorkerThread, this) {
   thread_.Start();
+  thread_started_ = true;
 }
 
 AsyncCertificateVerifier::~AsyncCertificateVerifier() {
@@ -51,8 +49,10 @@ AsyncCertificateVerifier::~AsyncCertificateVerifier() {
     internal::MutexLock lock(&mu_);
     queue_.push_back(Request{nullptr, nullptr, true});
   }
-  // Wait for thread to exit.
-  thread_.Join();
+  if (thread_started_) {
+    // Wait for thread to exit.
+    thread_.Join();
+  }
 }
 
 bool AsyncCertificateVerifier::Verify(
@@ -61,6 +61,11 @@ bool AsyncCertificateVerifier::Verify(
   internal::MutexLock lock(&mu_);
   queue_.push_back(Request{request, std::move(callback), false});
   return false;  // Asynchronous call
+}
+
+void AsyncCertificateVerifier::Cancel(
+    TlsCustomVerificationCheckRequest* request, const absl::Status& status) {
+  *status_from_cancellation_ = status;
 }
 
 void AsyncCertificateVerifier::WorkerThread(void* arg) {


### PR DESCRIPTION
This tries to address the issue mentioned in #34434.

Admittedly, it includes some to-be-wasted work if we eventually eliminate the C-core to C++ plumbing. But given that's not happening soon enough, I think it's worth fixing this now.
