### PR TITLE
[Protobuf] Absorb protobuf::MultiFileErrorCollector change

### DIFF
--- a/tools/distrib/python/grpcio_tools/BUILD.bazel
+++ b/tools/distrib/python/grpcio_tools/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
     includes = ["."],
     deps = [
         "//src/compiler:grpc_plugin_support",
+        "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protoc_lib",
     ],
 )

--- a/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/main.cc
@@ -29,6 +29,8 @@
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 
+#include "absl/strings/string_view.h"
+
 #include "src/compiler/python_generator.h"
 
 using ::google::protobuf::FileDescriptor;
@@ -105,14 +107,16 @@ class ErrorCollectorImpl : public MultiFileErrorCollector {
                      std::vector<::grpc_tools::ProtocWarning>* warnings)
       : errors_(errors), warnings_(warnings) {}
 
-  void AddError(const std::string& filename, int line, int column,
-                const std::string& message) {
-    errors_->emplace_back(filename, line, column, message);
+  void RecordError(absl::string_view filename, int line, int column,
+                   absl::string_view message) {
+    errors_->emplace_back(std::string(filename), line, column,
+                          std::string(message));
   }
 
-  void AddWarning(const std::string& filename, int line, int column,
-                  const std::string& message) {
-    warnings_->emplace_back(filename, line, column, message);
+  void RecordWarning(absl::string_view filename, int line, int column,
+                     absl::string_view message) {
+    warnings_->emplace_back(std::string(filename), line, column,
+                            std::string(message));
   }
 
  private:


### PR DESCRIPTION
This is to absorb protobuf's breaking change introduce by https://github.com/protocolbuffers/protobuf/pull/15060. This is required to upgrade protobuf to v26.

Internal b/324252829