### PR TITLE
[Security - TLS verifier] add status information to cancel

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -1074,9 +1074,12 @@ typedef struct grpc_tls_certificate_verifier_external {
    * request: request information exposed to the function implementer. It will
    *          be the same request object that was passed to verify(), and it
    *          tells the cancel() which request to cancel.
+   * code: status code for the cancellation.
+   * error_details: status message for the cancellation.
    */
   void (*cancel)(void* user_data,
-                 grpc_tls_custom_verification_check_request* request);
+                 grpc_tls_custom_verification_check_request* request,
+                 grpc_status_code code, const char* error_details);
   /**
    * A function pointer that does some additional destruction work when the
    * verifier is destroyed. This is used when the caller wants to associate some
@@ -1186,7 +1189,8 @@ int grpc_tls_certificate_verifier_verify(
  */
 void grpc_tls_certificate_verifier_cancel(
     grpc_tls_certificate_verifier* verifier,
-    grpc_tls_custom_verification_check_request* request);
+    grpc_tls_custom_verification_check_request* request, grpc_status_code code,
+    const char* error_details);
 
 /**
  * EXPERIMENTAL API - Subject to change

--- a/include/grpcpp/security/tls_certificate_verifier.h
+++ b/include/grpcpp/security/tls_certificate_verifier.h
@@ -23,6 +23,8 @@
 #include <utility>
 #include <vector>
 
+#include "absl/status/status.h"
+
 #include <grpc/grpc_security_constants.h>
 #include <grpc/status.h>
 #include <grpc/support/log.h>
@@ -116,7 +118,8 @@ class CertificateVerifier {
   // verification request is pending.
   //
   // request: the verification information associated with this request
-  void Cancel(TlsCustomVerificationCheckRequest* request);
+  void Cancel(TlsCustomVerificationCheckRequest* request,
+              const absl::Status& status);
 
   // Gets the core verifier used internally.
   grpc_tls_certificate_verifier* c_verifier() { return verifier_; }
@@ -181,7 +184,8 @@ class ExternalCertificateVerifier {
   // passed to Verify() with a status indicating the cancellation.
   //
   // request: the verification information associated with this request
-  virtual void Cancel(TlsCustomVerificationCheckRequest* request) = 0;
+  virtual void Cancel(TlsCustomVerificationCheckRequest* request,
+                      const absl::Status& status) = 0;
 
  protected:
   ExternalCertificateVerifier();
@@ -207,7 +211,8 @@ class ExternalCertificateVerifier {
       char** sync_error_details);
 
   static void CancelInCoreExternalVerifier(
-      void* user_data, grpc_tls_custom_verification_check_request* request);
+      void* user_data, grpc_tls_custom_verification_check_request* request,
+      grpc_status_code code, const char* error_details);
 
   static void DestructInCoreExternalVerifier(void* user_data);
 

--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_verifier.cc
@@ -23,13 +23,13 @@
 #include <string>
 #include <utility>
 
+#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
-#include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/security/credentials/tls/tls_utils.h"
@@ -210,9 +210,11 @@ int grpc_tls_certificate_verifier_verify(
 
 void grpc_tls_certificate_verifier_cancel(
     grpc_tls_certificate_verifier* verifier,
-    grpc_tls_custom_verification_check_request* request) {
+    grpc_tls_custom_verification_check_request* request, grpc_status_code code,
+    const char* error_details) {
   grpc_core::ExecCtx exec_ctx;
-  verifier->Cancel(request);
+  verifier->Cancel(request, absl::Status(static_cast<absl::StatusCode>(code),
+                                         error_details ? error_details : ""));
 }
 
 grpc_tls_certificate_verifier* grpc_tls_certificate_verifier_external_create(

--- a/src/core/lib/security/credentials/xds/xds_credentials.cc
+++ b/src/core/lib/security/credentials/xds/xds_credentials.cc
@@ -100,8 +100,8 @@ bool XdsCertificateVerifier::Verify(
   return true;  // synchronous check
 }
 
-void XdsCertificateVerifier::Cancel(
-    grpc_tls_custom_verification_check_request*) {}
+void XdsCertificateVerifier::Cancel(grpc_tls_custom_verification_check_request*,
+                                    const absl::Status&) {}
 
 int XdsCertificateVerifier::CompareImpl(
     const grpc_tls_certificate_verifier* other) const {

--- a/src/core/lib/security/credentials/xds/xds_credentials.h
+++ b/src/core/lib/security/credentials/xds/xds_credentials.h
@@ -52,7 +52,8 @@ class XdsCertificateVerifier : public grpc_tls_certificate_verifier {
   bool Verify(grpc_tls_custom_verification_check_request* request,
               std::function<void(absl::Status)>,
               absl::Status* sync_status) override;
-  void Cancel(grpc_tls_custom_verification_check_request*) override;
+  void Cancel(grpc_tls_custom_verification_check_request*,
+              const absl::Status&) override;
 
   UniqueTypeName type() const override;
 

--- a/src/core/lib/security/security_connector/tls/tls_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/tls_security_connector.cc
@@ -389,7 +389,7 @@ void TlsChannelSecurityConnector::check_peer(
 }
 
 void TlsChannelSecurityConnector::cancel_check_peer(
-    grpc_closure* on_peer_checked, grpc_error_handle /*error*/) {
+    grpc_closure* on_peer_checked, grpc_error_handle error) {
   auto* verifier = options_->certificate_verifier();
   if (verifier != nullptr) {
     grpc_tls_custom_verification_check_request* pending_verifier_request =
@@ -406,7 +406,7 @@ void TlsChannelSecurityConnector::cancel_check_peer(
       }
     }
     if (pending_verifier_request != nullptr) {
-      verifier->Cancel(pending_verifier_request);
+      verifier->Cancel(pending_verifier_request, error);
     }
   }
 }
@@ -668,7 +668,7 @@ void TlsServerSecurityConnector::check_peer(
 }
 
 void TlsServerSecurityConnector::cancel_check_peer(
-    grpc_closure* on_peer_checked, grpc_error_handle /*error*/) {
+    grpc_closure* on_peer_checked, grpc_error_handle error) {
   auto* verifier = options_->certificate_verifier();
   if (verifier != nullptr) {
     grpc_tls_custom_verification_check_request* pending_verifier_request =
@@ -685,7 +685,7 @@ void TlsServerSecurityConnector::cancel_check_peer(
       }
     }
     if (pending_verifier_request != nullptr) {
-      verifier->Cancel(pending_verifier_request);
+      verifier->Cancel(pending_verifier_request, error);
     }
   }
 }

--- a/test/core/util/tls_utils.h
+++ b/test/core/util/tls_utils.h
@@ -81,7 +81,8 @@ class SyncExternalVerifier {
                     void* callback_arg, grpc_status_code* sync_status,
                     char** sync_error_details);
 
-  static void Cancel(void*, grpc_tls_custom_verification_check_request*) {}
+  static void Cancel(void*, grpc_tls_custom_verification_check_request*,
+                     grpc_status_code, const char*) {}
 
   static void Destruct(void* user_data);
 
@@ -130,7 +131,8 @@ class AsyncExternalVerifier {
                     void* callback_arg, grpc_status_code* sync_status,
                     char** sync_error_details);
 
-  static void Cancel(void*, grpc_tls_custom_verification_check_request*) {}
+  static void Cancel(void*, grpc_tls_custom_verification_check_request*,
+                     grpc_status_code, const char*) {}
 
   static void Destruct(void* user_data);
 
@@ -168,7 +170,8 @@ class PeerPropertyExternalVerifier {
                     void* callback_arg, grpc_status_code* sync_status,
                     char** sync_error_details);
 
-  static void Cancel(void*, grpc_tls_custom_verification_check_request*) {}
+  static void Cancel(void*, grpc_tls_custom_verification_check_request*,
+                     grpc_status_code, const char*) {}
 
   static void Destruct(void* user_data);
 


### PR DESCRIPTION
#35868 got polluted. This reopens it cleanly with all the comments from that PR addressed.

Original description:

 > This tries to address the issue mentioned in https://github.com/grpc/grpc/pull/34434.

 > Admittedly, it includes some to-be-wasted work if we eventually eliminate the C-core to C++ plumbing. But given that's not happening soon enough, I think it's worth fixing this now.

