### PR TITLE
[Python Distribution] Add a check for file size (v1.61.x backport)

### DIFF
--- a/tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
+++ b/tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2024 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Checks if any of the Python artifacts exceeds a certern size limit since
+# Pypi has a per-file size limit.
+
+set -ex
+
+find . -path "*/artifacts/*" -size +80M | egrep '.*' && echo "Found Python artifacts larger than 80 MB." && FAILED="true"
+
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -54,6 +54,9 @@ cp -r artifacts/* input_artifacts/ || true
 # a better signal about which distribtest are affected by the currently broken artifact builds.
 tools/run_tests/task_runner.py -f distribtest linux python ${TASK_RUNNER_EXTRA_FILTERS} -j 12 -x distribtests/sponge_log.xml || FAILED="true"
 
+# This step checks if any of the artifacts exceeds a per-file size limit.
+tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
+
 tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh
 
 if [ "$FAILED" != "" ]

--- a/tools/internal_ci/macos/grpc_distribtests_python.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_python.sh
@@ -49,6 +49,9 @@ cp -r input_artifacts/python_*/* artifacts/ || true
 # TODO(jtattermusch): Here we would normally run python macos distribtests, but currently no such tests are defined
 # in distribtest_targets.py
 
+# This step checks if any of the artifacts exceeds a per-file size limit.
+tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
+
 tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh
 
 if [ "$FAILED" != "" ]

--- a/tools/internal_ci/windows/grpc_distribtests_python.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_python.bat
@@ -42,6 +42,9 @@ bash -c "cp -r input_artifacts/python_*/* artifacts/ || true"
 @rem TODO(jtattermusch): Here we would normally run python windows distribtests, but currently no such tests are defined
 @rem in distribtest_targets.py
 
+@rem This step checks if any of the artifacts exceeds a per-file size limit.
+bash tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
+
 bash tools/internal_ci/helper_scripts/store_artifacts_from_moved_src_tree.sh
 
 if not "%FAILED%" == "" (


### PR DESCRIPTION
Backport of #35831 to v1.61.x.
---
Add a step in distribution test which checks if any of the artifacts exceeds 80 MB since Pypi has a per-file size limit.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

