### PR TITLE
[Python Otel] Allow start observability without context manager

### DIFF
--- a/examples/python/observability/observability_greeter_client.py
+++ b/examples/python/observability/observability_greeter_client.py
@@ -54,14 +54,11 @@ def run():
     with grpc.insecure_channel(target="localhost:50051") as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         try:
-            response = stub.SayHello(
-                helloworld_pb2.HelloRequest(name="You")
-            )
+            response = stub.SayHello(helloworld_pb2.HelloRequest(name="You"))
             print(f"Greeter client received: {response.message}")
         except grpc.RpcError as rpc_error:
             print("Call failed with code: ", rpc_error.code())
     grpc_observability.end_open_telemetry_observability()
-
 
     # Sleep to make sure all metrics are exported.
     time.sleep(5)

--- a/examples/python/observability/observability_greeter_client.py
+++ b/examples/python/observability/observability_greeter_client.py
@@ -47,16 +47,21 @@ def run():
     provider = MeterProvider(metric_readers=[reader])
     otel_plugin = BaseOpenTelemetryPlugin(provider)
 
-    with grpc_observability.OpenTelemetryObservability(plugins=[otel_plugin]):
-        with grpc.insecure_channel(target="localhost:50051") as channel:
-            stub = helloworld_pb2_grpc.GreeterStub(channel)
-            try:
-                response = stub.SayHello(
-                    helloworld_pb2.HelloRequest(name="You")
-                )
-                print(f"Greeter client received: {response.message}")
-            except grpc.RpcError as rpc_error:
-                print("Call failed with code: ", rpc_error.code())
+    grpc_observability.start_open_telemetry_observability(plugins=[otel_plugin])
+    # You can also use context manager to start observability:
+    # with grpc_observability.OpenTelemetryObservability(plugins=[otel_plugin]):
+
+    with grpc.insecure_channel(target="localhost:50051") as channel:
+        stub = helloworld_pb2_grpc.GreeterStub(channel)
+        try:
+            response = stub.SayHello(
+                helloworld_pb2.HelloRequest(name="You")
+            )
+            print(f"Greeter client received: {response.message}")
+        except grpc.RpcError as rpc_error:
+            print("Call failed with code: ", rpc_error.code())
+    grpc_observability.end_open_telemetry_observability()
+
 
     # Sleep to make sure all metrics are exported.
     time.sleep(5)

--- a/examples/python/observability/observability_greeter_client.py
+++ b/examples/python/observability/observability_greeter_client.py
@@ -48,8 +48,6 @@ def run():
     otel_plugin = BaseOpenTelemetryPlugin(provider)
 
     grpc_observability.start_open_telemetry_observability(plugins=[otel_plugin])
-    # You can also use context manager to start observability:
-    # with grpc_observability.OpenTelemetryObservability(plugins=[otel_plugin]):
 
     with grpc.insecure_channel(target="localhost:50051") as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)

--- a/examples/python/observability/observability_greeter_server.py
+++ b/examples/python/observability/observability_greeter_server.py
@@ -78,6 +78,7 @@ def serve():
     server.stop(0)
     grpc_observability.end_open_telemetry_observability()
 
+
 if __name__ == "__main__":
     logging.basicConfig()
     serve()

--- a/examples/python/observability/observability_greeter_server.py
+++ b/examples/python/observability/observability_greeter_server.py
@@ -58,8 +58,6 @@ def serve():
     otel_plugin = BaseOpenTelemetryPlugin(provider)
 
     grpc_observability.start_open_telemetry_observability(plugins=[otel_plugin])
-    # You can also use context manager to start observability:
-    # with grpc_observability.OpenTelemetryObservability(plugins=[otel_plugin]):
 
     server = grpc.server(
         thread_pool=futures.ThreadPoolExecutor(max_workers=10),

--- a/examples/python/observability/observability_greeter_server.py
+++ b/examples/python/observability/observability_greeter_server.py
@@ -57,23 +57,26 @@ def serve():
     provider = MeterProvider(metric_readers=[reader])
     otel_plugin = BaseOpenTelemetryPlugin(provider)
 
-    with grpc_observability.OpenTelemetryObservability(plugins=[otel_plugin]):
-        server = grpc.server(
-            thread_pool=futures.ThreadPoolExecutor(max_workers=10),
-        )
-        helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
-        server.add_insecure_port("[::]:" + _SERVER_PORT)
-        server.start()
-        print("Server started, listening on " + _SERVER_PORT)
+    grpc_observability.start_open_telemetry_observability(plugins=[otel_plugin])
+    # You can also use context manager to start observability:
+    # with grpc_observability.OpenTelemetryObservability(plugins=[otel_plugin]):
 
-        # Sleep to make sure client made RPC call and all metrics are exported.
-        time.sleep(10)
-        print("Metrics exported on Server side:")
-        for metric in all_metrics:
-            print(metric)
+    server = grpc.server(
+        thread_pool=futures.ThreadPoolExecutor(max_workers=10),
+    )
+    helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
+    server.add_insecure_port("[::]:" + _SERVER_PORT)
+    server.start()
+    print("Server started, listening on " + _SERVER_PORT)
 
-        server.stop(0)
+    # Sleep to make sure client made RPC call and all metrics are exported.
+    time.sleep(10)
+    print("Metrics exported on Server side:")
+    for metric in all_metrics:
+        print(metric)
 
+    server.stop(0)
+    grpc_observability.end_open_telemetry_observability()
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/src/python/grpcio_observability/grpc_observability/__init__.py
+++ b/src/python/grpcio_observability/grpc_observability/__init__.py
@@ -15,6 +15,17 @@
 from grpc_observability._open_telemetry_observability import (
     OpenTelemetryObservability,
 )
+from grpc_observability._open_telemetry_observability import (
+    end_open_telemetry_observability,
+)
+from grpc_observability._open_telemetry_observability import (
+    start_open_telemetry_observability,
+)
 from grpc_observability._open_telemetry_plugin import OpenTelemetryPlugin
 
-__all__ = ("OpenTelemetryObservability", "OpenTelemetryPlugin")
+__all__ = (
+    "OpenTelemetryObservability",
+    "OpenTelemetryPlugin",
+    "start_open_telemetry_observability",
+    "end_open_telemetry_observability",
+)

--- a/src/python/grpcio_tests/tests/observability/_observability_api_test.py
+++ b/src/python/grpcio_tests/tests/observability/_observability_api_test.py
@@ -24,6 +24,8 @@ class AllTest(unittest.TestCase):
         expected_observability_code_elements = (
             "OpenTelemetryObservability",
             "OpenTelemetryPlugin",
+            "start_open_telemetry_observability",
+            "end_open_telemetry_observability",
         )
 
         self.assertCountEqual(

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -176,7 +176,6 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                 grpc_observability.start_open_telemetry_observability(
                     plugins=[]
                 )
-                pass
             except RuntimeError as exp:
                 self.assertIn("observability was already initiated", str(exp))
 

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -162,8 +162,8 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         grpc_observability.end_open_telemetry_observability()
 
     def testCallGlobalInitThrowErrorWhenGlobalCalled(self):
+        grpc_observability.start_open_telemetry_observability(plugins=[])
         try:
-            grpc_observability.start_open_telemetry_observability(plugins=[])
             grpc_observability.start_open_telemetry_observability(plugins=[])
         except RuntimeError as exp:
             self.assertIn("observability was already initiated", str(exp))
@@ -195,6 +195,19 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                     pass
             except RuntimeError as exp:
                 self.assertIn("observability was already initiated", str(exp))
+
+    def testNoErrorCallGlobalInitThenContextManager(self):
+        grpc_observability.start_open_telemetry_observability(plugins=[])
+        grpc_observability.end_open_telemetry_observability()
+
+        with grpc_observability.OpenTelemetryObservability(plugins=[]):
+            pass
+
+    def testNoErrorCallContextManagerThenGlobalInit(self):
+        with grpc_observability.OpenTelemetryObservability(plugins=[]):
+            pass
+        grpc_observability.start_open_telemetry_observability(plugins=[])
+        grpc_observability.end_open_telemetry_observability()
 
     def testRecordUnaryUnaryWithClientInterceptor(self):
         interceptor = _ClientUnaryUnaryInterceptor()

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -166,7 +166,9 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         try:
             grpc_observability.start_open_telemetry_observability(plugins=[])
         except RuntimeError as exp:
-            self.assertIn("observability was already initiated", str(exp))
+            self.assertIn(
+                "gPRC Python observability was already initialized", str(exp)
+            )
 
         grpc_observability.end_open_telemetry_observability()
 
@@ -177,7 +179,10 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                     plugins=[]
                 )
             except RuntimeError as exp:
-                self.assertIn("observability was already initiated", str(exp))
+                self.assertIn(
+                    "gPRC Python observability was already initialized",
+                    str(exp),
+                )
 
     def testCallContextManagerThrowErrorWhenGlobalInitCalled(self):
         grpc_observability.start_open_telemetry_observability(plugins=[])
@@ -185,7 +190,9 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             with grpc_observability.OpenTelemetryObservability(plugins=[]):
                 pass
         except RuntimeError as exp:
-            self.assertIn("observability was already initiated", str(exp))
+            self.assertIn(
+                "gPRC Python observability was already initialized", str(exp)
+            )
         grpc_observability.end_open_telemetry_observability()
 
     def testContextManagerThrowErrorWhenContextManagerCalled(self):
@@ -194,7 +201,10 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                 with grpc_observability.OpenTelemetryObservability(plugins=[]):
                     pass
             except RuntimeError as exp:
-                self.assertIn("observability was already initiated", str(exp))
+                self.assertIn(
+                    "gPRC Python observability was already initialized",
+                    str(exp),
+                )
 
     def testNoErrorCallGlobalInitThenContextManager(self):
         grpc_observability.start_open_telemetry_observability(plugins=[])

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -20,6 +20,7 @@ import sys
 import time
 from typing import Any, Callable, Dict, List, Optional, Set
 import unittest
+from unittest.mock import patch
 
 import grpc
 import grpc_observability
@@ -134,7 +135,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         if self._server:
             self._server.stop(0)
 
-    def testRecordUnaryUnary(self):
+    def testRecordUnaryUnaryUseContextManager(self):
         otel_plugin = BaseTestOpenTelemetryPlugin(self._provider)
         with grpc_observability.OpenTelemetryObservability(
             plugins=[otel_plugin]
@@ -145,6 +146,56 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
 
         self._validate_metrics_exist(self.all_metrics)
         self._validate_all_metrics_names(self.all_metrics)
+
+    def testRecordUnaryUnaryUseGlobalInit(self):
+        otel_plugin = BaseTestOpenTelemetryPlugin(self._provider)
+
+        grpc_observability.start_open_telemetry_observability(
+            plugins=[otel_plugin]
+        )
+        server, port = _test_server.start_server()
+        self._server = server
+        _test_server.unary_unary_call(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics)
+        grpc_observability.end_open_telemetry_observability()
+
+    def testCallGlobalInitThrowErrorWhenGlobalCalled(self):
+        try:
+            grpc_observability.start_open_telemetry_observability(plugins=[])
+            grpc_observability.start_open_telemetry_observability(plugins=[])
+        except RuntimeError as exp:
+            self.assertIn("observability was already initiated", str(exp))
+
+        grpc_observability.end_open_telemetry_observability()
+
+    def testCallGlobalInitThrowErrorWhenContextManagerCalled(self):
+        with grpc_observability.OpenTelemetryObservability(plugins=[]):
+            try:
+                grpc_observability.start_open_telemetry_observability(
+                    plugins=[]
+                )
+                pass
+            except RuntimeError as exp:
+                self.assertIn("observability was already initiated", str(exp))
+
+    def testCallContextManagerThrowErrorWhenGlobalInitCalled(self):
+        grpc_observability.start_open_telemetry_observability(plugins=[])
+        try:
+            with grpc_observability.OpenTelemetryObservability(plugins=[]):
+                pass
+        except RuntimeError as exp:
+            self.assertIn("observability was already initiated", str(exp))
+        grpc_observability.end_open_telemetry_observability()
+
+    def testContextManagerThrowErrorWhenContextManagerCalled(self):
+        with grpc_observability.OpenTelemetryObservability(plugins=[]):
+            try:
+                with grpc_observability.OpenTelemetryObservability(plugins=[]):
+                    pass
+            except RuntimeError as exp:
+                self.assertIn("observability was already initiated", str(exp))
 
     def testRecordUnaryUnaryWithClientInterceptor(self):
         interceptor = _ClientUnaryUnaryInterceptor()
@@ -212,7 +263,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         self._validate_metrics_exist(self.all_metrics)
         self._validate_all_metrics_names(self.all_metrics)
 
-    def testNoRecordAfterExit(self):
+    def testNoRecordAfterExitUseContextManager(self):
         otel_plugin = BaseTestOpenTelemetryPlugin(self._provider)
         with grpc_observability.OpenTelemetryObservability(
             plugins=[otel_plugin]
@@ -221,6 +272,26 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             self._server = server
             self._port = port
             _test_server.unary_unary_call(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics)
+
+        self.all_metrics = defaultdict(list)
+        _test_server.unary_unary_call(port=self._port)
+        with self.assertRaisesRegex(AssertionError, "No metrics was exported"):
+            self._validate_metrics_exist(self.all_metrics)
+
+    def testNoRecordAfterExitUseGlobal(self):
+        otel_plugin = BaseTestOpenTelemetryPlugin(self._provider)
+
+        grpc_observability.start_open_telemetry_observability(
+            plugins=[otel_plugin]
+        )
+        server, port = _test_server.start_server()
+        self._server = server
+        self._port = port
+        _test_server.unary_unary_call(port=port)
+        grpc_observability.end_open_telemetry_observability()
 
         self._validate_metrics_exist(self.all_metrics)
         self._validate_all_metrics_names(self.all_metrics)
@@ -342,7 +413,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         message: Optional[Callable[[], str]] = None,
     ) -> None:
         message = message or (lambda: "Proposition did not evaluate to true")
-        timeout = timeout or datetime.timedelta(seconds=10)
+        timeout = timeout or datetime.timedelta(seconds=5)
         end = datetime.datetime.now() + timeout
         while datetime.datetime.now() < end:
             if predicate():


### PR DESCRIPTION
Allow start observability globally with a new API `start_open_telemetry_observability`.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

