### PR TITLE
[ruby] fix interop test build

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
@@ -27,7 +27,7 @@ ${name}')
 cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
-rvm --default use ruby-3.0
+rvm --default use ruby-3.0.5
 
 # build Ruby interop client and server
 (cd src/ruby && gem install bundler -v 2.4.22 && bundle && bundle exec rake compile)


### PR DESCRIPTION
Followup to https://github.com/grpc/grpc/pull/35934

Trying to fix:

```
Required ruby-3.0.0 is not installed.
To install do: 'rvm install "ruby-3.0.0"'
```

