### PR TITLE
Added a min next ping time to avoid assertion issue.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -123,6 +123,8 @@
 
 #define DEFAULT_MAX_PENDING_INDUCED_FRAMES 10000
 
+#define MIN_PING_TIME 5 // ms
+
 #define GRPC_ARG_HTTP2_PING_ON_RST_STREAM_PERCENT \
   "grpc.http2.ping_on_rst_stream_percent"
 
@@ -2876,7 +2878,8 @@ static void finish_bdp_ping_locked(
                                     nullptr);
   GPR_ASSERT(t->next_bdp_ping_timer_handle == TaskHandle::kInvalid);
   t->next_bdp_ping_timer_handle =
-      t->event_engine->RunAfter(next_ping - grpc_core::Timestamp::Now(), [t] {
+      t->event_engine->RunAfter(std::max(next_ping - grpc_core::Timestamp::Now(),
+                                         grpc_core::Duration::Milliseconds(MIN_PING_TIME)), [t] {
         grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
         grpc_core::ExecCtx exec_ctx;
         next_bdp_ping_timer_expired(t.get());


### PR DESCRIPTION
See the following issue for more details:

https://github.com/grpc/grpc/issues/35943

There is race condition in the code that causes an assertion. Setting a minimum next ping duration seems to fix the problem.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

