### PR TITLE
[experiment] Disable promise_based_client_call test on Windows

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -78,7 +78,6 @@ EXPERIMENTS = {
                 "v3_compression_filter",
             ],
             "core_end2end_test": [
-                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -96,9 +95,6 @@ EXPERIMENTS = {
                 "rstpit",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "lame_client_test": [
-                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",
@@ -160,7 +156,6 @@ EXPERIMENTS = {
                 "v3_compression_filter",
             ],
             "core_end2end_test": [
-                "promise_based_client_call",
                 "promise_based_server_call",
                 "work_serializer_dispatch",
             ],
@@ -178,9 +173,6 @@ EXPERIMENTS = {
                 "rstpit",
                 "tcp_frame_size_tuning",
                 "tcp_rcv_lowat",
-            ],
-            "lame_client_test": [
-                "promise_based_client_call",
             ],
             "lb_unit_test": [
                 "work_serializer_dispatch",

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -96,7 +96,10 @@
 - name: pick_first_happy_eyeballs
   default: true
 - name: promise_based_client_call
-  default: false
+  default:
+    ios: broken
+    windows: broken
+    posix: false
 - name: promise_based_server_call
   default: false
 - name: registered_method_lookup_in_transport


### PR DESCRIPTION
There is a continuous failure in the master/windows/bazel_rbe/grpc_bazel_rbe_opt tests. These generate a lot of noise at the moment, and may be hiding other issues, so they are being disabled in CI.