### PR TITLE
[build] move byte_buffer out of grpc_base

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1406,6 +1406,21 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "byte_buffer",
+    srcs = [
+        "//src/core:lib/surface/byte_buffer.cc",
+        "//src/core:lib/surface/byte_buffer_reader.cc",
+    ],
+    language = "c++",
+    deps = [
+        "exec_ctx",
+        "gpr_public_hdrs",
+        "grpc_public_hdrs",
+        "//src/core:slice",
+    ],
+)
+
+grpc_cc_library(
     name = "iomgr",
     srcs = [
         "//src/core:lib/iomgr/cfstream_handle.cc",
@@ -1555,6 +1570,7 @@ grpc_cc_library(
     public_hdrs = GRPC_PUBLIC_HDRS + GRPC_PUBLIC_EVENT_ENGINE_HDRS,
     visibility = ["@grpc:alt_grpc_base_legacy"],
     deps = [
+        "byte_buffer",
         "channel_arg_names",
         "config_vars",
         "debug_location",
@@ -1640,8 +1656,6 @@ grpc_cc_library(
         "//src/core:lib/slice/b64.cc",
         "//src/core:lib/surface/api_trace.cc",
         "//src/core:lib/surface/builtins.cc",
-        "//src/core:lib/surface/byte_buffer.cc",
-        "//src/core:lib/surface/byte_buffer_reader.cc",
         "//src/core:lib/surface/call.cc",
         "//src/core:lib/surface/call_details.cc",
         "//src/core:lib/surface/call_log_batch.cc",
@@ -1718,6 +1732,7 @@ grpc_cc_library(
     public_hdrs = GRPC_PUBLIC_HDRS + GRPC_PUBLIC_EVENT_ENGINE_HDRS,
     visibility = ["@grpc:alt_grpc_base_legacy"],
     deps = [
+        "byte_buffer",
         "call_combiner",
         "call_trace",
         "channel_arg_names",


### PR DESCRIPTION
Fixes some internal build breakage caused by #35846.

b/326202311