### PR TITLE
Add gRPC-Go version 1.62.0 to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -296,6 +296,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.59.0", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.60.1", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.61.0", ReleaseInfo(runtimes=["go1.19"])),
+            ("v1.62.0", ReleaseInfo(runtimes=["go1.19"])),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
Interop run: https://fusion2.corp.google.com/ci/kokoro/prod:grpc%2Fcore%2Fexperimental%2Flinux%2Fgrpc_interop_matrix_adhoc/activity/99858b52-009a-404b-a9a7-1546e239d5d9/summary
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

