### PR TITLE
[test] Fix use-after-free in http proxy fixture

### DIFF
--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -602,6 +602,11 @@ static void on_accept(void* arg, grpc_endpoint* endpoint,
                       grpc_pollset* /*accepting_pollset*/,
                       grpc_tcp_server_acceptor* acceptor) {
   gpr_free(acceptor);
+  if (proxy_destroyed.load()) {
+    grpc_endpoint_shutdown(endpoint, absl::UnknownError("proxy shutdown"));
+    grpc_endpoint_destroy(endpoint);
+    return;
+  }
   grpc_end2end_http_proxy* proxy = static_cast<grpc_end2end_http_proxy*>(arg);
   proxy_ref(proxy);
   if (proxy->is_shutdown.load()) {


### PR DESCRIPTION
See MSAN failure here: https://source.cloud.google.com/results/invocations/f4240bd5-960a-4736-95ba-b9408979f8e0/targets/%2F%2Ftest%2Fcore%2Fend2end:cancel_after_invoke_test@poller%3Depoll1/log

