### PR TITLE
[python] Cython 3 compatibility: declare functions noexcept.

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -1,6 +1,6 @@
 # GRPC Python setup requirements
 coverage==4.5.4
-cython==0.29.21
+cython==3.0.0
 protobuf>=3.5.0.post1, < 4.0dev
 wheel==0.38.1
 oauth2client==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # GRPC Python setup requirements
 coverage>=4.0
-cython>=0.29.8,<3.0.0rc1
+cython>=3.0.0
 protobuf>=4.21.3,<5.0dev
 wheel>=0.29

--- a/setup.py
+++ b/setup.py
@@ -539,7 +539,7 @@ except ImportError:
         sys.stderr.write(
             "We could not find Cython. Setup may take 10-20 minutes.\n"
         )
-        SETUP_REQUIRES += ("cython>=0.23,<3.0.0rc1",)
+        SETUP_REQUIRES += ("cython>=3.0.0",)
 
 COMMAND_CLASS = {
     "doc": commands.SphinxDocumentation,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pxd.pxi
@@ -48,7 +48,7 @@ cdef class CallbackWrapper:
     @staticmethod
     cdef void functor_run(
             grpc_completion_queue_functor* functor,
-            int succeed)
+            int succeed) noexcept
 
     cdef grpc_completion_queue_functor *c_functor(self)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/callback_common.pyx.pxi
@@ -50,7 +50,7 @@ cdef class CallbackWrapper:
     @staticmethod
     cdef void functor_run(
             grpc_completion_queue_functor* functor,
-            int success):
+            int success) noexcept:
         cdef CallbackContext *context = <CallbackContext *>functor
         cdef object waiter = <object>context.waiter
         if not waiter.cancelled():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -316,7 +316,7 @@ def server_credentials_ssl_dynamic_cert_config(initial_cert_config,
   return credentials
 
 cdef grpc_ssl_certificate_config_reload_status _server_cert_config_fetcher_wrapper(
-        void* user_data, grpc_ssl_server_certificate_config **config) with gil:
+        void* user_data, grpc_ssl_server_certificate_config **config) noexcept with gil:
   # This is a credentials.ServerCertificateConfig
   cdef ServerCertificateConfig cert_config = None
   if not user_data:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pxd.pxi
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cdef void __prefork() nogil
+cdef void __prefork() noexcept nogil
 
 
-cdef void __postfork_parent() nogil
+cdef void __postfork_parent() noexcept nogil
 
 
-cdef void __postfork_child() nogil
+cdef void __postfork_child() noexcept nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -35,7 +35,7 @@ _GRPC_ENABLE_FORK_SUPPORT = (
 
 _fork_handler_failed = False
 
-cdef void __prefork() nogil:
+cdef void __prefork() noexcept nogil:
     with gil:
         global _fork_handler_failed
         _fork_handler_failed = False
@@ -49,14 +49,14 @@ cdef void __prefork() nogil:
             _fork_handler_failed = True
 
 
-cdef void __postfork_parent() nogil:
+cdef void __postfork_parent() noexcept nogil:
     with gil:
         with _fork_state.fork_in_progress_condition:
             _fork_state.fork_in_progress = False
             _fork_state.fork_in_progress_condition.notify_all()
 
 
-cdef void __postfork_child() nogil:
+cdef void __postfork_child() noexcept nogil:
     with gil:
         try:
             if _fork_handler_failed:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pyx.pxi
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 # TODO(https://github.com/grpc/grpc/issues/15662): Reform this.
-cdef void* _copy_pointer(void* pointer):
+cdef void* _copy_pointer(void* pointer) noexcept:
   return pointer
 
 
 # TODO(https://github.com/grpc/grpc/issues/15662): Reform this.
-cdef void _destroy_pointer(void* pointer):
+cdef void _destroy_pointer(void* pointer) noexcept:
   pass
 
 
-cdef int _compare_pointer(void* first_pointer, void* second_pointer):
+cdef int _compare_pointer(void* first_pointer, void* second_pointer) noexcept:
   if first_pointer < second_pointer:
     return -1
   elif first_pointer > second_pointer:


### PR DESCRIPTION
In Cython 3, cdef functions that really will not raise exceptions must be declared as `noexcept`. Fixed by this commit.

Update requirements to `cython >= 3.0` in requirements*.txt and setup.py.

Fixes issue #33918.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

