### PR TITLE
Fix csharp doc comments

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -82,7 +82,13 @@ bool GenerateDocCommentBodyImpl(grpc::protobuf::io::Printer* printer,
         printer->Print("///\n");
       }
       last_was_empty = false;
-      printer->Print("///$line$\n", "line", *it);
+      // If the comment has an extra slash at the start then this can cause the C# compiler
+      // to complain when generating the XML documentation
+      // Issue https://github.com/grpc/grpc/issues/35905
+      if (line[0] == '/') {
+        line.replace(0,1,"&#x2F;");
+      }
+      printer->Print("///$line$\n", "line", line);
     }
   }
   printer->Print("/// </summary>\n");


### PR DESCRIPTION
Fix C# document comments when there is an extra / at the start of a comment line.
See https://github.com/grpc/grpc/issues/35905

Related to https://github.com/protocolbuffers/protobuf/pull/15955 which also fixes the issue in protoc compiler.
