### PR TITLE
[Interop] Make C++ xDS Interop Client and Server Responsive to SIGTERM (v1.62.x backport)

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client
@@ -27,6 +27,10 @@ COPY . .
 RUN tools/bazel build //test/cpp/interop:xds_interop_client
 RUN cp -rL /workdir/bazel-bin/test/cpp/interop/xds_interop_client /artifacts/
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 FROM python:3.9-slim-bookworm
 
 ENV GRPC_VERBOSITY="DEBUG"
@@ -39,4 +43,7 @@ RUN apt-get update \
 
 COPY --from=0 /artifacts ./
 
-ENTRYPOINT ["/xds_interop_client"]
+# tini serves as PID 1 and enables the server to properly respond to signals.
+COPY --from=0 /tini /tini
+
+ENTRYPOINT ["/tini", "-g", "-vv",  "--",  "/xds_interop_client"]

--- a/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server
@@ -27,6 +27,10 @@ COPY . .
 RUN tools/bazel build //test/cpp/interop:xds_interop_server
 RUN cp -rL /workdir/bazel-bin/test/cpp/interop/xds_interop_server /artifacts/
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 FROM python:3.9-slim-bookworm
 
 ENV GRPC_VERBOSITY="DEBUG"
@@ -39,4 +43,7 @@ RUN apt-get update \
 
 COPY --from=0 /artifacts ./
 
-ENTRYPOINT ["/xds_interop_server"]
+# tini serves as PID 1 and enables the server to properly respond to signals.
+COPY --from=0 /tini /tini
+
+ENTRYPOINT ["/tini", "-g", "-vv",  "--",  "/xds_interop_server"]


### PR DESCRIPTION
Backport of #34518 to v1.62.x.
---
This PR adds `tini` to the C++ interop client and server to make them responsive to SIGTERM.