### PR TITLE
C++20 compat: use invoke_result_t for C++17 and up

### DIFF
--- a/src/core/lib/promise/detail/promise_like.h
+++ b/src/core/lib/promise/detail/promise_like.h
@@ -71,7 +71,12 @@ class PromiseLike<void>;
 
 template <typename F>
 class PromiseLike<F, absl::enable_if_t<!std::is_void<
-                         typename std::result_of<F()>::type>::value>> {
+#if __cplusplus >= 201703L
+                         std::invoke_result_t<F>
+#else
+                         typename std::result_of<F()>::type
+#endif
+                         >::value>> {
  private:
   GPR_NO_UNIQUE_ADDRESS F f_;
 

--- a/src/core/lib/promise/detail/promise_like.h
+++ b/src/core/lib/promise/detail/promise_like.h
@@ -71,7 +71,8 @@ class PromiseLike<void>;
 
 template <typename F>
 class PromiseLike<F, absl::enable_if_t<!std::is_void<
-#if __cplusplus >= 201703L
+#if (defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
                          std::invoke_result_t<F>
 #else
                          typename std::result_of<F()>::type


### PR DESCRIPTION
C++20 removes std::result_of in favor of std::invoke_result[_t], which was added in C++17. Android builds gRPC with C++20, but gRPC still supports source languages before C++17, so use `#if __cplusplus` to select between std::result_of or std::invoke_result[_t].