### PR TITLE
[python] server abort raises RpcError

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -404,7 +404,7 @@ class _Context(grpc.ServicerContext):
             self._state.code = code
             self._state.details = _common.encode(details)
             self._state.aborted = True
-            raise Exception()
+            _raise_rpc_error(self._state)
 
     def abort_with_status(self, status: grpc.Status) -> None:
         self._state.trailing_metadata = status.trailing_metadata


### PR DESCRIPTION
When grpc server code calls context.abort() or context.abort_with_status(), it should raise a better to raise a grpc.RpcError instead of just an Exception. This allows interceptor to distinguish between intentional aborts() and unexpected errors. It matches what happens when a client cancels an rpc call.

https://github.com/grpc/grpc/issues/36009

