### PR TITLE
[examples/cpp/systemd] switch to user units instead of requiring root permissions

### DIFF
--- a/examples/cpp/systemd_socket_activation/test.sh
+++ b/examples/cpp/systemd_socket_activation/test.sh
@@ -51,9 +51,6 @@ EOF
 
     # reload after adding units
     systemctl --user daemon-reload
-
-    ## starting at boot is not necessary for testing
-    # systemctl --user enable sdsockact.socket
 }
 
 teardown_after() {
@@ -94,4 +91,4 @@ if [ ${RESULT} -ne 0 ]; then
 fi
 pass "Response received"
 
-# teardown is called upon exit
+# teardown_after is called upon exit


### PR DESCRIPTION
Drop the requirement for root priviledges to run systemd socket activation test

Additionnal changes :
- Does not autostart (no need during a test)
- Better cleanup logic (cleanup even if the test fails)

Tested with :
- systemd 247 on debian 11
- iomgr (experiments event_engine_listener posix=false)

release notes: no