### PR TITLE
[unix path with systemd activation] fix scheme slashes + absolute path 

### DIFF
--- a/examples/cpp/systemd_socket_activation/client.cc
+++ b/examples/cpp/systemd_socket_activation/client.cc
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
       return 0;
     }
   } else {
-    target_str = "unix:/tmp/server";
+    target_str = "unix:///tmp/server";
   }
   GreeterClient greeter(
       grpc::CreateChannel(target_str, grpc::InsecureChannelCredentials()));

--- a/examples/cpp/systemd_socket_activation/server.cc
+++ b/examples/cpp/systemd_socket_activation/server.cc
@@ -41,7 +41,7 @@ class GreeterServiceImpl final : public Greeter::Service {
 };
 
 void RunServer() {
-  std::string server_address("unix:/tmp/server");
+  std::string server_address("unix:///tmp/server");
   GreeterServiceImpl service;
 
   grpc::EnableDefaultHealthCheckService(true);

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -103,8 +103,17 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
         "Path name should not have more than ", maxlen, " characters"));
   }
   un->sun_family = AF_UNIX;
-  path.copy(un->sun_path, path.size());
-  un->sun_path[path.size()] = '\0';
+  int offset_start = 0;
+  if (absl::StartsWith(path, "///")) {
+    std::cout << "offset" << std::endl;
+    offset_start = 2;
+  } else if (absl::StartsWith(path, "//")) {
+    return GRPC_ERROR_CREATE(absl::StrCat(
+        "Absolute path should start with either a single slash caracter, or triple slash characters"));
+  }
+  path.copy(un->sun_path, path.size() - offset_start, offset_start);
+  un->sun_path[path.size() - offset_start] = '\0';
+  std::cout << "un->sun_path " << un->sun_path <<  std::endl;
   resolved_addr->len = static_cast<socklen_t>(sizeof(*un));
   return absl::OkStatus();
 }

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -105,7 +105,6 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
   un->sun_family = AF_UNIX;
   int offset_start = 0;
   if (absl::StartsWith(path, "///")) {
-    std::cout << "offset" << std::endl;
     offset_start = 2;
   } else if (absl::StartsWith(path, "//")) {
     return GRPC_ERROR_CREATE(absl::StrCat(
@@ -113,7 +112,6 @@ grpc_error_handle UnixSockaddrPopulate(absl::string_view path,
   }
   path.copy(un->sun_path, path.size() - offset_start, offset_start);
   un->sun_path[path.size() - offset_start] = '\0';
-  std::cout << "un->sun_path " << un->sun_path <<  std::endl;
   resolved_addr->len = static_cast<socklen_t>(sizeof(*un));
   return absl::OkStatus();
 }


### PR DESCRIPTION
According to doc/naming.md, when a unix path can be
- `unix:relative`, example `unix:foo` or `unix:../bar`
- `unix:absolute`, example `unix:/tmp/foo`
- `unix://absolute`, example `unix:///tmp/foo`

Each form works _when not using systemd socket activation_,
i.e. it handles the "triple slash path" remaining after absl::ConsumePrefix()

But _with systemd socket activation_, the `unix:///tmp/foo` is not working,
because the remaining `///tmp/foo` provided to `sd_is_socket_unix` does
not seem to be handled correctly, as it expects a "natural path" `/tmp/foo`

So it does not identify it as matching one of the provided file descriptor,
and the test fails because the server side tries to open another socket
on disk, overlapping the one systemd created and the client tried
to use, thus failing with a timeout. This pull request fixes that case.

I included an additional error management for the case when only two
slashes are provided, e.g unix://tmp/foo : as per doc/naming.md, this
should never be a valid case.

Tested with :
- systemd 247 on debian 11
- iomgr (experiments event_engine_listener posix=false)

release notes: no