### PR TITLE
[systemd/unix-abstract] fix socket activation for "unix-abstract:" naming

### DIFF
--- a/src/core/lib/iomgr/systemd_utils.cc
+++ b/src/core/lib/iomgr/systemd_utils.cc
@@ -43,13 +43,13 @@ bool set_matching_sd_unix_fd(grpc_tcp_server* s,
   if (address.empty()) {
     return false;
   }
+  // sd_is_socket_unix() requires length=0 for normal filesystem unix socket
+  // but requires actual length (including leading null) for `unix-abstract:xxx`
+  size_t len = 0;
+  if (address[0] == 0) {
+    len = address.length();
+  }
   for (int i = fd_start; i < fd_start + n; i++) {
-    // sd_is_socket_unix() requires length=0 for normal filesystem unix socket
-    // but requires actual length (including leading null) for `unix-abstract:xxx`
-    size_t len = 0;
-    if (address[0] == 0) {
-      len = address.length();
-    }
     if (sd_is_socket_unix(i, SOCK_STREAM, 1, address.c_str(), len)) {
       grpc_tcp_server_set_pre_allocated_fd(s, i);
       return true;


### PR DESCRIPTION
systemd socket activation was not working with abstract unix sockets

sd_is_socket_unix() requires different length value depending on
the type of unix socket it is working on, so feed a value in 
accordance with the documentation

other additions : early return on error or empty addresses


Tested with :
- systemd 247 on debian 11
- iomgr (experiments event_engine_listener posix=false)
