### PR TITLE
[bazel/dbg copt] fix warning name for GCC

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -36,7 +36,7 @@ build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
 
 build:dbg --compilation_mode=dbg
-build:dbg --copt=-Werror=return-stack-address
+build:dbg --copt=-Werror=return-local-addr
 
 # Dynamic link cause issues like: `dyld: malformed mach-o: load commands size (59272) > 32768`
 # https://github.com/bazelbuild/bazel/issues/9190

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -36,7 +36,6 @@ build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
 
 build:dbg --compilation_mode=dbg
-build:dbg --copt=-Werror=return-local-addr
 
 # Dynamic link cause issues like: `dyld: malformed mach-o: load commands size (59272) > 32768`
 # https://github.com/bazelbuild/bazel/issues/9190


### PR DESCRIPTION
Reproduced with :
- bazel-bootstrap 3.5.1+ds-3 (pulling bazel 6.4.0)
- setting CC to gcc and CXX to g++ otherwise bazel does not detect it
- overall, using debian 11 using default gcc/g++ versions 10.2.1

When using --config=dbg, a warning name produces an error at the beginning of the compilation :

`cc1plus: error: '-Werror=return-stack-address':
no option '-Wreturn-stack-address';
did you mean '-Wreturn-local-addr'?`

Fixed the error following the compiler advice for GCC

PLEASE NOTE : I guess `return-stack-address` might be related to CLANG
and `return-local-addr` is the GCC equivalent. I do not know CLANG,
nor am i good enough with bazel to know how to make this option flexible
(so any help will be appreciated)