### PR TITLE
[systemd/unix] handles relative socket path 

### DIFF
--- a/src/core/lib/iomgr/systemd_utils.cc
+++ b/src/core/lib/iomgr/systemd_utils.cc
@@ -43,13 +43,13 @@ bool set_matching_sd_unix_fd(grpc_tcp_server* s,
   if (address.empty()) {
     return false;
   }
+  // sd_is_socket_unix() requires length=0 for normal filesystem unix socket
+  // but requires actual length (including leading null) for `unix-abstract:xxx`
+  size_t len = 0;
+  if (address[0] == 0) {
+    len = address.length();
+  }
   for (int i = fd_start; i < fd_start + n; i++) {
-    // sd_is_socket_unix() requires length=0 for normal filesystem unix socket
-    // but requires actual length (including leading null) for `unix-abstract:xxx`
-    size_t len = 0;
-    if (address[0] == 0) {
-      len = address.length();
-    }
     if (sd_is_socket_unix(i, SOCK_STREAM, 1, address.c_str(), len)) {
       grpc_tcp_server_set_pre_allocated_fd(s, i);
       return true;


### PR DESCRIPTION
systemd sd_is_socket_unix() does not seem to handle relative
socket path as expected

See https://lists.freedesktop.org/archives/systemd-devel/2024-March/050088.html
for a report on systemd mailing list, asking about the expected
behaviour for the path (relative or absolute) in that function

This fix rebuilds an absolute path to provide to systemd functions
so that the function can accurately match the path with the
provided fd and enable socket activation to work.

The commit bd23a8 on this PR is built over PR #36039

Tested with :
- systemd 247 on debian 11
- iomgr (experiments event_engine_listener posix=false)