### PR TITLE
[CI] Upgraded cocoapods to 1.12.0

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -99,7 +99,7 @@ then
   # cocoapods
   export LANG=en_US.UTF-8
   # use "sudo" to avoid permission error on kokoro monterey image
-  time sudo gem install cocoapods --version 1.11.3 --no-document --user-install
+  time sudo gem install cocoapods --version 1.12.0 --no-document --user-install
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master


### PR DESCRIPTION
This is needed to accommodate the recent Protobuf v26 change requiring cocoapod 1.12 or later.