### PR TITLE
[PSM Interop] Enable affinity_session_drain_test for cpp

### DIFF
--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -159,10 +159,11 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
   test_suites=(
-    "gamma.gamma_baseline_test"
-    "gamma.affinity_test"
-    "gamma.csm_observability_test"
-    "app_net_ssa_test"
+    "gamma.affinity_session_drain_test"
+#    "gamma.gamma_baseline_test"
+#    "gamma.affinity_test"
+#    "gamma.csm_observability_test"
+#    "app_net_ssa_test"
   )
   for test in "${test_suites[@]}"; do
     run_test $test || (( ++failed_tests ))

--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -159,11 +159,11 @@ main() {
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
   test_suites=(
+    "gamma.gamma_baseline_test"
+    "gamma.affinity_test"
     "gamma.affinity_session_drain_test"
-#    "gamma.gamma_baseline_test"
-#    "gamma.affinity_test"
-#    "gamma.csm_observability_test"
-#    "app_net_ssa_test"
+    "gamma.csm_observability_test"
+    "app_net_ssa_test"
   )
   for test in "${test_suites[@]}"; do
     run_test $test || (( ++failed_tests ))


### PR DESCRIPTION
Add `gamma.affinity_session_drain_test` to `grpc/core/master/linux/psm-csm` test suite.