### PR TITLE
[EventEngine] rm invalid assert (#35953)

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2897,7 +2897,6 @@ static void next_bdp_ping_timer_expired_locked(
     grpc_core::RefCountedPtr<grpc_chttp2_transport> t,
     GRPC_UNUSED grpc_error_handle error) {
   GPR_DEBUG_ASSERT(error.ok());
-  GPR_ASSERT(t->next_bdp_ping_timer_handle != TaskHandle::kInvalid);
   t->next_bdp_ping_timer_handle = TaskHandle::kInvalid;
   if (t->flow_control.bdp_estimator()->accumulator() == 0) {
     // Block the bdp ping till we receive more data.


### PR DESCRIPTION

Backports https://github.com/grpc/grpc/pull/35953 to v1.61.x

----

In the case where the timer delay is <= 0, RunAfter will return an invalid handle since the callback will not be cancellable. The asserting is invalid in this case. Based on how this handle is used, it seems there is no need for a check that the handle is set. It would only matter if `finish_bdp_ping` were called again before `next_bdp_ping_timer_expired` were called, which I don't think is possible.
