### PR TITLE
[PSM Interop] Enable affinity_session_drain_test for cpp (v1.62.x backport)

### DIFF
--- a/tools/internal_ci/linux/psm-csm.sh
+++ b/tools/internal_ci/linux/psm-csm.sh
@@ -161,6 +161,7 @@ main() {
   test_suites=(
     "gamma.gamma_baseline_test"
     "gamma.affinity_test"
+    "gamma.affinity_session_drain_test"
     "gamma.csm_observability_test"
     "app_net_ssa_test"
   )


### PR DESCRIPTION
Backport of #36064 to v1.62.x.
---
Add `gamma.affinity_session_drain_test` to `grpc/core/master/linux/psm-csm` test suite.