### PR TITLE
[ObjC] remove NSPrivacyAccessedAPICategorySystemBootTime from privacy manifest

### DIFF
--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -696,12 +696,12 @@ Pod::Spec.new do |s|
 
     # PrivacyInfo.xcprivacy is not part of BoringSSL repo, inject it during pod installation
     base64 --decode $opts <<EOF | gunzip > src/PrivacyInfo.xcprivacy
-      H4sICAAAAAAC/1ByaXZhY3lJbmZvLnhjcHJpdmFjeQC1kl9PwjAUxZ/Hp6h9Z1di/JsxAhskJAQXGQ8+
-      Nt0VG7a1aRuw395OHUhE8UHflrNzzj2/pNHgpSrJBrURsu7TXnhOCdZcFqJe9ekyn3Rv6CDuRGfpfZI/
-      ZmOiSmEsyZaj2TQhtAswVKpEgDRPSTabLnLiOwDGc0ros7XqDmC73YascYVcVo3RQKalQm3dzJd1fSAs
-      bEH9mff2gzleLQS3cSeI1uji+SLTYsO4yzXja78ygkb2f59YaRC++BJZlsgtFimzLHcKzS7BtGYOvm1O
-      ZcVEfdI+5ByNwWKYTY/U+4+gBQh+TrZBbzNW+wFHnQmzuJLaTUSJuajQWFapCD4SJ488IDNyDxV8mrm/
-      m1z1rsPeYSnscaDl+RewhTMWq5GUtsH7Y7KLy8ntL8h2WqtE8PY0484rAb5xoDEDAAA=
+      H4sICAAAAAAC/1ByaXZhY3lJbmZvLnhjcHJpdmFjeQCFUU1PwjAYPo9fUXtnr7uoMWMEN0iWEFykHDw2
+      3Ss2dGvTNuD+vUWdk4hya54+n3nT6VujyB6tk7qd0CS+pgRboWvZbid0wxbjOzrNRulV8Ziz52pOjJLO
+      k2rzsCxzQscAM2MUAhSsINWyXDMSPADmK0roq/fmHuBwOMT8yIqFbo5EB5XVBq3vlsFsHARx7WsaYj7d
+      T+oEtJbCZ6Mo3WGXrdaVlXsuOma52IWWKRzh8PvClUP4xcu1Uig81gX3nHUG3beCW8s7+NO50A2X7UX6
+      TAh0DutZVZ6xD4+oHxD9r+yFgea8DQXOMnPucattt5AKmWzQed6YFL4UF0OekDs9jIp+1Bxy85vkNk5O
+      TWGYA/1BeqxHUvg4YDZ6B1ry6jZXAgAA
     EOF
 
     # We are renaming openssl to openssl_grpc so that there is no conflict with openssl if it exists

--- a/src/objective-c/PrivacyInfo.xcprivacy
+++ b/src/objective-c/PrivacyInfo.xcprivacy
@@ -18,14 +18,6 @@
 				<string>C617.1</string>
 			</array>
 		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>35F9.1</string>
-			</array>
-		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
#35923 removed the use of mach_absolute_time in gpr.

There is still one usage in protobuf, which they have removed the usage in https://github.com/protocolbuffers/protobuf/pull/15554 but we haven't update yet.
However gRPC library does not depends on protobuf but upb, so we should no longer need NSPrivacyAccessedAPICategorySystemBootTime any more.