### PR TITLE
[CI] Refactor android_ndk docker

### DIFF
--- a/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
+++ b/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
@@ -32,14 +32,16 @@
       unzip cmd.zip && rm cmd.zip && ${'\\'}
       yes | ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses && ${'\\'}
       ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'tools' && ${'\\'}
+      ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'build-tools;30.0.2' && ${'\\'}
+      ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'platforms;android-26' && ${'\\'}
       ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'ndk;25.1.8937393' && ${'\\'}
       ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'cmake;3.22.1'
 
   # Install gcloud
-  RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && ${'\\'}
-      tar -xf google-cloud-cli-407.0.0-linux-x86_64.tar.gz && ${'\\'}
+  RUN wget -O google-cloud-cli.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-467.0.0-linux-x86_64.tar.gz && ${'\\'}
+      tar -xf google-cloud-cli.tar.gz && ${'\\'}
       ./google-cloud-sdk/install.sh --bash-completion=false --path-update=true && ${'\\'}
-      rm -rf google-cloud-cli-407.0.0-linux-x86_64.tar.gz
+      rm -rf google-cloud-cli.tar.gz
   RUN ln -s /google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
 
   # Define the default command.

--- a/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
+++ b/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:10
+  FROM debian:11
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_python_deps.include"/>
@@ -22,30 +22,18 @@
   <%include file="../../run_tests_addons.include"/>
   RUN apt update && apt upgrade -y
 
-  # Java required by Android SDK (using Eclipse Temurin Package)
-  RUN apt install -y wget apt-transport-https && ${'\\'}
-      mkdir -p /etc/apt/keyrings && ${'\\'}
-      wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc && ${'\\'}
-      echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
-  RUN apt update && apt install -y temurin-8-jdk
-
-  RUN apt-get -y autoremove && ${'\\'}
-      rm -rf /var/lib/apt/lists/*
+  # Java
+  RUN apt-get install -y openjdk-17-jdk
 
   # Install Android SDK
-  ENV ANDROID_SDK_VERSION 4333796
-  RUN mkdir -p /opt/android-sdk && cd /opt/android-sdk && ${'\\'}
-      wget -q https://dl.google.com/android/repository/sdk-tools-linux-$ANDROID_SDK_VERSION.zip && ${'\\'}
-      unzip -q sdk-tools-linux-$ANDROID_SDK_VERSION.zip && ${'\\'}
-      rm sdk-tools-linux-$ANDROID_SDK_VERSION.zip
-  ENV ANDROID_SDK_PATH /opt/android-sdk
   ENV ANDROID_HOME /opt/android-sdk
-  RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licenses
-
-  # Install Android NDK & CMake
-  # This is not required but desirable to reduce the time to download and the chance of download failure.
-  RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
-  RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.22.1'
+  RUN mkdir -p $ANDROID_HOME && ${'\\'}
+      wget -O cmd.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip && ${'\\'}
+      unzip cmd.zip && rm cmd.zip && ${'\\'}
+      yes | ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses && ${'\\'}
+      ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'tools' && ${'\\'}
+      ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'ndk;25.1.8937393' && ${'\\'}
+      ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'cmake;3.22.1'
 
   # Install gcloud
   RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && ${'\\'}

--- a/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
+++ b/templates/tools/dockerfile/test/android_ndk/Dockerfile.template
@@ -23,12 +23,12 @@
   RUN apt update && apt upgrade -y
 
   # Java
-  RUN apt-get install -y openjdk-17-jdk
+  RUN apt-get install -y openjdk-11-jdk
 
   # Install Android SDK
   ENV ANDROID_HOME /opt/android-sdk
   RUN mkdir -p $ANDROID_HOME && ${'\\'}
-      wget -O cmd.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip && ${'\\'}
+      wget -O cmd.zip https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip && ${'\\'}
       unzip cmd.zip && rm cmd.zip && ${'\\'}
       yes | ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses && ${'\\'}
       ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'tools' && ${'\\'}

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -87,7 +87,7 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/interoptest/grpc_interop_pythonasyncio.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_pythonasyncio@sha256:47127a7863097b436613885a8866a2ef055470452838ceebb31f692ac88ac1d1",
     "tools/dockerfile/interoptest/grpc_interop_ruby.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_ruby@sha256:efd7f41a736dd4b8f73b32f5215b86f6bfe9013c422dfcd77978de0253aaee45",
     "tools/dockerfile/interoptest/lb_interop_fake_servers.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/lb_interop_fake_servers@sha256:b89a51dd9147e1293f50ee64dd719fce5929ca7894d3770a3d80dbdecb99fd52",
-    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:f02e523b16f808f2a9719cbb287246b5c5c57f3e33a89a30bc96cd22358ae5b1",
+    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:ab154ecb062af2111d2d3550c4d3da3384201d9893bbd37d49e8160fc34bc137",
     "tools/dockerfile/test/bazel.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf",
     "tools/dockerfile/test/bazel_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel_arm64@sha256:3b087387c44dee405c1b80d6ff50994e6d8e90a4ef67cc94b4291f1a29c0ef41",
     "tools/dockerfile/test/binder_transport_apk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/binder_transport_apk@sha256:bf60a187cd2ce1abe8b4f32ae6479040a72ca6aa789cd5ab509f60ceb37a41f9",

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -87,7 +87,7 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/interoptest/grpc_interop_pythonasyncio.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_pythonasyncio@sha256:47127a7863097b436613885a8866a2ef055470452838ceebb31f692ac88ac1d1",
     "tools/dockerfile/interoptest/grpc_interop_ruby.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_ruby@sha256:efd7f41a736dd4b8f73b32f5215b86f6bfe9013c422dfcd77978de0253aaee45",
     "tools/dockerfile/interoptest/lb_interop_fake_servers.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/lb_interop_fake_servers@sha256:b89a51dd9147e1293f50ee64dd719fce5929ca7894d3770a3d80dbdecb99fd52",
-    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:2866e815ceaf7407a9017842b86c1bf1efc96abe77ecff88e932aa1b1ddf727e",
+    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:a6fbbb257a98cc181d5f9148be3b479d7524b511f65b86df28afa85053270fc3",
     "tools/dockerfile/test/bazel.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf",
     "tools/dockerfile/test/bazel_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel_arm64@sha256:3b087387c44dee405c1b80d6ff50994e6d8e90a4ef67cc94b4291f1a29c0ef41",
     "tools/dockerfile/test/binder_transport_apk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/binder_transport_apk@sha256:bf60a187cd2ce1abe8b4f32ae6479040a72ca6aa789cd5ab509f60ceb37a41f9",

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -87,7 +87,7 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/interoptest/grpc_interop_pythonasyncio.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_pythonasyncio@sha256:47127a7863097b436613885a8866a2ef055470452838ceebb31f692ac88ac1d1",
     "tools/dockerfile/interoptest/grpc_interop_ruby.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_ruby@sha256:efd7f41a736dd4b8f73b32f5215b86f6bfe9013c422dfcd77978de0253aaee45",
     "tools/dockerfile/interoptest/lb_interop_fake_servers.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/lb_interop_fake_servers@sha256:b89a51dd9147e1293f50ee64dd719fce5929ca7894d3770a3d80dbdecb99fd52",
-    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:a6fbbb257a98cc181d5f9148be3b479d7524b511f65b86df28afa85053270fc3",
+    "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:f02e523b16f808f2a9719cbb287246b5c5c57f3e33a89a30bc96cd22358ae5b1",
     "tools/dockerfile/test/bazel.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf",
     "tools/dockerfile/test/bazel_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel_arm64@sha256:3b087387c44dee405c1b80d6ff50994e6d8e90a4ef67cc94b4291f1a29c0ef41",
     "tools/dockerfile/test/binder_transport_apk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/binder_transport_apk@sha256:bf60a187cd2ce1abe8b4f32ae6479040a72ca6aa789cd5ab509f60ceb37a41f9",

--- a/tools/dockerfile/test/android_ndk.current_version
+++ b/tools/dockerfile/test/android_ndk.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:0f78d4ce4111e5fbbb74df9203fc1a96aac9db78@sha256:f02e523b16f808f2a9719cbb287246b5c5c57f3e33a89a30bc96cd22358ae5b1
+us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:5b30710d3f4e0ad76921b0a9216154ac26f67460@sha256:ab154ecb062af2111d2d3550c4d3da3384201d9893bbd37d49e8160fc34bc137

--- a/tools/dockerfile/test/android_ndk.current_version
+++ b/tools/dockerfile/test/android_ndk.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:5d5f4b1103c005259d3ee062708301e21cb7fcae@sha256:a6fbbb257a98cc181d5f9148be3b479d7524b511f65b86df28afa85053270fc3
+us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:0f78d4ce4111e5fbbb74df9203fc1a96aac9db78@sha256:f02e523b16f808f2a9719cbb287246b5c5c57f3e33a89a30bc96cd22358ae5b1

--- a/tools/dockerfile/test/android_ndk.current_version
+++ b/tools/dockerfile/test/android_ndk.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:7642d2e940a8b14b0f3b63798642869e544d8e01@sha256:2866e815ceaf7407a9017842b86c1bf1efc96abe77ecff88e932aa1b1ddf727e
+us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk:5d5f4b1103c005259d3ee062708301e21cb7fcae@sha256:a6fbbb257a98cc181d5f9148be3b479d7524b511f65b86df28afa85053270fc3

--- a/tools/dockerfile/test/android_ndk/Dockerfile
+++ b/tools/dockerfile/test/android_ndk/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:10
+FROM debian:11
 
 #=================
 # Basic C core dependencies
@@ -98,30 +98,18 @@ RUN mkdir /var/local/jenkins
 
 RUN apt update && apt upgrade -y
 
-# Java required by Android SDK (using Eclipse Temurin Package)
-RUN apt install -y wget apt-transport-https && \
-    mkdir -p /etc/apt/keyrings && \
-    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc && \
-    echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
-RUN apt update && apt install -y temurin-8-jdk
-
-RUN apt-get -y autoremove && \
-    rm -rf /var/lib/apt/lists/*
+# Java
+RUN apt-get install -y openjdk-17-jdk
 
 # Install Android SDK
-ENV ANDROID_SDK_VERSION 4333796
-RUN mkdir -p /opt/android-sdk && cd /opt/android-sdk && \
-    wget -q https://dl.google.com/android/repository/sdk-tools-linux-$ANDROID_SDK_VERSION.zip && \
-    unzip -q sdk-tools-linux-$ANDROID_SDK_VERSION.zip && \
-    rm sdk-tools-linux-$ANDROID_SDK_VERSION.zip
-ENV ANDROID_SDK_PATH /opt/android-sdk
 ENV ANDROID_HOME /opt/android-sdk
-RUN yes | $ANDROID_SDK_PATH/tools/bin/sdkmanager --licenses  # accept all licenses
-
-# Install Android NDK & CMake
-# This is not required but desirable to reduce the time to download and the chance of download failure.
-RUN mkdir -p ~/.android && touch ~/.android/repositories.cfg
-RUN $ANDROID_SDK_PATH/tools/bin/sdkmanager 'ndk;25.1.8937393' 'cmake;3.22.1'
+RUN mkdir -p $ANDROID_HOME && \
+    wget -O cmd.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip && \
+    unzip cmd.zip && rm cmd.zip && \
+    yes | ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses && \
+    ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'tools' && \
+    ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'ndk;25.1.8937393' && \
+    ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'cmake;3.22.1'
 
 # Install gcloud
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && \

--- a/tools/dockerfile/test/android_ndk/Dockerfile
+++ b/tools/dockerfile/test/android_ndk/Dockerfile
@@ -99,12 +99,12 @@ RUN mkdir /var/local/jenkins
 RUN apt update && apt upgrade -y
 
 # Java
-RUN apt-get install -y openjdk-17-jdk
+RUN apt-get install -y openjdk-11-jdk
 
 # Install Android SDK
 ENV ANDROID_HOME /opt/android-sdk
 RUN mkdir -p $ANDROID_HOME && \
-    wget -O cmd.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip && \
+    wget -O cmd.zip https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip && \
     unzip cmd.zip && rm cmd.zip && \
     yes | ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses && \
     ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'tools' && \

--- a/tools/dockerfile/test/android_ndk/Dockerfile
+++ b/tools/dockerfile/test/android_ndk/Dockerfile
@@ -108,14 +108,16 @@ RUN mkdir -p $ANDROID_HOME && \
     unzip cmd.zip && rm cmd.zip && \
     yes | ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME --licenses && \
     ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'tools' && \
+    ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'build-tools;30.0.2' && \
+    ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'platforms;android-26' && \
     ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'ndk;25.1.8937393' && \
     ./cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_HOME 'cmake;3.22.1'
 
 # Install gcloud
-RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-407.0.0-linux-x86_64.tar.gz && \
-    tar -xf google-cloud-cli-407.0.0-linux-x86_64.tar.gz && \
+RUN wget -O google-cloud-cli.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-467.0.0-linux-x86_64.tar.gz && \
+    tar -xf google-cloud-cli.tar.gz && \
     ./google-cloud-sdk/install.sh --bash-completion=false --path-update=true && \
-    rm -rf google-cloud-cli-407.0.0-linux-x86_64.tar.gz
+    rm -rf google-cloud-cli.tar.gz
 RUN ln -s /google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud
 
 # Define the default command.


### PR DESCRIPTION
Refactored android-ndk docker image to have
- Replaced a full Android SDK with a Android command line tool (generally good for docker usage) and bumped its version to the latest among ones that support JDK 11
- Upgraded Debian from 10 to 11
- Upgraded Java SDK 8 to 11
- Upgraded Google CLI to the latest