### PR TITLE
[grpc][Gpr_To_Absl_Logging] Making absl logging flags true

### DIFF
--- a/src/core/lib/config/config_vars.cc
+++ b/src/core/lib/config/config_vars.cc
@@ -95,7 +95,7 @@ ConfigVars::ConfigVars(const Overrides& overrides)
           FLAGS_grpc_not_use_system_ssl_roots, "GRPC_NOT_USE_SYSTEM_SSL_ROOTS",
           overrides.not_use_system_ssl_roots, false)),
       absl_logging_(LoadConfig(FLAGS_grpc_absl_logging, "GRPC_ABSL_LOGGING",
-                               overrides.absl_logging, false)),
+                               overrides.absl_logging, true)),
       dns_resolver_(LoadConfig(FLAGS_grpc_dns_resolver, "GRPC_DNS_RESOLVER",
                                overrides.dns_resolver, "")),
       verbosity_(LoadConfig(FLAGS_grpc_verbosity, "GRPC_VERBOSITY",

--- a/src/core/lib/config/config_vars.yaml
+++ b/src/core/lib/config/config_vars.yaml
@@ -128,6 +128,6 @@
     ECDHE-RSA-AES256-GCM-SHA384"
 - name: absl_logging
   type: bool
-  default: false
+  default: true
   description:
     Use absl logging from within gpr_log.


### PR DESCRIPTION

![Config_Vars_Absl (1)](https://github.com/grpc/grpc/assets/139093547/99076bed-34c1-4f45-926b-1bbf72c95ad8)
Flipping the flag to use absl logging instead of gpr_default_log_platform 


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

