### PR TITLE
[OTel C++] Do not add otel_plugin_test with CMake if the otel plugin is not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1238,7 +1238,6 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx orca_service_end2end_test)
   add_dependencies(buildtests_cxx orphanable_test)
   add_dependencies(buildtests_cxx osa_distance_test)
-  add_dependencies(buildtests_cxx otel_plugin_test)
   add_dependencies(buildtests_cxx out_of_bounds_bad_client_test)
   add_dependencies(buildtests_cxx outlier_detection_lb_config_parser_test)
   add_dependencies(buildtests_cxx outlier_detection_test)
@@ -20620,7 +20619,7 @@ target_link_libraries(osa_distance_test
 
 
 endif()
-if(gRPC_BUILD_TESTS)
+if(gRPC_BUILD_TESTS AND gRPC_BUILD_GRPCPP_OTEL_PLUGIN)
 
 add_executable(otel_plugin_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/echo.pb.cc

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -13210,8 +13210,9 @@ targets:
   - gtest
 - name: otel_plugin_test
   gtest: true
-  build: test
+  build: plugin_test
   language: c++
+  plugin_option: gRPC_BUILD_GRPCPP_OTEL_PLUGIN
   headers:
   - src/cpp/ext/otel/key_value_iterable.h
   - src/cpp/ext/otel/otel_call_tracer.h

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -200,7 +200,7 @@
   def is_generate_cmake_target(lib_or_target):
     """Returns True if a cmake target should be generated for given library/target."""
     # TODO(jtattermusch): extract the metadata to a centralized location.
-    if lib_or_target.build not in ["all", "plugin", "protoc", "tool", "test", "private"]:
+    if lib_or_target.build not in ["all", "plugin", "plugin_test", "protoc", "tool", "test", "private"]:
       return False
     if lib_or_target.boringssl:
       # Don't generate target for boringssl libs or tests
@@ -771,6 +771,12 @@
   % if is_generate_cmake_target(tgt):
   % if tgt.build in ["test", "private"]:
   if(gRPC_BUILD_TESTS)
+  <%block filter='platforms_condition_block(tgt.platforms)'>
+  ${cc_binary(tgt)}
+  </%block>
+  endif()
+  % elif tgt.build in ["plugin_test"]:
+  if(gRPC_BUILD_TESTS AND ${tgt.plugin_option})
   <%block filter='platforms_condition_block(tgt.platforms)'>
   ${cc_binary(tgt)}
   </%block>

--- a/templates/README.md
+++ b/templates/README.md
@@ -91,6 +91,7 @@ Currently, the "`build`" tag have these meanings:
 * `"all"`: library to build on `"make all"`, and install on the system.
 * `"plugin"`: library to build on `"make all"`, and install, but the corresponding CMake option defaults to off. The option needs to be declared manually at present to allow depending on third-party dependencies.
 * `"protoc"`: a protoc plugin to build on `"make all"` and install on the system.
+* `"plugin_test"`: A test that should only be built if the associated plugin is enabled. The plugin is mentioned in the `"plugin_option"` tag.
 * `"private"`: a library to only build for tests.
 * `"test"`: a test binary to run on `"make test"`.
 * `"tool"`: a binary to be built upon `"make tools"`.

--- a/tools/buildgen/build_cleaner.py
+++ b/tools/buildgen/build_cleaner.py
@@ -39,6 +39,7 @@ _ELEM_KEYS = [
     "build",
     "run",
     "language",
+    "plugin_option",
     "public_headers",
     "headers",
     "src",

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -536,7 +536,10 @@ def update_test_metadata_with_transitive_metadata(
     """Patches test build metadata with transitive metadata."""
     for lib_name, lib_dict in list(all_extra_metadata.items()):
         # Skip if it isn't not an test
-        if lib_dict.get("build") != "test" or lib_dict.get("_TYPE") != "target":
+        if (
+            lib_dict.get("build") != "test"
+            and lib_dict.get("build") != "plugin_test"
+        ) or lib_dict.get("_TYPE") != "target":
             continue
 
         bazel_rule = bazel_rules[_get_bazel_label(lib_name)]
@@ -752,6 +755,7 @@ def _convert_to_build_yaml_like(lib_dict: BuildMetadata) -> BuildYaml:
         lib_name
         for lib_name in list(lib_dict.keys())
         if lib_dict[lib_name].get("_TYPE", "library") == "test"
+        or lib_dict[lib_name].get("_TYPE", "library") == "plugin_test"
     ]
 
     # list libraries and targets in predefined order
@@ -1006,7 +1010,7 @@ def _generate_build_extra_metadata_for_tests(
                     " to %s" % (test_name, long_name)
                 )
                 test_metadata[test_name]["_RENAME"] = long_name
-
+    print(test_metadata["test/cpp/ext/otel:otel_plugin_test"])
     return test_metadata
 
 
@@ -1301,6 +1305,13 @@ _BUILD_EXTRA_METADATA = {
         "_TYPE": "target",
         "_RENAME": "grpc_cli",
     },
+    "test/cpp/ext/otel:otel_plugin_test": {
+        "language": "c++",
+        "build": "plugin_test",
+        "_TYPE": "target",
+        "plugin_option": "gRPC_BUILD_GRPCPP_OTEL_PLUGIN",
+        "_RENAME": "otel_plugin_test",
+    },
     # TODO(jtattermusch): create_jwt and verify_jwt breaks distribtests because it depends on grpc_test_utils and thus requires tests to be built
     # For now it's ok to disable them as these binaries aren't very useful anyway.
     # 'test/core/security:create_jwt': { 'language': 'c', 'build': 'tool', '_TYPE': 'target', '_RENAME': 'grpc_create_jwt' },
@@ -1418,10 +1429,10 @@ if "@com_google_protobuf//third_party/utf8_range:utf8_range" not in bazel_rules:
         "@com_google_protobuf//third_party/utf8_range:utf8_range"
     ]
     _BUILD_EXTRA_METADATA["@utf8_range//:utf8_range"] = md
-all_extra_metadata.update(_BUILD_EXTRA_METADATA)
 all_extra_metadata.update(
     _generate_build_extra_metadata_for_tests(tests, bazel_rules)
 )
+all_extra_metadata.update(_BUILD_EXTRA_METADATA)
 
 # Step 4: Compute the build metadata that will be used in the final build.yaml.
 # The final build metadata includes transitive dependencies, and sources/headers

--- a/tools/buildgen/plugins/check_attrs.py
+++ b/tools/buildgen/plugins/check_attrs.py
@@ -85,6 +85,7 @@ VALID_ATTRIBUTE_KEYS_MAP = {
         "language": one_of(("c", "c89", "c++", "csharp")),
         "maxlen": anything(),
         "platforms": subset_of(("linux", "mac", "posix", "windows")),
+        "plugin_option": anything(),
         "run": one_of((True, False)),
         "secure": one_of(("check", True, False)),
         "src": anything(),

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -6470,30 +6470,6 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
-    "name": "otel_plugin_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": true,
-    "language": "c++",
     "name": "out_of_bounds_bad_client_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
This should fix our interop builds