### PR TITLE
[time] Use grpc_core::Timestamp for start times used to compute deadlines

### DIFF
--- a/src/core/client_channel/dynamic_filters.h
+++ b/src/core/client_channel/dynamic_filters.h
@@ -51,7 +51,7 @@ class DynamicFilters : public RefCounted<DynamicFilters> {
       RefCountedPtr<DynamicFilters> channel_stack;
       grpc_polling_entity* pollent;
       grpc_slice path;
-      gpr_cycle_counter start_time;
+      Timestamp start_time;
       Timestamp deadline;
       Arena* arena;
       grpc_call_context_element* context;

--- a/src/core/client_channel/retry_filter_legacy_call_data.cc
+++ b/src/core/client_channel/retry_filter_legacy_call_data.cc
@@ -1714,9 +1714,15 @@ void RetryFilter::LegacyCallData::StartTransportStreamOpBatch(
 OrphanablePtr<ClientChannelFilter::FilterBasedLoadBalancedCall>
 RetryFilter::LegacyCallData::CreateLoadBalancedCall(
     absl::AnyInvocable<void()> on_commit, bool is_transparent_retry) {
-  grpc_call_element_args args = {owning_call_, nullptr,          call_context_,
-                                 path_,        /*start_time=*/0, deadline_,
-                                 arena_,       call_combiner_};
+  grpc_call_element_args args = {
+      owning_call_,
+      nullptr,
+      call_context_,
+      path_,
+      /*start_time(fix if needed)=*/Timestamp::InfPast(),
+      deadline_,
+      arena_,
+      call_combiner_};
   return chand_->client_channel()->CreateLoadBalancedCall(
       args, pollent_,
       // This callback holds a ref to the CallStackDestructionBarrier

--- a/src/core/client_channel/subchannel.h
+++ b/src/core/client_channel/subchannel.h
@@ -102,7 +102,7 @@ class SubchannelCall {
     RefCountedPtr<ConnectedSubchannel> connected_subchannel;
     grpc_polling_entity* pollent;
     Slice path;
-    gpr_cycle_counter start_time;
+    Timestamp start_time;
     Timestamp deadline;
     Arena* arena;
     grpc_call_context_element* context;

--- a/src/core/client_channel/subchannel_stream_client.cc
+++ b/src/core/client_channel/subchannel_stream_client.cc
@@ -206,8 +206,8 @@ void SubchannelStreamClient::CallState::StartCallLocked() {
       subchannel_stream_client_->connected_subchannel_,
       &pollent_,
       Slice::FromStaticString("/grpc.health.v1.Health/Watch"),
-      gpr_get_cycle_counter(),  // start_time
-      Timestamp::InfFuture(),   // deadline
+      Timestamp::Now(),        // start_time
+      Timestamp::InfFuture(),  // deadline
       arena_.get(),
       context_,
       &call_combiner_,

--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -87,7 +87,7 @@ struct grpc_call_element_args {
   const void* server_transport_data;
   grpc_call_context_element* context;
   const grpc_slice& path;
-  gpr_cycle_counter start_time;  // Note: not populated in subchannel stack.
+  grpc_core::Timestamp start_time;  // Note: not populated in subchannel stack.
   grpc_core::Timestamp deadline;
   grpc_core::Arena* arena;
   grpc_core::CallCombiner* call_combiner;

--- a/src/core/lib/gpr/time_precise.h
+++ b/src/core/lib/gpr/time_precise.h
@@ -27,8 +27,10 @@
 // low as a usec. Use other clock sources or gpr_precise_clock_now(),
 // where you need high resolution clocks.
 //
-// Using gpr_get_cycle_counter() is preferred to using Timestamp::Now()
-// whenever possible.
+// Use gpr_get_cycle_counter() only for stats latency calculation, and not for
+// any other reason such as checking for deadlines. There's currently a
+// discrepancy when mixing gpr_cycle_counter and gpr_timespec. Prefer to use
+// gpr_timespec or grpc_core::Timestamp::Now() for regular gRPC functionality.
 
 #if GPR_CYCLE_COUNTER_CUSTOM
 typedef int64_t gpr_cycle_counter;

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -141,6 +141,8 @@ grpc_call* grpc_channel_create_registered_call(
        registered_call_handle, deadline.tv_sec, deadline.tv_nsec,
        (int)deadline.clock_type, reserved));
   GPR_ASSERT(!reserved);
+  gpr_log(GPR_ERROR, "Call created %s",
+          grpc_core::Timestamp::Now().ToString().c_str());
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
   return grpc_core::Channel::FromC(channel)->CreateCall(


### PR DESCRIPTION
Fixes #34547

It turns out that there is a difference between the now value between gpr_cycle_counter and gpr_timespec when converted to grpc_core::Timestamp and this difference is around a second.

The main reason for this is - https://github.com/grpc/grpc/blob/c68e6c27ca54a8b7b98a21e6315c805f235d5dda/src/core/lib/gprpp/time.cc#L73 
which was introduced to fix time related bugs.
Additionally, we throw away the nsec component of the gpr_timespec to be efficient (since we are using std::atomic).

All in all, we don't want to mix and match `gpr_timespec` with `gpr_cycle_counter`. If we ever feel the need to, we should fix the discrepancy first.