### PR TITLE
[posix EventEngine] fix ResolvedAddressIsWildcard documentation

### DIFF
--- a/src/core/lib/event_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/tcp_socket_utils.h
@@ -57,7 +57,7 @@ void ResolvedAddressSetPort(EventEngine::ResolvedAddress& resolved_addr,
                             int port);
 
 // Returns the port number associated with the address if the given address is
-// not a wildcard ipv6 or ipv6 address. Otherwise returns absl::nullopt
+// a wildcard ipv4 or ipv6 address. Otherwise returns absl::nullopt
 absl::optional<int> ResolvedAddressIsWildcard(
     const EventEngine::ResolvedAddress& addr);
 


### PR DESCRIPTION
Fix the wording of the description of the function for the return value : current version says the opposite of what the function does. The current behaviour is to return the port used, but only when the address _is actually_ a wildcard address : 0.0.0.0 (ipv4) or :: (ipv6). Plus mention both ipv4 and ipv6 in the description.