### PR TITLE
[EventEngine] Rename and add tests for ResolvedAddress wildcard port accessor

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.cc
@@ -100,7 +100,7 @@ absl::StatusOr<int> PosixEngineListenerImpl::Bind(
     }
   }
 
-  auto used_port = ResolvedAddressIsWildcard(res_addr);
+  auto used_port = MaybeGetWildcardPortFromAddress(res_addr);
   // Update the callback. Any subsequent new sockets created and added to
   // acceptors_ in this function will invoke the new callback.
   acceptors_.UpdateOnAppendCallback(std::move(on_bind_new_fd));

--- a/src/core/lib/event_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/tcp_socket_utils.cc
@@ -311,7 +311,7 @@ void ResolvedAddressSetPort(EventEngine::ResolvedAddress& resolved_addr,
   }
 }
 
-absl::optional<int> ResolvedAddressIsWildcard(
+absl::optional<int> MaybeGetWildcardPortFromAddress(
     const EventEngine::ResolvedAddress& addr) {
   const EventEngine::ResolvedAddress* resolved_addr = &addr;
   EventEngine::ResolvedAddress addr4_normalized;

--- a/src/core/lib/event_engine/tcp_socket_utils.h
+++ b/src/core/lib/event_engine/tcp_socket_utils.h
@@ -58,7 +58,7 @@ void ResolvedAddressSetPort(EventEngine::ResolvedAddress& resolved_addr,
 
 // Returns the port number associated with the address if the given address is
 // a wildcard ipv4 or ipv6 address. Otherwise returns absl::nullopt
-absl::optional<int> ResolvedAddressIsWildcard(
+absl::optional<int> MaybeGetWildcardPortFromAddress(
     const EventEngine::ResolvedAddress& addr);
 
 // Returns true if resolved_addr is an VSOCK address. Otherwise returns false.

--- a/src/core/lib/event_engine/windows/windows_listener.cc
+++ b/src/core/lib/event_engine/windows/windows_listener.cc
@@ -354,7 +354,7 @@ absl::StatusOr<int> WindowsEventEngineListener::Bind(
     out_addr = tmp_addr;
   }
   // Treat :: or 0.0.0.0 as a family-agnostic wildcard.
-  if (ResolvedAddressIsWildcard(out_addr)) {
+  if (MaybeGetWildcardPortFromAddress(out_addr).has_value()) {
     out_addr = ResolvedAddressMakeWild6(out_port);
   }
   // open the socket

--- a/test/core/event_engine/tcp_socket_utils_test.cc
+++ b/test/core/event_engine/tcp_socket_utils_test.cc
@@ -313,6 +313,21 @@ TEST(TcpSocketUtilsTest, SockAddrPortTest) {
   EXPECT_EQ(ResolvedAddressToNormalizedString(wild6).value(), "[::]:22");
 }
 
+TEST(TcpSocketUtilsTest, ResolvedAddressIsWildcard) {
+  EventEngine::ResolvedAddress wild4 = ResolvedAddressMakeWild4(20);
+  EventEngine::ResolvedAddress wild6 = ResolvedAddressMakeWild6(20);
+  auto v4_port = ResolvedAddressIsWildcard(wild4);
+  ASSERT_TRUE(v4_port.has_value());
+  auto v6_port = ResolvedAddressIsWildcard(wild6);
+  ASSERT_TRUE(v6_port.has_value());
+  wild4 = MakeAddr4(kIPv4, sizeof(kIPv4));
+  v4_port = ResolvedAddressIsWildcard(wild4);
+  ASSERT_FALSE(v4_port.has_value());
+  wild6 = MakeAddr6(kMapped, sizeof(kMapped));
+  v6_port = ResolvedAddressIsWildcard(wild6);
+  ASSERT_FALSE(v6_port.has_value());
+}
+
 }  // namespace experimental
 }  // namespace grpc_event_engine
 

--- a/test/core/event_engine/tcp_socket_utils_test.cc
+++ b/test/core/event_engine/tcp_socket_utils_test.cc
@@ -313,18 +313,18 @@ TEST(TcpSocketUtilsTest, SockAddrPortTest) {
   EXPECT_EQ(ResolvedAddressToNormalizedString(wild6).value(), "[::]:22");
 }
 
-TEST(TcpSocketUtilsTest, ResolvedAddressIsWildcard) {
+TEST(TcpSocketUtilsTest, MaybeGetWildcardPortFromAddress) {
   EventEngine::ResolvedAddress wild4 = ResolvedAddressMakeWild4(20);
   EventEngine::ResolvedAddress wild6 = ResolvedAddressMakeWild6(20);
-  auto v4_port = ResolvedAddressIsWildcard(wild4);
+  auto v4_port = MaybeGetWildcardPortFromAddress(wild4);
   ASSERT_TRUE(v4_port.has_value());
-  auto v6_port = ResolvedAddressIsWildcard(wild6);
+  auto v6_port = MaybeGetWildcardPortFromAddress(wild6);
   ASSERT_TRUE(v6_port.has_value());
   wild4 = MakeAddr4(kIPv4, sizeof(kIPv4));
-  v4_port = ResolvedAddressIsWildcard(wild4);
+  v4_port = MaybeGetWildcardPortFromAddress(wild4);
   ASSERT_FALSE(v4_port.has_value());
   wild6 = MakeAddr6(kMapped, sizeof(kMapped));
-  v6_port = ResolvedAddressIsWildcard(wild6);
+  v6_port = MaybeGetWildcardPortFromAddress(wild6);
   ASSERT_FALSE(v6_port.has_value());
 }
 


### PR DESCRIPTION
The function name was not very descriptive of its behavior, and there were no tests that made the behavior clear. The documentation had been wrong for some time, fixed in https://github.com/grpc/grpc/pull/36143. CC @nipil 