### PR TITLE
Remove contradicting comment

### DIFF
--- a/include/grpc/status.h
+++ b/include/grpc/status.h
@@ -84,7 +84,6 @@ typedef enum {
      between FAILED_PRECONDITION, ABORTED, and UNAVAILABLE:
       (a) Use UNAVAILABLE if the client can retry just the failing call.
       (b) Use ABORTED if the client should retry at a higher-level
-          (e.g., restarting a read-modify-write sequence).
       (c) Use FAILED_PRECONDITION if the client should not retry until
           the system state has been explicitly fixed.  E.g., if an "rmdir"
           fails because the directory is non-empty, FAILED_PRECONDITION


### PR DESCRIPTION
```
(e.g., restarting a read-modify-write sequence).
```

actually stands for retrying conditional update request, which is covered by `(d)` ... `conflicting read-modify-write on the same resource`


