### PR TITLE
[build] Stop compiling every test.cc file for every config

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -556,11 +556,21 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
             **test_args
         )
 
+    native.cc_library(
+        name = "%s_library" % name,
+        testonly = 1,
+        srcs = srcs,
+        deps = core_deps,
+    )
+
     for poller_config in expand_tests(name, srcs, core_deps, tags, args, exclude_pollers, uses_polling, uses_event_engine, flaky):
+        if poller_config["srcs"] != srcs:
+            fail("srcs changed")
+        if poller_config["deps"] != core_deps:
+            fail("deps changed: %r --> %r" % (deps, poller_config["deps"]))
         native.cc_test(
             name = poller_config["name"],
-            srcs = poller_config["srcs"],
-            deps = poller_config["deps"],
+            deps = ["%s_library" % name],
             tags = poller_config["tags"],
             args = poller_config["args"],
             env = poller_config["env"],


### PR DESCRIPTION
Instead, build a library and re-use that across compilations.

This still invokes a link step per target, and we'll want to deal with that at some point too, but at least this makes some progress to not being as wasteful with our compilation resources.
