### PR TITLE
[systemd] Implement socket activation in event_engine

### DIFF
--- a/examples/cpp/systemd_socket_activation/README.md
+++ b/examples/cpp/systemd_socket_activation/README.md
@@ -11,3 +11,74 @@ The simplest way to exercise this is via `test.sh`. It roughly does the followin
 * Builds the gRPC client & server.
 * Reloads the systemd daemon.
 * Runs the gRPC client, which in turn runs the gRPC server.
+
+The test script runs multiple tests in sequence, order to :
+
+- show how to define the parameters for systemd
+- show what to use as grpc server endpoint
+- validate that these tuples of settings  and validate that systemd socket activation work
+
+The client log is printed on the console when run.
+
+The server log can be viewed in Systemd journal.
+
+### What cannot be implemented
+
+- Wildcard ports (`:0`) to auto-choose a port, as systemd does not offer the possibility of dynamic ports.
+
+### What is implemented and tested
+
+For the specific tested cases and expected results, see `test.sh`.
+
+General guidelines are the following :
+
+- Unix standard socket with absolute path :
+  - Systemd : `ListenStream=/tmp/server`
+  - gRPC server : `unix:/tmp/server` or `unix:///tmp/server`
+    (please mind the triple-slash, as stated in `Naming.md`)
+- Unix standard socket with relative path :
+  - Warning: *not compatible with symlinks in the socket path !*
+  - Systemd : `ListenStream=/tmp/server` and `WorkingDirectory=/tmp`
+  - gRPC server : `unix:server` or `unix:./server`
+- Unix abstract socket by name :
+  - Systemd : `ListenStream=@test_unix_abstract`
+  - gRPC server : `unix-abstract:test_unix_abstract`
+- IPv4 addresses :
+  - Systemd : `ListenStream=127.0.0.1:3456`
+  - gRPC server : `127.0.0.1:3456`
+- IPv4 wildcard addresses :
+  - Systemd : `ListenStream=0.0.0.0:3456`
+  - gRPC server : `0.0.0.0:3456`
+- IPv6 addresses :
+  - in dual-stack mode, use `BindIPv6Only=both` (or leave `BindIPv6Only=default`) in systemd socket unit
+  - in ipv6-only mode, use `BindIPv6Only=ipv6-only` in systemd socket unit
+- IPv6 addresses :
+  - Systemd : `ListenStream=[::1]:3456`
+  - gRPC server : `[::1]:3456`
+- IPv6 wildcard addresses :
+  - Systemd : `ListenStream=[::]:3456`
+  - gRPC server : `[::]:3456`
+- DNS records, resolving to addresses *in one of the formats listed above* :
+  - Warning : Systemd does not allow using DNS records in socket units
+  - Notice : on the server side, `example.org` resolves to `192.168.1.1`
+  - Systemd : `ListenStream=192.168.1.1:3456`
+  - gRPC server : `example.org:3456`
+- Option `grpc.expand_wildcard_addrs`, as weird as it would be :
+  - Systemd : one or multiple existing interface, such as `ListenStream=[::1]:3456`
+  - gRPC server : `[::]:3456`, which would expand into "one per host interface",
+    some of which would actually match the ones configured in Systemd
+    (for example, the `[::1]` above).
+  - So please mind the fact that Systemd will only start the server
+    *for connection coming on the addresses it is configured to listen on*.
+    So even though gRPC wildcard expansion will create additional listening
+    sockets to listen on, these listeners are only known to gRPC, and any
+    incoming connections on these listener will of course *not* trigger
+    an activation through Systemd. As a consequence, these additional gRPC
+    listeners would only be reachable when the server is running. If you
+    want more interface listeners to trigger activation, use additional
+    `ListenStream=` stanzas in your Systemd socket unit.
+
+### What is not implemented
+
+- Vsock addresses
+- Interface scope `[x]:y%dev`, for IPv6 link-local addresses

--- a/examples/cpp/systemd_socket_activation/server.cc
+++ b/examples/cpp/systemd_socket_activation/server.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <signal.h>
+
 #include <iostream>
 #include <memory>
 #include <string>
@@ -36,33 +38,108 @@ class GreeterServiceImpl final : public Greeter::Service {
                   HelloReply* reply) override {
     std::string prefix("Hello ");
     reply->set_message(prefix + request->name());
+    std::cout << "Client connected from " << context->peer() << std::endl;
     return Status::OK;
   }
 };
 
-void RunServer() {
-  std::string server_address("unix:/tmp/server");
+void* wait_for_sigint_then_shutdown(void* data) {
+  Server** server = static_cast<Server**>(data);
+
+  int signum = 0;
+  sigset_t sigset;
+  sigemptyset(&sigset);
+  sigaddset(&sigset, SIGINT);
+  sigwait(&sigset, &signum);
+
+  std::cout << "SIGINT received." << std::endl;
+
+  if (server && *server) {
+    std::cout << "Shut down server..." << std::endl;
+    (*server)->Shutdown();
+  }
+  return nullptr;
+}
+
+void RunServer(std::string server_address, bool expand_wildcard_addr) {
+  // Inhibit SIGINT in the main thread and all future threads
+  sigset_t sigset;
+  sigemptyset(&sigset);
+  sigaddset(&sigset, SIGINT);
+  pthread_sigmask(SIG_BLOCK, &sigset, nullptr);
+
+  // To share the server pointer to the thread
+  Server* _server = nullptr;
+
+  // Create a separate thread to wait on SIGINT to trigger server shutdown
+  pthread_t signal_thread;
+  pthread_create(&signal_thread, nullptr, wait_for_sigint_then_shutdown,
+                 &_server);
+
+  // gRPC service
   GreeterServiceImpl service;
 
   grpc::EnableDefaultHealthCheckService(true);
   grpc::reflection::InitProtoReflectionServerBuilderPlugin();
   ServerBuilder builder;
+
+  // Activate wildcard address expansion if requested
+  if (expand_wildcard_addr) {
+    builder.AddChannelArgument("grpc.expand_wildcard_addrs", 1);
+  }
+
   // Listen on the given address without any authentication mechanism.
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+
   // Register "service" as the instance through which we'll communicate with
   // clients. In this case it corresponds to an *synchronous* service.
   builder.RegisterService(&service);
+
   // Finally assemble the server.
   std::unique_ptr<Server> server(builder.BuildAndStart());
   std::cout << "Server listening on " << server_address << std::endl;
 
+  // update the server pointer in the thread
+  _server = server.get();
+
   // Wait for the server to shutdown. Note that some other thread must be
   // responsible for shutting down the server for this call to ever return.
   server->Wait();
+
+  // waiting for thread to terminate
+  pthread_join(signal_thread, nullptr);
+
+  std::cout << "Server finished" << std::endl;
 }
 
 int main(int argc, char** argv) {
-  RunServer();
+  // Argument "--listen=" designates the interface to listen on
+  std::string listen_str = "unix:///tmp/server";
+  std::string arg_listen_str("--listen");
+
+  // Argument "--expand-wildcard-addr" requests wildcard addr
+  // (0.0.0.0 and [::]) expansion into each local interface addr
+  bool expand_wildcard_addr = false;
+  std::string arg_expand_wilcard_str("--expand-wildcard-addr");
+
+  for (int i = 1; i < argc; i++) {
+    std::string arg_val = argv[i];
+    // listen arg
+    size_t start_pos = arg_val.find(arg_listen_str);
+    if (start_pos != std::string::npos) {
+      start_pos += arg_listen_str.size();
+      if (arg_val[start_pos] == '=') {
+        listen_str = arg_val.substr(start_pos + 1);
+      }
+    }
+    // expand arg
+    start_pos = arg_val.find(arg_expand_wilcard_str);
+    if (start_pos != std::string::npos) {
+      expand_wildcard_addr = true;
+    }
+  }
+
+  RunServer(listen_str, expand_wildcard_addr);
 
   return 0;
 }

--- a/examples/cpp/systemd_socket_activation/test.sh
+++ b/examples/cpp/systemd_socket_activation/test.sh
@@ -13,58 +13,285 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Run this script as root
+PORT=3465
 
-clean() {
-    echo "Cleaning..."
-    systemctl stop sdsockact.socket
-    systemctl stop sdsockact.service
-    systemctl daemon-reload
-    rm /tmp/greeter_server
-    rm /tmp/greeter_client
-    rm /etc/systemd/system/sdsockact.service
-    rm /etc/systemd/system/sdsockact.socket
-}
+# Run this script as normal user
 
 fail() {
-    clean
     echo "FAIL: $@" >&2
-    exit 1
 }
 
 pass() {
     echo "SUCCESS: $1"
 }
 
-bazel build --define=use_systemd=true //examples/cpp/systemd_socket_activation:all || fail "Failed to build sd_sock_act"
-cp ../../../bazel-bin/examples/cpp/systemd_socket_activation/server /tmp/greeter_server
-cp ../../../bazel-bin/examples/cpp/systemd_socket_activation/client /tmp/greeter_client
+setup() {
+    local sd_socket="$1"
+    local grpc_server="$2"
+    local working_dir="$3"
+    local bind_ipv6only="$4"
+    local additional_listener="$5"
+    local server_options="$6"
 
-cat << EOF > /etc/systemd/system/sdsockact.service
+    cp -f ../../../bazel-bin/examples/cpp/systemd_socket_activation/server /tmp/greeter_server
+    cp -f ../../../bazel-bin/examples/cpp/systemd_socket_activation/client /tmp/greeter_client
+
+    mkdir -p ~/.config/systemd/user/
+
+cat << EOF > ~/.config/systemd/user/sdsockact.service
 [Service]
-ExecStart=/tmp/greeter_server
+ExecStart=/tmp/greeter_server --listen="${grpc_server}" ${server_options}
+WorkingDirectory=${working_dir}
 EOF
 
-cat << EOF > /etc/systemd/system/sdsockact.socket
-[Socket]
-ListenStream=/tmp/server
-ReusePort=true
-
+cat << EOF > ~/.config/systemd/user/sdsockact.socket
 [Install]
 WantedBy=sockets.target
+[Socket]
+SocketMode=600
+BindIPv6Only=${bind_ipv6only}
+ListenStream=${sd_socket}
 EOF
 
-systemctl daemon-reload
-systemctl enable sdsockact.socket
-systemctl start sdsockact.socket
+    # tail ~/.config/systemd/user/sdsockact.socket ~/.config/systemd/user/sdsockact.service
 
-pushd /tmp
-./greeter_client | grep "Hello"
-if [ $? -ne 0 ]; then
-    popd
-    fail "Response not received"
-fi
+    # append the additional listener if present
+    if [[ "${additional_listener}" != "-" ]]
+    then
+        echo "ListenStream=${additional_listener}" >> ~/.config/systemd/user/sdsockact.socket
+    fi
 
-popd
-pass "Response received"
-clean
+    # reload after adding units
+    systemctl --user daemon-reload
+
+    # starts the listening socket but not the service
+    systemctl --user restart sdsockact.socket
+}
+
+teardown() {
+    systemctl --user stop sdsockact.socket
+    systemctl --user stop sdsockact.service
+    rm -f /tmp/greeter_server
+    rm -f /tmp/greeter_client
+    rm -f /tmp/server
+    rm -f ~/.config/systemd/user/sdsockact.service
+    rm -f ~/.config/systemd/user/sdsockact.socket
+    # reload after removing units
+    systemctl --user daemon-reload
+}
+
+TEST_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+    local sd_socket="${1}"
+    local grpc_server="${2}"
+    local grpc_client="${3}"
+    local working_dir="${4}"
+    local bind_ipv6only="${5}"
+    local additional_listener="${6}"
+    local server_options="${7}"
+
+    # setup systemd service and socket
+    setup ${sd_socket} ${grpc_server} ${working_dir} ${bind_ipv6only} ${additional_listener} ${server_options}
+
+    cd ${working_dir}
+
+    # run the client and trigger the server through socket activation
+    TEST_COUNT=$((TEST_COUNT+1))
+
+    echo "Client queries ${grpc_client}..."
+    /tmp/greeter_client --target=${grpc_client} | grep "Hello"
+    if [ $? -ne 0 ]; then
+        FAIL_COUNT=$((FAIL_COUNT+1))
+        fail "Response not received"
+    else
+        pass "Response received"
+    fi
+
+    cd - >/dev/null
+
+    # print connections state for network sockets
+    [[ "${grpc_server}" != *"unix"* ]] && ss -plant | awk "NR==1 || /:${PORT}/"
+
+    # request server shutdown by sending SIGINT
+    SERVICE_PID=$(systemctl --user show --property MainPID --value  sdsockact.service)
+    [[ -n "${SERVICE_PID}" ]] && [[ ${SERVICE_PID} -ne 0 ]] && kill -s SIGINT ${SERVICE_PID}
+
+    # cleanup by removing sytemd units
+    teardown
+}
+
+# run test
+
+track_test() {
+    echo "==== $1 ===="
+    $1
+}
+
+# tests unix socket
+
+test_sd_unix_relative() {
+    run_test "/tmp/server" "unix:server" "unix:server" "/tmp" "default" "-" "-"
+}
+
+test_sd_unix_relative_dot() {
+    run_test "/tmp/server" "unix:./server" "unix:./server" "/tmp" "default" "-" "-"
+}
+
+test_sd_unix_absolute() {
+    run_test "/tmp/server" "unix:/tmp/server" "unix:/tmp/server" "$(pwd)" "default" "-" "-"
+}
+
+test_sd_unix_absolute_scheme() {
+    run_test "/tmp/server" "unix:///tmp/server" "unix:///tmp/server" "$(pwd)" "default" "-" "-"
+}
+
+test_sd_unix_abstract() {
+    run_test "@test_unix_abstract" "unix-abstract:test_unix_abstract" "unix-abstract:test_unix_abstract" "$(pwd)" "default" "-" "-"
+}
+
+# tests ip
+
+test_sd_loopback_ipv4_port() {
+    run_test "127.0.0.1:${PORT}" "127.0.0.1:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "default" "-" "-"
+}
+
+test_sd_loopback_ipv6_dualstack_port() {
+    run_test "[::1]:${PORT}" "[::1]:${PORT}" "[::1]:${PORT}" "$(pwd)" "both" "-" "-"
+
+    # The address [::1] aka "IPv6 loopback" **even when dual-stack**,
+    # can only bind to an IPv6 loopback interface, but *not* an IPv4 loopback.
+    # This is in contrast to the [::] aka "IPv6 wildcard", which when dual-stack,
+    # can actually bind to any IPv6 and IPv4 interface at the same time.
+    # So below is an expected "FAIL by design", which is kept only for reference :
+    # run_test "[::1]:${PORT}" "[::1]:${PORT}" "127.0.0.1:{PORT}" "$(pwd)" "both" "-" "-"
+}
+
+test_sd_loopback_ipv6_only_port() {
+    run_test "[::1]:${PORT}" "[::1]:${PORT}" "[::1]:${PORT}" "$(pwd)" "ipv6-only" "-" "-"
+
+    # If the client would try 127.0.0.1, systemd would *not* activate and run the server,
+    # because systemd listening socket is ipv6 only. So if the client would try,
+    # 127.0.0.1 would fail. And even if the server would actually be started, the client
+    # connection would still not reach the server, because the listening socket is IPv6 only
+    # So below is an expected "FAIL by design", which is kept only for reference :
+    # run_test "[::1]:${PORT}" "[::1]:${PORT}" "127.0.0.1:{PORT}" "$(pwd)" "ipv6-only" "-" "-"
+}
+
+test_sd_wildcard_ipv4_expand_port() {
+    run_test "127.0.0.1:${PORT}" "0.0.0.0:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "default" "-" "--expand-wildcard-addr"
+}
+
+test_sd_wildcard_ipv6_expand_dualstack_port() {
+    run_test "127.0.0.1:${PORT}" "[::]:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "both" "-" "--expand-wildcard-addr"
+    run_test "[::1]:${PORT}" "[::]:${PORT}" "[::1]:${PORT}" "$(pwd)" "both" "-" "--expand-wildcard-addr"
+}
+
+test_sd_wildcard_ipv6_expand_only_port() {
+    run_test "127.0.0.1:${PORT}" "[::]:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "ipv6-only" "-" "--expand-wildcard-addr"
+    run_test "[::1]:${PORT}" "[::]:${PORT}" "[::1]:${PORT}" "$(pwd)" "ipv6-only" "-" "--expand-wildcard-addr"
+}
+
+test_sd_wildcard_ipv4_port() {
+    run_test "0.0.0.0:${PORT}" "0.0.0.0:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "default" "-" "-"
+}
+
+test_sd_wildcard_ipv6_dualstack_port() {
+    run_test "[::]:${PORT}" "[::]:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "both" "-" "-"
+    run_test "[::]:${PORT}" "[::]:${PORT}" "[::1]:${PORT}" "$(pwd)" "both" "-" "-"
+}
+
+test_sd_wildcard_ipv6_only_port_and_grpc_created_wildcard_ipv4() {
+    run_test "[::]:${PORT}" "[::]:${PORT}" "[::1]:${PORT}" "$(pwd)" "ipv6-only" "-" "-"
+
+    # If the client would try 127.0.0.1, systemd would *not* activate and run the server,
+    # because systemd listening socket is ipv6 only. So if the client would try that
+    # 127.0.0.1 would fail, even though the server *would* create a listener on that 127.0.0.1,
+    # if it were indeed run, because ListenerContainerAddWildcardAddresses() tries to add
+    # an ipv4 wildcard listener when the ipv6 wildcard returns an ipv6-only socket.
+    # So below is an expected "FAIL by design", which is kept only for reference :
+    # run_test "[::]:${PORT}" "[::]:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "ipv6-only" "-" "-"
+}
+
+test_sd_wildcard_ipv6_only_port_and_sd_wildcard_ipv4() {
+    run_test "[::]:${PORT}" "[::]:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "ipv6-only" "0.0.0.0:${PORT}" "-"
+    run_test "[::]:${PORT}" "[::]:${PORT}" "[::1]:${PORT}" "$(pwd)" "ipv6-only" "0.0.0.0:${PORT}" "-"
+}
+
+test_sd_localhost_ipv4() {
+    # due to DNS resolution, gRPC will add two listeners : 127.0.0.1 and [::1]
+    # only connections to 127.0.0.1 would trigger a activation via systemd,
+    # and gRPC would use this preallocated socket as a listener. But due to resolution,
+    # the gRPC created [::1] listener would only be available when the server is running,
+    # but could never trigger an activation through Systemd, which does not know it.
+    # Here the client IP will first be 127.0.0.1, as `localhost` the default system
+    # behaviour is to resolved into IPv6 ([::1]) first, then revert to IPv4 if it fails.
+    # So the client first tries to connect [::1] but it does not succeed, as System
+    # activation only listens on IPv4 loopback address. When the system falls back to
+    # IPv4, the connection succeeds (due to valid address for activation) and starts
+    # the server. The server finds the preallocated IPv4 socket and gets the IPv4 client.
+    # Ironically, due to gRPC DNS resolution, once the server is started, it adds
+    # an IPv6 listener for `localhost`, so the next client connections *while the server
+    # is running* would then actually arrive in IPv6, as most servers are "IPv6-first".
+    run_test "127.0.0.1:${PORT}" "localhost:${PORT}" "localhost:${PORT}" "$(pwd)" "default" "-" "-"
+}
+
+test_sd_localhost_ipv6() {
+    # due to DNS resolution, gRPC will add two listeners : 127.0.0.1 and [::1]
+    # only connections to [::1] would trigger a activation via systemd,
+    # and gRPC would use this preallocated socket as a listener. But due to resolution,
+    # the gRPC creates another 127.0.0.1 listener, which would only be available
+    # when the server is running, but could never trigger an activation through Systemd,
+    # which does not know it.
+    # So the system of the client first tries to connect [::1] and succeeds, as System
+    # activation listens on IPv6 loopback address. The server starts and finds the
+    # preallocated IPv6 socket and gets the IPv6 client. The server starts the other
+    # listener for the other resolved address (127.0.0.1) which will be accessible to
+    # IPv4 clients, but only while the server is running.
+    run_test "[::1]:${PORT}" "localhost:${PORT}" "localhost:${PORT}" "$(pwd)" "default" "-" "-"
+}
+
+test_sd_localhost_dualstack() {
+    # TODO(nipil): explain
+    # TODO(nipil): detect and explain client source ip
+    run_test "[::1]:${PORT}" "localhost:${PORT}" "127.0.0.1:${PORT}" "$(pwd)" "ipv6-only" "127.0.0.1:${PORT}" "-"
+    run_test "[::1]:${PORT}" "localhost:${PORT}" "[::1]:${PORT}" "$(pwd)" "ipv6-only" "127.0.0.1:${PORT}" "-"
+}
+
+# main
+
+echo "==== building ===="
+bazel build --define=use_systemd=true //examples/cpp/systemd_socket_activation:all || {
+    fail "Failed to build systemd_socket_activation"
+    exit
+}
+
+track_test test_sd_unix_relative
+track_test test_sd_unix_relative_dot
+track_test test_sd_unix_absolute
+track_test test_sd_unix_absolute_scheme
+
+track_test test_sd_unix_abstract
+
+track_test test_sd_loopback_ipv4_port
+track_test test_sd_loopback_ipv6_dualstack_port
+track_test test_sd_loopback_ipv6_only_port
+
+track_test test_sd_wildcard_ipv4_port
+
+track_test test_sd_wildcard_ipv6_dualstack_port
+track_test test_sd_wildcard_ipv6_only_port_and_grpc_created_wildcard_ipv4
+track_test test_sd_wildcard_ipv6_only_port_and_sd_wildcard_ipv4
+
+track_test test_sd_wildcard_ipv4_expand_port
+track_test test_sd_wildcard_ipv6_expand_dualstack_port
+track_test test_sd_wildcard_ipv6_expand_only_port
+
+track_test test_sd_localhost_ipv4
+track_test test_sd_localhost_ipv6
+track_test test_sd_localhost_dualstack
+
+echo "==== ${FAIL_COUNT} tests failed, ${TEST_COUNT} tests run ===="
+
+exit ${FAIL_COUNT}

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2013,6 +2013,7 @@ grpc_cc_library(
         "posix_event_engine_event_poller",
         "posix_event_engine_internal_errqueue",
         "posix_event_engine_lockfree_event",
+        "posix_event_engine_systemd",
         "posix_event_engine_wakeup_fd_posix",
         "posix_event_engine_wakeup_fd_posix_default",
         "status_helper",
@@ -2048,6 +2049,7 @@ grpc_cc_library(
         "iomgr_port",
         "posix_event_engine_closure",
         "posix_event_engine_event_poller",
+        "posix_event_engine_systemd",
         "posix_event_engine_wakeup_fd_posix",
         "posix_event_engine_wakeup_fd_posix_default",
         "status_helper",
@@ -2223,6 +2225,7 @@ grpc_cc_library(
     deps = [
         "event_engine_tcp_socket_utils",
         "iomgr_port",
+        "posix_event_engine_systemd",
         "posix_event_engine_tcp_socket_utils",
         "socket_mutator",
         "status_helper",
@@ -2256,6 +2259,7 @@ grpc_cc_library(
         "posix_event_engine_endpoint",
         "posix_event_engine_event_poller",
         "posix_event_engine_listener_utils",
+        "posix_event_engine_systemd",
         "posix_event_engine_tcp_socket_utils",
         "socket_mutator",
         "status_helper",
@@ -2264,6 +2268,27 @@ grpc_cc_library(
         "//:event_engine_base_hdrs",
         "//:exec_ctx",
         "//:gpr",
+    ],
+)
+
+grpc_cc_library(
+    name = "posix_event_engine_systemd",
+    srcs = [
+        "lib/event_engine/posix_engine/posix_engine_systemd.cc",
+    ],
+    hdrs = [
+        "lib/event_engine/posix_engine/posix_engine_systemd.h",
+    ],
+    defines = select({
+        "//:systemd": ["HAVE_LIBSYSTEMD"],
+        "//conditions:default": [],
+    }),
+    external_deps = [
+    ],
+    deps = [
+        "//:event_engine_base_hdrs",
+        "iomgr_port",
+        "status_helper",
     ],
 )
 

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener_utils.h
@@ -56,14 +56,19 @@ class ListenerSocketsContainer {
 };
 
 // Creates and configures a socket to be used by the EventEngine Listener. The
-// type of the socket to create is determined by the by the passed address. The
-// socket configuration is specified by passed tcp options. If successful, it
+// type of the socket to create is determined by the passed address. The socket
+// configuration is specified by passed tcp options. The optional
+// sd_preallocated_fd designs an existing file descriptor to build the
+// ListenerSocket around, instead of creating it from scratch. This is useful
+// for example when the program is started by systemd socket activation system,
+// which provides already-setup listening file descriptors. If successful, it
 // returns a ListenerSocketsContainer::ListenerSocket type which holds the
 // socket fd and its dsmode. If unsuccessful, it returns a Not-OK status.
 absl::StatusOr<ListenerSocketsContainer::ListenerSocket>
 CreateAndPrepareListenerSocket(
     const PosixTcpOptions& options,
-    const grpc_event_engine::experimental::EventEngine::ResolvedAddress& addr);
+    const grpc_event_engine::experimental::EventEngine::ResolvedAddress& addr,
+    absl::optional<int> sd_preallocated_fd);
 
 // Instead of creating and adding a socket bound to specific address, this
 // function creates and adds a socket bound to the wildcard address on the

--- a/src/core/lib/event_engine/posix_engine/posix_engine_systemd.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_systemd.cc
@@ -1,0 +1,259 @@
+// Copyright 2022 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/lib/event_engine/posix_engine/posix_engine_systemd.h"
+
+#include "absl/strings/match.h"
+
+#include <grpc/support/log.h>
+
+#include "src/core/lib/gprpp/status_helper.h"
+#include "src/core/lib/gprpp/strerror.h"
+#include "src/core/lib/iomgr/port.h"
+
+// copied from tcp_socket_utils for sockaddr_un
+#ifdef GRPC_HAVE_UNIX_SOCKET
+#ifdef GPR_WINDOWS
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+#else
+#include <sys/un.h>
+#endif  // GPR_WINDOWS
+#endif  // GRPC_HAVE_UNIX_SOCKET
+
+#ifdef HAVE_LIBSYSTEMD
+#include <systemd/sd-daemon.h>
+#endif  // HAVE_LIBSYSTEMD
+
+namespace grpc_event_engine {
+namespace experimental {
+
+#ifdef HAVE_LIBSYSTEMD
+
+// Checks if sockets were provided by systemd socket activation.
+//
+// IMPORTANT: Every file descriptor provided at startup must remain *open*
+// for the call to sd_listen_fds() to not fail with EBADF.
+//
+// REASON: As seen in Systemd source code `sd-daemon.c`, the sd_listen_fds()
+//   function will exit with errno=EBADF(9) if *ANY* of the provided fd
+//   are closed. This is because sd_listen_fds() has side effects
+//   in fd_cloexec : fcntl F_GETFD/F_SETFD do fail on closed fd,
+//   doing an early return with the errno value, which bubbles up.
+//
+// WORKAROUND: do *not* close Systemd provided file descriptors.
+//   Systemd advises in its manual that you should not close them
+//   anyway (nor calling shutdown) so prevent these actions in pollers.
+//
+// In any case, return an error if it happens instead of hiding it.
+absl::StatusOr<int> GetSystemdPreallocatedFdCount() {
+  int result = sd_listen_fds(0);
+  if (result < 0) {
+    return absl::InternalError(absl::StrFormat(
+        "GetSystemdPreallocatedFdCount: sd_listen_fds() failed: %s. Could not "
+        "get number of preallocated Systemd file descriptors, maybe some of the"
+        "preallocated file descriptors have been closed since startup ?",
+        grpc_core::StrError(result).c_str()));
+  }
+  return result;
+}
+
+bool IsSystemdPreallocatedFdOrLogErrorsWithFalseFallback(int fd) {
+    auto result = IsSystemdPreallocatedFd(fd);
+    // In case no error can bubble up, so log it
+    if (!result.ok()) {
+      gpr_log(GPR_ERROR, result.status().ToString().c_str());
+    }
+    // And let the caller know that we consider that
+    // the file descriptors were *not* preallocated.
+    return result.value_or(false);
+}
+
+absl::StatusOr<bool> IsSystemdPreallocatedFd(int fd) {
+  auto result = GetSystemdPreallocatedFdCount();
+  GRPC_RETURN_IF_ERROR(result.status());
+  return SD_LISTEN_FDS_START <= fd && fd < SD_LISTEN_FDS_START + result.value();
+}
+
+absl::optional<int> MaybeGetSockOptIntValue(int fd, int level, int optname) {
+  int value;
+  socklen_t value_size = sizeof(value);
+  getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &value, &value_size);
+  if (value == -1) {
+    gpr_log(GPR_ERROR,
+            "MaybeGetSockOptIntValue: getsockopt(%i, %i, %i) failed: %s", fd,
+            level, optname, grpc_core::StrError(errno).c_str());
+    return absl::nullopt;
+  }
+  return value;
+}
+
+absl::optional<int> MaybeGetSystemdPreallocatedFdFromNetAddr(
+    int fd, const EventEngine::ResolvedAddress& addr) {
+  // Checks provided addr against systemd info
+  if (sd_is_socket_sockaddr(fd, SOCK_STREAM, addr.address(), addr.size(), 1)) {
+    return fd;
+  }
+  return absl::nullopt;
+}
+
+absl::optional<int> MaybeGetSystemdPreallocatedFdFromUnixAbstractAddr(
+    int fd, const EventEngine::ResolvedAddress& addr) {
+  // abstract unix path are in the form of "\0name"
+  auto sa_un = reinterpret_cast<const struct sockaddr_un*>(addr.address());
+  int path_len = addr.size() - sizeof(sa_un->sun_family);
+
+  // Checks that the provided addr path matches the information systemd
+  // has about that abstract unix socket, with length including first null
+  if (sd_is_socket_unix(fd, SOCK_STREAM, 1, sa_un->sun_path, path_len)) {
+    return fd;
+  }
+
+  return absl::nullopt;
+}
+
+absl::optional<int> MaybeGetSystemdPreallocatedFdFromUnixNormalAddr(
+    int fd, const EventEngine::ResolvedAddress& addr) {
+  auto sa_un = reinterpret_cast<const struct sockaddr_un*>(addr.address());
+  absl::string_view addr_un_path(sa_un->sun_path);
+
+  // Path provided in the form of `unix:///foo/bar` were transformed into
+  // `///foo/bar` in Chttp2ServerAddPort, so clean it up into `/foo/bar`
+  // in order to have a possible match with systemd "natural" full path.
+  if (absl::StartsWith(addr_un_path, "///")) {
+    addr_un_path.remove_prefix(2);
+  }
+
+  // Path provided in the form of `unix://foo/bar` are invalid according
+  // to Naming documentation, and were transformed into `//foo/bar`
+  /// in Chttp2ServerAddPort, so reject them explicitely here
+  if (absl::StartsWith(addr_un_path, "//")) {
+    gpr_log(GPR_ERROR, "Invalid address: %s (check the number of /)",
+            addr_un_path.data());
+    return absl::nullopt;
+  }
+
+  // Path provided in the form of `unix:relative`, `unix:./relative`, or
+  // `unix:../relative`, are relative (in nature) and cannot be matched
+  // to systemd socket information. Systemd which requires an absolute
+  // path as per `man 5 systemd-socket` for the `ListenSocket` option.
+  char buffer[PATH_MAX];
+  if (!absl::StartsWith(addr_un_path, "/")) {
+    // Rebuilds an absolute path from the current working directory. This
+    // is not a foolproof method, as there could be symlinks/ or hardlinks
+    // making it that the path from systemd.socket could be different from
+    // the absolute path after it has been rebuilt from the relative path.
+    if (realpath(addr_un_path.data(), buffer) == nullptr) {
+      gpr_log(GPR_ERROR, "realpath(%s) failed: %s", addr_un_path.data(),
+              grpc_core::StrError(errno).c_str());
+      return absl::nullopt;
+    }
+    addr_un_path = absl::string_view(buffer);
+  }
+
+  // Checks that the provided addr path matches the information systemd
+  // has about that normal unix socket. length=0 for normal unix sockets.
+  if (sd_is_socket_unix(fd, SOCK_STREAM, 1, addr_un_path.data(), 0)) {
+    return fd;
+  }
+
+  return absl::nullopt;
+}
+
+absl::optional<int> MaybeGetSystemdPreallocatedFdFromUnixAddr(
+    int fd, const EventEngine::ResolvedAddress& addr) {
+  auto sa_un = reinterpret_cast<const struct sockaddr_un*>(addr.address());
+  if (sa_un->sun_path[0] == '\0') {
+    return MaybeGetSystemdPreallocatedFdFromUnixAbstractAddr(fd, addr);
+  } else {
+    return MaybeGetSystemdPreallocatedFdFromUnixNormalAddr(fd, addr);
+  }
+}
+
+absl::StatusOr<absl::optional<int>> MaybeGetSystemdPreallocatedFdFromAddr(
+    const EventEngine::ResolvedAddress& addr) {
+  auto result = GetSystemdPreallocatedFdCount();
+  GRPC_RETURN_IF_ERROR(result.status());
+
+  int sd_fd_count = result.value();
+  gpr_log(GPR_DEBUG, "Found %i systemd activation sockets", sd_fd_count);
+  if (sd_fd_count == 0) {
+    return absl::nullopt;
+  }
+
+  // For each of the provided socket, try to match with the provided address
+  for (int fd = SD_LISTEN_FDS_START; fd < SD_LISTEN_FDS_START + sd_fd_count;
+       fd++) {
+    // check that the systemd socket is actually a listening connection
+    // as per man 5 systemd.socket, because of the `Accept=` option, which
+    // allows for systemd to spawn the service once per accepted connection.
+    // GRPC expects a listening socket, so do not allow "accepted" sockets.
+    absl::optional<int> opt_val =
+        MaybeGetSockOptIntValue(fd, SOL_SOCKET, SO_ACCEPTCONN);
+    if (!opt_val) {
+      continue;
+    }
+    if (*opt_val != 1) {
+      gpr_log(GPR_ERROR, "Systemd socket %i is not in listening mode", fd);
+      continue;
+    }
+
+    // Only `ListenStream` option of man 5 systemd.socket is supported
+    // here, as GRPC is connection oriented. Check that the systemd socket is
+    // actually a STREAM connection
+    opt_val = MaybeGetSockOptIntValue(fd, SOL_SOCKET, SO_TYPE);
+    if (!opt_val) {
+      continue;
+    }
+    if (*opt_val != SOCK_STREAM) {
+      gpr_log(GPR_ERROR, "Systemd socket %i is not a stream socket", fd);
+      continue;
+    }
+
+    // Check that the provided address matches the socket
+    auto family = addr.address()->sa_family;
+    if (family == AF_UNIX) {
+      auto sd_fd = MaybeGetSystemdPreallocatedFdFromUnixAddr(fd, addr);
+      if (sd_fd) return *sd_fd;
+    } else if (family == AF_INET || family == AF_INET6) {
+      auto sd_fd = MaybeGetSystemdPreallocatedFdFromNetAddr(fd, addr);
+      if (sd_fd) return *sd_fd;
+    } else {
+      gpr_log(GPR_ERROR,
+              "Systemd socket %i is of an unsupported family (sa_family=%i)",
+              fd, addr.address()->sa_family);
+    }
+  }
+  return absl::nullopt;
+}
+
+#else  // HAVE_LIBSYSTEMD
+
+absl::StatusOr<bool> IsSystemdPreallocatedFd(int fd) { return false; }
+
+bool IsSystemdPreallocatedFdOrLogErrorsWithFalseFallback(int fd) {
+  return false;
+}
+
+absl::StatusOr<absl::optional<int>> MaybeGetSystemdPreallocatedFdFromAddr(
+    const EventEngine::ResolvedAddress& addr) {
+  return absl::nullopt;
+}
+
+#endif  // HAVE_LIBSYSTEMD
+
+}  // namespace experimental
+}  // namespace grpc_event_engine

--- a/src/core/lib/event_engine/posix_engine/posix_engine_systemd.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_systemd.h
@@ -1,0 +1,42 @@
+// Copyright 2022 gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef GRPC_SRC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENGINE_SYSTEMD_H
+#define GRPC_SRC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENGINE_SYSTEMD_H
+
+#include <grpc/event_engine/event_engine.h>
+
+namespace grpc_event_engine {
+namespace experimental {
+
+// Checks if a particular file descriptor is part of the file
+// descriptors provided by systemd when the process is started
+// through socket activation
+absl::StatusOr<bool> IsSystemdPreallocatedFd(int fd);
+
+// Same as above, but log and swallows the errors.
+// Useful in contexts where status cannot bubble up.
+// Fallbacks to false, to consider the FD is *not* preallocated
+// and thus will attempt to be managed in the normal workflow
+bool IsSystemdPreallocatedFdOrLogErrorsWithFalseFallback(int fd);
+
+// Checks the provided address matches the information of one
+// of the file descriptors provided by systemd when the process
+// is started through socket activation.
+absl::StatusOr<absl::optional<int>> MaybeGetSystemdPreallocatedFdFromAddr(
+    const EventEngine::ResolvedAddress& addr);
+
+}  // namespace experimental
+}  // namespace grpc_event_engine
+
+#endif  // GRPC_SRC_CORE_LIB_EVENT_ENGINE_POSIX_ENGINE_POSIX_ENGINE_SYSTEMD_H


### PR DESCRIPTION
Implemented and tested :
- unix absolute and relative socket path
- unix abstract socket
- ipv4 unicast and wildcard
- ipv6 unicast and wildcard, dual-stack or ipv6-only
- wildcard address expansion
- with epoll1 and poll pollers

Not implemented :
- VSock activation
- Interface scope for ipv6 link-local addresses

Incompatible features :
- wildcard ports

Includes dynamic test suite (_edit : all 23 test fixtures in `test.sh` are passing_)
- of the same kind of fixes as were done in previous PR for unix sockets for iomgr (see PR list below)
- of the full IPv4/IPv6 server handling code, which i did not touch in the PR above, but are fully working here

iomgr PR for unix sockets and test suite : #36035, #36036, #36039, #36041 and #36042