### PR TITLE
[Deps] Ruby uses protobuf 4.x

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 3.26'
+  s.add_dependency 'google-protobuf', '~> 4.26'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
   s.add_development_dependency 'bundler',            '>= 1.9'

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 4.26'
+  s.add_dependency 'google-protobuf', '~> 3.25'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
   s.add_development_dependency 'bundler',            '>= 1.9'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -32,7 +32,7 @@
     s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
     s.platform      = Gem::Platform::RUBY
 
-    s.add_dependency 'google-protobuf', '~> ${settings.protobuf_major_minor_version}'
+    s.add_dependency 'google-protobuf', '~> 4.${settings.protobuf_version.split(".")[1]}'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
     s.add_development_dependency 'bundler',            '>= 1.9'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -32,7 +32,10 @@
     s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
     s.platform      = Gem::Platform::RUBY
 
-    s.add_dependency 'google-protobuf', '~> 4.${settings.protobuf_version.split(".")[1]}'
+    ## Once protobuf 4.x is working with other dependencies,
+    ## please replace the following fixed 3.25 version with
+    ## '~> 4.${settings.protobuf_version.split(".")[1]}'
+    s.add_dependency 'google-protobuf', '~> 3.25'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
     s.add_development_dependency 'bundler',            '>= 1.9'

--- a/tools/buildgen/plugins/expand_version.py
+++ b/tools/buildgen/plugins/expand_version.py
@@ -134,6 +134,3 @@ def mako_plugin(dictionary):
             settings[version_tag] = Version(
                 version_str, override_major=override_major
             )
-    settings["protobuf_major_minor_version"] = ".".join(
-        settings["protobuf_version"].split(".")[:2]
-    )


### PR DESCRIPTION
Protobuf for Ruby bumped the major version to 4. [package](https://rubygems.org/gems/google-protobuf) so the Ruby gemspec should be updated to have 4 instead of 3. 

But gRPC's other dependencies don't work with Protobuf 4.x so I fixed the version of google-protobuf for gRPC Ruby to 3.25 which was the last version gRPC used.