### PR TITLE
[time] Fix Timestamp minus arithmetic when rhs is InfPast or InfFuture

### DIFF
--- a/src/core/lib/gprpp/time.h
+++ b/src/core/lib/gprpp/time.h
@@ -322,6 +322,12 @@ inline Timestamp operator-(Timestamp lhs, Duration rhs) {
 inline Timestamp operator+(Duration lhs, Timestamp rhs) { return rhs + lhs; }
 
 inline Duration operator-(Timestamp lhs, Timestamp rhs) {
+  if (rhs == Timestamp::InfPast() && lhs != Timestamp::InfPast()) {
+    return Duration::Infinity();
+  }
+  if (rhs == Timestamp::InfFuture() && lhs != Timestamp::InfFuture()) {
+    return Duration::NegativeInfinity();
+  }
   return Duration::Milliseconds(
       time_detail::MillisAdd(lhs.milliseconds_after_process_epoch(),
                              -rhs.milliseconds_after_process_epoch()));

--- a/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
+++ b/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
@@ -483,7 +483,8 @@ float WeightedRoundRobin::EndpointWeight::GetWeight(
     return 0;
   }
   // If we don't have at least blackout_period worth of data, return 0.
-  if (now - non_empty_since_ < blackout_period) {
+  if (blackout_period > Duration::Zero() &&
+      now - non_empty_since_ < blackout_period) {
     ++*num_not_yet_usable;
     return 0;
   }

--- a/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
+++ b/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
@@ -214,7 +214,7 @@ class WeightedRoundRobin : public LoadBalancingPolicy {
     Mutex mu_;
     float weight_ ABSL_GUARDED_BY(&mu_) = 0;
     Timestamp non_empty_since_ ABSL_GUARDED_BY(&mu_) = Timestamp::InfFuture();
-    Timestamp last_update_time_ ABSL_GUARDED_BY(&mu_) = Timestamp::InfPast();
+    Timestamp last_update_time_ ABSL_GUARDED_BY(&mu_) = Timestamp::InfFuture();
   };
 
   class WrrEndpointList : public EndpointList {
@@ -483,8 +483,7 @@ float WeightedRoundRobin::EndpointWeight::GetWeight(
     return 0;
   }
   // If we don't have at least blackout_period worth of data, return 0.
-  if (blackout_period > Duration::Zero() &&
-      now - non_empty_since_ < blackout_period) {
+  if (now - non_empty_since_ < blackout_period) {
     ++*num_not_yet_usable;
     return 0;
   }

--- a/test/core/gprpp/time_test.cc
+++ b/test/core/gprpp/time_test.cc
@@ -30,6 +30,12 @@ TEST(TimestampTest, Infinities) {
             Timestamp::InfFuture());
   EXPECT_EQ(Timestamp::InfPast() + Duration::Milliseconds(1),
             Timestamp::InfPast());
+  // EXPECT_EQ(absl::Now() - absl::InfinitePast(), absl::InfiniteDuration());
+  EXPECT_EQ(Timestamp::Now() - Timestamp::InfPast(), Duration::Infinity());
+  EXPECT_TRUE(Timestamp::Now() - Timestamp::InfPast() < Duration::Minutes(5));
+  // EXPECT_EQ(absl::Now() - absl::InfiniteFuture(), -absl::InfiniteDuration());
+  EXPECT_EQ(Timestamp::Now() - Timestamp::InfFuture(),
+            Duration::NegativeInfinity());
 }
 
 TEST(TimestampTest, ToString) {

--- a/test/core/gprpp/time_test.cc
+++ b/test/core/gprpp/time_test.cc
@@ -32,9 +32,24 @@ TEST(TimestampTest, Infinities) {
             Timestamp::InfPast());
   // EXPECT_EQ(absl::Now() - absl::InfinitePast(), absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::Now() - Timestamp::InfPast(), Duration::Infinity());
-  EXPECT_TRUE(Timestamp::Now() - Timestamp::InfPast() < Duration::Minutes(5));
   // EXPECT_EQ(absl::Now() - absl::InfiniteFuture(), -absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::Now() - Timestamp::InfFuture(),
+            Duration::NegativeInfinity());
+  // EXPECT_EQ(absl::InfinitePast() - absl::InfinitePast(),
+  //           -absl::InfiniteDuration());
+  EXPECT_EQ(Timestamp::InfPast() - Timestamp::InfPast(),
+            Duration::NegativeInfinity());
+  // EXPECT_EQ(absl::InfiniteFuture() - absl::InfinitePast(),
+  //           absl::InfiniteDuration());
+  EXPECT_EQ(Timestamp::InfFuture() - Timestamp::InfPast(),
+            Duration::Infinity());
+  // EXPECT_EQ(absl::InfiniteFuture() - absl::InfiniteFuture(),
+  //           absl::InfiniteDuration());
+  EXPECT_EQ(Timestamp::InfFuture() - Timestamp::InfFuture(),
+            Duration::Infinity());
+  // EXPECT_EQ(absl::InfinitePast() - absl::InfiniteFuture(),
+  //           -absl::InfiniteDuration());
+  EXPECT_EQ(Timestamp::InfPast() - Timestamp::InfFuture(),
             Duration::NegativeInfinity());
 }
 

--- a/test/core/gprpp/time_test.cc
+++ b/test/core/gprpp/time_test.cc
@@ -30,25 +30,15 @@ TEST(TimestampTest, Infinities) {
             Timestamp::InfFuture());
   EXPECT_EQ(Timestamp::InfPast() + Duration::Milliseconds(1),
             Timestamp::InfPast());
-  // EXPECT_EQ(absl::Now() - absl::InfinitePast(), absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::Now() - Timestamp::InfPast(), Duration::Infinity());
-  // EXPECT_EQ(absl::Now() - absl::InfiniteFuture(), -absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::Now() - Timestamp::InfFuture(),
             Duration::NegativeInfinity());
-  // EXPECT_EQ(absl::InfinitePast() - absl::InfinitePast(),
-  //           -absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::InfPast() - Timestamp::InfPast(),
             Duration::NegativeInfinity());
-  // EXPECT_EQ(absl::InfiniteFuture() - absl::InfinitePast(),
-  //           absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::InfFuture() - Timestamp::InfPast(),
             Duration::Infinity());
-  // EXPECT_EQ(absl::InfiniteFuture() - absl::InfiniteFuture(),
-  //           absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::InfFuture() - Timestamp::InfFuture(),
             Duration::Infinity());
-  // EXPECT_EQ(absl::InfinitePast() - absl::InfiniteFuture(),
-  //           -absl::InfiniteDuration());
   EXPECT_EQ(Timestamp::InfPast() - Timestamp::InfFuture(),
             Duration::NegativeInfinity());
 }


### PR DESCRIPTION
modeled after absl/time

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

