### PR TITLE
[Python 3.7] Drop 3.7 tests

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -797,13 +797,6 @@ class PythonLanguage(object):
 
         # TODO: Supported version range should be defined by a single
         # source of truth.
-        python37_config = _python_config_generator(
-            name="py37",
-            major="3",
-            minor="7",
-            bits=bits,
-            config_vars=config_vars,
-        )
         python38_config = _python_config_generator(
             name="py38",
             major="3",
@@ -862,11 +855,9 @@ class PythonLanguage(object):
             else:
                 # Default set tested on master. Test oldest and newest.
                 return (
-                    python37_config,
+                    python38_config,
                     python312_config,
                 )
-        elif args.compiler == "python3.7":
-            return (python37_config,)
         elif args.compiler == "python3.8":
             return (python38_config,)
         elif args.compiler == "python3.9":
@@ -885,7 +876,6 @@ class PythonLanguage(object):
             return (python39_config,)
         elif args.compiler == "all_the_cpythons":
             return (
-                python37_config,
                 python38_config,
                 python39_config,
                 python310_config,


### PR DESCRIPTION
We [updated protobuf to v5.26.1](https://github.com/grpc/grpc/pull/35796), which now [requires at least Python 3.8](https://github.com/google/oss-policies-info/blob/main/foundational-python-support-matrix.md).

We still need support Python 3.7 for GCF (Google Cloud Function), as a short term solution, we'll update protobuf requirements in `grpcio_tools` and keeps publishing 3.7 artifacts, this PR disables 3.7 tests so that the protobuf upgrade PR won't break any tests.

#### Testing
* Verified that we're still publishing 3.7 artifacts by checking `grpc_distribtests_python` [results](https://pantheon.corp.google.com/storage/browser/_details/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/grpc_distribtests_python/29608/20240402-150943/github/grpc/artifacts/grpcio_tools-1.63.0.dev0-cp38-cp38-manylinux_2_17_aarch64.whl;tab=live_object?e=13802955&mods=-logs_tg_prod).

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

