### PR TITLE
[CI] Added MSVC 2022 test

### DIFF
--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -118,7 +118,8 @@ If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (
   cmake -G "%GRPC_CMAKE_GENERATOR%" -A "%GRPC_CMAKE_ARCHITECTURE%" %CMAKE_SYSTEM_VERSION_ARG% -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64 -DgRPC_BUILD_GRPCPP_OTEL_PLUGIN=ON -DgRPC_ABSL_PROVIDER=package -DgRPC_BUILD_TESTS=ON -DgRPC_BUILD_MSVC_MP_COUNT=%GRPC_RUN_TESTS_JOBS% -DCMAKE_INSTALL_PREFIX="%INSTALL_PATH%" %* ../.. || goto :error
 
   @rem GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
-  cmake --build . --target buildtests_%GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX% --config %MSBUILD_CONFIG% -j%GRPC_RUN_TESTS_JOBS% || goto :error
+  @rem Don't add -j option here because it will disable gRPC_BUILD_MSVC_MP_COUNT option
+  cmake --build . --target buildtests_%GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX% --config %MSBUILD_CONFIG% || goto :error
 )
 
 endlocal

--- a/tools/run_tests/helper_scripts/build_cxx.bat
+++ b/tools/run_tests/helper_scripts/build_cxx.bat
@@ -29,6 +29,18 @@ If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2019" (
   echo on
 )
 
+If "%GRPC_BUILD_ACTIVATE_VS_TOOLS%" == "2022" (
+  @rem set cl.exe build environment to build with VS2022 tooling
+  @rem this is required for Ninja build to work
+  call "%VS170COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %GRPC_BUILD_VS_TOOLS_ARCHITECTURE%
+  @rem restore command echo
+  echo on
+)
+
+@rem Setting the env variable to a single space translates to passing no argument
+@rem when evaluated on the command line.
+set "CMAKE_SYSTEM_VERSION_ARG= "
+
 If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 16 2019" (
   @rem Always use the newest Windows 10 SDK available.
   @rem A new-enough Windows 10 SDK that supports C++11's stdalign.h is required
@@ -41,10 +53,11 @@ If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 16 2019" (
   @rem When using Ninja generator, this problem doesn't happen.
   @rem See b/275694647 and https://gitlab.kitware.com/cmake/cmake/-/issues/16202#note_140259
   set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0"
-) else (
-  @rem Setting the env variable to a single space translates to passing no argument
-  @rem when evaluated on the command line.
-  set "CMAKE_SYSTEM_VERSION_ARG= "
+)
+
+If "%GRPC_CMAKE_GENERATOR%" == "Visual Studio 17 2022" (
+  @rem The same as above.
+  set "CMAKE_SYSTEM_VERSION_ARG=-DCMAKE_SYSTEM_VERSION=10.0"
 )
 
 If "%GRPC_CMAKE_GENERATOR%" == "Ninja" (

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -284,6 +284,7 @@ class CLanguage(object):
                     "default",
                     "cmake",
                     "cmake_ninja_vs2019",
+                    "cmake_ninja_vs2022",
                     "cmake_vs2019",
                     "cmake_vs2022",
                 ],
@@ -300,6 +301,9 @@ class CLanguage(object):
                 # the compiler used is exactly the same as for cmake_vs2017
                 cmake_generator = "Ninja"
                 activate_vs_tools = "2019"
+            elif self.args.compiler == "cmake_ninja_vs2022":
+                cmake_generator = "Ninja"
+                activate_vs_tools = "2022"
             elif self.args.compiler == "cmake_vs2019":
                 cmake_generator = "Visual Studio 16 2019"
             elif self.args.compiler == "cmake_vs2022":
@@ -1678,6 +1682,7 @@ argp.add_argument(
         "coreclr",
         "cmake",
         "cmake_ninja_vs2019",
+        "cmake_ninja_vs2022",
         "cmake_vs2019",
         "cmake_vs2022",
         "mono",

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -377,74 +377,32 @@ def _create_portability_test_jobs(
             timeout_seconds=_CPP_RUNTESTS_TIMEOUT,
         )
 
-    # portability C on Windows 64-bit (x86 is the default)
+    # portability C & C++ on Windows 64-bit
     test_jobs += _generate_jobs(
-        languages=["c"],
-        configs=["dbg"],
-        platforms=["windows"],
-        arch="x64",
-        compiler="default",
-        labels=["portability", "corelang"],
-        extra_args=extra_args,
-        inner_jobs=inner_jobs,
-    )
-
-    # portability C on Windows with the "Visual Studio" cmake
-    # generator, i.e. not using Ninja (to verify that we can still build with msbuild)
-    test_jobs += _generate_jobs(
-        languages=["c"],
+        languages=["c", "c++"],
         configs=["dbg"],
         platforms=["windows"],
         arch="default",
-        compiler="cmake_vs2019",
+        compiler="cmake_ninja_vs2019",
         labels=["portability", "corelang"],
         extra_args=extra_args,
-        inner_jobs=inner_jobs,
-    )
-
-    # portability C on Windows with the "Visual Studio" cmake
-    # generator, i.e. not using Ninja (to verify that we can still build with msbuild)
-    test_jobs += _generate_jobs(
-        languages=["c"],
-        configs=["dbg"],
-        platforms=["windows"],
-        arch="default",
-        compiler="cmake_vs2022",
-        labels=["portability", "corelang"],
-        extra_args=extra_args,
-        inner_jobs=inner_jobs,
-    )
-
-    # portability C++ on Windows
-    # TODO(jtattermusch): some of the tests are failing, so we force --build_only
-    test_jobs += _generate_jobs(
-        languages=["c++"],
-        configs=["dbg"],
-        platforms=["windows"],
-        arch="default",
-        compiler="default",
-        labels=["portability", "corelang"],
-        extra_args=extra_args + ["--build_only"],
         inner_jobs=inner_jobs,
         timeout_seconds=_CPP_RUNTESTS_TIMEOUT,
     )
 
-    # portability C and C++ on Windows using VS2019 (build only)
-    # TODO(jtattermusch): The C tests with exactly the same config are already running as part of the
-    # basictests_c suite (so we force --build_only to avoid running them twice).
-    # The C++ tests aren't all passing, so also force --build_only.
-    # NOTE(veblush): This is not neded as default=cmake_ninja_vs2019
-    # test_jobs += _generate_jobs(
-    #     languages=["c", "c++"],
-    #     configs=["dbg"],
-    #     platforms=["windows"],
-    #     arch="x64",
-    #     compiler="cmake_ninja_vs2019",
-    #     labels=["portability", "corelang"],
-    #     extra_args=extra_args + ["--build_only"],
-    #     inner_jobs=inner_jobs,
-    #     timeout_seconds=_CPP_RUNTESTS_TIMEOUT,
-    # )
+    # portability C and C++ on Windows with the "Visual Studio 2022" cmake
+    # generator, i.e. not using Ninja (to verify that we can still build with msbuild)
+    test_jobs += _generate_jobs(
+        languages=["c", "c++"],
+        configs=["dbg"],
+        platforms=["windows"],
+        arch="x64",
+        compiler="cmake_vs2022",
+        labels=["portability", "corelang"],
+        extra_args=extra_args,
+        inner_jobs=inner_jobs,
+        timeout_seconds=_CPP_RUNTESTS_TIMEOUT,
+    )
 
     # C and C++ with no-exceptions on Linux
     test_jobs += _generate_jobs(

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -402,6 +402,19 @@ def _create_portability_test_jobs(
         inner_jobs=inner_jobs,
     )
 
+    # portability C on Windows with the "Visual Studio" cmake
+    # generator, i.e. not using Ninja (to verify that we can still build with msbuild)
+    test_jobs += _generate_jobs(
+        languages=["c"],
+        configs=["dbg"],
+        platforms=["windows"],
+        arch="default",
+        compiler="cmake_vs2022",
+        labels=["portability", "corelang"],
+        extra_args=extra_args,
+        inner_jobs=inner_jobs,
+    )
+
     # portability C++ on Windows
     # TODO(jtattermusch): some of the tests are failing, so we force --build_only
     test_jobs += _generate_jobs(


### PR DESCRIPTION
- Added Visual C++ 2022 test to Windows C/C++ test set
- Windows potability test is now running two tests
  - CMake / Ninja / Visual C++ 2019 on x86
  - CMake / MSBuild / Visual C++ 2022 on x64
