### PR TITLE
[rbac] Fix read of uninitialized variable

### DIFF
--- a/src/core/ext/filters/rbac/rbac_service_config_parser.cc
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.cc
@@ -203,7 +203,7 @@ struct RbacConfig {
                           ValidationErrors* errors);
       };
 
-      int action;
+      int action = static_cast<int>(Rbac::Action::kDeny);
       std::map<std::string, Policy> policies;
       // Defaults to kNone since its json field is optional.
       Rbac::AuditCondition audit_condition = Rbac::AuditCondition::kNone;
@@ -801,7 +801,7 @@ void RbacConfig::RbacPolicy::Rules::JsonPostLoad(const Json& json,
   if (rbac_action != Rbac::Action::kAllow &&
       rbac_action != Rbac::Action::kDeny) {
     ValidationErrors::ScopedField field(errors, ".action");
-    errors->AddError("unknown action");
+    errors->AddError(absl::StrCat("unknown action ", rbac_action));
   }
   // Parse and validate audit_condition field.
   auto condition = LoadJsonObjectField<int>(json.object(), args,


### PR DESCRIPTION
When parsing `action` fails we don't touch that memory in the object loader, yet we still call `PostLoad` to fill in any other errors. In that case we are currently relying on undefined behavior to have this test work -- why msan didn't flag it upsets me.

Default `action` to some safe value to avoid the undefined behavior, and log the bad action in the error message to ease debugging here in the future.