### PR TITLE
[Deps] Revert "Bump cryptography from 3.4.6 to 42.0.4 in /tools/internal_ci/…

### DIFF
--- a/tools/internal_ci/helper_scripts/requirements.linux_perf.txt
+++ b/tools/internal_ci/helper_scripts/requirements.linux_perf.txt
@@ -1,4 +1,4 @@
-cryptography==42.0.4
+cryptography==3.4.6
 PyJWT==2.0.1
 requests==2.25.1
 scipy==1.5.4

--- a/tools/internal_ci/helper_scripts/requirements.macos.txt
+++ b/tools/internal_ci/helper_scripts/requirements.macos.txt
@@ -1,5 +1,5 @@
 cython<3.0.0rc1
-cryptography==42.0.4
+cryptography==3.4.6
 PyJWT==2.0.1
 pyOpenSSL==20.0.1
 PyYAML==6.0


### PR DESCRIPTION
Rolling this (https://github.com/grpc/grpc/pull/36153) back as master branch is failing in mac with the following error

```
+ python3 workspace_python_macos_opt_native/tools/run_tests/run_tests.py -t -j 4 -x run_tests/python_macos_opt_native/sponge_log.xml --report_suite_name python_macos_opt_native -l python -c opt --iomgr_platform native --max_time 3600 --report_multi_target
Traceback (most recent call last):
  File "/Volumes/BuildData/tmpfs/altsrc/github/grpc/workspace_python_macos_opt_native/tools/run_tests/run_tests.py", line 50, in 
    from python_utils.upload_test_results import upload_results_to_bq
  File "/Volumes/BuildData/tmpfs/altsrc/github/grpc/workspace_python_macos_opt_native/tools/run_tests/python_utils/upload_test_results.py", line 30, in 
    import big_query_utils
  File "/Volumes/BuildData/tmpfs/altsrc/github/grpc/workspace_python_macos_opt_native/tools/gcp/utils/big_query_utils.py", line 21, in 
    from apiclient import discovery
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/apiclient/__init__.py", line 3, in 
    from googleapiclient import channel, discovery, errors, http, mimeparse, model
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/googleapiclient/discovery.py", line 64, in 
    from googleapiclient import _auth, mimeparse
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/googleapiclient/_auth.py", line 34, in 
    import oauth2client.client
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/oauth2client/client.py", line 45, in 
    from oauth2client import crypt
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/oauth2client/crypt.py", line 45, in 
    from oauth2client import _openssl_crypt
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/oauth2client/_openssl_crypt.py", line 16, in 
    from OpenSSL import crypto
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/OpenSSL/__init__.py", line 8, in 
    from OpenSSL import crypto, SSL
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1556, in 
    class X509StoreFlags(object):
  File "/Users/kbuilder/.local/lib/python3.10/site-packages/OpenSSL/crypto.py", line 1575, in X509StoreFlags
    NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?
```