### PR TITLE
[Test] PDB files on diet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,8 @@ if(MSVC)
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /utf-8")
   # Inconsistent object sizes can cause stack corruption and should be treated as an error
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /we4789")
+  # To decrease the size of PDB files
+  set(CMAKE_EXE_LINKER_FLAGS "/opt:ref /opt:icf /pdbcompress")
 endif()
 if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -424,6 +424,8 @@
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /utf-8")
     # Inconsistent object sizes can cause stack corruption and should be treated as an error
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /we4789")
+    # To decrease the size of PDB files
+    set(CMAKE_EXE_LINKER_FLAGS "/opt:ref /opt:icf /pdbcompress")
   endif()
   if (MINGW)
     add_definitions(-D_WIN32_WINNT=0x600)


### PR DESCRIPTION
PDB files are consuming a significant amount of storage space on our Windows test machines. With each PDB file being around 200MB and every target having its own corresponding file, the disk usage adds up quickly.

Fortunately, we can address this issue without sacrificing debugging functionality. [Shrink my Program Database (PDB) file](https://devblogs.microsoft.com/cppblog/shrink-my-program-database-pdb-file/) outlines several techniques to reduce PDB file size. We can implement these methods to achieve our goal. (From my experiment, the compression option only can reduce a 200MB PDB file by 60%)

This change only picks options which don't reduce debuggability.