### PR TITLE
[test] Run `ServiceConfigParserDeathTest.DoubleRegistration` test first

### DIFF
--- a/test/core/service_config/service_config_test.cc
+++ b/test/core/service_config/service_config_test.cc
@@ -368,7 +368,8 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidValue) {
       << service_config.status();
 }
 
-TEST(ServiceConfigParserTest, DoubleRegistration) {
+TEST(ServiceConfigParserDeathTest, DoubleRegistration) {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
   CoreConfiguration::Reset();
   ASSERT_DEATH_IF_SUPPORTED(
       CoreConfiguration::WithSubstituteBuilder builder(


### PR DESCRIPTION
Seeing the following error in the [grpc_portability](https://fusion2.corp.google.com/ci;ids=1930537984/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_portability/activity/3abaaa26-ee47-4ae6-a7ca-29c42e92857a/tests) build:

```
2024-04-05 04:25:38,790 WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1712290838.800474 1083330 config.cc:239] gRPC experiments: work_serializer_dispatch:off; default-enabled: call_status_override_on_cancellation, event_engine_dns, event_engine_listener, http2_stats_fix, monitoring_experiment, pending_queue_cap, work_serializer_clears_time_cache
I0000 00:00:1712290838.800793 1083330 ev_epoll1_linux.cc:123] grpc epoll fd: 3
Note: Google Test filter = ServiceConfigParserTest.DoubleRegistration
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ServiceConfigParserTest
[ RUN      ] ServiceConfigParserTest.DoubleRegistration

[WARNING] /var/local/git/grpc/third_party/googletest/googletest/src/gtest-death-test.cc:1102:: Death tests use fork(), which is unsafe particularly in a threaded context. For this test, Google Test detected 4 threads. See https://github.com/google/googletest/blob/main/docs/advanced.md#death-tests-and-threads for more explanation and suggested solutions, especially if this is the last message you see before your test times o
ut.

2024-04-05 04:25:38,791 TIMEOUT: cmake/build/service_config_test --gtest_filter=ServiceConfigParserTest.DoubleRegistration  GRPC_POLL_STRATEGY=epoll1 [pid=1083328, time=300.0sec]
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

