### PR TITLE
[test] Change to "threadsafe" mode for `ChannelInitDeathTest.CanAddBeforeAllTwice`

### DIFF
--- a/test/core/service_config/service_config_test.cc
+++ b/test/core/service_config/service_config_test.cc
@@ -368,7 +368,8 @@ TEST_F(ServiceConfigTest, Parser2ErrorInvalidValue) {
       << service_config.status();
 }
 
-TEST(ServiceConfigParserTest, DoubleRegistration) {
+TEST(ServiceConfigParserDeathTest, DoubleRegistration) {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
   CoreConfiguration::Reset();
   ASSERT_DEATH_IF_SUPPORTED(
       CoreConfiguration::WithSubstituteBuilder builder(

--- a/test/core/surface/channel_init_test.cc
+++ b/test/core/surface/channel_init_test.cc
@@ -174,7 +174,8 @@ TEST(ChannelInitTest, CanAddBeforeAllOnce) {
             std::vector<std::string>({"foo", "bar", "baz", "aaa"}));
 }
 
-TEST(ChannelInitTest, CanAddBeforeAllTwice) {
+TEST(ChannelInitDeathTest, CanAddBeforeAllTwice) {
+  GTEST_FLAG_SET(death_test_style, "threadsafe");
   ChannelInit::Builder b;
   b.RegisterFilter(GRPC_CLIENT_CHANNEL, FilterNamed("foo")).BeforeAll();
   b.RegisterFilter(GRPC_CLIENT_CHANNEL, FilterNamed("bar")).BeforeAll();


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

