### PR TITLE
[Fix Python Deadlock] Guard grpc_google_default_credentials_create with nogil

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -437,8 +437,9 @@ cdef class ComputeEngineChannelCredentials(ChannelCredentials):
       raise ValueError("Call credentials may not be NULL.")
 
   cdef grpc_channel_credentials *c(self) except *:
-    self._c_creds = grpc_google_default_credentials_create(self._call_creds)
-    return self._c_creds
+    with nogil:
+      self._c_creds = grpc_google_default_credentials_create(self._call_creds)
+      return self._c_creds
 
 
 def channel_credentials_compute_engine(call_creds):

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -14,11 +14,11 @@
 """Test of gRPC Python's application-layer API."""
 
 import logging
-import pytest
 import threading
 import unittest
 
 import grpc
+import pytest
 
 from tests.unit import _from_grpc_import_star
 from tests.unit import test_common

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -155,7 +155,7 @@ class ChannelTest(unittest.TestCase):
         for thread in threads:
             thread.join()
 
-    def test_multiple_compute_secure_channel(self):
+    def test_multiple_compute_engine_secure_channel(self):
         _THREAD_COUNT = 10
         wait_group = test_common.WaitGroup(_THREAD_COUNT)
 

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -117,21 +117,28 @@ def compute_engine_channel_credentials(request):
     class TestCallCredentials(grpc.AuthMetadataPlugin):
         def __call__(self, context, callback):
             callback((), None)
+
     test_call_credentials = TestCallCredentials()
     call_credentials = grpc.metadata_call_credentials(
         test_call_credentials, "test call credentials"
     )
-    request.cls.compute_engine_channel_credentials = grpc.compute_engine_channel_credentials(call_credentials)
+    request.cls.compute_engine_channel_credentials = (
+        grpc.compute_engine_channel_credentials(call_credentials)
+    )
 
 
 @pytest.mark.usefixtures("compute_engine_channel_credentials")
 class ChannelTest(unittest.TestCase):
     def test_ssl_secure_channel(self):
-        channel = grpc.secure_channel("google.com:443", grpc.ssl_channel_credentials())
+        channel = grpc.secure_channel(
+            "google.com:443", grpc.ssl_channel_credentials()
+        )
         channel.close()
 
     def test_compute_engine_secure_channel(self):
-        channel = grpc.secure_channel("google.com:443", self.compute_engine_channel_credentials)
+        channel = grpc.secure_channel(
+            "google.com:443", self.compute_engine_channel_credentials
+        )
         channel.close()
 
     def test_multiple_ssl_secure_channel(self):
@@ -141,7 +148,9 @@ class ChannelTest(unittest.TestCase):
         def create_secure_channel():
             wait_group.done()
             wait_group.wait()
-            channel = grpc.secure_channel("google.com:443", grpc.ssl_channel_credentials())
+            channel = grpc.secure_channel(
+                "google.com:443", grpc.ssl_channel_credentials()
+            )
             channel.close()
 
         threads = []
@@ -161,7 +170,9 @@ class ChannelTest(unittest.TestCase):
         def create_secure_channel():
             wait_group.done()
             wait_group.wait()
-            channel = grpc.secure_channel("google.com:443", self.compute_engine_channel_credentials)
+            channel = grpc.secure_channel(
+                "google.com:443", self.compute_engine_channel_credentials
+            )
             channel.close()
 
         threads = []

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -131,7 +131,7 @@ class ChannelTest(unittest.TestCase):
         channel = grpc.secure_channel("google.com:443", self.ssl_channel_credentials)
         channel.close()
 
-    def test_compute_secure_channel(self):
+    def test_compute_engine_secure_channel(self):
         channel = grpc.secure_channel("google.com:443", self.compute_engine_channel_credentials)
         channel.close()
 

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -113,7 +113,7 @@ class ChannelConnectivityTest(unittest.TestCase):
 
 
 @pytest.fixture(scope="class")
-def channel_credentials(request):
+def compute_engine_channel_credentials(request):
     class TestCallCredentials(grpc.AuthMetadataPlugin):
         def __call__(self, context, callback):
             callback((), None)
@@ -122,13 +122,12 @@ def channel_credentials(request):
         test_call_credentials, "test call credentials"
     )
     request.cls.compute_engine_channel_credentials = grpc.compute_engine_channel_credentials(call_credentials)
-    request.cls.ssl_channel_credentials = grpc.ssl_channel_credentials()
 
 
 @pytest.mark.usefixtures("channel_credentials")
 class ChannelTest(unittest.TestCase):
     def test_ssl_secure_channel(self):
-        channel = grpc.secure_channel("google.com:443", self.ssl_channel_credentials)
+        channel = grpc.secure_channel("google.com:443", grpc.ssl_channel_credentials())
         channel.close()
 
     def test_compute_engine_secure_channel(self):
@@ -142,7 +141,7 @@ class ChannelTest(unittest.TestCase):
         def create_secure_channel():
             wait_group.done()
             wait_group.wait()
-            channel = grpc.secure_channel("google.com:443", self.ssl_channel_credentials)
+            channel = grpc.secure_channel("google.com:443", grpc.ssl_channel_credentials())
             channel.close()
 
         threads = []

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -124,7 +124,7 @@ def compute_engine_channel_credentials(request):
     request.cls.compute_engine_channel_credentials = grpc.compute_engine_channel_credentials(call_credentials)
 
 
-@pytest.mark.usefixtures("channel_credentials")
+@pytest.mark.usefixtures("compute_engine_channel_credentials")
 class ChannelTest(unittest.TestCase):
     def test_ssl_secure_channel(self):
         channel = grpc.secure_channel("google.com:443", grpc.ssl_channel_credentials())

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -14,6 +14,7 @@
 """Test of gRPC Python's application-layer API."""
 
 import logging
+import pytest
 import threading
 import unittest
 
@@ -117,12 +118,24 @@ class ChannelTest(unittest.TestCase):
         channel = grpc.secure_channel("google.com:443", channel_credentials)
         channel.close()
 
-    def test_multiple_secure_channel(self):
+    @pytest.mark.parametrize("use_compute_engine_credentials_in_test", [False, True])
+    def test_multiple_secure_channel(use_compute_engine_credentials_in_test):
         _THREAD_COUNT = 10
         wait_group = test_common.WaitGroup(_THREAD_COUNT)
 
-        def create_secure_channel():
-            channel_credentials = grpc.ssl_channel_credentials()
+        def create_secure_channel(use_compute_engine_credentials):
+            if use_compute_engine_credentials:
+                class TestCallCredentials(grpc.AuthMetadataPlugin):
+                    def __call__(self, context, callback):
+                        callback((), None)
+                test_call_credentials = TestCallCredentials()
+                call_credentials = grpc.metadata_call_credentials(
+                    test_call_credentials, "test call credentials"
+                )
+                channel_credentials = grpc.compute_engine_channel_credentials(call_credentials=call_credentials)
+            else:
+                channel_credentials = grpc.ssl_channel_credentials()
+
             wait_group.done()
             wait_group.wait()
             channel = grpc.secure_channel("google.com:443", channel_credentials)
@@ -130,7 +143,7 @@ class ChannelTest(unittest.TestCase):
 
         threads = []
         for _ in range(_THREAD_COUNT):
-            thread = threading.Thread(target=create_secure_channel)
+            thread = threading.Thread(target=create_secure_channel, args=(use_compute_engine_credentials_in_test,))
             thread.setDaemon(True)
             thread.start()
             threads.append(thread)


### PR DESCRIPTION
This fix is similar to https://github.com/grpc/grpc/pull/34712 but for `grpc_google_default_credentials_create` rather than `grpc_ssl_credentials_create`

Fixes https://github.com/grpc/grpc/issues/36265
Fixes https://github.com/googleapis/python-bigtable/issues/949