### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33126,6 +33126,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_cluster_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -33421,6 +33422,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_cluster_type_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -33682,6 +33684,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_core_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -33976,6 +33979,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_csds_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -34171,6 +34175,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_config
     grpc++_test_util
   )
@@ -34418,6 +34423,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_fault_injection_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -34994,6 +35000,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_outlier_detection_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -35180,6 +35187,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_override_host_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -35454,6 +35462,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_pick_first_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -35633,6 +35642,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_ring_hash_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -35816,6 +35826,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_rls_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -36120,6 +36131,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_routing_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -36381,6 +36393,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(xds_wrr_end2end_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -20473,6 +20473,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20565,6 +20566,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20658,6 +20660,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20764,6 +20767,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20829,6 +20833,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
   platforms:
@@ -20908,6 +20913,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21102,6 +21108,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21162,6 +21169,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21252,6 +21260,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21312,6 +21321,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21373,6 +21383,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21475,6 +21486,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21563,6 +21575,7 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -25,6 +25,7 @@ grpc_cc_library(
     name = "xds_server",
     srcs = ["xds_server.cc"],
     hdrs = ["xds_server.h"],
+    external_deps = ["absl/log:check"],
     visibility = ["@grpc:xds_end2end_test_utils"],
     deps = [
         "//:gpr",
@@ -66,6 +67,7 @@ grpc_cc_library(
     srcs = ["xds_end2end_test_lib.cc"],
     hdrs = ["xds_end2end_test_lib.h"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     deps = [
@@ -109,6 +111,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -183,6 +186,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_cluster_type_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -291,6 +295,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_outlier_detection_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,
@@ -343,6 +348,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_ring_hash_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)

--- a/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 
@@ -63,9 +64,9 @@ class ClusterTypeTest : public XdsEnd2endTest {
     for (int port : ports) {
       absl::StatusOr<grpc_core::URI> lb_uri =
           grpc_core::URI::Parse(grpc_core::LocalIpUri(port));
-      GPR_ASSERT(lb_uri.ok());
+      CHECK(lb_uri.ok());
       grpc_resolved_address address;
-      GPR_ASSERT(grpc_parse_uri(*lb_uri, &address));
+      CHECK(grpc_parse_uri(*lb_uri, &address));
       addresses.emplace_back(address, grpc_core::ChannelArgs());
     }
     return addresses;

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -246,7 +246,7 @@ class FakeCertificateProviderFactory
       absl::string_view name,
       FakeCertificateProvider::CertDataMapWrapper* cert_data_map)
       : name_(name), cert_data_map_(cert_data_map) {
-    CHECK(cert_data_map != nullptr);
+    CHECK_NE(cert_data_map, nullptr);
   }
 
   absl::string_view name() const override { return name_; }
@@ -263,7 +263,7 @@ class FakeCertificateProviderFactory
   CreateCertificateProvider(
       grpc_core::RefCountedPtr<grpc_core::CertificateProviderFactory::Config>
       /*config*/) override {
-    CHECK(cert_data_map_ != nullptr);
+    CHECK_NE(cert_data_map_, nullptr);
     return grpc_core::MakeRefCounted<FakeCertificateProvider>(
         cert_data_map_->Get());
   }
@@ -1006,7 +1006,7 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
     options.set_verify_server_certs(true);
     options.set_certificate_verifier(std::move(verifier));
     auto channel_creds = grpc::experimental::TlsCredentials(options);
-    CHECK(channel_creds.get() != nullptr);
+    CHECK_NE(channel_creds.get(), nullptr);
     return CreateCustomChannel(uri, channel_creds, args);
   }
 
@@ -1027,7 +1027,7 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
     options.set_verify_server_certs(true);
     options.set_certificate_verifier(std::move(verifier));
     auto channel_creds = grpc::experimental::TlsCredentials(options);
-    CHECK(channel_creds.get() != nullptr);
+    CHECK_NE(channel_creds.get(), nullptr);
     return CreateCustomChannel(uri, channel_creds, args);
   }
 

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -32,6 +32,7 @@
 #include <gtest/gtest.h>
 
 #include "absl/functional/bind_front.h"
+#include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
@@ -245,7 +246,7 @@ class FakeCertificateProviderFactory
       absl::string_view name,
       FakeCertificateProvider::CertDataMapWrapper* cert_data_map)
       : name_(name), cert_data_map_(cert_data_map) {
-    GPR_ASSERT(cert_data_map != nullptr);
+    CHECK(cert_data_map != nullptr);
   }
 
   absl::string_view name() const override { return name_; }
@@ -262,7 +263,7 @@ class FakeCertificateProviderFactory
   CreateCertificateProvider(
       grpc_core::RefCountedPtr<grpc_core::CertificateProviderFactory::Config>
       /*config*/) override {
-    GPR_ASSERT(cert_data_map_ != nullptr);
+    CHECK(cert_data_map_ != nullptr);
     return grpc_core::MakeRefCounted<FakeCertificateProvider>(
         cert_data_map_->Get());
   }
@@ -1005,7 +1006,7 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
     options.set_verify_server_certs(true);
     options.set_certificate_verifier(std::move(verifier));
     auto channel_creds = grpc::experimental::TlsCredentials(options);
-    GPR_ASSERT(channel_creds.get() != nullptr);
+    CHECK(channel_creds.get() != nullptr);
     return CreateCustomChannel(uri, channel_creds, args);
   }
 
@@ -1026,7 +1027,7 @@ class XdsServerSecurityTest : public XdsEnd2endTest {
     options.set_verify_server_certs(true);
     options.set_certificate_verifier(std::move(verifier));
     auto channel_creds = grpc::experimental::TlsCredentials(options);
-    GPR_ASSERT(channel_creds.get() != nullptr);
+    CHECK(channel_creds.get() != nullptr);
     return CreateCustomChannel(uri, channel_creds, args);
   }
 

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -847,7 +847,7 @@ XdsEnd2endTest::CreateTlsFallbackCredentials() {
   options.set_verify_server_certs(true);
   options.set_check_call_host(false);
   auto channel_creds = grpc::experimental::TlsCredentials(options);
-  CHECK(channel_creds.get() != nullptr);
+  CHECK_NE(channel_creds.get(), nullptr);
   return channel_creds;
 }
 

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -26,6 +26,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -135,7 +136,7 @@ class XdsEnd2endTest::ServerThread::XdsChannelArgsServerBuilderOption
 
 void XdsEnd2endTest::ServerThread::Start() {
   gpr_log(GPR_INFO, "starting %s server on port %d", Type(), port_);
-  GPR_ASSERT(!running_);
+  CHECK(!running_);
   running_ = true;
   StartAllServices();
   grpc_core::Mutex mu;
@@ -846,7 +847,7 @@ XdsEnd2endTest::CreateTlsFallbackCredentials() {
   options.set_verify_server_certs(true);
   options.set_check_call_host(false);
   auto channel_creds = grpc::experimental::TlsCredentials(options);
-  GPR_ASSERT(channel_creds.get() != nullptr);
+  CHECK(channel_creds.get() != nullptr);
   return channel_creds;
 }
 

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -25,6 +25,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -932,7 +933,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
   // use a uniform distribution instead. We need a better estimate of how many
   // RPCs are needed with what error tolerance.
   static size_t ComputeIdealNumRpcs(double p, double error_tolerance) {
-    GPR_ASSERT(p >= 0 && p <= 1);
+    CHECK(p >= 0 && p <= 1);
     size_t num_rpcs =
         ceil(p * (1 - p) * 5.00 * 5.00 / error_tolerance / error_tolerance);
     num_rpcs += 1000;  // Add 1K as a buffer to avoid flakiness.

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -933,7 +933,8 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
   // use a uniform distribution instead. We need a better estimate of how many
   // RPCs are needed with what error tolerance.
   static size_t ComputeIdealNumRpcs(double p, double error_tolerance) {
-    CHECK(p >= 0 && p <= 1);
+    CHECK_GE(p, 0);
+    CHECK_LE(p, 1);
     size_t num_rpcs =
         ceil(p * (1 - p) * 5.00 * 5.00 / error_tolerance / error_tolerance);
     num_rpcs += 1000;  // Add 1K as a buffer to avoid flakiness.

--- a/test/cpp/end2end/xds/xds_outlier_detection_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_outlier_detection_end2end_test.cc
@@ -20,6 +20,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
+
 #include "src/core/client_channel/backup_poller.h"
 #include "src/core/lib/config/config_vars.h"
 #include "src/proto/grpc/testing/xds/v3/cluster.grpc.pb.h"
@@ -202,7 +204,7 @@ TEST_P(OutlierDetectionTest, SuccessRateMaxPercent) {
     } else if (backends_[i]->backend_service()->request_count() == 100) {
       ++regular_load_backend_count;
     } else {
-      GPR_ASSERT(1);
+      CHECK(1);
     }
   }
   EXPECT_EQ(1, empty_load_backend_count);
@@ -616,7 +618,7 @@ TEST_P(OutlierDetectionTest, FailurePercentageMaxPercentage) {
     } else if (backends_[i]->backend_service()->request_count() == 100) {
       ++regular_load_backend_count;
     } else {
-      GPR_ASSERT(1);
+      CHECK(1);
     }
   }
   EXPECT_EQ(1, empty_load_backend_count);
@@ -984,7 +986,7 @@ TEST_P(OutlierDetectionTest, SuccessRateAndFailurePercentage) {
       // The extra load could go to 2 remaining backends or just 1 of them.
       ++double_load_backend_count;
     } else if (backends_[i]->backend_service()->request_count() > 300) {
-      GPR_ASSERT(1);
+      CHECK(1);
     }
   }
   EXPECT_EQ(2, empty_load_backend_count);

--- a/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -69,9 +70,9 @@ class RingHashTest : public XdsEnd2endTest {
     for (int port : ports) {
       absl::StatusOr<grpc_core::URI> lb_uri =
           grpc_core::URI::Parse(grpc_core::LocalIpUri(port));
-      GPR_ASSERT(lb_uri.ok());
+      CHECK(lb_uri.ok());
       grpc_resolved_address address;
-      GPR_ASSERT(grpc_parse_uri(*lb_uri, &address));
+      CHECK(grpc_parse_uri(*lb_uri, &address));
       addresses.emplace_back(address, grpc_core::ChannelArgs());
     }
     return addresses;

--- a/test/cpp/end2end/xds/xds_server.cc
+++ b/test/cpp/end2end/xds/xds_server.cc
@@ -22,6 +22,7 @@
 #include <thread>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/log.h>
@@ -125,7 +126,7 @@ void AdsServiceImpl::ProcessUnsubscriptions(
     gpr_log(GPR_INFO, "ADS[%p]: Unsubscribe to type=%s name=%s state=%p", this,
             resource_type.c_str(), resource_name.c_str(), &subscription_state);
     auto resource_it = resource_name_map->find(resource_name);
-    GPR_ASSERT(resource_it != resource_name_map->end());
+    CHECK(resource_it != resource_name_map->end());
     auto& resource_state = resource_it->second;
     resource_state.subscriptions.erase(&subscription_state);
     if (resource_state.subscriptions.empty() &&
@@ -192,7 +193,7 @@ uint64_t LrsServiceImpl::ClientStats::total_issued_requests() const {
 uint64_t LrsServiceImpl::ClientStats::dropped_requests(
     const std::string& category) const {
   auto iter = dropped_requests_.find(category);
-  GPR_ASSERT(iter != dropped_requests_.end());
+  CHECK(iter != dropped_requests_.end());
   return iter->second;
 }
 

--- a/test/cpp/end2end/xds/xds_server.h
+++ b/test/cpp/end2end/xds/xds_server.h
@@ -23,6 +23,7 @@
 #include <thread>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/log.h>
@@ -355,7 +356,7 @@ class AdsServiceImpl
     if (request.response_nonce().empty()) {
       int client_resource_type_version = 0;
       if (!request.version_info().empty()) {
-        GPR_ASSERT(absl::SimpleAtoi(request.version_info(),
+        CHECK(absl::SimpleAtoi(request.version_info(),
                                     &client_resource_type_version));
       }
       if (check_version_callack_ != nullptr) {
@@ -364,7 +365,7 @@ class AdsServiceImpl
       }
     } else {
       int client_nonce;
-      GPR_ASSERT(absl::SimpleAtoi(request.response_nonce(), &client_nonce));
+      CHECK(absl::SimpleAtoi(request.response_nonce(), &client_nonce));
       // Check for ACK or NACK.
       ResponseState response_state;
       if (!request.has_error_detail()) {

--- a/test/cpp/end2end/xds/xds_server.h
+++ b/test/cpp/end2end/xds/xds_server.h
@@ -357,7 +357,7 @@ class AdsServiceImpl
       int client_resource_type_version = 0;
       if (!request.version_info().empty()) {
         CHECK(absl::SimpleAtoi(request.version_info(),
-                                    &client_resource_type_version));
+                               &client_resource_type_version));
       }
       if (check_version_callack_ != nullptr) {
         check_version_callack_(request.type_url(),


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT
Replacing GPR_ASSERT with absl CHECK

Will not be replacing CHECK with CHECK_EQ , CHECK_NE etc because there are too many callsites. Only a few - which fit into single - line regex will be changed. This would be small in number just to reduce the load later.

Replacing CHECK with CHECK_EQ , CHECK_NE etc could be done using Cider-V once these changes are submitted if we want to clean up later. Given that we have 5000+ instances of GPR_ASSERT to edit, Doing it manually is too much work for both the author and reviewer.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

