### PR TITLE
systemd socket activation: add support for abstract unix domain sockets

### DIFF
--- a/examples/cpp/systemd_socket_activation/server.cc
+++ b/examples/cpp/systemd_socket_activation/server.cc
@@ -40,8 +40,8 @@ class GreeterServiceImpl final : public Greeter::Service {
   }
 };
 
-void RunServer() {
-  std::string server_address("unix:/tmp/server");
+void RunServer(const std::string addr) {
+  std::string server_address(addr);
   GreeterServiceImpl service;
 
   grpc::EnableDefaultHealthCheckService(true);
@@ -62,7 +62,30 @@ void RunServer() {
 }
 
 int main(int argc, char** argv) {
-  RunServer();
+  std::string target_str;
+  std::string arg_str("--target");
+
+  if (argc > 1) {
+    std::string arg_val = argv[1];
+    size_t start_pos = arg_val.find(arg_str);
+    if (start_pos != std::string::npos) {
+      start_pos += arg_str.size();
+      if (arg_val[start_pos] == '=') {
+        target_str = arg_val.substr(start_pos + 1);
+      } else {
+        std::cout << "The only correct argument syntax is --target="
+                  << std::endl;
+        return 0;
+      }
+    } else {
+      std::cout << "The only acceptable argument is --target=" << std::endl;
+      return 0;
+    }
+  } else {
+    target_str = "unix:/tmp/server";
+  }
+
+  RunServer(target_str);
 
   return 0;
 }

--- a/examples/cpp/systemd_socket_activation/test.sh
+++ b/examples/cpp/systemd_socket_activation/test.sh
@@ -16,18 +16,17 @@
 # Run this script as root
 
 clean() {
-    echo "Cleaning..."
     systemctl stop sdsockact.socket
     systemctl stop sdsockact.service
     systemctl daemon-reload
-    rm /tmp/greeter_server
-    rm /tmp/greeter_client
     rm /etc/systemd/system/sdsockact.service
     rm /etc/systemd/system/sdsockact.socket
 }
 
 fail() {
     clean
+    rm /tmp/greeter_server
+    rm /tmp/greeter_client
     echo "FAIL: $@" >&2
     exit 1
 }
@@ -36,35 +35,48 @@ pass() {
     echo "SUCCESS: $1"
 }
 
-bazel build --define=use_systemd=true //examples/cpp/systemd_socket_activation:all || fail "Failed to build sd_sock_act"
-cp ../../../bazel-bin/examples/cpp/systemd_socket_activation/server /tmp/greeter_server
-cp ../../../bazel-bin/examples/cpp/systemd_socket_activation/client /tmp/greeter_client
+test_socket() {
+    modifier=${1}
+    name=${2}
+    abstract=${3}
 
 cat << EOF > /etc/systemd/system/sdsockact.service
 [Service]
-ExecStart=/tmp/greeter_server
+ExecStart=/tmp/greeter_server --target="${modifier}${name}"
 EOF
 
 cat << EOF > /etc/systemd/system/sdsockact.socket
 [Socket]
-ListenStream=/tmp/server
+ListenStream=${abstract}${name}
 ReusePort=true
 
 [Install]
 WantedBy=sockets.target
 EOF
 
-systemctl daemon-reload
-systemctl enable sdsockact.socket
-systemctl start sdsockact.socket
+    systemctl daemon-reload
+    systemctl enable sdsockact.socket
+    systemctl start sdsockact.socket
 
-pushd /tmp
-./greeter_client | grep "Hello"
-if [ $? -ne 0 ]; then
+    pushd /tmp
+    ./greeter_client --target="${modifier}${name}" | grep "Hello"
+    if [ $? -ne 0 ]; then
+        popd
+        fail "Response not received for ${name} socket"
+    fi
     popd
-    fail "Response not received"
-fi
+    pass "Response received for ${name} socket"
+    clean
 
-popd
-pass "Response received"
-clean
+}
+
+bazel build --define=use_systemd=true //examples/cpp/systemd_socket_activation:all || fail "Failed to build sd_sock_act"
+cp ../../../bazel-bin/examples/cpp/systemd_socket_activation/server /tmp/greeter_server
+cp ../../../bazel-bin/examples/cpp/systemd_socket_activation/client /tmp/greeter_client
+
+test_socket "unix:" "/tmp/unixsk" ""
+test_socket "unix-abstract:" "abstract" "@"
+test_socket "" "0.0.0.0:5023" ""
+
+rm /tmp/greeter_server
+rm /tmp/greeter_client

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -329,7 +329,7 @@ static void deactivated_all_ports(grpc_tcp_server* s) {
     grpc_tcp_listener* sp;
     for (sp = s->head; sp; sp = sp->next) {
       // Do not unlink if there is a pre-allocated FD
-      if (grpc_tcp_server_pre_allocated_fd(s) <= 0) {
+      if (grpc_tcp_server_pre_allocated_fd(s) < 0) {
         grpc_unlink_if_unix_domain_socket(&sp->addr);
       }
       GRPC_CLOSURE_INIT(&sp->destroyed_closure, destroyed_port, s,
@@ -702,7 +702,7 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
 
   /* Do not unlink if there are pre-allocated FDs, or it will stop
      working after the first client connects */
-  if (grpc_tcp_server_pre_allocated_fd(s) <= 0) {
+  if (grpc_tcp_server_pre_allocated_fd(s) < 0) {
     grpc_unlink_if_unix_domain_socket(addr);
   }
 

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -165,7 +165,7 @@ grpc_error_handle grpc_tcp_server_add_addr(grpc_tcp_server* s,
   fd = grpc_tcp_server_pre_allocated_fd(s);
 
   // Check if FD has been pre-allocated
-  if (fd > 0) {
+  if (fd >= 0) {
     int family = grpc_sockaddr_get_family(addr);
     // Set dsmode value
     if (family == AF_INET6) {


### PR DESCRIPTION
Currently, gRPC supports systemd socket activation for regular AF_UNIX and AF_INET sockets, but not AF_UNIX sockets in the abstract namespace. Add support for those as well.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

