### PR TITLE
[Python test] Fix a typo in bazelify_tests target

### DIFF
--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -422,7 +422,7 @@ test_suite(
         ":artifact_protoc_linux_x64_build_test",
         ":artifact_protoc_linux_x86_build_test",
         ":artifact_python_linux_x64_manylinux2014_cp312_build_test",
-        ":artifact_python_linux_x64_manylinux2014_cp38_build_test",
+        ":artifact_python_linux_x64_manylinux2014_cp39_build_test",
         ":package_csharp_linux_build_test",
         ":package_python_linux_build_test",
     ],


### PR DESCRIPTION
Typo introduced in: https://github.com/grpc/grpc/pull/34450
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

