### PR TITLE
[PSM Interop] Enable More CSM test for Python and add tini to Python interop client image (v1.62.x backport)

### DIFF
--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.client
@@ -11,6 +11,10 @@ COPY . .
 RUN tools/bazel build -c dbg //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client
 RUN cp -rL /workdir/bazel-bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client* /artifacts/
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 FROM python:3.9-slim-bookworm
 
 ENV GRPC_VERBOSITY="DEBUG"
@@ -25,4 +29,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 COPY --from=0 /artifacts ./
 
-ENTRYPOINT ["/xds_interop_client"]
+# tini serves as PID 1 and enables the server to properly respond to signals.
+COPY --from=0 /tini /tini
+
+ENTRYPOINT ["/tini", "-g", "-vv",  "--",  "/xds_interop_client"]

--- a/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server
+++ b/src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server
@@ -11,6 +11,10 @@ COPY . .
 RUN tools/bazel build -c dbg //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_server
 RUN cp -rL /workdir/bazel-bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server* /artifacts/
 
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 FROM python:3.9-slim-bookworm
 
 ENV GRPC_VERBOSITY="DEBUG"
@@ -25,4 +29,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 COPY --from=0 /artifacts ./
 
-ENTRYPOINT ["/xds_interop_server"]
+# tini serves as PID 1 and enables the server to properly respond to signals.
+COPY --from=0 /tini /tini
+
+ENTRYPOINT ["/tini", "-g", "-vv",  "--",  "/xds_interop_server"]

--- a/tools/internal_ci/linux/psm-csm-python.sh
+++ b/tools/internal_ci/linux/psm-csm-python.sh
@@ -19,8 +19,7 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-## We're only testing Python client for now
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-server"
+readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-server"
 readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
@@ -48,7 +47,7 @@ build_test_app_docker_images() {
     .
 
   docker build \
-    -f tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server \
+    -f src/python/grpcio_tests/tests_py3_only/interop/Dockerfile.server \
     -t "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" \
     .
 
@@ -176,7 +175,9 @@ main() {
   local failed_tests=0
   test_suites=(
     "gamma.gamma_baseline_test"
+    "gamma.affinity_session_drain_test"
     "gamma.affinity_test"
+    "app_net_ssa_test"
   )
   for test in "${test_suites[@]}"; do
     run_test $test || (( ++failed_tests ))


### PR DESCRIPTION
Backport of #36253 to v1.62.x.
---
[Python Client]  Verified by manually trigger test including the new session drain test:
- [x] [grpc/core/master/linux/psm-csm-python](https://source.cloud.google.com/results/invocations/60ee9457-6c4a-4c13-ab01-f8370d499cca)
 
[Python Client] With `app_net_ssa_test`:
- [x] [grpc/core/master/linux/psm-csm-python](https://source.cloud.google.com/results/invocations/5a928e0d-6b81-418a-8817-a0739d9796d6)


[Python Client And Server] All psm-csm tests:
- [x] [grpc/core/master/linux/psm-csm-python](https://source.cloud.google.com/results/invocations/7d064c41-7759-41de-9ae1-099d5ec05797)
  - Note we're using C++ 1.62.x image for session drain test server. 

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

