### PR TITLE
[test] increase timeout

### DIFF
--- a/test/cpp/interop/backend_metrics_lb_policy_test.cc
+++ b/test/cpp/interop/backend_metrics_lb_policy_test.cc
@@ -124,7 +124,7 @@ TEST(BackendMetricsLbPolicyTest, TestOobMetricsReceipt) {
   // This report is sent on start, available immediately
   auto report = tracker.WaitForOobLoadReport(
       [](auto report) { return report.cpu_utilization() == 0.5; },
-      absl::Milliseconds(1500), 3);
+      absl::Seconds(5) * grpc_test_slowdown_factor(), 3);
   ASSERT_TRUE(report.has_value());
   EXPECT_EQ(report->cpu_utilization(), 0.5);
   for (size_t i = 0; i < 3; i++) {


### PR DESCRIPTION
This fixes rare failure under MSAN. This does not increate the test run time:

MSAN build:
```
//test/cpp/interop:backend_metrics_lb_policy_test@poller=poll            PASSED in 59.2s
  Stats over 5000 runs: max = 59.2s, min = 4.9s, avg = 6.5s, dev = 2.8s
```

Opt/no MSAN:
```
//test/cpp/interop:backend_metrics_lb_policy_test@poller=poll            PASSED in 26.7s
  Stats over 5000 runs: max = 26.7s, min = 4.9s, avg = 7.7s, dev = 2.8s
```