### PR TITLE
[channel-init] Do not register max-age filter when chaotic-good is enabled.

### DIFF
--- a/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
@@ -307,13 +307,15 @@ void RegisterLegacyChannelIdleFilters(CoreConfiguration::Builder* builder) {
       .If([](const ChannelArgs& channel_args) {
         return GetClientIdleTimeout(channel_args) != Duration::Infinity();
       });
-  builder->channel_init()
-      ->RegisterV2Filter<LegacyMaxAgeFilter>(GRPC_SERVER_CHANNEL)
-      .ExcludeFromMinimalStack()
-      .If([](const ChannelArgs& channel_args) {
-        return LegacyMaxAgeFilter::Config::FromChannelArgs(channel_args)
-            .enable();
-      });
+  if (!grpc_core::IsChaoticGoodEnabled()) {
+    builder->channel_init()
+        ->RegisterV2Filter<LegacyMaxAgeFilter>(GRPC_SERVER_CHANNEL)
+        .ExcludeFromMinimalStack()
+        .If([](const ChannelArgs& channel_args) {
+          return LegacyMaxAgeFilter::Config::FromChannelArgs(channel_args)
+              .enable();
+        });
+  }
 }
 
 LegacyMaxAgeFilter::LegacyMaxAgeFilter(grpc_channel_stack* channel_stack,

--- a/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
@@ -307,7 +307,7 @@ void RegisterLegacyChannelIdleFilters(CoreConfiguration::Builder* builder) {
       .If([](const ChannelArgs& channel_args) {
         return GetClientIdleTimeout(channel_args) != Duration::Infinity();
       });
-  if (!grpc_core::IsChaoticGoodEnabled()) {
+  if (!IsChaoticGoodEnabled()) {
     builder->channel_init()
         ->RegisterV2Filter<LegacyMaxAgeFilter>(GRPC_SERVER_CHANNEL)
         .ExcludeFromMinimalStack()


### PR DESCRIPTION
follow-up on #36225 
