### PR TITLE
[PSM Interop] Migrate to Artifact Registry (v1.56.x backport)

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb.sh
@@ -19,8 +19,9 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/cpp-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/cpp-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 
@@ -40,7 +41,7 @@ build_test_app_docker_images() {
   echo "Building C++ xDS interop test app Docker images"
   docker build -f "${SRC_DIR}/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
   docker build -f "${SRC_DIR}/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server" -t "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then

--- a/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_lb_python.sh
@@ -19,8 +19,9 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/python-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/python-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 readonly LANGUAGE_NAME="Python"
@@ -52,7 +53,7 @@ build_test_app_docker_images() {
 
   popd
 
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
 
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"

--- a/tools/internal_ci/linux/grpc_xds_k8s_run_xtest.sh
+++ b/tools/internal_ci/linux/grpc_xds_k8s_run_xtest.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ## xDS test server/client Docker images
-readonly IMAGE_REPO="gcr.io/grpc-testing/xds-interop"
+readonly IMAGE_REPO="us-docker.pkg.dev/grpc-testing/psm-interop"
 
 find_latest() {
   gcloud container images list-tags --filter='tags~v1\.\d+\.x' "${IMAGE_REPO}/${1}-${2}" --flatten='tags[]' --format='value(tags)' | sort --version-sort | tail -n 1

--- a/tools/internal_ci/linux/grpc_xds_url_map.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map.sh
@@ -19,7 +19,8 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test client Docker images
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/cpp-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 
@@ -37,7 +38,7 @@ readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 build_test_app_docker_images() {
   echo "Building C++ xDS interop test app Docker images"
   docker build -f "${SRC_DIR}/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then
     tag_and_push_docker_image "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}" "${TESTING_VERSION}"

--- a/tools/internal_ci/linux/grpc_xds_url_map_python.sh
+++ b/tools/internal_ci/linux/grpc_xds_url_map_python.sh
@@ -19,7 +19,8 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test client Docker images
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/python-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 readonly LANGUAGE_NAME="Python"
@@ -46,7 +47,7 @@ build_test_app_docker_images() {
 
   popd
 
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
 
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then

--- a/tools/internal_ci/linux/psm-security-python.sh
+++ b/tools/internal_ci/linux/psm-security-python.sh
@@ -19,8 +19,9 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/python-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/python-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/python-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 readonly LANGUAGE_NAME="Python"
@@ -54,7 +55,7 @@ build_test_app_docker_images() {
 
   popd
 
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
 
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"

--- a/tools/internal_ci/linux/psm-security.sh
+++ b/tools/internal_ci/linux/psm-security.sh
@@ -19,8 +19,9 @@ set -eo pipefail
 readonly GITHUB_REPOSITORY_NAME="grpc"
 readonly TEST_DRIVER_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/${TEST_DRIVER_REPO_OWNER:-grpc}/psm-interop/${TEST_DRIVER_BRANCH:-main}/.kokoro/psm_interop_kokoro_lib.sh"
 ## xDS test server/client Docker images
-readonly SERVER_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-server"
-readonly CLIENT_IMAGE_NAME="gcr.io/grpc-testing/xds-interop/cpp-client"
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+readonly SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/cpp-server"
+readonly CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/cpp-client"
 readonly FORCE_IMAGE_BUILD="${FORCE_IMAGE_BUILD:-0}"
 readonly BUILD_APP_PATH="interop-testing/build/install/grpc-interop-testing"
 
@@ -41,7 +42,7 @@ build_test_app_docker_images() {
   echo "Building C++ xDS interop test app Docker images"
   docker build -f "${SRC_DIR}/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_client" -t "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
   docker build -f "${SRC_DIR}/tools/dockerfile/interoptest/grpc_interop_cxx_xds/Dockerfile.xds_server" -t "${SERVER_IMAGE_NAME}:${GIT_COMMIT}" "${SRC_DIR}"
-  gcloud -q auth configure-docker
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
   docker push "${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
   docker push "${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
   if is_version_branch "${TESTING_VERSION}"; then


### PR DESCRIPTION
Backport of #36273 to v1.56.x.
---
Migrate PSM Interop images from Container Registry (gcr.io) to Artifact Registry (pkg.dev).
