### PR TITLE
grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9539,6 +9539,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(cf_engine_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7560,6 +7560,7 @@ target_include_directories(bad_ping_test
 target_link_libraries(bad_ping_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8036,6 +8037,7 @@ target_include_directories(binary_metadata_test
 target_link_libraries(binary_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8479,6 +8481,7 @@ target_include_directories(call_creds_test
 target_link_libraries(call_creds_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8686,6 +8689,7 @@ target_include_directories(call_host_override_test
 target_link_libraries(call_host_override_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8792,6 +8796,7 @@ target_include_directories(cancel_after_accept_test
 target_link_libraries(cancel_after_accept_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8855,6 +8860,7 @@ target_include_directories(cancel_after_client_done_test
 target_link_libraries(cancel_after_client_done_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8918,6 +8924,7 @@ target_include_directories(cancel_after_invoke_test
 target_link_libraries(cancel_after_invoke_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -8981,6 +8988,7 @@ target_include_directories(cancel_after_round_trip_test
 target_link_libraries(cancel_after_round_trip_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -9091,6 +9099,7 @@ target_include_directories(cancel_before_invoke_test
 target_link_libraries(cancel_before_invoke_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -9196,6 +9205,7 @@ target_include_directories(cancel_in_a_vacuum_test
 target_link_libraries(cancel_in_a_vacuum_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -9259,6 +9269,7 @@ target_include_directories(cancel_with_status_test
 target_link_libraries(cancel_with_status_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -9577,6 +9588,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(cf_event_engine_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -10364,6 +10376,7 @@ target_include_directories(client_auth_filter_test
 target_link_libraries(client_auth_filter_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -10413,6 +10426,7 @@ target_include_directories(client_authority_filter_test
 target_link_libraries(client_authority_filter_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -10911,6 +10925,7 @@ target_include_directories(client_streaming_test
 target_link_libraries(client_streaming_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -11250,6 +11265,7 @@ target_include_directories(compressed_payload_test
 target_link_libraries(compressed_payload_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -11535,6 +11551,7 @@ target_include_directories(connectivity_test
 target_link_libraries(connectivity_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -11966,6 +11983,7 @@ target_include_directories(default_host_test
 target_link_libraries(default_host_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -12175,6 +12193,7 @@ target_include_directories(disappearing_server_test
 target_link_libraries(disappearing_server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -12495,6 +12514,7 @@ target_include_directories(empty_batch_test
 target_link_libraries(empty_batch_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -13879,6 +13899,7 @@ target_include_directories(filter_causes_close_test
 target_link_libraries(filter_causes_close_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -13942,6 +13963,7 @@ target_include_directories(filter_context_test
 target_link_libraries(filter_context_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -14005,6 +14027,7 @@ target_include_directories(filter_init_fails_test
 target_link_libraries(filter_init_fails_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -14055,6 +14078,7 @@ target_include_directories(filter_test_test
 target_link_libraries(filter_test_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_unsecure
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
@@ -14118,6 +14142,7 @@ target_include_directories(filtered_metadata_test
 target_link_libraries(filtered_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -14648,6 +14673,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(fuzzing_event_engine_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     ${_gRPC_PROTOBUF_LIBRARIES}
     grpc_test_util
   )
@@ -14697,6 +14723,7 @@ target_include_directories(fuzzing_event_engine_unittest
 target_link_libraries(fuzzing_event_engine_unittest
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -14909,6 +14936,7 @@ target_include_directories(graceful_server_shutdown_test
 target_link_libraries(graceful_server_shutdown_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -15277,6 +15305,7 @@ target_include_directories(grpc_authz_test
 target_link_libraries(grpc_authz_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -16038,6 +16067,7 @@ target_include_directories(grpc_tls_crl_provider_test
 target_link_libraries(grpc_tls_crl_provider_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -16279,6 +16309,7 @@ target_include_directories(h2_ssl_cert_test
 target_link_libraries(h2_ssl_cert_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_test_util
 )
 
@@ -16671,6 +16702,7 @@ target_include_directories(high_initial_seqno_test
 target_link_libraries(high_initial_seqno_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -16980,6 +17012,7 @@ target_include_directories(hpack_size_test
 target_link_libraries(hpack_size_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -17137,6 +17170,7 @@ target_include_directories(http2_stats_test
 target_link_libraries(http2_stats_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -17589,6 +17623,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(inproc_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     ${_gRPC_PROTOBUF_LIBRARIES}
     grpc_test_util
   )
@@ -18033,6 +18068,7 @@ target_include_directories(invoke_large_request_test
 target_link_libraries(invoke_large_request_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -18079,6 +18115,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   target_link_libraries(iocp_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -18422,6 +18459,7 @@ target_include_directories(keepalive_timeout_test
 target_link_libraries(keepalive_timeout_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -18528,6 +18566,7 @@ target_include_directories(large_metadata_test
 target_link_libraries(large_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -19201,6 +19240,7 @@ target_include_directories(max_concurrent_streams_test
 target_link_libraries(max_concurrent_streams_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -19264,6 +19304,7 @@ target_include_directories(max_connection_age_test
 target_link_libraries(max_connection_age_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -19327,6 +19368,7 @@ target_include_directories(max_connection_idle_test
 target_link_libraries(max_connection_idle_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -19390,6 +19432,7 @@ target_include_directories(max_message_length_test
 target_link_libraries(max_message_length_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -20073,6 +20116,7 @@ target_include_directories(negative_deadline_test
 target_link_libraries(negative_deadline_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -20168,6 +20212,7 @@ target_include_directories(no_logging_test
 target_link_libraries(no_logging_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -20231,6 +20276,7 @@ target_include_directories(no_op_test
 target_link_libraries(no_op_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -20513,6 +20559,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(oracle_event_engine_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -20843,6 +20890,7 @@ target_include_directories(outlier_detection_test
 target_link_libraries(outlier_detection_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -21162,6 +21210,7 @@ target_include_directories(payload_test
 target_link_libraries(payload_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -21331,6 +21380,7 @@ target_include_directories(pick_first_test
 target_link_libraries(pick_first_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -21537,6 +21587,7 @@ target_include_directories(ping_pong_streaming_test
 target_link_libraries(ping_pong_streaming_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -21651,6 +21702,7 @@ target_include_directories(ping_test
 target_link_libraries(ping_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -21844,6 +21896,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(posix_endpoint_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -21935,6 +21988,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(posix_event_engine_connect_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -21987,6 +22041,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(posix_event_engine_native_dns_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -22042,6 +22097,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(posix_event_engine_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++_test_util
   )
 
@@ -22647,6 +22703,7 @@ target_include_directories(proxy_auth_test
 target_link_libraries(proxy_auth_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23224,6 +23281,7 @@ target_include_directories(registered_call_test
 target_link_libraries(registered_call_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23332,6 +23390,7 @@ target_include_directories(request_with_flags_test
 target_link_libraries(request_with_flags_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23395,6 +23454,7 @@ target_include_directories(request_with_payload_test
 target_link_libraries(request_with_payload_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23729,6 +23789,7 @@ target_include_directories(resource_quota_server_test
 target_link_libraries(resource_quota_server_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23834,6 +23895,7 @@ target_include_directories(retry_cancel_after_first_attempt_starts_test
 target_link_libraries(retry_cancel_after_first_attempt_starts_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23897,6 +23959,7 @@ target_include_directories(retry_cancel_during_delay_test
 target_link_libraries(retry_cancel_during_delay_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -23960,6 +24023,7 @@ target_include_directories(retry_cancel_with_multiple_send_batches_test
 target_link_libraries(retry_cancel_with_multiple_send_batches_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24023,6 +24087,7 @@ target_include_directories(retry_cancellation_test
 target_link_libraries(retry_cancellation_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24086,6 +24151,7 @@ target_include_directories(retry_disabled_test
 target_link_libraries(retry_disabled_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24149,6 +24215,7 @@ target_include_directories(retry_exceeds_buffer_size_in_delay_test
 target_link_libraries(retry_exceeds_buffer_size_in_delay_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24212,6 +24279,7 @@ target_include_directories(retry_exceeds_buffer_size_in_initial_batch_test
 target_link_libraries(retry_exceeds_buffer_size_in_initial_batch_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24275,6 +24343,7 @@ target_include_directories(retry_exceeds_buffer_size_in_subsequent_batch_test
 target_link_libraries(retry_exceeds_buffer_size_in_subsequent_batch_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24338,6 +24407,7 @@ target_include_directories(retry_lb_drop_test
 target_link_libraries(retry_lb_drop_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24401,6 +24471,7 @@ target_include_directories(retry_lb_fail_test
 target_link_libraries(retry_lb_fail_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24464,6 +24535,7 @@ target_include_directories(retry_non_retriable_status_before_trailers_test
 target_link_libraries(retry_non_retriable_status_before_trailers_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24527,6 +24599,7 @@ target_include_directories(retry_non_retriable_status_test
 target_link_libraries(retry_non_retriable_status_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24590,6 +24663,7 @@ target_include_directories(retry_per_attempt_recv_timeout_on_last_attempt_test
 target_link_libraries(retry_per_attempt_recv_timeout_on_last_attempt_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24653,6 +24727,7 @@ target_include_directories(retry_per_attempt_recv_timeout_test
 target_link_libraries(retry_per_attempt_recv_timeout_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24716,6 +24791,7 @@ target_include_directories(retry_recv_initial_metadata_test
 target_link_libraries(retry_recv_initial_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24779,6 +24855,7 @@ target_include_directories(retry_recv_message_replay_test
 target_link_libraries(retry_recv_message_replay_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24842,6 +24919,7 @@ target_include_directories(retry_recv_message_test
 target_link_libraries(retry_recv_message_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24905,6 +24983,7 @@ target_include_directories(retry_recv_trailing_metadata_error_test
 target_link_libraries(retry_recv_trailing_metadata_error_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -24968,6 +25047,7 @@ target_include_directories(retry_send_initial_metadata_refs_test
 target_link_libraries(retry_send_initial_metadata_refs_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25031,6 +25111,7 @@ target_include_directories(retry_send_op_fails_test
 target_link_libraries(retry_send_op_fails_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25094,6 +25175,7 @@ target_include_directories(retry_send_recv_batch_test
 target_link_libraries(retry_send_recv_batch_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25157,6 +25239,7 @@ target_include_directories(retry_server_pushback_delay_test
 target_link_libraries(retry_server_pushback_delay_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25220,6 +25303,7 @@ target_include_directories(retry_server_pushback_disabled_test
 target_link_libraries(retry_server_pushback_disabled_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25325,6 +25409,7 @@ target_include_directories(retry_streaming_after_commit_test
 target_link_libraries(retry_streaming_after_commit_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25388,6 +25473,7 @@ target_include_directories(retry_streaming_succeeds_before_replay_finished_test
 target_link_libraries(retry_streaming_succeeds_before_replay_finished_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25451,6 +25537,7 @@ target_include_directories(retry_streaming_test
 target_link_libraries(retry_streaming_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25514,6 +25601,7 @@ target_include_directories(retry_test
 target_link_libraries(retry_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25619,6 +25707,7 @@ target_include_directories(retry_throttled_test
 target_link_libraries(retry_throttled_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25682,6 +25771,7 @@ target_include_directories(retry_too_many_attempts_test
 target_link_libraries(retry_too_many_attempts_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25745,6 +25835,7 @@ target_include_directories(retry_transparent_goaway_test
 target_link_libraries(retry_transparent_goaway_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25808,6 +25899,7 @@ target_include_directories(retry_transparent_max_concurrent_streams_test
 target_link_libraries(retry_transparent_max_concurrent_streams_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25871,6 +25963,7 @@ target_include_directories(retry_transparent_not_sent_on_wire_test
 target_link_libraries(retry_transparent_not_sent_on_wire_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25934,6 +26027,7 @@ target_include_directories(retry_unref_before_finish_test
 target_link_libraries(retry_unref_before_finish_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -25997,6 +26091,7 @@ target_include_directories(retry_unref_before_recv_test
 target_link_libraries(retry_unref_before_recv_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -26047,6 +26142,7 @@ target_include_directories(ring_hash_test
 target_link_libraries(ring_hash_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -26211,6 +26307,7 @@ target_include_directories(round_robin_test
 target_link_libraries(round_robin_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -26983,6 +27080,7 @@ target_include_directories(server_finishes_request_test
 target_link_libraries(server_finishes_request_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -27268,6 +27366,7 @@ target_include_directories(server_streaming_test
 target_link_libraries(server_streaming_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -27532,6 +27631,7 @@ target_include_directories(shutdown_finishes_calls_test
 target_link_libraries(shutdown_finishes_calls_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -27595,6 +27695,7 @@ target_include_directories(shutdown_finishes_tags_test
 target_link_libraries(shutdown_finishes_tags_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -27722,6 +27823,7 @@ target_include_directories(simple_delayed_request_test
 target_link_libraries(simple_delayed_request_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -27785,6 +27887,7 @@ target_include_directories(simple_metadata_test
 target_link_libraries(simple_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -27892,6 +27995,7 @@ target_include_directories(simple_request_test
 target_link_libraries(simple_request_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -28819,6 +28923,7 @@ target_include_directories(streaming_error_response_test
 target_link_libraries(streaming_error_response_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -29441,6 +29546,7 @@ target_include_directories(tcp_socket_utils_test
 target_link_libraries(tcp_socket_utils_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc
 )
 
@@ -29490,6 +29596,7 @@ target_include_directories(test_core_channel_channelz_test
 target_link_libraries(test_core_channel_channelz_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc++
   grpc_test_util
 )
@@ -29552,6 +29659,7 @@ target_include_directories(test_core_end2end_channelz_test
 target_link_libraries(test_core_end2end_channelz_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -29599,6 +29707,7 @@ target_include_directories(test_core_event_engine_posix_timer_heap_test
 target_link_libraries(test_core_event_engine_posix_timer_heap_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   absl::statusor
   gpr
 )
@@ -29697,6 +29806,7 @@ target_link_libraries(test_core_event_engine_slice_buffer_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
   absl::hash
+  absl::check
   absl::statusor
   absl::utility
   gpr
@@ -30083,6 +30193,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(test_core_transport_test_suite_chaotic_good_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     ${_gRPC_PROTOBUF_LIBRARIES}
     grpc_test_util
   )
@@ -30663,6 +30774,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(thready_posix_event_engine_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -30813,6 +30925,7 @@ target_include_directories(timeout_before_request_call_test
 target_link_libraries(timeout_before_request_call_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -31258,6 +31371,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(traced_buffer_list_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -31320,6 +31434,7 @@ target_include_directories(trailing_metadata_test
 target_link_libraries(trailing_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -32105,6 +32220,7 @@ target_include_directories(weighted_round_robin_test
 target_link_libraries(weighted_round_robin_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )
@@ -32150,6 +32266,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   target_link_libraries(win_socket_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -32239,6 +32356,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX OR _gRPC_PLATFORM_WINDOWS)
   target_link_libraries(windows_endpoint_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -32500,6 +32618,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(work_serializer_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc_test_util
   )
 
@@ -32562,6 +32681,7 @@ target_include_directories(write_buffering_at_end_test
 target_link_libraries(write_buffering_at_end_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -32625,6 +32745,7 @@ target_include_directories(write_buffering_test
 target_link_libraries(write_buffering_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_authorization_provider
   grpc_unsecure
   grpc_test_util
@@ -32746,6 +32867,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(writes_per_rpc_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
+    absl::check
     grpc++
     grpc_test_util
   )
@@ -35503,6 +35625,7 @@ target_include_directories(xds_override_host_test
 target_link_libraries(xds_override_host_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   ${_gRPC_PROTOBUF_LIBRARIES}
   grpc_test_util
 )

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -7439,6 +7439,7 @@ targets:
   - test/core/event_engine/cf/cf_engine_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5869,6 +5869,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6097,6 +6098,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6362,6 +6364,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6607,6 +6610,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6683,6 +6687,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6746,6 +6751,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6809,6 +6815,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6872,6 +6879,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6952,6 +6960,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -7030,6 +7039,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -7093,6 +7103,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -7452,6 +7463,7 @@ targets:
   - test/core/event_engine/test_suite/tests/timer_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -7839,6 +7851,7 @@ targets:
   - test/core/filters/filter_test.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -7856,6 +7869,7 @@ targets:
   - test/core/filters/filter_test.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -8053,6 +8067,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8229,6 +8244,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8369,6 +8385,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8540,6 +8557,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8641,6 +8659,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8777,6 +8796,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9572,6 +9592,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9635,6 +9656,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9698,6 +9720,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9715,6 +9738,7 @@ targets:
   - test/core/filters/filter_test_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_unsecure
   - protobuf
   - grpc_test_util
@@ -9779,6 +9803,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -10206,6 +10231,7 @@ targets:
   - test/core/event_engine/test_suite/tests/timer_test.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   platforms:
@@ -10224,6 +10250,7 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine_unittest.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
 - name: generic_end2end_test
@@ -10325,6 +10352,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -10525,6 +10553,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -10827,6 +10856,7 @@ targets:
   - test/core/tsi/transport_security_test_lib.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
 - name: grpc_tool_test
@@ -10930,6 +10960,7 @@ targets:
   - test/core/event_engine/event_engine_test_utils.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
 - name: h2_ssl_session_reuse_test
   gtest: true
@@ -11091,6 +11122,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11289,6 +11321,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11377,6 +11410,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11532,6 +11566,7 @@ targets:
   - test/core/transport/test_suite/test_main.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   platforms:
@@ -11862,6 +11897,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11876,6 +11912,7 @@ targets:
   - test/core/event_engine/windows/iocp_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -12064,6 +12101,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12139,6 +12177,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12554,6 +12593,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12617,6 +12657,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12680,6 +12721,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12743,6 +12785,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13029,6 +13072,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13104,6 +13148,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13167,6 +13212,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13270,6 +13316,7 @@ targets:
   - test/core/event_engine/test_suite/tests/server_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -13381,6 +13428,7 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -13539,6 +13587,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13664,6 +13713,7 @@ targets:
   - test/core/util/fake_stats_plugin.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -13801,6 +13851,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13895,6 +13946,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13957,6 +14009,7 @@ targets:
   - test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -13991,6 +14044,7 @@ targets:
   - test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -14018,6 +14072,7 @@ targets:
   - test/cpp/util/windows/manifest_file.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -14051,6 +14106,7 @@ targets:
   - test/cpp/util/windows/manifest_file.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -14316,6 +14372,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14575,6 +14632,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14653,6 +14711,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14716,6 +14775,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14931,6 +14991,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15005,6 +15066,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15068,6 +15130,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15131,6 +15194,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15194,6 +15258,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15257,6 +15322,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15320,6 +15386,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15383,6 +15450,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15446,6 +15514,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15509,6 +15578,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15572,6 +15642,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15635,6 +15706,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15698,6 +15770,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15761,6 +15834,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15824,6 +15898,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15887,6 +15962,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15950,6 +16026,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16013,6 +16090,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16076,6 +16154,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16139,6 +16218,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16202,6 +16282,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16265,6 +16346,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16328,6 +16410,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16391,6 +16474,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16465,6 +16549,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16528,6 +16613,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16591,6 +16677,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16654,6 +16741,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16728,6 +16816,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16791,6 +16880,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16854,6 +16944,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16917,6 +17008,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16980,6 +17072,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17043,6 +17136,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17106,6 +17200,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17124,6 +17219,7 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -17181,6 +17277,7 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -17512,6 +17609,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17663,6 +17761,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17795,6 +17894,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17858,6 +17958,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17937,6 +18038,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18000,6 +18102,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18077,6 +18180,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18435,6 +18539,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18714,6 +18819,7 @@ targets:
   - test/core/event_engine/tcp_socket_utils_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc
   uses_polling: false
 - name: test_core_channel_channelz_test
@@ -18730,6 +18836,7 @@ targets:
   - test/cpp/util/channel_trace_proto_helper.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++
   - grpc_test_util
 - name: test_core_end2end_channelz_test
@@ -18792,6 +18899,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18813,6 +18921,7 @@ targets:
   - test/core/event_engine/posix/timer_heap_test.cc
   deps:
   - gtest
+  - absl/log:check
   - absl/status:statusor
   - gpr
   uses_polling: false
@@ -18866,6 +18975,7 @@ targets:
   deps:
   - gtest
   - absl/hash:hash
+  - absl/log:check
   - absl/status:statusor
   - absl/utility:utility
   - gpr
@@ -19048,6 +19158,7 @@ targets:
   - test/core/transport/test_suite/test_main.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   platforms:
@@ -19249,6 +19360,7 @@ targets:
   - test/core/event_engine/test_suite/thready_posix_event_engine_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19341,6 +19453,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -19497,6 +19610,7 @@ targets:
   - test/core/event_engine/posix/traced_buffer_list_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19563,6 +19677,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -19911,6 +20026,7 @@ targets:
   - test/core/util/fake_stats_plugin.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -19925,6 +20041,7 @@ targets:
   - test/core/event_engine/windows/win_socket_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19956,6 +20073,7 @@ targets:
   - test/core/event_engine/windows/windows_endpoint_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -20192,6 +20310,7 @@ targets:
   - test/core/gprpp/work_serializer_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -20257,6 +20376,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -20320,6 +20440,7 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -20377,6 +20498,7 @@ targets:
   - test/cpp/performance/writes_per_rpc_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc++
   - grpc_test_util
   platforms:
@@ -21309,6 +21431,7 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
+  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false

--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -129,7 +129,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "slice_buffer_test",
     srcs = ["slice_buffer_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:gpr_platform",
@@ -181,6 +184,7 @@ grpc_cc_test(
     name = "tcp_socket_utils_test",
     srcs = ["tcp_socket_utils_test.cc"],
     external_deps = [
+        "absl/log:check",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -216,6 +220,7 @@ grpc_cc_library(
     srcs = ["event_engine_test_utils.cc"],
     hdrs = ["event_engine_test_utils.h"],
     external_deps = [
+        "absl/log:check",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",

--- a/test/core/event_engine/cf/BUILD
+++ b/test/core/event_engine/cf/BUILD
@@ -20,7 +20,10 @@ grpc_cc_library(
     name = "cf_engine_unit_test_lib",
     testonly = True,
     srcs = ["cf_engine_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_linux",

--- a/test/core/event_engine/cf/BUILD
+++ b/test/core/event_engine/cf/BUILD
@@ -45,7 +45,10 @@ grpc_cc_test(
     name = "cf_engine_test",
     timeout = "short",
     srcs = ["cf_engine_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_linux",

--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -42,7 +42,7 @@ namespace experimental {
 TEST(CFEventEngineTest, TestConnectionTimeout) {
   // use a non-routable IP so connection will timeout
   auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
   grpc_core::Notification client_signal;
@@ -64,7 +64,7 @@ TEST(CFEventEngineTest, TestConnectionTimeout) {
 TEST(CFEventEngineTest, TestConnectionCancelled) {
   // use a non-routable IP so to cancel connection before timeout
   auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -42,7 +42,7 @@ namespace experimental {
 TEST(CFEventEngineTest, TestConnectionTimeout) {
   // use a non-routable IP so connection will timeout
   auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
   grpc_core::Notification client_signal;
@@ -64,7 +64,7 @@ TEST(CFEventEngineTest, TestConnectionTimeout) {
 TEST(CFEventEngineTest, TestConnectionCancelled) {
   // use a non-routable IP so to cancel connection before timeout
   auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -18,6 +18,7 @@
 
 #include <thread>
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 #include "gmock/gmock.h"
@@ -41,7 +42,7 @@ namespace experimental {
 TEST(CFEventEngineTest, TestConnectionTimeout) {
   // use a non-routable IP so connection will timeout
   auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
   grpc_core::Notification client_signal;
@@ -63,7 +64,7 @@ TEST(CFEventEngineTest, TestConnectionTimeout) {
 TEST(CFEventEngineTest, TestConnectionCancelled) {
   // use a non-routable IP so to cancel connection before timeout
   auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -102,7 +102,8 @@ std::string ExtractSliceBufferIntoString(SliceBuffer* buf) {
 absl::Status SendValidatePayload(absl::string_view data,
                                  EventEngine::Endpoint* send_endpoint,
                                  EventEngine::Endpoint* receive_endpoint) {
-  CHECK_NE(receive_endpoint != nullptr && send_endpoint, nullptr);
+  CHECK_NE(receive_endpoint, nullptr);
+  CHECK_NE(send_endpoint, nullptr);
   int num_bytes_written = data.size();
   grpc_core::Notification read_signal;
   grpc_core::Notification write_signal;

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -121,7 +121,7 @@ absl::Status SendValidatePayload(absl::string_view data,
   std::function<void(absl::Status)> read_cb;
   read_cb = [receive_endpoint, &read_slice_buf, &read_store_buf, &read_cb,
              &read_signal, &args](absl::Status status) {
-    CHECK_OK(status.ok());
+    CHECK_OK(status);
     if (read_slice_buf.Length() == static_cast<size_t>(args.read_hint_bytes)) {
       read_slice_buf.MoveFirstNBytesIntoSliceBuffer(read_slice_buf.Length(),
                                                     read_store_buf);
@@ -143,7 +143,7 @@ absl::Status SendValidatePayload(absl::string_view data,
   // Start asynchronous writing at the send_endpoint.
   if (send_endpoint->Write(
           [&write_signal](absl::Status status) {
-            CHECK_OK(status.ok());
+            CHECK_OK(status);
             write_signal.Notify();
           },
           &write_slice_buf, nullptr)) {
@@ -186,7 +186,7 @@ absl::Status ConnectionManager::BindAndStartListener(
 
   ChannelArgsEndpointConfig config;
   auto status = event_engine->CreateListener(
-      std::move(accept_cb), [](absl::Status status) { CHECK_OK(status.ok()); },
+      std::move(accept_cb), [](absl::Status status) { CHECK_OK(status); },
       config, std::make_unique<grpc_core::MemoryQuota>("foo"));
   if (!status.ok()) {
     return status.status();
@@ -201,7 +201,7 @@ absl::Status ConnectionManager::BindAndStartListener(
       return bind_status.status();
     }
   }
-  CHECK_OK(listener->Start().ok());
+  CHECK_OK(listener->Start());
   // Insert same listener pointer for all bind addresses after the listener
   // has started successfully.
   for (auto& addr : addrs) {

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -242,7 +242,7 @@ ConnectionManager::CreateConnection(std::string target_addr,
     // There is a listener for the specified address. Wait until it
     // creates a ServerEndpoint after accepting the connection.
     auto server_endpoint = last_in_progress_connection_.GetServerEndpoint();
-    CHECK_NE(server_endpoint, nullptr);
+    CHECK(server_endpoint != nullptr);
     // Set last_in_progress_connection_ to nullptr
     return std::make_tuple(std::move(client_endpoint),
                            std::move(server_endpoint));

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -101,7 +102,7 @@ std::string ExtractSliceBufferIntoString(SliceBuffer* buf) {
 absl::Status SendValidatePayload(absl::string_view data,
                                  EventEngine::Endpoint* send_endpoint,
                                  EventEngine::Endpoint* receive_endpoint) {
-  GPR_ASSERT(receive_endpoint != nullptr && send_endpoint != nullptr);
+  CHECK(receive_endpoint != nullptr && send_endpoint != nullptr);
   int num_bytes_written = data.size();
   grpc_core::Notification read_signal;
   grpc_core::Notification write_signal;
@@ -120,7 +121,7 @@ absl::Status SendValidatePayload(absl::string_view data,
   std::function<void(absl::Status)> read_cb;
   read_cb = [receive_endpoint, &read_slice_buf, &read_store_buf, &read_cb,
              &read_signal, &args](absl::Status status) {
-    GPR_ASSERT(status.ok());
+    CHECK(status.ok());
     if (read_slice_buf.Length() == static_cast<size_t>(args.read_hint_bytes)) {
       read_slice_buf.MoveFirstNBytesIntoSliceBuffer(read_slice_buf.Length(),
                                                     read_store_buf);
@@ -131,7 +132,7 @@ absl::Status SendValidatePayload(absl::string_view data,
     read_slice_buf.MoveFirstNBytesIntoSliceBuffer(read_slice_buf.Length(),
                                                   read_store_buf);
     if (receive_endpoint->Read(read_cb, &read_slice_buf, &args)) {
-      GPR_ASSERT(read_slice_buf.Length() != 0);
+      CHECK(read_slice_buf.Length() != 0);
       read_cb(absl::OkStatus());
     }
   };
@@ -142,7 +143,7 @@ absl::Status SendValidatePayload(absl::string_view data,
   // Start asynchronous writing at the send_endpoint.
   if (send_endpoint->Write(
           [&write_signal](absl::Status status) {
-            GPR_ASSERT(status.ok());
+            CHECK(status.ok());
             write_signal.Notify();
           },
           &write_slice_buf, nullptr)) {
@@ -185,9 +186,8 @@ absl::Status ConnectionManager::BindAndStartListener(
 
   ChannelArgsEndpointConfig config;
   auto status = event_engine->CreateListener(
-      std::move(accept_cb),
-      [](absl::Status status) { GPR_ASSERT(status.ok()); }, config,
-      std::make_unique<grpc_core::MemoryQuota>("foo"));
+      std::move(accept_cb), [](absl::Status status) { CHECK(status.ok()); },
+      config, std::make_unique<grpc_core::MemoryQuota>("foo"));
   if (!status.ok()) {
     return status.status();
   }
@@ -201,7 +201,7 @@ absl::Status ConnectionManager::BindAndStartListener(
       return bind_status.status();
     }
   }
-  GPR_ASSERT(listener->Start().ok());
+  CHECK(listener->Start().ok());
   // Insert same listener pointer for all bind addresses after the listener
   // has started successfully.
   for (auto& addr : addrs) {
@@ -241,7 +241,7 @@ ConnectionManager::CreateConnection(std::string target_addr,
     // There is a listener for the specified address. Wait until it
     // creates a ServerEndpoint after accepting the connection.
     auto server_endpoint = last_in_progress_connection_.GetServerEndpoint();
-    GPR_ASSERT(server_endpoint != nullptr);
+    CHECK(server_endpoint != nullptr);
     // Set last_in_progress_connection_ to nullptr
     return std::make_tuple(std::move(client_endpoint),
                            std::move(server_endpoint));

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -133,7 +133,7 @@ absl::Status SendValidatePayload(absl::string_view data,
     read_slice_buf.MoveFirstNBytesIntoSliceBuffer(read_slice_buf.Length(),
                                                   read_store_buf);
     if (receive_endpoint->Read(read_cb, &read_slice_buf, &args)) {
-      CHECK_NE(read_slice_buf.Length(), 0);
+      CHECK_NE(read_slice_buf.Length(), 0u);
       read_cb(absl::OkStatus());
     }
   };

--- a/test/core/event_engine/fuzzing_event_engine/BUILD
+++ b/test/core/event_engine/fuzzing_event_engine/BUILD
@@ -25,6 +25,7 @@ grpc_cc_library(
     name = "fuzzing_event_engine",
     srcs = ["fuzzing_event_engine.cc"],
     hdrs = ["fuzzing_event_engine.h"],
+    external_deps = ["absl/log:check"],
     deps = [
         ":fuzzing_event_engine_proto",
         "//:event_engine_base_hdrs",

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -112,7 +112,7 @@ FuzzingEventEngine::FuzzingEventEngine(
   // Whilst a fuzzing EventEngine is active we override grpc's now function.
   g_orig_gpr_now_impl = gpr_now_impl;
   gpr_now_impl = GlobalNowImpl;
-  CHECK(g_fuzzing_event_engine == nullptr);
+  CHECK_EQ(g_fuzzing_event_engine, nullptr);
   g_fuzzing_event_engine = this;
   grpc_core::TestOnlySetProcessEpoch(NowAsTimespec(GPR_CLOCK_MONOTONIC));
 
@@ -610,7 +610,7 @@ gpr_timespec FuzzingEventEngine::GlobalNowImpl(gpr_clock_type clock_type) {
   if (g_fuzzing_event_engine == nullptr) {
     return gpr_inf_future(clock_type);
   }
-  CHECK(g_fuzzing_event_engine != nullptr);
+  CHECK_NE(g_fuzzing_event_engine, nullptr);
   grpc_core::MutexLock lock(&*now_mu_);
   return g_fuzzing_event_engine->NowAsTimespec(clock_type);
 }
@@ -624,7 +624,7 @@ void FuzzingEventEngine::UnsetGlobalHooks() {
 }
 
 FuzzingEventEngine::ListenerInfo::~ListenerInfo() {
-  CHECK(g_fuzzing_event_engine != nullptr);
+  CHECK_NE(g_fuzzing_event_engine, nullptr);
   g_fuzzing_event_engine->Run(
       [on_shutdown = std::move(on_shutdown),
        shutdown_status = std::move(shutdown_status)]() mutable {

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -167,7 +167,7 @@ void FuzzingEventEngine::Tick(Duration max_time) {
         incr = std::max(incr, std::chrono::duration_cast<Duration>(
                                   std::chrono::milliseconds(1)));
         now_ += incr;
-        CHECK(now_.time_since_epoch().count() >= 0);
+        CHECK_GE(now_.time_since_epoch().count(), 0);
         ++current_tick_;
         incremented_time = true;
       }

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -22,6 +22,7 @@
 #include <limits>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 
@@ -111,7 +112,7 @@ FuzzingEventEngine::FuzzingEventEngine(
   // Whilst a fuzzing EventEngine is active we override grpc's now function.
   g_orig_gpr_now_impl = gpr_now_impl;
   gpr_now_impl = GlobalNowImpl;
-  GPR_ASSERT(g_fuzzing_event_engine == nullptr);
+  CHECK(g_fuzzing_event_engine == nullptr);
   g_fuzzing_event_engine = this;
   grpc_core::TestOnlySetProcessEpoch(NowAsTimespec(GPR_CLOCK_MONOTONIC));
 
@@ -136,7 +137,7 @@ void FuzzingEventEngine::FuzzingDone() {
 gpr_timespec FuzzingEventEngine::NowAsTimespec(gpr_clock_type clock_type) {
   // TODO(ctiller): add a facility to track realtime and monotonic clocks
   // separately to simulate divergence.
-  GPR_ASSERT(clock_type != GPR_TIMESPAN);
+  CHECK(clock_type != GPR_TIMESPAN);
   const Duration d = now_.time_since_epoch();
   auto secs = std::chrono::duration_cast<std::chrono::seconds>(d);
   return {secs.count(), static_cast<int32_t>((d - secs).count()), clock_type};
@@ -166,7 +167,7 @@ void FuzzingEventEngine::Tick(Duration max_time) {
         incr = std::max(incr, std::chrono::duration_cast<Duration>(
                                   std::chrono::milliseconds(1)));
         now_ += incr;
-        GPR_ASSERT(now_.time_since_epoch().count() >= 0);
+        CHECK(now_.time_since_epoch().count() >= 0);
         ++current_tick_;
         incremented_time = true;
       }
@@ -299,7 +300,7 @@ absl::Status FuzzingEventEngine::FuzzingListener::Start() {
 }
 
 bool FuzzingEventEngine::EndpointMiddle::Write(SliceBuffer* data, int index) {
-  GPR_ASSERT(!closed[index]);
+  CHECK(!closed[index]);
   const int peer_index = 1 - index;
   if (data->Length() == 0) return true;
   size_t write_len = std::numeric_limits<size_t>::max();
@@ -345,8 +346,8 @@ bool FuzzingEventEngine::FuzzingEndpoint::Write(
     const WriteArgs*) {
   grpc_core::global_stats().IncrementSyscallWrite();
   grpc_core::MutexLock lock(&*mu_);
-  GPR_ASSERT(!middle_->closed[my_index()]);
-  GPR_ASSERT(!middle_->writing[my_index()]);
+  CHECK(!middle_->closed[my_index()]);
+  CHECK(!middle_->writing[my_index()]);
   // If the write succeeds immediately, then we return true.
   if (middle_->Write(data, my_index())) return true;
   middle_->writing[my_index()] = true;
@@ -361,7 +362,7 @@ void FuzzingEventEngine::FuzzingEndpoint::ScheduleDelayedWrite(
       RunType::kWrite, [middle = std::move(middle), index, data,
                         on_writable = std::move(on_writable)]() mutable {
         grpc_core::ReleasableMutexLock lock(&*mu_);
-        GPR_ASSERT(middle->writing[index]);
+        CHECK(middle->writing[index]);
         if (middle->closed[index]) {
           g_fuzzing_event_engine->RunLocked(
               RunType::kRunAfter,
@@ -409,7 +410,7 @@ bool FuzzingEventEngine::FuzzingEndpoint::Read(
     const ReadArgs*) {
   buffer->Clear();
   grpc_core::MutexLock lock(&*mu_);
-  GPR_ASSERT(!middle_->closed[my_index()]);
+  CHECK(!middle_->closed[my_index()]);
   if (middle_->pending[peer_index()].empty()) {
     // If the endpoint is closed, fail asynchronously.
     if (middle_->closed[peer_index()]) {
@@ -589,7 +590,7 @@ EventEngine::TaskHandle FuzzingEventEngine::RunAfterLocked(
 
 bool FuzzingEventEngine::Cancel(TaskHandle handle) {
   grpc_core::MutexLock lock(&*mu_);
-  GPR_ASSERT(handle.keys[1] == kTaskHandleSalt);
+  CHECK(handle.keys[1] == kTaskHandleSalt);
   const intptr_t id = handle.keys[0];
   auto it = tasks_by_id_.find(id);
   if (it == tasks_by_id_.end()) {
@@ -609,7 +610,7 @@ gpr_timespec FuzzingEventEngine::GlobalNowImpl(gpr_clock_type clock_type) {
   if (g_fuzzing_event_engine == nullptr) {
     return gpr_inf_future(clock_type);
   }
-  GPR_ASSERT(g_fuzzing_event_engine != nullptr);
+  CHECK(g_fuzzing_event_engine != nullptr);
   grpc_core::MutexLock lock(&*now_mu_);
   return g_fuzzing_event_engine->NowAsTimespec(clock_type);
 }
@@ -623,7 +624,7 @@ void FuzzingEventEngine::UnsetGlobalHooks() {
 }
 
 FuzzingEventEngine::ListenerInfo::~ListenerInfo() {
-  GPR_ASSERT(g_fuzzing_event_engine != nullptr);
+  CHECK(g_fuzzing_event_engine != nullptr);
   g_fuzzing_event_engine->Run(
       [on_shutdown = std::move(on_shutdown),
        shutdown_status = std::move(shutdown_status)]() mutable {

--- a/test/core/event_engine/posix/BUILD
+++ b/test/core/event_engine/posix/BUILD
@@ -40,7 +40,10 @@ grpc_cc_library(
 grpc_cc_test(
     name = "timer_heap_test",
     srcs = ["timer_heap_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -142,7 +145,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "traced_buffer_list_test",
     srcs = ["traced_buffer_list_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_windows",
@@ -176,7 +182,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "posix_endpoint_test",
     srcs = ["posix_endpoint_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_windows",
@@ -221,7 +230,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "posix_event_engine_connect_test",
     srcs = ["posix_event_engine_connect_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_mac",

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -81,7 +81,7 @@ std::list<Connection> CreateConnectedEndpoints(
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification* server_signal = new grpc_core::Notification();
 
@@ -105,7 +105,7 @@ std::list<Connection> CreateConnectedEndpoints(
       std::move(accept_cb),
       [](absl::Status status) { ASSERT_TRUE(status.ok()); }, config,
       std::make_unique<grpc_core::MemoryQuota>("foo"));
-  CHECK(listener.ok());
+  CHECK_OK(listener.ok());
 
   EXPECT_TRUE((*listener)->Bind(*resolved_addr).ok());
   EXPECT_TRUE((*listener)->Start().ok());

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -81,7 +81,7 @@ std::list<Connection> CreateConnectedEndpoints(
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification* server_signal = new grpc_core::Notification();
 
@@ -105,7 +105,7 @@ std::list<Connection> CreateConnectedEndpoints(
       std::move(accept_cb),
       [](absl::Status status) { ASSERT_TRUE(status.ok()); }, config,
       std::make_unique<grpc_core::MemoryQuota>("foo"));
-  CHECK_OK(listener.ok());
+  CHECK_OK(listener);
 
   EXPECT_TRUE((*listener)->Bind(*resolved_addr).ok());
   EXPECT_TRUE((*listener)->Start().ok());

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
@@ -80,7 +81,7 @@ std::list<Connection> CreateConnectedEndpoints(
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification* server_signal = new grpc_core::Notification();
 
@@ -104,7 +105,7 @@ std::list<Connection> CreateConnectedEndpoints(
       std::move(accept_cb),
       [](absl::Status status) { ASSERT_TRUE(status.ok()); }, config,
       std::make_unique<grpc_core::MemoryQuota>("foo"));
-  GPR_ASSERT(listener.ok());
+  CHECK(listener.ok());
 
   EXPECT_TRUE((*listener)->Bind(*resolved_addr).ok());
   EXPECT_TRUE((*listener)->Start().ok());

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -145,7 +146,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectTimeoutOrRstTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
   std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();
@@ -174,7 +175,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectCancellationTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
   std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -146,7 +146,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectTimeoutOrRstTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
   std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();
@@ -175,7 +175,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectCancellationTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
   std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -146,7 +146,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectTimeoutOrRstTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
   std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();
@@ -175,7 +175,7 @@ TEST(PosixEventEngineTest, IndefiniteConnectCancellationTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
   std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();

--- a/test/core/event_engine/posix/timer_heap_test.cc
+++ b/test/core/event_engine/posix/timer_heap_test.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "absl/log/check.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -169,7 +170,7 @@ TEST(TimerHeapTest, RandomMutations) {
         pq.Pop();
         for (size_t i = 0; i < elems_size; i++) {
           if (top == &elems[i].elem) {
-            GPR_ASSERT(elems[i].inserted);
+            CHECK(elems[i].inserted);
             elems[i].inserted = false;
           }
         }
@@ -191,7 +192,7 @@ TEST(TimerHeapTest, RandomMutations) {
           }
         }
       }
-      GPR_ASSERT(pq.Top()->deadline == *min_deadline);
+      CHECK(pq.Top()->deadline == *min_deadline);
     }
   }
 }

--- a/test/core/event_engine/posix/traced_buffer_list_test.cc
+++ b/test/core/event_engine/posix/traced_buffer_list_test.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "absl/log/check.h"
 #include "gtest/gtest.h"
 
 #include <grpc/support/atm.h>
@@ -45,7 +46,7 @@ constexpr uint64_t kMaxAdvanceTimeMillis = 24ull * 365 * 3600 * 1000;
 
 gpr_timespec g_now;
 gpr_timespec now_impl(gpr_clock_type clock_type) {
-  GPR_ASSERT(clock_type != GPR_TIMESPAN);
+  CHECK(clock_type != GPR_TIMESPAN);
   gpr_timespec ts = g_now;
   ts.clock_type = clock_type;
   return ts;

--- a/test/core/event_engine/slice_buffer_test.cc
+++ b/test/core/event_engine/slice_buffer_test.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <utility>
 
+#include "absl/log/check.h"
 #include "gtest/gtest.h"
 
 #include <grpc/event_engine/slice.h>
@@ -32,7 +33,7 @@ using ::grpc_event_engine::experimental::SliceBuffer;
 static constexpr int kNewSliceLength = 100;
 
 Slice MakeSlice(size_t len) {
-  GPR_ASSERT(len > 0);
+  CHECK(len > 0);
   unsigned char* contents = static_cast<unsigned char*>(gpr_malloc(len));
   memset(contents, 'a', len);
   return Slice(grpc_slice_new(contents, len, gpr_free));

--- a/test/core/event_engine/slice_buffer_test.cc
+++ b/test/core/event_engine/slice_buffer_test.cc
@@ -33,7 +33,7 @@ using ::grpc_event_engine::experimental::SliceBuffer;
 static constexpr int kNewSliceLength = 100;
 
 Slice MakeSlice(size_t len) {
-  CHECK(len > 0);
+  CHECK_GT(len, 0);
   unsigned char* contents = static_cast<unsigned char*>(gpr_malloc(len));
   memset(contents, 'a', len);
   return Slice(grpc_slice_new(contents, len, gpr_free));

--- a/test/core/event_engine/tcp_socket_utils_test.cc
+++ b/test/core/event_engine/tcp_socket_utils_test.cc
@@ -73,7 +73,7 @@ EventEngine::ResolvedAddress MakeAddr4(const uint8_t* data, size_t data_len) {
       const_cast<sockaddr*>(resolved_addr4.address()));
   memset(&resolved_addr4, 0, sizeof(resolved_addr4));
   addr4->sin_family = AF_INET;
-  CHECK(data_len == sizeof(addr4->sin_addr.s_addr));
+  CHECK_EQ(data_len, sizeof(addr4->sin_addr.s_addr));
   memcpy(&addr4->sin_addr.s_addr, data, data_len);
   addr4->sin_port = htons(12345);
   return EventEngine::ResolvedAddress(
@@ -87,7 +87,7 @@ EventEngine::ResolvedAddress MakeAddr6(const uint8_t* data, size_t data_len) {
       const_cast<sockaddr*>(resolved_addr6.address()));
   memset(&resolved_addr6, 0, sizeof(resolved_addr6));
   addr6->sin6_family = AF_INET6;
-  CHECK(data_len == sizeof(addr6->sin6_addr.s6_addr));
+  CHECK_EQ(data_len, sizeof(addr6->sin6_addr.s6_addr));
   memcpy(&addr6->sin6_addr.s6_addr, data, data_len);
   addr6->sin6_port = htons(12345);
   return EventEngine::ResolvedAddress(

--- a/test/core/event_engine/tcp_socket_utils_test.cc
+++ b/test/core/event_engine/tcp_socket_utils_test.cc
@@ -45,6 +45,7 @@
 #endif  // GPR_WINDOWS
 #endif  // GRPC_HAVE_UNIX_SOCKET
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "gtest/gtest.h"
@@ -72,7 +73,7 @@ EventEngine::ResolvedAddress MakeAddr4(const uint8_t* data, size_t data_len) {
       const_cast<sockaddr*>(resolved_addr4.address()));
   memset(&resolved_addr4, 0, sizeof(resolved_addr4));
   addr4->sin_family = AF_INET;
-  GPR_ASSERT(data_len == sizeof(addr4->sin_addr.s_addr));
+  CHECK(data_len == sizeof(addr4->sin_addr.s_addr));
   memcpy(&addr4->sin_addr.s_addr, data, data_len);
   addr4->sin_port = htons(12345);
   return EventEngine::ResolvedAddress(
@@ -86,7 +87,7 @@ EventEngine::ResolvedAddress MakeAddr6(const uint8_t* data, size_t data_len) {
       const_cast<sockaddr*>(resolved_addr6.address()));
   memset(&resolved_addr6, 0, sizeof(resolved_addr6));
   addr6->sin6_family = AF_INET6;
-  GPR_ASSERT(data_len == sizeof(addr6->sin6_addr.s6_addr));
+  CHECK(data_len == sizeof(addr6->sin6_addr.s6_addr));
   memcpy(&addr6->sin6_addr.s6_addr, data, data_len);
   addr6->sin6_port = htons(12345);
   return EventEngine::ResolvedAddress(

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -26,7 +26,10 @@ grpc_cc_library(
     testonly = True,
     srcs = ["event_engine_test_framework.cc"],
     hdrs = ["event_engine_test_framework.h"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     deps = [
         "//:grpc",
         "//test/core/event_engine:event_engine_test_utils",

--- a/test/core/event_engine/test_suite/event_engine_test_framework.h
+++ b/test/core/event_engine/test_suite/event_engine_test_framework.h
@@ -69,13 +69,13 @@ class EventEngineTest : public testing::Test {
  protected:
   std::shared_ptr<grpc_event_engine::experimental::EventEngine>
   NewEventEngine() {
-    CHECK(g_ee_factory != nullptr);
+    CHECK_NE(g_ee_factory, nullptr);
     return (*g_ee_factory)();
   }
 
   std::shared_ptr<grpc_event_engine::experimental::EventEngine>
   NewOracleEventEngine() {
-    CHECK(g_oracle_ee_factory != nullptr);
+    CHECK_NE(g_oracle_ee_factory, nullptr);
     return (*g_oracle_ee_factory)();
   }
 };

--- a/test/core/event_engine/test_suite/event_engine_test_framework.h
+++ b/test/core/event_engine/test_suite/event_engine_test_framework.h
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include "absl/functional/any_invocable.h"
+#include "absl/log/check.h"
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/support/log.h>
@@ -68,13 +69,13 @@ class EventEngineTest : public testing::Test {
  protected:
   std::shared_ptr<grpc_event_engine::experimental::EventEngine>
   NewEventEngine() {
-    GPR_ASSERT(g_ee_factory != nullptr);
+    CHECK(g_ee_factory != nullptr);
     return (*g_ee_factory)();
   }
 
   std::shared_ptr<grpc_event_engine::experimental::EventEngine>
   NewOracleEventEngine() {
-    GPR_ASSERT(g_oracle_ee_factory != nullptr);
+    CHECK(g_oracle_ee_factory != nullptr);
     return (*g_oracle_ee_factory)();
   }
 };

--- a/test/core/event_engine/test_suite/posix/BUILD
+++ b/test/core/event_engine/test_suite/posix/BUILD
@@ -23,6 +23,7 @@ grpc_cc_library(
     testonly = True,
     srcs = ["oracle_event_engine_posix.cc"],
     hdrs = ["oracle_event_engine_posix.h"],
+    external_deps = ["absl/log:check"],
     tags = [
         "cpu:10",
         "no_windows",

--- a/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
+++ b/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
@@ -139,7 +139,7 @@ std::string ReadBytes(int sockfd, int& saved_errno, int num_expected_bytes) {
                               num_expected_bytes - read_data.length());
     if (saved_errno == EAGAIN &&
         read_data.length() < static_cast<size_t>(num_expected_bytes)) {
-      CHECK(BlockUntilReadable(sockfd).ok());
+      CHECK_OK(BlockUntilReadable(sockfd).ok());
     } else if (saved_errno != 0 && num_expected_bytes > 0) {
       read_data.clear();
       break;
@@ -179,7 +179,7 @@ int WriteBytes(int sockfd, int& saved_errno, std::string write_bytes) {
     ret = TryWriteBytes(sockfd, saved_errno, write_bytes);
     if (saved_errno == EAGAIN && ret < static_cast<int>(write_bytes.length())) {
       CHECK(ret >= 0);
-      CHECK(BlockUntilWritable(sockfd).ok());
+      CHECK_OK(BlockUntilWritable(sockfd).ok());
     } else if (saved_errno != 0) {
       CHECK(ret < 0);
       return ret;
@@ -234,7 +234,7 @@ PosixOracleEndpoint::~PosixOracleEndpoint() {
 bool PosixOracleEndpoint::Read(absl::AnyInvocable<void(absl::Status)> on_read,
                                SliceBuffer* buffer, const ReadArgs* args) {
   grpc_core::MutexLock lock(&mu_);
-  CHECK(buffer != nullptr);
+  CHECK_NE(buffer, nullptr);
   int read_hint_bytes =
       args != nullptr ? std::max(1, static_cast<int>(args->read_hint_bytes))
                       : 0;
@@ -248,7 +248,7 @@ bool PosixOracleEndpoint::Write(
     absl::AnyInvocable<void(absl::Status)> on_writable, SliceBuffer* data,
     const WriteArgs* /*args*/) {
   grpc_core::MutexLock lock(&mu_);
-  CHECK(data != nullptr);
+  CHECK_NE(data, nullptr);
   write_ops_channel_ = WriteOperation(data, std::move(on_writable));
   write_op_signal_->Notify();
   return false;

--- a/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
+++ b/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <memory>
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -138,7 +139,7 @@ std::string ReadBytes(int sockfd, int& saved_errno, int num_expected_bytes) {
                               num_expected_bytes - read_data.length());
     if (saved_errno == EAGAIN &&
         read_data.length() < static_cast<size_t>(num_expected_bytes)) {
-      GPR_ASSERT(BlockUntilReadable(sockfd).ok());
+      CHECK(BlockUntilReadable(sockfd).ok());
     } else if (saved_errno != 0 && num_expected_bytes > 0) {
       read_data.clear();
       break;
@@ -177,10 +178,10 @@ int WriteBytes(int sockfd, int& saved_errno, std::string write_bytes) {
     saved_errno = 0;
     ret = TryWriteBytes(sockfd, saved_errno, write_bytes);
     if (saved_errno == EAGAIN && ret < static_cast<int>(write_bytes.length())) {
-      GPR_ASSERT(ret >= 0);
-      GPR_ASSERT(BlockUntilWritable(sockfd).ok());
+      CHECK(ret >= 0);
+      CHECK(BlockUntilWritable(sockfd).ok());
     } else if (saved_errno != 0) {
-      GPR_ASSERT(ret < 0);
+      CHECK(ret < 0);
       return ret;
     }
     write_bytes = write_bytes.substr(ret, std::string::npos);
@@ -233,7 +234,7 @@ PosixOracleEndpoint::~PosixOracleEndpoint() {
 bool PosixOracleEndpoint::Read(absl::AnyInvocable<void(absl::Status)> on_read,
                                SliceBuffer* buffer, const ReadArgs* args) {
   grpc_core::MutexLock lock(&mu_);
-  GPR_ASSERT(buffer != nullptr);
+  CHECK(buffer != nullptr);
   int read_hint_bytes =
       args != nullptr ? std::max(1, static_cast<int>(args->read_hint_bytes))
                       : 0;
@@ -247,7 +248,7 @@ bool PosixOracleEndpoint::Write(
     absl::AnyInvocable<void(absl::Status)> on_writable, SliceBuffer* data,
     const WriteArgs* /*args*/) {
   grpc_core::MutexLock lock(&mu_);
-  GPR_ASSERT(data != nullptr);
+  CHECK(data != nullptr);
   write_ops_channel_ = WriteOperation(data, std::move(on_writable));
   write_op_signal_->Notify();
   return false;
@@ -310,7 +311,7 @@ PosixOracleListener::PosixOracleListener(
 
 absl::Status PosixOracleListener::Start() {
   grpc_core::MutexLock lock(&mu_);
-  GPR_ASSERT(!listener_fds_.empty());
+  CHECK(!listener_fds_.empty());
   if (std::exchange(is_started_, true)) {
     return absl::InternalError("Cannot start listener more than once ...");
   }
@@ -334,14 +335,14 @@ PosixOracleListener::~PosixOracleListener() {
     shutdown(listener_fds_[i], SHUT_RDWR);
   }
   // Send a STOP message over the pipe.
-  GPR_ASSERT(write(pipefd_[1], kStopMessage, strlen(kStopMessage)) != -1);
+  CHECK(write(pipefd_[1], kStopMessage, strlen(kStopMessage)) != -1);
   serve_.Join();
   on_shutdown_(absl::OkStatus());
 }
 
 void PosixOracleListener::HandleIncomingConnections() {
   gpr_log(GPR_INFO, "Starting accept thread ...");
-  GPR_ASSERT(!listener_fds_.empty());
+  CHECK(!listener_fds_.empty());
   int nfds = listener_fds_.size();
   // Add one extra file descriptor to poll the pipe fd.
   ++nfds;

--- a/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
+++ b/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
@@ -178,10 +178,10 @@ int WriteBytes(int sockfd, int& saved_errno, std::string write_bytes) {
     saved_errno = 0;
     ret = TryWriteBytes(sockfd, saved_errno, write_bytes);
     if (saved_errno == EAGAIN && ret < static_cast<int>(write_bytes.length())) {
-      CHECK(ret >= 0);
+      CHECK_GE(ret, 0);
       CHECK_OK(BlockUntilWritable(sockfd).ok());
     } else if (saved_errno != 0) {
-      CHECK(ret < 0);
+      CHECK_LT(ret, 0);
       return ret;
     }
     write_bytes = write_bytes.substr(ret, std::string::npos);

--- a/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
+++ b/test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
@@ -139,7 +139,7 @@ std::string ReadBytes(int sockfd, int& saved_errno, int num_expected_bytes) {
                               num_expected_bytes - read_data.length());
     if (saved_errno == EAGAIN &&
         read_data.length() < static_cast<size_t>(num_expected_bytes)) {
-      CHECK_OK(BlockUntilReadable(sockfd).ok());
+      CHECK_OK(BlockUntilReadable(sockfd));
     } else if (saved_errno != 0 && num_expected_bytes > 0) {
       read_data.clear();
       break;
@@ -179,7 +179,7 @@ int WriteBytes(int sockfd, int& saved_errno, std::string write_bytes) {
     ret = TryWriteBytes(sockfd, saved_errno, write_bytes);
     if (saved_errno == EAGAIN && ret < static_cast<int>(write_bytes.length())) {
       CHECK_GE(ret, 0);
-      CHECK_OK(BlockUntilWritable(sockfd).ok());
+      CHECK_OK(BlockUntilWritable(sockfd));
     } else if (saved_errno != 0) {
       CHECK_LT(ret, 0);
       return ret;

--- a/test/core/event_engine/test_suite/tests/BUILD
+++ b/test/core/event_engine/test_suite/tests/BUILD
@@ -86,6 +86,7 @@ grpc_cc_library(
     testonly = True,
     srcs = ["client_test.cc"],
     hdrs = ["client_test.h"],
+    external_deps = ["absl/log:check"],
     deps = [
         "//src/core:channel_args",
         "//test/core/event_engine:event_engine_test_utils",

--- a/test/core/event_engine/test_suite/tests/client_test.cc
+++ b/test/core/event_engine/test_suite/tests/client_test.cc
@@ -108,7 +108,7 @@ TEST_F(EventEngineClientTest, ConnectExchangeBidiDataTransferTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
   std::unique_ptr<EventEngine::Endpoint> client_endpoint;
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/test_suite/tests/client_test.cc
+++ b/test/core/event_engine/test_suite/tests/client_test.cc
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -107,7 +108,7 @@ TEST_F(EventEngineClientTest, ConnectExchangeBidiDataTransferTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
   std::unique_ptr<EventEngine::Endpoint> client_endpoint;
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/test_suite/tests/client_test.cc
+++ b/test/core/event_engine/test_suite/tests/client_test.cc
@@ -108,7 +108,7 @@ TEST_F(EventEngineClientTest, ConnectExchangeBidiDataTransferTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
   std::unique_ptr<EventEngine::Endpoint> client_endpoint;
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/test_suite/tests/server_test.cc
+++ b/test/core/event_engine/test_suite/tests/server_test.cc
@@ -105,7 +105,7 @@ TEST_F(EventEngineServerTest, ServerConnectExchangeBidiDataTransferTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK(resolved_addr.ok());
+  CHECK_OK(resolved_addr.ok());
   std::unique_ptr<EventEngine::Endpoint> client_endpoint;
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/test_suite/tests/server_test.cc
+++ b/test/core/event_engine/test_suite/tests/server_test.cc
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -104,7 +105,7 @@ TEST_F(EventEngineServerTest, ServerConnectExchangeBidiDataTransferTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  GPR_ASSERT(resolved_addr.ok());
+  CHECK(resolved_addr.ok());
   std::unique_ptr<EventEngine::Endpoint> client_endpoint;
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/test_suite/tests/server_test.cc
+++ b/test/core/event_engine/test_suite/tests/server_test.cc
@@ -105,7 +105,7 @@ TEST_F(EventEngineServerTest, ServerConnectExchangeBidiDataTransferTest) {
   std::string target_addr = absl::StrCat(
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
-  CHECK_OK(resolved_addr.ok());
+  CHECK_OK(resolved_addr);
   std::unique_ptr<EventEngine::Endpoint> client_endpoint;
   std::unique_ptr<EventEngine::Endpoint> server_endpoint;
   grpc_core::Notification client_signal;

--- a/test/core/event_engine/test_suite/tools/BUILD
+++ b/test/core/event_engine/test_suite/tools/BUILD
@@ -24,6 +24,7 @@ grpc_cc_binary(
     name = "windows_event_engine_echo_client",
     testonly = True,
     srcs = ["windows_event_engine_factory.cc"],
+    external_deps = ["absl/log:check"],
     tags = [
         "bazel_only",
         "no_linux",
@@ -40,6 +41,7 @@ grpc_cc_binary(
     name = "posix_event_engine_echo_client",
     testonly = True,
     srcs = ["posix_event_engine_factory.cc"],
+    external_deps = ["absl/log:check"],
     tags = [
         "bazel_only",
         "no_windows",
@@ -59,6 +61,7 @@ grpc_cc_library(
     external_deps = [
         "absl/flags:flag",
         "absl/flags:parse",
+        "absl/log:check",
     ],
     language = "C++",
     deps = [

--- a/test/core/event_engine/test_suite/tools/echo_client.cc
+++ b/test/core/event_engine/test_suite/tools/echo_client.cc
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include <stdlib.h>
 
+#include "absl/log/check.h"
+
 #include <grpc/event_engine/slice.h>
 #include <grpc/support/port_platform.h>
 
@@ -78,7 +80,7 @@ void SendMessage(EventEngine::Endpoint* endpoint, int message_id) {
   grpc_core::Notification write_done;
   endpoint->Write(
       [&](absl::Status status) {
-        GPR_ASSERT(status.ok());
+        CHECK(status.ok());
         write_done.Notify();
       },
       &buf, nullptr);
@@ -118,7 +120,7 @@ void RunUntilInterrupted() {
           .resolver_registry()
           .AddDefaultPrefixIfNeeded(absl::GetFlag(FLAGS_target));
   auto addr = URIToResolvedAddress(canonical_target);
-  GPR_ASSERT(addr.ok());
+  CHECK(addr.ok());
   engine->Connect(
       [&](absl::StatusOr<std::unique_ptr<EventEngine::Endpoint>> ep) {
         if (!ep.ok()) {
@@ -131,7 +133,7 @@ void RunUntilInterrupted() {
       },
       *addr, config, memory_quota->CreateMemoryAllocator("client"), 2h);
   connected.WaitForNotification();
-  GPR_ASSERT(endpoint.get() != nullptr);
+  CHECK(endpoint.get() != nullptr);
   gpr_log(GPR_DEBUG, "peer addr: %s",
           ResolvedAddressToString(endpoint->GetPeerAddress())->c_str());
   gpr_log(GPR_DEBUG, "local addr: %s",

--- a/test/core/event_engine/test_suite/tools/echo_client.cc
+++ b/test/core/event_engine/test_suite/tools/echo_client.cc
@@ -80,7 +80,7 @@ void SendMessage(EventEngine::Endpoint* endpoint, int message_id) {
   grpc_core::Notification write_done;
   endpoint->Write(
       [&](absl::Status status) {
-        CHECK_OK(status.ok());
+        CHECK_OK(status);
         write_done.Notify();
       },
       &buf, nullptr);
@@ -120,7 +120,7 @@ void RunUntilInterrupted() {
           .resolver_registry()
           .AddDefaultPrefixIfNeeded(absl::GetFlag(FLAGS_target));
   auto addr = URIToResolvedAddress(canonical_target);
-  CHECK_OK(addr.ok());
+  CHECK_OK(addr);
   engine->Connect(
       [&](absl::StatusOr<std::unique_ptr<EventEngine::Endpoint>> ep) {
         if (!ep.ok()) {

--- a/test/core/event_engine/test_suite/tools/echo_client.cc
+++ b/test/core/event_engine/test_suite/tools/echo_client.cc
@@ -80,7 +80,7 @@ void SendMessage(EventEngine::Endpoint* endpoint, int message_id) {
   grpc_core::Notification write_done;
   endpoint->Write(
       [&](absl::Status status) {
-        CHECK(status.ok());
+        CHECK_OK(status.ok());
         write_done.Notify();
       },
       &buf, nullptr);
@@ -120,7 +120,7 @@ void RunUntilInterrupted() {
           .resolver_registry()
           .AddDefaultPrefixIfNeeded(absl::GetFlag(FLAGS_target));
   auto addr = URIToResolvedAddress(canonical_target);
-  CHECK(addr.ok());
+  CHECK_OK(addr.ok());
   engine->Connect(
       [&](absl::StatusOr<std::unique_ptr<EventEngine::Endpoint>> ep) {
         if (!ep.ok()) {
@@ -133,7 +133,7 @@ void RunUntilInterrupted() {
       },
       *addr, config, memory_quota->CreateMemoryAllocator("client"), 2h);
   connected.WaitForNotification();
-  CHECK(endpoint.get() != nullptr);
+  CHECK_NE(endpoint.get(), nullptr);
   gpr_log(GPR_DEBUG, "peer addr: %s",
           ResolvedAddressToString(endpoint->GetPeerAddress())->c_str());
   gpr_log(GPR_DEBUG, "local addr: %s",

--- a/test/core/event_engine/test_suite/tools/posix_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/posix_event_engine_factory.cc
@@ -40,7 +40,7 @@ CustomEventEngineFactory() {
 absl::AnyInvocable<
     std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
-  CHECK(false && "This tool was not built for Posix environments.");
+  CHECK(false) <<  "This tool was not built for Posix environments.");
 }
 
 #endif

--- a/test/core/event_engine/test_suite/tools/posix_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/posix_event_engine_factory.cc
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include "absl/functional/any_invocable.h"
+#include "absl/log/check.h"
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/support/port_platform.h>
@@ -39,7 +40,7 @@ CustomEventEngineFactory() {
 absl::AnyInvocable<
     std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
-  GPR_ASSERT(false && "This tool was not built for Posix environments.");
+  CHECK(false && "This tool was not built for Posix environments.");
 }
 
 #endif

--- a/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
@@ -39,7 +39,7 @@ CustomEventEngineFactory() {
 absl::AnyInvocable<
     std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
-  CHECK(false && "This tool was not built for Windows.");
+  CHECK(false) <<  "This tool was not built for Windows.");
 }
 
 #endif

--- a/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
@@ -15,6 +15,7 @@
 #include <memory>
 
 #include "absl/functional/any_invocable.h"
+#include "absl/log/check.h"
 
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/support/log.h>
@@ -38,7 +39,7 @@ CustomEventEngineFactory() {
 absl::AnyInvocable<
     std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
-  GPR_ASSERT(false && "This tool was not built for Windows.");
+  CHECK(false && "This tool was not built for Windows.");
 }
 
 #endif

--- a/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
@@ -39,7 +39,7 @@ CustomEventEngineFactory() {
 absl::AnyInvocable<
     std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
-  CHECK(false) <<  "This tool was not built for Windows.");
+  CHECK(false) <<  "This tool was not built for Windows.";
 }
 
 #endif

--- a/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
@@ -39,7 +39,7 @@ CustomEventEngineFactory() {
 absl::AnyInvocable<
     std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
-  CHECK(false) <<  "This tool was not built for Windows.";
+  CHECK(false) << "This tool was not built for Windows.";
 }
 
 #endif

--- a/test/core/event_engine/windows/BUILD
+++ b/test/core/event_engine/windows/BUILD
@@ -90,7 +90,10 @@ grpc_cc_library(
     name = "create_sockpair",
     srcs = ["create_sockpair.cc"],
     hdrs = ["create_sockpair.h"],
-    external_deps = ["absl/status"],
+    external_deps = [
+        "absl/log:check",
+        "absl/status",
+    ],
     language = "C++",
     tags = [
         "no_linux",

--- a/test/core/event_engine/windows/create_sockpair.cc
+++ b/test/core/event_engine/windows/create_sockpair.cc
@@ -17,6 +17,7 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 
 #include "src/core/lib/event_engine/windows/win_socket.h"
@@ -42,15 +43,14 @@ void CreateSockpair(SOCKET sockpair[2], DWORD flags) {
   int addr_len = sizeof(addr);
 
   lst_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0, flags);
-  GPR_ASSERT(lst_sock != INVALID_SOCKET);
+  CHECK(lst_sock != INVALID_SOCKET);
 
-  GPR_ASSERT(bind(lst_sock, (sockaddr*)&addr, sizeof(addr)) != SOCKET_ERROR);
-  GPR_ASSERT(listen(lst_sock, SOMAXCONN) != SOCKET_ERROR);
-  GPR_ASSERT(getsockname(lst_sock, (sockaddr*)&addr, &addr_len) !=
-             SOCKET_ERROR);
+  CHECK(bind(lst_sock, (sockaddr*)&addr, sizeof(addr)) != SOCKET_ERROR);
+  CHECK(listen(lst_sock, SOMAXCONN) != SOCKET_ERROR);
+  CHECK(getsockname(lst_sock, (sockaddr*)&addr, &addr_len) != SOCKET_ERROR);
 
   cli_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0, flags);
-  GPR_ASSERT(cli_sock != INVALID_SOCKET);
+  CHECK(cli_sock != INVALID_SOCKET);
 
   auto result =
       WSAConnect(cli_sock, (sockaddr*)&addr, addr_len, NULL, NULL, NULL, NULL);
@@ -62,7 +62,7 @@ void CreateSockpair(SOCKET sockpair[2], DWORD flags) {
     abort();
   }
   svr_sock = accept(lst_sock, (sockaddr*)&addr, &addr_len);
-  GPR_ASSERT(svr_sock != INVALID_SOCKET);
+  CHECK(svr_sock != INVALID_SOCKET);
   closesocket(lst_sock);
   // TODO(hork): see if we can migrate this to IPv6, or break up the socket prep
   // stages.


### PR DESCRIPTION
grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT
Replacing GPR_ASSERT with absl CHECK

Will not be replacing CHECK with CHECK_EQ , CHECK_NE etc because there are too many callsites. Only a few - which fit into single - line regex will be changed. This would be small in number just to reduce the load later.

Replacing CHECK with CHECK_EQ , CHECK_NE etc could be done using Cider-V once these changes are submitted if we want to clean up later. Given that we have 5000+ instances of GPR_ASSERT to edit, Doing it manually is too much work for both the author and reviewer.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

