### PR TITLE
[Dep] Removing unnecessary upb targets

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -21,11 +21,6 @@ def grpc_deps():
     """Loads dependencies need to compile and test the grpc library."""
 
     native.bind(
-        name = "upb_amalgamation_lib",
-        actual = "@com_google_protobuf//upb:amalgamation",
-    )
-
-    native.bind(
         name = "upb_base_lib",
         actual = "@com_google_protobuf//upb/base",
     )
@@ -46,16 +41,6 @@ def grpc_deps():
     )
 
     native.bind(
-        name = "upb_lib_descriptor",
-        actual = "@com_google_protobuf//upb:descriptor_upb_proto",
-    )
-
-    native.bind(
-        name = "upb_lib_descriptor_reflection",
-        actual = "@com_google_protobuf//upb:descriptor_upb_proto_reflection",
-    )
-
-    native.bind(
         name = "upb_textformat_lib",
         actual = "@com_google_protobuf//upb/text",
     )
@@ -63,11 +48,6 @@ def grpc_deps():
     native.bind(
         name = "upb_json_lib",
         actual = "@com_google_protobuf//upb/json",
-    )
-
-    native.bind(
-        name = "upb_generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
-        actual = "@com_google_protobuf//upb:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
     )
 
     native.bind(

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -604,9 +604,8 @@ def _expand_upb_proto_library_rules(bazel_rules):
             # deps is not properly fetched from bazel query for upb_c_proto_library target
             # so add the upb dependency manually
             bazel_rule["deps"] = [
-                "//external:upb_lib",
-                "//external:upb_lib_descriptor",
-                "//external:upb_generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
+                "@com_google_protobuf//upb:descriptor_upb_proto",
+                "@com_google_protobuf//upb:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me",
             ]
             # populate the upb_c_proto_library rule with pre-generated upb headers
             # and sources using proto_rule
@@ -1338,7 +1337,7 @@ _BAZEL_DEPS_QUERIES = [
     'deps(kind("^proto_library", @envoy_api//envoy/...))',
     # Make sure we have source info for all the targets that _expand_upb_proto_library_rules artificially adds
     # as upb_c_proto_library dependencies.
-    'deps("//external:upb_generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me")',
+    'deps("@com_google_protobuf//upb:generated_code_support__only_for_generated_code_do_not_use__i_give_permission_to_break_me")',
 ]
 
 # Step 1: run a bunch of "bazel query --output xml" queries to collect

--- a/tools/distrib/fix_build_deps.py
+++ b/tools/distrib/fix_build_deps.py
@@ -170,7 +170,6 @@ EXTERNAL_DEPS = {
     "upb/mem/arena.hpp": "upb_mem_lib",
     "upb/text/encode.h": "upb_textformat_lib",
     "upb/reflection/def.hpp": "upb_reflection",
-    "upb/upb.h": "upb_amalgamation_lib",
     "xxhash.h": "xxhash",
     "zlib.h": "madler_zlib",
 }


### PR DESCRIPTION
Removing unnecessary upb targets except the following public targets
- `@com_google_protobuf//upb:base`
- `@com_google_protobuf//upb:mem`
- `@com_google_protobuf//upb:message`
- `@com_google_protobuf//upb:reflection`
- `@com_google_protobuf//upb/json`
- `@com_google_protobuf//upb/text`

Context: Internal b/332756248
