### PR TITLE
[examples/cpp] Fix missing parentheses

### DIFF
--- a/examples/cpp/keepalive/CMakeLists.txt
+++ b/examples/cpp/keepalive/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(hw_grpc_proto
 
 # Targets greeter_[async_](client|server)
 foreach(_target
-  greeter_callback_client greeter_callback_server
+  greeter_callback_client greeter_callback_server)
   add_executable(${_target} "${_target}.cc")
   target_link_libraries(${_target}
     hw_grpc_proto


### PR DESCRIPTION
I found missing parentheses in `examples/cpp/keepalive/CMakeLists.txt`.

Here is the screenshot of the CMake error message and result message after fixing it.

<img width="1090" alt="Screenshot 2024-04-11 at 21 00 07" src="https://github.com/grpc/grpc/assets/19762108/fc78c2c9-b1e4-433a-b70f-17b0da2dd8bc">