### PR TITLE
[call-v3] Improve ChannelFilter::Args structure

### DIFF
--- a/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
@@ -128,6 +128,11 @@ struct LegacyMaxAgeFilter::Config {
   }
 };
 
+// We need access to the channel stack here to send a goaway - but that access
+// is deprecated and will be removed when call-v3 is fully enabled. This filter
+// will be removed at that time also, so just disable the deprecation warning
+// for now.
+ABSL_INTERNAL_DISABLE_DEPRECATED_DECLARATION_WARNING
 absl::StatusOr<LegacyClientIdleFilter> LegacyClientIdleFilter::Create(
     const ChannelArgs& args, ChannelFilter::Args filter_args) {
   LegacyClientIdleFilter filter(filter_args.channel_stack(),
@@ -141,6 +146,7 @@ absl::StatusOr<LegacyMaxAgeFilter> LegacyMaxAgeFilter::Create(
                             Config::FromChannelArgs(args));
   return absl::StatusOr<LegacyMaxAgeFilter>(std::move(filter));
 }
+ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING
 
 void LegacyMaxAgeFilter::Shutdown() {
   max_age_activity_.Reset();

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -141,9 +141,7 @@ absl::StatusOr<FaultInjectionFilter> FaultInjectionFilter::Create(
 }
 
 FaultInjectionFilter::FaultInjectionFilter(ChannelFilter::Args filter_args)
-    : index_(grpc_channel_stack_filter_instance_number(
-          filter_args.channel_stack(),
-          filter_args.uninitialized_channel_element())),
+    : index_(filter_args.instance_id()),
       service_config_parser_index_(
           FaultInjectionServiceConfigParser::ParserIndex()),
       mu_(new Mutex) {}

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -88,9 +88,7 @@ absl::StatusOr<RbacFilter> RbacFilter::Create(const ChannelArgs& args,
   if (auth_context == nullptr) {
     return GRPC_ERROR_CREATE("No auth context found");
   }
-  return RbacFilter(grpc_channel_stack_filter_instance_number(
-                        filter_args.channel_stack(),
-                        filter_args.uninitialized_channel_element()),
+  return RbacFilter(filter_args.instance_id(),
                     EvaluateArgs::PerChannelArgs(auth_context, args));
 }
 

--- a/src/core/ext/filters/stateful_session/stateful_session_filter.cc
+++ b/src/core/ext/filters/stateful_session/stateful_session_filter.cc
@@ -78,9 +78,7 @@ absl::StatusOr<StatefulSessionFilter> StatefulSessionFilter::Create(
 }
 
 StatefulSessionFilter::StatefulSessionFilter(ChannelFilter::Args filter_args)
-    : index_(grpc_channel_stack_filter_instance_number(
-          filter_args.channel_stack(),
-          filter_args.uninitialized_channel_element())),
+    : index_(filter_args.instance_id()),
       service_config_parser_index_(
           StatefulSessionServiceConfigParser::ParserIndex()) {}
 

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -88,9 +88,19 @@ class ChannelFilter {
                   grpc_channel_element* channel_element)
         : channel_stack_(channel_stack), channel_element_(channel_element) {}
 
+    ABSL_DEPRECATED("Direct access to channel stack is deprecated")
     grpc_channel_stack* channel_stack() const { return channel_stack_; }
-    grpc_channel_element* uninitialized_channel_element() {
-      return channel_element_;
+
+    // Get the instance id of this filter.
+    // This id is unique amongst all filters /of the same type/ and densely
+    // packed (starting at 0) for a given channel stack instantiation.
+    // eg. for a stack with filter types A B C A B D A the instance ids would be
+    // 0 0 0 1 1 0 2.
+    // This is useful for filters that need to store per-instance data in a
+    // parallel data structure.
+    size_t instance_id() const {
+      return grpc_channel_stack_filter_instance_number(channel_stack_,
+                                                       channel_element_);
     }
 
    private:


### PR DESCRIPTION
Deprecate things that mention channel stacks directly... a future change will mutate the internal data structure.