### PR TITLE
Float CocoaPods abseil dep for patches

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -22,7 +22,7 @@
 Pod::Spec.new do |s|
   s.name     = 'gRPC-C++'
   # TODO (mxyan): use version that match gRPC version when pod is stabilized
-  version = '1.62.1'
+  version = '1.62.2'
   s.version  = version
   s.summary  = 'gRPC C++ library'
   s.homepage = 'https://grpc.io'
@@ -225,7 +225,7 @@ Pod::Spec.new do |s|
     ss.dependency "#{s.name}/Privacy", version
     ss.dependency "#{s.name}/Interface", version
     ss.dependency 'gRPC-Core', version
-    abseil_version = '1.20240116.1'
+    abseil_version = '~> 1.20240116.1'
     ss.dependency 'abseil/algorithm/container', abseil_version
     ss.dependency 'abseil/base/base', abseil_version
     ss.dependency 'abseil/base/config', abseil_version

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -21,7 +21,7 @@
 
 Pod::Spec.new do |s|
   s.name     = 'gRPC-Core'
-  version = '1.62.1'
+  version = '1.62.2'
   s.version  = version
   s.summary  = 'Core cross-platform gRPC library, written in C'
   s.homepage = 'https://grpc.io'
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.requires_arc = false
 
   name = 'grpc'
-  abseil_version = '1.20240116.1'
+  abseil_version = '~> 1.20240116.1'
 
   # When creating a dynamic framework, name it grpc.framework instead of gRPC-Core.framework.
   # This lets users write their includes like `#include <grpc/grpc.h>` as opposed to `#include


### PR DESCRIPTION
Float the CocoaPods abseil dependencies so abseil patches get picked up.

This makes CocoaPods behavior consistent with Swift Package Manager.

Note that 1.20240116.2 is required to support macOS and Catalyst with Xcode 15. 

https://github.com/firebase/firebase-ios-sdk/actions/runs/8650156045/job/23718073321 demonstrates the build failure

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

