### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASERT

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -896,6 +896,7 @@ grpc_cc_library(
     name = "grpc++_public_hdrs",
     hdrs = GRPCXX_PUBLIC_HDRS,
     external_deps = [
+        "absl/log:check",
         "absl/strings:cord",
         "absl/synchronization",
         "protobuf_headers",

--- a/BUILD
+++ b/BUILD
@@ -781,6 +781,7 @@ grpc_cc_library(
         "absl/base:log_severity",
         "absl/functional:any_invocable",
         "absl/log",
+        "absl/log:check",
         "absl/memory",
         "absl/random",
         "absl/status",

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -130,6 +130,7 @@ libs:
   - absl/flags:flag
   - absl/flags:marshalling
   - absl/functional:any_invocable
+  - absl/log:check
   - absl/log:log
   - absl/memory:memory
   - absl/random:random
@@ -3621,7 +3622,6 @@ libs:
   - test/core/util/tracer_util.cc
   - test/cpp/microbenchmarks/helpers.cc
   deps:
-  - absl/log:check
   - benchmark
   - grpc++_unsecure
   - grpc_test_util_unsecure
@@ -5641,7 +5641,6 @@ targets:
   - test/cpp/end2end/async_end2end_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: auth_context_test
   gtest: true
@@ -5791,7 +5790,6 @@ targets:
   - test/cpp/interop/backend_metrics_lb_policy_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
   - grpc++_test_config
@@ -5866,7 +5864,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6095,7 +6092,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6126,7 +6122,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: binder_transport_test
   gtest: true
@@ -6361,7 +6356,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6602,7 +6596,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6679,7 +6672,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6743,7 +6735,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6807,7 +6798,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6871,7 +6861,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -6952,7 +6941,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -7031,7 +7019,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -7095,7 +7082,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -7431,7 +7417,6 @@ targets:
   - test/core/event_engine/cf/cf_engine_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -7456,7 +7441,6 @@ targets:
   - test/core/event_engine/test_suite/tests/timer_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -7478,7 +7462,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: channel_args_test
   gtest: true
@@ -7608,7 +7591,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpcpp_channelz
   - grpc++_test_util
 - name: check_gcp_environment_linux_test
@@ -7839,7 +7821,6 @@ targets:
   - test/core/filters/filter_test.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -7857,7 +7838,6 @@ targets:
   - test/core/filters/filter_test.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -7878,7 +7858,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: client_channel_service_config_test
   gtest: true
@@ -7950,7 +7929,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: client_lb_end2end_test
   gtest: true
@@ -7975,7 +7953,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -8055,7 +8032,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8232,7 +8208,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8373,7 +8348,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8392,7 +8366,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: context_test
   gtest: true
@@ -8457,7 +8430,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: crl_ssl_transport_security_test
   gtest: true
@@ -8545,7 +8517,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8564,7 +8535,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: destroy_grpclb_channel_with_active_connect_stress_test
   gtest: true
@@ -8647,7 +8617,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8784,7 +8753,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -8808,7 +8776,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -8831,7 +8798,6 @@ targets:
   - test/cpp/end2end/interceptors_util.cc
   - test/cpp/end2end/test_service_impl.cc
   deps:
-  - absl/log:check
   - grpc++_test
   - grpc++_test_util
 - name: endpoint_addresses_test
@@ -9575,7 +9541,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9639,7 +9604,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9703,7 +9667,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9721,7 +9684,6 @@ targets:
   - test/core/filters/filter_test_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_unsecure
   - protobuf
   - grpc_test_util
@@ -9786,7 +9748,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -9806,7 +9767,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: flow_control_test
   gtest: true
@@ -9937,7 +9897,6 @@ targets:
   - absl/base:config
   - absl/functional:function_ref
   - absl/hash:hash
-  - absl/log:check
   - absl/meta:type_traits
   - absl/status:statusor
   - absl/types:span
@@ -10204,7 +10163,6 @@ targets:
   - test/core/event_engine/test_suite/tests/timer_test.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   platforms:
@@ -10223,7 +10181,6 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine_unittest.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
 - name: generic_end2end_test
@@ -10325,7 +10282,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -10340,7 +10296,6 @@ targets:
   - test/core/transport/chttp2/graceful_shutdown_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: grpc_alts_credentials_options_test
   gtest: true
@@ -10463,7 +10418,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc++_test_util
 - name: grpc_authz_test
@@ -10526,7 +10480,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -10829,7 +10782,6 @@ targets:
   - test/core/tsi/transport_security_test_lib.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
 - name: grpc_tool_test
@@ -10875,7 +10827,6 @@ targets:
   - test/cpp/grpclb/grpclb_api_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: grpclb_end2end_test
   gtest: true
@@ -10896,7 +10847,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
   platforms:
@@ -10933,7 +10883,6 @@ targets:
   - test/core/event_engine/event_engine_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: h2_ssl_session_reuse_test
   gtest: true
@@ -11033,7 +10982,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: high_initial_seqno_test
   gtest: true
@@ -11095,7 +11043,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11294,7 +11241,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11310,7 +11256,6 @@ targets:
   - src/proto/grpc/testing/test.proto
   - test/cpp/interop/http2_client.cc
   deps:
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: http2_settings_test
@@ -11383,7 +11328,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11451,7 +11395,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: idle_filter_state_test
   gtest: true
@@ -11539,7 +11482,6 @@ targets:
   - test/core/transport/test_suite/test_main.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   platforms:
@@ -11772,7 +11714,6 @@ targets:
   - test/cpp/interop/client_helper.cc
   - test/cpp/interop/interop_client.cc
   deps:
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: interop_server
@@ -11790,7 +11731,6 @@ targets:
   - test/cpp/interop/interop_server_bootstrap.cc
   - test/cpp/interop/server_helper.cc
   deps:
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: invalid_call_argument_test
@@ -11865,7 +11805,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -11880,7 +11819,6 @@ targets:
   - test/core/event_engine/windows/iocp_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -12069,7 +12007,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12145,7 +12082,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12556,7 +12492,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12620,7 +12555,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12684,7 +12618,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12748,7 +12681,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -12793,7 +12725,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: message_compress_test
   gtest: true
@@ -13035,7 +12966,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13111,7 +13041,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13175,7 +13104,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13204,7 +13132,6 @@ targets:
   - test/cpp/end2end/nonblocking_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: notification_test
   gtest: true
@@ -13279,7 +13206,6 @@ targets:
   - test/core/event_engine/test_suite/tests/server_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -13346,7 +13272,6 @@ targets:
   - test/cpp/ext/otel/otel_test_library.cc
   deps:
   - gtest
-  - absl/log:check
   - opentelemetry-cpp::api
   - opentelemetry-cpp::metrics
   - grpc++_test_util
@@ -13391,7 +13316,6 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -13550,7 +13474,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13671,7 +13594,6 @@ targets:
   - test/core/util/fake_stats_plugin.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -13809,7 +13731,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13904,7 +13825,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -13948,7 +13868,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: posix_endpoint_test
   gtest: true
@@ -13967,7 +13886,6 @@ targets:
   - test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -14002,7 +13920,6 @@ targets:
   - test/core/event_engine/test_suite/posix/oracle_event_engine_posix.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -14030,7 +13947,6 @@ targets:
   - test/cpp/util/windows/manifest_file.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -14064,7 +13980,6 @@ targets:
   - test/cpp/util/windows/manifest_file.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -14255,7 +14170,6 @@ targets:
   - test/cpp/util/proto_reflection_descriptor_database.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_reflection
   - grpc++_test_util
 - name: proto_utils_test
@@ -14330,7 +14244,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14374,7 +14287,6 @@ targets:
   - test/cpp/qps/server_sync.cc
   - test/cpp/qps/usage_timer.cc
   deps:
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: qps_worker
@@ -14408,7 +14320,6 @@ targets:
   - test/cpp/qps/usage_timer.cc
   - test/cpp/qps/worker.cc
   deps:
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: query_extensions_test
@@ -14468,7 +14379,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: rbac_service_config_parser_test
   gtest: true
@@ -14592,7 +14502,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14605,7 +14514,6 @@ targets:
   - test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -14671,7 +14579,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14735,7 +14642,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -14951,7 +14857,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15026,7 +14931,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15090,7 +14994,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15154,7 +15057,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15218,7 +15120,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15282,7 +15183,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15346,7 +15246,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15410,7 +15309,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15474,7 +15372,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15538,7 +15435,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15602,7 +15498,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15666,7 +15561,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15730,7 +15624,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15794,7 +15687,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15858,7 +15750,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15922,7 +15813,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -15986,7 +15876,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16050,7 +15939,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16114,7 +16002,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16178,7 +16065,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16242,7 +16128,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16306,7 +16191,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16370,7 +16254,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16434,7 +16317,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16509,7 +16391,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16573,7 +16454,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16637,7 +16517,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16701,7 +16580,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16776,7 +16654,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16840,7 +16717,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16904,7 +16780,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -16968,7 +16843,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17032,7 +16906,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17096,7 +16969,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17160,7 +17032,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17179,7 +17050,6 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -17208,7 +17078,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: rls_lb_config_parser_test
@@ -17237,7 +17106,6 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -17373,7 +17241,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: server_builder_test
   gtest: true
@@ -17569,7 +17436,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17590,7 +17456,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: server_registered_method_bad_client_test
   gtest: true
@@ -17721,7 +17586,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17751,7 +17615,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: service_config_test
   gtest: true
@@ -17792,7 +17655,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: shutdown_finishes_calls_test
   gtest: true
@@ -17854,7 +17716,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17918,7 +17779,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -17936,7 +17796,6 @@ targets:
   - test/cpp/end2end/shutdown_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: simple_delayed_request_test
   gtest: true
@@ -17998,7 +17857,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18062,7 +17920,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18140,7 +17997,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18437,7 +18293,6 @@ targets:
   - test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: streaming_error_response_test
   gtest: true
@@ -18499,7 +18354,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18553,7 +18407,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: string_ref_test
   gtest: true
@@ -18779,7 +18632,6 @@ targets:
   - test/core/event_engine/tcp_socket_utils_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc
   uses_polling: false
 - name: test_core_channel_channelz_test
@@ -18796,7 +18648,6 @@ targets:
   - test/cpp/util/channel_trace_proto_helper.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
 - name: test_core_end2end_channelz_test
@@ -18859,7 +18710,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -18881,7 +18731,6 @@ targets:
   - test/core/event_engine/posix/timer_heap_test.cc
   deps:
   - gtest
-  - absl/log:check
   - absl/status:statusor
   - gpr
   uses_polling: false
@@ -18935,7 +18784,6 @@ targets:
   deps:
   - gtest
   - absl/hash:hash
-  - absl/log:check
   - absl/status:statusor
   - absl/utility:utility
   - gpr
@@ -19118,7 +18966,6 @@ targets:
   - test/core/transport/test_suite/test_main.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   platforms:
@@ -19153,7 +19000,6 @@ targets:
   - test/cpp/end2end/test_service_impl.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: test_cpp_ext_chaotic_good_test
   gtest: true
@@ -19320,7 +19166,6 @@ targets:
   - test/core/event_engine/test_suite/thready_posix_event_engine_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19413,7 +19258,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -19499,7 +19343,6 @@ targets:
   - test/cpp/end2end/tls_credentials_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: tls_key_export_test
   gtest: true
@@ -19514,7 +19357,6 @@ targets:
   - test/cpp/end2end/tls_key_export_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: tls_security_connector_test
   gtest: true
@@ -19558,7 +19400,6 @@ targets:
   - test/core/transport/chttp2/too_many_pings_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
 - name: traced_buffer_list_test
@@ -19570,7 +19411,6 @@ targets:
   - test/core/event_engine/posix/traced_buffer_list_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19637,7 +19477,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -19986,7 +19825,6 @@ targets:
   - test/core/util/fake_stats_plugin.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -20001,7 +19839,6 @@ targets:
   - test/core/event_engine/windows/win_socket_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -20033,7 +19870,6 @@ targets:
   - test/core/event_engine/windows/windows_endpoint_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -20270,7 +20106,6 @@ targets:
   - test/core/gprpp/work_serializer_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -20336,7 +20171,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -20400,7 +20234,6 @@ targets:
   - test/core/util/test_lb_policies.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_authorization_provider
   - grpc_unsecure
   - grpc_test_util
@@ -20458,7 +20291,6 @@ targets:
   - test/cpp/performance/writes_per_rpc_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
   platforms:
@@ -20604,7 +20436,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20697,7 +20528,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20791,7 +20621,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20812,7 +20641,6 @@ targets:
   - test/cpp/end2end/xds/xds_credentials_end2end_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
 - name: xds_credentials_test
   gtest: true
@@ -20899,7 +20727,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -20965,7 +20792,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_config
   - grpc++_test_util
   platforms:
@@ -21043,7 +20869,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21103,7 +20928,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21298,7 +21122,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21359,7 +21182,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21391,7 +21213,6 @@ targets:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
   deps:
   - gtest
-  - absl/log:check
   - protobuf
   - grpc_test_util
   uses_polling: false
@@ -21451,7 +21272,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21512,7 +21332,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21574,7 +21393,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21677,7 +21495,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux
@@ -21706,7 +21523,6 @@ targets:
   - test/cpp/interop/xds_stats_watcher_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_reflection
   - grpcpp_channelz
   - grpc_test_util
@@ -21767,7 +21583,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_test_util
   platforms:
   - linux

--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -22,6 +22,8 @@
 #include <stdarg.h>
 #include <stdlib.h> /* for abort() */
 
+#include "absl/log/check.h"
+
 #include <grpc/support/port_platform.h>
 
 #ifdef __cplusplus
@@ -92,15 +94,10 @@ GPRAPI void gpr_assertion_failed(const char* filename, int line,
    Intended for internal invariants.  If the error can be recovered from,
    without the possibility of corruption, or might best be reflected via
    an exception in a higher-level language, consider returning error code.  */
-#define GPR_ASSERT(x)                               \
-  do {                                              \
-    if (GPR_UNLIKELY(!(x))) {                       \
-      gpr_assertion_failed(__FILE__, __LINE__, #x); \
-    }                                               \
-  } while (0)
+#define GPR_ASSERT(x) CHECK(x)
 
 #ifndef NDEBUG
-#define GPR_DEBUG_ASSERT(x) GPR_ASSERT(x)
+#define GPR_DEBUG_ASSERT(x) CHECK(x)
 #else
 #define GPR_DEBUG_ASSERT(x)
 #endif


### PR DESCRIPTION
GPR_ASERT will now use absl CHECK 



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

