### PR TITLE
[esoteric] Eliminate unused argument errors with GPR_DEBUG_ASSERT

### DIFF
--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -102,7 +102,7 @@ GPRAPI void gpr_assertion_failed(const char* filename, int line,
 #ifndef NDEBUG
 #define GPR_DEBUG_ASSERT(x) GPR_ASSERT(x)
 #else
-#define GPR_DEBUG_ASSERT(x)
+#define GPR_DEBUG_ASSERT(x) GPR_ASSERT(true || (x))
 #endif
 
 #ifdef __cplusplus

--- a/include/grpcpp/support/callback_common.h
+++ b/include/grpcpp/support/callback_common.h
@@ -207,7 +207,9 @@ class CallbackWithSuccessTag : public grpc_completion_queue_functor {
     auto* ops = ops_;
 #endif
     bool do_callback = ops_->FinalizeResult(&ignored, &ok);
+#ifndef NDEBUG
     GPR_DEBUG_ASSERT(ignored == ops);
+#endif
 
     if (do_callback) {
       CatchingCallback(func_, ok);

--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -644,7 +644,9 @@ class ClientChannelFilter::SubchannelWrapper final
               chand, this, subchannel_.get());
     }
     GRPC_CHANNEL_STACK_REF(chand_->owning_stack_, "SubchannelWrapper");
+#ifndef NDEBUG
     GPR_DEBUG_ASSERT(chand_->work_serializer_->RunningInWorkSerializer());
+#endif
     if (chand_->channelz_node_ != nullptr) {
       auto* subchannel_node = subchannel_->channelz_node();
       if (subchannel_node != nullptr) {

--- a/src/core/load_balancing/xds/xds_cluster_impl.cc
+++ b/src/core/load_balancing/xds/xds_cluster_impl.cc
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-#include <grpc/support/port_platform.h>
-
 #include <stddef.h>
 #include <stdint.h>
 
@@ -36,6 +34,7 @@
 
 #include <grpc/impl/connectivity_state.h>
 #include <grpc/support/log.h>
+#include <grpc/support/port_platform.h>
 
 #include "src/core/client_channel/client_channel_internal.h"
 #include "src/core/ext/xds/xds_bootstrap.h"
@@ -328,7 +327,9 @@ class XdsClusterImplLb::Picker::SubchannelCallTracker final
   ~SubchannelCallTracker() override {
     locality_stats_.reset(DEBUG_LOCATION, "SubchannelCallTracker");
     call_counter_.reset(DEBUG_LOCATION, "SubchannelCallTracker");
+#ifndef NDEBUG
     GPR_DEBUG_ASSERT(!started_);
+#endif
   }
 
   void Start() override {


### PR DESCRIPTION
Eliminate cases where we get unused parameter errors only because of a debug assert, and because of short-circuit evaluation not add any overhead into release builds.