### PR TITLE
[Fix Python Deadlock] Guard grpc_google_default_credentials_create with nogil (v1.62.x backport)

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -437,8 +437,9 @@ cdef class ComputeEngineChannelCredentials(ChannelCredentials):
       raise ValueError("Call credentials may not be NULL.")
 
   cdef grpc_channel_credentials *c(self) except *:
-    self._c_creds = grpc_google_default_credentials_create(self._call_creds)
-    return self._c_creds
+    with nogil:
+      self._c_creds = grpc_google_default_credentials_create(self._call_creds)
+      return self._c_creds
 
 
 def channel_credentials_compute_engine(call_creds):


### PR DESCRIPTION
Backport of #36266 to v1.62.x.
---
This fix is similar to https://github.com/grpc/grpc/pull/34712 but for `grpc_google_default_credentials_create` rather than `grpc_ssl_credentials_create`

Fixes https://github.com/grpc/grpc/issues/36265
Fixes https://github.com/googleapis/python-bigtable/issues/949