### PR TITLE
[Gpr_To_Absl_Logging] Disable absl logging

### DIFF
--- a/src/core/lib/config/config_vars.cc
+++ b/src/core/lib/config/config_vars.cc
@@ -95,7 +95,7 @@ ConfigVars::ConfigVars(const Overrides& overrides)
           FLAGS_grpc_not_use_system_ssl_roots, "GRPC_NOT_USE_SYSTEM_SSL_ROOTS",
           overrides.not_use_system_ssl_roots, false)),
       absl_logging_(LoadConfig(FLAGS_grpc_absl_logging, "GRPC_ABSL_LOGGING",
-                               overrides.absl_logging, true)),
+                               overrides.absl_logging, false)),
       dns_resolver_(LoadConfig(FLAGS_grpc_dns_resolver, "GRPC_DNS_RESOLVER",
                                overrides.dns_resolver, "")),
       verbosity_(LoadConfig(FLAGS_grpc_verbosity, "GRPC_VERBOSITY",

--- a/src/core/lib/config/config_vars.yaml
+++ b/src/core/lib/config/config_vars.yaml
@@ -128,6 +128,6 @@
     ECDHE-RSA-AES256-GCM-SHA384"
 - name: absl_logging
   type: bool
-  default: true
+  default: false
   description:
     Use absl logging from within gpr_log.


### PR DESCRIPTION
Absl logging was made the default in #36121. This is a behavior change since absl logging doesn't use the same configuration that gpr logging does (for example, `GRPC_VERBOSITY`). 

Disabling absl logging for the release branch since we haven't had a gRFC for this change.