### PR TITLE
[handshaker] Change handshake manager to clean up read buffer even if endpoint is null

### DIFF
--- a/src/core/lib/transport/handshaker.cc
+++ b/src/core/lib/transport/handshaker.cc
@@ -101,11 +101,6 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
             HandshakerArgsString(&args_).c_str());
   }
   GPR_ASSERT(index_ <= handshakers_.size());
-  if (args_.read_buffer != nullptr) {
-    grpc_slice_buffer_destroy(args_.read_buffer);
-    gpr_free(args_.read_buffer);
-    args_.read_buffer = nullptr;
-  }
   // If we got an error or we've been shut down or we're exiting early or
   // we've finished the last handshaker, invoke the on_handshake_done
   // callback.  Otherwise, call the next handshaker.
@@ -124,8 +119,13 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
         grpc_endpoint_shutdown(args_.endpoint, error);
         grpc_endpoint_destroy(args_.endpoint);
         args_.endpoint = nullptr;
-        args_.args = ChannelArgs();
       }
+      if (args_.read_buffer != nullptr) {
+        grpc_slice_buffer_destroy(args_.read_buffer);
+        gpr_free(args_.read_buffer);
+        args_.read_buffer = nullptr;
+      }
+      args_.args = ChannelArgs();
     }
     if (GRPC_TRACE_FLAG_ENABLED(grpc_handshaker_trace)) {
       gpr_log(GPR_INFO,

--- a/src/core/lib/transport/handshaker.cc
+++ b/src/core/lib/transport/handshaker.cc
@@ -101,6 +101,11 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
             HandshakerArgsString(&args_).c_str());
   }
   GPR_ASSERT(index_ <= handshakers_.size());
+  if (args_.read_buffer != nullptr) {
+        grpc_slice_buffer_destroy(args_.read_buffer);
+        gpr_free(args_.read_buffer);
+        args_.read_buffer = nullptr;
+  }
   // If we got an error or we've been shut down or we're exiting early or
   // we've finished the last handshaker, invoke the on_handshake_done
   // callback.  Otherwise, call the next handshaker.
@@ -120,9 +125,6 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
         grpc_endpoint_destroy(args_.endpoint);
         args_.endpoint = nullptr;
         args_.args = ChannelArgs();
-        grpc_slice_buffer_destroy(args_.read_buffer);
-        gpr_free(args_.read_buffer);
-        args_.read_buffer = nullptr;
       }
     }
     if (GRPC_TRACE_FLAG_ENABLED(grpc_handshaker_trace)) {

--- a/src/core/lib/transport/handshaker.cc
+++ b/src/core/lib/transport/handshaker.cc
@@ -102,9 +102,9 @@ bool HandshakeManager::CallNextHandshakerLocked(grpc_error_handle error) {
   }
   GPR_ASSERT(index_ <= handshakers_.size());
   if (args_.read_buffer != nullptr) {
-        grpc_slice_buffer_destroy(args_.read_buffer);
-        gpr_free(args_.read_buffer);
-        args_.read_buffer = nullptr;
+    grpc_slice_buffer_destroy(args_.read_buffer);
+    gpr_free(args_.read_buffer);
+    args_.read_buffer = nullptr;
   }
   // If we got an error or we've been shut down or we're exiting early or
   // we've finished the last handshaker, invoke the on_handshake_done


### PR DESCRIPTION
This leak only impacts handshakers that don't have any endpoint associated with them and if the shutdown occurs at the same time as the handshaker finishing successfully. Currently the memory allocated for the read buffer is only cleaned up if the endpoint is not a nullptr triggering the leak. This change unilaterally cleans up the memory for this condition.




cc: @markdroth 

