### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21037,6 +21037,7 @@ target_include_directories(parsed_metadata_test
 target_link_libraries(parsed_metadata_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
+  absl::check
   grpc_test_util
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -13440,6 +13440,7 @@ targets:
   - test/core/transport/parsed_metadata_test.cc
   deps:
   - gtest
+  - absl/log:check
   - grpc_test_util
 - name: parser_test
   gtest: true

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -98,6 +98,7 @@ grpc_cc_test(
     name = "parsed_metadata_test",
     srcs = ["parsed_metadata_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     language = "C++",

--- a/test/core/transport/binder/end2end/BUILD
+++ b/test/core/transport/binder/end2end/BUILD
@@ -63,7 +63,7 @@ grpc_cc_library(
     testonly = 1,
     srcs = ["testing_channel_create.cc"],
     hdrs = ["testing_channel_create.h"],
-    external_deps = [],
+    external_deps = ["absl/log:check"],
     deps = [
         ":fake_binder",
         "//:grpc++_base",

--- a/test/core/transport/binder/end2end/fuzzers/BUILD
+++ b/test/core/transport/binder/end2end/fuzzers/BUILD
@@ -35,6 +35,7 @@ grpc_proto_library(
 grpc_cc_library(
     name = "fuzzer_utils",
     srcs = ["fuzzer_utils.cc"],
+    external_deps = ["absl/log:check"],
     language = "c++",
     public_hdrs = ["fuzzer_utils.h"],
     deps = [
@@ -53,6 +54,7 @@ grpc_proto_fuzzer(
         "client_fuzzer.cc",
     ],
     corpus = "binder_transport_client_fuzzer_corpus",
+    external_deps = ["absl/log:check"],
     owner = "binder",
     proto = "client.proto",
     tags = [
@@ -76,6 +78,7 @@ grpc_proto_fuzzer(
         "server_fuzzer.cc",
     ],
     corpus = "binder_transport_server_fuzzer_corpus",
+    external_deps = ["absl/log:check"],
     owner = "binder",
     proto = "server.proto",
     tags = [

--- a/test/core/transport/binder/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/client_fuzzer.cc
@@ -15,6 +15,7 @@
 #include <thread>
 #include <utility>
 
+#include "absl/log/check.h"
 #include "absl/memory/memory.h"
 
 #include <grpc/grpc.h>

--- a/test/core/transport/binder/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/client_fuzzer.cc
@@ -110,7 +110,7 @@ DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
     grpc_call_error error = grpc_call_start_batch(
         call, ops, static_cast<size_t>(op - ops), tag(1), nullptr);
     int requested_calls = 1;
-    GPR_ASSERT(GRPC_CALL_OK == error);
+    CHECK_EQ(error, GRPC_CALL_OK);
     grpc_event ev;
     while (true) {
       grpc_core::ExecCtx::Get()->Flush();
@@ -135,13 +135,13 @@ DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
     for (int i = 0; i < requested_calls; i++) {
       ev = grpc_completion_queue_next(cq, gpr_inf_past(GPR_CLOCK_REALTIME),
                                       nullptr);
-      GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+      CHECK(ev.type == GRPC_OP_COMPLETE);
     }
     grpc_completion_queue_shutdown(cq);
     for (int i = 0; i < requested_calls; i++) {
       ev = grpc_completion_queue_next(cq, gpr_inf_past(GPR_CLOCK_REALTIME),
                                       nullptr);
-      GPR_ASSERT(ev.type == GRPC_QUEUE_SHUTDOWN);
+      CHECK(ev.type == GRPC_QUEUE_SHUTDOWN);
     }
     grpc_call_unref(call);
     grpc_completion_queue_destroy(cq);

--- a/test/core/transport/binder/end2end/fuzzers/fuzzer_utils.cc
+++ b/test/core/transport/binder/end2end/fuzzers/fuzzer_utils.cc
@@ -23,7 +23,7 @@ std::thread* g_fuzzing_thread = nullptr;
 
 template <typename... Args>
 void CreateFuzzingThread(Args&&... args) {
-  GPR_ASSERT(g_fuzzing_thread == nullptr);
+  CHECK_EQ(g_fuzzing_thread, nullptr);
   g_fuzzing_thread = new std::thread(std::forward<Args>(args)...);
 }
 

--- a/test/core/transport/binder/end2end/fuzzers/fuzzer_utils.cc
+++ b/test/core/transport/binder/end2end/fuzzers/fuzzer_utils.cc
@@ -14,6 +14,8 @@
 
 #include "test/core/transport/binder/end2end/fuzzers/fuzzer_utils.h"
 
+#include "absl/log/check.h"
+
 namespace grpc_binder {
 namespace fuzzing {
 

--- a/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
@@ -62,7 +62,7 @@ DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
     grpc_metadata_array_init(&request_metadata1);
     int requested_calls = 0;
 
-    GPR_ASSERT(GRPC_CALL_OK ==
+    CHECK(GRPC_CALL_OK ==
                grpc_server_request_call(server, &call1, &call_details1,
                                         &request_metadata1, cq, cq, tag(1)));
     requested_calls++;
@@ -111,7 +111,7 @@ DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
         grpc_core::ExecCtx::Get()->InvalidateNow();
       } while (ev.type != GRPC_OP_COMPLETE &&
                grpc_core::Timestamp::Now() < deadline);
-      GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+      CHECK(ev.type == GRPC_OP_COMPLETE);
     }
     grpc_completion_queue_shutdown(cq);
     for (int i = 0; i <= requested_calls; i++) {
@@ -121,7 +121,7 @@ DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
         grpc_core::ExecCtx::Get()->InvalidateNow();
       } while (ev.type != GRPC_QUEUE_SHUTDOWN &&
                grpc_core::Timestamp::Now() < deadline);
-      GPR_ASSERT(ev.type == GRPC_QUEUE_SHUTDOWN);
+      CHECK(ev.type == GRPC_QUEUE_SHUTDOWN);
     }
     grpc_server_destroy(server);
     grpc_completion_queue_destroy(cq);

--- a/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
@@ -63,8 +63,8 @@ DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
     int requested_calls = 0;
 
     CHECK(GRPC_CALL_OK ==
-               grpc_server_request_call(server, &call1, &call_details1,
-                                        &request_metadata1, cq, cq, tag(1)));
+          grpc_server_request_call(server, &call1, &call_details1,
+                                   &request_metadata1, cq, cq, tag(1)));
     requested_calls++;
 
     grpc_event ev;

--- a/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "absl/log/check.h"
+
 #include <grpc/grpc.h>
 
 #include "src/core/ext/transport/binder/transport/binder_transport.h"

--- a/test/core/transport/binder/end2end/testing_channel_create.cc
+++ b/test/core/transport/binder/end2end/testing_channel_create.cc
@@ -16,6 +16,8 @@
 
 #include <utility>
 
+#include "absl/log/check.h"
+
 #include <grpcpp/security/binder_security_policy.h>
 
 #include "src/core/ext/transport/binder/transport/binder_transport.h"

--- a/test/core/transport/binder/end2end/testing_channel_create.cc
+++ b/test/core/transport/binder/end2end/testing_channel_create.cc
@@ -124,9 +124,9 @@ grpc_channel* grpc_binder_channel_create_for_testing(
       grpc_binder::end2end_testing::CreateClientServerBindersPairForTesting();
   grpc_error_handle error = grpc_core::Server::FromC(server)->SetupTransport(
       server_transport, nullptr, server_args, nullptr);
-  GPR_ASSERT(error.ok());
+  CHECK_OK(error);
   auto channel = grpc_core::ChannelCreate(
       "binder", client_args, GRPC_CLIENT_DIRECT_CHANNEL, client_transport);
-  GPR_ASSERT(channel.ok());
+  CHECK_OK(channel);
   return channel->release()->c_ptr();
 }

--- a/test/core/transport/chaotic_good/BUILD
+++ b/test/core/transport/chaotic_good/BUILD
@@ -77,6 +77,7 @@ grpc_cc_test(
     name = "frame_test",
     srcs = ["frame_test.cc"],
     external_deps = [
+        "absl/log:check",
         "absl/random",
         "absl/status",
         "absl/status:statusor",
@@ -93,6 +94,7 @@ grpc_proto_fuzzer(
     srcs = ["frame_fuzzer.cc"],
     corpus = "frame_fuzzer_corpus",
     external_deps = [
+        "absl/log:check",
         "absl/random:bit_gen_ref",
         "absl/status:statusor",
     ],
@@ -221,6 +223,7 @@ grpc_cc_test(
     name = "chaotic_good_server_test",
     srcs = ["chaotic_good_server_test.cc"],
     external_deps = [
+        "absl/log:check",
         "absl/strings",
         "absl/time",
         "gtest",

--- a/test/core/transport/chaotic_good/chaotic_good_server_test.cc
+++ b/test/core/transport/chaotic_good/chaotic_good_server_test.cc
@@ -18,6 +18,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 #include "absl/time/time.h"
 #include "gmock/gmock.h"

--- a/test/core/transport/chaotic_good/chaotic_good_server_test.cc
+++ b/test/core/transport/chaotic_good/chaotic_good_server_test.cc
@@ -66,8 +66,8 @@ class ChaoticGoodServerTest : public ::testing::Test {
     auto ev = grpc_completion_queue_pluck(
         shutdown_cq, nullptr, grpc_timeout_milliseconds_to_deadline(15000),
         nullptr);
-    GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
-    GPR_ASSERT(ev.tag == nullptr);
+    CHECK(ev.type == GRPC_OP_COMPLETE);
+    CHECK_EQ(ev.tag, nullptr);
     grpc_completion_queue_destroy(shutdown_cq);
     grpc_server_destroy(server_);
   }
@@ -82,8 +82,8 @@ class ChaoticGoodServerTest : public ::testing::Test {
 
   void ConstructConnector() {
     auto uri = URI::Parse("ipv6:" + addr_);
-    GPR_ASSERT(uri.ok());
-    GPR_ASSERT(grpc_parse_uri(*uri, &resolved_addr_));
+    CHECK_OK(uri);
+    CHECK(grpc_parse_uri(*uri, &resolved_addr_));
     args_.address = &resolved_addr_;
     args_.deadline = Timestamp::Now() + Duration::Seconds(5);
     args_.channel_args = channel_args();

--- a/test/core/transport/chaotic_good/frame_fuzzer.cc
+++ b/test/core/transport/chaotic_good/frame_fuzzer.cc
@@ -56,7 +56,7 @@ void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   HPackCompressor hpack_compressor;
   auto serialized = input.Serialize(&hpack_compressor);
   CHECK(serialized.control.Length() >=
-             24);  // Initial output buffer size is 64 byte.
+        24);  // Initial output buffer size is 64 byte.
   uint8_t header_bytes[24];
   serialized.control.MoveFirstNBytesIntoBuffer(24, header_bytes);
   auto header = FrameHeader::Parse(header_bytes);

--- a/test/core/transport/chaotic_good/frame_fuzzer.cc
+++ b/test/core/transport/chaotic_good/frame_fuzzer.cc
@@ -18,6 +18,7 @@
 #include <limits>
 #include <memory>
 
+#include "absl/log/check.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/status/statusor.h"
 

--- a/test/core/transport/chaotic_good/frame_fuzzer.cc
+++ b/test/core/transport/chaotic_good/frame_fuzzer.cc
@@ -55,7 +55,7 @@ template <typename T>
 void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   HPackCompressor hpack_compressor;
   auto serialized = input.Serialize(&hpack_compressor);
-  GPR_ASSERT(serialized.control.Length() >=
+  CHECK(serialized.control.Length() >=
              24);  // Initial output buffer size is 64 byte.
   uint8_t header_bytes[24];
   serialized.control.MoveFirstNBytesIntoBuffer(24, header_bytes);
@@ -67,15 +67,15 @@ void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
     }
     Crash("Failed to parse header");
   }
-  GPR_ASSERT(header->type == expected_frame_type);
+  CHECK(header->type == expected_frame_type);
   T output;
   HPackParser hpack_parser;
   DeterministicBitGen bitgen;
   auto deser = output.Deserialize(&hpack_parser, header.value(),
                                   absl::BitGenRef(bitgen), GetContext<Arena>(),
                                   std::move(serialized), FuzzerFrameLimits());
-  GPR_ASSERT(deser.ok());
-  GPR_ASSERT(output == input);
+  CHECK_OK(deser);
+  CHECK(output == input);
 }
 
 template <typename T>

--- a/test/core/transport/chaotic_good/frame_test.cc
+++ b/test/core/transport/chaotic_good/frame_test.cc
@@ -34,8 +34,7 @@ template <typename T>
 void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   HPackCompressor hpack_compressor;
   auto serialized = input.Serialize(&hpack_compressor);
-  CHECK(serialized.control.Length() >=
-             24);  // Initial output buffer size is 64 byte.
+  CHECK_GE(serialized.control.Length(), 24);  // Initial output buffer size is 64 byte.
   uint8_t header_bytes[24];
   serialized.control.MoveFirstNBytesIntoBuffer(24, header_bytes);
   auto header = FrameHeader::Parse(header_bytes);

--- a/test/core/transport/chaotic_good/frame_test.cc
+++ b/test/core/transport/chaotic_good/frame_test.cc
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 
+#include "absl/log/check.h"
 #include "absl/random/random.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -34,7 +35,8 @@ template <typename T>
 void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   HPackCompressor hpack_compressor;
   auto serialized = input.Serialize(&hpack_compressor);
-  CHECK_GE(serialized.control.Length() ,24);  // Initial output buffer size is 64 byte.
+  CHECK_GE(serialized.control.Length(),
+           24);  // Initial output buffer size is 64 byte.
   uint8_t header_bytes[24];
   serialized.control.MoveFirstNBytesIntoBuffer(24, header_bytes);
   auto header = FrameHeader::Parse(header_bytes);

--- a/test/core/transport/chaotic_good/frame_test.cc
+++ b/test/core/transport/chaotic_good/frame_test.cc
@@ -34,7 +34,7 @@ template <typename T>
 void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   HPackCompressor hpack_compressor;
   auto serialized = input.Serialize(&hpack_compressor);
-  CHECK_GE(serialized.control.Length(), 24);  // Initial output buffer size is 64 byte.
+  CHECK_GE(serialized.control.Length() ,24);  // Initial output buffer size is 64 byte.
   uint8_t header_bytes[24];
   serialized.control.MoveFirstNBytesIntoBuffer(24, header_bytes);
   auto header = FrameHeader::Parse(header_bytes);

--- a/test/core/transport/chaotic_good/frame_test.cc
+++ b/test/core/transport/chaotic_good/frame_test.cc
@@ -34,7 +34,7 @@ template <typename T>
 void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   HPackCompressor hpack_compressor;
   auto serialized = input.Serialize(&hpack_compressor);
-  GPR_ASSERT(serialized.control.Length() >=
+  CHECK(serialized.control.Length() >=
              24);  // Initial output buffer size is 64 byte.
   uint8_t header_bytes[24];
   serialized.control.MoveFirstNBytesIntoBuffer(24, header_bytes);
@@ -42,7 +42,7 @@ void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   if (!header.ok()) {
     Crash("Failed to parse header");
   }
-  GPR_ASSERT(header->type == expected_frame_type);
+  CHECK(header->type == expected_frame_type);
   T output;
   HPackParser hpack_parser;
   absl::BitGen bitgen;
@@ -53,8 +53,8 @@ void AssertRoundTrips(const T& input, FrameType expected_frame_type) {
   auto deser =
       output.Deserialize(&hpack_parser, header.value(), absl::BitGenRef(bitgen),
                          arena.get(), std::move(serialized), TestFrameLimits());
-  GPR_ASSERT(deser.ok());
-  GPR_ASSERT(output == input);
+  CHECK_OK(deser);
+  CHECK(output == input);
 }
 
 TEST(FrameTest, SettingsFrameRoundTrips) {

--- a/test/core/transport/chttp2/flow_control_fuzzer.cc
+++ b/test/core/transport/chttp2/flow_control_fuzzer.cc
@@ -246,7 +246,7 @@ void FlowControlFuzzer::Perform(const flow_control_fuzzer::Action& action) {
           bdp->AddIncomingBytes(stream_write.size);
         }
         StreamFlowControl::IncomingUpdateContext upd(&stream->fc);
-        CHECK(upd.RecvData(stream_write.size).ok());
+        CHECK_OK(upd.RecvData(stream_write.size));
         PerformAction(upd.MakeAction(), stream);
       }
       send_from_remote_.pop_front();

--- a/test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
+++ b/test/core/transport/chttp2/remove_stream_from_stalled_lists_test.cc
@@ -199,7 +199,7 @@ class TestServer {
           grpc_call_error error = grpc_server_request_call(
               server_, &call, &call_details, &request_metadata_recv, call_cq,
               cq_, request_call_tag);
-          CHECK(error == GRPC_CALL_OK);
+          CHECK_EQ(error, GRPC_CALL_OK);
         }
       }
       grpc_event event = grpc_completion_queue_next(

--- a/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
+++ b/test/core/transport/chttp2/stream_leak_with_queued_flow_control_update_test.cc
@@ -79,7 +79,7 @@ class TestServer {
     grpc_call* call;
     grpc_call_error error = grpc_server_request_call(
         server_, &call, &call_details, &request_metadata_recv, cq_, cq_, tag);
-    CHECK(error == GRPC_CALL_OK);
+    CHECK_EQ(error, GRPC_CALL_OK);
     grpc_event event = grpc_completion_queue_next(
         cq_, gpr_inf_future(GPR_CLOCK_REALTIME), nullptr);
     CHECK(event.type == GRPC_OP_COMPLETE);
@@ -111,7 +111,7 @@ class TestServer {
     op++;
     error = grpc_call_start_batch(call, ops, static_cast<size_t>(op - ops), tag,
                                   nullptr);
-    CHECK(error == GRPC_CALL_OK);
+    CHECK_EQ(error, GRPC_CALL_OK);
     event = grpc_completion_queue_next(cq_, gpr_inf_future(GPR_CLOCK_REALTIME),
                                        nullptr);
     CHECK(event.type == GRPC_OP_COMPLETE);

--- a/test/core/transport/chttp2/streams_not_seen_test.cc
+++ b/test/core/transport/chttp2/streams_not_seen_test.cc
@@ -364,7 +364,7 @@ class StreamsNotSeenTest : public ::testing::Test {
   }
 
   static void OnWriteDone(void* arg, grpc_error_handle error) {
-    CHECK(error.ok());
+    CHECK_OK(error);
     Notification* on_write_done_notification_ = static_cast<Notification*>(arg);
     on_write_done_notification_->Notify();
   }

--- a/test/core/transport/chttp2/too_many_pings_test.cc
+++ b/test/core/transport/chttp2/too_many_pings_test.cc
@@ -441,7 +441,7 @@ grpc_core::Resolver::Result BuildResolverResult(
     if (!uri.ok()) {
       gpr_log(GPR_ERROR, "Failed to parse uri. Error: %s",
               uri.status().ToString().c_str());
-      CHECK(uri.ok());
+      CHECK_OK(uri);
     }
     grpc_resolved_address address;
     CHECK(grpc_parse_uri(*uri, &address));
@@ -701,8 +701,8 @@ void PerformCallWithResponsePayload(grpc_channel* channel, grpc_server* server,
   cqv.Verify();
 
   CHECK(status == GRPC_STATUS_OK);
-  CHECK(0 == grpc_slice_str_cmp(details, "xyz"));
-  CHECK(0 == grpc_slice_str_cmp(call_details.method, "/foo"));
+  CHECK_EQ(grpc_slice_str_cmp(details, "xyz"), 0);
+  CHECK_EQ(grpc_slice_str_cmp(call_details.method, "/foo"), 0);
   CHECK_EQ(was_cancelled, 0);
   CHECK(byte_buffer_eq_slice(response_payload_recv, response_payload_slice));
 

--- a/test/core/transport/parsed_metadata_test.cc
+++ b/test/core/transport/parsed_metadata_test.cc
@@ -55,7 +55,7 @@ struct Int32Trait {
   static int32_t MementoToValue(int32_t memento) { return memento; }
   static int32_t ParseMemento(Slice slice, bool, MetadataParseErrorFn) {
     int32_t out;
-    GPR_ASSERT(absl::SimpleAtoi(slice.as_string_view(), &out));
+    CHECK(absl::SimpleAtoi(slice.as_string_view(), &out));
     return out;
   }
   static std::string DisplayValue(int32_t value) {
@@ -75,7 +75,7 @@ struct Int64Trait {
   static int64_t MementoToValue(int64_t memento) { return -memento; }
   static int64_t ParseMemento(Slice slice, bool, MetadataParseErrorFn) {
     int64_t out;
-    GPR_ASSERT(absl::SimpleAtoi(slice.as_string_view(), &out));
+    CHECK(absl::SimpleAtoi(slice.as_string_view(), &out));
     return out;
   }
   static std::string DisplayValue(int64_t value) {
@@ -95,7 +95,7 @@ struct IntptrTrait {
   static intptr_t MementoToValue(intptr_t memento) { return memento / 2; }
   static intptr_t ParseMemento(Slice slice, bool, MetadataParseErrorFn) {
     intptr_t out;
-    GPR_ASSERT(absl::SimpleAtoi(slice.as_string_view(), &out));
+    CHECK(absl::SimpleAtoi(slice.as_string_view(), &out));
     return out;
   }
   static std::string DisplayValue(intptr_t value) {

--- a/test/core/transport/parsed_metadata_test.cc
+++ b/test/core/transport/parsed_metadata_test.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "absl/log/check.h"
 #include "absl/strings/numbers.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"

--- a/test/core/transport/test_suite/BUILD
+++ b/test/core/transport/test_suite/BUILD
@@ -48,7 +48,10 @@ grpc_cc_library(
     name = "chaotic_good_fixture",
     testonly = 1,
     srcs = ["chaotic_good_fixture.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     deps = [
         "fixture",
         "//src/core:chaotic_good_client_transport",

--- a/test/core/transport/test_suite/chaotic_good_fixture.cc
+++ b/test/core/transport/test_suite/chaotic_good_fixture.cc
@@ -14,6 +14,7 @@
 
 #include <memory>
 
+#include "absl/log/check.h"
 #include "gmock/gmock.h"
 
 #include "src/core/ext/transport/chaotic_good/client_transport.h"

--- a/test/core/transport/test_suite/chaotic_good_fixture.cc
+++ b/test/core/transport/test_suite/chaotic_good_fixture.cc
@@ -67,13 +67,13 @@ EndpointPair CreateEndpointPair(
       [](absl::Status) {}, endpoint_config,
       std::make_unique<MemoryQuotaBasedMemoryAllocatorFactory>(
           resource_quota->memory_quota()));
-  GPR_ASSERT(listener->Bind(resolved_address).ok());
-  GPR_ASSERT(listener->Start().ok());
+  CHECK_OK(listener->Bind(resolved_address));
+  CHECK_OK(listener->Start());
 
   event_engine->Connect(
       [&client_endpoint](
           absl::StatusOr<std::unique_ptr<EventEngine::Endpoint>> endpoint) {
-        GPR_ASSERT(endpoint.ok());
+        CHECK_OK(endpoint);
         client_endpoint = std::move(endpoint).value();
       },
       resolved_address, endpoint_config,

--- a/test/core/transport/test_suite/fuzzer_main.cc
+++ b/test/core/transport/test_suite/fuzzer_main.cc
@@ -37,8 +37,8 @@ static void dont_log(gpr_log_func_args* /*args*/) {}
 DEFINE_PROTO_FUZZER(const transport_test_suite::Msg& msg) {
   const auto& tests = grpc_core::TransportTestRegistry::Get().tests();
   const auto& fixtures = grpc_core::TransportFixtureRegistry::Get().fixtures();
-  GPR_ASSERT(!tests.empty());
-  GPR_ASSERT(!fixtures.empty());
+  CHECK(!tests.empty());
+  CHECK(!fixtures.empty());
   const int test_id = msg.test_id() % tests.size();
   const int fixture_id = msg.fixture_id() % fixtures.size();
 
@@ -62,5 +62,5 @@ DEFINE_PROTO_FUZZER(const transport_test_suite::Msg& msg) {
                             msg.event_engine_actions(), bitgen);
   test->RunTest();
   delete test;
-  GPR_ASSERT(!::testing::Test::HasFailure());
+  CHECK(!::testing::Test::HasFailure());
 }

--- a/test/core/transport/test_suite/fuzzer_main.cc
+++ b/test/core/transport/test_suite/fuzzer_main.cc
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
+
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/support/log.h>
 

--- a/test/core/transport/test_suite/grpc_transport_test.bzl
+++ b/test/core/transport/test_suite/grpc_transport_test.bzl
@@ -35,6 +35,7 @@ def grpc_transport_test(name, deps):
         srcs = ["fuzzer_main.cc"],
         tags = ["no_windows", "no_mac"],
         external_deps = [
+            "absl/log:check",
             "gtest",
         ],
         deps = [


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT
Replacing GPR_ASSERT with absl CHECK

These changes have been made using string replacement and regex.

Will not be replacing all instances of CHECK with CHECK_EQ , CHECK_NE etc because there are too many callsites. Only ones which are doable using very simple regex with least chance of failure will be replaced.

Given that we have 5000+ instances of GPR_ASSERT to edit, Doing it manually is too much work for both the author and reviewer.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

