### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5815,7 +5815,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   target_link_libraries(fd_conservation_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
-    absl::check
     grpc_test_util
   )
 
@@ -5929,6 +5928,7 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(static_stride_scheduler_benchmark
     ${_gRPC_ALLTARGETS_LIBRARIES}
     absl::algorithm_container
+    absl::check
     absl::span
     ${_gRPC_BENCHMARK_LIBRARIES}
     gpr
@@ -6129,7 +6129,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(address_sorting_test_unsecure
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
-    absl::check
     grpc++_unsecure
     grpc_test_util_unsecure
     grpc++_test_config
@@ -8334,7 +8333,6 @@ target_include_directories(buffer_list_test
 target_link_libraries(buffer_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc_test_util
 )
 
@@ -12868,7 +12866,6 @@ target_include_directories(endpoint_pair_test
 target_link_libraries(endpoint_pair_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc_test_util
 )
 
@@ -13019,7 +13016,6 @@ target_include_directories(error_test
 target_link_libraries(error_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc_test_util
 )
 
@@ -23765,7 +23761,6 @@ target_include_directories(resolve_address_using_ares_resolver_test
 target_link_libraries(resolve_address_using_ares_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc_test_util
   grpc++_test_config
 )
@@ -23872,7 +23867,6 @@ target_include_directories(resolve_address_using_native_resolver_test
 target_link_libraries(resolve_address_using_native_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc_test_util
   grpc++_test_config
 )
@@ -26613,7 +26607,6 @@ target_include_directories(secure_endpoint_test
 target_link_libraries(secure_endpoint_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc_test_util
 )
 
@@ -28462,7 +28455,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(socket_utils_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
-    absl::check
     grpc_test_util
   )
 
@@ -29604,7 +29596,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(tcp_posix_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
-    absl::check
     grpc_test_util
   )
 
@@ -30392,7 +30383,6 @@ target_include_directories(test_cpp_client_credentials_test
 target_link_libraries(test_cpp_client_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc++
   grpc_test_util
 )
@@ -30552,7 +30542,6 @@ target_include_directories(test_cpp_server_credentials_test
 target_link_libraries(test_cpp_server_credentials_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc++
   grpc_test_util
 )
@@ -30972,7 +30961,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   target_link_libraries(time_jump_test
     ${_gRPC_ALLTARGETS_LIBRARIES}
     gtest
-    absl::check
     grpc++
     grpc_test_util
   )
@@ -31216,7 +31204,6 @@ target_include_directories(timer_test
 target_link_libraries(timer_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
-  absl::check
   grpc++
   grpc_test_util
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5982,7 +5982,6 @@ target_include_directories(test_core_iomgr_timer_list_test
 
 target_link_libraries(test_core_iomgr_timer_list_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::check
   grpc_test_util
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5214,7 +5214,6 @@ targets:
   - test/core/util/slice_splitter.cc
   - test/core/util/tracer_util.cc
   deps:
-  - absl/log:check
   - grpc_test_util
   uses_polling: false
 - name: activity_test

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5140,7 +5140,6 @@ targets:
   - test/core/util/slice_splitter.cc
   - test/core/util/tracer_util.cc
   deps:
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -5176,6 +5175,7 @@ targets:
   - test/core/load_balancing/static_stride_scheduler_benchmark.cc
   deps:
   - absl/algorithm:container
+  - absl/log:check
   - absl/types:span
   - benchmark
   - gpr
@@ -5311,7 +5311,6 @@ targets:
   - test/cpp/util/subprocess.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++_unsecure
   - grpc_test_util_unsecure
   - grpc++_test_config
@@ -6276,7 +6275,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: byte_buffer_test
   gtest: true
@@ -8988,7 +8986,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: env_test
   gtest: true
@@ -9046,7 +9043,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   uses_polling: false
 - name: error_utils_test
@@ -15315,7 +15311,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   - grpc++_test_config
 - name: resolve_address_using_native_resolver_posix_test
@@ -15385,7 +15380,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   - grpc++_test_config
 - name: resource_quota_end2end_stress_test
@@ -17766,7 +17760,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
 - name: security_connector_test
   gtest: true
@@ -18712,7 +18705,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19192,7 +19184,6 @@ targets:
   - test/core/util/tracer_util.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc_test_util
   platforms:
   - linux
@@ -19594,7 +19585,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
 - name: test_cpp_end2end_ssl_credentials_test
@@ -19662,7 +19652,6 @@ targets:
   - test/cpp/util/tls_test_utils.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
 - name: test_cpp_util_slice_test
@@ -19794,7 +19783,6 @@ targets:
   - test/cpp/common/time_jump_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
   platforms:
@@ -19927,7 +19915,6 @@ targets:
   - test/cpp/common/timer_test.cc
   deps:
   - gtest
-  - absl/log:check
   - grpc++
   - grpc_test_util
 - name: tls_certificate_verifier_test

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include "absl/log/check.h"
+
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
@@ -29,7 +31,6 @@
 #include <grpc/slice.h>
 #include <grpc/status.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>

--- a/test/core/bad_ssl/bad_ssl_test.cc
+++ b/test/core/bad_ssl/bad_ssl_test.cc
@@ -29,6 +29,7 @@
 #include <grpc/slice.h>
 #include <grpc/status.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
@@ -101,12 +102,12 @@ static void run_test(const char* target, size_t nops) {
   op++;
   error = grpc_call_start_batch(c, ops, nops, grpc_core::CqVerifier::tag(1),
                                 nullptr);
-  GPR_ASSERT(GRPC_CALL_OK == error);
+  CHECK_EQ(error, GRPC_CALL_OK);
 
   cqv.Expect(grpc_core::CqVerifier::tag(1), true);
   cqv.Verify();
 
-  GPR_ASSERT(status != GRPC_STATUS_OK);
+  CHECK(status != GRPC_STATUS_OK);
 
   grpc_call_unref(c);
   grpc_slice_unref(details);

--- a/test/core/bad_ssl/generate_tests.bzl
+++ b/test/core/bad_ssl/generate_tests.bzl
@@ -33,9 +33,9 @@ def grpc_bad_ssl_tests():
         name = "bad_ssl_test_server",
         srcs = ["server_common.cc"],
         hdrs = ["server_common.h"],
-            external_deps = [
-                "absl/log:check",
-            ],
+        external_deps = [
+            "absl/log:check",
+        ],
         deps = [
             "//test/core/util:grpc_test_util",
             "//test/core/util:grpc_test_util_base",

--- a/test/core/bad_ssl/generate_tests.bzl
+++ b/test/core/bad_ssl/generate_tests.bzl
@@ -33,6 +33,9 @@ def grpc_bad_ssl_tests():
         name = "bad_ssl_test_server",
         srcs = ["server_common.cc"],
         hdrs = ["server_common.h"],
+            external_deps = [
+                "absl/log:check",
+            ],
         deps = [
             "//test/core/util:grpc_test_util",
             "//test/core/util:grpc_test_util_base",
@@ -48,6 +51,9 @@ def grpc_bad_ssl_tests():
         grpc_cc_test(
             name = "bad_ssl_%s_test" % t,
             srcs = ["bad_ssl_test.cc"],
+            external_deps = [
+                "absl/log:check",
+            ],
             data = [
                 ":bad_ssl_%s_server" % t,
                 "//src/core/tsi/test_creds:badserver.key",

--- a/test/core/bad_ssl/server_common.cc
+++ b/test/core/bad_ssl/server_common.cc
@@ -20,6 +20,7 @@
 
 #include <signal.h>
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
@@ -42,7 +43,7 @@ const char* bad_ssl_addr(int argc, char** argv) {
   gpr_cmdline_add_string(cl, "bind", "Bind host:port", &addr);
   gpr_cmdline_parse(cl, argc, argv);
   gpr_cmdline_destroy(cl);
-  GPR_ASSERT(addr);
+  CHECK(addr);
   return addr;
 }
 
@@ -67,7 +68,7 @@ void bad_ssl_run(grpc_server* server) {
   error = grpc_server_request_call(server, &s, &call_details,
                                    &request_metadata_recv, cq, cq,
                                    reinterpret_cast<void*>(1));
-  GPR_ASSERT(GRPC_CALL_OK == error);
+  CHECK_EQ(error, GRPC_CALL_OK);
 
   signal(SIGINT, sigint_handler);
   while (!shutdown_finished) {
@@ -75,7 +76,7 @@ void bad_ssl_run(grpc_server* server) {
       gpr_log(GPR_INFO, "Shutting down due to SIGINT");
       shutdown_cq = grpc_completion_queue_create_for_pluck(nullptr);
       grpc_server_shutdown_and_notify(server, shutdown_cq, nullptr);
-      GPR_ASSERT(grpc_completion_queue_pluck(
+      CHECK(grpc_completion_queue_pluck(
                      shutdown_cq, nullptr, grpc_timeout_seconds_to_deadline(5),
                      nullptr)
                      .type == GRPC_OP_COMPLETE);
@@ -90,11 +91,11 @@ void bad_ssl_run(grpc_server* server) {
         nullptr);
     switch (ev.type) {
       case GRPC_OP_COMPLETE:
-        GPR_ASSERT(ev.tag == (void*)1);
-        GPR_ASSERT(ev.success == 0);
+        CHECK(ev.tag == (void*)1);
+        CHECK_EQ(ev.success, 0);
         break;
       case GRPC_QUEUE_SHUTDOWN:
-        GPR_ASSERT(shutdown_started);
+        CHECK(shutdown_started);
         shutdown_finished = 1;
         break;
       case GRPC_QUEUE_TIMEOUT:
@@ -102,7 +103,7 @@ void bad_ssl_run(grpc_server* server) {
     }
   }
 
-  GPR_ASSERT(s == nullptr);
+  CHECK_EQ(s, nullptr);
   grpc_call_details_destroy(&call_details);
   grpc_metadata_array_destroy(&request_metadata_recv);
 }

--- a/test/core/bad_ssl/server_common.cc
+++ b/test/core/bad_ssl/server_common.cc
@@ -21,6 +21,7 @@
 #include <signal.h>
 
 #include "absl/log/check.h"
+
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
@@ -76,10 +77,10 @@ void bad_ssl_run(grpc_server* server) {
       gpr_log(GPR_INFO, "Shutting down due to SIGINT");
       shutdown_cq = grpc_completion_queue_create_for_pluck(nullptr);
       grpc_server_shutdown_and_notify(server, shutdown_cq, nullptr);
-      CHECK(grpc_completion_queue_pluck(
-                     shutdown_cq, nullptr, grpc_timeout_seconds_to_deadline(5),
-                     nullptr)
-                     .type == GRPC_OP_COMPLETE);
+      CHECK(grpc_completion_queue_pluck(shutdown_cq, nullptr,
+                                        grpc_timeout_seconds_to_deadline(5),
+                                        nullptr)
+                .type == GRPC_OP_COMPLETE);
       grpc_completion_queue_destroy(shutdown_cq);
       grpc_completion_queue_shutdown(cq);
       shutdown_started = 1;

--- a/test/core/bad_ssl/servers/alpn.cc
+++ b/test/core/bad_ssl/servers/alpn.cc
@@ -20,11 +20,12 @@
 
 #include <string.h>
 
+#include "absl/log/check.h"
+
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/useful.h"

--- a/test/core/bad_ssl/servers/alpn.cc
+++ b/test/core/bad_ssl/servers/alpn.cc
@@ -24,6 +24,7 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/useful.h"
@@ -54,7 +55,7 @@ size_t grpc_chttp2_num_alpn_versions(void) {
 }
 
 const char* grpc_chttp2_get_alpn_version_index(size_t i) {
-  GPR_ASSERT(i < GPR_ARRAY_SIZE(fake_versions));
+  CHECK(i < GPR_ARRAY_SIZE(fake_versions));
   return fake_versions[i];
 }
 
@@ -72,7 +73,7 @@ int main(int argc, char** argv) {
   ssl_creds = grpc_ssl_server_credentials_create(nullptr, &pem_key_cert_pair, 1,
                                                  0, nullptr);
   server = grpc_server_create(nullptr, nullptr);
-  GPR_ASSERT(grpc_server_add_http2_port(server, addr, ssl_creds));
+  CHECK(grpc_server_add_http2_port(server, addr, ssl_creds));
   grpc_server_credentials_release(ssl_creds);
 
   bad_ssl_run(server);

--- a/test/core/bad_ssl/servers/cert.cc
+++ b/test/core/bad_ssl/servers/cert.cc
@@ -16,11 +16,12 @@
 //
 //
 
+#include "absl/log/check.h"
+
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/iomgr/error.h"

--- a/test/core/bad_ssl/servers/cert.cc
+++ b/test/core/bad_ssl/servers/cert.cc
@@ -20,6 +20,7 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/iomgr/error.h"
@@ -47,7 +48,7 @@ int main(int argc, char** argv) {
   ssl_creds = grpc_ssl_server_credentials_create(nullptr, &pem_key_cert_pair, 1,
                                                  0, nullptr);
   server = grpc_server_create(nullptr, nullptr);
-  GPR_ASSERT(grpc_server_add_http2_port(server, addr, ssl_creds));
+  CHECK(grpc_server_add_http2_port(server, addr, ssl_creds));
   grpc_server_credentials_release(ssl_creds);
 
   bad_ssl_run(server);

--- a/test/core/channel/BUILD
+++ b/test/core/channel/BUILD
@@ -35,7 +35,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "channel_args_test",
     srcs = ["channel_args_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -82,6 +85,7 @@ grpc_cc_test(
     name = "minimal_stack_is_minimal_test",
     srcs = ["minimal_stack_is_minimal_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     language = "C++",

--- a/test/core/channel/channel_args_test.cc
+++ b/test/core/channel/channel_args_test.cc
@@ -20,6 +20,7 @@
 
 #include <string.h>
 
+#include "absl/log/check.h"
 #include "gtest/gtest.h"
 
 #include <grpc/credentials.h>
@@ -27,7 +28,6 @@
 #include <grpc/grpc_security.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/useful.h"
@@ -262,8 +262,7 @@ TEST(GrpcChannelArgsTest, Create) {
 
   CHECK_EQ(strcmp(ch_args->args[1].key, to_add[1].key), 0);
   CHECK(ch_args->args[1].type == to_add[1].type);
-  CHECK(strcmp(ch_args->args[1].value.string, to_add[1].value.string) ==
-             0);
+  CHECK(strcmp(ch_args->args[1].value.string, to_add[1].value.string) == 0);
 
   grpc_channel_args_destroy(ch_args);
 }
@@ -322,10 +321,9 @@ grpc_channel_args* mutate_channel_args(const char* target,
   CHECK_NE(old_args, nullptr);
   CHECK_EQ(grpc_channel_args_find(old_args, "arg_int")->value.integer, 0);
   CHECK(strcmp(grpc_channel_args_find(old_args, "arg_str")->value.string,
-                    "arg_str_val") == 0);
-  CHECK(
-      grpc_channel_args_find(old_args, "arg_pointer")->value.pointer.vtable ==
-      &fake_pointer_arg_vtable);
+               "arg_str_val") == 0);
+  CHECK(grpc_channel_args_find(old_args, "arg_pointer")->value.pointer.vtable ==
+        &fake_pointer_arg_vtable);
 
   if (strcmp(target, "no_op_mutator") == 0) {
     return old_args;

--- a/test/core/channel/channel_args_test.cc
+++ b/test/core/channel/channel_args_test.cc
@@ -27,6 +27,7 @@
 #include <grpc/grpc_security.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/useful.h"
@@ -254,14 +255,14 @@ TEST(GrpcChannelArgsTest, Create) {
                                              const_cast<char*>("str value"));
   ch_args = grpc_channel_args_copy_and_add(nullptr, to_add, 2);
 
-  GPR_ASSERT(ch_args->num_args == 2);
-  GPR_ASSERT(strcmp(ch_args->args[0].key, to_add[0].key) == 0);
-  GPR_ASSERT(ch_args->args[0].type == to_add[0].type);
-  GPR_ASSERT(ch_args->args[0].value.integer == to_add[0].value.integer);
+  CHECK_EQ(ch_args->num_args, 2);
+  CHECK_EQ(strcmp(ch_args->args[0].key, to_add[0].key), 0);
+  CHECK(ch_args->args[0].type == to_add[0].type);
+  CHECK(ch_args->args[0].value.integer == to_add[0].value.integer);
 
-  GPR_ASSERT(strcmp(ch_args->args[1].key, to_add[1].key) == 0);
-  GPR_ASSERT(ch_args->args[1].type == to_add[1].type);
-  GPR_ASSERT(strcmp(ch_args->args[1].value.string, to_add[1].value.string) ==
+  CHECK_EQ(strcmp(ch_args->args[1].key, to_add[1].key), 0);
+  CHECK(ch_args->args[1].type == to_add[1].type);
+  CHECK(strcmp(ch_args->args[1].value.string, to_add[1].value.string) ==
              0);
 
   grpc_channel_args_destroy(ch_args);
@@ -318,11 +319,11 @@ TEST(GrpcChannelArgsTest, ChannelCreateWithArgs) {
 grpc_channel_args* mutate_channel_args(const char* target,
                                        grpc_channel_args* old_args,
                                        grpc_channel_stack_type /*type*/) {
-  GPR_ASSERT(old_args != nullptr);
-  GPR_ASSERT(grpc_channel_args_find(old_args, "arg_int")->value.integer == 0);
-  GPR_ASSERT(strcmp(grpc_channel_args_find(old_args, "arg_str")->value.string,
+  CHECK_NE(old_args, nullptr);
+  CHECK_EQ(grpc_channel_args_find(old_args, "arg_int")->value.integer, 0);
+  CHECK(strcmp(grpc_channel_args_find(old_args, "arg_str")->value.string,
                     "arg_str_val") == 0);
-  GPR_ASSERT(
+  CHECK(
       grpc_channel_args_find(old_args, "arg_pointer")->value.pointer.vtable ==
       &fake_pointer_arg_vtable);
 
@@ -330,7 +331,7 @@ grpc_channel_args* mutate_channel_args(const char* target,
     return old_args;
   }
 
-  GPR_ASSERT(strcmp(target, "minimal_stack_mutator") == 0);
+  CHECK_EQ(strcmp(target, "minimal_stack_mutator"), 0);
   const char* args_to_remove[] = {"arg_int", "arg_str", "arg_pointer"};
 
   grpc_arg no_deadline_filter_arg = grpc_channel_arg_integer_create(

--- a/test/core/channel/minimal_stack_is_minimal_test.cc
+++ b/test/core/channel/minimal_stack_is_minimal_test.cc
@@ -34,13 +34,13 @@
 #include <string>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 
 #include <grpc/grpc.h>
 #include <grpc/impl/channel_arg_names.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_args.h"

--- a/test/core/channel/minimal_stack_is_minimal_test.cc
+++ b/test/core/channel/minimal_stack_is_minimal_test.cc
@@ -40,6 +40,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/impl/channel_arg_names.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_args.h"
@@ -95,7 +96,7 @@ std::vector<std::string> MakeStack(const char* transport_name,
   builder.SetTarget("foo.test.google.fr");
   {
     grpc_core::ExecCtx exec_ctx;
-    GPR_ASSERT(grpc_core::CoreConfiguration::Get().channel_init().CreateStack(
+    CHECK(grpc_core::CoreConfiguration::Get().channel_init().CreateStack(
         &builder));
   }
 

--- a/test/core/ext/filters/event_engine_client_channel_resolver/BUILD
+++ b/test/core/ext/filters/event_engine_client_channel_resolver/BUILD
@@ -24,6 +24,7 @@ grpc_proto_fuzzer(
     size = "enormous",
     srcs = ["resolver_fuzzer.cc"],
     corpus = "resolver_fuzzer_corpus",
+    external_deps = ["absl/log:check"],
     language = "C++",
     proto = "resolver_fuzzer.proto",
     proto_deps = [

--- a/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
+++ b/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
@@ -26,6 +26,7 @@
 #include "absl/strings/string_view.h"
 
 #include <grpc/event_engine/event_engine.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
@@ -240,7 +241,7 @@ grpc_core::ResolverArgs ConstructResolverArgs(
     std::shared_ptr<grpc_core::WorkSerializer> work_serializer) {
   grpc_core::ResolverArgs resolver_args;
   auto uri = grpc_core::URI::Parse("dns:localhost");
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   resolver_args.uri = *uri;
   resolver_args.args = channel_args;
   resolver_args.pollset_set = nullptr;

--- a/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
+++ b/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
@@ -20,13 +20,13 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/functional/any_invocable.h"
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/event_engine/event_engine.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 

--- a/test/core/gpr/BUILD
+++ b/test/core/gpr/BUILD
@@ -61,6 +61,7 @@ grpc_cc_test(
     name = "log_test",
     srcs = ["log_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     language = "C++",

--- a/test/core/gpr/log_test.cc
+++ b/test/core/gpr/log_test.cc
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include "absl/log/check.h"
+
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
@@ -48,10 +49,10 @@ static void test_should_not_log(gpr_log_func_args* /*args*/) {
   gpr_set_log_function(test_should_log);        \
   log_func_reached = false;                     \
   gpr_log_message(SEVERITY, "hello 1 2 3");     \
-  CHECK(log_func_reached);                 \
+  CHECK(log_func_reached);                      \
   log_func_reached = false;                     \
   gpr_log(SEVERITY, "hello %d %d %d", 1, 2, 3); \
-  CHECK(log_func_reached);                 \
+  CHECK(log_func_reached);                      \
   gpr_set_log_function(nullptr);
 
 #define test_log_function_unreached(SEVERITY)   \

--- a/test/core/gpr/log_test.cc
+++ b/test/core/gpr/log_test.cc
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
@@ -30,9 +31,9 @@
 static bool log_func_reached = false;
 
 static void test_callback(gpr_log_func_args* args) {
-  GPR_ASSERT(0 == strcmp(__FILE__, args->file));
-  GPR_ASSERT(args->severity == GPR_LOG_SEVERITY_INFO);
-  GPR_ASSERT(0 == strcmp(args->message, "hello 1 2 3"));
+  CHECK_EQ(strcmp(__FILE__, args->file), 0);
+  CHECK(args->severity == GPR_LOG_SEVERITY_INFO);
+  CHECK_EQ(strcmp(args->message, "hello 1 2 3"), 0);
 }
 
 static void test_should_log(gpr_log_func_args* /*args*/) {
@@ -47,10 +48,10 @@ static void test_should_not_log(gpr_log_func_args* /*args*/) {
   gpr_set_log_function(test_should_log);        \
   log_func_reached = false;                     \
   gpr_log_message(SEVERITY, "hello 1 2 3");     \
-  GPR_ASSERT(log_func_reached);                 \
+  CHECK(log_func_reached);                 \
   log_func_reached = false;                     \
   gpr_log(SEVERITY, "hello %d %d %d", 1, 2, 3); \
-  GPR_ASSERT(log_func_reached);                 \
+  CHECK(log_func_reached);                 \
   gpr_set_log_function(nullptr);
 
 #define test_log_function_unreached(SEVERITY)   \
@@ -65,7 +66,7 @@ TEST(LogTest, Basic) {
   gpr_log(GPR_INFO, "%s", "hello world");
   gpr_log(GPR_ERROR, "%s", "hello world");
   // should succeed
-  GPR_ASSERT(1);
+  CHECK(1);
   gpr_set_log_function(test_callback);
   gpr_log_message(GPR_INFO, "hello 1 2 3");
   gpr_log(GPR_INFO, "hello %d %d %d", 1, 2, 3);

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -220,6 +220,7 @@ grpc_cc_test(
     name = "dual_ref_counted_test",
     srcs = ["dual_ref_counted_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     language = "C++",
@@ -234,6 +235,7 @@ grpc_cc_test(
     srcs = ["ref_counted_ptr_test.cc"],
     external_deps = [
         "absl/container:flat_hash_set",
+        "absl/log:check",
         "gtest",
     ],
     language = "C++",
@@ -337,6 +339,7 @@ grpc_proto_fuzzer(
     name = "chunked_vector_fuzzer",
     srcs = ["chunked_vector_fuzzer.cc"],
     corpus = "chunked_vector_corpora",
+    external_deps = ["absl/log:check"],
     language = "C++",
     proto = "chunked_vector_fuzzer.proto",
     tags = ["no_windows"],

--- a/test/core/gprpp/chunked_vector_fuzzer.cc
+++ b/test/core/gprpp/chunked_vector_fuzzer.cc
@@ -20,8 +20,9 @@
 #include <utility>
 #include <vector>
 
-#include <grpc/event_engine/memory_allocator.h>
 #include "absl/log/check.h"
+
+#include <grpc/event_engine/memory_allocator.h>
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/chunked_vector.h"

--- a/test/core/gprpp/chunked_vector_fuzzer.cc
+++ b/test/core/gprpp/chunked_vector_fuzzer.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <grpc/event_engine/memory_allocator.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/chunked_vector.h"
@@ -46,15 +47,15 @@ struct Comparison {
 
   // Check that both chunked and std are equivalent.
   void AssertOk() const {
-    GPR_ASSERT(std.size() == chunked.size());
+    CHECK(std.size() == chunked.size());
     auto it_chunked = chunked.cbegin();
     auto it_std = std.cbegin();
     while (it_std != std.cend()) {
-      GPR_ASSERT(**it_std == **it_chunked);
+      CHECK(**it_std == **it_chunked);
       ++it_chunked;
       ++it_std;
     }
-    GPR_ASSERT(it_chunked == chunked.cend());
+    CHECK(it_chunked == chunked.cend());
   }
 };
 

--- a/test/core/gprpp/dual_ref_counted_test.cc
+++ b/test/core/gprpp/dual_ref_counted_test.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "absl/log/check.h"
 #include "gtest/gtest.h"
 
 #include "test/core/util/test_config.h"

--- a/test/core/gprpp/dual_ref_counted_test.cc
+++ b/test/core/gprpp/dual_ref_counted_test.cc
@@ -29,7 +29,7 @@ namespace {
 class Foo : public DualRefCounted<Foo> {
  public:
   Foo() = default;
-  ~Foo() override { GPR_ASSERT(shutting_down_); }
+  ~Foo() override { CHECK(shutting_down_); }
 
   void Orphaned() override { shutting_down_ = true; }
 
@@ -92,7 +92,7 @@ TEST(DualRefCounted, RefAndWeakRefAsSubclass) {
 class FooWithTracing : public DualRefCounted<FooWithTracing> {
  public:
   FooWithTracing() : DualRefCounted("FooWithTracing") {}
-  ~FooWithTracing() override { GPR_ASSERT(shutting_down_); }
+  ~FooWithTracing() override { CHECK(shutting_down_); }
 
   void Orphaned() override { shutting_down_ = true; }
 

--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -23,6 +23,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "gtest/gtest.h"
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/dual_ref_counted.h"
@@ -274,7 +275,7 @@ class Bar : public DualRefCounted<Bar> {
 
   explicit Bar(int value) : value_(value) {}
 
-  ~Bar() override { GPR_ASSERT(shutting_down_); }
+  ~Bar() override { CHECK(shutting_down_); }
 
   void Orphaned() override { shutting_down_ = true; }
 
@@ -430,7 +431,7 @@ class BarWithTracing : public DualRefCounted<BarWithTracing> {
  public:
   BarWithTracing() : DualRefCounted("BarWithTracing") {}
 
-  ~BarWithTracing() override { GPR_ASSERT(shutting_down_); }
+  ~BarWithTracing() override { CHECK(shutting_down_); }
 
   void Orphaned() override { shutting_down_ = true; }
 
@@ -453,7 +454,7 @@ class WeakBaseClass : public DualRefCounted<WeakBaseClass> {
  public:
   WeakBaseClass() {}
 
-  ~WeakBaseClass() override { GPR_ASSERT(shutting_down_); }
+  ~WeakBaseClass() override { CHECK(shutting_down_); }
 
   void Orphaned() override { shutting_down_ = true; }
 

--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -21,9 +21,9 @@
 #include <memory>
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/log/check.h"
 #include "gtest/gtest.h"
 
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/dual_ref_counted.h"

--- a/test/core/handshake/BUILD
+++ b/test/core/handshake/BUILD
@@ -40,6 +40,7 @@ grpc_cc_library(
     name = "server_ssl_common",
     srcs = ["server_ssl_common.cc"],
     hdrs = ["server_ssl_common.h"],
+    external_deps = ["absl/log:check"],
     tags = ["no_windows"],
     deps = [
         "//:gpr",
@@ -96,6 +97,9 @@ grpc_cc_test(
 #        "//src/core/tsi/test_creds:ca.pem",
 #        "//src/core/tsi/test_creds:server1.key",
 #        "//src/core/tsi/test_creds:server1.pem",
+#    ],
+#    external_deps = [
+#        "absl/log:check",
 #    ],
 #    language = "C++",
 #    tags = ["no_mac", no_windows"],

--- a/test/core/handshake/server_ssl_common.cc
+++ b/test/core/handshake/server_ssl_common.cc
@@ -34,6 +34,7 @@
 #include <openssl/ssl.h>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/credentials.h>
@@ -41,7 +42,6 @@
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>

--- a/test/core/handshake/server_ssl_common.cc
+++ b/test/core/handshake/server_ssl_common.cc
@@ -41,6 +41,7 @@
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
@@ -131,7 +132,7 @@ void server_thread(void* arg) {
   // Start server listening on local port.
   std::string addr = absl::StrCat("127.0.0.1:", port);
   grpc_server* server = grpc_server_create(nullptr, nullptr);
-  GPR_ASSERT(grpc_server_add_http2_port(server, addr.c_str(), ssl_creds));
+  CHECK(grpc_server_add_http2_port(server, addr.c_str(), ssl_creds));
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
 
@@ -148,7 +149,7 @@ void server_thread(void* arg) {
   while (!gpr_event_get(&client_handshake_complete) && retries-- > 0) {
     const gpr_timespec cq_deadline = grpc_timeout_seconds_to_deadline(1);
     grpc_event ev = grpc_completion_queue_next(cq, cq_deadline, nullptr);
-    GPR_ASSERT(ev.type == GRPC_QUEUE_TIMEOUT);
+    CHECK(ev.type == GRPC_QUEUE_TIMEOUT);
   }
 
   gpr_log(GPR_INFO, "Shutting down server");
@@ -157,7 +158,7 @@ void server_thread(void* arg) {
 
   const gpr_timespec cq_deadline = grpc_timeout_seconds_to_deadline(5);
   grpc_event ev = grpc_completion_queue_next(cq, cq_deadline, nullptr);
-  GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+  CHECK(ev.type == GRPC_OP_COMPLETE);
 
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq);
@@ -181,7 +182,7 @@ bool server_ssl_test(const char* alpn_list[], unsigned int alpn_list_len,
   // Launch the gRPC server thread.
   bool ok;
   grpc_core::Thread thd("grpc_ssl_test", server_thread, &s, &ok);
-  GPR_ASSERT(ok);
+  CHECK(ok);
   thd.Start();
 
   // The work in server_thread will cause the SSL initialization to take place
@@ -232,7 +233,7 @@ bool server_ssl_test(const char* alpn_list[], unsigned int alpn_list_len,
     memcpy(p, alpn_list[i], len);
     p += len;
   }
-  GPR_ASSERT(SSL_CTX_set_alpn_protos(ctx, alpn_protos, alpn_protos_len) == 0);
+  CHECK_EQ(SSL_CTX_set_alpn_protos(ctx, alpn_protos, alpn_protos_len), 0);
 
   // Try and connect to server. We allow a bounded number of retries as we might
   // be racing with the server setup on its separate thread.
@@ -244,12 +245,12 @@ bool server_ssl_test(const char* alpn_list[], unsigned int alpn_list_len,
       sleep(1);
     }
   }
-  GPR_ASSERT(sock > 0);
+  CHECK_GT(sock, 0);
   gpr_log(GPR_INFO, "Connected to server on port %d", s.port());
 
   // Establish a SSL* and connect at SSL layer.
   SSL* ssl = SSL_new(ctx);
-  GPR_ASSERT(ssl);
+  CHECK(ssl);
   SSL_set_fd(ssl, sock);
   if (SSL_connect(ssl) <= 0) {
     ERR_print_errors_fp(stderr);

--- a/test/core/handshake/verify_peer_options.cc
+++ b/test/core/handshake/verify_peer_options.cc
@@ -32,13 +32,13 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
+#include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
@@ -152,7 +152,7 @@ static bool verify_peer_options_test(verify_peer_options* verify_options) {
   // Initially the channel will be idle, the
   // grpc_channel_check_connectivity_state triggers an attempt to connect.
   CHECK(grpc_channel_check_connectivity_state(
-                 channel, 1 /* try_to_connect */) == GRPC_CHANNEL_IDLE);
+            channel, 1 /* try_to_connect */) == GRPC_CHANNEL_IDLE);
 
   // Wait a bounded number of times for the channel to be ready. When the
   // channel is ready, the initial TLS handshake will have successfully

--- a/test/core/handshake/verify_peer_options.cc
+++ b/test/core/handshake/verify_peer_options.cc
@@ -38,6 +38,7 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
@@ -70,7 +71,7 @@ static void server_thread(void* arg) {
   // Start server listening on local port.
   std::string addr = absl::StrCat("127.0.0.1:", port);
   grpc_server* server = grpc_server_create(nullptr, nullptr);
-  GPR_ASSERT(grpc_server_add_http2_port(server, addr.c_str(), ssl_creds));
+  CHECK(grpc_server_add_http2_port(server, addr.c_str(), ssl_creds));
 
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
 
@@ -85,7 +86,7 @@ static void server_thread(void* arg) {
   while (!gpr_event_get(&client_handshake_complete) && retries-- > 0) {
     const gpr_timespec cq_deadline = grpc_timeout_seconds_to_deadline(1);
     grpc_event ev = grpc_completion_queue_next(cq, cq_deadline, nullptr);
-    GPR_ASSERT(ev.type == GRPC_QUEUE_TIMEOUT);
+    CHECK(ev.type == GRPC_QUEUE_TIMEOUT);
   }
 
   gpr_log(GPR_INFO, "Shutting down server");
@@ -95,7 +96,7 @@ static void server_thread(void* arg) {
 
   const gpr_timespec cq_deadline = grpc_timeout_seconds_to_deadline(60);
   grpc_event ev = grpc_completion_queue_next(cq, cq_deadline, nullptr);
-  GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+  CHECK(ev.type == GRPC_OP_COMPLETE);
 
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq);
@@ -131,7 +132,7 @@ static bool verify_peer_options_test(verify_peer_options* verify_options) {
   // Launch the gRPC server thread.
   bool ok;
   grpc_core::Thread thd("grpc_client_ssl_test", server_thread, &port, &ok);
-  GPR_ASSERT(ok);
+  CHECK(ok);
   thd.Start();
 
   // Establish a channel pointing at the TLS server. Since the gRPC runtime is
@@ -146,11 +147,11 @@ static bool verify_peer_options_test(verify_peer_options* verify_options) {
   grpc_args.args = &ssl_name_override;
   grpc_channel* channel =
       grpc_channel_create(target.c_str(), ssl_creds, &grpc_args);
-  GPR_ASSERT(channel);
+  CHECK(channel);
 
   // Initially the channel will be idle, the
   // grpc_channel_check_connectivity_state triggers an attempt to connect.
-  GPR_ASSERT(grpc_channel_check_connectivity_state(
+  CHECK(grpc_channel_check_connectivity_state(
                  channel, 1 /* try_to_connect */) == GRPC_CHANNEL_IDLE);
 
   // Wait a bounded number of times for the channel to be ready. When the
@@ -166,7 +167,7 @@ static bool verify_peer_options_test(verify_peer_options* verify_options) {
         channel, state, grpc_timeout_seconds_to_deadline(3), cq, nullptr);
     gpr_timespec cq_deadline = grpc_timeout_seconds_to_deadline(5);
     grpc_event ev = grpc_completion_queue_next(cq, cq_deadline, nullptr);
-    GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+    CHECK(ev.type == GRPC_OP_COMPLETE);
     state =
         grpc_channel_check_connectivity_state(channel, 0 /* try_to_connect */);
   }
@@ -229,25 +230,25 @@ int main(int argc, char* argv[]) {
   verify_options.verify_peer_callback = nullptr;
   verify_options.verify_peer_callback_userdata = nullptr;
   verify_options.verify_peer_destruct = nullptr;
-  GPR_ASSERT(verify_peer_options_test(&verify_options));
-  GPR_ASSERT(strlen(callback_target_host) == 0);
-  GPR_ASSERT(strlen(callback_target_pem) == 0);
-  GPR_ASSERT(callback_userdata == nullptr);
-  GPR_ASSERT(destruct_userdata == nullptr);
+  CHECK(verify_peer_options_test(&verify_options));
+  CHECK_EQ(strlen(callback_target_host), 0);
+  CHECK_EQ(strlen(callback_target_pem), 0);
+  CHECK_EQ(callback_userdata, nullptr);
+  CHECK_EQ(destruct_userdata, nullptr);
 
   // Running with the callbacks and verify we get the expected values
   verify_options.verify_peer_callback = verify_callback;
   verify_options.verify_peer_callback_userdata = static_cast<void*>(&userdata);
   verify_options.verify_peer_destruct = verify_destruct;
-  GPR_ASSERT(verify_peer_options_test(&verify_options));
-  GPR_ASSERT(strcmp(callback_target_host, "foo.test.google.fr") == 0);
-  GPR_ASSERT(strcmp(callback_target_pem, server_cert.c_str()) == 0);
-  GPR_ASSERT(callback_userdata == static_cast<void*>(&userdata));
-  GPR_ASSERT(destruct_userdata == static_cast<void*>(&userdata));
+  CHECK(verify_peer_options_test(&verify_options));
+  CHECK_EQ(strcmp(callback_target_host, "foo.test.google.fr"), 0);
+  CHECK_EQ(strcmp(callback_target_pem, server_cert.c_str()), 0);
+  CHECK(callback_userdata == static_cast<void*>(&userdata));
+  CHECK(destruct_userdata == static_cast<void*>(&userdata));
 
   // If the callback returns non-zero, initializing the channel should fail.
   callback_return_value = 1;
-  GPR_ASSERT(!verify_peer_options_test(&verify_options));
+  CHECK(!verify_peer_options_test(&verify_options));
 
   grpc_shutdown();
   return 0;

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -66,6 +66,7 @@ grpc_cc_library(
     testonly = True,
     srcs = ["httpcli_test_util.cc"],
     hdrs = ["httpcli_test_util.h"],
+    external_deps = ["absl/log:check"],
     deps = [
         "//:gpr",
         "//:subprocess",
@@ -84,7 +85,10 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [
@@ -110,7 +114,10 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [

--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -29,6 +29,7 @@
 #include <ares.h>
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/time/clock.h"
@@ -38,7 +39,6 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
@@ -253,8 +253,7 @@ void InjectNonResponsiveDNSServer(ares_channel* channel) {
   dns_server_addrs[0].tcp_port = g_fake_non_responsive_dns_server_port;
   dns_server_addrs[0].udp_port = g_fake_non_responsive_dns_server_port;
   dns_server_addrs[0].next = nullptr;
-  CHECK(ares_set_servers_ports(*channel, dns_server_addrs) ==
-             ARES_SUCCESS);
+  CHECK(ares_set_servers_ports(*channel, dns_server_addrs) == ARES_SUCCESS);
 }
 
 TEST_F(HttpRequestTest, CancelGetDuringDNSResolution) {

--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -38,6 +38,7 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
@@ -94,7 +95,7 @@ class HttpRequestTest : public ::testing::Test {
   void RunAndKick(const std::function<void()>& f) {
     grpc_core::MutexLockForGprMu lock(mu_);
     f();
-    GPR_ASSERT(GRPC_LOG_IF_ERROR(
+    CHECK(GRPC_LOG_IF_ERROR(
         "pollset_kick",
         grpc_pollset_kick(grpc_polling_entity_pollset(&pops_), nullptr)));
   }
@@ -102,9 +103,9 @@ class HttpRequestTest : public ::testing::Test {
   void PollUntil(const std::function<bool()>& predicate, absl::Time deadline) {
     gpr_mu_lock(mu_);
     while (!predicate()) {
-      GPR_ASSERT(absl::Now() < deadline);
+      CHECK(absl::Now() < deadline);
       grpc_pollset_worker* worker = nullptr;
-      GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      CHECK(GRPC_LOG_IF_ERROR(
           "pollset_work", grpc_pollset_work(grpc_polling_entity_pollset(&pops_),
                                             &worker, NSecondsTime(1))));
       gpr_mu_unlock(mu_);
@@ -164,10 +165,10 @@ void OnFinish(void* arg, grpc_error_handle error) {
   grpc_http_response response = request_state->response;
   gpr_log(GPR_INFO, "response status=%d error=%s", response.status,
           grpc_core::StatusToString(error).c_str());
-  GPR_ASSERT(error.ok());
-  GPR_ASSERT(response.status == 200);
-  GPR_ASSERT(response.body_length == strlen(expect));
-  GPR_ASSERT(0 == memcmp(expect, response.body, response.body_length));
+  CHECK(error.ok());
+  CHECK_EQ(response.status, 200);
+  CHECK(response.body_length == strlen(expect));
+  CHECK_EQ(memcmp(expect, response.body, response.body_length), 0);
   request_state->test->RunAndKick(
       [request_state]() { request_state->done = true; });
 }
@@ -183,7 +184,7 @@ void OnFinishExpectFailure(void* arg, grpc_error_handle error) {
   grpc_http_response response = request_state->response;
   gpr_log(GPR_INFO, "response status=%d error=%s", response.status,
           grpc_core::StatusToString(error).c_str());
-  GPR_ASSERT(!error.ok());
+  CHECK(!error.ok());
   request_state->test->RunAndKick(
       [request_state]() { request_state->done = true; });
 }
@@ -197,7 +198,7 @@ TEST_F(HttpRequestTest, Get) {
   memset(&req, 0, sizeof(req));
   auto uri = grpc_core::URI::Create("http", host, "/get", {} /* query params */,
                                     "" /* fragment */);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
       grpc_core::HttpRequest::Get(
           std::move(*uri), nullptr /* channel args */, pops(), &req,
@@ -223,7 +224,7 @@ TEST_F(HttpRequestTest, Post) {
   req.body_length = 5;
   auto uri = grpc_core::URI::Create("http", host, "/post",
                                     {} /* query params */, "" /* fragment */);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
       grpc_core::HttpRequest::Post(
           std::move(*uri), nullptr /* channel args */, pops(), &req,
@@ -252,7 +253,7 @@ void InjectNonResponsiveDNSServer(ares_channel* channel) {
   dns_server_addrs[0].tcp_port = g_fake_non_responsive_dns_server_port;
   dns_server_addrs[0].udp_port = g_fake_non_responsive_dns_server_port;
   dns_server_addrs[0].next = nullptr;
-  GPR_ASSERT(ares_set_servers_ports(*channel, dns_server_addrs) ==
+  CHECK(ares_set_servers_ports(*channel, dns_server_addrs) ==
              ARES_SUCCESS);
 }
 
@@ -280,7 +281,7 @@ TEST_F(HttpRequestTest, CancelGetDuringDNSResolution) {
       auto uri = grpc_core::URI::Create(
           "http", "dont-care-since-wont-be-resolved.test.com:443", "/get",
           {} /* query params */, "" /* fragment */);
-      GPR_ASSERT(uri.ok());
+      CHECK(uri.ok());
       grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
           grpc_core::HttpRequest::Get(
               std::move(*uri), nullptr /* channel args */, pops(), &req,
@@ -336,7 +337,7 @@ TEST_F(HttpRequestTest, CancelGetWhileReadingResponse) {
       auto uri = grpc_core::URI::Create("http", fake_http_server_ptr->address(),
                                         "/get", {} /* query params */,
                                         "" /* fragment */);
-      GPR_ASSERT(uri.ok());
+      CHECK(uri.ok());
       grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
           grpc_core::HttpRequest::Get(
               std::move(*uri), nullptr /* channel args */, pops(), &req,
@@ -397,7 +398,7 @@ TEST_F(HttpRequestTest, CancelGetRacesWithConnectionFailure) {
       auto uri =
           grpc_core::URI::Create("http", fake_server_address, "/get",
                                  {} /* query params */, "" /* fragment */);
-      GPR_ASSERT(uri.ok());
+      CHECK(uri.ok());
       grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
           grpc_core::HttpRequest::Get(
               std::move(*uri), nullptr /* channel args */, pops(), &req,
@@ -462,7 +463,7 @@ TEST_F(HttpRequestTest, CallerPollentsAreNotReferencedAfterCallbackIsRan) {
           request_state.pollset_set_to_destroy_eagerly);
   auto uri = grpc_core::URI::Create("http", fake_server_address, "/get",
                                     {} /* query params */, "" /* fragment */);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
       grpc_core::HttpRequest::Get(
           std::move(*uri), nullptr /* channel args */,
@@ -515,7 +516,7 @@ TEST_F(HttpRequestTest,
   memset(&req, 0, sizeof(req));
   auto uri = grpc_core::URI::Create("http", host, "/get", {} /* query params */,
                                     "" /* fragment */);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
       grpc_core::HttpRequest::Get(
           std::move(*uri), nullptr /* channel args */, pops(), &req,

--- a/test/core/http/httpcli_test_util.cc
+++ b/test/core/http/httpcli_test_util.cc
@@ -26,6 +26,7 @@
 #include "absl/types/optional.h"
 
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/string_util.h>
@@ -60,7 +61,7 @@ HttpRequestTestServer StartHttpRequestTestServer(int argc, char** argv,
   } else {
     root = gpr_strdup(".");
   }
-  GPR_ASSERT(argc <= 2);
+  CHECK_LE(argc, 2);
   if (argc == 2) {
     args.push_back(gpr_strdup(argv[1]));
   } else {
@@ -92,7 +93,7 @@ HttpRequestTestServer StartHttpRequestTestServer(int argc, char** argv,
   }
   gpr_subprocess* server =
       gpr_subprocess_create(args.size(), const_cast<const char**>(args.data()));
-  GPR_ASSERT(server);
+  CHECK(server);
   for (size_t i = 0; i < args.size(); i++) {
     gpr_free(args[i]);
   }

--- a/test/core/http/httpcli_test_util.cc
+++ b/test/core/http/httpcli_test_util.cc
@@ -22,11 +22,11 @@
 #include <string>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/strings/str_cat.h"
 #include "absl/types/optional.h"
 
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/string_util.h>

--- a/test/core/http/httpscli_test.cc
+++ b/test/core/http/httpscli_test.cc
@@ -36,6 +36,7 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
@@ -101,7 +102,7 @@ class HttpsCliTest : public ::testing::Test {
   void RunAndKick(const std::function<void()>& f) {
     grpc_core::MutexLockForGprMu lock(mu_);
     f();
-    GPR_ASSERT(GRPC_LOG_IF_ERROR(
+    CHECK(GRPC_LOG_IF_ERROR(
         "pollset_kick",
         grpc_pollset_kick(grpc_polling_entity_pollset(&pops_), nullptr)));
   }
@@ -109,9 +110,9 @@ class HttpsCliTest : public ::testing::Test {
   void PollUntil(const std::function<bool()>& predicate, absl::Time deadline) {
     gpr_mu_lock(mu_);
     while (!predicate()) {
-      GPR_ASSERT(absl::Now() < deadline);
+      CHECK(absl::Now() < deadline);
       grpc_pollset_worker* worker = nullptr;
-      GPR_ASSERT(GRPC_LOG_IF_ERROR(
+      CHECK(GRPC_LOG_IF_ERROR(
           "pollset_work", grpc_pollset_work(grpc_polling_entity_pollset(&pops_),
                                             &worker, NSecondsTime(1))));
       gpr_mu_unlock(mu_);
@@ -164,10 +165,10 @@ void OnFinish(void* arg, grpc_error_handle error) {
   grpc_http_response response = request_state->response;
   gpr_log(GPR_INFO, "response status=%d error=%s", response.status,
           grpc_core::StatusToString(error).c_str());
-  GPR_ASSERT(error.ok());
-  GPR_ASSERT(response.status == 200);
-  GPR_ASSERT(response.body_length == strlen(expect));
-  GPR_ASSERT(0 == memcmp(expect, response.body, response.body_length));
+  CHECK(error.ok());
+  CHECK_EQ(response.status, 200);
+  CHECK(response.body_length == strlen(expect));
+  CHECK_EQ(memcmp(expect, response.body, response.body_length), 0);
   request_state->test->RunAndKick(
       [request_state]() { request_state->done = true; });
 }
@@ -177,7 +178,7 @@ void OnFinishExpectFailure(void* arg, grpc_error_handle error) {
   grpc_http_response response = request_state->response;
   gpr_log(GPR_INFO, "response status=%d error=%s", response.status,
           grpc_core::StatusToString(error).c_str());
-  GPR_ASSERT(!error.ok());
+  CHECK(!error.ok());
   request_state->test->RunAndKick(
       [request_state]() { request_state->done = true; });
 }
@@ -195,7 +196,7 @@ TEST_F(HttpsCliTest, Get) {
   grpc_channel_args args = {1, &ssl_override_arg};
   auto uri = grpc_core::URI::Create("https", host, "/get",
                                     {} /* query params */, "" /* fragment */);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
       grpc_core::HttpRequest::Get(
           std::move(*uri), &args, pops(), &req, NSecondsTime(15),
@@ -223,7 +224,7 @@ TEST_F(HttpsCliTest, Post) {
   grpc_channel_args args = {1, &ssl_override_arg};
   auto uri = grpc_core::URI::Create("https", host, "/post",
                                     {} /* query params */, "" /* fragment */);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_core::OrphanablePtr<grpc_core::HttpRequest> http_request =
       grpc_core::HttpRequest::Post(
           std::move(*uri), &args /* channel args */, pops(), &req,

--- a/test/core/http/httpscli_test.cc
+++ b/test/core/http/httpscli_test.cc
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/time/clock.h"
@@ -36,7 +37,6 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -23,6 +23,7 @@ grpc_fuzzer(
     name = "json_fuzzer",
     srcs = ["fuzzer.cc"],
     corpus = "corpus",
+    external_deps = ["absl/log:check"],
     language = "C++",
     tags = ["no_windows"],
     deps = [

--- a/test/core/json/fuzzer.cc
+++ b/test/core/json/fuzzer.cc
@@ -19,11 +19,11 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/json.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/json/json_reader.h"

--- a/test/core/json/fuzzer.cc
+++ b/test/core/json/fuzzer.cc
@@ -23,6 +23,7 @@
 #include "absl/strings/string_view.h"
 
 #include <grpc/support/json.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/json/json_reader.h"
@@ -37,8 +38,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (json.ok()) {
     auto text2 = grpc_core::JsonDump(*json);
     auto json2 = grpc_core::JsonParse(text2);
-    GPR_ASSERT(json2.ok());
-    GPR_ASSERT(*json == *json2);
+    CHECK(json2.ok());
+    CHECK(*json == *json2);
   }
   return 0;
 }

--- a/test/core/load_balancing/BUILD
+++ b/test/core/load_balancing/BUILD
@@ -28,6 +28,7 @@ grpc_cc_library(
     testonly = True,
     hdrs = ["lb_policy_test_lib.h"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     language = "C++",
@@ -191,6 +192,7 @@ grpc_cc_test(
     srcs = ["static_stride_scheduler_benchmark.cc"],
     external_deps = [
         "absl/algorithm:container",
+        "absl/log:check",
         "benchmark",
     ],
     language = "C++",

--- a/test/core/load_balancing/lb_policy_test_lib.h
+++ b/test/core/load_balancing/lb_policy_test_lib.h
@@ -196,13 +196,13 @@ class LoadBalancingPolicyTest : public ::testing::Test {
         auto* w =
             static_cast<InternalSubchannelDataWatcherInterface*>(watcher.get());
         if (w->type() == OrcaProducer::Type()) {
-          CHECK_EQ(orca_watcher_, nullptr);
+          CHECK(orca_watcher_ == nullptr);
           orca_watcher_.reset(static_cast<OrcaWatcher*>(watcher.release()));
           state_->orca_watchers_.insert(orca_watcher_.get());
         } else if (w->type() == HealthProducer::Type()) {
           // TODO(roth): Support health checking in test framework.
           // For now, we just hard-code this to the raw connectivity state.
-          CHECK_EQ(health_watcher_, nullptr);
+          CHECK(health_watcher_ == nullptr);
           CHECK_EQ(health_watcher_wrapper_, nullptr);
           health_watcher_.reset(static_cast<HealthWatcher*>(watcher.release()));
           auto connectivity_watcher = health_watcher_->TakeWatcher();
@@ -730,7 +730,7 @@ class LoadBalancingPolicyTest : public ::testing::Test {
     lb_policy_ =
         CoreConfiguration::Get().lb_policy_registry().CreateLoadBalancingPolicy(
             lb_policy_name_, std::move(args));
-    CHECK_NE(lb_policy_, nullptr);
+    CHECK(lb_policy_ != nullptr);
   }
 
   void TearDown() override {

--- a/test/core/load_balancing/lb_policy_test_lib.h
+++ b/test/core/load_balancing/lb_policy_test_lib.h
@@ -35,6 +35,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/functional/any_invocable.h"
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
@@ -50,7 +51,6 @@
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 

--- a/test/core/load_balancing/lb_policy_test_lib.h
+++ b/test/core/load_balancing/lb_policy_test_lib.h
@@ -50,6 +50,7 @@
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
@@ -195,14 +196,14 @@ class LoadBalancingPolicyTest : public ::testing::Test {
         auto* w =
             static_cast<InternalSubchannelDataWatcherInterface*>(watcher.get());
         if (w->type() == OrcaProducer::Type()) {
-          GPR_ASSERT(orca_watcher_ == nullptr);
+          CHECK_EQ(orca_watcher_, nullptr);
           orca_watcher_.reset(static_cast<OrcaWatcher*>(watcher.release()));
           state_->orca_watchers_.insert(orca_watcher_.get());
         } else if (w->type() == HealthProducer::Type()) {
           // TODO(roth): Support health checking in test framework.
           // For now, we just hard-code this to the raw connectivity state.
-          GPR_ASSERT(health_watcher_ == nullptr);
-          GPR_ASSERT(health_watcher_wrapper_ == nullptr);
+          CHECK_EQ(health_watcher_, nullptr);
+          CHECK_EQ(health_watcher_wrapper_, nullptr);
           health_watcher_.reset(static_cast<HealthWatcher*>(watcher.release()));
           auto connectivity_watcher = health_watcher_->TakeWatcher();
           auto* connectivity_watcher_ptr = connectivity_watcher.get();
@@ -562,7 +563,7 @@ class LoadBalancingPolicyTest : public ::testing::Test {
       auto it = test_->subchannel_pool_.find(key);
       if (it == test_->subchannel_pool_.end()) {
         auto address_uri = grpc_sockaddr_to_uri(&address);
-        GPR_ASSERT(address_uri.ok());
+        CHECK(address_uri.ok());
         it = test_->subchannel_pool_
                  .emplace(std::piecewise_construct, std::forward_as_tuple(key),
                           std::forward_as_tuple(std::move(*address_uri), test_))
@@ -729,7 +730,7 @@ class LoadBalancingPolicyTest : public ::testing::Test {
     lb_policy_ =
         CoreConfiguration::Get().lb_policy_registry().CreateLoadBalancingPolicy(
             lb_policy_name_, std::move(args));
-    GPR_ASSERT(lb_policy_ != nullptr);
+    CHECK_NE(lb_policy_, nullptr);
   }
 
   void TearDown() override {
@@ -757,7 +758,7 @@ class LoadBalancingPolicyTest : public ::testing::Test {
   }
 
   LoadBalancingPolicy* lb_policy() const {
-    GPR_ASSERT(lb_policy_ != nullptr);
+    CHECK_NE(lb_policy_, nullptr);
     return lb_policy_.get();
   }
 
@@ -776,9 +777,9 @@ class LoadBalancingPolicyTest : public ::testing::Test {
   // Converts an address URI into a grpc_resolved_address.
   static grpc_resolved_address MakeAddress(absl::string_view address_uri) {
     auto uri = URI::Parse(address_uri);
-    GPR_ASSERT(uri.ok());
+    CHECK(uri.ok());
     grpc_resolved_address address;
-    GPR_ASSERT(grpc_parse_uri(*uri, &address));
+    CHECK(grpc_parse_uri(*uri, &address));
     return address;
   }
 
@@ -1222,7 +1223,7 @@ class LoadBalancingPolicyTest : public ::testing::Test {
   RefCountedPtr<LoadBalancingPolicy::SubchannelPicker> ExpectRoundRobinStartup(
       absl::Span<const EndpointAddresses> endpoints,
       SourceLocation location = SourceLocation()) {
-    GPR_ASSERT(!endpoints.empty());
+    CHECK(!endpoints.empty());
     // There should be a subchannel for every address.
     // We will wind up connecting to the first address for every endpoint.
     std::vector<std::vector<SubchannelState*>> endpoint_subchannels;

--- a/test/core/load_balancing/lb_policy_test_lib.h
+++ b/test/core/load_balancing/lb_policy_test_lib.h
@@ -758,7 +758,7 @@ class LoadBalancingPolicyTest : public ::testing::Test {
   }
 
   LoadBalancingPolicy* lb_policy() const {
-    CHECK_NE(lb_policy_, nullptr);
+    CHECK(lb_policy_ != nullptr);
     return lb_policy_.get();
   }
 

--- a/test/core/load_balancing/static_stride_scheduler_benchmark.cc
+++ b/test/core/load_balancing/static_stride_scheduler_benchmark.cc
@@ -26,6 +26,7 @@
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/no_destruct.h"
@@ -62,7 +63,7 @@ void BM_StaticStrideSchedulerPickNonAtomic(benchmark::State& state) {
       StaticStrideScheduler::Make(
           absl::MakeSpan(Weights()).subspan(0, state.range(0)),
           [&] { return sequence++; });
-  GPR_ASSERT(scheduler.has_value());
+  CHECK(scheduler.has_value());
   for (auto s : state) {
     benchmark::DoNotOptimize(scheduler->Pick());
   }
@@ -77,7 +78,7 @@ void BM_StaticStrideSchedulerPickAtomic(benchmark::State& state) {
       StaticStrideScheduler::Make(
           absl::MakeSpan(Weights()).subspan(0, state.range(0)),
           [&] { return sequence.fetch_add(1, std::memory_order_relaxed); });
-  GPR_ASSERT(scheduler.has_value());
+  CHECK(scheduler.has_value());
   for (auto s : state) {
     benchmark::DoNotOptimize(scheduler->Pick());
   }
@@ -93,7 +94,7 @@ void BM_StaticStrideSchedulerMake(benchmark::State& state) {
         StaticStrideScheduler::Make(
             absl::MakeSpan(Weights()).subspan(0, state.range(0)),
             [&] { return sequence++; });
-    GPR_ASSERT(scheduler.has_value());
+    CHECK(scheduler.has_value());
   }
 }
 BENCHMARK(BM_StaticStrideSchedulerMake)

--- a/test/core/load_balancing/static_stride_scheduler_benchmark.cc
+++ b/test/core/load_balancing/static_stride_scheduler_benchmark.cc
@@ -22,11 +22,11 @@
 #include <benchmark/benchmark.h>
 
 #include "absl/algorithm/container.h"
+#include "absl/log/check.h"
 #include "absl/random/random.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
 
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/no_destruct.h"

--- a/test/core/network_benchmarks/BUILD
+++ b/test/core/network_benchmarks/BUILD
@@ -27,6 +27,7 @@ licenses(["notice"])
 grpc_cc_binary(
     name = "low_level_ping_pong",
     srcs = ["low_level_ping_pong.cc"],
+    external_deps = ["absl/log:check"],
     language = "C++",
     tags = ["no_windows"],
     deps = [

--- a/test/core/network_benchmarks/low_level_ping_pong.cc
+++ b/test/core/network_benchmarks/low_level_ping_pong.cc
@@ -36,6 +36,7 @@
 #include <sys/socket.h>
 
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
@@ -122,8 +123,8 @@ static int poll_read_bytes(int fd, char* buf, size_t read_size, int spin) {
       }
     }
     if (err == 0 && spin) continue;
-    GPR_ASSERT(err == 1);
-    GPR_ASSERT(pfd.revents == POLLIN);
+    CHECK_EQ(err, 1);
+    CHECK(pfd.revents == POLLIN);
     do {
       err2 = read(fd, buf + bytes_read, read_size - bytes_read);
     } while (err2 < 0 && errno == EINTR);
@@ -162,9 +163,9 @@ static int epoll_read_bytes(struct thread_args* args, char* buf, int spin) {
       return -1;
     }
     if (err == 0 && spin) continue;
-    GPR_ASSERT(err == 1);
-    GPR_ASSERT(ev.events & EPOLLIN);
-    GPR_ASSERT(ev.data.fd == args->fds.read_fd);
+    CHECK_EQ(err, 1);
+    CHECK(ev.events & EPOLLIN);
+    CHECK(ev.data.fd == args->fds.read_fd);
     do {
       do {
         err2 =
@@ -176,7 +177,7 @@ static int epoll_read_bytes(struct thread_args* args, char* buf, int spin) {
       // done to ensure we see an EAGAIN
     } while (bytes_read < read_size);
   } while (bytes_read < read_size);
-  GPR_ASSERT(bytes_read == read_size);
+  CHECK(bytes_read == read_size);
   return 0;
 }
 

--- a/test/core/network_benchmarks/low_level_ping_pong.cc
+++ b/test/core/network_benchmarks/low_level_ping_pong.cc
@@ -35,8 +35,9 @@
 #endif
 #include <sys/socket.h>
 
-#include <grpc/support/alloc.h>
 #include "absl/log/check.h"
+
+#include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -519,6 +519,7 @@ grpc_proto_fuzzer(
     corpus = "promise_fuzzer_corpus",
     external_deps = [
         "absl/functional:any_invocable",
+        "absl/log:check",
         "absl/status",
         "absl/types:optional",
     ],

--- a/test/core/promise/promise_fuzzer.cc
+++ b/test/core/promise/promise_fuzzer.cc
@@ -20,10 +20,10 @@
 #include <vector>
 
 #include "absl/functional/any_invocable.h"
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/types/optional.h"
 
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/promise/activity.h"
@@ -128,8 +128,7 @@ class Fuzzer {
       explicit BoundScheduler(Scheduler scheduler)
           : fuzzer_(scheduler.fuzzer) {}
       void ScheduleWakeup() {
-        CHECK(static_cast<ActivityType*>(this) ==
-                   fuzzer_->activity_.get());
+        CHECK(static_cast<ActivityType*>(this) == fuzzer_->activity_.get());
         CHECK_EQ(fuzzer_->wakeup_, nullptr);
         fuzzer_->wakeup_ = [this]() {
           static_cast<ActivityType*>(this)->RunScheduledWakeup();

--- a/test/core/promise/promise_fuzzer.cc
+++ b/test/core/promise/promise_fuzzer.cc
@@ -129,7 +129,7 @@ class Fuzzer {
           : fuzzer_(scheduler.fuzzer) {}
       void ScheduleWakeup() {
         CHECK(static_cast<ActivityType*>(this) == fuzzer_->activity_.get());
-        CHECK_EQ(fuzzer_->wakeup_, nullptr);
+        CHECK(fuzzer_->wakeup_ == nullptr);
         fuzzer_->wakeup_ = [this]() {
           static_cast<ActivityType*>(this)->RunScheduledWakeup();
         };

--- a/test/core/promise/promise_fuzzer.cc
+++ b/test/core/promise/promise_fuzzer.cc
@@ -23,6 +23,7 @@
 #include "absl/status/status.h"
 #include "absl/types/optional.h"
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/promise/activity.h"
@@ -64,10 +65,10 @@ class Fuzzer {
         Scheduler{this},
         [this](absl::Status status) {
           // Must only be called once
-          GPR_ASSERT(!done_);
+          CHECK(!done_);
           // If we became certain of the eventual status, verify it.
           if (expected_status_.has_value()) {
-            GPR_ASSERT(status == *expected_status_);
+            CHECK(status == *expected_status_);
           }
           // Mark ourselves done.
           done_ = true;
@@ -114,7 +115,7 @@ class Fuzzer {
     ExpectCancelled();
     activity_.reset();
     if (wakeup_ != nullptr) std::exchange(wakeup_, nullptr)();
-    GPR_ASSERT(done_);
+    CHECK(done_);
   }
 
  private:
@@ -127,9 +128,9 @@ class Fuzzer {
       explicit BoundScheduler(Scheduler scheduler)
           : fuzzer_(scheduler.fuzzer) {}
       void ScheduleWakeup() {
-        GPR_ASSERT(static_cast<ActivityType*>(this) ==
+        CHECK(static_cast<ActivityType*>(this) ==
                    fuzzer_->activity_.get());
-        GPR_ASSERT(fuzzer_->wakeup_ == nullptr);
+        CHECK_EQ(fuzzer_->wakeup_, nullptr);
         fuzzer_->wakeup_ = [this]() {
           static_cast<ActivityType*>(this)->RunScheduledWakeup();
         };

--- a/test/core/resolver/BUILD
+++ b/test/core/resolver/BUILD
@@ -21,7 +21,10 @@ licenses(["notice"])
 grpc_cc_test(
     name = "endpoint_addresses_test",
     srcs = ["endpoint_addresses_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,

--- a/test/core/resolver/endpoint_addresses_test.cc
+++ b/test/core/resolver/endpoint_addresses_test.cc
@@ -23,6 +23,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
@@ -38,9 +39,9 @@ namespace {
 
 grpc_resolved_address MakeAddress(absl::string_view address_uri) {
   auto uri = URI::Parse(address_uri);
-  GPR_ASSERT(uri.ok());
+  CHECK(uri.ok());
   grpc_resolved_address address;
-  GPR_ASSERT(grpc_parse_uri(*uri, &address));
+  CHECK(grpc_parse_uri(*uri, &address));
   return address;
 }
 

--- a/test/core/resolver/endpoint_addresses_test.cc
+++ b/test/core/resolver/endpoint_addresses_test.cc
@@ -18,12 +18,12 @@
 
 #include <set>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 

--- a/test/core/resource_quota/BUILD
+++ b/test/core/resource_quota/BUILD
@@ -46,6 +46,7 @@ grpc_cc_library(
     name = "call_checker",
     testonly = True,
     hdrs = ["call_checker.h"],
+    external_deps = ["absl/log:check"],
     language = "c++",
     deps = ["//:gpr"],
 )

--- a/test/core/resource_quota/call_checker.h
+++ b/test/core/resource_quota/call_checker.h
@@ -17,6 +17,7 @@
 
 #include <memory>
 
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 namespace grpc_core {
@@ -33,11 +34,11 @@ class CallChecker {
  public:
   explicit CallChecker(bool optional) : optional_(optional) {}
   ~CallChecker() {
-    if (!optional_) GPR_ASSERT(called_);
+    if (!optional_) CHECK(called_);
   }
 
   void Called() {
-    GPR_ASSERT(!called_);
+    CHECK(!called_);
     called_ = true;
   }
 

--- a/test/core/resource_quota/call_checker.h
+++ b/test/core/resource_quota/call_checker.h
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "absl/log/check.h"
+
 #include <grpc/support/log.h>
 
 namespace grpc_core {

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -23,6 +23,7 @@ grpc_fuzzer(
     name = "percent_encode_fuzzer",
     srcs = ["percent_encode_fuzzer.cc"],
     corpus = "percent_encode_corpus",
+    external_deps = ["absl/log:check"],
     language = "C++",
     tags = ["no_windows"],
     deps = [
@@ -93,7 +94,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "slice_buffer_test",
     srcs = ["slice_buffer_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:check",
+        "gtest",
+    ],
     uses_event_engine = False,
     uses_polling = False,
     deps = [

--- a/test/core/slice/percent_encode_fuzzer.cc
+++ b/test/core/slice/percent_encode_fuzzer.cc
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include <grpc/grpc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 
 #include "src/core/lib/slice/percent_encoding.h"
@@ -39,7 +40,7 @@ static void test(const uint8_t* data, size_t size,
   auto permissive_decoded_output =
       grpc_core::PermissivePercentDecodeSlice(std::move(output));
   // decoded output must always match the input
-  GPR_ASSERT(input == permissive_decoded_output);
+  CHECK(input == permissive_decoded_output);
   grpc_shutdown();
 }
 

--- a/test/core/slice/percent_encode_fuzzer.cc
+++ b/test/core/slice/percent_encode_fuzzer.cc
@@ -21,8 +21,9 @@
 
 #include <utility>
 
-#include <grpc/grpc.h>
 #include "absl/log/check.h"
+
+#include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
 #include "src/core/lib/slice/percent_encoding.h"

--- a/test/core/slice/slice_buffer_test.cc
+++ b/test/core/slice/slice_buffer_test.cc
@@ -23,6 +23,7 @@
 
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
+#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
@@ -34,7 +35,7 @@ using ::grpc_core::SliceBuffer;
 static constexpr int kNewSliceLength = 100;
 
 Slice MakeSlice(size_t len) {
-  GPR_ASSERT(len > 0);
+  CHECK_GT(len, 0);
   unsigned char* contents = static_cast<unsigned char*>(gpr_malloc(len));
   memset(contents, 'a', len);
   return Slice(grpc_slice_new(contents, len, gpr_free));

--- a/test/core/slice/slice_buffer_test.cc
+++ b/test/core/slice/slice_buffer_test.cc
@@ -19,11 +19,11 @@
 #include <memory>
 #include <utility>
 
+#include "absl/log/check.h"
 #include "gtest/gtest.h"
 
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
-#include "absl/log/check.h"
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging GPR_ASSERT
Replacing GPR_ASSERT with absl CHECK.
These changes have been made using string replacement and regex.
Will not be replacing all instances of CHECK with CHECK_EQ , CHECK_NE etc because there are too many callsites. Only ones which are doable using very simple regex with least chance of failure will be replaced.
Given that we have 5000+ instances of GPR_ASSERT to edit, Doing it manually is too much work for both the author and reviewer.


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

