### PR TITLE
Optionally crash benchmark QPS client worker if it fails to connect to the server target.

### DIFF
--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -400,7 +400,8 @@ std::unique_ptr<ScenarioResult> RunScenario(
     char addr[256];
     // we use port # of -1 to indicate inproc
     int driver_port = (!run_inproc) ? grpc_pick_unused_port_or_die() : -1;
-    local_workers.emplace_back(new QpsWorker(driver_port, 0, credential_type));
+    local_workers.emplace_back(
+        new QpsWorker(driver_port, 0, credential_type));
     sprintf(addr, "localhost:%d", driver_port);
     if (spawn_local_worker_count < 0) {
       workers.push_front(addr);

--- a/test/cpp/qps/qps_worker.h
+++ b/test/cpp/qps/qps_worker.h
@@ -39,11 +39,13 @@ extern std::vector<grpc::testing::Server*>* g_inproc_servers;
 class QpsWorker {
  public:
   explicit QpsWorker(int driver_port, int server_port,
-                     const std::string& credential_type);
+                     const std::string& credential_type,
+                     bool die_on_connection_failure = true);
   ~QpsWorker();
 
   bool Done() const;
   void MarkDone();
+  bool die_on_connection_failure() const;
 
   std::shared_ptr<Channel> InProcessChannel(const ChannelArguments& args) {
     return server_->InProcessChannel(args);
@@ -52,6 +54,7 @@ class QpsWorker {
  private:
   std::unique_ptr<WorkerServiceImpl> impl_;
   std::unique_ptr<grpc::Server> server_;
+  const bool die_on_connection_failure_;
 
   gpr_atm done_;
 };

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -38,6 +38,9 @@ ABSL_FLAG(int32_t, server_port, 0,
           "config message");
 ABSL_FLAG(std::string, credential_type, grpc::testing::kInsecureCredentialsType,
           "Credential type for communication with driver");
+ABSL_FLAG(bool, die_on_connection_failure, true,
+          "Whether the worker should crash if it cannot connect to the server "
+          "while operating as a client.");
 
 static bool got_sigint = false;
 
@@ -51,7 +54,8 @@ std::vector<grpc::testing::Server*>* g_inproc_servers = nullptr;
 static void RunServer() {
   QpsWorker worker(absl::GetFlag(FLAGS_driver_port),
                    absl::GetFlag(FLAGS_server_port),
-                   absl::GetFlag(FLAGS_credential_type));
+                   absl::GetFlag(FLAGS_credential_type),
+                   absl::GetFlag(FLAGS_die_on_connection_failure));
 
   while (!got_sigint && !worker.Done()) {
     gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),


### PR DESCRIPTION
By default, the QPS worker will crash if it cannot connect to the server target while operating as a client.

When explicitly set to false, the `die_on_connection_failure` flag (true by default) will keep the QPS worker process running if it fails to connect to the server target. Instead of dying, the QPS worker will finish the client threads, cancel the context to end the benchmark run and terminate the QPS JSON driver, and revert to the idle state of waiting for a `RunClient` or `RunServer` invocation.

This is useful in benchmark setups where runs are invoked continuously on long-lived QPS worker processes, reducing spurious worker deaths and the need for manual restarts due to transient connectivity failures.

CC: @apolcyn 
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

