### PR TITLE
[EventEngine] Rewrite mock_endpoint to EventEngine::Endpoint

### DIFF
--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -400,7 +400,7 @@ namespace testing {
 
 ApiFuzzer::ApiFuzzer(const fuzzing_event_engine::Actions& actions)
     : BasicFuzzer(actions) {
-  ResetDNSResolver(std::make_unique<FuzzerDNSResolver>(engine()));
+  ResetDNSResolver(std::make_unique<FuzzerDNSResolver>(engine().get()));
   grpc_dns_lookup_hostname_ares = my_dns_lookup_ares;
   grpc_cancel_ares_request = my_cancel_ares_request;
 

--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -60,7 +60,7 @@ class ClientFuzzer final : public BasicFuzzer {
       : BasicFuzzer(msg.event_engine_actions()) {
     ExecCtx exec_ctx;
     UpdateMinimumRunTime(
-        ScheduleReads(msg.network_input()[0], mock_endpoint_, engine()));
+        ScheduleReads(msg.network_input()[0], mock_endpoint_, engine().get()));
     ChannelArgs args =
         CoreConfiguration::Get()
             .channel_args_preconditioning()
@@ -92,7 +92,7 @@ class ClientFuzzer final : public BasicFuzzer {
   grpc_server* server() override { return nullptr; }
   grpc_channel* channel() override { return channel_; }
 
-  grpc_endpoint* mock_endpoint_ = grpc_mock_endpoint_create(discard_write);
+  grpc_endpoint* mock_endpoint_ = grpc_mock_endpoint_create(engine());
   grpc_channel* channel_ = nullptr;
 };
 

--- a/test/core/end2end/fuzzers/fuzzing_common.h
+++ b/test/core/end2end/fuzzers/fuzzing_common.h
@@ -111,8 +111,9 @@ class BasicFuzzer {
 
   RefCountedPtr<ResourceQuota> resource_quota() { return resource_quota_; }
 
-  grpc_event_engine::experimental::FuzzingEventEngine* engine() {
-    return engine_.get();
+  std::shared_ptr<grpc_event_engine::experimental::FuzzingEventEngine>
+  engine() {
+    return engine_;
   }
 
   grpc_completion_queue* cq() { return cq_; }

--- a/test/core/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/end2end/fuzzers/server_fuzzer.cc
@@ -63,7 +63,7 @@ class ServerFuzzer final : public BasicFuzzer {
     grpc_server_start(server_);
     for (const auto& input : msg.network_input()) {
       UpdateMinimumRunTime(ScheduleConnection(
-          input, engine(), FuzzingEnvironment{resource_quota()}, 1234));
+          input, engine().get(), FuzzingEnvironment{resource_quota()}, 1234));
     }
   }
 

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -67,7 +67,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   {
     grpc_core::ExecCtx exec_ctx;
 
-    grpc_endpoint* mock_endpoint = grpc_mock_endpoint_create(discard_write);
+    auto engine = GetDefaultEventEngine();
+    grpc_endpoint* mock_endpoint = grpc_mock_endpoint_create(engine);
 
     grpc_mock_endpoint_put_read(
         mock_endpoint, grpc_slice_from_copied_buffer((const char*)data, size));
@@ -95,8 +96,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     state.done_callback_called = false;
     auto handshake_mgr =
         grpc_core::MakeRefCounted<grpc_core::HandshakeManager>();
-    auto channel_args = grpc_core::ChannelArgs().SetObject<EventEngine>(
-        GetDefaultEventEngine());
+    auto channel_args =
+        grpc_core::ChannelArgs().SetObject<EventEngine>(std::move(engine));
     sc->add_handshakers(channel_args, nullptr, handshake_mgr.get());
     handshake_mgr->DoHandshake(mock_endpoint, channel_args, deadline,
                                nullptr /* acceptor */, on_handshake_done,

--- a/test/core/test_util/mock_endpoint.cc
+++ b/test/core/test_util/mock_endpoint.cc
@@ -76,6 +76,7 @@ bool MockEndpoint::Read(absl::AnyInvocable<void(absl::Status)> on_read,
   grpc_core::MutexLock lock(&mu_);
   if (read_buffer_.Count() > 0) {
     CHECK(buffer->Count() == 0);
+    CHECK(!on_read_);
     read_buffer_.Swap(*buffer);
     engine_->Run([cb = std::move(on_read)]() mutable { cb(absl::OkStatus()); });
   } else if (reads_done_) {

--- a/test/core/transport/chttp2/ping_configuration_test.cc
+++ b/test/core/transport/chttp2/ping_configuration_test.cc
@@ -41,18 +41,15 @@ namespace {
 class ConfigurationTest : public ::testing::Test {
  protected:
   ConfigurationTest() {
-    mock_endpoint_ = grpc_mock_endpoint_create(DiscardWrite);
+    auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
+    mock_endpoint_ = grpc_mock_endpoint_create(engine);
     grpc_mock_endpoint_finish_put_reads(mock_endpoint_);
     args_ = args_.SetObject(ResourceQuota::Default());
-    args_ = args_.SetObject(
-        grpc_event_engine::experimental::GetDefaultEventEngine());
+    args_ = args_.SetObject(std::move(engine));
   }
 
   grpc_endpoint* mock_endpoint_ = nullptr;
   ChannelArgs args_;
-
- private:
-  static void DiscardWrite(grpc_slice /*slice*/) {}
 };
 
 TEST_F(ConfigurationTest, ClientKeepaliveDefaults) {


### PR DESCRIPTION
Notes:
* The special `on_write` callback was never used, all slices were discarded. I removed that functionality.