### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -78,6 +78,7 @@ grpc_cc_library(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "protobuf",
     ],
     deps = [

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -45,6 +45,7 @@ grpc_cc_library(
     hdrs = [
         "proto_reflection_descriptor_database.h",
     ],
+    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc++",
         "//:grpc++_config_proto",
@@ -142,6 +143,7 @@ grpc_cc_library(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "protobuf",
         "protobuf_clib",
     ],
@@ -176,6 +178,7 @@ grpc_cc_library(
     hdrs = [
         "metrics_server.h",
     ],
+    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc++",
         "//src/proto/grpc/testing:metrics_proto",
@@ -339,6 +342,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
     ],
     language = "c++",
@@ -365,6 +369,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,

--- a/test/cpp/util/channelz_sampler.cc
+++ b/test/cpp/util/channelz_sampler.cc
@@ -28,6 +28,7 @@
 
 #include "absl/flags/flag.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "google/protobuf/text_format.h"
@@ -133,8 +134,8 @@ class ChannelzSampler final {
     Status status = channelz_stub_->GetChannel(
         &get_channel_context, get_channel_request, &get_channel_response);
     if (!status.ok()) {
-      gpr_log(GPR_ERROR, "GetChannelRPC failed: %s",
-              get_channel_context.debug_error_string().c_str());
+      LOG(ERROR) << "GetChannelRPC failed: "
+                 << get_channel_context.debug_error_string();
       CHECK(0);
     }
     return get_channel_response.channel();
@@ -152,8 +153,8 @@ class ChannelzSampler final {
                                                   get_subchannel_request,
                                                   &get_subchannel_response);
     if (!status.ok()) {
-      gpr_log(GPR_ERROR, "GetSubchannelRPC failed: %s",
-              get_subchannel_context.debug_error_string().c_str());
+      LOG(ERROR) << "GetSubchannelRPC failed: "
+                 << get_subchannel_context.debug_error_string();
       CHECK(0);
     }
     return get_subchannel_response.subchannel();
@@ -170,8 +171,8 @@ class ChannelzSampler final {
     Status status = channelz_stub_->GetSocket(
         &get_socket_context, get_socket_request, &get_socket_response);
     if (!status.ok()) {
-      gpr_log(GPR_ERROR, "GetSocketRPC failed: %s",
-              get_socket_context.debug_error_string().c_str());
+      LOG(ERROR) << "GetSocketRPC failed: "
+                 << get_socket_context.debug_error_string();
       CHECK(0);
     }
     return get_socket_response.socket();
@@ -297,10 +298,9 @@ class ChannelzSampler final {
         grpc::testing::GetCredentialsProvider()->GetChannelCredentials(
             custom_credentials_type, &channel_args);
     if (!channel_creds) {
-      gpr_log(GPR_ERROR,
-              "Wrong user credential type: %s. Allowed credential types: "
-              "INSECURE_CREDENTIALS, ssl, alts, google_default_credentials.",
-              custom_credentials_type.c_str());
+      LOG(ERROR) << "Wrong user credential type: " << custom_credentials_type
+                 << ". Allowed credential types: INSECURE_CREDENTIALS, ssl, "
+                    "alts, google_default_credentials.";
       CHECK(0);
     }
     std::shared_ptr<grpc::Channel> channel =
@@ -324,15 +324,14 @@ class ChannelzSampler final {
           &get_servers_context, get_servers_request, &get_servers_response);
       if (!status.ok()) {
         if (status.error_code() == StatusCode::UNIMPLEMENTED) {
-          gpr_log(GPR_ERROR,
-                  "Error status UNIMPLEMENTED. Please check and make sure "
-                  "channelz has been registered on the server being queried.");
+          LOG(ERROR) << "Error status UNIMPLEMENTED. Please check and make "
+                        "sure channelz has been registered on the server being "
+                        "queried.";
         } else {
-          gpr_log(GPR_ERROR,
-                  "GetServers RPC with GetServersRequest.server_start_id=%d, "
-                  "failed: %s",
-                  static_cast<int>(server_start_id),
-                  get_servers_context.debug_error_string().c_str());
+          LOG(ERROR) << "GetServers RPC with "
+                        "GetServersRequest.server_start_id="
+                     << server_start_id << ", failed: "
+                     << get_servers_context.debug_error_string();
         }
         CHECK(0);
       }
@@ -384,11 +383,10 @@ class ChannelzSampler final {
           &get_top_channels_context, get_top_channels_request,
           &get_top_channels_response);
       if (!status.ok()) {
-        gpr_log(GPR_ERROR,
-                "GetTopChannels RPC with "
-                "GetTopChannelsRequest.channel_start_id=%d failed: %s",
-                static_cast<int>(channel_start_id),
-                get_top_channels_context.debug_error_string().c_str());
+        LOG(ERROR) << "GetTopChannels RPC with "
+                      "GetTopChannelsRequest.channel_start_id="
+                   << channel_start_id << " failed: "
+                   << get_top_channels_context.debug_error_string();
         CHECK(0);
       }
       for (const auto& _topchannel : get_top_channels_response.channel()) {

--- a/test/cpp/util/channelz_sampler_test.cc
+++ b/test/cpp/util/channelz_sampler_test.cc
@@ -25,6 +25,7 @@
 #include <thread>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
@@ -85,7 +86,7 @@ void RunClient(const std::string& client_id, gpr_event* done_ev) {
   std::unique_ptr<grpc::testing::TestService::Stub> stub =
       grpc::testing::TestService::NewStub(
           grpc::CreateChannel(server_address, channel_creds));
-  gpr_log(GPR_INFO, "Client %s is echoing!", client_id.c_str());
+  LOG(INFO) << "Client " << client_id << " is echoing!";
   while (true) {
     if (gpr_event_wait(done_ev, grpc_timeout_seconds_to_deadline(1)) !=
         nullptr) {
@@ -96,7 +97,7 @@ void RunClient(const std::string& client_id, gpr_event* done_ev) {
     ClientContext context;
     Status status = stub->EmptyCall(&context, request, &response);
     if (!status.ok()) {
-      gpr_log(GPR_ERROR, "Client echo failed.");
+      LOG(ERROR) << "Client echo failed.";
       CHECK(0);
     }
   }
@@ -125,7 +126,7 @@ TEST(ChannelzSamplerTest, SimpleTest) {
   builder.AddListeningPort(server_address, server_creds);
   builder.RegisterService(&service);
   std::unique_ptr<Server> server(builder.BuildAndStart());
-  gpr_log(GPR_INFO, "Server listening on %s", server_address.c_str());
+  LOG(INFO) << "Server listening on " << server_address;
   const int kWaitForServerSeconds = 10;
   ASSERT_TRUE(WaitForConnection(kWaitForServerSeconds));
   // client threads
@@ -144,19 +145,17 @@ TEST(ChannelzSamplerTest, SimpleTest) {
   int status = test_driver->Join();
   if (WIFEXITED(status)) {
     if (WEXITSTATUS(status)) {
-      gpr_log(GPR_ERROR,
-              "Channelz sampler test test-runner exited with code %d",
-              WEXITSTATUS(status));
+      LOG(ERROR) << "Channelz sampler test test-runner exited with code "
+                 << WEXITSTATUS(status);
       CHECK(0);  // log the line number of the assertion failure
     }
   } else if (WIFSIGNALED(status)) {
-    gpr_log(GPR_ERROR, "Channelz sampler test test-runner ended from signal %d",
-            WTERMSIG(status));
+    LOG(ERROR) << "Channelz sampler test test-runner ended from signal "
+               << WTERMSIG(status);
     CHECK(0);
   } else {
-    gpr_log(GPR_ERROR,
-            "Channelz sampler test test-runner ended with unknown status %d",
-            status);
+    LOG(ERROR) << "Channelz sampler test test-runner ended with unknown status "
+               << status;
     CHECK(0);
   }
   delete test_driver;

--- a/test/cpp/util/cli_credentials.cc
+++ b/test/cpp/util/cli_credentials.cc
@@ -19,6 +19,7 @@
 #include "test/cpp/util/cli_credentials.h"
 
 #include "absl/flags/flag.h"
+#include "absl/log/log.h"
 
 #include <grpc/slice.h>
 #include <grpc/support/log.h>
@@ -97,9 +98,9 @@ CliCredentials::GetChannelCredentials() const {
       auto cert = grpc_core::LoadFile(absl::GetFlag(FLAGS_ssl_client_cert),
                                       /*add_null_terminator=*/false);
       if (!cert.ok()) {
-        gpr_log(GPR_ERROR, "error loading file %s: %s",
-                absl::GetFlag(FLAGS_ssl_client_cert).c_str(),
-                cert.status().ToString().c_str());
+        LOG(ERROR) << "error loading file "
+                   << absl::GetFlag(FLAGS_ssl_client_cert) << ": "
+                   << cert.status();
       } else {
         ssl_creds_options.pem_cert_chain = std::string(cert->as_string_view());
       }
@@ -108,9 +109,9 @@ CliCredentials::GetChannelCredentials() const {
       auto key = grpc_core::LoadFile(absl::GetFlag(FLAGS_ssl_client_key),
                                      /*add_null_terminator=*/false);
       if (!key.ok()) {
-        gpr_log(GPR_ERROR, "error loading file %s: %s",
-                absl::GetFlag(FLAGS_ssl_client_key).c_str(),
-                key.status().ToString().c_str());
+        LOG(ERROR) << "error loading file "
+                   << absl::GetFlag(FLAGS_ssl_client_key) << ": "
+                   << key.status();
       } else {
         ssl_creds_options.pem_private_key = std::string(key->as_string_view());
       }

--- a/test/cpp/util/metrics_server.cc
+++ b/test/cpp/util/metrics_server.cc
@@ -18,6 +18,8 @@
 
 #include "test/cpp/util/metrics_server.h"
 
+#include "absl/log/log.h"
+
 #include <grpc/support/log.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
@@ -54,7 +56,7 @@ long QpsGauge::Get() {
 grpc::Status MetricsServiceImpl::GetAllGauges(
     ServerContext* /*context*/, const EmptyMessage* /*request*/,
     ServerWriter<GaugeResponse>* writer) {
-  gpr_log(GPR_DEBUG, "GetAllGauges called");
+  VLOG(2) << "GetAllGauges called";
 
   std::lock_guard<std::mutex> lock(mu_);
   for (auto it = qps_gauges_.begin(); it != qps_gauges_.end(); it++) {
@@ -99,7 +101,7 @@ std::shared_ptr<QpsGauge> MetricsServiceImpl::CreateQpsGauge(
 // Starts the metrics server and returns the grpc::Server instance. Call Wait()
 // on the returned server instance.
 std::unique_ptr<grpc::Server> MetricsServiceImpl::StartServer(int port) {
-  gpr_log(GPR_INFO, "Building metrics server..");
+  LOG(INFO) << "Building metrics server..";
 
   const std::string address = "0.0.0.0:" + std::to_string(port);
 
@@ -108,8 +110,8 @@ std::unique_ptr<grpc::Server> MetricsServiceImpl::StartServer(int port) {
   builder.RegisterService(this);
 
   std::unique_ptr<grpc::Server> server(builder.BuildAndStart());
-  gpr_log(GPR_INFO, "Metrics server %s started. Ready to receive requests..",
-          address.c_str());
+  LOG(INFO) << "Metrics server " << address
+            << " started. Ready to receive requests..";
 
   return server;
 }

--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -22,6 +22,8 @@
 
 #include "absl/log/log.h"
 
+#include "src/core/lib/gprpp/crash.h"
+
 using grpc::reflection::v1alpha::ErrorResponse;
 using grpc::reflection::v1alpha::ListServiceResponse;
 using grpc::reflection::v1alpha::ServerReflection;

--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -20,9 +20,7 @@
 
 #include <vector>
 
-#include <grpc/support/log.h>
-
-#include "src/core/lib/gprpp/crash.h"
+#include "absl/log/log.h"
 
 using grpc::reflection::v1alpha::ErrorResponse;
 using grpc::reflection::v1alpha::ListServiceResponse;
@@ -86,23 +84,19 @@ bool ProtoReflectionDescriptorDatabase::FindFileByName(
              ServerReflectionResponse::MessageResponseCase::kErrorResponse) {
     const ErrorResponse& error = response.error_response();
     if (error.error_code() == StatusCode::NOT_FOUND) {
-      gpr_log(GPR_INFO, "NOT_FOUND from server for FindFileByName(%s)",
-              filename.c_str());
+      LOG(INFO) << "NOT_FOUND from server for FindFileByName(" << filename
+                << ")";
     } else {
-      gpr_log(GPR_INFO,
-              "Error on FindFileByName(%s)\n\tError code: %d\n"
-              "\tError Message: %s",
-              filename.c_str(), error.error_code(),
-              error.error_message().c_str());
+      LOG(INFO) << "Error on FindFileByName(" << filename
+                << ")\n\tError code: " << error.error_code()
+                << "\n\tError Message: " << error.error_message();
     }
   } else {
-    gpr_log(
-        GPR_INFO,
-        "Error on FindFileByName(%s) response type\n"
-        "\tExpecting: %d\n\tReceived: %d",
-        filename.c_str(),
-        ServerReflectionResponse::MessageResponseCase::kFileDescriptorResponse,
-        response.message_response_case());
+    LOG(INFO) << "Error on FindFileByName(" << filename
+              << ") response type\n\tExpecting: "
+              << ServerReflectionResponse::MessageResponseCase::
+                     kFileDescriptorResponse
+              << "\n\tReceived: " << response.message_response_case();
   }
 
   return cached_db_.FindFileByName(filename, output);
@@ -134,24 +128,19 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
     const ErrorResponse& error = response.error_response();
     if (error.error_code() == StatusCode::NOT_FOUND) {
       missing_symbols_.insert(symbol_name);
-      gpr_log(GPR_INFO,
-              "NOT_FOUND from server for FindFileContainingSymbol(%s)",
-              symbol_name.c_str());
+      LOG(INFO) << "NOT_FOUND from server for FindFileContainingSymbol("
+                << symbol_name << ")";
     } else {
-      gpr_log(GPR_INFO,
-              "Error on FindFileContainingSymbol(%s)\n"
-              "\tError code: %d\n\tError Message: %s",
-              symbol_name.c_str(), error.error_code(),
-              error.error_message().c_str());
+      LOG(INFO) << "Error on FindFileContainingSymbol(" << symbol_name
+                << ")\n\tError code: " << error.error_code()
+                << "\n\tError Message: " << error.error_message();
     }
   } else {
-    gpr_log(
-        GPR_INFO,
-        "Error on FindFileContainingSymbol(%s) response type\n"
-        "\tExpecting: %d\n\tReceived: %d",
-        symbol_name.c_str(),
-        ServerReflectionResponse::MessageResponseCase::kFileDescriptorResponse,
-        response.message_response_case());
+    LOG(INFO) << "Error on FindFileContainingSymbol(" << symbol_name
+              << ") response type\n\tExpecting: "
+              << ServerReflectionResponse::MessageResponseCase::
+                     kFileDescriptorResponse
+              << "\n\tReceived: " << response.message_response_case();
   }
   return cached_db_.FindFileContainingSymbol(symbol_name, output);
 }
@@ -167,7 +156,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
   if (missing_extensions_.find(containing_type) != missing_extensions_.end() &&
       missing_extensions_[containing_type].find(field_number) !=
           missing_extensions_[containing_type].end()) {
-    gpr_log(GPR_INFO, "nested map.");
+    LOG(INFO) << "nested map.";
     return false;
   }
 
@@ -194,24 +183,20 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
         missing_extensions_[containing_type] = {};
       }
       missing_extensions_[containing_type].insert(field_number);
-      gpr_log(GPR_INFO,
-              "NOT_FOUND from server for FindFileContainingExtension(%s, %d)",
-              containing_type.c_str(), field_number);
+      LOG(INFO) << "NOT_FOUND from server for FindFileContainingExtension("
+                << containing_type << ", " << field_number << ")";
     } else {
-      gpr_log(GPR_INFO,
-              "Error on FindFileContainingExtension(%s, %d)\n"
-              "\tError code: %d\n\tError Message: %s",
-              containing_type.c_str(), field_number, error.error_code(),
-              error.error_message().c_str());
+      LOG(INFO) << "Error on FindFileContainingExtension(" << containing_type
+                << ", " << field_number
+                << ")\n\tError code: " << error.error_code()
+                << "\n\tError Message: " << error.error_message();
     }
   } else {
-    gpr_log(
-        GPR_INFO,
-        "Error on FindFileContainingExtension(%s, %d) response type\n"
-        "\tExpecting: %d\n\tReceived: %d",
-        containing_type.c_str(), field_number,
-        ServerReflectionResponse::MessageResponseCase::kFileDescriptorResponse,
-        response.message_response_case());
+    LOG(INFO) << "Error on FindFileContainingExtension(" << containing_type
+              << ", " << field_number << ") response type\n\tExpecting: "
+              << ServerReflectionResponse::MessageResponseCase::
+                     kFileDescriptorResponse
+              << "\n\tReceived: " << response.message_response_case();
   }
 
   return cached_db_.FindFileContainingExtension(containing_type, field_number,
@@ -245,14 +230,12 @@ bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbers(
              ServerReflectionResponse::MessageResponseCase::kErrorResponse) {
     const ErrorResponse& error = response.error_response();
     if (error.error_code() == StatusCode::NOT_FOUND) {
-      gpr_log(GPR_INFO, "NOT_FOUND from server for FindAllExtensionNumbers(%s)",
-              extendee_type.c_str());
+      LOG(INFO) << "NOT_FOUND from server for FindAllExtensionNumbers("
+                << extendee_type << ")";
     } else {
-      gpr_log(GPR_INFO,
-              "Error on FindAllExtensionNumbersExtension(%s)\n"
-              "\tError code: %d\n\tError Message: %s",
-              extendee_type.c_str(), error.error_code(),
-              error.error_message().c_str());
+      LOG(INFO) << "Error on FindAllExtensionNumbersExtension(" << extendee_type
+                << ")\n\tError code: " << error.error_code()
+                << "\n\tError Message: " << error.error_message();
     }
   }
   return false;
@@ -278,16 +261,13 @@ bool ProtoReflectionDescriptorDatabase::GetServices(
   } else if (response.message_response_case() ==
              ServerReflectionResponse::MessageResponseCase::kErrorResponse) {
     const ErrorResponse& error = response.error_response();
-    gpr_log(GPR_INFO,
-            "Error on GetServices()\n\tError code: %d\n"
-            "\tError Message: %s",
-            error.error_code(), error.error_message().c_str());
+    LOG(INFO) << "Error on GetServices()\n\tError code: " << error.error_code()
+              << "\n\tError Message: " << error.error_message();
   } else {
-    gpr_log(
-        GPR_INFO,
-        "Error on GetServices() response type\n\tExpecting: %d\n\tReceived: %d",
-        ServerReflectionResponse::MessageResponseCase::kListServicesResponse,
-        response.message_response_case());
+    LOG(INFO)
+        << "Error on GetServices() response type\n\tExpecting: "
+        << ServerReflectionResponse::MessageResponseCase::kListServicesResponse
+        << "\n\tReceived: " << response.message_response_case();
   }
   return false;
 }

--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -27,6 +27,7 @@
 
 #include "absl/flags/flag.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
@@ -104,7 +105,7 @@ class DefaultCredentialsProvider : public CredentialsProvider {
       auto it(std::find(added_secure_type_names_.begin(),
                         added_secure_type_names_.end(), type));
       if (it == added_secure_type_names_.end()) {
-        gpr_log(GPR_ERROR, "Unsupported credentials type %s.", type.c_str());
+        LOG(ERROR) << "Unsupported credentials type " << type;
         return nullptr;
       }
       return added_secure_type_providers_[it - added_secure_type_names_.begin()]
@@ -137,7 +138,7 @@ class DefaultCredentialsProvider : public CredentialsProvider {
       auto it(std::find(added_secure_type_names_.begin(),
                         added_secure_type_names_.end(), type));
       if (it == added_secure_type_names_.end()) {
-        gpr_log(GPR_ERROR, "Unsupported credentials type %s.", type.c_str());
+        LOG(ERROR) << "Unsupported credentials type " << type;
         return nullptr;
       }
       return added_secure_type_providers_[it - added_secure_type_names_.begin()]


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping
1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)
