### PR TITLE
[build] Add an assertion for no leaks, use it for event engine shutdown

### DIFF
--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -81,7 +81,7 @@ void WaitForSingleOwner(std::shared_ptr<EventEngine> engine) {
   int n = 0;
   while (engine.use_count() > 1) {
     ++n;
-    if (n == 100) AsanAssertNoLeaks();
+    if (n % 100 == 0) AsanAssertNoLeaks();
     GRPC_LOG_EVERY_N_SEC(2, GPR_INFO, "engine.use_count() = %ld",
                          engine.use_count());
     absl::SleepFor(absl::Milliseconds(100));

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -41,6 +41,7 @@
 #include "src/core/lib/gprpp/notification.h"
 #include "src/core/lib/gprpp/time.h"
 #include "src/core/lib/resource_quota/memory_quota.h"
+#include "test/core/test_util/build.h"
 
 // IWYU pragma: no_include <sys/socket.h>
 
@@ -77,7 +78,10 @@ std::string GetNextSendMessage() {
 }
 
 void WaitForSingleOwner(std::shared_ptr<EventEngine> engine) {
+  int n = 0;
   while (engine.use_count() > 1) {
+    ++n;
+    if (n == 100) AsanAssertNoLeaks();
     GRPC_LOG_EVERY_N_SEC(2, GPR_INFO, "engine.use_count() = %ld",
                          engine.use_count());
     absl::SleepFor(absl::Milliseconds(100));

--- a/test/core/test_util/build.cc
+++ b/test/core/test_util/build.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "test/core/test_util/build.h"
-
 // Define GRPC_BUILD_HAS_ASAN as 1 or 0 depending on if we're building under
 // ASAN.
 #if defined(__has_feature)

--- a/test/core/test_util/build.cc
+++ b/test/core/test_util/build.cc
@@ -12,6 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "test/core/test_util/build.h"
+
+// Define GRPC_BUILD_HAS_ASAN as 1 or 0 depending on if we're building under
+// ASAN.
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define GRPC_BUILD_HAS_ASAN 1
+#else
+#define GRPC_BUILD_HAS_ASAN 0
+#endif
+#else
+#ifdef ADDRESS_SANITIZER
+#define GRPC_BUILD_HAS_ASAN 1
+#else
+#define GRPC_BUILD_HAS_ASAN 0
+#endif
+#endif
+
+// Define GRPC_BUILD_HAS_TSAN as 1 or 0 depending on if we're building under
+// TSAN.
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define GRPC_BUILD_HAS_TSAN 1
+#else
+#define GRPC_BUILD_HAS_TSAN 0
+#endif
+#else
+#ifdef THREAD_SANITIZER
+#define GRPC_BUILD_HAS_TSAN 1
+#else
+#define GRPC_BUILD_HAS_TSAN 0
+#endif
+#endif
+
+// Define GRPC_BUILD_HAS_MSAN as 1 or 0 depending on if we're building under
+// MSAN.
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#define GRPC_BUILD_HAS_MSAN 1
+#else
+#define GRPC_BUILD_HAS_MSAN 0
+#endif
+#else
+#ifdef MEMORY_SANITIZER
+#define GRPC_BUILD_HAS_MSAN 1
+#else
+#define GRPC_BUILD_HAS_MSAN 0
+#endif
+#endif
+
+#if GRPC_BUILD_HAS_ASAN
+#include <sanitizer/lsan_interface.h>
+#endif
+
 bool BuiltUnderValgrind() {
 #ifdef RUNNING_ON_VALGRIND
   return true;
@@ -20,53 +74,17 @@ bool BuiltUnderValgrind() {
 #endif
 }
 
-bool BuiltUnderTsan() {
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
-  return true;
-#else
-  return false;
-#endif
-#else
-#ifdef THREAD_SANITIZER
-  return true;
-#else
-  return false;
-#endif
+bool BuiltUnderTsan() { return GRPC_BUILD_HAS_TSAN != 0; }
+
+bool BuiltUnderAsan() { return GRPC_BUILD_HAS_ASAN != 0; }
+
+void AsanAssertNoLeaks() {
+#if GRPC_BUILD_HAS_ASAN
+  __lsan_do_leak_check();
 #endif
 }
 
-bool BuiltUnderAsan() {
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-  return true;
-#else
-  return false;
-#endif
-#else
-#ifdef ADDRESS_SANITIZER
-  return true;
-#else
-  return false;
-#endif
-#endif
-}
-
-bool BuiltUnderMsan() {
-#if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
-  return true;
-#else
-  return false;
-#endif
-#else
-#ifdef MEMORY_SANITIZER
-  return true;
-#else
-  return false;
-#endif
-#endif
-}
+bool BuiltUnderMsan() { return GRPC_BUILD_HAS_MSAN != 0; }
 
 bool BuiltUnderUbsan() {
 #ifdef GRPC_UBSAN

--- a/test/core/test_util/build.h
+++ b/test/core/test_util/build.h
@@ -30,4 +30,7 @@ bool BuiltUnderMsan();
 // Returns whether this is built under UndefinedBehaviorSanitizer
 bool BuiltUnderUbsan();
 
+// Force a leak check if built under ASAN. If there are leaks, crash.
+void AsanAssertNoLeaks();
+
 #endif  // GRPC_TEST_CORE_TEST_UTIL_BUILD_H


### PR DESCRIPTION
Add a test utility to assert there are no memory leaks at an arbitrary point in code (when running under ASAN).
Use that utility to help diagnose why event engine fails to shut down.

.. also moves some preprocessor junk around in build.cc to make that file a little easier to parse