### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -109,6 +109,7 @@ grpc_cc_library(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -1286,16 +1286,12 @@ void InteropClient::PerformSoakTest(
     LOG(INFO) << "(server_uri: " << server_uri
               << ") soak test ran: " << soak_iterations
               << " iterations. total_failures: " << total_failures
-              << " is within "
-                 "max_failures_threshold: "
-              << max_failures << ". "
-              << "median_soak_iteration_latency: " << latency_ms_median
-              << " ms. "
-              << "90th_soak_iteration_latency: " << latency_ms_90th << " ms. "
-              << "worst_soak_iteration_latency: " << latency_ms_worst << " ms. "
-              << "See breakdown above for which iterations succeeded, failed, "
-                 "and "
-                 "why for more info.";
+              << " is within max_failures_threshold: " << max_failures
+              << ". median_soak_iteration_latency: " << latency_ms_median
+              << " ms. 90th_soak_iteration_latency: " << latency_ms_90th
+              << " ms. worst_soak_iteration_latency: " << latency_ms_worst
+              << " ms. See breakdown above for which iterations succeeded, "
+                 "failed, and why for more info.";
   }
 }
 

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -209,7 +209,7 @@ bool InteropClient::AssertStatusCode(const Status& s, StatusCode expected_code,
   LOG(ERROR) << "Error status code: " << s.error_code()
              << " (expected: " << expected_code
              << "), message: " << s.error_message()
-             << ", debug string: " << optional_debug_string << ".";
+             << ", debug string: " << optional_debug_string;
 
   // In case of transient transient/retryable failures (like a broken
   // connection) we may or may not abort (see TransientFailureOrAbort())
@@ -520,7 +520,7 @@ bool InteropClient::DoResponseStreaming() {
     // most likely due to connection failure.
     LOG(ERROR) << "DoResponseStreaming(): Read fewer streams (" << i
                << ") than response_stream_sizes.size() ("
-               << response_stream_sizes.size() << ").";
+               << response_stream_sizes.size() << ")";
     return TransientFailureOrAbort();
   }
 
@@ -549,7 +549,7 @@ bool InteropClient::DoClientCompressedStreaming() {
       serviceStub_.Get()->StreamingInputCall(&probe_context, &probe_res));
 
   if (!probe_stream->Write(probe_req)) {
-    LOG(ERROR) << __func__ << "(): stream->Write() failed.";
+    LOG(ERROR) << __func__ << "(): stream->Write() failed";
     return TransientFailureOrAbort();
   }
   Status s = probe_stream->Finish();
@@ -583,7 +583,7 @@ bool InteropClient::DoClientCompressedStreaming() {
   request.mutable_expect_compressed()->set_value(false);
   VLOG(2) << "Sending streaming request with compression disabled";
   if (!stream->Write(request, wopts)) {
-    LOG(ERROR) << __func__ << "(): stream->Write() failed.";
+    LOG(ERROR) << __func__ << "(): stream->Write() failed";
     return TransientFailureOrAbort();
   }
   CHECK(stream->WritesDone());
@@ -606,7 +606,7 @@ bool InteropClient::DoServerCompressedStreaming() {
         absl::StrFormat("(compression=%s; size=%d)",
                         compressions[i] ? "true" : "false", sizes[i]);
 
-    VLOG(2) << "Sending request streaming rpc " << log_suffix.c_str() << ".";
+    VLOG(2) << "Sending request streaming rpc " << log_suffix.c_str();
 
     ResponseParameters* const response_parameter =
         request.add_response_parameters();
@@ -705,7 +705,7 @@ bool InteropClient::DoHalfDuplex() {
     response_parameter->set_size(response_stream_sizes[i]);
 
     if (!stream->Write(request)) {
-      LOG(ERROR) << "DoHalfDuplex(): stream->Write() failed. i=" << i << ".";
+      LOG(ERROR) << "DoHalfDuplex(): stream->Write() failed. i=" << i;
       return TransientFailureOrAbort();
     }
   }
@@ -756,12 +756,12 @@ bool InteropClient::DoPingPong() {
     payload->set_body(std::string(request_stream_sizes[i], '\0'));
 
     if (!stream->Write(request)) {
-      LOG(ERROR) << "DoPingPong(): stream->Write() failed. i: " << i << ".";
+      LOG(ERROR) << "DoPingPong(): stream->Write() failed. i: " << i;
       return TransientFailureOrAbort();
     }
 
     if (!stream->Read(&response)) {
-      LOG(ERROR) << "DoPingPong(): stream->Read() failed. i:" << i << ".";
+      LOG(ERROR) << "DoPingPong(): stream->Read() failed. i:" << i;
       return TransientFailureOrAbort();
     }
 
@@ -820,12 +820,12 @@ bool InteropClient::DoCancelAfterFirstResponse() {
   StreamingOutputCallResponse response;
 
   if (!stream->Write(request)) {
-    LOG(ERROR) << "DoCancelAfterFirstResponse(): stream->Write() failed.";
+    LOG(ERROR) << "DoCancelAfterFirstResponse(): stream->Write() failed";
     return TransientFailureOrAbort();
   }
 
   if (!stream->Read(&response)) {
-    LOG(ERROR) << "DoCancelAfterFirstResponse(): stream->Read failed.";
+    LOG(ERROR) << "DoCancelAfterFirstResponse(): stream->Read failed";
     return TransientFailureOrAbort();
   }
   CHECK(response.payload().body() == std::string(31415, '\0'));
@@ -969,7 +969,7 @@ bool InteropClient::DoPickFirstUnary() {
     }
     if (response.server_id() != server_id) {
       LOG(ERROR) << "#" << i << " rpc hits server_id " << response.server_id()
-                 << ", expect server_id " << server_id << ".";
+                 << ", expect server_id " << server_id;
       return false;
     }
   }
@@ -1032,11 +1032,11 @@ bool InteropClient::DoOrcaOob() {
     orca_report->mutable_utilization()->emplace("util", 0.30499);
     StreamingOutputCallResponse response;
     if (!stream->Write(request)) {
-      LOG(ERROR) << "DoOrcaOob(): stream->Write() failed.";
+      LOG(ERROR) << "DoOrcaOob(): stream->Write() failed";
       return TransientFailureOrAbort();
     }
     if (!stream->Read(&response)) {
-      LOG(ERROR) << "DoOrcaOob(): stream->Read failed.";
+      LOG(ERROR) << "DoOrcaOob(): stream->Read failed";
       return TransientFailureOrAbort();
     }
     CHECK(load_report_tracker_
@@ -1061,11 +1061,11 @@ bool InteropClient::DoOrcaOob() {
     orca_report->mutable_utilization()->emplace("util", 0.2039);
     StreamingOutputCallResponse response;
     if (!stream->Write(request)) {
-      LOG(ERROR) << "DoOrcaOob(): stream->Write() failed.";
+      LOG(ERROR) << "DoOrcaOob(): stream->Write() failed";
       return TransientFailureOrAbort();
     }
     if (!stream->Read(&response)) {
-      LOG(ERROR) << "DoOrcaOob(): stream->Read failed.";
+      LOG(ERROR) << "DoOrcaOob(): stream->Read failed";
       return TransientFailureOrAbort();
     }
     CHECK(

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -273,8 +273,7 @@ bool InteropClient::PerformLargeUnary(SimpleRequest* request,
 bool InteropClient::DoComputeEngineCreds(
     const std::string& default_service_account,
     const std::string& oauth_scope) {
-  VLOG(2) <<
-          "Sending a large unary rpc with compute engine credentials ...");
+  VLOG(2) << "Sending a large unary rpc with compute engine credentials ...";
   SimpleRequest request;
   SimpleResponse response;
   request.set_fill_username(true);
@@ -297,8 +296,7 @@ bool InteropClient::DoComputeEngineCreds(
 
 bool InteropClient::DoOauth2AuthToken(const std::string& username,
                                       const std::string& oauth_scope) {
-  VLOG(2) <<
-          "Sending a unary rpc with raw oauth2 access token credentials ...");
+  VLOG(2) << "Sending a unary rpc with raw oauth2 access token credentials ...";
   SimpleRequest request;
   SimpleResponse response;
   request.set_fill_username(true);
@@ -347,8 +345,7 @@ bool InteropClient::DoPerRpcCreds(const std::string& json_key) {
 }
 
 bool InteropClient::DoJwtTokenCreds(const std::string& username) {
-  VLOG(2) <<
-          "Sending a large unary rpc with JWT token credentials ...");
+  VLOG(2) << "Sending a large unary rpc with JWT token credentials ...";
   SimpleRequest request;
   SimpleResponse response;
   request.set_fill_username(true);
@@ -365,8 +362,7 @@ bool InteropClient::DoJwtTokenCreds(const std::string& username) {
 
 bool InteropClient::DoGoogleDefaultCredentials(
     const std::string& default_service_account) {
-  VLOG(2) <<
-          "Sending a large unary rpc with GoogleDefaultCredentials...");
+  VLOG(2) << "Sending a large unary rpc with GoogleDefaultCredentials...";
   SimpleRequest request;
   SimpleResponse response;
   request.set_fill_username(true);
@@ -421,8 +417,7 @@ bool InteropClient::DoClientCompressedUnary() {
     std::string log_suffix =
         absl::StrFormat("(compression=%s)", compressions[i] ? "true" : "false");
 
-    VLOG(2) << "Sending compressed unary request " <<
-            log_suffix.c_str());
+    VLOG(2) << "Sending compressed unary request " << log_suffix;
     SimpleRequest request;
     SimpleResponse response;
     request.mutable_expect_compressed()->set_value(compressions[i]);
@@ -431,8 +426,7 @@ bool InteropClient::DoClientCompressedUnary() {
       return false;
     }
 
-    VLOG(2) << "Compressed unary request failed " <<
-            log_suffix.c_str());
+    VLOG(2) << "Compressed unary request failed " << log_suffix;
   }
 
   return true;
@@ -444,8 +438,7 @@ bool InteropClient::DoServerCompressedUnary() {
     std::string log_suffix =
         absl::StrFormat("(compression=%s)", compressions[i] ? "true" : "false");
 
-    VLOG(2) << "Sending unary request for compressed response "
-            << log_suffix.c_str();
+    VLOG(2) << "Sending unary request for compressed response " << log_suffix;
     SimpleRequest request;
     SimpleResponse response;
     request.mutable_response_compressed()->set_value(compressions[i]);
@@ -455,7 +448,7 @@ bool InteropClient::DoServerCompressedUnary() {
       return false;
     }
 
-    VLOG(2) << "Request for compressed unary failed " << log_suffix.c_str();
+    VLOG(2) << "Request for compressed unary failed " << log_suffix;
   }
 
   return true;


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping
1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :
1. If the above mapping is correct.
2. The content of the log is as before.

gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.