### PR TITLE
Revert "[channelz] add synchronization for channel traces (#36434)"

### DIFF
--- a/src/core/channelz/channel_trace.h
+++ b/src/core/channelz/channel_trace.h
@@ -22,14 +22,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "absl/base/thread_annotations.h"
-
 #include <grpc/slice.h>
 #include <grpc/support/port_platform.h>
+#include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
-#include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/json/json.h"
 
 namespace grpc_core {
@@ -112,26 +110,25 @@ class ChannelTrace {
     size_t memory_usage() const { return memory_usage_; }
 
    private:
-    const gpr_timespec timestamp_;
-    const Severity severity_;
-    const grpc_slice data_;
-    const size_t memory_usage_;
+    Severity severity_;
+    grpc_slice data_;
+    gpr_timespec timestamp_;
+    TraceEvent* next_;
     // the tracer object for the (sub)channel that this trace event refers to.
-    const RefCountedPtr<BaseNode> referenced_entity_;
-    TraceEvent* next_ = nullptr;
+    RefCountedPtr<BaseNode> referenced_entity_;
+    size_t memory_usage_;
   };  // TraceEvent
 
   // Internal helper to add and link in a trace event
   void AddTraceEventHelper(TraceEvent* new_trace_event);
 
-  const size_t max_event_memory_;
-  const gpr_timespec time_created_;
-
-  mutable Mutex mu_;
-  uint64_t num_events_logged_ ABSL_GUARDED_BY(mu_) = 0;
-  size_t event_list_memory_usage_ ABSL_GUARDED_BY(mu_) = 0;
-  TraceEvent* head_trace_ ABSL_GUARDED_BY(mu_) = nullptr;
-  TraceEvent* tail_trace_ ABSL_GUARDED_BY(mu_) = nullptr;
+  gpr_mu tracer_mu_;
+  uint64_t num_events_logged_;
+  size_t event_list_memory_usage_;
+  size_t max_event_memory_;
+  TraceEvent* head_trace_;
+  TraceEvent* tail_trace_;
+  gpr_timespec time_created_;
 };
 
 }  // namespace channelz

--- a/test/core/channelz/channel_trace_test.cc
+++ b/test/core/channelz/channel_trace_test.cc
@@ -21,9 +21,7 @@
 #include <stdlib.h>
 
 #include <string>
-#include <thread>
 
-#include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
 
 #include <grpc/credentials.h>
@@ -317,28 +315,6 @@ TEST(ChannelTracerTest, TestTotalEviction) {
   grpc_slice huge_slice = grpc_slice_malloc(kTraceEventSize * (kNumEvents + 1));
   tracer.AddTraceEvent(ChannelTrace::Severity::Info, huge_slice);
   ValidateChannelTraceCustom(&tracer, kNumEvents + 1, 0);
-}
-
-// Tests that the code is thread-safe.
-TEST(ChannelTracerTest, ThreadSafety) {
-  ExecCtx exec_ctx;
-  ChannelTrace tracer(kEventListMemoryLimit);
-  absl::Notification done;
-  std::vector<std::unique_ptr<std::thread>> threads;
-  for (size_t i = 0; i < 10; ++i) {
-    threads.push_back(std::make_unique<std::thread>([&]() {
-      do {
-        AddSimpleTrace(&tracer);
-      } while (!done.HasBeenNotified());
-    }));
-  }
-  for (size_t i = 0; i < 10; ++i) {
-    tracer.RenderJson();
-  }
-  done.Notify();
-  for (const auto& thd : threads) {
-    thd->join();
-  }
 }
 
 }  // namespace testing


### PR DESCRIPTION
This reverts commit 459abbec5af097a74cbf578fcd5278492e48c065.

This is breaking our windows CI tests -
```
[ RUN      ] ChannelTracerTest.TestMultipleEviction

T:\altsrc\github\grpc\workspace_c++_windows_dbg_native_default_cmake_ninja_vs2019\test\core\channelz\channel_trace_test.cc(65): error: Expected equality of these values:

  array.array().size()

    Which is: 3

  expected

    Which is: 4



[  FAILED  ] ChannelTracerTest.TestMultipleEviction (40 ms)
```
https://btx.cloud.google.com/invocations/88c4dde7-a66b-4e3a-9ad6-80212bb691f3/targets/github%2Fgrpc%2Frun_tests%2Fcpp_windows_dbg_native_default_cmake_ninja_vs2019;config=default/tests