### PR TITLE
[Interop Build] Increase docker build timeout

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1220,7 +1220,7 @@ def build_interop_image_jobspec(language, tag=None):
         cmdline=["tools/run_tests/dockerize/build_interop_image.sh"],
         environ=env,
         shortname="build_docker_%s" % (language),
-        timeout_seconds=30 * 60,
+        timeout_seconds=45 * 60,
     )
     build_job.tag = tag
     return build_job


### PR DESCRIPTION
We're seeing some timeout in recent `grpc_interop_toprod` build ([one example](https://btx.cloud.google.com/invocations/0e42343c-3ace-40b5-b24a-ee35e9fb71da/targets/github%2Fgrpc%2Finterop_docker_build;config=default/tests)).

Looking at past runs, these jobs consistently take 1000~1700 seconds, which sometimes leads to timeout issues, use this PR to increase timeout. 

Manul run: http://sponge/c8c077ea-1232-4da9-a99a-8d50685f6cae

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

