### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -25,7 +25,10 @@ grpc_cc_library(
     name = "xds_server",
     srcs = ["xds_server.cc"],
     hdrs = ["xds_server.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     visibility = ["@grpc:xds_end2end_test_utils"],
     deps = [
         "//:gpr",
@@ -349,6 +352,7 @@ grpc_cc_test(
     srcs = ["xds_ring_hash_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)

--- a/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_ring_hash_end2end_test.cc
@@ -13,17 +13,19 @@
 // limitations under the License.
 //
 
-#include <gmock/gmock.h>
-#include <grpc/event_engine/endpoint_config.h>
-#include <gtest/gtest.h>
-
 #include <string>
 #include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+
+#include <grpc/event_engine/endpoint_config.h>
+
 #include "src/core/client_channel/backup_poller.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/config/config_vars.h"

--- a/test/cpp/end2end/xds/xds_server.h
+++ b/test/cpp/end2end/xds/xds_server.h
@@ -286,7 +286,7 @@ class AdsServiceImpl
           did_work = true;
           LOG(INFO) << "ADS[" << debug_label_ << "]: Received request for type "
                     << request.type_url() << " with content "
-                    << request.DebugString() ;
+                    << request.DebugString();
           SentState& sent_state = sent_state_map[request.type_url()];
           // Process request.
           ProcessRequest(request, &update_queue, &subscription_map, &sent_state,
@@ -295,7 +295,7 @@ class AdsServiceImpl
       }
       if (response.has_value()) {
         LOG(INFO) << "ADS[" << debug_label_
-                  << "]: Sending response: " << response->DebugString() ;
+                  << "]: Sending response: " << response->DebugString();
         stream->Write(response.value());
       }
       response.reset();
@@ -316,8 +316,7 @@ class AdsServiceImpl
       }
       if (response.has_value()) {
         LOG(INFO) << "ADS[" << debug_label_
-                  << "]: Sending update response: " << response->DebugString()
-                  ;
+                  << "]: Sending update response: " << response->DebugString();
         stream->Write(response.value());
       }
       {
@@ -384,7 +383,7 @@ class AdsServiceImpl
         response_state.state = ResponseState::ACKED;
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client ACKed resource_type=" << request.type_url()
-                  << " version=" << request.version_info() ;
+                  << " version=" << request.version_info();
       } else {
         response_state.state = ResponseState::NACKED;
         if (check_nack_status_code_ != nullptr) {
@@ -395,7 +394,7 @@ class AdsServiceImpl
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client NACKed resource_type=" << request.type_url()
                   << " version=" << request.version_info() << ": "
-                  << response_state.error_message ;
+                  << response_state.error_message;
       }
       resource_type_response_state_[request.type_url()].emplace_back(
           std::move(response_state));
@@ -427,7 +426,7 @@ class AdsServiceImpl
                                     sent_state->resource_type_version)) {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: Sending update for type=" << request.type_url()
-                  << " name=" << resource_name ;
+                  << " name=" << resource_name;
         resources_added_to_response.emplace(resource_name);
         if (!response->has_value()) response->emplace();
         if (resource_state.resource.has_value()) {
@@ -442,7 +441,7 @@ class AdsServiceImpl
       } else {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client does not need update for type="
-                  << request.type_url() << " name=" << resource_name ;
+                  << request.type_url() << " name=" << resource_name;
       }
     }
     // Process unsubscriptions for any resource no longer
@@ -467,7 +466,7 @@ class AdsServiceImpl
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(ads_mu_) {
     LOG(INFO) << "ADS[" << debug_label_
               << "]: Received update for type=" << resource_type
-              << " name=" << resource_name ;
+              << " name=" << resource_name;
     auto& subscription_name_map = (*subscription_map)[resource_type];
     auto& resource_type_state = resource_map_[resource_type];
     auto& resource_name_map = resource_type_state.resource_name_map;
@@ -478,7 +477,7 @@ class AdsServiceImpl
                                     sent_state->resource_type_version)) {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: Sending update for type=" << resource_type
-                  << " name=" << resource_name ;
+                  << " name=" << resource_name;
         response->emplace();
         if (resource_state.resource.has_value()) {
           auto* resource = (*response)->add_resources();
@@ -778,7 +777,7 @@ class LrsServiceImpl
       while (stream->Read(&request)) {
         LOG(INFO) << "LRS[" << debug_label_
                   << "]: received client load report message: "
-                  << request.DebugString() ;
+                  << request.DebugString();
         std::vector<ClientStats> stats;
         for (const auto& cluster_stats : request.cluster_stats()) {
           stats.emplace_back(cluster_stats);

--- a/test/cpp/end2end/xds/xds_server.h
+++ b/test/cpp/end2end/xds/xds_server.h
@@ -243,7 +243,7 @@ class AdsServiceImpl
                   << "]: StreamAggregatedResources forcing early failure "
                      "with status code: "
                   << forced_ads_failure_.value().error_code() << ", message: "
-                  << forced_ads_failure_.value().error_message() << ".";
+                  << forced_ads_failure_.value().error_message();
         return forced_ads_failure_.value();
       }
     }
@@ -286,17 +286,16 @@ class AdsServiceImpl
           did_work = true;
           LOG(INFO) << "ADS[" << debug_label_ << "]: Received request for type "
                     << request.type_url() << " with content "
-                    << request.DebugString() << ".";
-          SentState& sent_state = sent_state_map[request.type_url()];
+                    << request.DebugString() SentState& sent_state =
+              sent_state_map[request.type_url()];
           // Process request.
           ProcessRequest(request, &update_queue, &subscription_map, &sent_state,
                          &response);
         }
       }
       if (response.has_value()) {
-        LOG(INFO) << "ADS[" << debug_label_
-                  << "]: Sending response: " << response->DebugString() << ".";
-        stream->Write(response.value());
+        LOG(INFO) << "ADS[" << debug_label_ << "]: Sending response: "
+                  << response->DebugString() stream->Write(response.value());
       }
       response.reset();
       // Look for updates and decide what to handle.
@@ -315,10 +314,11 @@ class AdsServiceImpl
         }
       }
       if (response.has_value()) {
-        LOG(INFO) << "ADS[" << debug_label_
-                  << "]: Sending update response: " << response->DebugString()
-                  << ".";
-        stream->Write(response.value());
+        LOG(INFO) << "ADS[" << debug_label_ << "]: Sending update response: "
+                  << response
+                         ->DebugString()
+
+                             stream->Write(response.value());
       }
       {
         grpc_core::MutexLock lock(&ads_mu_);
@@ -384,7 +384,7 @@ class AdsServiceImpl
         response_state.state = ResponseState::ACKED;
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client ACKed resource_type=" << request.type_url()
-                  << " version=" << request.version_info() << ".";
+                  << " version=" << request.version_info()
       } else {
         response_state.state = ResponseState::NACKED;
         if (check_nack_status_code_ != nullptr) {
@@ -395,7 +395,7 @@ class AdsServiceImpl
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client NACKed resource_type=" << request.type_url()
                   << " version=" << request.version_info() << ": "
-                  << response_state.error_message << ".";
+                  << response_state.error_message
       }
       resource_type_response_state_[request.type_url()].emplace_back(
           std::move(response_state));
@@ -427,8 +427,9 @@ class AdsServiceImpl
                                     sent_state->resource_type_version)) {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: Sending update for type=" << request.type_url()
-                  << " name=" << resource_name << ".";
-        resources_added_to_response.emplace(resource_name);
+                  << " name="
+                  << resource_name resources_added_to_response.emplace(
+                         resource_name);
         if (!response->has_value()) response->emplace();
         if (resource_state.resource.has_value()) {
           auto* resource = (*response)->add_resources();
@@ -442,7 +443,7 @@ class AdsServiceImpl
       } else {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client does not need update for type="
-                  << request.type_url() << " name=" << resource_name << ".";
+                  << request.type_url() << " name=" << resource_name
       }
     }
     // Process unsubscriptions for any resource no longer
@@ -467,8 +468,8 @@ class AdsServiceImpl
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(ads_mu_) {
     LOG(INFO) << "ADS[" << debug_label_
               << "]: Received update for type=" << resource_type
-              << " name=" << resource_name << ".";
-    auto& subscription_name_map = (*subscription_map)[resource_type];
+              << " name=" << resource_name auto& subscription_name_map =
+        (*subscription_map)[resource_type];
     auto& resource_type_state = resource_map_[resource_type];
     auto& resource_name_map = resource_type_state.resource_name_map;
     auto it = subscription_name_map.find(resource_name);
@@ -478,8 +479,7 @@ class AdsServiceImpl
                                     sent_state->resource_type_version)) {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: Sending update for type=" << resource_type
-                  << " name=" << resource_name << ".";
-        response->emplace();
+                  << " name=" << resource_name response->emplace();
         if (resource_state.resource.has_value()) {
           auto* resource = (*response)->add_resources();
           resource->CopyFrom(resource_state.resource.value());
@@ -778,8 +778,7 @@ class LrsServiceImpl
       while (stream->Read(&request)) {
         LOG(INFO) << "LRS[" << debug_label_
                   << "]: received client load report message: "
-                  << request.DebugString() << ".";
-        std::vector<ClientStats> stats;
+                  << request.DebugString() std::vector<ClientStats> stats;
         for (const auto& cluster_stats : request.cluster_stats()) {
           stats.emplace_back(cluster_stats);
         }

--- a/test/cpp/end2end/xds/xds_server.h
+++ b/test/cpp/end2end/xds/xds_server.h
@@ -286,16 +286,17 @@ class AdsServiceImpl
           did_work = true;
           LOG(INFO) << "ADS[" << debug_label_ << "]: Received request for type "
                     << request.type_url() << " with content "
-                    << request.DebugString() SentState& sent_state =
-              sent_state_map[request.type_url()];
+                    << request.DebugString() ;
+          SentState& sent_state = sent_state_map[request.type_url()];
           // Process request.
           ProcessRequest(request, &update_queue, &subscription_map, &sent_state,
                          &response);
         }
       }
       if (response.has_value()) {
-        LOG(INFO) << "ADS[" << debug_label_ << "]: Sending response: "
-                  << response->DebugString() stream->Write(response.value());
+        LOG(INFO) << "ADS[" << debug_label_
+                  << "]: Sending response: " << response->DebugString() ;
+        stream->Write(response.value());
       }
       response.reset();
       // Look for updates and decide what to handle.
@@ -314,11 +315,10 @@ class AdsServiceImpl
         }
       }
       if (response.has_value()) {
-        LOG(INFO) << "ADS[" << debug_label_ << "]: Sending update response: "
-                  << response
-                         ->DebugString()
-
-                             stream->Write(response.value());
+        LOG(INFO) << "ADS[" << debug_label_
+                  << "]: Sending update response: " << response->DebugString()
+                  ;
+        stream->Write(response.value());
       }
       {
         grpc_core::MutexLock lock(&ads_mu_);
@@ -384,7 +384,7 @@ class AdsServiceImpl
         response_state.state = ResponseState::ACKED;
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client ACKed resource_type=" << request.type_url()
-                  << " version=" << request.version_info()
+                  << " version=" << request.version_info() ;
       } else {
         response_state.state = ResponseState::NACKED;
         if (check_nack_status_code_ != nullptr) {
@@ -395,7 +395,7 @@ class AdsServiceImpl
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client NACKed resource_type=" << request.type_url()
                   << " version=" << request.version_info() << ": "
-                  << response_state.error_message
+                  << response_state.error_message ;
       }
       resource_type_response_state_[request.type_url()].emplace_back(
           std::move(response_state));
@@ -427,9 +427,8 @@ class AdsServiceImpl
                                     sent_state->resource_type_version)) {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: Sending update for type=" << request.type_url()
-                  << " name="
-                  << resource_name resources_added_to_response.emplace(
-                         resource_name);
+                  << " name=" << resource_name ;
+        resources_added_to_response.emplace(resource_name);
         if (!response->has_value()) response->emplace();
         if (resource_state.resource.has_value()) {
           auto* resource = (*response)->add_resources();
@@ -443,7 +442,7 @@ class AdsServiceImpl
       } else {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: client does not need update for type="
-                  << request.type_url() << " name=" << resource_name
+                  << request.type_url() << " name=" << resource_name ;
       }
     }
     // Process unsubscriptions for any resource no longer
@@ -468,8 +467,8 @@ class AdsServiceImpl
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(ads_mu_) {
     LOG(INFO) << "ADS[" << debug_label_
               << "]: Received update for type=" << resource_type
-              << " name=" << resource_name auto& subscription_name_map =
-        (*subscription_map)[resource_type];
+              << " name=" << resource_name ;
+    auto& subscription_name_map = (*subscription_map)[resource_type];
     auto& resource_type_state = resource_map_[resource_type];
     auto& resource_name_map = resource_type_state.resource_name_map;
     auto it = subscription_name_map.find(resource_name);
@@ -479,7 +478,8 @@ class AdsServiceImpl
                                     sent_state->resource_type_version)) {
         LOG(INFO) << "ADS[" << debug_label_
                   << "]: Sending update for type=" << resource_type
-                  << " name=" << resource_name response->emplace();
+                  << " name=" << resource_name ;
+        response->emplace();
         if (resource_state.resource.has_value()) {
           auto* resource = (*response)->add_resources();
           resource->CopyFrom(resource_state.resource.value());
@@ -778,7 +778,8 @@ class LrsServiceImpl
       while (stream->Read(&request)) {
         LOG(INFO) << "LRS[" << debug_label_
                   << "]: received client load report message: "
-                  << request.DebugString() std::vector<ClientStats> stats;
+                  << request.DebugString() ;
+        std::vector<ClientStats> stats;
         for (const auto& cluster_stats : request.cluster_stats()) {
           stats.emplace_back(cluster_stats);
         }

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -26,7 +26,6 @@
 #include <vector>
 
 #include "absl/log/check.h"
-#include "absl/log/log.h"
 #include "google/protobuf/timestamp.pb.h"
 
 #include <grpc/support/alloc.h>

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "google/protobuf/timestamp.pb.h"
 
 #include <grpc/support/alloc.h>


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping
1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :
1. If the above mapping is correct.
2. The content of the log is as before.

gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
