### PR TITLE
[EventEngine] Rely on RAII for lifeguard

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -38,7 +38,6 @@
 #include "src/core/lib/backoff/backoff.h"
 #include "src/core/lib/event_engine/common_closures.h"
 #include "src/core/lib/event_engine/thread_local.h"
-#include "src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h"
 #include "src/core/lib/event_engine/trace.h"
 #include "src/core/lib/event_engine/work_queue/basic_work_queue.h"
 #include "src/core/lib/event_engine/work_queue/work_queue.h"

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -229,12 +229,6 @@ WorkStealingThreadPool::WorkStealingThreadPoolImpl::WorkStealingThreadPoolImpl(
     size_t reserve_threads)
     : reserve_threads_(reserve_threads), queue_(this) {}
 
-WorkStealingThreadPool::WorkStealingThreadPoolImpl::
-    ~WorkStealingThreadPoolImpl() {
-  grpc_core::MutexLock lock(&lifeguard_ptr_mu_);
-  lifeguard_.reset();
-}
-
 void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Start() {
   for (size_t i = 0; i < reserve_threads_; i++) {
     StartThread();
@@ -245,7 +239,7 @@ void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Start() {
 
 void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Run(
     EventEngine::Closure* closure) {
-  DCHECK(!IsQuiesced());
+  CHECK(!IsQuiesced());
   if (g_local_queue != nullptr && g_local_queue->owner() == this) {
     g_local_queue->Add(closure);
   } else {

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -18,7 +18,6 @@
 #include "src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h"
 
 #include <inttypes.h>
-#include <unistd.h>
 
 #include <atomic>
 #include <chrono>

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
@@ -105,6 +105,7 @@ class WorkStealingThreadPool final : public ThreadPool {
       : public std::enable_shared_from_this<WorkStealingThreadPoolImpl> {
    public:
     explicit WorkStealingThreadPoolImpl(size_t reserve_threads);
+    ~WorkStealingThreadPoolImpl();
     // Start all threads.
     void Start();
     // Add a closure to a work queue, preferably a thread-local queue if
@@ -155,11 +156,7 @@ class WorkStealingThreadPool final : public ThreadPool {
     class Lifeguard {
      public:
       explicit Lifeguard(WorkStealingThreadPoolImpl* pool);
-      // Start the lifeguard thread.
-      void Start();
-      // Block until the lifeguard thread is shut down.
-      // Afterwards, reset the lifeguard state so it can start again cleanly.
-      void BlockUntilShutdownAndReset();
+      ~Lifeguard();
 
      private:
       // The main body of the lifeguard thread.
@@ -194,7 +191,8 @@ class WorkStealingThreadPool final : public ThreadPool {
     // at a time.
     std::atomic<bool> throttled_{false};
     WorkSignal work_signal_;
-    Lifeguard lifeguard_;
+    grpc_core::Mutex lifeguard_ptr_mu_;
+    std::unique_ptr<Lifeguard> lifeguard_ ABSL_GUARDED_BY(lifeguard_ptr_mu_);
     // Set of threads for verbose failure debugging
     grpc_core::Mutex thd_set_mu_;
     absl::flat_hash_set<gpr_thd_id> thds_ ABSL_GUARDED_BY(thd_set_mu_);

--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
@@ -105,7 +105,6 @@ class WorkStealingThreadPool final : public ThreadPool {
       : public std::enable_shared_from_this<WorkStealingThreadPoolImpl> {
    public:
     explicit WorkStealingThreadPoolImpl(size_t reserve_threads);
-    ~WorkStealingThreadPoolImpl();
     // Start all threads.
     void Start();
     // Add a closure to a work queue, preferably a thread-local queue if


### PR DESCRIPTION
This makes lifeguard easier to manage and removes one case of hang in fork test.