### PR TITLE
[http2] Fix http2_stats test's usage of GlobalPluginStatsRegistry

### DIFF
--- a/test/core/end2end/tests/http2_stats.cc
+++ b/test/core/end2end/tests/http2_stats.cc
@@ -199,6 +199,7 @@ CORE_END2END_TEST(Http2FullstackSingleHopTest, StreamStats) {
   g_mu = new Mutex();
   g_client_call_ended_notify = new CoreEnd2endTest::TestNotification(this);
   g_server_call_ended_notify = new CoreEnd2endTest::TestNotification(this);
+  GlobalStatsPluginRegistryTestPeer::ResetGlobalStatsPluginRegistry();
   GlobalStatsPluginRegistry::RegisterStatsPlugin(
       std::make_shared<NewFakeStatsPlugin>());
   auto send_from_client = RandomSlice(10);
@@ -265,8 +266,6 @@ CORE_END2END_TEST(Http2FullstackSingleHopTest, StreamStats) {
   EXPECT_GE(server_transport_stats.incoming.framing_bytes, 32);
   EXPECT_LE(server_transport_stats.incoming.framing_bytes, 58);
 
-  delete ServerCallTracerFactory::Get(ChannelArgs());
-  ServerCallTracerFactory::RegisterGlobal(nullptr);
   delete g_client_call_ended_notify;
   g_client_call_ended_notify = nullptr;
   delete g_server_call_ended_notify;


### PR DESCRIPTION
This should fix errors of the form - 
https://source.cloud.google.com/results/invocations/84e6c8cd-78df-45a3-8898-d703a2d38ac5/targets/%2F%2Ftest%2Fcore%2Fend2end:http2_stats_test@poller%3Dpoll/log
```
*** SIGSEGV received at time=1715064982 on cpu 0 ***
PC: @     0xffffaf404250  (unknown)  absl::lts_20240116::Mutex::Lock()
    @     0xffffb406e818        224  absl::lts_20240116::AbslFailureSignalHandler()
    @     0xffffb45297b0       4768  (unknown)
    @     0xffffb0266888         32  grpc_core::DelegatingClientCallTracer::DelegatingClientCallAttemptTracer::RecordEnd()
    @     0xffffb14de408         64  grpc_core::ClientChannelFilter::FilterBasedLoadBalancedCall::Orphan()
    @     0xffffb14fd2b0         48  grpc_core::RetryFilter::LegacyCallData::~LegacyCallData()
    @     0xffffb14fc8e4         32  grpc_core::RetryFilter::LegacyCallData::Destroy()
    @     0xffffb0ebc5bc         32  grpc_call_stack_destroy()
    @     0xffffb14f4e34         48  grpc_core::DynamicFilters::Call::Destroy()
    @     0xffffaff752b0         48  grpc_core::ExecCtx::Flush()
    @     0xffffb44a6fb0         64  grpc_core::ExecCtx::~ExecCtx()
    @     0xffffb14f2a90        160  absl::lts_20240116::internal_any_invocable::LocalInvoker<>()
    @     0xffffb072c2fc         48  grpc_event_engine::experimental::SelfDeletingClosure::Run()
    @     0xffffb072bd78         32  grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step()
    @     0xffffb072ba7c        112  grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody()
    @     0xffffb072c33c         48  grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::$_0::__invoke()
    @     0xffffafb4bdc0         80  grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix()::{lambda()#1}::__invoke()
    @     0xffffaef95648         80  start_thread
```

I wasn't able to reproduce this but the fix seems correct.
Internal ref: b/339452200