### PR TITLE
Revert "[transport] Centralize ref-counting between transports (#36460)"

### DIFF
--- a/src/core/ext/transport/chaotic_good/client_transport.h
+++ b/src/core/ext/transport/chaotic_good/client_transport.h
@@ -85,7 +85,7 @@ class ChaoticGoodClientTransport final : public ClientTransport {
   grpc_endpoint* GetEndpoint() override { return nullptr; }
   void Orphan() override {
     AbortWithError();
-    Unref();
+    delete this;
   }
 
   void StartCall(CallHandler call_handler) override;

--- a/src/core/ext/transport/chaotic_good/server_transport.h
+++ b/src/core/ext/transport/chaotic_good/server_transport.h
@@ -96,7 +96,7 @@ class ChaoticGoodServerTransport final : public ServerTransport {
   void SetPollsetSet(grpc_stream*, grpc_pollset_set*) override {}
   void PerformOp(grpc_transport_op*) override;
   grpc_endpoint* GetEndpoint() override { return nullptr; }
-  void Orphan() override { Unref(); }
+  void Orphan() override { delete this; }
 
   void SetAcceptor(Acceptor* acceptor) override;
   void AbortWithError();

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -143,6 +143,8 @@ static bool g_default_server_keepalive_permit_without_calls = false;
 
 #define MAX_CLIENT_STREAM_ID 0x7fffffffu
 grpc_core::TraceFlag grpc_keepalive_trace(false, "http_keepalive");
+grpc_core::DebugOnlyTraceFlag grpc_trace_chttp2_refcount(false,
+                                                         "chttp2_refcount");
 
 // forward declarations of various callbacks that we'll build closures around
 static void write_action_begin_locked(
@@ -593,7 +595,12 @@ static void init_keepalive_pings_if_enabled_locked(
 grpc_chttp2_transport::grpc_chttp2_transport(
     const grpc_core::ChannelArgs& channel_args, grpc_endpoint* ep,
     bool is_client)
-    : ep(ep),
+    : grpc_core::RefCounted<grpc_chttp2_transport,
+                            grpc_core::NonPolymorphicRefCount>(
+          GRPC_TRACE_FLAG_ENABLED(grpc_trace_chttp2_refcount)
+              ? "chttp2_refcount"
+              : nullptr),
+      ep(ep),
       peer_string(
           grpc_core::Slice::FromCopiedString(grpc_endpoint_get_peer(ep))),
       memory_owner(channel_args.GetObject<grpc_core::ResourceQuota>()

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -223,18 +223,16 @@ typedef enum {
   GRPC_CHTTP2_KEEPALIVE_STATE_DISABLED,
 } grpc_chttp2_keepalive_state;
 
-struct grpc_chttp2_transport final : public grpc_core::FilterStackTransport,
-                                     public grpc_core::KeepsGrpcInitialized {
+struct grpc_chttp2_transport final
+    : public grpc_core::FilterStackTransport,
+      public grpc_core::RefCounted<grpc_chttp2_transport,
+                                   grpc_core::NonPolymorphicRefCount>,
+      public grpc_core::KeepsGrpcInitialized {
   grpc_chttp2_transport(const grpc_core::ChannelArgs& channel_args,
                         grpc_endpoint* ep, bool is_client);
   ~grpc_chttp2_transport() override;
 
   void Orphan() override;
-
-  grpc_core::RefCountedPtr<grpc_chttp2_transport> Ref() {
-    return grpc_core::FilterStackTransport::RefAsSubclass<
-        grpc_chttp2_transport>();
-  }
 
   size_t SizeOfStream() const override;
   bool HackyDisableStreamOpBatchCoalescingInConnectedChannel() const override;

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -502,7 +502,7 @@ class FilterStackTransport;
 class ClientTransport;
 class ServerTransport;
 
-class Transport : public InternallyRefCounted<Transport> {
+class Transport : public Orphanable {
  public:
   struct RawPointerChannelArgTag {};
   static absl::string_view ChannelArgName() { return GRPC_ARG_TRANSPORT; }


### PR DESCRIPTION
This reverts commit 03e2bf22c512a9f6e722d48bff5008c076727cbc.

I don't know why but this causes issues when building gcc7 -
https://github.com/googleapis/google-cloud-cpp/pull/14153/checks?check_run_id=24734699214

