### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
@@ -154,7 +154,8 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
                     BinderTransportTxCode::SETUP_TRANSPORT) &&
         code <= static_cast<transaction_code_t>(
                     BinderTransportTxCode::PING_RESPONSE))) {
-    LOG(INFO) << "Received unknown control message. Shutdown transport gracefully.";
+    LOG(INFO)
+        << "Received unknown control message. Shutdown transport gracefully.";
     // TODO(waynetu): Shutdown transport gracefully.
     return absl::OkStatus();
   }
@@ -210,7 +211,8 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
       break;
     }
     case BinderTransportTxCode::SHUTDOWN_TRANSPORT: {
-      LOG(ERROR) << "Received SHUTDOWN_TRANSPORT request but not implemented yet.";
+      LOG(ERROR)
+          << "Received SHUTDOWN_TRANSPORT request but not implemented yet.";
       return absl::UnimplementedError("SHUTDOWN_TRANSPORT");
     }
     case BinderTransportTxCode::ACKNOWLEDGE_BYTES: {

--- a/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
+++ b/src/core/ext/transport/binder/wire_format/wire_reader_impl.cc
@@ -26,6 +26,7 @@
 
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/memory/memory.h"
 #include "absl/status/statusor.h"
 
@@ -136,9 +137,9 @@ void WireReaderImpl::SendSetupTransport(Binder* binder) {
 std::unique_ptr<Binder> WireReaderImpl::RecvSetupTransport() {
   // TODO(b/191941760): avoid blocking, handle wire_writer_noti lifetime
   // better
-  gpr_log(GPR_DEBUG, "start waiting for noti");
+  VLOG(2) << "start waiting for noti";
   connection_noti_.WaitForNotification();
-  gpr_log(GPR_DEBUG, "end waiting for noti");
+  VLOG(2) << "end waiting for noti";
   return std::move(other_end_binder_);
 }
 
@@ -153,8 +154,7 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
                     BinderTransportTxCode::SETUP_TRANSPORT) &&
         code <= static_cast<transaction_code_t>(
                     BinderTransportTxCode::PING_RESPONSE))) {
-    gpr_log(GPR_INFO,
-            "Received unknown control message. Shutdown transport gracefully.");
+    LOG(INFO) << "Received unknown control message. Shutdown transport gracefully.";
     // TODO(waynetu): Shutdown transport gracefully.
     return absl::OkStatus();
   }
@@ -210,8 +210,7 @@ absl::Status WireReaderImpl::ProcessTransaction(transaction_code_t code,
       break;
     }
     case BinderTransportTxCode::SHUTDOWN_TRANSPORT: {
-      gpr_log(GPR_ERROR,
-              "Received SHUTDOWN_TRANSPORT request but not implemented yet.");
+      LOG(ERROR) << "Received SHUTDOWN_TRANSPORT request but not implemented yet.";
       return absl::UnimplementedError("SHUTDOWN_TRANSPORT");
     }
     case BinderTransportTxCode::ACKNOWLEDGE_BYTES: {
@@ -286,16 +285,16 @@ absl::Status WireReaderImpl::ProcessStreamingTransaction(
             tx_process_result.ToString().c_str());
     // Something went wrong when receiving transaction. Cancel failed requests.
     if (cancellation_flags & kFlagPrefix) {
-      gpr_log(GPR_INFO, "cancelling initial metadata");
+      LOG(INFO) << "cancelling initial metadata";
       transport_stream_receiver_->NotifyRecvInitialMetadata(code,
                                                             tx_process_result);
     }
     if (cancellation_flags & kFlagMessageData) {
-      gpr_log(GPR_INFO, "cancelling message data");
+      LOG(INFO) << "cancelling message data";
       transport_stream_receiver_->NotifyRecvMessage(code, tx_process_result);
     }
     if (cancellation_flags & kFlagSuffix) {
-      gpr_log(GPR_INFO, "cancelling trailing metadata");
+      LOG(INFO) << "cancelling trailing metadata";
       transport_stream_receiver_->NotifyRecvTrailingMetadata(
           code, tx_process_result, 0);
     }
@@ -338,7 +337,7 @@ absl::Status WireReaderImpl::ProcessStreamingTransactionImpl(
   // intended behavior.
   // TODO(waynetu): What should be returned here?
   if (flags == 0) {
-    gpr_log(GPR_INFO, "[WARNING] Receive empty transaction. Ignored.");
+    LOG(INFO) << "[WARNING] Receive empty transaction. Ignored.";
     return absl::OkStatus();
   }
 

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -35,6 +35,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/hash/hash.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/meta/type_traits.h"
 #include "absl/random/random.h"
 #include "absl/status/status.h"
@@ -1324,7 +1325,7 @@ static bool contains_non_ok_status(grpc_metadata_batch* batch) {
 
 static void log_metadata(const grpc_metadata_batch* md_batch, uint32_t id,
                          bool is_client, bool is_initial) {
-  gpr_log(GPR_INFO, "--metadata--");
+  LOG(INFO) << "--metadata--";
   const std::string prefix = absl::StrCat(
       "HTTP:", id, is_initial ? ":HDR" : ":TRL", is_client ? ":CLI:" : ":SVR:");
   md_batch->Log([&prefix](absl::string_view key, absl::string_view value) {

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -42,6 +42,7 @@
 #endif
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/escaping.h"
@@ -114,7 +115,7 @@ static const EVP_MD* evp_md_from_alg(const char* alg) {
 static Json parse_json_part_from_jwt(const char* str, size_t len) {
   std::string string;
   if (!absl::WebSafeBase64Unescape(absl::string_view(str, len), &string)) {
-    gpr_log(GPR_ERROR, "Invalid base64.");
+    LOG(ERROR) << "Invalid base64.";
     return Json();  // JSON null
   }
   auto json = grpc_core::JsonParse(string);
@@ -163,13 +164,13 @@ static jose_header* jose_header_from_json(Json json) {
   Json::Object::const_iterator it;
   jose_header* h = grpc_core::Zalloc<jose_header>();
   if (json.type() != Json::Type::kObject) {
-    gpr_log(GPR_ERROR, "JSON value is not an object");
+    LOG(ERROR) << "JSON value is not an object";
     goto error;
   }
   // Check alg field.
   it = json.object().find("alg");
   if (it == json.object().end()) {
-    gpr_log(GPR_ERROR, "Missing alg field.");
+    LOG(ERROR) << "Missing alg field.";
     goto error;
   }
   // We only support RSA-1.5 signatures for now.
@@ -180,7 +181,7 @@ static jose_header* jose_header_from_json(Json json) {
   if (it->second.type() != Json::Type::kString ||
       strncmp(alg_value, "RS", 2) != 0 ||
       evp_md_from_alg(alg_value) == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid alg field");
+    LOG(ERROR) << "Invalid alg field";
     goto error;
   }
   h->alg = alg_value;
@@ -319,13 +320,13 @@ grpc_jwt_verifier_status grpc_jwt_claims_check(const grpc_jwt_claims* claims,
   skewed_now =
       gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), grpc_jwt_verifier_clock_skew);
   if (gpr_time_cmp(skewed_now, claims->nbf) < 0) {
-    gpr_log(GPR_ERROR, "JWT is not valid yet.");
+    LOG(ERROR) << "JWT is not valid yet.";
     return GRPC_JWT_VERIFIER_TIME_CONSTRAINT_FAILURE;
   }
   skewed_now =
       gpr_time_sub(gpr_now(GPR_CLOCK_REALTIME), grpc_jwt_verifier_clock_skew);
   if (gpr_time_cmp(skewed_now, claims->exp) > 0) {
-    gpr_log(GPR_ERROR, "JWT is expired.");
+    LOG(ERROR) << "JWT is expired.";
     return GRPC_JWT_VERIFIER_TIME_CONSTRAINT_FAILURE;
   }
 
@@ -430,7 +431,7 @@ struct grpc_jwt_verifier {
 
 static Json json_from_http(const grpc_http_response* response) {
   if (response == nullptr) {
-    gpr_log(GPR_ERROR, "HTTP response is NULL.");
+    LOG(ERROR) << "HTTP response is NULL.";
     return Json();  // JSON null
   }
   if (response->status != 200) {
@@ -441,7 +442,7 @@ static Json json_from_http(const grpc_http_response* response) {
   auto json = grpc_core::JsonParse(
       absl::string_view(response->body, response->body_length));
   if (!json.ok()) {
-    gpr_log(GPR_ERROR, "Invalid JSON found in response.");
+    LOG(ERROR) << "Invalid JSON found in response.";
     return Json();  // JSON null
   }
   return std::move(*json);
@@ -464,12 +465,12 @@ static EVP_PKEY* extract_pkey_from_x509(const char* x509_str) {
   BIO_write(bio, x509_str, static_cast<int>(len));
   x509 = PEM_read_bio_X509(bio, nullptr, nullptr, nullptr);
   if (x509 == nullptr) {
-    gpr_log(GPR_ERROR, "Unable to parse x509 cert.");
+    LOG(ERROR) << "Unable to parse x509 cert.";
     goto end;
   }
   result = X509_get_pubkey(x509);
   if (result == nullptr) {
-    gpr_log(GPR_ERROR, "Cannot find public key in X509 cert.");
+    LOG(ERROR) << "Cannot find public key in X509 cert.";
   }
 
 end:
@@ -482,7 +483,7 @@ static BIGNUM* bignum_from_base64(const char* b64) {
   if (b64 == nullptr) return nullptr;
   std::string string;
   if (!absl::WebSafeBase64Unescape(b64, &string)) {
-    gpr_log(GPR_ERROR, "Invalid base64 for big num.");
+    LOG(ERROR) << "Invalid base64 for big num.";
     return nullptr;
   }
   return BN_bin2bn(reinterpret_cast<const uint8_t*>(string.data()),
@@ -540,27 +541,27 @@ static EVP_PKEY* pkey_from_jwk(const Json& json, const char* kty) {
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
   rsa = RSA_new();
   if (rsa == nullptr) {
-    gpr_log(GPR_ERROR, "Could not create rsa key.");
+    LOG(ERROR) << "Could not create rsa key.";
     goto end;
   }
 #endif
   it = json.object().find("n");
   if (it == json.object().end()) {
-    gpr_log(GPR_ERROR, "Missing RSA public key field.");
+    LOG(ERROR) << "Missing RSA public key field.";
     goto end;
   }
   tmp_n = bignum_from_base64(validate_string_field(it->second, "n"));
   if (tmp_n == nullptr) goto end;
   it = json.object().find("e");
   if (it == json.object().end()) {
-    gpr_log(GPR_ERROR, "Missing RSA public key field.");
+    LOG(ERROR) << "Missing RSA public key field.";
     goto end;
   }
   tmp_e = bignum_from_base64(validate_string_field(it->second, "e"));
   if (tmp_e == nullptr) goto end;
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
   if (!RSA_set0_key(rsa, tmp_n, tmp_e, nullptr)) {
-    gpr_log(GPR_ERROR, "Cannot set RSA key from inputs.");
+    LOG(ERROR) << "Cannot set RSA key from inputs.";
     goto end;
   }
   // RSA_set0_key takes ownership on success.
@@ -573,21 +574,21 @@ static EVP_PKEY* pkey_from_jwk(const Json& json, const char* kty) {
   if (!OSSL_PARAM_BLD_push_BN(bld, "n", tmp_n) ||
       !OSSL_PARAM_BLD_push_BN(bld, "e", tmp_e) ||
       (params = OSSL_PARAM_BLD_to_param(bld)) == NULL) {
-    gpr_log(GPR_ERROR, "Could not create OSSL_PARAM");
+    LOG(ERROR) << "Could not create OSSL_PARAM";
     goto end;
   }
 
   ctx = EVP_PKEY_CTX_new_from_name(nullptr, "RSA", nullptr);
   if (ctx == nullptr) {
-    gpr_log(GPR_ERROR, "Could not create rsa key.");
+    LOG(ERROR) << "Could not create rsa key.";
     goto end;
   }
   if (EVP_PKEY_fromdata_init(ctx) <= 0) {
-    gpr_log(GPR_ERROR, "Could not create rsa key.");
+    LOG(ERROR) << "Could not create rsa key.";
     goto end;
   }
   if (EVP_PKEY_fromdata(ctx, &result, EVP_PKEY_KEYPAIR, params) <= 0) {
-    gpr_log(GPR_ERROR, "Cannot set RSA key from inputs.");
+    LOG(ERROR) << "Cannot set RSA key from inputs.";
     goto end;
   }
 #endif
@@ -618,8 +619,7 @@ static EVP_PKEY* find_verification_key(const Json& json, const char* header_alg,
     return extract_pkey_from_x509(cur->string().c_str());
   }
   if (jwt_keys->type() != Json::Type::kArray) {
-    gpr_log(GPR_ERROR,
-            "Unexpected value type of keys property in jwks key set.");
+    LOG(ERROR) << "Unexpected value type of keys property in jwks key set.";
     return nullptr;
   }
   // Key format is specified in:
@@ -661,21 +661,21 @@ static int verify_jwt_signature(EVP_PKEY* key, const char* alg,
 
   CHECK_NE(md, nullptr);  // Checked before.
   if (md_ctx == nullptr) {
-    gpr_log(GPR_ERROR, "Could not create EVP_MD_CTX.");
+    LOG(ERROR) << "Could not create EVP_MD_CTX.";
     goto end;
   }
   if (EVP_DigestVerifyInit(md_ctx, nullptr, md, nullptr, key) != 1) {
-    gpr_log(GPR_ERROR, "EVP_DigestVerifyInit failed.");
+    LOG(ERROR) << "EVP_DigestVerifyInit failed.";
     goto end;
   }
   if (EVP_DigestVerifyUpdate(md_ctx, GRPC_SLICE_START_PTR(signed_data),
                              GRPC_SLICE_LENGTH(signed_data)) != 1) {
-    gpr_log(GPR_ERROR, "EVP_DigestVerifyUpdate failed.");
+    LOG(ERROR) << "EVP_DigestVerifyUpdate failed.";
     goto end;
   }
   if (EVP_DigestVerifyFinal(md_ctx, GRPC_SLICE_START_PTR(signature),
                             GRPC_SLICE_LENGTH(signature)) != 1) {
-    gpr_log(GPR_ERROR, "JWT signature verification failed.");
+    LOG(ERROR) << "JWT signature verification failed.";
 
     goto end;
   }
@@ -742,7 +742,7 @@ static void on_openid_config_retrieved(void* user_data,
   if (json.type() == Json::Type::kNull) goto error;
   cur = find_property_by_name(json, "jwks_uri");
   if (cur == nullptr) {
-    gpr_log(GPR_ERROR, "Could not find jwks_uri in openid config.");
+    LOG(ERROR) << "Could not find jwks_uri in openid config.";
     goto error;
   }
   jwks_uri = validate_string_field(*cur, "jwks_uri");
@@ -843,11 +843,11 @@ static void retrieve_key_and_verify(verifier_cb_ctx* ctx) {
   CHECK(ctx != nullptr && ctx->header != nullptr && ctx->claims != nullptr);
   iss = ctx->claims->iss;
   if (ctx->header->kid == nullptr) {
-    gpr_log(GPR_ERROR, "Missing kid in jose header.");
+    LOG(ERROR) << "Missing kid in jose header.";
     goto error;
   }
   if (iss == nullptr) {
-    gpr_log(GPR_ERROR, "Missing iss in claims.");
+    LOG(ERROR) << "Missing iss in claims.";
     goto error;
   }
 
@@ -862,7 +862,7 @@ static void retrieve_key_and_verify(verifier_cb_ctx* ctx) {
     CHECK_NE(ctx->verifier, nullptr);
     mapping = verifier_get_mapping(ctx->verifier, email_domain);
     if (mapping == nullptr) {
-      gpr_log(GPR_ERROR, "Missing mapping for issuer email.");
+      LOG(ERROR) << "Missing mapping for issuer email.";
       goto error;
     }
     host = gpr_strdup(mapping->key_url_prefix);

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -34,6 +34,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -1138,8 +1139,7 @@ void FilterStackCall::RecvTrailingFilter(grpc_metadata_batch* b,
     } else if (!is_client()) {
       SetFinalStatus(absl::OkStatus());
     } else {
-      gpr_log(GPR_DEBUG,
-              "Received trailing metadata with no error and no status");
+      VLOG(2) << "Received trailing metadata with no error and no status";
       SetFinalStatus(grpc_error_set_int(GRPC_ERROR_CREATE("No status received"),
                                         StatusIntProperty::kRpcStatus,
                                         GRPC_STATUS_UNKNOWN));

--- a/src/core/load_balancing/xds/xds_override_host.cc
+++ b/src/core/load_balancing/xds/xds_override_host.cc
@@ -32,6 +32,7 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/functional/function_ref.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -530,7 +531,7 @@ XdsOverrideHostLb::Picker::PickOverridenHost(
   // a connection attempt and queue the pick until that attempt completes.
   if (idle_subchannel != nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_xds_override_host_trace)) {
-      gpr_log(GPR_INFO, "Picker override found IDLE subchannel");
+      LOG(INFO) << "Picker override found IDLE subchannel";
     }
     // Deletes itself after the connection is requested.
     new SubchannelConnectionRequester(std::move(idle_subchannel));
@@ -540,7 +541,7 @@ XdsOverrideHostLb::Picker::PickOverridenHost(
   // queue the pick and wait for the connection attempt to complete.
   if (found_connecting) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_xds_override_host_trace)) {
-      gpr_log(GPR_INFO, "Picker override found CONNECTING subchannel");
+      LOG(INFO) << "Picker override found CONNECTING subchannel";
     }
     return PickResult::Queue();
   }
@@ -549,7 +550,7 @@ XdsOverrideHostLb::Picker::PickOverridenHost(
   // creation of a subchannel for that entry.
   if (!address_with_no_subchannel.empty()) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_xds_override_host_trace)) {
-      gpr_log(GPR_INFO, "Picker override found entry with no subchannel");
+      LOG(INFO) << "Picker override found entry with no subchannel";
     }
     if (!IsWorkSerializerDispatchEnabled()) {
       new SubchannelCreationRequester(policy_, address_with_no_subchannel);

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -207,7 +207,8 @@ static tsi_result handshaker_result_create_frame_protector(
     const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
     tsi_frame_protector** protector) {
   if (self == nullptr || protector == nullptr) {
-    LOG(ERROR) << "Invalid arguments to handshaker_result_create_frame_protector()";
+    LOG(ERROR)
+        << "Invalid arguments to handshaker_result_create_frame_protector()";
     return TSI_INVALID_ARGUMENT;
   }
   alts_tsi_handshaker_result* result =

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "upb/mem/arena.hpp"
 
 #include <grpc/credentials.h>
@@ -87,7 +88,7 @@ typedef struct alts_tsi_handshaker_result {
 static tsi_result handshaker_result_extract_peer(
     const tsi_handshaker_result* self, tsi_peer* peer) {
   if (self == nullptr || peer == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid argument to handshaker_result_extract_peer()");
+    LOG(ERROR) << "Invalid argument to handshaker_result_extract_peer()";
     return TSI_INVALID_ARGUMENT;
   }
   alts_tsi_handshaker_result* result =
@@ -97,7 +98,7 @@ static tsi_result handshaker_result_extract_peer(
   tsi_result ok = tsi_construct_peer(kTsiAltsNumOfPeerProperties, peer);
   int index = 0;
   if (ok != TSI_OK) {
-    gpr_log(GPR_ERROR, "Failed to construct tsi peer");
+    LOG(ERROR) << "Failed to construct tsi peer";
     return ok;
   }
   CHECK_NE(&peer->properties[index], nullptr);
@@ -106,7 +107,7 @@ static tsi_result handshaker_result_extract_peer(
       &peer->properties[index]);
   if (ok != TSI_OK) {
     tsi_peer_destruct(peer);
-    gpr_log(GPR_ERROR, "Failed to set tsi peer property");
+    LOG(ERROR) << "Failed to set tsi peer property";
     return ok;
   }
   index++;
@@ -116,7 +117,7 @@ static tsi_result handshaker_result_extract_peer(
       &peer->properties[index]);
   if (ok != TSI_OK) {
     tsi_peer_destruct(peer);
-    gpr_log(GPR_ERROR, "Failed to set tsi peer property");
+    LOG(ERROR) << "Failed to set tsi peer property";
   }
   index++;
   CHECK_NE(&peer->properties[index], nullptr);
@@ -126,7 +127,7 @@ static tsi_result handshaker_result_extract_peer(
       GRPC_SLICE_LENGTH(result->rpc_versions), &peer->properties[index]);
   if (ok != TSI_OK) {
     tsi_peer_destruct(peer);
-    gpr_log(GPR_ERROR, "Failed to set tsi peer property");
+    LOG(ERROR) << "Failed to set tsi peer property";
   }
   index++;
   CHECK_NE(&peer->properties[index], nullptr);
@@ -136,7 +137,7 @@ static tsi_result handshaker_result_extract_peer(
       GRPC_SLICE_LENGTH(result->serialized_context), &peer->properties[index]);
   if (ok != TSI_OK) {
     tsi_peer_destruct(peer);
-    gpr_log(GPR_ERROR, "Failed to set tsi peer property");
+    LOG(ERROR) << "Failed to set tsi peer property";
   }
   index++;
   CHECK_NE(&peer->properties[index], nullptr);
@@ -146,7 +147,7 @@ static tsi_result handshaker_result_extract_peer(
       &peer->properties[index]);
   if (ok != TSI_OK) {
     tsi_peer_destruct(peer);
-    gpr_log(GPR_ERROR, "Failed to set tsi peer property");
+    LOG(ERROR) << "Failed to set tsi peer property";
   }
   CHECK(++index == kTsiAltsNumOfPeerProperties);
   return ok;
@@ -163,8 +164,7 @@ static tsi_result handshaker_result_create_zero_copy_grpc_protector(
     const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
     tsi_zero_copy_grpc_protector** protector) {
   if (self == nullptr || protector == nullptr) {
-    gpr_log(GPR_ERROR,
-            "Invalid arguments to create_zero_copy_grpc_protector()");
+    LOG(ERROR) << "Invalid arguments to create_zero_copy_grpc_protector()";
     return TSI_INVALID_ARGUMENT;
   }
   alts_tsi_handshaker_result* result =
@@ -198,7 +198,7 @@ static tsi_result handshaker_result_create_zero_copy_grpc_protector(
       /*is_integrity_only=*/false, /*enable_extra_copy=*/false,
       max_output_protected_frame_size, protector);
   if (ok != TSI_OK) {
-    gpr_log(GPR_ERROR, "Failed to create zero-copy grpc protector");
+    LOG(ERROR) << "Failed to create zero-copy grpc protector";
   }
   return ok;
 }
@@ -207,8 +207,7 @@ static tsi_result handshaker_result_create_frame_protector(
     const tsi_handshaker_result* self, size_t* max_output_protected_frame_size,
     tsi_frame_protector** protector) {
   if (self == nullptr || protector == nullptr) {
-    gpr_log(GPR_ERROR,
-            "Invalid arguments to handshaker_result_create_frame_protector()");
+    LOG(ERROR) << "Invalid arguments to handshaker_result_create_frame_protector()";
     return TSI_INVALID_ARGUMENT;
   }
   alts_tsi_handshaker_result* result =
@@ -219,7 +218,7 @@ static tsi_result handshaker_result_create_frame_protector(
       kAltsAes128GcmRekeyKeyLength, result->is_client, /*is_rekey=*/true,
       max_output_protected_frame_size, protector);
   if (ok != TSI_OK) {
-    gpr_log(GPR_ERROR, "Failed to create frame protector");
+    LOG(ERROR) << "Failed to create frame protector";
   }
   return ok;
 }
@@ -228,8 +227,7 @@ static tsi_result handshaker_result_get_unused_bytes(
     const tsi_handshaker_result* self, const unsigned char** bytes,
     size_t* bytes_size) {
   if (self == nullptr || bytes == nullptr || bytes_size == nullptr) {
-    gpr_log(GPR_ERROR,
-            "Invalid arguments to handshaker_result_get_unused_bytes()");
+    LOG(ERROR) << "Invalid arguments to handshaker_result_get_unused_bytes()";
     return TSI_INVALID_ARGUMENT;
   }
   alts_tsi_handshaker_result* result =
@@ -267,7 +265,7 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
                                              bool is_client,
                                              tsi_handshaker_result** result) {
   if (result == nullptr || resp == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid arguments to create_handshaker_result()");
+    LOG(ERROR) << "Invalid arguments to create_handshaker_result()";
     return TSI_INVALID_ARGUMENT;
   }
   const grpc_gcp_HandshakerResult* hresult =
@@ -275,42 +273,42 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
   const grpc_gcp_Identity* identity =
       grpc_gcp_HandshakerResult_peer_identity(hresult);
   if (identity == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid identity");
+    LOG(ERROR) << "Invalid identity";
     return TSI_FAILED_PRECONDITION;
   }
   upb_StringView peer_service_account =
       grpc_gcp_Identity_service_account(identity);
   if (peer_service_account.size == 0) {
-    gpr_log(GPR_ERROR, "Invalid peer service account");
+    LOG(ERROR) << "Invalid peer service account";
     return TSI_FAILED_PRECONDITION;
   }
   upb_StringView key_data = grpc_gcp_HandshakerResult_key_data(hresult);
   if (key_data.size < kAltsAes128GcmRekeyKeyLength) {
-    gpr_log(GPR_ERROR, "Bad key length");
+    LOG(ERROR) << "Bad key length";
     return TSI_FAILED_PRECONDITION;
   }
   const grpc_gcp_RpcProtocolVersions* peer_rpc_version =
       grpc_gcp_HandshakerResult_peer_rpc_versions(hresult);
   if (peer_rpc_version == nullptr) {
-    gpr_log(GPR_ERROR, "Peer does not set RPC protocol versions.");
+    LOG(ERROR) << "Peer does not set RPC protocol versions.";
     return TSI_FAILED_PRECONDITION;
   }
   upb_StringView application_protocol =
       grpc_gcp_HandshakerResult_application_protocol(hresult);
   if (application_protocol.size == 0) {
-    gpr_log(GPR_ERROR, "Invalid application protocol");
+    LOG(ERROR) << "Invalid application protocol";
     return TSI_FAILED_PRECONDITION;
   }
   upb_StringView record_protocol =
       grpc_gcp_HandshakerResult_record_protocol(hresult);
   if (record_protocol.size == 0) {
-    gpr_log(GPR_ERROR, "Invalid record protocol");
+    LOG(ERROR) << "Invalid record protocol";
     return TSI_FAILED_PRECONDITION;
   }
   const grpc_gcp_Identity* local_identity =
       grpc_gcp_HandshakerResult_local_identity(hresult);
   if (local_identity == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid local identity");
+    LOG(ERROR) << "Invalid local identity";
     return TSI_FAILED_PRECONDITION;
   }
   upb_StringView local_service_account =
@@ -331,7 +329,7 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
   bool serialized = grpc_gcp_rpc_protocol_versions_encode(
       peer_rpc_version, rpc_versions_arena.ptr(), &sresult->rpc_versions);
   if (!serialized) {
-    gpr_log(GPR_ERROR, "Failed to serialize peer's RPC protocol versions.");
+    LOG(ERROR) << "Failed to serialize peer's RPC protocol versions.";
     return TSI_FAILED_PRECONDITION;
   }
   upb::Arena context_arena;
@@ -348,7 +346,7 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
       context, const_cast<grpc_gcp_RpcProtocolVersions*>(peer_rpc_version));
   grpc_gcp_Identity* peer_identity = const_cast<grpc_gcp_Identity*>(identity);
   if (peer_identity == nullptr) {
-    gpr_log(GPR_ERROR, "Null peer identity in ALTS context.");
+    LOG(ERROR) << "Null peer identity in ALTS context.";
     return TSI_FAILED_PRECONDITION;
   }
   if (grpc_gcp_Identity_attributes_size(identity) != 0) {
@@ -372,7 +370,7 @@ tsi_result alts_tsi_handshaker_result_create(grpc_gcp_HandshakerResp* resp,
   char* serialized_ctx = grpc_gcp_AltsContext_serialize(
       context, context_arena.ptr(), &serialized_ctx_length);
   if (serialized_ctx == nullptr) {
-    gpr_log(GPR_ERROR, "Failed to serialize peer's ALTS context.");
+    LOG(ERROR) << "Failed to serialize peer's ALTS context.";
     return TSI_FAILED_PRECONDITION;
   }
   sresult->serialized_context =
@@ -388,7 +386,7 @@ static void on_handshaker_service_resp_recv(void* arg,
                                             grpc_error_handle error) {
   alts_handshaker_client* client = static_cast<alts_handshaker_client*>(arg);
   if (client == nullptr) {
-    gpr_log(GPR_ERROR, "ALTS handshaker client is nullptr");
+    LOG(ERROR) << "ALTS handshaker client is nullptr";
     return;
   }
   bool success = true;
@@ -440,7 +438,7 @@ static tsi_result alts_tsi_handshaker_continue_handshaker_next(
         handshaker->client_vtable_for_testing, handshaker->is_client,
         handshaker->max_frame_size, error);
     if (client == nullptr) {
-      gpr_log(GPR_ERROR, "Failed to create ALTS handshaker client");
+      LOG(ERROR) << "Failed to create ALTS handshaker client";
       if (error != nullptr) *error = "Failed to create ALTS handshaker client";
       return TSI_FAILED_PRECONDITION;
     }
@@ -449,7 +447,7 @@ static tsi_result alts_tsi_handshaker_continue_handshaker_next(
       CHECK_EQ(handshaker->client, nullptr);
       handshaker->client = client;
       if (handshaker->shutdown) {
-        gpr_log(GPR_INFO, "TSI handshake shutdown");
+        LOG(INFO) << "TSI handshake shutdown";
         if (error != nullptr) *error = "TSI handshaker shutdown";
         return TSI_HANDSHAKE_SHUTDOWN;
       }
@@ -529,7 +527,7 @@ static tsi_result handshaker_next(
     size_t* /*bytes_to_send_size*/, tsi_handshaker_result** /*result*/,
     tsi_handshaker_on_next_done_cb cb, void* user_data, std::string* error) {
   if (self == nullptr || cb == nullptr) {
-    gpr_log(GPR_ERROR, "Invalid arguments to handshaker_next()");
+    LOG(ERROR) << "Invalid arguments to handshaker_next()";
     if (error != nullptr) *error = "invalid argument";
     return TSI_INVALID_ARGUMENT;
   }
@@ -538,7 +536,7 @@ static tsi_result handshaker_next(
   {
     grpc_core::MutexLock lock(&handshaker->mu);
     if (handshaker->shutdown) {
-      gpr_log(GPR_INFO, "TSI handshake shutdown");
+      LOG(INFO) << "TSI handshake shutdown";
       if (error != nullptr) *error = "handshake shutdown";
       return TSI_HANDSHAKE_SHUTDOWN;
     }
@@ -569,7 +567,7 @@ static tsi_result handshaker_next(
     tsi_result ok = alts_tsi_handshaker_continue_handshaker_next(
         handshaker, received_bytes, received_bytes_size, cb, user_data, error);
     if (ok != TSI_OK) {
-      gpr_log(GPR_ERROR, "Failed to schedule ALTS handshaker requests");
+      LOG(ERROR) << "Failed to schedule ALTS handshaker requests";
       return ok;
     }
   }
@@ -651,7 +649,7 @@ tsi_result alts_tsi_handshaker_create(
     size_t user_specified_max_frame_size) {
   if (handshaker_service_url == nullptr || self == nullptr ||
       options == nullptr || (is_client && target_name == nullptr)) {
-    gpr_log(GPR_ERROR, "Invalid arguments to alts_tsi_handshaker_create()");
+    LOG(ERROR) << "Invalid arguments to alts_tsi_handshaker_create()";
     return TSI_INVALID_ARGUMENT;
   }
   bool use_dedicated_cq = interested_parties == nullptr;


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.
We have the following mapping
1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)
Reviewers need to check :
1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
