### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/src/core/ext/transport/cronet/BUILD
+++ b/src/core/ext/transport/cronet/BUILD
@@ -41,6 +41,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "cronet_c_for_grpc",
     ],
     language = "c++",


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.