### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -37,6 +37,7 @@ grpc_cc_test(
     srcs = ["timer_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -52,6 +53,7 @@ grpc_cc_test(
     srcs = ["time_jump_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -92,6 +92,7 @@ grpc_cc_library(
     srcs = ["rls_server.cc"],
     hdrs = ["rls_server.h"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     deps = [
@@ -187,6 +188,7 @@ grpc_cc_binary(
     srcs = ["client_crash_test_server.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:check",
         "gtest",
     ],
     deps = [
@@ -207,6 +209,7 @@ grpc_cc_test(
     name = "client_fork_test",
     srcs = ["client_fork_test.cc"],
     external_deps = [
+        "absl/log:check",
         "absl/strings",
         "gtest",
     ],
@@ -371,6 +374,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "end2end_test",
     size = "large",
+    external_deps = ["absl/log:check"],
     flaky = True,  # TODO(b/151704375)
     shard_count = 10,
     tags = [
@@ -489,6 +493,7 @@ grpc_cc_test(
     name = "mock_test",
     srcs = ["mock_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -764,6 +769,7 @@ grpc_cc_test(
     name = "server_load_reporting_end2end_test",
     srcs = ["server_load_reporting_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = [
@@ -782,6 +788,7 @@ grpc_cc_test(
     name = "flaky_network_test",
     srcs = ["flaky_network_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = [
@@ -828,6 +835,7 @@ grpc_cc_test(
     name = "streaming_throughput_test",
     srcs = ["streaming_throughput_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = [
@@ -851,6 +859,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["thread_stress_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     shard_count = 5,
@@ -1035,6 +1044,7 @@ grpc_cc_test(
     name = "orca_service_end2end_test",
     srcs = ["orca_service_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1080,6 +1090,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = ["ssl_credentials_test"],
@@ -1106,6 +1117,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = ["tls_credentials_test"],

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -29,6 +29,7 @@ grpc_cc_library(
     external_deps = [
         "gtest",
         "absl/log:check",
+        "absl/log:log",
         "absl/synchronization",
     ],
     deps = [
@@ -65,6 +66,7 @@ grpc_cc_library(
     hdrs = ["connection_attempt_injector.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         "//:grpc",
@@ -93,6 +95,7 @@ grpc_cc_library(
     hdrs = ["rls_server.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -107,6 +110,7 @@ grpc_cc_test(
     srcs = ["async_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     shard_count = 10,
@@ -189,6 +193,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -210,6 +215,7 @@ grpc_cc_test(
     srcs = ["client_fork_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -235,6 +241,7 @@ grpc_cc_test(
     srcs = ["client_callback_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -452,6 +459,7 @@ grpc_cc_test(
     srcs = ["hybrid_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -494,6 +502,7 @@ grpc_cc_test(
     srcs = ["mock_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -570,6 +579,7 @@ grpc_cc_test(
     srcs = ["rls_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/types:optional",
         "gtest",
     ],
@@ -704,6 +714,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -730,6 +741,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -770,6 +782,7 @@ grpc_cc_test(
     srcs = ["server_load_reporting_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -789,6 +802,7 @@ grpc_cc_test(
     srcs = ["flaky_network_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -816,6 +830,7 @@ grpc_cc_test(
     srcs = ["shutdown_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -836,6 +851,7 @@ grpc_cc_test(
     srcs = ["streaming_throughput_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -860,6 +876,7 @@ grpc_cc_test(
     srcs = ["thread_stress_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     shard_count = 5,
@@ -884,6 +901,7 @@ grpc_cc_test(
     srcs = ["cfstream_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -913,6 +931,7 @@ grpc_cc_test(
     srcs = ["message_allocator_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -934,6 +953,7 @@ grpc_cc_test(
     srcs = ["context_allocator_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -955,6 +975,7 @@ grpc_cc_test(
     srcs = ["port_sharing_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1045,6 +1066,7 @@ grpc_cc_test(
     srcs = ["orca_service_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1091,6 +1113,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["ssl_credentials_test"],
@@ -1118,6 +1141,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["tls_credentials_test"],
@@ -1146,6 +1170,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["crl_provider_test"],

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -162,6 +162,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_cluster_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -217,6 +218,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_core_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,
@@ -243,6 +245,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_csds_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -324,6 +327,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_wrr_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -410,6 +414,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_routing_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -458,6 +463,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_override_host_end2end_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -71,6 +71,7 @@ grpc_cc_library(
     hdrs = ["xds_end2end_test_lib.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -115,6 +116,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -163,6 +165,7 @@ grpc_cc_test(
     srcs = ["xds_cluster_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -191,6 +194,7 @@ grpc_cc_test(
     srcs = ["xds_cluster_type_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -219,6 +223,7 @@ grpc_cc_test(
     srcs = ["xds_core_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -246,6 +251,7 @@ grpc_cc_test(
     srcs = ["xds_csds_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -328,6 +334,7 @@ grpc_cc_test(
     srcs = ["xds_wrr_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -415,6 +422,7 @@ grpc_cc_test(
     srcs = ["xds_routing_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -464,6 +472,7 @@ grpc_cc_test(
     srcs = ["xds_override_host_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS

--- a/test/cpp/ext/filters/logging/BUILD
+++ b/test/cpp/ext/filters/logging/BUILD
@@ -26,6 +26,7 @@ grpc_cc_library(
     srcs = ["library.cc"],
     hdrs = ["library.h"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -85,6 +85,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -131,6 +132,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -171,6 +173,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":client_helper_lib",
@@ -187,6 +190,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -206,6 +210,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":client_helper_lib",
@@ -225,6 +230,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = ["no_windows"],
     deps = [
@@ -285,6 +291,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -314,7 +321,10 @@ grpc_cc_library(
         "pre_stop_hook_server.h",
         "xds_interop_server_lib.h",
     ],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         "//:grpc++",
         "//:grpc++_reflection",
@@ -335,6 +345,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -384,7 +395,10 @@ grpc_cc_library(
         "istio_echo_server_lib.cc",
     ],
     hdrs = ["istio_echo_server_lib.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         "//:grpc++",
         "//src/proto/grpc/testing:istio_echo_proto",
@@ -399,6 +413,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":istio_echo_server_lib",
@@ -456,6 +471,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -472,6 +488,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     language = "C++",
     tags = ["nobuilder"],
@@ -490,6 +507,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -522,6 +540,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     tags = [
         "no_windows",
@@ -547,6 +566,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     tags = ["nobuilder"],

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -224,6 +224,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:check",
     ],
     tags = ["no_windows"],
     deps = [
@@ -313,6 +314,7 @@ grpc_cc_library(
         "pre_stop_hook_server.h",
         "xds_interop_server_lib.h",
     ],
+    external_deps = ["absl/log:check"],
     deps = [
         "//:grpc++",
         "//:grpc++_reflection",
@@ -332,6 +334,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:check",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -381,6 +384,7 @@ grpc_cc_library(
         "istio_echo_server_lib.cc",
     ],
     hdrs = ["istio_echo_server_lib.h"],
+    external_deps = ["absl/log:check"],
     deps = [
         "//:grpc++",
         "//src/proto/grpc/testing:istio_echo_proto",
@@ -394,6 +398,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:check",
     ],
     deps = [
         ":istio_echo_server_lib",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -253,6 +253,7 @@ grpc_cc_test(
     args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = [
         "no_mac",
@@ -400,6 +401,7 @@ grpc_cc_library(
     hdrs = ["callback_test_service.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "benchmark",
     ],
     deps = [
@@ -448,6 +450,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":bm_callback_test_service_impl",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -369,6 +369,7 @@ grpc_cc_test(
     args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = [
         "no_mac",

--- a/test/cpp/naming/generate_resolver_component_tests.bzl
+++ b/test/cpp/naming/generate_resolver_component_tests.bzl
@@ -33,6 +33,7 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
                 "gtest",
             ],
             deps = [
@@ -55,6 +56,7 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
                 "gtest",
             ],
             deps = [
@@ -78,6 +80,7 @@ def generate_resolver_component_tests():
             external_deps = [
                 "absl/flags:flag",
                 "absl/log:check",
+                "absl/log:log",
                 "absl/strings",
             ],
             deps = [

--- a/test/cpp/performance/BUILD
+++ b/test/cpp/performance/BUILD
@@ -23,6 +23,7 @@ grpc_cc_test(
     srcs = ["writes_per_rpc_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -26,6 +26,7 @@ grpc_cc_library(
     hdrs = ["parse_json.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "protobuf",
     ],
     deps = ["//:grpc++"],
@@ -49,7 +50,10 @@ grpc_cc_library(
         "qps_worker.h",
         "server.h",
     ],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         ":histogram",
         ":interarrival",
@@ -133,6 +137,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":benchmark_config",
@@ -146,7 +151,10 @@ grpc_cc_binary(
 grpc_cc_test(
     name = "inproc_sync_unary_ping_pong_test",
     srcs = ["inproc_sync_unary_ping_pong_test.cc"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -183,7 +191,10 @@ grpc_cc_test(
     name = "qps_openloop_test",
     srcs = ["qps_openloop_test.cc"],
     exec_properties = LARGE_MACHINE,
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     tags = ["no_windows"],  # LARGE_MACHINE is not configured for windows RBE
     deps = [
         ":benchmark_config",
@@ -197,7 +208,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "secure_sync_unary_ping_pong_test",
     srcs = ["secure_sync_unary_ping_pong_test.cc"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -211,7 +225,10 @@ grpc_cc_library(
     name = "usage_timer",
     srcs = ["usage_timer.cc"],
     hdrs = ["usage_timer.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = ["//:gpr"],
 )
 
@@ -245,6 +262,7 @@ grpc_cc_binary(
     srcs = ["scenario_runner.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     deps = [
         ":benchmark_config",

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -146,6 +146,7 @@ grpc_cc_binary(
 grpc_cc_test(
     name = "inproc_sync_unary_ping_pong_test",
     srcs = ["inproc_sync_unary_ping_pong_test.cc"],
+    external_deps = ["absl/log:check"],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -182,6 +183,7 @@ grpc_cc_test(
     name = "qps_openloop_test",
     srcs = ["qps_openloop_test.cc"],
     exec_properties = LARGE_MACHINE,
+    external_deps = ["absl/log:check"],
     tags = ["no_windows"],  # LARGE_MACHINE is not configured for windows RBE
     deps = [
         ":benchmark_config",
@@ -195,6 +197,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "secure_sync_unary_ping_pong_test",
     srcs = ["secure_sync_unary_ping_pong_test.cc"],
+    external_deps = ["absl/log:check"],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -208,6 +211,7 @@ grpc_cc_library(
     name = "usage_timer",
     srcs = ["usage_timer.cc"],
     hdrs = ["usage_timer.h"],
+    external_deps = ["absl/log:check"],
     deps = ["//:gpr"],
 )
 
@@ -216,6 +220,7 @@ grpc_cc_binary(
     srcs = ["worker.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:check",
     ],
     deps = [
         ":qps_worker_impl",
@@ -231,6 +236,7 @@ grpc_py_binary(
     testonly = True,
     srcs = ["scenario_runner.py"],
     data = ["scenario_runner_cc"],
+    external_deps = ["absl/log:check"],
     python_version = "PY3",
 )
 

--- a/test/cpp/qps/qps_benchmark_script.bzl
+++ b/test/cpp/qps/qps_benchmark_script.bzl
@@ -58,6 +58,7 @@ def qps_json_driver_batch():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
             ],
             tags = [
                 "qps_json_driver",
@@ -85,6 +86,7 @@ def json_run_localhost_batch():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
             ],
             deps = [
                 "//:gpr",

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -53,6 +53,7 @@ grpc_cc_test(
     name = "server_request_call_test",
     srcs = ["server_request_call_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -54,6 +54,7 @@ grpc_cc_test(
     srcs = ["server_request_call_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/server/load_reporter/BUILD
+++ b/test/cpp/server/load_reporter/BUILD
@@ -36,6 +36,7 @@ grpc_cc_test(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "gtest",
         "opencensus-stats-test",
     ],

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -26,6 +26,7 @@ grpc_cc_test(
     srcs = ["thread_manager_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -25,6 +25,7 @@ grpc_cc_test(
     name = "thread_manager_test",
     srcs = ["thread_manager_test.cc"],
     external_deps = [
+        "absl/log:check",
         "gtest",
     ],
     deps = [


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.