### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/test/core/event_engine/BUILD
+++ b/test/core/event_engine/BUILD
@@ -39,6 +39,7 @@ grpc_cc_test(
     name = "forkable_test",
     srcs = ["forkable_test.cc"],
     external_deps = [
+        "absl/log:log",
         "absl/types:optional",
         "gtest",
     ],
@@ -221,6 +222,7 @@ grpc_cc_library(
     hdrs = ["event_engine_test_utils.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",

--- a/test/core/event_engine/fuzzing_event_engine/BUILD
+++ b/test/core/event_engine/fuzzing_event_engine/BUILD
@@ -25,7 +25,10 @@ grpc_cc_library(
     name = "fuzzing_event_engine",
     srcs = ["fuzzing_event_engine.cc"],
     hdrs = ["fuzzing_event_engine.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         ":fuzzing_event_engine_proto",
         "//:event_engine_base_hdrs",

--- a/test/core/event_engine/posix/BUILD
+++ b/test/core/event_engine/posix/BUILD
@@ -26,6 +26,7 @@ grpc_cc_library(
     testonly = True,
     srcs = ["posix_engine_test_utils.cc"],
     hdrs = ["posix_engine_test_utils.h"],
+    external_deps = ["absl/log:log"],
     tags = [
         "no_windows",
     ],
@@ -68,7 +69,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "timer_manager_test",
     srcs = ["timer_manager_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -83,7 +87,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "event_poller_posix_test",
     srcs = ["event_poller_posix_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_windows",
@@ -184,6 +191,7 @@ grpc_cc_test(
     srcs = ["posix_endpoint_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -211,7 +219,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "posix_engine_listener_utils_test",
     srcs = ["posix_engine_listener_utils_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "no_windows",
@@ -232,6 +243,7 @@ grpc_cc_test(
     srcs = ["posix_event_engine_connect_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/core/event_engine/test_suite/posix/BUILD
+++ b/test/core/event_engine/test_suite/posix/BUILD
@@ -23,7 +23,10 @@ grpc_cc_library(
     testonly = True,
     srcs = ["oracle_event_engine_posix.cc"],
     hdrs = ["oracle_event_engine_posix.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     tags = [
         "cpu:10",
         "no_windows",

--- a/test/core/event_engine/test_suite/tests/BUILD
+++ b/test/core/event_engine/test_suite/tests/BUILD
@@ -42,6 +42,9 @@ grpc_cc_library(
     testonly = True,
     srcs = ["timer_test.cc"],
     hdrs = ["timer_test.h"],
+    external_deps = [
+        "absl/log:log",
+    ],
     deps = [
         "//test/core/event_engine:event_engine_test_utils",
         "//test/core/event_engine/test_suite:event_engine_test_framework",
@@ -62,6 +65,7 @@ grpc_cc_library(
         "//test/cpp/naming/utils:tcp_connect",
     ],
     external_deps = [
+        "absl/log:log",
         "absl/status:statusor",
         "absl/strings",
         "absl/strings:str_format",

--- a/test/core/event_engine/test_suite/tools/BUILD
+++ b/test/core/event_engine/test_suite/tools/BUILD
@@ -62,6 +62,7 @@ grpc_cc_library(
         "absl/flags:flag",
         "absl/flags:parse",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [

--- a/test/core/event_engine/windows/BUILD
+++ b/test/core/event_engine/windows/BUILD
@@ -21,6 +21,7 @@ grpc_cc_test(
     timeout = "short",
     srcs = ["iocp_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
         "absl/types:variant",
     ],
@@ -92,6 +93,7 @@ grpc_cc_library(
     hdrs = ["create_sockpair.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/status",
     ],
     language = "C++",


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.
