### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/test/core/network_benchmarks/BUILD
+++ b/test/core/network_benchmarks/BUILD
@@ -27,7 +27,10 @@ licenses(["notice"])
 grpc_cc_binary(
     name = "low_level_ping_pong",
     srcs = ["low_level_ping_pong.cc"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -599,7 +599,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "sleep_test",
     srcs = ["sleep_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "c++",
     tags = ["promise_test"],
     uses_event_engine = False,
@@ -652,6 +655,7 @@ grpc_cc_test(
     srcs = ["party_test.cc"],
     external_deps = [
         "absl/base:core_headers",
+        "absl/log:log",
         "gtest",
     ],
     language = "c++",

--- a/test/core/resolver/BUILD
+++ b/test/core/resolver/BUILD
@@ -40,6 +40,7 @@ grpc_cc_test(
     name = "binder_resolver_test",
     srcs = ["binder_resolver_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -54,7 +55,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "dns_resolver_test",
     srcs = ["dns_resolver_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -66,7 +70,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "dns_resolver_cooldown_test",
     srcs = ["dns_resolver_cooldown_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -80,7 +87,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "sockaddr_resolver_test",
     srcs = ["sockaddr_resolver_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/core/resource_quota/BUILD
+++ b/test/core/resource_quota/BUILD
@@ -117,6 +117,7 @@ grpc_cc_test(
     srcs = ["memory_quota_stress_test.cc"],
     external_deps = [
         "absl/base:core_headers",
+        "absl/log:log",
         "absl/strings",
         "absl/types:optional",
         "gtest",

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -60,6 +60,7 @@ grpc_cc_library(
     name = "oauth2_utils",
     srcs = ["oauth2_utils.cc"],
     hdrs = ["oauth2_utils.h"],
+    external_deps = ["absl/log:log"],
     language = "C++",
     visibility = ["//test/cpp:__subpackages__"],
     deps = ["//:grpc"],
@@ -68,7 +69,10 @@ grpc_cc_library(
 grpc_cc_test(
     name = "auth_context_test",
     srcs = ["auth_context_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -99,6 +103,7 @@ grpc_cc_test(
     srcs = ["credentials_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -144,7 +149,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "json_token_test",
     srcs = ["json_token_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = ["credential_token_tests"],
     uses_event_engine = False,
@@ -177,7 +185,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "secure_endpoint_test",
     srcs = ["secure_endpoint_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     flaky = True,
     language = "C++",
     deps = [
@@ -193,7 +204,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "security_connector_test",
     srcs = ["security_connector_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -255,7 +269,10 @@ grpc_cc_binary(
 grpc_cc_binary(
     name = "fetch_oauth2",
     srcs = ["fetch_oauth2.cc"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     language = "C++",
     deps = [
         ":oauth2_utils",
@@ -322,7 +339,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "alts_security_connector_test",
     srcs = ["alts_security_connector_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -440,7 +460,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "grpc_tls_certificate_verifier_test",
     srcs = ["grpc_tls_certificate_verifier_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -65,6 +65,7 @@ grpc_cc_test(
     name = "slice_test",
     srcs = ["slice_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -81,7 +82,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "slice_string_helpers_test",
     srcs = ["slice_string_helpers_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,

--- a/test/core/surface/BUILD
+++ b/test/core/surface/BUILD
@@ -21,7 +21,10 @@ grpc_package(name = "test/core/surface")
 grpc_cc_test(
     name = "grpc_byte_buffer_reader_test",
     srcs = ["byte_buffer_reader_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -49,7 +52,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "grpc_completion_queue_test",
     srcs = ["completion_queue_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -61,7 +67,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "completion_queue_threading_test",
     srcs = ["completion_queue_threading_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -73,7 +82,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "concurrent_connectivity_test",
     srcs = ["concurrent_connectivity_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -120,7 +132,10 @@ grpc_cc_test(
     data = [
         "//src/core/tsi/test_creds:ca.pem",
     ],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -150,7 +165,10 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
@@ -178,7 +196,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "server_test",
     srcs = ["server_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -136,6 +136,7 @@ grpc_cc_library(
     hdrs = ["xds_transport_fake.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
         "absl/types:optional",
     ],
@@ -182,6 +183,7 @@ grpc_proto_fuzzer(
     name = "xds_client_fuzzer",
     srcs = ["xds_client_fuzzer.cc"],
     corpus = "xds_client_corpora",
+    external_deps = ["absl/log:log"],
     language = "C++",
     proto = "xds_client_fuzzer.proto",
     proto_deps = [


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.
