### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/test/core/gpr/BUILD
+++ b/test/core/gpr/BUILD
@@ -47,7 +47,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "env_test",
     srcs = ["env_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -62,6 +65,7 @@ grpc_cc_test(
     srcs = ["log_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -47,6 +47,7 @@ grpc_cc_test(
     external_deps = [
         "absl/debugging:stacktrace",
         "absl/debugging:symbolize",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -193,7 +194,10 @@ grpc_cc_test(
     name = "mpscq_test",
     srcs = ["mpscq_test.cc"],
     exec_properties = LARGE_MACHINE,
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],  # LARGE_MACHINE is not configured for windows RBE
     uses_event_engine = False,
@@ -381,7 +385,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "single_set_ptr_test",
     srcs = ["single_set_ptr_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "c++",
     uses_event_engine = False,
     uses_polling = False,

--- a/test/core/handshake/BUILD
+++ b/test/core/handshake/BUILD
@@ -26,7 +26,10 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [
@@ -40,7 +43,10 @@ grpc_cc_library(
     name = "server_ssl_common",
     srcs = ["server_ssl_common.cc"],
     hdrs = ["server_ssl_common.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     tags = ["no_windows"],
     deps = [
         "//:gpr",
@@ -100,6 +106,7 @@ grpc_cc_test(
 #    ],
 #    external_deps = [
 #        "absl/log:check",
+#        "absl/log:log",
 #    ],
 #    language = "C++",
 #    tags = ["no_mac", no_windows"],

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -66,7 +66,10 @@ grpc_cc_library(
     testonly = True,
     srcs = ["httpcli_test_util.cc"],
     hdrs = ["httpcli_test_util.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         "//:gpr",
         "//:subprocess",
@@ -87,6 +90,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -116,6 +120,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -26,7 +26,10 @@ grpc_cc_library(
     name = "endpoint_tests",
     srcs = ["endpoint_tests.cc"],
     hdrs = ["endpoint_tests.h"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     language = "C++",
     visibility = [
         "//test:__subpackages__",
@@ -62,6 +65,7 @@ grpc_cc_test(
     srcs = ["endpoint_pair_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -82,6 +86,7 @@ grpc_cc_test(
     name = "error_test",
     srcs = ["error_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -113,7 +118,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "fd_posix_test",
     srcs = ["fd_posix_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = ["no_windows"],
     deps = [
@@ -146,6 +154,7 @@ grpc_cc_test(
     external_deps = [
         "absl/flags:flag",
         "absl/flags:parse",
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -168,6 +177,7 @@ grpc_cc_test(
     external_deps = [
         "absl/flags:flag",
         "absl/flags:parse",
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -186,6 +196,7 @@ grpc_cc_test(
     srcs = ["resolve_address_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -205,6 +216,7 @@ grpc_cc_test(
     srcs = ["resolve_address_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -239,7 +251,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "tcp_client_posix_test",
     srcs = ["tcp_client_posix_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "endpoint_test",
@@ -260,6 +275,7 @@ grpc_cc_test(
     srcs = ["tcp_posix_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -314,7 +330,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "tcp_server_posix_test",
     srcs = ["tcp_server_posix_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "event_engine_listener_test",
@@ -331,7 +350,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "timer_heap_test",
     srcs = ["timer_heap_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -348,6 +370,7 @@ grpc_cc_test(
     srcs = ["timer_list_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     uses_event_engine = False,

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -37,6 +37,7 @@ grpc_cc_test(
     name = "json_test",
     srcs = ["json_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/core/load_balancing/BUILD
+++ b/test/core/load_balancing/BUILD
@@ -29,6 +29,7 @@ grpc_cc_library(
     hdrs = ["lb_policy_test_lib.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -104,7 +105,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "outlier_detection_test",
     srcs = ["outlier_detection_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "lb_unit_test",
@@ -140,7 +144,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "xds_override_host_test",
     srcs = ["xds_override_host_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "lb_unit_test",
@@ -230,7 +237,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "weighted_round_robin_test",
     srcs = ["weighted_round_robin_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = [
         "lb_unit_test",

--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -46,6 +46,7 @@ grpc_cc_binary(
         "absl/flags:flag",
         "absl/flags:parse",
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = [
         "bazel_only",
@@ -69,6 +70,7 @@ grpc_cc_binary(
         "absl/flags:flag",
         "absl/flags:parse",
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = [
         "bazel_only",
@@ -94,6 +96,7 @@ grpc_cc_binary(
         "absl/flags:flag",
         "absl/flags:parse",
         "absl/log:check",
+        "absl/log:log",
         "absl/time",
     ],
     tags = [
@@ -118,6 +121,7 @@ grpc_cc_binary(
     srcs = ["callback_server.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
         "absl/flags:parse",
         "absl/log:check",
     ],
@@ -159,6 +163,7 @@ grpc_cc_test(
         "absl/algorithm:container",
         "absl/flags:flag",
         "absl/flags:parse",
+        "absl/log:log",
     ],
     language = "C++",
     tags = MEMORY_USAGE_TAGS,


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.
