### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -81,6 +81,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/status:statusor",
         "absl/strings",
         "absl/strings:str_format",
@@ -119,6 +120,7 @@ grpc_cc_library(
         "absl/base:core_headers",
         "absl/debugging:failure_signal_handler",
         "absl/log:check",
+        "absl/log:log",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -165,6 +167,7 @@ grpc_cc_library(
     external_deps = [
         "absl/debugging:failure_signal_handler",
         "absl/log:check",
+        "absl/log:log",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -202,7 +205,10 @@ grpc_cc_library(
 grpc_cc_test(
     name = "cmdline_test",
     srcs = ["cmdline_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -221,6 +227,7 @@ grpc_cc_library(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,
@@ -238,7 +245,10 @@ grpc_cc_library(
 grpc_cc_test(
     name = "histogram_test",
     srcs = ["histogram_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = ["nofixdeps"],
     uses_event_engine = False,
@@ -280,6 +290,7 @@ grpc_cc_test(
         "stack_tracer_test.cc",
     ],
     external_deps = [
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -302,6 +313,7 @@ grpc_cc_library(
     hdrs = ["test_lb_policies.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/status",
         "absl/status:statusor",
         "absl/strings",
@@ -341,6 +353,7 @@ grpc_cc_library(
     hdrs = ["fake_udp_and_tcp_server.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/status:statusor",
         "absl/strings",
     ],
@@ -506,6 +519,7 @@ grpc_cc_library(
         "absl/container:flat_hash_map",
         "absl/functional:any_invocable",
         "absl/log:check",
+        "absl/log:log",
         "absl/status",
         "absl/strings",
         "absl/types:optional",

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -39,6 +39,7 @@ grpc_cc_test(
     name = "interception_chain_test",
     srcs = ["interception_chain_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/core/transport/binder/end2end/BUILD
+++ b/test/core/transport/binder/end2end/BUILD
@@ -27,6 +27,7 @@ grpc_cc_library(
     srcs = ["fake_binder.cc"],
     hdrs = ["fake_binder.h"],
     external_deps = [
+        "absl/log:log",
         "absl/memory",
         "absl/random",
         "absl/strings",

--- a/test/core/transport/binder/end2end/fuzzers/BUILD
+++ b/test/core/transport/binder/end2end/fuzzers/BUILD
@@ -35,7 +35,10 @@ grpc_proto_library(
 grpc_cc_library(
     name = "fuzzer_utils",
     srcs = ["fuzzer_utils.cc"],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     language = "c++",
     public_hdrs = ["fuzzer_utils.h"],
     deps = [

--- a/test/core/transport/chaotic_good/BUILD
+++ b/test/core/transport/chaotic_good/BUILD
@@ -95,6 +95,7 @@ grpc_proto_fuzzer(
     corpus = "frame_fuzzer_corpus",
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/random:bit_gen_ref",
         "absl/status:statusor",
     ],
@@ -224,6 +225,7 @@ grpc_cc_test(
     srcs = ["chaotic_good_server_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
         "absl/time",
         "gtest",

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -141,7 +141,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bin_decoder_test",
     srcs = ["bin_decoder_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -169,7 +172,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bin_encoder_test",
     srcs = ["bin_encoder_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -292,7 +298,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "hpack_encoder_test",
     srcs = ["hpack_encoder_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     tags = ["hpack_test"],
     uses_event_engine = False,
@@ -373,6 +382,7 @@ grpc_cc_test(
     srcs = ["settings_timeout_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -391,6 +401,7 @@ grpc_cc_test(
     srcs = ["too_many_pings_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -410,7 +421,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "varint_test",
     srcs = ["varint_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     uses_event_engine = False,
     uses_polling = False,
@@ -434,6 +448,7 @@ grpc_cc_test(
     exec_properties = LARGE_MACHINE,
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",
@@ -454,6 +469,7 @@ grpc_cc_test(
     srcs = ["stream_leak_with_queued_flow_control_update_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/core/transport/test_suite/BUILD
+++ b/test/core/transport/test_suite/BUILD
@@ -71,6 +71,7 @@ grpc_cc_library(
     hdrs = ["test.h"],
     external_deps = [
         "absl/functional:any_invocable",
+        "absl/log:log",
         "absl/random",
         "absl/random:bit_gen_ref",
         "absl/strings",

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -111,6 +111,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -167,7 +168,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "transport_security_test",
     srcs = ["transport_security_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     language = "C++",
     deps = [
         "//:gpr",

--- a/test/core/tsi/alts/fake_handshaker/BUILD
+++ b/test/core/tsi/alts/fake_handshaker/BUILD
@@ -59,6 +59,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [

--- a/test/core/tsi/alts/handshaker/BUILD
+++ b/test/core/tsi/alts/handshaker/BUILD
@@ -22,6 +22,7 @@ grpc_cc_library(
     name = "alts_handshaker_service_api_test_lib",
     srcs = ["alts_handshaker_service_api_test_lib.cc"],
     hdrs = ["alts_handshaker_service_api_test_lib.h"],
+    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc",
     ],
@@ -83,6 +84,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.
