### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD

### DIFF
--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -37,6 +37,7 @@ grpc_cc_test(
     srcs = ["timer_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -52,6 +53,7 @@ grpc_cc_test(
     srcs = ["time_jump_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -27,6 +27,7 @@ grpc_cc_library(
     srcs = ["test_service_impl.cc"],
     hdrs = ["test_service_impl.h"],
     external_deps = [
+        "absl/log:log",
         "gtest",
         "absl/log:check",
         "absl/synchronization",
@@ -65,6 +66,7 @@ grpc_cc_library(
     hdrs = ["connection_attempt_injector.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         "//:grpc",
@@ -92,6 +94,7 @@ grpc_cc_library(
     srcs = ["rls_server.cc"],
     hdrs = ["rls_server.h"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -106,6 +109,7 @@ grpc_cc_test(
     srcs = ["async_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     shard_count = 10,
@@ -187,6 +191,7 @@ grpc_cc_binary(
     srcs = ["client_crash_test_server.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -207,6 +212,7 @@ grpc_cc_test(
     name = "client_fork_test",
     srcs = ["client_fork_test.cc"],
     external_deps = [
+        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -232,6 +238,7 @@ grpc_cc_test(
     srcs = ["client_callback_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -371,6 +378,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "end2end_test",
     size = "large",
+    external_deps = ["absl/log:log"],
     flaky = True,  # TODO(b/151704375)
     shard_count = 10,
     tags = [
@@ -448,6 +456,7 @@ grpc_cc_test(
     srcs = ["hybrid_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -489,6 +498,7 @@ grpc_cc_test(
     name = "mock_test",
     srcs = ["mock_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -565,6 +575,7 @@ grpc_cc_test(
     srcs = ["rls_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "absl/types:optional",
         "gtest",
     ],
@@ -599,6 +610,7 @@ grpc_cc_test(
     srcs = ["service_config_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -699,6 +711,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -725,6 +738,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -764,6 +778,7 @@ grpc_cc_test(
     name = "server_load_reporting_end2end_test",
     srcs = ["server_load_reporting_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -782,6 +797,7 @@ grpc_cc_test(
     name = "flaky_network_test",
     srcs = ["flaky_network_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -809,6 +825,7 @@ grpc_cc_test(
     srcs = ["shutdown_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -828,6 +845,7 @@ grpc_cc_test(
     name = "streaming_throughput_test",
     srcs = ["streaming_throughput_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -851,6 +869,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["thread_stress_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     shard_count = 5,
@@ -875,6 +894,7 @@ grpc_cc_test(
     srcs = ["cfstream_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -904,6 +924,7 @@ grpc_cc_test(
     srcs = ["message_allocator_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -925,6 +946,7 @@ grpc_cc_test(
     srcs = ["context_allocator_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -946,6 +968,7 @@ grpc_cc_test(
     srcs = ["port_sharing_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1035,6 +1058,7 @@ grpc_cc_test(
     name = "orca_service_end2end_test",
     srcs = ["orca_service_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1080,6 +1104,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = ["ssl_credentials_test"],
@@ -1106,6 +1131,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = ["tls_credentials_test"],
@@ -1134,6 +1160,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["crl_provider_test"],

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -71,6 +71,7 @@ grpc_cc_library(
     hdrs = ["xds_end2end_test_lib.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -115,6 +116,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -162,6 +164,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_cluster_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -190,6 +193,7 @@ grpc_cc_test(
     srcs = ["xds_cluster_type_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -217,6 +221,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_core_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -243,6 +248,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_csds_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -324,6 +330,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_wrr_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -410,6 +417,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_routing_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -458,6 +466,7 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_override_host_end2end_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS

--- a/test/cpp/ext/filters/logging/BUILD
+++ b/test/cpp/ext/filters/logging/BUILD
@@ -26,6 +26,7 @@ grpc_cc_library(
     srcs = ["library.cc"],
     hdrs = ["library.h"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -69,6 +69,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -131,6 +132,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -171,6 +173,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":client_helper_lib",
@@ -187,6 +190,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -206,6 +210,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":client_helper_lib",
@@ -224,6 +229,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     tags = ["no_windows"],
     deps = [
@@ -284,6 +290,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -313,6 +320,7 @@ grpc_cc_library(
         "pre_stop_hook_server.h",
         "xds_interop_server_lib.h",
     ],
+    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc++",
         "//:grpc++_reflection",
@@ -332,6 +340,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -381,6 +390,7 @@ grpc_cc_library(
         "istio_echo_server_lib.cc",
     ],
     hdrs = ["istio_echo_server_lib.h"],
+    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc++",
         "//src/proto/grpc/testing:istio_echo_proto",
@@ -394,6 +404,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     deps = [
         ":istio_echo_server_lib",
@@ -451,6 +462,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -467,6 +479,7 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     language = "C++",
     tags = ["nobuilder"],
@@ -485,6 +498,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -542,6 +556,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     language = "C++",
     tags = ["nobuilder"],

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -253,6 +253,7 @@ grpc_cc_test(
     args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = [
         "no_mac",
@@ -368,6 +369,7 @@ grpc_cc_test(
     args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     tags = [
         "no_mac",
@@ -400,6 +402,7 @@ grpc_cc_library(
     hdrs = ["callback_test_service.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "benchmark",
     ],
     deps = [
@@ -448,6 +451,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":bm_callback_test_service_impl",

--- a/test/cpp/naming/generate_resolver_component_tests.bzl
+++ b/test/cpp/naming/generate_resolver_component_tests.bzl
@@ -33,6 +33,7 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
                 "gtest",
             ],
             deps = [
@@ -55,6 +56,7 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
                 "gtest",
             ],
             deps = [
@@ -78,6 +80,7 @@ def generate_resolver_component_tests():
             external_deps = [
                 "absl/flags:flag",
                 "absl/log:check",
+                "absl/log:log",
                 "absl/strings",
             ],
             deps = [

--- a/test/cpp/performance/BUILD
+++ b/test/cpp/performance/BUILD
@@ -23,6 +23,7 @@ grpc_cc_test(
     srcs = ["writes_per_rpc_test.cc"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -26,6 +26,7 @@ grpc_cc_library(
     hdrs = ["parse_json.h"],
     external_deps = [
         "absl/log:check",
+        "absl/log:log",
         "protobuf",
     ],
     deps = ["//:grpc++"],
@@ -49,7 +50,10 @@ grpc_cc_library(
         "qps_worker.h",
         "server.h",
     ],
-    external_deps = ["absl/log:check"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log:log",
+    ],
     deps = [
         ":histogram",
         ":interarrival",
@@ -133,6 +137,7 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
     ],
     deps = [
         ":benchmark_config",
@@ -146,6 +151,7 @@ grpc_cc_binary(
 grpc_cc_test(
     name = "inproc_sync_unary_ping_pong_test",
     srcs = ["inproc_sync_unary_ping_pong_test.cc"],
+    external_deps = ["absl/log:log"],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -182,6 +188,7 @@ grpc_cc_test(
     name = "qps_openloop_test",
     srcs = ["qps_openloop_test.cc"],
     exec_properties = LARGE_MACHINE,
+    external_deps = ["absl/log:log"],
     tags = ["no_windows"],  # LARGE_MACHINE is not configured for windows RBE
     deps = [
         ":benchmark_config",
@@ -195,6 +202,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "secure_sync_unary_ping_pong_test",
     srcs = ["secure_sync_unary_ping_pong_test.cc"],
+    external_deps = ["absl/log:log"],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -208,6 +216,7 @@ grpc_cc_library(
     name = "usage_timer",
     srcs = ["usage_timer.cc"],
     hdrs = ["usage_timer.h"],
+    external_deps = ["absl/log:log"],
     deps = ["//:gpr"],
 )
 
@@ -216,6 +225,7 @@ grpc_cc_binary(
     srcs = ["worker.cc"],
     external_deps = [
         "absl/flags:flag",
+        "absl/log:log",
     ],
     deps = [
         ":qps_worker_impl",
@@ -231,6 +241,7 @@ grpc_py_binary(
     testonly = True,
     srcs = ["scenario_runner.py"],
     data = ["scenario_runner_cc"],
+    external_deps = ["absl/log:log"],
     python_version = "PY3",
 )
 

--- a/test/cpp/qps/qps_benchmark_script.bzl
+++ b/test/cpp/qps/qps_benchmark_script.bzl
@@ -85,6 +85,7 @@ def json_run_localhost_batch():
             ],
             external_deps = [
                 "absl/log:check",
+                "absl/log:log",
             ],
             deps = [
                 "//:gpr",

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -53,6 +53,7 @@ grpc_cc_test(
     name = "server_request_call_test",
     srcs = ["server_request_call_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/server/load_reporter/BUILD
+++ b/test/cpp/server/load_reporter/BUILD
@@ -36,6 +36,7 @@ grpc_cc_test(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
+        "absl/log:log",
         "gtest",
         "opencensus-stats-test",
     ],

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -25,6 +25,7 @@ grpc_cc_test(
     name = "thread_manager_test",
     srcs = ["thread_manager_test.cc"],
     external_deps = [
+        "absl/log:log",
         "gtest",
     ],
     deps = [


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD
In this CL we are just editing the build and bzl files to add dependencies.
This is done to prevent merge conflict and constantly having to re-make the make files using generate_projects.sh for each set of changes.
