### PR TITLE
Revert "[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - BUILD (#36607)"

### DIFF
--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -37,7 +37,6 @@ grpc_cc_test(
     srcs = ["timer_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -53,7 +52,6 @@ grpc_cc_test(
     srcs = ["time_jump_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = [

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -27,7 +27,6 @@ grpc_cc_library(
     srcs = ["test_service_impl.cc"],
     hdrs = ["test_service_impl.h"],
     external_deps = [
-        "absl/log:log",
         "gtest",
         "absl/log:check",
         "absl/synchronization",
@@ -66,7 +65,6 @@ grpc_cc_library(
     hdrs = ["connection_attempt_injector.h"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
     ],
     deps = [
         "//:grpc",
@@ -94,7 +92,6 @@ grpc_cc_library(
     srcs = ["rls_server.cc"],
     hdrs = ["rls_server.h"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -109,7 +106,6 @@ grpc_cc_test(
     srcs = ["async_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     shard_count = 10,
@@ -191,7 +187,6 @@ grpc_cc_binary(
     srcs = ["client_crash_test_server.cc"],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -212,7 +207,6 @@ grpc_cc_test(
     name = "client_fork_test",
     srcs = ["client_fork_test.cc"],
     external_deps = [
-        "absl/log:log",
         "absl/strings",
         "gtest",
     ],
@@ -238,7 +232,6 @@ grpc_cc_test(
     srcs = ["client_callback_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -378,7 +371,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "end2end_test",
     size = "large",
-    external_deps = ["absl/log:log"],
     flaky = True,  # TODO(b/151704375)
     shard_count = 10,
     tags = [
@@ -456,7 +448,6 @@ grpc_cc_test(
     srcs = ["hybrid_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -498,7 +489,6 @@ grpc_cc_test(
     name = "mock_test",
     srcs = ["mock_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -575,7 +565,6 @@ grpc_cc_test(
     srcs = ["rls_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "absl/types:optional",
         "gtest",
     ],
@@ -610,7 +599,6 @@ grpc_cc_test(
     srcs = ["service_config_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -711,7 +699,6 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -738,7 +725,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -778,7 +764,6 @@ grpc_cc_test(
     name = "server_load_reporting_end2end_test",
     srcs = ["server_load_reporting_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -797,7 +782,6 @@ grpc_cc_test(
     name = "flaky_network_test",
     srcs = ["flaky_network_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -825,7 +809,6 @@ grpc_cc_test(
     srcs = ["shutdown_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -845,7 +828,6 @@ grpc_cc_test(
     name = "streaming_throughput_test",
     srcs = ["streaming_throughput_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -869,7 +851,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["thread_stress_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     shard_count = 5,
@@ -894,7 +875,6 @@ grpc_cc_test(
     srcs = ["cfstream_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = [
@@ -924,7 +904,6 @@ grpc_cc_test(
     srcs = ["message_allocator_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -946,7 +925,6 @@ grpc_cc_test(
     srcs = ["context_allocator_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -968,7 +946,6 @@ grpc_cc_test(
     srcs = ["port_sharing_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1058,7 +1035,6 @@ grpc_cc_test(
     name = "orca_service_end2end_test",
     srcs = ["orca_service_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = ["cpp_end2end_test"],
@@ -1104,7 +1080,6 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = ["ssl_credentials_test"],
@@ -1131,7 +1106,6 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:server1.pem",
     ],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = ["tls_credentials_test"],
@@ -1160,7 +1134,6 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["crl_provider_test"],

--- a/test/cpp/end2end/xds/BUILD
+++ b/test/cpp/end2end/xds/BUILD
@@ -71,7 +71,6 @@ grpc_cc_library(
     hdrs = ["xds_end2end_test_lib.h"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     deps = [
@@ -116,7 +115,6 @@ grpc_cc_test(
     ],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -164,7 +162,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_cluster_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -193,7 +190,6 @@ grpc_cc_test(
     srcs = ["xds_cluster_type_end2end_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -221,7 +217,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_core_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     flaky = True,
@@ -248,7 +243,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_csds_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -330,7 +324,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_wrr_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS
@@ -417,7 +410,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_routing_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     flaky = True,  # TODO(b/144705388)
@@ -466,7 +458,6 @@ grpc_cc_test(
     size = "large",
     srcs = ["xds_override_host_end2end_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     linkstatic = True,  # Fixes dyld error on MacOS

--- a/test/cpp/ext/filters/logging/BUILD
+++ b/test/cpp/ext/filters/logging/BUILD
@@ -26,7 +26,6 @@ grpc_cc_library(
     srcs = ["library.cc"],
     hdrs = ["library.h"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     language = "C++",

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -69,7 +69,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -132,7 +131,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -173,7 +171,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
     ],
     deps = [
         ":client_helper_lib",
@@ -190,7 +187,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -210,7 +206,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
     ],
     deps = [
         ":client_helper_lib",
@@ -229,7 +224,6 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
     ],
     tags = ["no_windows"],
     deps = [
@@ -290,7 +284,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -320,7 +313,6 @@ grpc_cc_library(
         "pre_stop_hook_server.h",
         "xds_interop_server_lib.h",
     ],
-    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc++",
         "//:grpc++_reflection",
@@ -340,7 +332,6 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -390,7 +381,6 @@ grpc_cc_library(
         "istio_echo_server_lib.cc",
     ],
     hdrs = ["istio_echo_server_lib.h"],
-    external_deps = ["absl/log:log"],
     deps = [
         "//:grpc++",
         "//src/proto/grpc/testing:istio_echo_proto",
@@ -404,7 +394,6 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
     ],
     deps = [
         ":istio_echo_server_lib",
@@ -462,7 +451,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
     ],
     language = "C++",
     deps = [
@@ -479,7 +467,6 @@ grpc_cc_binary(
     ],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
     ],
     language = "C++",
     tags = ["nobuilder"],
@@ -498,7 +485,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
         "otel/exporters/prometheus:prometheus_exporter",
         "otel/sdk/src/metrics",
     ],
@@ -556,7 +542,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
     ],
     language = "C++",
     tags = ["nobuilder"],

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -253,7 +253,6 @@ grpc_cc_test(
     args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
     ],
     tags = [
         "no_mac",
@@ -369,7 +368,6 @@ grpc_cc_test(
     args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
     ],
     tags = [
         "no_mac",
@@ -402,7 +400,6 @@ grpc_cc_library(
     hdrs = ["callback_test_service.h"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "benchmark",
     ],
     deps = [
@@ -451,7 +448,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
     ],
     deps = [
         ":bm_callback_test_service_impl",

--- a/test/cpp/naming/generate_resolver_component_tests.bzl
+++ b/test/cpp/naming/generate_resolver_component_tests.bzl
@@ -33,7 +33,6 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/log:check",
-                "absl/log:log",
                 "gtest",
             ],
             deps = [
@@ -56,7 +55,6 @@ def generate_resolver_component_tests():
             ],
             external_deps = [
                 "absl/log:check",
-                "absl/log:log",
                 "gtest",
             ],
             deps = [
@@ -80,7 +78,6 @@ def generate_resolver_component_tests():
             external_deps = [
                 "absl/flags:flag",
                 "absl/log:check",
-                "absl/log:log",
                 "absl/strings",
             ],
             deps = [

--- a/test/cpp/performance/BUILD
+++ b/test/cpp/performance/BUILD
@@ -23,7 +23,6 @@ grpc_cc_test(
     srcs = ["writes_per_rpc_test.cc"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -26,7 +26,6 @@ grpc_cc_library(
     hdrs = ["parse_json.h"],
     external_deps = [
         "absl/log:check",
-        "absl/log:log",
         "protobuf",
     ],
     deps = ["//:grpc++"],
@@ -50,10 +49,7 @@ grpc_cc_library(
         "qps_worker.h",
         "server.h",
     ],
-    external_deps = [
-        "absl/log:check",
-        "absl/log:log",
-    ],
+    external_deps = ["absl/log:check"],
     deps = [
         ":histogram",
         ":interarrival",
@@ -137,7 +133,6 @@ grpc_cc_binary(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
     ],
     deps = [
         ":benchmark_config",
@@ -151,7 +146,6 @@ grpc_cc_binary(
 grpc_cc_test(
     name = "inproc_sync_unary_ping_pong_test",
     srcs = ["inproc_sync_unary_ping_pong_test.cc"],
-    external_deps = ["absl/log:log"],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -188,7 +182,6 @@ grpc_cc_test(
     name = "qps_openloop_test",
     srcs = ["qps_openloop_test.cc"],
     exec_properties = LARGE_MACHINE,
-    external_deps = ["absl/log:log"],
     tags = ["no_windows"],  # LARGE_MACHINE is not configured for windows RBE
     deps = [
         ":benchmark_config",
@@ -202,7 +195,6 @@ grpc_cc_test(
 grpc_cc_test(
     name = "secure_sync_unary_ping_pong_test",
     srcs = ["secure_sync_unary_ping_pong_test.cc"],
-    external_deps = ["absl/log:log"],
     deps = [
         ":benchmark_config",
         ":driver_impl",
@@ -216,7 +208,6 @@ grpc_cc_library(
     name = "usage_timer",
     srcs = ["usage_timer.cc"],
     hdrs = ["usage_timer.h"],
-    external_deps = ["absl/log:log"],
     deps = ["//:gpr"],
 )
 
@@ -225,7 +216,6 @@ grpc_cc_binary(
     srcs = ["worker.cc"],
     external_deps = [
         "absl/flags:flag",
-        "absl/log:log",
     ],
     deps = [
         ":qps_worker_impl",
@@ -241,7 +231,6 @@ grpc_py_binary(
     testonly = True,
     srcs = ["scenario_runner.py"],
     data = ["scenario_runner_cc"],
-    external_deps = ["absl/log:log"],
     python_version = "PY3",
 )
 

--- a/test/cpp/qps/qps_benchmark_script.bzl
+++ b/test/cpp/qps/qps_benchmark_script.bzl
@@ -85,7 +85,6 @@ def json_run_localhost_batch():
             ],
             external_deps = [
                 "absl/log:check",
-                "absl/log:log",
             ],
             deps = [
                 "//:gpr",

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -53,7 +53,6 @@ grpc_cc_test(
     name = "server_request_call_test",
     srcs = ["server_request_call_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     tags = ["no_windows"],

--- a/test/cpp/server/load_reporter/BUILD
+++ b/test/cpp/server/load_reporter/BUILD
@@ -36,7 +36,6 @@ grpc_cc_test(
     external_deps = [
         "absl/flags:flag",
         "absl/log:check",
-        "absl/log:log",
         "gtest",
         "opencensus-stats-test",
     ],

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -25,7 +25,6 @@ grpc_cc_test(
     name = "thread_manager_test",
     srcs = ["thread_manager_test.cc"],
     external_deps = [
-        "absl/log:log",
         "gtest",
     ],
     deps = [


### PR DESCRIPTION
This reverts commit 15850972ddba9c1262a9d51341da03bc607bd934.

Breaks the bazel distribtests. https://source.cloud.google.com/results/invocations/da317d7c-5240-445f-8953-68a840ccc892/targets/%2F%2Ftools%2Fbazelify_tests%2Ftest:bazel_distribtest_6.5.0_buildtest/log
