### PR TITLE
[Test] Install g++ before gen_upb_api

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -75,7 +75,7 @@ then
   rm -rf third_party/upb/upb
   cp -r third_party/protobuf/upb third_party/upb
   # generate upb gen source codes
-  sudo apt-get install -y build-essential gcc g++
+  export CC=gcc
   tools/codegen/core/gen_upb_api.sh
   # update utf8_range
   rm -rf third_party/utf8_range

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -75,7 +75,8 @@ then
   rm -rf third_party/upb/upb
   cp -r third_party/protobuf/upb third_party/upb
   # generate upb gen source codes
-  apt-get update && apt-get install -y build-essential
+  sudo apt-get update
+  sudo apt-get install -y build-essential
   tools/codegen/core/gen_upb_api.sh
   # update utf8_range
   rm -rf third_party/utf8_range

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -75,8 +75,7 @@ then
   rm -rf third_party/upb/upb
   cp -r third_party/protobuf/upb third_party/upb
   # generate upb gen source codes
-  sudo apt-get update
-  sudo apt-get install -y build-essential
+  sudo apt-get install -y build-essential gcc g++
   tools/codegen/core/gen_upb_api.sh
   # update utf8_range
   rm -rf third_party/utf8_range

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -74,6 +74,8 @@ then
   # update upb
   rm -rf third_party/upb/upb
   cp -r third_party/protobuf/upb third_party/upb
+  # generate upb gen source codes
+  apt-get update && apt-get install -y build-essential
   tools/codegen/core/gen_upb_api.sh
   # update utf8_range
   rm -rf third_party/utf8_range


### PR DESCRIPTION
This is to address the following error error thrown when running protobuf-at-head. This is because Bazel needs a C++ compiler to run `tools/codegen/core/gen_upb_api.sh`. 

```
Auto-Configuration Error: Cannot find gcc or CC (clang); either correct your path or set the CC environment variable
```

This is not ideal as installing `build-essential` package takes time but let's fix it first and get this installed in the CI image later.