### PR TITLE
[Clean-up] Fix deprecated protobuf function usages

### DIFF
--- a/test/cpp/end2end/message_allocator_end2end_test.cc
+++ b/test/cpp/end2end/message_allocator_end2end_test.cc
@@ -326,10 +326,8 @@ class ArenaAllocatorTest : public MessageAllocatorEnd2endTestBase {
     class MessageHolderImpl : public MessageHolder<EchoRequest, EchoResponse> {
      public:
       MessageHolderImpl() {
-        set_request(
-            google::protobuf::Arena::CreateMessage<EchoRequest>(&arena_));
-        set_response(
-            google::protobuf::Arena::CreateMessage<EchoResponse>(&arena_));
+        set_request(google::protobuf::Arena::Create<EchoRequest>(&arena_));
+        set_response(google::protobuf::Arena::Create<EchoResponse>(&arena_));
       }
       void Release() override { delete this; }
       void FreeRequest() override { CHECK(0); }


### PR DESCRIPTION
Resolved the use of deprecated protobuf functions that would have caused clang-tidy issues with the upcoming protobuf release. The error encountered was:

```
2024-05-15 16:47:15,874 9074 warnings generated.
test/cpp/end2end/message_allocator_end2end_test.cc:330:38: error: 'CreateMessage' is deprecated: Use Create [clang-diagnostic-deprecated-declarations,-warnings-as-errors]
  330 |             google::protobuf::Arena::CreateMessage(&arena_));
      |                                      ^
bazel-out/k8-fastbuild/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/arena.h:179:3: note: 'CreateMessage' has been explicitly marked deprecated here
  179 |   ABSL_DEPRECATED("Use Create")
      |   ^
external/com_google_absl/absl/base/attributes.h:683:49: note: expanded from macro 'ABSL_DEPRECATED'
  683 | #define ABSL_DEPRECATED(message) __attribute__((deprecated(message)))
      |                                                 ^
test/cpp/end2end/message_allocator_end2end_test.cc:332:38: error: 'CreateMessage' is deprecated: Use Create [clang-diagnostic-deprecated-declarations,-warnings-as-errors]
  332 |             google::protobuf::Arena::CreateMessage(&arena_));
      |                                      ^
bazel-out/k8-fastbuild/bin/external/com_google_protobuf/src/google/protobuf/_virtual_includes/protobuf_lite/google/protobuf/arena.h:179:3: note: 'CreateMessage' has been explicitly marked deprecated here
  179 |   ABSL_DEPRECATED("Use Create")
      |   ^
external/com_google_absl/absl/base/attributes.h:683:49: note: expanded from macro 'ABSL_DEPRECATED'
  683 | #define ABSL_DEPRECATED(message) __attribute__((deprecated(message)))
      |                         
```