### PR TITLE
[channel trace test] fix Windows portability tests

### DIFF
--- a/src/core/channelz/channel_trace.cc
+++ b/src/core/channelz/channel_trace.cc
@@ -125,6 +125,7 @@ void ChannelTrace::AddTraceEventHelper(TraceEvent* new_trace_event) {
   event_list_memory_usage_ += new_trace_event->memory_usage();
   // maybe garbage collect the tail until we are under the memory limit.
   while (event_list_memory_usage_ > max_event_memory_) {
+gpr_log(GPR_ERROR, "GC: event_list_memory_usage_=%lu max_event_memory_=%lu head_trace_->memory_usage()=%lu", event_list_memory_usage_, max_event_memory_, head_trace_->memory_usage());
     TraceEvent* to_free = head_trace_;
     event_list_memory_usage_ -= to_free->memory_usage();
     head_trace_ = head_trace_->next();

--- a/src/core/channelz/channel_trace.cc
+++ b/src/core/channelz/channel_trace.cc
@@ -125,7 +125,6 @@ void ChannelTrace::AddTraceEventHelper(TraceEvent* new_trace_event) {
   event_list_memory_usage_ += new_trace_event->memory_usage();
   // maybe garbage collect the tail until we are under the memory limit.
   while (event_list_memory_usage_ > max_event_memory_) {
-gpr_log(GPR_ERROR, "GC: event_list_memory_usage_=%lu max_event_memory_=%lu head_trace_->memory_usage()=%lu", event_list_memory_usage_, max_event_memory_, head_trace_->memory_usage());
     TraceEvent* to_free = head_trace_;
     event_list_memory_usage_ -= to_free->memory_usage();
     head_trace_ = head_trace_->next();

--- a/test/core/channelz/channel_trace_test.cc
+++ b/test/core/channelz/channel_trace_test.cc
@@ -321,7 +321,8 @@ TEST(ChannelTracerTest, TestEviction) {
 
 TEST(ChannelTracerTest, TestMultipleEviction) {
   ExecCtx exec_ctx;
-  const int kTraceEventSize = GetSizeofTraceEvent();
+  const size_t kTraceEventSize = GetSizeofTraceEvent();
+gpr_log(GPR_ERROR, "kTraceEventSize=%lu", kTraceEventSize);
   const int kNumEvents = 5;
   ChannelTrace tracer(kTraceEventSize * kNumEvents);
   std::list<::testing::Matcher<Json>> matchers;

--- a/test/core/channelz/channel_trace_test.cc
+++ b/test/core/channelz/channel_trace_test.cc
@@ -322,7 +322,6 @@ TEST(ChannelTracerTest, TestEviction) {
 TEST(ChannelTracerTest, TestMultipleEviction) {
   ExecCtx exec_ctx;
   const size_t kTraceEventSize = GetSizeofTraceEvent();
-gpr_log(GPR_ERROR, "kTraceEventSize=%lu", kTraceEventSize);
   const int kNumEvents = 5;
   ChannelTrace tracer(kTraceEventSize * kNumEvents);
   std::list<::testing::Matcher<Json>> matchers;

--- a/test/core/channelz/channel_trace_test.cc
+++ b/test/core/channelz/channel_trace_test.cc
@@ -338,14 +338,12 @@ gpr_log(GPR_ERROR, "kTraceEventSize=%lu", kTraceEventSize);
   // At this point the list is full, and each subsequent enntry will cause an
   // eviction. We will now add in a trace event that has a copied string. This
   // uses more memory, so it will cause a double eviciction.
-  tracer.AddTraceEvent(
-      ChannelTrace::Severity::Info,
-      grpc_slice_from_copied_string(
-          "long enough string to trigger a multiple eviction"));
+  std::string msg(GRPC_SLICE_INLINED_SIZE + 1, 'x');
+  tracer.AddTraceEvent(ChannelTrace::Severity::Info,
+                       grpc_slice_from_cpp_string(msg));
   matchers.pop_front();
   matchers.pop_front();
-  matchers.push_back(IsTraceEvent(
-      "long enough string to trigger a multiple eviction", "CT_INFO"));
+  matchers.push_back(IsTraceEvent(msg, "CT_INFO"));
   Json json = tracer.RenderJson();
   ValidateJsonProtoTranslation(json);
   EXPECT_THAT(json, IsChannelTrace(kNumEvents + 1,


### PR DESCRIPTION
This fixes breakage triggered by #36434.

Changing the order of the data members in `TraceEvent` caused the total size of the structure to be different, which meant that the long string we were adding was enough to cause 3 events to be evicted instead of 2.

b/339066599