### PR TITLE
[logging] Fix logging for when metrics/tracing is not enabled

### DIFF
--- a/src/core/ext/filters/logging/logging_filter.cc
+++ b/src/core/ext/filters/logging/logging_filter.cc
@@ -369,13 +369,14 @@ void ClientLoggingFilter::Call::OnClientInitialMetadata(
     return;
   }
   call_data_->LogClientHeader(
-      /*is_client=*/true, GetContext<CallTracerAnnotationInterface>(), md);
+      /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(), md);
 }
 
 void ClientLoggingFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
   if (!call_data_.has_value()) return;
   call_data_->LogServerHeader(
-      /*is_client=*/true, GetContext<CallTracerAnnotationInterface>(), &md);
+      /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
+      &md);
 }
 
 void ClientLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
@@ -383,32 +384,33 @@ void ClientLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
   if (md.get(GrpcCallWasCancelled()).value_or(false) &&
       md.get(GrpcStatusMetadata()) == GRPC_STATUS_CANCELLED) {
     call_data_->LogCancel(
-        /*is_client=*/true, GetContext<CallTracerAnnotationInterface>());
+        /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>());
     return;
   }
   call_data_->LogServerTrailer(
-      /*is_client=*/true, GetContext<CallTracerAnnotationInterface>(), &md);
+      /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
+      &md);
 }
 
 void ClientLoggingFilter::Call::OnClientToServerMessage(
     const Message& message) {
   if (!call_data_.has_value()) return;
   call_data_->LogClientMessage(
-      /*is_client=*/true, GetContext<CallTracerAnnotationInterface>(),
+      /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
       message.payload());
 }
 
 void ClientLoggingFilter::Call::OnClientToServerHalfClose() {
   if (!call_data_.has_value()) return;
   call_data_->LogClientHalfClose(
-      /*is_client=*/true, GetContext<CallTracerAnnotationInterface>());
+      /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>());
 }
 
 void ClientLoggingFilter::Call::OnServerToClientMessage(
     const Message& message) {
   if (!call_data_.has_value()) return;
   call_data_->LogServerMessage(
-      /*is_client=*/true, GetContext<CallTracerAnnotationInterface>(),
+      /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
       message.payload());
 }
 
@@ -432,13 +434,15 @@ void ServerLoggingFilter::Call::OnClientInitialMetadata(ClientMetadata& md) {
     return;
   }
   call_data_->LogClientHeader(
-      /*is_client=*/false, GetContext<CallTracerAnnotationInterface>(), md);
+      /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
+      md);
 }
 
 void ServerLoggingFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
   if (!call_data_.has_value()) return;
   call_data_->LogServerHeader(
-      /*is_client=*/false, GetContext<CallTracerAnnotationInterface>(), &md);
+      /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
+      &md);
 }
 
 void ServerLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
@@ -446,32 +450,33 @@ void ServerLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
   if (md.get(GrpcCallWasCancelled()).value_or(false) &&
       md.get(GrpcStatusMetadata()) == GRPC_STATUS_CANCELLED) {
     call_data_->LogCancel(
-        /*is_client=*/false, GetContext<CallTracerAnnotationInterface>());
+        /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>());
     return;
   }
   call_data_->LogServerTrailer(
-      /*is_client=*/false, GetContext<CallTracerAnnotationInterface>(), &md);
+      /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
+      &md);
 }
 
 void ServerLoggingFilter::Call::OnClientToServerMessage(
     const Message& message) {
   if (!call_data_.has_value()) return;
   call_data_->LogClientMessage(
-      /*is_client=*/false, GetContext<CallTracerAnnotationInterface>(),
+      /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
       message.payload());
 }
 
 void ServerLoggingFilter::Call::OnClientToServerHalfClose() {
   if (!call_data_.has_value()) return;
   call_data_->LogClientHalfClose(
-      /*is_client=*/false, GetContext<CallTracerAnnotationInterface>());
+      /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>());
 }
 
 void ServerLoggingFilter::Call::OnServerToClientMessage(
     const Message& message) {
   if (!call_data_.has_value()) return;
   call_data_->LogServerMessage(
-      /*is_client=*/false, GetContext<CallTracerAnnotationInterface>(),
+      /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
       message.payload());
 }
 

--- a/src/core/lib/promise/context.h
+++ b/src/core/lib/promise/context.h
@@ -119,6 +119,12 @@ T* GetContext() {
   return p;
 }
 
+// Retrieve the current value of a context, or nullptr if the value is unset.
+template <typename T>
+T* MaybeGetContext() {
+  return promise_detail::Context<T>::get();
+}
+
 // Given a promise and a context, return a promise that has that context set.
 template <typename T, typename F>
 promise_detail::WithContext<T, F> WithContext(F f, T* context) {

--- a/test/cpp/ext/filters/logging/library.h
+++ b/test/cpp/ext/filters/logging/library.h
@@ -104,7 +104,6 @@ class LoggingTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
     g_test_logging_sink = new TestLoggingSink;
-    grpc::RegisterOpenCensusPlugin();
     grpc_core::RegisterLoggingFilter(g_test_logging_sink);
   }
 

--- a/test/cpp/ext/filters/logging/logging_census_integration_test.cc
+++ b/test/cpp/ext/filters/logging/logging_census_integration_test.cc
@@ -319,5 +319,6 @@ TEST_F(LoggingCensusIntegrationTest, Basic) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc::RegisterOpenCensusPlugin();
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/36598 made a change to the logging filter which required `CallTracerAnnotationInterface` to always be present on the call. That is only the case when metrics/tracing is enabled, which is not always the case.

Also, modify the test to test that logging works even if metrics/tracing is not enabled.

Internal ref - b/341794662
