### PR TITLE
[PSM Interop] Skip Circuit Breaking test in the legacy test driver

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -69,7 +69,7 @@ export PYTHONUNBUFFERED=true
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
   /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
-    --test_case="ping_pong,circuit_breaking" \
+    --test_case="ping_pong" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -70,7 +70,7 @@ bazel build test/cpp/interop:xds_interop_client
 GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
    /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
-    --test_case="ping_pong,circuit_breaking" \
+    --test_case="ping_pong" \
     --project_id=grpc-testing \
     --project_num=830293263384 \
     --source_image=projects/grpc-testing/global/images/xds-test-server-5 \

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -4070,11 +4070,11 @@ try:
             # https://github.com/grpc/psm-interop/blob/main/tests/circuit_breaking_test.py
             # To avoid backports, skipping it in the driver.
             if test_case == "circuit_breaking":
-              logger.info(
+                logger.info(
                     "Ported to https://github.com/grpc/psm-interop/"
                     "blob/main/tests/circuit_breaking_test.py"
                 )
-              continue
+                continue
 
             if test_case in _V3_TEST_CASES and not args.xds_v3_support:
                 logger.info(

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -4066,6 +4066,16 @@ try:
         client_env["GRPC_XDS_EXPERIMENTAL_ENABLE_TIMEOUT"] = "true"
         client_env["GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION"] = "true"
         for test_case in args.test_case:
+            # Circuit breaking ported to the new framework.
+            # https://github.com/grpc/psm-interop/blob/main/tests/circuit_breaking_test.py
+            # To avoid backports, skipping it in the driver.
+            if test_case == "circuit_breaking":
+              logger.info(
+                    "Ported to https://github.com/grpc/psm-interop/"
+                    "blob/main/tests/circuit_breaking_test.py"
+                )
+              continue
+
             if test_case in _V3_TEST_CASES and not args.xds_v3_support:
                 logger.info(
                     "skipping test %s due to missing v3 support", test_case


### PR DESCRIPTION
Circuit breaking ported to the new framework: https://github.com/grpc/psm-interop/blob/main/tests/circuit_breaking_test.py.

To avoid backports, skipping it in the legacy test driver.

ref b/227678751