### PR TITLE
[ruby] trying to debug dlopen failures

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -958,12 +958,14 @@ class RubyLanguage(object):
                 # indefinitely, and on "dbg" builds until the Event Engine
                 # migration completes.
                 continue
+            environment = dict(_FORCE_ENVIRON_FOR_WRAPPERS)
+            environment["LD_DEBUG"] = "all"
             tests.append(
                 self.config.job_spec(
                     ["ruby", test],
                     shortname=test,
                     timeout_seconds=20 * 60,
-                    environ=_FORCE_ENVIRON_FOR_WRAPPERS,
+                    environ=environment,
                 )
             )
         return tests


### PR DESCRIPTION
Example: https://btx.cloud.google.com/invocations/d185d5b0-4aa3-4419-8313-ef027f196049/log

