### PR TITLE
C++20 compat: use invoke_result_t for C++17 and up (#36016)

### DIFF
--- a/src/core/lib/promise/detail/promise_like.h
+++ b/src/core/lib/promise/detail/promise_like.h
@@ -71,7 +71,13 @@ class PromiseLike<void>;
 
 template <typename F>
 class PromiseLike<F, absl::enable_if_t<!std::is_void<
-                         typename std::result_of<F()>::type>::value>> {
+#if (defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+                         std::invoke_result_t<F>
+#else
+                         typename std::result_of<F()>::type
+#endif
+                         >::value>> {
  private:
   GPR_NO_UNIQUE_ADDRESS F f_;
 


### PR DESCRIPTION
Backport https://github.com/grpc/grpc/pull/36016 to v1.64.x