### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/tools/codegen/core/gen_join.py
+++ b/tools/codegen/core/gen_join.py
@@ -70,13 +70,13 @@ struct JoinState<Traits, ${",".join(f"P{i}" for i in range(0,n))}> {
 % for i in range(0,n):
     if (!ready.is_set(${i})) {
       if (grpc_trace_promise_primitives.enabled()) {
-        gpr_log(GPR_DEBUG, "join[%p]: begin poll joint ${i+1}/${n}", this);
+        VLOG(2) << "join[" << this << "]: begin poll joint ${i+1}/${n}";
       }
       auto poll = promise${i}();
       if (grpc_trace_promise_primitives.enabled()) {
         auto* p = poll.value_if_ready();
-        gpr_log(GPR_DEBUG, "join[%p]: joint ${i+1}/${n} %s", this, 
-                p != nullptr? (Traits::IsOk(*p)? "ready" : "early-error") : "pending");
+        VLOG(2) << "join[" << this << "]: joint ${i+1}/${n} "
+                << (p != nullptr ? (Traits::IsOk(*p)? "ready" : "early-error") : "pending");
       }
       if (auto* p = poll.value_if_ready()) {
         if (Traits::IsOk(*p)) {
@@ -88,7 +88,7 @@ struct JoinState<Traits, ${",".join(f"P{i}" for i in range(0,n))}> {
         }
       }
     } else if (grpc_trace_promise_primitives.enabled()) {
-      gpr_log(GPR_DEBUG, "join[%p]: joint ${i+1}/${n} already ready", this);
+      VLOG(2) << "join[" << this << "]: joint ${i+1}/${n} already ready";
     }
 % endfor
     if (ready.all()) {
@@ -109,12 +109,12 @@ front_matter = """
 #include <grpc/support/port_platform.h>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 
 #include "src/core/lib/gprpp/construct_destruct.h"
 #include "src/core/lib/promise/detail/promise_like.h"
 #include "src/core/lib/promise/poll.h"
 #include "src/core/lib/gprpp/bitset.h"
-#include <grpc/support/log.h>
 #include <tuple>
 #include <type_traits>
 #include <utility>

--- a/tools/codegen/core/gen_seq.py
+++ b/tools/codegen/core/gen_seq.py
@@ -143,16 +143,18 @@ tail${i}:
 % for i in range(0,n-1):
       case State::kState${i}: {
         if (grpc_trace_promise_primitives.enabled()) {
-          gpr_log(whence.file(), whence.line(), GPR_LOG_SEVERITY_DEBUG, "seq[%p]: begin poll step ${i+1}/${n}", this);
+          VLOG(2).AtLocation(whence.file(), whence.line()) 
+                << "seq[" << this << "]: begin poll step ${i+1}/${n}";
         }
         auto result = ${"prior."*(n-1-i)}current_promise();
         PromiseResult${i}* p = result.value_if_ready();
         if (grpc_trace_promise_primitives.enabled()) {
-          gpr_log(whence.file(), whence.line(), GPR_LOG_SEVERITY_DEBUG, "seq[%p]: poll step ${i+1}/${n} gets %s", this, 
-                  p != nullptr
+          VLOG(2).AtLocation(whence.file(), whence.line())
+                << "seq[" << this << "]: poll step ${i+1}/${n} gets "
+                << (p != nullptr
                     ? (PromiseResultTraits${i}::IsOk(*p)
-                      ? "ready" 
-                      : absl::StrCat("early-error:", PromiseResultTraits${i}::ErrorString(*p)).c_str()) 
+                      ? "ready"
+                      : absl::StrCat("early-error:", PromiseResultTraits${i}::ErrorString(*p)).c_str())
                     : "pending");
         }
         if (p == nullptr) return Pending{};
@@ -170,11 +172,14 @@ tail${i}:
       default:
       case State::kState${n-1}: {
         if (grpc_trace_promise_primitives.enabled()) {
-          gpr_log(whence.file(), whence.line(), GPR_LOG_SEVERITY_DEBUG, "seq[%p]: begin poll step ${n}/${n}", this);
+          VLOG(2).AtLocation(whence.file(), whence.line()) 
+                << "seq[" << this << "]: begin poll step ${n}/${n}";
         }
         auto result = current_promise();
         if (grpc_trace_promise_primitives.enabled()) {
-          gpr_log(whence.file(), whence.line(), GPR_LOG_SEVERITY_DEBUG, "seq[%p]: poll step ${n}/${n} gets %s", this, result.ready()? "ready" : "pending");
+          VLOG(2).AtLocation(whence.file(), whence.line()) 
+                << "seq[" << this << "]: poll step ${n}/${n} gets " 
+                << (result.ready()? "ready" : "pending");
         }
         auto* p = result.value_if_ready();
         if (p == nullptr) return Pending{};
@@ -198,10 +203,9 @@ front_matter = """
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/base/attributes.h"
 #include "absl/strings/str_cat.h"
-
-#include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/construct_destruct.h"
 #include "src/core/lib/gprpp/debug_location.h"
@@ -216,8 +220,8 @@ front_matter = """
 // previous step and yield a promise. Note that most of the machinery in
 // PromiseFactory exists to make it possible for those promise-factory-like
 // objects to be anything that's convenient.
-// Traits defines how we move from one step to the next. Traits sets up the 
-// wrapping and escape handling for the sequence. 
+// Traits defines how we move from one step to the next. Traits sets up the
+// wrapping and escape handling for the sequence.
 // Promises return wrapped values that the trait can inspect and unwrap before
 // passing them to the next element of the sequence. The trait can
 // also interpret a wrapped value as an escape value, which terminates


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
