### PR TITLE
[Python Server] Remove abstractmethod notation for add_registered_method_handlers (v1.64.x backport)

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1454,7 +1454,6 @@ class Server(abc.ABC):
         """
         raise NotImplementedError()
 
-    @abc.abstractmethod
     def add_registered_method_handlers(self, service_name, method_handlers):
         """Registers GenericRpcHandlers with this Server.
 
@@ -1468,7 +1467,6 @@ class Server(abc.ABC):
           method_handlers: A dictionary that maps method names to corresponding
             RpcMethodHandler.
         """
-        raise NotImplementedError()
 
     @abc.abstractmethod
     def add_insecure_port(self, address):

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -136,7 +136,6 @@ class Server(abc.ABC):
           A bool indicates if the operation times out.
         """
 
-    @abc.abstractmethod
     def add_registered_method_handlers(self, service_name, method_handlers):
         """Registers GenericRpcHandlers with this Server.
 
@@ -147,7 +146,6 @@ class Server(abc.ABC):
           method_handlers: A dictionary that maps method names to corresponding
             RpcMethodHandler.
         """
-        raise NotImplementedError()
 
 
 # pylint: disable=too-many-public-methods


### PR DESCRIPTION
Backport of #36684 to v1.64.x.
---
Remove `@abc.abstractmethod` so we don't break backward compatibility.

Fix: https://github.com/grpc/grpc/issues/36683

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

