### PR TITLE
[Python Otel] Deprecate target_attribute_filter

### DIFF
--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
@@ -102,8 +102,10 @@ class OpenTelemetryPlugin:
         enabled for this OpenTelemetryPlugin.
           meter_provider: A MeterProvider which will be used to collect telemetry data,
         or None which means no metrics will be collected.
-          target_attribute_filter: Once provided, this will be called per channel to decide
-        whether to record the target attribute on client or to replace it with "other".
+          target_attribute_filter: [DEPRECATED] This attribute is deprecated and should
+        not be used.
+        Once provided, this will be called per channel to decide whether to record the
+        target attribute on client or to replace it with "other".
         This helps reduce the cardinality on metrics in cases where many channels
         are created with different targets in the same binary (which might happen
         for example, if the channel target string uses IP addresses directly).


### PR DESCRIPTION
We decided to deprecate `target_attribute_filter` in https://github.com/grpc/proposal/pull/431.

This PR marks the attribute as deprecated.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

