### PR TITLE
[Clean-up] Fix MSAN and UBSAN issues found by clang-19

### DIFF
--- a/include/grpcpp/impl/call_op_set.h
+++ b/include/grpcpp/impl/call_op_set.h
@@ -771,7 +771,9 @@ class CallOpRecvInitialMetadata {
 class CallOpClientRecvStatus {
  public:
   CallOpClientRecvStatus()
-      : recv_status_(nullptr), debug_error_string_(nullptr) {}
+      : metadata_map_(nullptr),
+        recv_status_(nullptr),
+        debug_error_string_(nullptr) {}
 
   void ClientRecvStatus(grpc::ClientContext* context, Status* status) {
     client_context_ = context;

--- a/test/core/end2end/multiple_server_queues_test.cc
+++ b/test/core/end2end/multiple_server_queues_test.cc
@@ -37,6 +37,7 @@ int main(int argc, char** argv) {
   attr.version = 1;
   attr.cq_completion_type = GRPC_CQ_NEXT;
   attr.cq_polling_type = GRPC_CQ_DEFAULT_POLLING;
+  attr.cq_shutdown_cb = nullptr;
   cq1 = grpc_completion_queue_create(
       grpc_completion_queue_factory_lookup(&attr), &attr, nullptr);
 

--- a/test/core/surface/completion_queue_test.cc
+++ b/test/core/surface/completion_queue_test.cc
@@ -78,7 +78,7 @@ TEST(GrpcCompletionQueueTest, TestNoOp) {
   grpc_cq_completion_type completion_types[] = {GRPC_CQ_NEXT, GRPC_CQ_PLUCK};
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   LOG_TEST("test_no_op");
 
   attr.version = 1;
@@ -97,7 +97,7 @@ TEST(GrpcCompletionQueueTest, TestPollsetConversion) {
   grpc_cq_polling_type polling_types[] = {GRPC_CQ_DEFAULT_POLLING,
                                           GRPC_CQ_NON_LISTENING};
   grpc_completion_queue* cq;
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
 
   LOG_TEST("test_pollset_conversion");
 
@@ -118,7 +118,7 @@ TEST(GrpcCompletionQueueTest, TestWaitEmpty) {
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
   grpc_completion_queue* cc;
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   grpc_event event;
 
   LOG_TEST("test_wait_empty");
@@ -145,7 +145,7 @@ TEST(GrpcCompletionQueueTest, TestCqEndOp) {
   grpc_cq_completion completion;
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   void* tag = create_test_tag();
 
   LOG_TEST("test_cq_end_op");
@@ -178,7 +178,7 @@ TEST(GrpcCompletionQueueTest, TestCqTlsCacheFull) {
   grpc_cq_completion completion;
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   void* tag = create_test_tag();
   void* res_tag;
   int ok;
@@ -219,7 +219,7 @@ TEST(GrpcCompletionQueueTest, TestCqTlsCacheEmpty) {
   grpc_completion_queue* cc;
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   void* res_tag;
   int ok;
 
@@ -246,7 +246,7 @@ TEST(GrpcCompletionQueueTest, TestShutdownThenNextPolling) {
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
   grpc_completion_queue* cc;
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   grpc_event event;
   LOG_TEST("test_shutdown_then_next_polling");
 
@@ -268,7 +268,7 @@ TEST(GrpcCompletionQueueTest, TestShutdownThenNextWithTimeout) {
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
   grpc_completion_queue* cc;
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   grpc_event event;
   LOG_TEST("test_shutdown_then_next_with_timeout");
 
@@ -294,7 +294,7 @@ TEST(GrpcCompletionQueueTest, TestPluck) {
   grpc_cq_completion completions[GPR_ARRAY_SIZE(tags)];
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   unsigned i, j;
 
   LOG_TEST("test_pluck");
@@ -348,7 +348,7 @@ TEST(GrpcCompletionQueueTest, TestPluckAfterShutdown) {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
   grpc_event ev;
   grpc_completion_queue* cc;
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
 
   LOG_TEST("test_pluck_after_shutdown");
 
@@ -372,7 +372,7 @@ TEST(GrpcCompletionQueueTest, TestCallback) {
   grpc_cq_completion completions[GPR_ARRAY_SIZE(tags)];
   grpc_cq_polling_type polling_types[] = {
       GRPC_CQ_DEFAULT_POLLING, GRPC_CQ_NON_LISTENING, GRPC_CQ_NON_POLLING};
-  grpc_completion_queue_attributes attr;
+  grpc_completion_queue_attributes attr = {};
   unsigned i;
   static gpr_mu mu, shutdown_mu;
   static gpr_cv cv, shutdown_cv;


### PR DESCRIPTION
Fixed various MSAN and UBSAN issues found in an attempt to bump the clang version used for RBE. (https://github.com/grpc/grpc/pull/36685) As our xSAN tests are using RBE, it revealed a few new issues. This PR is to fix all of those.