### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/cpp/server/external_connection_acceptor_impl.cc
+++ b/src/cpp/server/external_connection_acceptor_impl.cc
@@ -22,8 +22,8 @@
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/server_builder.h>
 #include <grpcpp/support/byte_buffer.h>
 #include <grpcpp/support/channel_arguments.h>
@@ -69,10 +69,8 @@ void ExternalConnectionAcceptorImpl::HandleNewConnection(
   grpc_core::MutexLock lock(&mu_);
   if (shutdown_ || !started_) {
     // TODO(yangg) clean up.
-    gpr_log(
-        GPR_ERROR,
-        "NOT handling external connection with fd %d, started %d, shutdown %d",
-        p->fd, started_, shutdown_);
+    LOG(ERROR) << "NOT handling external connection with fd " << p->fd
+               << ", started " << started_ << ", shutdown " << shutdown_;
     return;
   }
   if (handler_) {

--- a/src/cpp/server/health/default_health_check_service.cc
+++ b/src/cpp/server/health/default_health_check_service.cc
@@ -24,11 +24,11 @@
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "upb/base/string_view.h"
 #include "upb/mem/arena.hpp"
 
 #include <grpc/slice.h>
-#include <grpc/support/log.h>
 #include <grpcpp/impl/rpc_method.h>
 #include <grpcpp/impl/rpc_service_method.h>
 #include <grpcpp/impl/server_callback_handlers.h>
@@ -259,8 +259,8 @@ DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::WatchReactor(
     ++service_->num_watches_;
   }
   bool success = DecodeRequest(*request, &service_name_);
-  gpr_log(GPR_DEBUG, "[HCS %p] watcher %p \"%s\": watch call started", service_,
-          this, service_name_.c_str());
+  VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+          << service_name_ << "\": watch call started";
   if (!success) {
     MaybeFinishLocked(Status(StatusCode::INTERNAL, "could not parse request"));
     return;
@@ -271,15 +271,14 @@ DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::WatchReactor(
 
 void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::
     SendHealth(ServingStatus status) {
-  gpr_log(GPR_DEBUG,
-          "[HCS %p] watcher %p \"%s\": SendHealth() for ServingStatus %d",
-          service_, this, service_name_.c_str(), status);
+  VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+          << service_name_ << "\": SendHealth() for ServingStatus " << status;
   grpc::internal::MutexLock lock(&mu_);
   // If there's already a send in flight, cache the new status, and
   // we'll start a new send for it when the one in flight completes.
   if (write_pending_) {
-    gpr_log(GPR_DEBUG, "[HCS %p] watcher %p \"%s\": queuing write", service_,
-            this, service_name_.c_str());
+    VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+            << service_name_ << "\": queuing write";
     pending_status_ = status;
     return;
   }
@@ -307,17 +306,16 @@ void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::
         Status(StatusCode::INTERNAL, "could not encode response"));
     return;
   }
-  gpr_log(GPR_DEBUG,
-          "[HCS %p] watcher %p \"%s\": starting write for ServingStatus %d",
-          service_, this, service_name_.c_str(), status);
+  VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+          << service_name_ << "\": starting write for ServingStatus " << status;
   write_pending_ = true;
   StartWrite(&response_);
 }
 
 void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::
     OnWriteDone(bool ok) {
-  gpr_log(GPR_DEBUG, "[HCS %p] watcher %p \"%s\": OnWriteDone(): ok=%d",
-          service_, this, service_name_.c_str(), ok);
+  VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+          << service_name_ << "\": OnWriteDone(): ok=" << ok;
   response_.Clear();
   grpc::internal::MutexLock lock(&mu_);
   if (!ok) {
@@ -341,8 +339,8 @@ void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::
 }
 
 void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::OnDone() {
-  gpr_log(GPR_DEBUG, "[HCS %p] watcher %p \"%s\": OnDone()", service_, this,
-          service_name_.c_str());
+  VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+          << service_name_ << "\": OnDone()";
   service_->database_->UnregisterWatch(service_name_, this);
   {
     grpc::internal::MutexLock lock(&service_->mu_);
@@ -356,13 +354,13 @@ void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::OnDone() {
 
 void DefaultHealthCheckService::HealthCheckServiceImpl::WatchReactor::
     MaybeFinishLocked(Status status) {
-  gpr_log(GPR_DEBUG,
-          "[HCS %p] watcher %p \"%s\": MaybeFinishLocked() with code=%d msg=%s",
-          service_, this, service_name_.c_str(), status.error_code(),
-          status.error_message().c_str());
+  VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+          << service_name_
+          << "\": MaybeFinishLocked() with code=" << status.error_code()
+          << " msg=" << status.error_message();
   if (!finish_called_) {
-    gpr_log(GPR_DEBUG, "[HCS %p] watcher %p \"%s\": actually calling Finish()",
-            service_, this, service_name_.c_str());
+    VLOG(2) << "[HCS " << service_ << "] watcher " << this << " \""
+            << service_name_ << "\": actually calling Finish()";
     finish_called_ = true;
     Finish(status);
   }

--- a/src/cpp/server/load_reporter/load_data_store.cc
+++ b/src/cpp/server/load_reporter/load_data_store.cc
@@ -27,8 +27,8 @@
 #include <unordered_map>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/iomgr/socket_utils.h"
@@ -150,13 +150,13 @@ void PerBalancerStore::MergeRow(const LoadRecordKey& key,
   // During suspension, the load data received will be dropped.
   if (!suspended_) {
     load_record_map_[key].MergeFrom(value);
-    gpr_log(GPR_DEBUG,
-            "[PerBalancerStore %p] Load data merged (Key: %s, Value: %s).",
-            this, key.ToString().c_str(), value.ToString().c_str());
+    VLOG(2) << "[PerBalancerStore " << this
+            << "] Load data merged (Key: " << key.ToString()
+            << ", Value: " << value.ToString() << ").";
   } else {
-    gpr_log(GPR_DEBUG,
-            "[PerBalancerStore %p] Load data dropped (Key: %s, Value: %s).",
-            this, key.ToString().c_str(), value.ToString().c_str());
+    VLOG(2) << "[PerBalancerStore " << this
+            << "] Load data dropped (Key: " << key.ToString()
+            << ", Value: " << value.ToString() << ").";
   }
   // We always keep track of num_calls_in_progress_, so that when this
   // store is resumed, we still have a correct value of
@@ -170,12 +170,12 @@ void PerBalancerStore::MergeRow(const LoadRecordKey& key,
 void PerBalancerStore::Suspend() {
   suspended_ = true;
   load_record_map_.clear();
-  gpr_log(GPR_DEBUG, "[PerBalancerStore %p] Suspended.", this);
+  VLOG(2) << "[PerBalancerStore " << this << "] Suspended.";
 }
 
 void PerBalancerStore::Resume() {
   suspended_ = false;
-  gpr_log(GPR_DEBUG, "[PerBalancerStore %p] Resumed.", this);
+  VLOG(2) << "[PerBalancerStore " << this << "] Resumed.";
 }
 
 uint64_t PerBalancerStore::GetNumCallsInProgressForReport() {
@@ -260,11 +260,9 @@ void PerHostStore::AssignOrphanedStore(PerBalancerStore* orphaned_store,
   auto it = assigned_stores_.find(new_receiver);
   CHECK(it != assigned_stores_.end());
   it->second.insert(orphaned_store);
-  gpr_log(GPR_INFO,
-          "[PerHostStore %p] Re-assigned orphaned store (%p) with original LB"
-          " ID of %s to new receiver %s",
-          this, orphaned_store, orphaned_store->lb_id().c_str(),
-          new_receiver.c_str());
+  LOG(INFO) << "[PerHostStore " << this << "] Re-assigned orphaned store ("
+            << orphaned_store << ") with original LB ID of "
+            << orphaned_store->lb_id() << " to new receiver " << new_receiver;
 }
 
 void PerHostStore::SetUpForNewLbId(const std::string& lb_id,
@@ -306,17 +304,16 @@ void LoadDataStore::MergeRow(const std::string& hostname,
   if (in_progress_delta != 0) {
     auto it_tracker = unknown_balancer_id_trackers_.find(key.lb_id());
     if (it_tracker == unknown_balancer_id_trackers_.end()) {
-      gpr_log(
-          GPR_DEBUG,
-          "[LoadDataStore %p] Start tracking unknown balancer (lb_id_: %s).",
-          this, key.lb_id().c_str());
+      VLOG(2) << "[LoadDataStore " << this
+              << "] Start tracking unknown balancer (lb_id_: " << key.lb_id()
+              << ").";
       unknown_balancer_id_trackers_.insert(
           {key.lb_id(), static_cast<uint64_t>(in_progress_delta)});
     } else if ((it_tracker->second += in_progress_delta) == 0) {
       unknown_balancer_id_trackers_.erase(it_tracker);
-      gpr_log(GPR_DEBUG,
-              "[LoadDataStore %p] Stop tracking unknown balancer (lb_id_: %s).",
-              this, key.lb_id().c_str());
+      VLOG(2) << "[LoadDataStore " << this
+              << "] Stop tracking unknown balancer (lb_id_: " << key.lb_id()
+              << ").";
     }
   }
 }

--- a/src/cpp/server/load_reporter/load_data_store.cc
+++ b/src/cpp/server/load_reporter/load_data_store.cc
@@ -111,9 +111,8 @@ std::string LoadRecordKey::GetClientIpBytes() const {
   } else if (client_ip_hex_.size() == kIpv4AddressLength) {
     uint32_t ip_bytes;
     if (sscanf(client_ip_hex_.c_str(), "%x", &ip_bytes) != 1) {
-      gpr_log(GPR_ERROR,
-              "Can't parse client IP (%s) from a hex string to an integer.",
-              client_ip_hex_.c_str());
+      LOG(ERROR) << "Can't parse client IP (" << client_ip_hex_
+                 << ") from a hex string to an integer.";
       return "";
     }
     ip_bytes = grpc_htonl(ip_bytes);
@@ -124,10 +123,9 @@ std::string LoadRecordKey::GetClientIpBytes() const {
     for (size_t i = 0; i < 4; ++i) {
       if (sscanf(client_ip_hex_.substr(i * 8, (i + 1) * 8).c_str(), "%x",
                  ip_bytes + i) != 1) {
-        gpr_log(
-            GPR_ERROR,
-            "Can't parse client IP part (%s) from a hex string to an integer.",
-            client_ip_hex_.substr(i * 8, (i + 1) * 8).c_str());
+        LOG(ERROR) << "Can't parse client IP part ("
+                   << client_ip_hex_.substr(i * 8, (i + 1) * 8)
+                   << ") from a hex string to an integer.";
         return "";
       }
       ip_bytes[i] = grpc_htonl(ip_bytes[i]);

--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -29,7 +29,6 @@
 #import "test/core/test_util/port.h"
 
 #import <grpc/support/alloc.h>
-#import <grpc/support/log.h>
 
 #import "src/core/lib/channel/channel_args.h"
 #import "src/core/lib/gprpp/env.h"
@@ -322,7 +321,7 @@ unsigned int parse_h2_length(const char *field) {
     long len;
     BOOL coalesced = NO;
     while ((len = SSL_read(ssl, buf, sizeof(buf))) > 0) {
-      gpr_log(GPR_DEBUG, "Read len: %ld", len);
+      VLOG(2) << "Read len: " << len;
 
       // Analyze the HTTP/2 frames in the same TLS PDU to identify if
       // coalescing is successful


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
