### PR TITLE
[build] rename android platforms to match CPU arch

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -66,30 +66,6 @@ bool_flag(
     build_setting_default = False,
 )
 
-platform(
-    name = "android_x86_64",
-    constraint_values = [
-        "@platforms//os:android",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
-platform(
-    name = "android_arm64",
-    constraint_values = [
-        "@platforms//os:android",
-        "@platforms//cpu:arm64",
-    ],
-)
-
-platform(
-    name = "android_armv7",
-    constraint_values = [
-        "@platforms//os:android",
-        "@platforms//cpu:armv7",
-    ],
-)
-
 config_setting(
     name = "grpc_no_rls_flag",
     flag_values = {":disable_grpc_rls": "true"},

--- a/bazel/platforms/android/BUILD
+++ b/bazel/platforms/android/BUILD
@@ -1,3 +1,17 @@
+# Copyright 2024 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 platform(
     name = "x86_64",
     constraint_values = [

--- a/bazel/platforms/android/BUILD
+++ b/bazel/platforms/android/BUILD
@@ -1,0 +1,23 @@
+platform(
+    name = "x86_64",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "arm64-v8a",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+platform(
+    name = "armeabi-v7a",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:armv7",
+    ],
+)

--- a/examples/android/binder/java/io/grpc/binder/cpp/README.md
+++ b/examples/android/binder/java/io/grpc/binder/cpp/README.md
@@ -13,7 +13,7 @@
     ```
     bazel build \
       --extra_toolchains=@androidndk//:all \
-      --android_platforms=//:android_x86_64,//:android_armv7,//:android_arm64 \
+      --android_platforms=//bazel/platforms/android:x86_64,//bazel/platforms/android:armeabi-v7a,//bazel/platforms/android:arm64-v8a \
       --copt=-Wno-unknown-warning-option \
       //examples/android/binder/java/io/grpc/binder/cpp/exampleserver:app \
       //examples/android/binder/java/io/grpc/binder/cpp/exampleclient:app

--- a/tools/internal_ci/linux/grpc_binder_transport_apk_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_binder_transport_apk_build_in_docker.sh
@@ -26,7 +26,7 @@ bazel_binder_example_app/bazel_wrapper \
   --bazelrc=tools/remote_build/include/test_locally_with_resultstore_results.bazelrc \
   build \
   --extra_toolchains=@androidndk//:all \
-  --android_platforms=//:android_x86_64,//:android_armv7,//:android_arm64 \
+  --android_platforms=//bazel/platforms/android:x86_64,//bazel/platforms/android:armeabi-v7a,//bazel/platforms/android:arm64-v8a \
   //examples/android/binder/java/io/grpc/binder/cpp/exampleclient:app \
   //examples/android/binder/java/io/grpc/binder/cpp/exampleserver:app
 


### PR DESCRIPTION
Work around for https://github.com/bazelbuild/bazel/issues/15837#issuecomment-2127758141

Fixes a problem where the example client and server APKs would build but could not be installed (`INSTALL_FAILED_NO_MATCHING_ABIS: Failed to extract native libraries`)

