### PR TITLE
[grpc][Python] Added deprecation warning for future unsupported Python version

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -18,6 +18,7 @@ import contextlib
 import enum
 import logging
 import sys
+import warnings
 
 from grpc import _compression
 from grpc._cython import cygrpc as _cygrpc
@@ -32,6 +33,22 @@ try:
     from grpc._grpcio_metadata import __version__
 except ImportError:
     __version__ = "dev0"
+
+PROJECT_NAME = "gRPC"
+VERSION_TO_BE_DROPPED = (3, 8)
+EXPECTED_ERROR_RELEASE_VERSION = "v1.68.0"
+EXPECTED_ERROR_RELEASE_DATE = "October 29, 2024"
+
+current_version = sys.version_info[:2]
+
+if current_version == VERSION_TO_BE_DROPPED:
+    warning_message = (
+        f" ⚠️  Support for Python {VERSION_TO_BE_DROPPED[0]}.{VERSION_TO_BE_DROPPED[1]} will end in {EXPECTED_ERROR_RELEASE_VERSION} "
+        f"(scheduled for {EXPECTED_ERROR_RELEASE_DATE}). ⚠️ \n "
+        f"Please upgrade your Python installation to ensure compatibility with future {PROJECT_NAME} releases."
+    )
+
+    warnings.warn(warning_message, DeprecationWarning, stacklevel=2)
 
 ############################## Future Interface  ###############################
 

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -42,8 +42,8 @@ class LoggingTest(unittest.TestCase):
 
             import grpc
         """
-        out, err = self._verifyScriptSucceeds(script)
-        self.assertEqual(0, len(err), "unexpected output to stderr")
+        out, err, returncode = self._verifyScriptSucceeds(script)
+        self.assertEqual(0, returncode, "unexpected output to stderr")
 
     def test_can_configure_logger(self):
         script = """if True:
@@ -95,7 +95,7 @@ class LoggingTest(unittest.TestCase):
             "process failed with exit code %d (stdout: %s, stderr: %s)"
             % (process.returncode, out, err),
         )
-        return out, err
+        return out, err, process.returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Added deprecation warning message for Python 3.8 

While building from source user will see a warning message for soon to be deprecated python version.

DeprecationWarning:  ⚠️  Support for Python 3.8 will end in v1.68.0 (scheduled for October 29, 2024). ⚠️ 
 Please upgrade your Python installation to ensure compatibility with future gRPC releases.

