### PR TITLE
[CI] Disabled ODR violation from ASAN

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -54,6 +54,7 @@ build:asan --copt=-DADDRESS_SANITIZER  # used by absl
 build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 build:asan --action_env=LSAN_OPTIONS=suppressions=test/core/test_util/lsan_suppressions.txt:report_objects=1
+build:asan --action_env=ASAN_OPTIONS=detect_odr_violation=0  # https://github.com/google/sanitizers/issues/1017
 
 build:fuzzer_asan --strip=never
 build:fuzzer_asan --define=grpc_build_fuzzers=true
@@ -68,6 +69,7 @@ build:fuzzer_asan --copt=-DADDRESS_SANITIZER  # used by absl
 build:fuzzer_asan --linkopt=-fsanitize=fuzzer,address
 build:fuzzer_asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 build:fuzzer_asan --action_env=LSAN_OPTIONS=suppressions=test/core/test_util/lsan_suppressions.txt:report_objects=1
+build:fuzzer_asan --action_env=ASAN_OPTIONS=detect_odr_violation=0  # https://github.com/google/sanitizers/issues/1017
 
 build:coverage --copt=-fprofile-instr-generate
 build:coverage --copt=-fcoverage-mapping
@@ -96,6 +98,7 @@ build:asan_macos --copt=-fno-omit-frame-pointer
 build:asan_macos --copt=-DGPR_NO_DIRECT_SYSCALLS
 build:asan_macos --linkopt=-fsanitize=address
 build:asan_macos --action_env=ASAN_OPTIONS=detect_leaks=0
+build:asan_macos --action_env=ASAN_OPTIONS=detect_odr_violation=0  # https://github.com/google/sanitizers/issues/1017
 build:asan_macos --dynamic_mode=off
 
 build:msan --strip=never


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/36753 has this ASAN test failure with the following error which doesn't seem to make sense. ([full log](https://btx.cloud.google.com/invocations/a587e5cc-ca1e-46ed-a3c3-199c581583db/targets))

```
Executing tests from //test/cpp/util:grpc_tool_test@poller=epoll1
-----------------------------------------------------------------------------
=================================================================
==15==ERROR: AddressSanitizer: odr-violation (0x7fcfa2961400):
  [1] size=66 'typeinfo name for google::protobuf::compiler::java::ImmutableExtensionLiteGenerator' external/com_google_protobuf/src/google/protobuf/compiler/java/lite/extension.cc in /b/f/w/bazel-out/k8-fastbuild/bin/test/cpp/util/grpc_tool_test@poller=epoll1.runfiles/com_github_grpc_grpc/test/cpp/util/../../../_solib_k8/libexternal_Scom_Ugoogle_Uprotobuf_Ssrc_Sgoogle_Sprotobuf_Scompiler_Sjava_Slite_Sliblite.so
  [2] size=66 'typeinfo name for google::protobuf::compiler::java::ImmutableExtensionLiteGenerator' external/com_google_protobuf/src/google/protobuf/compiler/java/lite/extension.cc in /b/f/w/bazel-out/k8-fastbuild/bin/test/cpp/util/grpc_tool_test@poller=epoll1.runfiles/com_github_grpc_grpc/test/cpp/util/../../../_solib_k8/libexternal_Scom_Ugoogle_Uprotobuf_Ssrc_Sgoogle_Sprotobuf_Scompiler_Sjava_Slite_Slibfield_Ugenerators.so
These globals were registered at these points:
  [1]:
    #0 0x5626b4ea1488 in __asan_register_globals /tmp/clang-build/src/compiler-rt/lib/asan/asan_globals.cpp:369:3
    #1 0x5626b4ea2559 in __asan_register_elf_globals /tmp/clang-build/src/compiler-rt/lib/asan/asan_globals.cpp:352:3
    #2 0x7fcfa3fa4b99  (/lib64/ld-linux-x86-64.so.2+0x11b99) (BuildId: 7ae2aaae1a0e5b262df913ee0885582d2e327982)

  [2]:
    #0 0x5626b4ea1488 in __asan_register_globals /tmp/clang-build/src/compiler-rt/lib/asan/asan_globals.cpp:369:3
    #1 0x5626b4ea2559 in __asan_register_elf_globals /tmp/clang-build/src/compiler-rt/lib/asan/asan_globals.cpp:352:3
    #2 0x7fcfa3fa4b99  (/lib64/ld-linux-x86-64.so.2+0x11b99) (BuildId: 7ae2aaae1a0e5b262df913ee0885582d2e327982)

==15==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'typeinfo name for google::protobuf::compiler::java::ImmutableExtensionLiteGenerator' at external/com_google_protobuf/src/google/protobuf/compiler/java/lite/extension.cc in /b/f/w/bazel-out/k8-fastbuild/bin/test/cpp/util/grpc_tool_test@poller=epoll1.runfiles/com_github_grpc_grpc/test/cpp/util/../../../_solib_k8/libexternal_Scom_Ugoogle_Uprotobuf_Ssrc_Sgoogle_Sprotobuf_Scompiler_Sjava_Slite_Sliblite.so
==15==ABORTING
```

This turned out to be a known issue described at https://github.com/google/sanitizers/issues/1017 and there is much to do other than disabling the ODR test. I gave a try to "-mllvm -asan-use-private-alias=1" option but it didn't change the result so I turned into this way.
