### PR TITLE
[benchmark] Disable benchmarks for dotnet in CI.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -131,9 +131,9 @@ configLangArgs32core+=( -l c++ )
 runnerLangArgs+=( -l "cxx:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}" )
 
 # dotnet
-configLangArgs8core+=( -l dotnet )
-configLangArgs32core+=( -l dotnet )
-runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
+# configLangArgs8core+=( -l dotnet )
+# configLangArgs32core+=( -l dotnet )
+# runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
 
 # # go
 configLangArgs8core+=( -l go )

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -125,9 +125,9 @@ configLangArgs32core+=( -l c++ )
 runnerLangArgs+=( -l "cxx:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}" )
 
 # dotnet
-configLangArgs8core+=( -l dotnet )
-configLangArgs32core+=( -l dotnet )
-runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
+# configLangArgs8core+=( -l dotnet )
+# configLangArgs32core+=( -l dotnet )
+# runnerLangArgs+=( -l "dotnet:${GRPC_DOTNET_REPO}:${GRPC_DOTNET_COMMIT}" )
 
 # # go
 configLangArgs8core+=( -l go )


### PR DESCRIPTION
Build is failing, so temporarily removing dotnet from benchmarks CI.

