### PR TITLE
[Interop] Update image versions

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -132,8 +132,8 @@ LANG_RELEASE_MATRIX = {
             ("v1.60.0", ReleaseInfo()),
             ("v1.61.0", ReleaseInfo()),
             ("v1.62.0", ReleaseInfo()),
-            ("v1.63.0", ReleaseInfo()),
-            ("v1.64.0", ReleaseInfo()),
+            ("v1.63.1", ReleaseInfo()),
+            ("v1.64.1", ReleaseInfo()),
         ]
     ),
     "go": OrderedDict(
@@ -791,7 +791,7 @@ LANG_RELEASE_MATRIX = {
                 ),
             ),
             (
-                "v1.64.0",
+                "v1.64.1",
                 ReleaseInfo(
                     runtimes=["python"], testcases_file="python__master"
                 ),


### PR DESCRIPTION
Use 1.63.1 and 1.64.1 for C++. Use 1.64.1 for Python.