### PR TITLE
[Fix] new clang -Wmissing-template-arg-list-after-template-kw warning

### DIFF
--- a/src/core/lib/promise/detail/basic_seq.h
+++ b/src/core/lib/promise/detail/basic_seq.h
@@ -99,7 +99,7 @@ class BasicSeqIter {
           }
           cur_ = next;
           state_.~State();
-          Construct(&state_, Traits::template CallSeqFactory<Factory, Iter*>(
+          Construct(&state_, Traits::CallSeqFactory(
                                  f_, *cur_, std::move(arg)));
           return PollNonEmpty();
         });

--- a/src/core/lib/promise/detail/basic_seq.h
+++ b/src/core/lib/promise/detail/basic_seq.h
@@ -99,8 +99,8 @@ class BasicSeqIter {
           }
           cur_ = next;
           state_.~State();
-          Construct(&state_,
-                    Traits::template CallSeqFactory(f_, *cur_, std::move(arg)));
+          Construct(&state_, Traits::template CallSeqFactory<Factory, Iter*>(
+                                 f_, *cur_, std::move(arg)));
           return PollNonEmpty();
         });
   }

--- a/src/core/lib/promise/detail/basic_seq.h
+++ b/src/core/lib/promise/detail/basic_seq.h
@@ -99,8 +99,7 @@ class BasicSeqIter {
           }
           cur_ = next;
           state_.~State();
-          Construct(&state_, Traits::CallSeqFactory(
-                                 f_, *cur_, std::move(arg)));
+          Construct(&state_, Traits::CallSeqFactory(f_, *cur_, std::move(arg)));
           return PollNonEmpty();
         });
   }


### PR DESCRIPTION
Clang now requires a template argument list after the use of the template keyword. Edit this
instance to remove the template keyword since there are no template arguments.

See https://github.com/llvm/llvm-project/pull/80801. 