### PR TITLE
Remove extraneous template keyword

### DIFF
--- a/src/core/lib/promise/detail/basic_seq.h
+++ b/src/core/lib/promise/detail/basic_seq.h
@@ -100,7 +100,7 @@ class BasicSeqIter {
           cur_ = next;
           state_.~State();
           Construct(&state_,
-                    Traits::template CallSeqFactory(f_, *cur_, std::move(arg)));
+                    Traits::CallSeqFactory(f_, *cur_, std::move(arg)));
           return PollNonEmpty();
         });
   }


### PR DESCRIPTION
The template keyword should only be used if we have angle brackets after the method.

Fixes code broken by upcoming clang change: https://github.com/llvm/llvm-project/pull/80801
