### PR TITLE
[CI] Updated clang docker images to use Debian 12

### DIFF
--- a/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM silkeh/clang:17-bullseye
+  FROM silkeh/clang:17-bookworm
 
   ADD clang_format_all_the_things.sh /
   

--- a/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:17-bullseye
+  FROM silkeh/clang:17-bookworm
   
   # Install prerequisites for the clang-tidy script
   RUN apt-get update && apt-get install -y python3 jq git && apt-get clean

--- a/templates/tools/dockerfile/test/cxx_clang_17_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_clang_17_x64/Dockerfile.template
@@ -14,11 +14,11 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM silkeh/clang:17-bullseye
+  FROM silkeh/clang:17-bookworm
   
   RUN apt update && apt -y upgrade && apt install -y build-essential curl git time wget zip && apt clean
   <%include file="../../git_avoid_dubious_ownership_error.include"/>
-  <%include file="../../run_tests_python_deps.include"/>
+  <%include file="../../run_tests_python_deps_pep668.include"/>
   <%include file="../../cxx_test_deps.include"/>
   <%include file="../../cmake.include"/>
   <%include file="../../ccache.include"/>

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 
-  FROM silkeh/clang:17-bullseye
+  FROM silkeh/clang:17-bookworm
 
   <%include file="../../apt_get_basic.include"/>
 

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -94,7 +94,7 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/test/csharp_debian11_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_debian11_arm64@sha256:4d4bc5f15e03f3d3d8fd889670ecde2c66a2e4d2dd9db80733c05c1d90c8a248",
     "tools/dockerfile/test/csharp_debian11_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_debian11_x64@sha256:0763d919b17b4cfe5b65aff3bf911c04e9e4d46d11649858742033facd9f534f",
     "tools/dockerfile/test/cxx_alpine_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_alpine_x64@sha256:5beda19bcf186b6c9606f4265e38c99bb4308f25bc0987e0fc15164f3c205232",
-    "tools/dockerfile/test/cxx_clang_17_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_17_x64@sha256:05d81ad07055c3409a2c60c3c95c4d19300419caaece5df20169b2b903963f0d",
+    "tools/dockerfile/test/cxx_clang_17_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_17_x64@sha256:f4e88cdfe074ee33abbe01f97f945ded0f144693f1eeac4d541a256a7812a21a",
     "tools/dockerfile/test/cxx_clang_6_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_6_x64@sha256:eebbaf353522d523ec9a7acb34bb3ae194e22ea7493c85c01437719e30da205d",
     "tools/dockerfile/test/cxx_debian11_openssl102_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_openssl102_x64@sha256:477ae0da7ff7faa9cf195c0d32472fec4cf8b7325505c63e00b5c794c9a4b1a7",
     "tools/dockerfile/test/cxx_debian11_openssl111_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_openssl111_x64@sha256:d383e66d4a089f9305768e3037faa2a887ff91565b0f3ddd96985dca94e9754f",
@@ -113,5 +113,5 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/test/rbe_ubuntu2004.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rbe_ubuntu2004@sha256:b3eb1a17b7b091e3c5648a803076b2c40601242ff91c04d55997af6641305f68",
     "tools/dockerfile/test/ruby_debian11_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_debian11_arm64@sha256:d2e79919b2e2d4cc36a29682ecb5170641df4fb506cfb453978ffdeb8a841bd9",
     "tools/dockerfile/test/ruby_debian11_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_debian11_x64@sha256:6e8b4696ba0661f11a31ed0992a94d2efcd889a018f57160f0e2fb62963f3593",
-    "tools/dockerfile/test/sanity.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/sanity@sha256:4b3bc3934f41dc1e123db3123841af84f07dd68f44b564e29ba1d85bb21df707",
+    "tools/dockerfile/test/sanity.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/sanity@sha256:f138b3aae124e2d6e1a08c5078fb944db7470deeba17ef083aacf3faf939059e",
 }

--- a/tools/dockerfile/grpc_clang_format/Dockerfile
+++ b/tools/dockerfile/grpc_clang_format/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:17-bullseye
+FROM silkeh/clang:17-bookworm
 
 ADD clang_format_all_the_things.sh /
 

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:17-bullseye
+FROM silkeh/clang:17-bookworm
 
 # Install prerequisites for the clang-tidy script
 RUN apt-get update && apt-get install -y python3 jq git && apt-get clean

--- a/tools/dockerfile/test/cxx_clang_17_x64.current_version
+++ b/tools/dockerfile/test/cxx_clang_17_x64.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_17_x64:3cbc0c7981febd613345e38415736a0ba09f3281@sha256:05d81ad07055c3409a2c60c3c95c4d19300419caaece5df20169b2b903963f0d
+us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_clang_17_x64:178d7f05c6a124b14824b92cccca2ecc37711e62@sha256:f4e88cdfe074ee33abbe01f97f945ded0f144693f1eeac4d541a256a7812a21a

--- a/tools/dockerfile/test/cxx_clang_17_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_clang_17_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:17-bullseye
+FROM silkeh/clang:17-bookworm
 
 RUN apt update && apt -y upgrade && apt install -y build-essential curl git time wget zip && apt clean
 #=================
@@ -37,7 +37,10 @@ RUN apt-get update && apt-get install -y \
   && apt-get clean
 
 # use pinned version of pip to avoid sudden breakages
-RUN python3 -m pip install --upgrade pip==19.3.1
+# Some newer distros that have already implemented PEP 668. Use of
+# --break-system-packages is to workaround that. We should look into using
+# virtualenv in Dockerfile though.
+RUN python3 -m pip install --break-system-packages --upgrade pip==19.3.1
 
 # TODO(jtattermusch): currently six is needed for tools/run_tests scripts
 # but since our python2 usage is deprecated, we should get rid of it.

--- a/tools/dockerfile/test/sanity.current_version
+++ b/tools/dockerfile/test/sanity.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:ed5f64033b5ac0038b25be49f8e53439e000461f@sha256:4b3bc3934f41dc1e123db3123841af84f07dd68f44b564e29ba1d85bb21df707
+us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:be1a47c2ca2af05342eebeeb0d5853453b7cfb60@sha256:f138b3aae124e2d6e1a08c5078fb944db7470deeba17ef083aacf3faf939059e

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM silkeh/clang:17-bullseye
+FROM silkeh/clang:17-bookworm
 
 #=================
 # Basic C core dependencies

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -260,6 +260,7 @@ then
 
   if [ "$("$PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
   then
+    # shellcheck disable=SC2261
     "${PYTHON}" -m pip install futures>=2.2.0 enum34>=1.0.4
   fi
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -216,6 +216,7 @@ pip_install_dir "$ROOT/src/python/grpcio_admin"
 pip_install_dir "$ROOT/src/python/grpcio_testing"
 
 # Build/install tests
+# shellcheck disable=SC2261
 pip_install coverage==7.2.0 oauth2client==4.1.0 \
             google-auth>=1.35.0 requests==2.31.0 \
             googleapis-common-protos>=1.5.5 rsa==4.0 absl-py==1.4.0 \

--- a/tools/run_tests/performance/build_performance_node.sh
+++ b/tools/run_tests/performance/build_performance_node.sh
@@ -15,7 +15,7 @@
 
 set +ex
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090 disable=SC1091
 . "$HOME/.nvm/nvm.sh"
 
 nvm install 10

--- a/tools/run_tests/performance/run_worker_node.sh
+++ b/tools/run_tests/performance/run_worker_node.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090 disable=SC1091
 . "$HOME/.nvm/nvm.sh"
 
 nvm use 10

--- a/tools/run_tests/sanity/check_version.sh
+++ b/tools/run_tests/sanity/check_version.sh
@@ -26,17 +26,17 @@ check_key () {
     build=$(grep "^$key =" < $buildfile | awk -F\" '{print $2}')
     yaml=$(grep "^ *${key}:" < $yamlfile | head -1 | awk '{print $2}')
 
-    if [ x"$build" = x ] ; then
+    if [ "$build" = "" ] ; then
         echo "$key not defined in $buildfile"
         status=1
     fi
 
-    if [ x"$yaml" = x ] ; then
+    if [ "$yaml" = "" ] ; then
         echo "$key not defined in $yamlfile"
         status=1
     fi
 
-    if [ x"$build" != x"$yaml" ] ; then
+    if [ "$build" != "$yaml" ] ; then
         echo "$key mismatch between $buildfile ($build) and $yamlfile ($yaml)"
         status=1
     fi


### PR DESCRIPTION
All clang docker images here are based on Debian 11 (Bullseye) but now we're moving to Debian 12 (Bookworm) primarily to use the recent versions of Cmake >= 3.20 to use CXX_STANDARD=23 for some tests ([doc](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html))