### PR TITLE
Add --address_type to interop and xds test descriptions

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1287,6 +1287,12 @@ Servers should accept these arguments:
 
     * Whether to use a plaintext or encrypted connection
 
+Servers that want to be used for dual stack testing must accept this argument:
+
+* --address_type=IPV4|IPV6|IPV4_IPV6
+    
+    * What type of addresses to listen on. Default IPV4_IPV6
+
 Servers must support TLS with ALPN. They should use
 [server1.pem](https://github.com/grpc/grpc/blob/master/src/core/tsi/test_creds/server1.pem)
 for their certificate.

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -17,6 +17,12 @@ Server should accept these arguments:
     *   When set to true it uses XdsServerCredentials with the test server for security test cases.
         In case of secure mode, port and maintenance_port should be different.
 
+Servers that want to support dual stack testing (like Java) should also accept:
+
+*  --address_type=IPV4|IPV6|IPV4_IPV6
+    *   Type of IP address to bind to.  IPV4_IPV6 will use the wildcard address.
+        IPV4 and IPV6 will cause server to bind to one non-localhost and the localhost address of the appropriate type
+
 In addition, when handling requests, if the initial request metadata contains the `rpc-behavior` key, it should modify its handling of the request as follows:
 
  - If the value matches `sleep-<int>`, the server should wait the specified number of seconds before resuming behavior matching and RPC processing.


### PR DESCRIPTION
This documents the changes the the test server classes in https://github.com/grpc/grpc-java/pull/11231
