### PR TITLE
Fix race due to use of TryLock in grpc_event_engine::experimental::TimerList::TimerCheck

### DIFF
--- a/src/core/lib/event_engine/posix_engine/timer.cc
+++ b/src/core/lib/event_engine/posix_engine/timer.cc
@@ -298,12 +298,10 @@ TimerList::TimerCheck(grpc_core::Timestamp* next) {
     return std::vector<experimental::EventEngine::Closure*>();
   }
 
-  if (!checker_mu_.TryLock()) return absl::nullopt;
-  std::vector<experimental::EventEngine::Closure*> run =
-      FindExpiredTimers(now, next);
-  checker_mu_.Unlock();
-
-  return std::move(run);
+  {
+    absl::MutexLock lock(&checker_mu_);
+    return FindExpiredTimers(now, next);
+  }
 }
 
 }  // namespace experimental

--- a/src/core/lib/event_engine/posix_engine/timer.h
+++ b/src/core/lib/event_engine/posix_engine/timer.h
@@ -149,8 +149,8 @@ class TimerList {
   grpc_core::Mutex mu_;
   // The deadline of the next timer due across all timer shards
   std::atomic<uint64_t> min_timer_;
-  // Allow only one FindExpiredTimers at once (used as a TryLock, protects no
-  // fields but ensures limits on concurrency)
+  // Allow only one FindExpiredTimers at once (protects no fields but ensures
+  // limits on concurrency)
   grpc_core::Mutex checker_mu_;
   // Array of timer shards. Whenever a timer (Timer *) is added, its address
   // is hashed to select the timer shard to add the timer to


### PR DESCRIPTION
TryLock returns true only with high-probility when the lock is held [link](https://github.com/abseil/abseil-cpp/blob/master/absl/synchronization/mutex.h#L191), because it uses relaxed load for initial check if unlocked. If it spuriously returned
false when the lock was not held, it was possible that there was a queued timer which was not
detected and the next wakeup time was left to InfiniteFuture.
This could lead to delays in firing the timer if no other timers were set to kick the TimerListHost.

Instead of using TryLock just use a regular Lock.  If there are multiple threads calling TimerCheck this could lead to some contention, but AFAICT such threads woudl eventually just block anyway waiting to be kicked so I don't think it would matter.  If there are concerns it could perhaps be switched to an atomic-based method for single execution similar to the spinlock used in [the generic run_some_expired_timers function](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/timer_generic.cc#L590)
