### PR TITLE
Explicitly check if candidate is not None when closing aio channel

### DIFF
--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -419,7 +419,10 @@ class Channel(_base_channel.Channel):
             # Locate ones created by `aio.Call`.
             frame = stack[0]
             candidate = frame.f_locals.get("self")
-            if candidate is not None:  # https://github.com/grpc/grpc/pull/36837
+            # Explicitly check for a non-null candidate instead of the more pythonic 'if candidate:'
+            # because doing 'if candidate:' assumes that the coroutine implements '__bool__' which
+            # might not always be the case.
+            if candidate is not None:
                 if isinstance(candidate, _base_call.Call):
                     if hasattr(candidate, "_channel"):
                         # For intercepted Call object

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -419,7 +419,7 @@ class Channel(_base_channel.Channel):
             # Locate ones created by `aio.Call`.
             frame = stack[0]
             candidate = frame.f_locals.get("self")
-            if candidate:
+            if candidate is not None:
                 if isinstance(candidate, _base_call.Call):
                     if hasattr(candidate, "_channel"):
                         # For intercepted Call object

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -419,7 +419,7 @@ class Channel(_base_channel.Channel):
             # Locate ones created by `aio.Call`.
             frame = stack[0]
             candidate = frame.f_locals.get("self")
-            if candidate is not None:
+            if candidate is not None:  # https://github.com/grpc/grpc/pull/36837
                 if isinstance(candidate, _base_call.Call):
                     if hasattr(candidate, "_channel"):
                         # For intercepted Call object


### PR DESCRIPTION
When using gRPC client alongside kopf (Python framework for writing K8s operators), the existing code fails because of https://github.com/nolar/kopf/blob/9243c8fbb2a36c1b7cad1f65a647d3b9876a5b17/kopf/_cogs/aiokits/aiotoggles.py#L40. This is because the existing `if candidate:` condition invokes the `__bool__` magic method of the `Toggle` class from kopf.