### PR TITLE
[CI] Use 32 cores for clang-tidy CI job

### DIFF
--- a/tools/internal_ci/linux/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/grpc_clang_tidy.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux clang-tidy --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux clang-tidy --inner_jobs 16 -j 1 --internal_ci"
+  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 --internal_ci"
 }


### PR DESCRIPTION
This task was parallelized into 16 sub-tasks, but 32 cores are available. Let's see if this speeds up CI, the clang-tidy job usually takes about 30m to 40m.