### PR TITLE
[Build] Fix for gcc-9

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -35,7 +35,8 @@ EXPERIMENT_ENABLES = {
     "pick_first_new": "pick_first_new",
     "promise_based_client_call": "event_engine_client,event_engine_listener,promise_based_client_call",
     "promise_based_server_call": "promise_based_server_call",
-    "chaotic_good": "chaotic_good,event_engine_client,event_engine_listener,promise_based_client_call,promise_based_server_call",
+    # Disabling in 1.64.x due to a compiler error. See https://github.com/grpc/grpc/pull/36839
+    #"chaotic_good": "chaotic_good,event_engine_client,event_engine_listener,promise_based_client_call,promise_based_server_call",
     "promise_based_inproc_transport": "event_engine_client,event_engine_listener,promise_based_client_call,promise_based_inproc_transport,promise_based_server_call",
     "rstpit": "rstpit",
     "schedule_cancellation_over_write": "schedule_cancellation_over_write",
@@ -146,7 +147,7 @@ EXPERIMENTS = {
         },
         "off": {
             "core_end2end_test": [
-                "chaotic_good",
+                #"chaotic_good",
                 "event_engine_client",
                 "promise_based_client_call",
                 "promise_based_server_call",

--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -35,8 +35,7 @@ EXPERIMENT_ENABLES = {
     "pick_first_new": "pick_first_new",
     "promise_based_client_call": "event_engine_client,event_engine_listener,promise_based_client_call",
     "promise_based_server_call": "promise_based_server_call",
-    # Disabling in 1.64.x due to a compiler error. See https://github.com/grpc/grpc/pull/36839
-    #"chaotic_good": "chaotic_good,event_engine_client,event_engine_listener,promise_based_client_call,promise_based_server_call",
+    "chaotic_good": "chaotic_good,event_engine_client,event_engine_listener,promise_based_client_call,promise_based_server_call",
     "promise_based_inproc_transport": "event_engine_client,event_engine_listener,promise_based_client_call,promise_based_inproc_transport,promise_based_server_call",
     "rstpit": "rstpit",
     "schedule_cancellation_over_write": "schedule_cancellation_over_write",
@@ -147,7 +146,6 @@ EXPERIMENTS = {
         },
         "off": {
             "core_end2end_test": [
-                #"chaotic_good",
                 "event_engine_client",
                 "promise_based_client_call",
                 "promise_based_server_call",

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -65,7 +65,7 @@
   expiry: 2024/09/09
   owner: ctiller@google.com
   requires: [promise_based_client_call, promise_based_server_call]
-  test_tags: [core_end2end_test]
+  test_tags: []
 - name: client_privacy
   description:
     If set, client privacy

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -3732,7 +3732,7 @@ class MaybeOpImpl {
 
   MaybeOpImpl(const MaybeOpImpl&) = delete;
   MaybeOpImpl& operator=(const MaybeOpImpl&) = delete;
-  MaybeOpImpl(MaybeOpImpl&& other) noexcept { Crash("not implemented"); }
+  MaybeOpImpl(MaybeOpImpl&& /*other*/) noexcept { Crash("not implemented"); }
   MaybeOpImpl& operator=(MaybeOpImpl&& other) noexcept {
     op_ = other.op_;
     if (absl::holds_alternative<Dismissed>(state_)) {

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -3732,8 +3732,7 @@ class MaybeOpImpl {
 
   MaybeOpImpl(const MaybeOpImpl&) = delete;
   MaybeOpImpl& operator=(const MaybeOpImpl&) = delete;
-  MaybeOpImpl(MaybeOpImpl&& other) noexcept
-      : state_(MoveState(other.state_)), op_(other.op_) {}
+  MaybeOpImpl(MaybeOpImpl&& other) noexcept { Crash("not implemented"); }
   MaybeOpImpl& operator=(MaybeOpImpl&& other) noexcept {
     op_ = other.op_;
     if (absl::holds_alternative<Dismissed>(state_)) {

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -353,6 +353,7 @@ grpc_cc_test(
     ],
     args = grpc_benchmark_args(),
     tags = [
+        "manual",  # See https://github.com/grpc/grpc/pull/36839
         "no_mac",  # to emulate "excluded_poll_engines: poll"
         "no_windows",
     ],


### PR DESCRIPTION
1.64.x doesn't build with gcc-9. This PR "fixes" it crashing at the offending site. This is fine since this code is not used yet.

This is a strange one since we have CI tests with gcc-7 and gcc-12, but gcc-9 has thrown errors. We are considering add builds for intermediate versions, but we do not have infinite testing resources either, so it's a bit of a balancing act.

```
Step #2: external/com_github_grpc_grpc/src/core/lib/surface/call.cc: In constructor 'grpc_core::{anonymous}::MaybeOpImpl<SetupFn>::MaybeOpImpl(grpc_core::{anonymous}::MaybeOpImpl<SetupFn>&&) [with SetupFn = grpc_core::ServerCallSpine::CommitBatch(const grpc_op*, size_t, void*, bool)::<lambda(const grpc_op&)>]':
Step #2: external/com_github_grpc_grpc/src/core/lib/surface/call.cc:3736:55: internal compiler error: in assign_temp, at function.c:982
Step #2:  3736 |       : state_(MoveState(other.state_)), op_(other.op_) {}
Step #2:       |                              
```