### PR TITLE
[CI] Add clang-cl build to CI

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -110,6 +110,7 @@ GRPC_LLVM_WINDOWS_WARNING_FLAGS = GRPC_LLVM_WARNING_FLAGS + [
     # TODO(hork): clean up EE offenses
     "-Wno-missing-field-initializers",
     "-Wno-non-virtual-dtor",
+    "-Wno-thread-safety-reference-return",
 
     # TODO(ctiller): offense: dump_args. signed to unsigned
     "-Wno-sign-conversion",
@@ -145,9 +146,11 @@ GRPC_LLVM_WINDOWS_WARNING_FLAGS = GRPC_LLVM_WARNING_FLAGS + [
     "-Wno-suggest-override",
     "-Wno-documentation",
     "-Wno-documentation-unknown-command",
+    "-Wno-unsafe-buffer-usage",
 
     ### possibly bad warnings for this codebase
     "-Wno-covered-switch-default",
+    "-Wno-switch-default",
     "-Wno-switch-enum",
     "-Wno-c99-extensions",
     "-Wno-unused-private-field",  # GRPC_UNUSED does not appear to work for private fields

--- a/tools/internal_ci/windows/grpc_build_clang_cl.bat
+++ b/tools/internal_ci/windows/grpc_build_clang_cl.bat
@@ -1,0 +1,41 @@
+@rem Copyright 2024 gRPC authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+@rem Avoid slow finalization after the script has exited.
+@rem See the script's prologue for info on the correct invocation pattern.
+setlocal EnableDelayedExpansion
+IF "%cd%"=="T:\src" (
+  call %~dp0\..\..\..\tools\internal_ci\helper_scripts\move_src_tree_and_respawn_itself.bat %0
+  echo respawn script has finished with exitcode !errorlevel!
+  exit /b !errorlevel!
+)
+endlocal
+
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
+
+@rem Install clang-cl
+choco install -y llvm
+set BAZEL_LLVM="C:\Program Files\LLVM"
+
+@rem Install bazel
+@rem Side effect of the tools/bazel script is that it downloads the correct version of bazel binary.
+mkdir C:\bazel
+bash -c "tools/bazel --version && cp tools/bazel-*.exe /c/bazel/bazel.exe"
+set PATH=C:\bazel;%PATH%
+bazel --version
+
+bazel --config=clang-cl --config=windows_opt build --build_tag_filters=-no_windows :all src/core:all

--- a/tools/internal_ci/windows/grpc_build_clang_cl.bat
+++ b/tools/internal_ci/windows/grpc_build_clang_cl.bat
@@ -30,8 +30,9 @@ call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
 @rem Install clang-cl
 echo "!TIME!: Installing llvm"
-choco install -y llvm
+choco install -y llvm --version=18.1.6
 set BAZEL_LLVM="C:\Program Files\LLVM"
+clang-cl --version
 
 @rem Install bazel
 @rem Side effect of the tools/bazel script is that it downloads the correct version of bazel binary.

--- a/tools/internal_ci/windows/grpc_build_clang_cl.bat
+++ b/tools/internal_ci/windows/grpc_build_clang_cl.bat
@@ -25,17 +25,23 @@ endlocal
 @rem enter repo root
 cd /d %~dp0\..\..\..
 
+echo "!TIME!: Preparing for the Windows build"
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
 @rem Install clang-cl
+echo "!TIME!: Installing llvm"
 choco install -y llvm
 set BAZEL_LLVM="C:\Program Files\LLVM"
 
 @rem Install bazel
 @rem Side effect of the tools/bazel script is that it downloads the correct version of bazel binary.
+echo "!TIME!: Installing bazel"
 mkdir C:\bazel
 bash -c "tools/bazel --version && cp tools/bazel-*.exe /c/bazel/bazel.exe"
 set PATH=C:\bazel;%PATH%
 bazel --version
 
-bazel --config=clang-cl --config=windows_opt build --build_tag_filters=-no_windows :all src/core:all
+echo "!TIME!: Running the bazel build"
+bazel build --config=clang-cl --config=windows_opt --build_tag_filters=-no_windows :all src/core:all
+
+echo "!TIME!: Job Finished"

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_c.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_c.cfg
@@ -1,30 +1,41 @@
-# Copyright 2019 The gRPC Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# # Copyright 2019 The gRPC Authors
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
 
-# Config file for the internal CI (in protobuf text format)
+# # Config file for the internal CI (in protobuf text format)
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
+# # Location of the continuous shell script in repository.
+# build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
+# timeout_mins: 120
+# action {
+#   define_artifacts {
+#     regex: "**/*sponge_log.*"
+#     regex: "github/grpc/reports/**"
+#   }
+# }
+
+# env_vars {
+#   key: "RUN_TESTS_FLAGS"
+#   value: "-f basictests windows c -j 1 --inner_jobs 8 --internal_ci --max_time=3600"
+# }
+
+
+# DO NOT SUBMIT: hijacking this existing test to exercise new kokoro batch script
+build_file: "grpc/tools/internal_ci/windows/grpc_build_clang_cl.bat"
 timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
   }
-}
-
-env_vars {
-  key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows c -j 1 --inner_jobs 8 --internal_ci --max_time=3600"
 }

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_c.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_c.cfg
@@ -1,41 +1,30 @@
-# # Copyright 2019 The gRPC Authors
-# #
-# # Licensed under the Apache License, Version 2.0 (the "License");
-# # you may not use this file except in compliance with the License.
-# # You may obtain a copy of the License at
-# #
-# #     http://www.apache.org/licenses/LICENSE-2.0
-# #
-# # Unless required by applicable law or agreed to in writing, software
-# # distributed under the License is distributed on an "AS IS" BASIS,
-# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# # See the License for the specific language governing permissions and
-# # limitations under the License.
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# # Config file for the internal CI (in protobuf text format)
+# Config file for the internal CI (in protobuf text format)
 
-# # Location of the continuous shell script in repository.
-# build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-# timeout_mins: 120
-# action {
-#   define_artifacts {
-#     regex: "**/*sponge_log.*"
-#     regex: "github/grpc/reports/**"
-#   }
-# }
-
-# env_vars {
-#   key: "RUN_TESTS_FLAGS"
-#   value: "-f basictests windows c -j 1 --inner_jobs 8 --internal_ci --max_time=3600"
-# }
-
-
-# DO NOT SUBMIT: hijacking this existing test to exercise new kokoro batch script
-build_file: "grpc/tools/internal_ci/windows/grpc_build_clang_cl.bat"
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
 timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
   }
+}
+
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "-f basictests windows c -j 1 --inner_jobs 8 --internal_ci --max_time=3600"
 }

--- a/tools/internal_ci/windows/pull_request/grpc_build_clang_cl.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_build_clang_cl.cfg
@@ -1,0 +1,25 @@
+# Copyright 2024 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/grpc_build_clang_cl.bat"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}


### PR DESCRIPTION
This adds a clang-cl Windows build to the set of Github presubmit jobs. It builds the codebase with strict warnings enabled, including thread annotation checks, and the rest of diagnostics we've been missing on Windows.

Here's [a successful run](https://btx.cloud.google.com/invocations/448792b6-3cff-4987-975a-af5e19526fc0/targets/grpc%2Fcore%2Fpull_request%2Fwindows%2Fgrpc_basictests_c/log) of the script (hijacking the C basic tests kokoro job, ignore that bit)