### PR TITLE
Fix `py_grpc_library()`

### DIFF
--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -190,11 +190,7 @@ def _generate_pb2_grpc_src_impl(context):
     arguments = []
     tools = [context.executable._protoc, context.executable._grpc_plugin]
     out_dir = get_out_dir(protos, context)
-    if out_dir.import_path:
-        # is virtual imports
-        out_path = out_dir.path
-    else:
-        out_path = context.genfiles_dir.path
+    out_path = out_dir.path
     arguments += get_plugin_args(
         context.executable._grpc_plugin,
         plugin_flags,


### PR DESCRIPTION
When compiling `py_grpc_targets()` inside `grpc` but from another repo
```
bazel build @com_github_grpc_grpc//examples/protos/...
```

it fails with 

```
ERROR: /HOME/.cache/bazel/_bazel_USER/fd4fdbf199c391947827c3edce697300/external/com_github_grpc_grpc/examples/protos/BUILD:73:16: output 'external/com_github_grpc_grpc/examples/protos/helloworld_pb2_grpc.py' was not created
ERROR: /HOME/.cache/bazel/_bazel_USER/fd4fdbf199c391947827c3edce697300/external/com_github_grpc_grpc/examples/protos/BUILD:73:16: ProtocInvocation external/com_github_grpc_grpc/examples/protos/helloworld_pb2_grpc.py failed: not all outputs were created or valid
```

Reproduction examples:
```
# WORKSPACE
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "com_github_grpc_grpc",
    sha256 = "c9f9ae6e4d6f40464ee9958be4068087881ed6aa37e30d0e64d40ed7be39dd01",
    strip_prefix = "grpc-1.62.1",
    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.62.1.tar.gz"],
)

load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
grpc_deps()

load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
grpc_extra_deps()
```

```
# MODULE.bazel
bazel_dep(name = "grpc", version = "1.62.1.bcr.1", repo_name = "com_github_grpc_grpc")
```

This patch makes these targets compile correctly.

This is a regression which has been introduced in #31013.