### PR TITLE
[Security] add knob for deny_undetermined

### DIFF
--- a/include/grpc/grpc_crl_provider.h
+++ b/include/grpc/grpc_crl_provider.h
@@ -68,9 +68,7 @@ class CrlProvider {
   // Not finding a CRL is a specific behavior. Per RFC5280, not having a CRL to
   // check for a given certificate means that we cannot know for certain if the
   // status is Revoked or Unrevoked and instead is Undetermined. How a user
-  // handles an Undetermined CRL is up to them. We use absl::IsNotFound as an
-  // analogue for not finding the Crl from the provider, thus the certificate in
-  // question is Undetermined.
+  // handles an Undetermined CRL is up to them.
   // Defaults to treating it as `Unrevoked`.
   bool DenyUndetermined() { return deny_undetermined_; };
 

--- a/include/grpc/grpc_crl_provider.h
+++ b/include/grpc/grpc_crl_provider.h
@@ -63,10 +63,14 @@ class CrlProvider {
   // Get the CRL associated with a certificate. Read-only.
   virtual std::shared_ptr<Crl> GetCrl(
       const CertificateInfo& certificate_info) = 0;
+  bool DenyUndetermined() { return deny_undetermined_; };
+
+ protected:
+  bool deny_undetermined_ = false;
 };
 
 absl::StatusOr<std::shared_ptr<CrlProvider>> CreateStaticCrlProvider(
-    absl::Span<const std::string> crls);
+    absl::Span<const std::string> crls, bool deny_undetermined = false);
 
 // Creates a CRL Provider that periodically and asynchronously reloads a
 // directory. The refresh_duration minimum is 60 seconds. The
@@ -77,7 +81,8 @@ absl::StatusOr<std::shared_ptr<CrlProvider>> CreateStaticCrlProvider(
 // your monitoring and alerting setup.
 absl::StatusOr<std::shared_ptr<CrlProvider>> CreateDirectoryReloaderCrlProvider(
     absl::string_view directory, std::chrono::seconds refresh_duration,
-    std::function<void(absl::Status)> reload_error_callback);
+    std::function<void(absl::Status)> reload_error_callback,
+    bool deny_undetermined = false);
 
 }  // namespace experimental
 }  // namespace grpc_core

--- a/include/grpc/grpc_crl_provider.h
+++ b/include/grpc/grpc_crl_provider.h
@@ -65,6 +65,12 @@ class CrlProvider {
       const CertificateInfo& certificate_info) = 0;
   // Returns whether a revocation status of `Undetermined` should be treated as
   // `Revoked` (deny connections) or `Unrevoked` (allowing connections).
+  // Not finding a CRL is a specific behavior. Per RFC5280, not having a CRL to
+  // check for a given certificate means that we cannot know for certain if the
+  // status is Revoked or Unrevoked and instead is Undetermined. How a user
+  // handles an Undetermined CRL is up to them. We use absl::IsNotFound as an
+  // analogue for not finding the Crl from the provider, thus the certificate in
+  // question is Undetermined.
   // Defaults to treating it as `Unrevoked`.
   bool DenyUndetermined() { return deny_undetermined_; };
 

--- a/include/grpc/grpc_crl_provider.h
+++ b/include/grpc/grpc_crl_provider.h
@@ -64,7 +64,8 @@ class CrlProvider {
   virtual std::shared_ptr<Crl> GetCrl(
       const CertificateInfo& certificate_info) = 0;
   // Returns whether a revocation status of `Undetermined` should be treated as
-  // `Revoked` or `Unrevoked`. Defaults to treating it as `Unrevoked`.
+  // `Revoked` (deny connections) or `Unrevoked` (allowing connections).
+  // Defaults to treating it as `Unrevoked`.
   bool DenyUndetermined() { return deny_undetermined_; };
 
  protected:

--- a/include/grpc/grpc_crl_provider.h
+++ b/include/grpc/grpc_crl_provider.h
@@ -63,6 +63,8 @@ class CrlProvider {
   // Get the CRL associated with a certificate. Read-only.
   virtual std::shared_ptr<Crl> GetCrl(
       const CertificateInfo& certificate_info) = 0;
+  // Returns whether a revocation status of `Undetermined` should be treated as
+  // `Revoked` or `Unrevoked`. Defaults to treating it as `Unrevoked`.
   bool DenyUndetermined() { return deny_undetermined_; };
 
  protected:

--- a/src/core/lib/security/credentials/tls/grpc_tls_crl_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_crl_provider.cc
@@ -120,7 +120,7 @@ absl::StatusOr<std::unique_ptr<CrlImpl>> CrlImpl::Create(X509_CRL* crl) {
 CrlImpl::~CrlImpl() { X509_CRL_free(crl_); }
 
 absl::StatusOr<std::shared_ptr<CrlProvider>> CreateStaticCrlProvider(
-    absl::Span<const std::string> crls) {
+    absl::Span<const std::string> crls, bool deny_undetermined) {
   absl::flat_hash_map<std::string, std::shared_ptr<Crl>> crl_map;
   for (const auto& raw_crl : crls) {
     absl::StatusOr<std::unique_ptr<Crl>> crl = Crl::Parse(raw_crl);
@@ -135,7 +135,8 @@ absl::StatusOr<std::shared_ptr<CrlProvider>> CreateStaticCrlProvider(
               "The first one in the span will be used.");
     }
   }
-  StaticCrlProvider provider = StaticCrlProvider(std::move(crl_map));
+  StaticCrlProvider provider =
+      StaticCrlProvider(std::move(crl_map), deny_undetermined);
   return std::make_shared<StaticCrlProvider>(std::move(provider));
 }
 
@@ -150,13 +151,14 @@ std::shared_ptr<Crl> StaticCrlProvider::GetCrl(
 
 absl::StatusOr<std::shared_ptr<CrlProvider>> CreateDirectoryReloaderCrlProvider(
     absl::string_view directory, std::chrono::seconds refresh_duration,
-    std::function<void(absl::Status)> reload_error_callback) {
+    std::function<void(absl::Status)> reload_error_callback,
+    bool deny_undetermined) {
   if (refresh_duration < std::chrono::seconds(60)) {
     return absl::InvalidArgumentError("Refresh duration minimum is 60 seconds");
   }
   auto provider = std::make_shared<DirectoryReloaderCrlProvider>(
       refresh_duration, reload_error_callback, /*event_engine=*/nullptr,
-      MakeDirectoryReader(directory));
+      MakeDirectoryReader(directory), deny_undetermined);
   // This could be slow to do at startup, but we want to
   // make sure it's done before the provider is used.
   provider->UpdateAndStartTimer();
@@ -166,10 +168,11 @@ absl::StatusOr<std::shared_ptr<CrlProvider>> CreateDirectoryReloaderCrlProvider(
 DirectoryReloaderCrlProvider::DirectoryReloaderCrlProvider(
     std::chrono::seconds duration, std::function<void(absl::Status)> callback,
     std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine,
-    std::shared_ptr<DirectoryReader> directory_impl)
+    std::shared_ptr<DirectoryReader> directory_impl, bool deny_undetermined)
     : refresh_duration_(Duration::FromSecondsAsDouble(duration.count())),
       reload_error_callback_(std::move(callback)),
       crl_directory_(std::move(directory_impl)) {
+  deny_undetermined_ = deny_undetermined;
   // Must be called before `GetDefaultEventEngine`
   grpc_init();
   if (event_engine == nullptr) {

--- a/src/core/lib/security/credentials/tls/grpc_tls_crl_provider.h
+++ b/src/core/lib/security/credentials/tls/grpc_tls_crl_provider.h
@@ -51,8 +51,11 @@ class StaticCrlProvider : public CrlProvider {
   // Each element of the input vector is expected to be the raw contents of a
   // CRL file.
   explicit StaticCrlProvider(
-      absl::flat_hash_map<std::string, std::shared_ptr<Crl>> crls)
-      : crls_(std::move(crls)) {}
+      absl::flat_hash_map<std::string, std::shared_ptr<Crl>> crls,
+      bool deny_undetermined = false)
+      : crls_(std::move(crls)) {
+    deny_undetermined_ = deny_undetermined;
+  }
   std::shared_ptr<Crl> GetCrl(const CertificateInfo& certificate_info) override;
 
  private:
@@ -101,7 +104,8 @@ class DirectoryReloaderCrlProvider
       std::chrono::seconds duration, std::function<void(absl::Status)> callback,
       std::shared_ptr<grpc_event_engine::experimental::EventEngine>
           event_engine,
-      std::shared_ptr<DirectoryReader> directory_impl);
+      std::shared_ptr<DirectoryReader> directory_impl,
+      bool deny_undetermined = false);
 
   ~DirectoryReloaderCrlProvider() override;
   std::shared_ptr<Crl> GetCrl(const CertificateInfo& certificate_info) override;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1076,8 +1076,9 @@ static int CheckCertRevocation(grpc_core::experimental::CrlProvider* provider,
   // analogue for not finding the Crl from the provider, thus the certificate in
   // question is Undetermined.
   if (absl::IsNotFound(crl.status())) {
-    // TODO(gtcooke94) knob for undetermined being revoked or unrevoked. By
-    // default, unrevoked.
+    if (provider->DenyUndetermined()) {
+      return 0;
+    }
     return 1;
   } else if (!crl.ok()) {
     // This is an unexpected error, return false

--- a/test/core/security/grpc_tls_crl_provider_test.cc
+++ b/test/core/security/grpc_tls_crl_provider_test.cc
@@ -202,6 +202,22 @@ TEST_F(CrlProviderTest, StaticCrlProviderLookupIssuerNotFound) {
   EXPECT_EQ(crl, nullptr);
 }
 
+TEST_F(CrlProviderTest, StaticCrlProviderDenyUndeterminedDefault) {
+  std::vector<std::string> crl_strings = {GetFileContents(kCrlPath.data())};
+  absl::StatusOr<std::shared_ptr<CrlProvider>> provider =
+      experimental::CreateStaticCrlProvider(crl_strings);
+  ASSERT_TRUE(provider.ok()) << provider.status();
+  EXPECT_FALSE((*provider)->DenyUndetermined());
+}
+
+TEST_F(CrlProviderTest, StaticCrlProviderDenyUndeterminedTrue) {
+  std::vector<std::string> crl_strings = {GetFileContents(kCrlPath.data())};
+  absl::StatusOr<std::shared_ptr<CrlProvider>> provider =
+      experimental::CreateStaticCrlProvider(crl_strings, true);
+  ASSERT_TRUE(provider.ok()) << provider.status();
+  EXPECT_TRUE((*provider)->DenyUndetermined());
+}
+
 TEST_F(DirectoryReloaderCrlProviderTest, CrlLookupGood) {
   auto provider =
       CreateCrlProvider(kCrlDirectory, std::chrono::seconds(60), nullptr);

--- a/test/core/tsi/crl_ssl_transport_security_test.cc
+++ b/test/core/tsi/crl_ssl_transport_security_test.cc
@@ -469,6 +469,40 @@ TEST_P(CrlSslTransportSecurityTest, CrlFromBadCa) {
                                         *provider, false, false, false);
   fixture->Run();
 }
+TEST_P(CrlSslTransportSecurityTest,
+       CrlProviderGoodCertMissingCrlDenyUndetermined) {
+  // Create a provider with no CRLs
+  absl::StatusOr<std::shared_ptr<grpc_core::experimental::CrlProvider>>
+      provider = grpc_core::experimental::CreateStaticCrlProvider({}, true);
+  ASSERT_TRUE(provider.ok());
+
+  // Because we have no CRLs, every certificate will be seen as Undetermined.
+  // Regardless of the fact that it's not revoked, because we set
+  // deny_undetermined to true, it will stop connection establishment
+  auto* fixture = new SslTsiTestFixture(kValidKeyPath, kValidCertPath,
+                                        kValidKeyPath, kValidCertPath, nullptr,
+                                        *provider, false, false, false);
+  fixture->Run();
+}
+
+TEST_P(CrlSslTransportSecurityTest,
+       CrlProviderRevokedIntermediateMissingRootCrlDenyUndetermined) {
+  std::string intermediate_crl =
+      grpc_core::testing::GetFileContents(kIntermediateCrlPath);
+
+  // The CRL that would revoke the intermediate CRL is missing. Because we
+  // explicitly set deny_undetermined to true, this will result in a failure to
+  // connect
+  absl::StatusOr<std::shared_ptr<grpc_core::experimental::CrlProvider>>
+      provider = grpc_core::experimental::CreateStaticCrlProvider(
+          {intermediate_crl}, true);
+  ASSERT_TRUE(provider.ok());
+
+  auto* fixture = new SslTsiTestFixture(
+      kRevokedIntermediateKeyPath, kRevokedIntermediateCertPath, kValidKeyPath,
+      kValidCertPath, nullptr, *provider, false, false, false);
+  fixture->Run();
+}
 
 // TODO(gtcooke94) Add nullptr issuer test cases - this is not simple to test
 // the way the code is currently designed - we plan to refactor ways the OpenSSL

--- a/test/cpp/end2end/crl_provider_test.cc
+++ b/test/cpp/end2end/crl_provider_test.cc
@@ -78,6 +78,14 @@ TEST(DirectoryReloaderCrlProviderTestNoFixture, Construction) {
   auto provider = grpc_core::experimental::CreateDirectoryReloaderCrlProvider(
       kCrlDirectoryPath, std::chrono::seconds(60), nullptr);
   ASSERT_TRUE(provider.ok()) << provider.status();
+  EXPECT_FALSE((*provider)->DenyUndetermined());
+}
+
+TEST(DirectoryReloaderCrlProviderTestNoFixture, DenyUndeterminedTrue) {
+  auto provider = grpc_core::experimental::CreateDirectoryReloaderCrlProvider(
+      kCrlDirectoryPath, std::chrono::seconds(60), nullptr, true);
+  ASSERT_TRUE(provider.ok()) << provider.status();
+  EXPECT_TRUE((*provider)->DenyUndetermined());
 }
 
 class CrlProviderTest : public ::testing::Test {


### PR DESCRIPTION
This has been a TODO in the CRL Provider stack for some time.
If a CRL for a given issuer is _not_ found in a provider, there resulting revocation status for _any_ certificate from that issuer will be `Undetermined`. This flag allows a user to treat `Undetermined` as `Revoked`. The default behavior is to treat `Undetermined` as `Unrevoked`.