### PR TITLE
[Gpr_To_Absl_Logging] Move function to test header form log.h

### DIFF
--- a/grpc.def
+++ b/grpc.def
@@ -236,7 +236,6 @@ EXPORTS
     gpr_log_message
     gpr_set_log_verbosity
     gpr_log_verbosity_init
-    gpr_disable_all_logs
     gpr_set_log_function
     gpr_assertion_failed
     gpr_format_message

--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -69,8 +69,6 @@ GPRAPI void gpr_set_log_verbosity(gpr_log_severity min_severity_to_print);
 
 GPRAPI void gpr_log_verbosity_init(void);
 
-GPRAPI void gpr_disable_all_logs(void);
-
 /** Log overrides: applications can use this API to intercept logging calls
    and use their own implementations */
 

--- a/src/core/util/log.cc
+++ b/src/core/util/log.cc
@@ -187,8 +187,3 @@ void gpr_log_verbosity_init() {
 void gpr_set_log_function(gpr_log_func f) {
   gpr_atm_no_barrier_store(&g_log_func, (gpr_atm)(f ? f : gpr_default_log));
 }
-
-void gpr_disable_all_logs() {
-  absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
-  absl::SetVLogLevel("*grpc*/*", -1);
-}

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.c
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.c
@@ -259,7 +259,6 @@ gpr_should_log_type gpr_should_log_import;
 gpr_log_message_type gpr_log_message_import;
 gpr_set_log_verbosity_type gpr_set_log_verbosity_import;
 gpr_log_verbosity_init_type gpr_log_verbosity_init_import;
-gpr_disable_all_logs_type gpr_disable_all_logs_import;
 gpr_set_log_function_type gpr_set_log_function_import;
 gpr_assertion_failed_type gpr_assertion_failed_import;
 gpr_format_message_type gpr_format_message_import;
@@ -550,7 +549,6 @@ void grpc_rb_load_imports(HMODULE library) {
   gpr_log_message_import = (gpr_log_message_type) GetProcAddress(library, "gpr_log_message");
   gpr_set_log_verbosity_import = (gpr_set_log_verbosity_type) GetProcAddress(library, "gpr_set_log_verbosity");
   gpr_log_verbosity_init_import = (gpr_log_verbosity_init_type) GetProcAddress(library, "gpr_log_verbosity_init");
-  gpr_disable_all_logs_import = (gpr_disable_all_logs_type) GetProcAddress(library, "gpr_disable_all_logs");
   gpr_set_log_function_import = (gpr_set_log_function_type) GetProcAddress(library, "gpr_set_log_function");
   gpr_assertion_failed_import = (gpr_assertion_failed_type) GetProcAddress(library, "gpr_assertion_failed");
   gpr_format_message_import = (gpr_format_message_type) GetProcAddress(library, "gpr_format_message");

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -753,9 +753,6 @@ extern gpr_set_log_verbosity_type gpr_set_log_verbosity_import;
 typedef void(*gpr_log_verbosity_init_type)(void);
 extern gpr_log_verbosity_init_type gpr_log_verbosity_init_import;
 #define gpr_log_verbosity_init gpr_log_verbosity_init_import
-typedef void(*gpr_disable_all_logs_type)(void);
-extern gpr_disable_all_logs_type gpr_disable_all_logs_import;
-#define gpr_disable_all_logs gpr_disable_all_logs_import
 typedef void(*gpr_set_log_function_type)(gpr_log_func func);
 extern gpr_set_log_function_type gpr_set_log_function_import;
 #define gpr_set_log_function gpr_set_log_function_import

--- a/test/core/call/yodel/fuzzer_main.cc
+++ b/test/core/call/yodel/fuzzer_main.cc
@@ -31,6 +31,7 @@
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h"
 #include "test/core/test_util/fuzz_config_vars.h"
 #include "test/core/test_util/proto_bit_gen.h"
+#include "test/core/test_util/test_config.h"
 
 bool squelch = true;
 
@@ -43,7 +44,7 @@ DEFINE_PROTO_FUZZER(const transport_test_suite::Msg& msg) {
   const int test_id = msg.test_id() % tests->size();
 
   if (squelch && !grpc_core::GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
 
   grpc_core::ConfigVars::Overrides overrides =

--- a/test/core/end2end/end2end_test_fuzzer.cc
+++ b/test/core/end2end/end2end_test_fuzzer.cc
@@ -43,6 +43,7 @@
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h"
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h"
 #include "test/core/test_util/fuzz_config_vars.h"
+#include "test/core/test_util/test_config.h"
 
 using ::grpc_event_engine::experimental::FuzzingEventEngine;
 using ::grpc_event_engine::experimental::GetDefaultEventEngine;
@@ -91,7 +92,7 @@ void RunEnd2endFuzzer(const core_end2end_test_fuzzer::Msg& msg) {
   const int test_id = msg.test_id() % tests.size();
 
   if (squelch && !GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
 
   // TODO(ctiller): make this per fixture?

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -69,6 +69,7 @@
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h"
 #include "test/core/test_util/fuzz_config_vars.h"
 #include "test/core/test_util/fuzzing_channel_args.h"
+#include "test/core/test_util/test_config.h"
 
 // IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
 
@@ -504,7 +505,7 @@ using grpc_core::testing::ApiFuzzer;
 
 DEFINE_PROTO_FUZZER(const api_fuzzer::Msg& msg) {
   if (squelch && !grpc_core::GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_core::ApplyFuzzConfigVars(msg.config_vars());
   grpc_core::TestOnlyReloadExperimentsFromConfigVariables();

--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -43,6 +43,7 @@
 #include "test/core/end2end/fuzzers/network_input.h"
 #include "test/core/test_util/fuzz_config_vars.h"
 #include "test/core/test_util/mock_endpoint.h"
+#include "test/core/test_util/test_config.h"
 
 bool squelch = true;
 bool leak_check = true;
@@ -99,7 +100,7 @@ class ClientFuzzer final : public BasicFuzzer {
 
 DEFINE_PROTO_FUZZER(const fuzzer_input::Msg& msg) {
   if (squelch && !grpc_core::GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   if (msg.network_input().size() != 1) return;
   grpc_core::ApplyFuzzConfigVars(msg.config_vars());

--- a/test/core/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/end2end/fuzzers/server_fuzzer.cc
@@ -31,6 +31,7 @@
 #include "test/core/end2end/fuzzers/fuzzing_common.h"
 #include "test/core/end2end/fuzzers/network_input.h"
 #include "test/core/test_util/fuzz_config_vars.h"
+#include "test/core/test_util/test_config.h"
 
 bool squelch = true;
 bool leak_check = true;
@@ -95,7 +96,7 @@ void RunServerFuzzer(
     absl::FunctionRef<void(grpc_server*, int, const ChannelArgs&)>
         server_setup) {
   if (squelch && !GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   static const int once = []() {
     ForceEnableExperiment("event_engine_client", true);

--- a/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
+++ b/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
@@ -48,6 +48,7 @@
 #include "test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.pb.h"
 #include "test/core/test_util/fuzz_config_vars.h"
 #include "test/core/test_util/fuzzing_channel_args.h"
+#include "test/core/test_util/test_config.h"
 
 bool squelch = true;
 
@@ -254,7 +255,7 @@ grpc_core::ResolverArgs ConstructResolverArgs(
 
 DEFINE_PROTO_FUZZER(const event_engine_client_channel_resolver::Msg& msg) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   bool done_resolving = false;
   grpc_core::ApplyFuzzConfigVars(msg.config_vars());

--- a/test/core/nanopb/fuzzer_response.cc
+++ b/test/core/nanopb/fuzzer_response.cc
@@ -22,6 +22,8 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
+#include "test/core/test_util/test_config.h"
+
 bool squelch = true;
 bool leak_check = true;
 
@@ -29,7 +31,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* /*data*/,
                                       size_t /*size*/) {
   grpc_init();
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
 
   // TODO(veblush): Convert this to upb.

--- a/test/core/nanopb/fuzzer_serverlist.cc
+++ b/test/core/nanopb/fuzzer_serverlist.cc
@@ -22,6 +22,8 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
+#include "test/core/test_util/test_config.h"
+
 bool squelch = true;
 bool leak_check = true;
 
@@ -29,7 +31,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* /*data*/,
                                       size_t /*size*/) {
   grpc_init();
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
 
   // TODO(veblush): Convert this to upb.

--- a/test/core/resource_quota/BUILD
+++ b/test/core/resource_quota/BUILD
@@ -169,5 +169,6 @@ grpc_proto_fuzzer(
         "//src/core:memory_quota",
         "//src/core:useful",
         "//test/core/test_util:fuzz_config_vars",
+        "//test/core/test_util:grpc_test_util",
     ],
 )

--- a/test/core/resource_quota/memory_quota_fuzzer.cc
+++ b/test/core/resource_quota/memory_quota_fuzzer.cc
@@ -41,6 +41,7 @@
 #include "test/core/resource_quota/call_checker.h"
 #include "test/core/resource_quota/memory_quota_fuzzer.pb.h"
 #include "test/core/test_util/fuzz_config_vars.h"
+#include "test/core/test_util/test_config.h"
 
 bool squelch = true;
 bool leak_check = true;
@@ -189,7 +190,7 @@ class Fuzzer {
 
 DEFINE_PROTO_FUZZER(const memory_quota_fuzzer::Msg& msg) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_core::ApplyFuzzConfigVars(msg.config_vars());
   grpc_core::TestOnlyReloadExperimentsFromConfigVariables();

--- a/test/core/security/alts_credentials_fuzzer.cc
+++ b/test/core/security/alts_credentials_fuzzer.cc
@@ -33,6 +33,7 @@
 #include "src/core/lib/security/credentials/alts/check_gcp_environment.h"
 #include "src/core/lib/security/credentials/alts/grpc_alts_credentials_options.h"
 #include "test/core/test_util/fuzzer_util.h"
+#include "test/core/test_util/test_config.h"
 
 using grpc_core::testing::grpc_fuzzer_get_next_byte;
 using grpc_core::testing::grpc_fuzzer_get_next_string;
@@ -63,7 +64,7 @@ static void read_target_service_accounts(
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (squelch && !grpc_core::GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   input_stream inp = {data, data + size};
   grpc_init();

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -29,6 +29,7 @@
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/core/lib/security/security_connector/security_connector.h"
 #include "test/core/test_util/mock_endpoint.h"
+#include "test/core/test_util/test_config.h"
 #include "test/core/test_util/tls_utils.h"
 
 #define CA_CERT_PATH "src/core/tsi/test_creds/ca.pem"
@@ -59,7 +60,7 @@ static void on_handshake_done(void* arg, grpc_error_handle error) {
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_init();
   {

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -120,6 +120,7 @@ grpc_cc_library(
         "absl/base:core_headers",
         "absl/debugging:failure_signal_handler",
         "absl/log:check",
+        "absl/log:globals",
         "absl/log:log",
         "absl/status",
         "absl/status:statusor",

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -150,6 +150,11 @@ bool grpc_wait_until_shutdown(int64_t time_s) {
   return true;
 }
 
+void gpr_disable_all_logs() {
+  absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
+  absl::SetVLogLevel("*grpc*/*", -1);
+}
+
 namespace grpc {
 namespace testing {
 

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 #include "absl/debugging/failure_signal_handler.h"
+#include "absl/log/globals.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
@@ -150,7 +151,7 @@ bool grpc_wait_until_shutdown(int64_t time_s) {
   return true;
 }
 
-void gpr_disable_all_logs() {
+void grpc_disable_all_absl_logs() {
   absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
   absl::SetVLogLevel("*grpc*/*", -1);
 }

--- a/test/core/test_util/test_config.h
+++ b/test/core/test_util/test_config.h
@@ -42,6 +42,9 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms);
 // Prefer TestEnvironment below.
 void grpc_test_init(int* argc, char** argv);
 
+// Disable all absl logs via SetMinLogLevel and SetVLogLevel
+void gpr_disable_all_logs(void);
+
 // Wait until gRPC is fully shut down.
 // Returns if grpc is shutdown
 bool grpc_wait_until_shutdown(int64_t time_s);

--- a/test/core/test_util/test_config.h
+++ b/test/core/test_util/test_config.h
@@ -43,7 +43,7 @@ gpr_timespec grpc_timeout_milliseconds_to_deadline(int64_t time_ms);
 void grpc_test_init(int* argc, char** argv);
 
 // Disable all absl logs via SetMinLogLevel and SetVLogLevel
-void gpr_disable_all_logs(void);
+void grpc_disable_all_absl_logs(void);
 
 // Wait until gRPC is fully shut down.
 // Returns if grpc is shutdown

--- a/test/core/transport/binder/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/client_fuzzer.cc
@@ -27,6 +27,7 @@
 #include "src/core/lib/surface/channel.h"
 #include "src/core/lib/surface/channel_create.h"
 #include "src/libfuzzer/libfuzzer_macro.h"
+#include "test/core/test_util/test_config.h"
 #include "test/core/transport/binder/end2end/fuzzers/binder_transport_fuzzer.pb.h"
 #include "test/core/transport/binder/end2end/fuzzers/fuzzer_utils.h"
 
@@ -37,7 +38,7 @@ static void* tag(intptr_t t) { return reinterpret_cast<void*>(t); }
 
 DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_init();
   {

--- a/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
+++ b/test/core/transport/binder/end2end/fuzzers/server_fuzzer.cc
@@ -22,6 +22,7 @@
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/server/server.h"
 #include "src/libfuzzer/libfuzzer_macro.h"
+#include "test/core/test_util/test_config.h"
 #include "test/core/transport/binder/end2end/fuzzers/binder_transport_fuzzer.pb.h"
 #include "test/core/transport/binder/end2end/fuzzers/fuzzer_utils.h"
 
@@ -32,7 +33,7 @@ static void* tag(intptr_t t) { return reinterpret_cast<void*>(t); }
 
 DEFINE_PROTO_FUZZER(const binder_transport_fuzzer::Input& input) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_init();
   {

--- a/test/core/transport/chttp2/hpack_parser_fuzzer_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_fuzzer_test.cc
@@ -43,6 +43,7 @@
 #include "src/libfuzzer/libfuzzer_macro.h"
 #include "test/core/test_util/fuzz_config_vars.h"
 #include "test/core/test_util/proto_bit_gen.h"
+#include "test/core/test_util/test_config.h"
 #include "test/core/transport/chttp2/hpack_parser_fuzzer.pb.h"
 
 // IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
@@ -52,7 +53,7 @@ bool leak_check = true;
 
 DEFINE_PROTO_FUZZER(const hpack_parser_fuzzer::Msg& msg) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_core::ProtoBitGen proto_bit_src(msg.random_numbers());
   grpc_core::ApplyFuzzConfigVars(msg.config_vars());

--- a/test/core/transport/chttp2/hpack_sync_fuzzer.cc
+++ b/test/core/transport/chttp2/hpack_sync_fuzzer.cc
@@ -47,6 +47,7 @@
 #include "src/libfuzzer/libfuzzer_macro.h"
 #include "test/core/test_util/fuzz_config_vars.h"
 #include "test/core/test_util/proto_bit_gen.h"
+#include "test/core/test_util/test_config.h"
 #include "test/core/transport/chttp2/hpack_sync_fuzzer.pb.h"
 
 bool squelch = true;
@@ -169,7 +170,7 @@ void FuzzOneInput(const hpack_sync_fuzzer::Msg& msg) {
 
 DEFINE_PROTO_FUZZER(const hpack_sync_fuzzer::Msg& msg) {
   if (squelch) {
-    gpr_disable_all_logs();
+    grpc_disable_all_absl_logs();
   }
   grpc_core::ApplyFuzzConfigVars(msg.config_vars());
   grpc_core::TestOnlyReloadExperimentsFromConfigVariables();

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -158,6 +158,7 @@ grpc_cc_binary(
     language = "C++",
     deps = [
         "//:grpc++",
+        "//test/core/test_util:grpc_test_util",
         "//test/cpp/util:metrics_server_lib",
         "//test/cpp/util:test_config",
     ],

--- a/test/cpp/interop/metrics_client.cc
+++ b/test/cpp/interop/metrics_client.cc
@@ -27,6 +27,7 @@
 #include "src/core/lib/gprpp/crash.h"
 #include "src/proto/grpc/testing/metrics.grpc.pb.h"
 #include "src/proto/grpc/testing/metrics.pb.h"
+#include "test/core/test_util/test_config.h"
 #include "test/cpp/util/metrics_server.h"
 #include "test/cpp/util/test_config.h"
 
@@ -90,7 +91,7 @@ int main(int argc, char** argv) {
   // The output of metrics client is in some cases programmatically parsed (for
   // example by the stress test framework). So, we do not want any of the log
   // from the grpc library appearing on stdout.
-  gpr_disable_all_logs();
+  grpc_disable_all_absl_logs();
 
   std::shared_ptr<grpc::Channel> channel(
       grpc::CreateChannel(absl::GetFlag(FLAGS_metrics_server_address),


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Move function to test header form log.h
This is not really needed in log.h