### PR TITLE
[Python Test] Remove googleapis-common-protos from build_python

### DIFF
--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -218,7 +218,7 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 # Build/install tests
 pip_install coverage==7.2.0 oauth2client==4.1.0 \
             google-auth>=1.35.0 requests==2.31.0 \
-            googleapis-common-protos>=1.5.5 rsa==4.0 absl-py==1.4.0 \
+            rsa==4.0 absl-py==1.4.0 \
             opentelemetry-sdk==1.21.0
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos


### PR DESCRIPTION
Trigger a run with master config:
* https://fusion2.corp.google.com/invocations/fde3739f-6862-433d-b436-3bb8d62b610c
  * Only Ruby failed, it's also failing on master
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

