### PR TITLE
[infra] Remove CODEOWNERS for rollouts.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 /bazel/** @veblush @gnossen
 /bazel/experiments.yaml
+/bazel/rollouts.yaml
 /cmake/** @veblush @apolcyn
 /src/core/client_channel/** @markdroth
 /src/core/ext/transport/chttp2/transport/** @ctiller


### PR DESCRIPTION
There is already an exception for `experiments.yaml`, but any change to that file still adds @veblush and @gnossen to every PR. This is correcting an oversight.

See https://github.com/grpc/grpc/pull/36876