### PR TITLE
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/cpp/server/backend_metric_recorder.cc
+++ b/src/cpp/server/backend_metric_recorder.cc
@@ -177,7 +177,7 @@ void ServerMetricRecorder::ClearCpuUtilization() {
   UpdateBackendMetricDataState(
       [](BackendMetricData* data) { data->cpu_utilization = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] CPU utilization cleared.", this);
+    LOG(INFO) << "[" << this << "] CPU utilization cleared.";
   }
 }
 
@@ -185,7 +185,7 @@ void ServerMetricRecorder::ClearMemoryUtilization() {
   UpdateBackendMetricDataState(
       [](BackendMetricData* data) { data->mem_utilization = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Mem utilization cleared.", this);
+    LOG(INFO) << "[" << this << "] Mem utilization cleared.";
   }
 }
 
@@ -193,21 +193,21 @@ void ServerMetricRecorder::ClearApplicationUtilization() {
   UpdateBackendMetricDataState(
       [](BackendMetricData* data) { data->application_utilization = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Application utilization cleared.", this);
+    LOG(INFO) << "[" << this << "] Application utilization cleared.";
   }
 }
 
 void ServerMetricRecorder::ClearQps() {
   UpdateBackendMetricDataState([](BackendMetricData* data) { data->qps = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] QPS utilization cleared.", this);
+    LOG(INFO) << "[" << this << "] QPS utilization cleared.";
   }
 }
 
 void ServerMetricRecorder::ClearEps() {
   UpdateBackendMetricDataState([](BackendMetricData* data) { data->eps = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] EPS utilization cleared.", this);
+    LOG(INFO) << "[" << this << "] EPS utilization cleared.";
   }
 }
 

--- a/src/cpp/server/backend_metric_recorder.cc
+++ b/src/cpp/server/backend_metric_recorder.cc
@@ -24,7 +24,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <grpc/support/log.h>
+#include "absl/log/log.h"
+
 #include <grpcpp/ext/call_metric_recorder.h>
 #include <grpcpp/ext/server_metric_recorder.h>
 
@@ -69,36 +70,35 @@ void ServerMetricRecorder::UpdateBackendMetricDataState(
 void ServerMetricRecorder::SetCpuUtilization(double value) {
   if (!IsUtilizationWithSoftLimitsValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] CPU utilization rejected: %f", this, value);
+      LOG(INFO) << "[%p] CPU utilization rejected: " << value;
     }
     return;
   }
   UpdateBackendMetricDataState(
       [value](BackendMetricData* data) { data->cpu_utilization = value; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] CPU utilization set: %f", this, value);
+    LOG(INFO) << "[%p] CPU utilization set: " << value;
   }
 }
 
 void ServerMetricRecorder::SetMemoryUtilization(double value) {
   if (!IsUtilizationValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Mem utilization rejected: %f", this, value);
+      LOG(INFO) << "[%p] Mem utilization rejected: " << value;
     }
     return;
   }
   UpdateBackendMetricDataState(
       [value](BackendMetricData* data) { data->mem_utilization = value; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Mem utilization set: %f", this, value);
+    LOG(INFO) << "[%p] Mem utilization set: " << value;
   }
 }
 
 void ServerMetricRecorder::SetApplicationUtilization(double value) {
   if (!IsUtilizationWithSoftLimitsValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Application utilization rejected: %f", this,
-              value);
+      LOG(INFO) << "[%p] Application utilization rejected: " << value;
     }
     return;
   }
@@ -106,49 +106,49 @@ void ServerMetricRecorder::SetApplicationUtilization(double value) {
     data->application_utilization = value;
   });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Application utilization set: %f", this, value);
+    LOG(INFO) << "[%p] Application utilization set: " << value;
   }
 }
 
 void ServerMetricRecorder::SetQps(double value) {
   if (!IsRateValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] QPS rejected: %f", this, value);
+      LOG(INFO) << "[%p] QPS rejected: " << value;
     }
     return;
   }
   UpdateBackendMetricDataState(
       [value](BackendMetricData* data) { data->qps = value; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] QPS set: %f", this, value);
+    LOG(INFO) << "[%p] QPS set: " << value;
   }
 }
 
 void ServerMetricRecorder::SetEps(double value) {
   if (!IsRateValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] EPS rejected: %f", this, value);
+      LOG(INFO) << "[%p] EPS rejected: " << value;
     }
     return;
   }
   UpdateBackendMetricDataState(
       [value](BackendMetricData* data) { data->eps = value; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] EPS set: %f", this, value);
+    LOG(INFO) << "[%p] EPS set: " << value;
   }
 }
 
 void ServerMetricRecorder::SetNamedUtilization(string_ref name, double value) {
   if (!IsUtilizationValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Named utilization rejected: %f name: %s", this,
-              value, std::string(name.data(), name.size()).c_str());
+      LOG(INFO) << "[%p] Named utilization rejected: " << value
+                << " name: " << std::string(name.data(), name.size());
     }
     return;
   }
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Named utilization set: %f name: %s", this, value,
-            std::string(name.data(), name.size()).c_str());
+    LOG(INFO) << "[%p] Named utilization set: " << value
+              << " name: " << std::string(name.data(), name.size());
   }
   UpdateBackendMetricDataState([name, value](BackendMetricData* data) {
     data->utilization[absl::string_view(name.data(), name.size())] = value;
@@ -158,8 +158,8 @@ void ServerMetricRecorder::SetNamedUtilization(string_ref name, double value) {
 void ServerMetricRecorder::SetAllNamedUtilization(
     std::map<string_ref, double> named_utilization) {
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] All named utilization updated. size: %" PRIuPTR,
-            this, named_utilization.size());
+    LOG(INFO) << "[%p] All named utilization updated. size: "
+              << named_utilization.size();
   }
   UpdateBackendMetricDataState(
       [utilization = std::move(named_utilization)](BackendMetricData* data) {
@@ -175,7 +175,7 @@ void ServerMetricRecorder::ClearCpuUtilization() {
   UpdateBackendMetricDataState(
       [](BackendMetricData* data) { data->cpu_utilization = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] CPU utilization cleared.", this);
+    LOG(INFO) << "[%p] CPU utilization cleared.";
   }
 }
 
@@ -183,7 +183,7 @@ void ServerMetricRecorder::ClearMemoryUtilization() {
   UpdateBackendMetricDataState(
       [](BackendMetricData* data) { data->mem_utilization = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Mem utilization cleared.", this);
+    LOG(INFO) << "[%p] Mem utilization cleared.";
   }
 }
 
@@ -191,28 +191,28 @@ void ServerMetricRecorder::ClearApplicationUtilization() {
   UpdateBackendMetricDataState(
       [](BackendMetricData* data) { data->application_utilization = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Application utilization cleared.", this);
+    LOG(INFO) << "[%p] Application utilization cleared.";
   }
 }
 
 void ServerMetricRecorder::ClearQps() {
   UpdateBackendMetricDataState([](BackendMetricData* data) { data->qps = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] QPS utilization cleared.", this);
+    LOG(INFO) << "[%p] QPS utilization cleared.";
   }
 }
 
 void ServerMetricRecorder::ClearEps() {
   UpdateBackendMetricDataState([](BackendMetricData* data) { data->eps = -1; });
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] EPS utilization cleared.", this);
+    LOG(INFO) << "[%p] EPS utilization cleared.";
   }
 }
 
 void ServerMetricRecorder::ClearNamedUtilization(string_ref name) {
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Named utilization cleared. name: %s", this,
-            std::string(name.data(), name.size()).c_str());
+    LOG(INFO) << "[%p] Named utilization cleared. name: "
+              << std::string(name.data(), name.size());
   }
   UpdateBackendMetricDataState([name](BackendMetricData* data) {
     data->utilization.erase(absl::string_view(name.data(), name.size()));
@@ -233,12 +233,12 @@ ServerMetricRecorder::GetMetricsIfChanged() const {
   }
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
     const auto& data = result->data;
-    gpr_log(GPR_INFO,
-            "[%p] GetMetrics() returned: seq:%" PRIu64
-            " cpu:%f mem:%f app:%f qps:%f eps:%f utilization size: %" PRIuPTR,
-            this, result->sequence_number, data.cpu_utilization,
-            data.mem_utilization, data.application_utilization, data.qps,
-            data.eps, data.utilization.size());
+    LOG(INFO) << "[%p] GetMetrics() returned: seq:" << result->sequence_number
+              << " cpu:" << data.cpu_utilization
+              << " mem:" << data.mem_utilization
+              << " app:" << data.application_utilization << " qps:" << data.qps
+              << " eps:" << data.eps
+              << " utilization size: " << data.utilization.size();
   }
   return result;
 }
@@ -249,13 +249,13 @@ experimental::CallMetricRecorder&
 BackendMetricState::RecordCpuUtilizationMetric(double value) {
   if (!IsUtilizationWithSoftLimitsValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] CPU utilization value rejected: %f", this, value);
+      LOG(INFO) << "[%p] CPU utilization value rejected: " << value;
     }
     return *this;
   }
   cpu_utilization_.store(value, std::memory_order_relaxed);
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] CPU utilization recorded: %f", this, value);
+    LOG(INFO) << "[%p] CPU utilization recorded: " << value;
   }
   return *this;
 }
@@ -264,13 +264,13 @@ experimental::CallMetricRecorder&
 BackendMetricState::RecordMemoryUtilizationMetric(double value) {
   if (!IsUtilizationValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Mem utilization value rejected: %f", this, value);
+      LOG(INFO) << "[%p] Mem utilization value rejected: " << value;
     }
     return *this;
   }
   mem_utilization_.store(value, std::memory_order_relaxed);
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Mem utilization recorded: %f", this, value);
+    LOG(INFO) << "[%p] Mem utilization recorded: " << value;
   }
   return *this;
 }
@@ -279,14 +279,13 @@ experimental::CallMetricRecorder&
 BackendMetricState::RecordApplicationUtilizationMetric(double value) {
   if (!IsUtilizationWithSoftLimitsValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Application utilization value rejected: %f", this,
-              value);
+      LOG(INFO) << "[%p] Application utilization value rejected: " << value;
     }
     return *this;
   }
   application_utilization_.store(value, std::memory_order_relaxed);
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Application utilization recorded: %f", this, value);
+    LOG(INFO) << "[%p] Application utilization recorded: " << value;
   }
   return *this;
 }
@@ -295,13 +294,13 @@ experimental::CallMetricRecorder& BackendMetricState::RecordQpsMetric(
     double value) {
   if (!IsRateValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] QPS value rejected: %f", this, value);
+      LOG(INFO) << "[%p] QPS value rejected: " << value;
     }
     return *this;
   }
   qps_.store(value, std::memory_order_relaxed);
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] QPS recorded: %f", this, value);
+    LOG(INFO) << "[%p] QPS recorded: " << value;
   }
   return *this;
 }
@@ -310,13 +309,13 @@ experimental::CallMetricRecorder& BackendMetricState::RecordEpsMetric(
     double value) {
   if (!IsRateValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] EPS value rejected: %f", this, value);
+      LOG(INFO) << "[%p] EPS value rejected: " << value;
     }
     return *this;
   }
   eps_.store(value, std::memory_order_relaxed);
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] EPS recorded: %f", this, value);
+    LOG(INFO) << "[%p] EPS recorded: " << value;
   }
   return *this;
 }
@@ -325,8 +324,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordUtilizationMetric(
     string_ref name, double value) {
   if (!IsUtilizationValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Utilization value rejected: %s %f", this,
-              std::string(name.data(), name.length()).c_str(), value);
+      LOG(INFO) << "[%p] Utilization value rejected: "
+                << std::string(name.data(), name.length()) << " " << value;
     }
     return *this;
   }
@@ -334,8 +333,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordUtilizationMetric(
   absl::string_view name_sv(name.data(), name.length());
   utilization_[name_sv] = value;
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Utilization recorded: %s %f", this,
-            std::string(name_sv).c_str(), value);
+    LOG(INFO) << "[%p] Utilization recorded: " << std::string(name_sv) << " "
+              << value;
   }
   return *this;
 }
@@ -346,8 +345,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordRequestCostMetric(
   absl::string_view name_sv(name.data(), name.length());
   request_cost_[name_sv] = value;
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Request cost recorded: %s %f", this,
-            std::string(name_sv).c_str(), value);
+    LOG(INFO) << "[%p] Request cost recorded: " << std::string(name_sv) << " "
+              << value;
   }
   return *this;
 }
@@ -358,8 +357,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordNamedMetric(
   absl::string_view name_sv(name.data(), name.length());
   named_metrics_[name_sv] = value;
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Named metric recorded: %s %f", this,
-            std::string(name_sv).c_str(), value);
+    LOG(INFO) << "[%p] Named metric recorded: " << std::string(name_sv) << " "
+              << value;
   }
   return *this;
 }
@@ -406,13 +405,7 @@ BackendMetricData BackendMetricState::GetBackendMetricData() {
     }
   }
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO,
-            "[%p] Backend metric data returned: cpu:%f mem:%f qps:%f eps:%f "
-            "utilization size:%" PRIuPTR " request_cost size:%" PRIuPTR
-            "named_metrics size:%" PRIuPTR,
-            this, data.cpu_utilization, data.mem_utilization, data.qps,
-            data.eps, data.utilization.size(), data.request_cost.size(),
-            data.named_metrics.size());
+    LOG(INFO) << "[%p] Backend metric data returned: cpu:" << data.cpu_uti
   }
   return data;
 }

--- a/src/cpp/server/backend_metric_recorder.cc
+++ b/src/cpp/server/backend_metric_recorder.cc
@@ -99,8 +99,8 @@ void ServerMetricRecorder::SetMemoryUtilization(double value) {
 void ServerMetricRecorder::SetApplicationUtilization(double value) {
   if (!IsUtilizationWithSoftLimitsValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Application utilization rejected: %f", this,
-              value);
+      LOG(INFO) << "[" << this
+                << "] Application utilization rejected: " << value;
     }
     return;
   }
@@ -143,14 +143,14 @@ void ServerMetricRecorder::SetEps(double value) {
 void ServerMetricRecorder::SetNamedUtilization(string_ref name, double value) {
   if (!IsUtilizationValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Named utilization rejected: %f name: %s", this,
-              value, std::string(name.data(), name.size()).c_str());
+      LOG(INFO) << "[" << this << "] Named utilization rejected: " << value
+                << " name: " << std::string(name.data(), name.size());
     }
     return;
   }
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Named utilization set: %f name: %s", this, value,
-            std::string(name.data(), name.size()).c_str());
+    LOG(INFO) << "[" << this << "] Named utilization set: " << value
+              << " name: " << std::string(name.data(), name.size());
   }
   UpdateBackendMetricDataState([name, value](BackendMetricData* data) {
     data->utilization[absl::string_view(name.data(), name.size())] = value;
@@ -160,8 +160,8 @@ void ServerMetricRecorder::SetNamedUtilization(string_ref name, double value) {
 void ServerMetricRecorder::SetAllNamedUtilization(
     std::map<string_ref, double> named_utilization) {
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] All named utilization updated. size: %" PRIuPTR,
-            this, named_utilization.size());
+    LOG(INFO) << "[" << this << "] All named utilization updated. size: "
+              << named_utilization.size();
   }
   UpdateBackendMetricDataState(
       [utilization = std::move(named_utilization)](BackendMetricData* data) {
@@ -213,8 +213,8 @@ void ServerMetricRecorder::ClearEps() {
 
 void ServerMetricRecorder::ClearNamedUtilization(string_ref name) {
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Named utilization cleared. name: %s", this,
-            std::string(name.data(), name.size()).c_str());
+    LOG(INFO) << "[" << this << "] Named utilization cleared. name: "
+              << std::string(name.data(), name.size());
   }
   UpdateBackendMetricDataState([name](BackendMetricData* data) {
     data->utilization.erase(absl::string_view(name.data(), name.size()));
@@ -235,12 +235,13 @@ ServerMetricRecorder::GetMetricsIfChanged() const {
   }
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
     const auto& data = result->data;
-    gpr_log(GPR_INFO,
-            "[%p] GetMetrics() returned: seq:%" PRIu64
-            " cpu:%f mem:%f app:%f qps:%f eps:%f utilization size: %" PRIuPTR,
-            this, result->sequence_number, data.cpu_utilization,
-            data.mem_utilization, data.application_utilization, data.qps,
-            data.eps, data.utilization.size());
+    LOG(INFO) << "[" << this
+              << "] GetMetrics() returned: seq:" << result->sequence_number
+              << " cpu:" << data.cpu_utilization
+              << " mem:" << data.mem_utilization
+              << " app:" << data.application_utilization << " qps:" << data.qps
+              << " eps:" << data.eps
+              << " utilization size: " << data.utilization.size();
   }
   return result;
 }
@@ -327,8 +328,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordUtilizationMetric(
     string_ref name, double value) {
   if (!IsUtilizationValid(value)) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-      gpr_log(GPR_INFO, "[%p] Utilization value rejected: %s %f", this,
-              std::string(name.data(), name.length()).c_str(), value);
+      LOG(INFO) << "[" << this << "] Utilization value rejected: "
+                << std::string(name.data(), name.length()) << " " << value;
     }
     return *this;
   }
@@ -336,8 +337,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordUtilizationMetric(
   absl::string_view name_sv(name.data(), name.length());
   utilization_[name_sv] = value;
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Utilization recorded: %s %f", this,
-            std::string(name_sv).c_str(), value);
+    LOG(INFO) << "[" << this << "] Utilization recorded: " << name_sv << " "
+              << value;
   }
   return *this;
 }
@@ -348,8 +349,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordRequestCostMetric(
   absl::string_view name_sv(name.data(), name.length());
   request_cost_[name_sv] = value;
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Request cost recorded: %s %f", this,
-            std::string(name_sv).c_str(), value);
+    LOG(INFO) << "[" << this << "] Request cost recorded: " << name_sv << " "
+              << value;
   }
   return *this;
 }
@@ -360,8 +361,8 @@ experimental::CallMetricRecorder& BackendMetricState::RecordNamedMetric(
   absl::string_view name_sv(name.data(), name.length());
   named_metrics_[name_sv] = value;
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO, "[%p] Named metric recorded: %s %f", this,
-            std::string(name_sv).c_str(), value);
+    LOG(INFO) << "[" << this << "] Named metric recorded: " << name_sv << " "
+              << value;
   }
   return *this;
 }
@@ -408,13 +409,13 @@ BackendMetricData BackendMetricState::GetBackendMetricData() {
     }
   }
   if (GRPC_TRACE_FLAG_ENABLED(backend_metric)) {
-    gpr_log(GPR_INFO,
-            "[%p] Backend metric data returned: cpu:%f mem:%f qps:%f eps:%f "
-            "utilization size:%" PRIuPTR " request_cost size:%" PRIuPTR
-            "named_metrics size:%" PRIuPTR,
-            this, data.cpu_utilization, data.mem_utilization, data.qps,
-            data.eps, data.utilization.size(), data.request_cost.size(),
-            data.named_metrics.size());
+    LOG(INFO) << "[" << this
+              << "] Backend metric data returned: cpu:" << data.cpu_utilization
+              << " mem:" << data.mem_utilization << " qps:" << data.qps
+              << " eps:" << data.eps
+              << " utilization size:" << data.utilization.size()
+              << " request_cost size:" << data.request_cost.size()
+              << "named_metrics size:" << data.named_metrics.size();
   }
   return data;
 }


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
