### PR TITLE
[fix] updated invocation_metadata return type hint

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -18,7 +18,6 @@ from typing import Generic, Iterable, Mapping, NoReturn, Optional, Sequence
 
 import grpc
 
-from ._metadata import Metadata
 from ._typing import DoneCallbackType
 from ._typing import MetadataType
 from ._typing import RequestType
@@ -225,7 +224,7 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         """
 
     @abc.abstractmethod
-    def invocation_metadata(self) -> Optional[Metadata]:
+    def invocation_metadata(self) -> Optional[MetadataType]:
         """Accesses the metadata sent by the client.
 
         Returns:

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -18,6 +18,7 @@ from typing import Generic, Iterable, Mapping, NoReturn, Optional, Sequence
 
 import grpc
 
+from ._metadata import Metadata
 from ._typing import DoneCallbackType
 from ._typing import MetadataType
 from ._typing import RequestType


### PR DESCRIPTION
Updated the type hint for return type of grpc.aio.ServicerContext.invocation_metadata() to Optional[MetadataType] instead of Optional[Metadata].

MetadataType is already defined to be a Sequence[MetadatumType] and hence the type hint will reflect the sequence being returned, hence solving the [user's reported issue](https://github.com/grpc/grpc/issues/36613)