### PR TITLE
Update ruby google-protobuf gem dependency to >= 3.25

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 3.25'
+  s.add_dependency 'google-protobuf', '>= 3.25', '< 5.0'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
   s.add_development_dependency 'bundler',            '>= 1.9'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -35,7 +35,7 @@
     ## Once protobuf 4.x is working with other dependencies,
     ## please replace the following fixed 3.25 version with
     ## '~> 4.${settings.protobuf_version.split(".")[1]}'
-    s.add_dependency 'google-protobuf', '~> 3.25'
+    s.add_dependency 'google-protobuf', '>= 3.25', '< 5.0'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
     s.add_development_dependency 'bundler',            '>= 1.9'


### PR DESCRIPTION
fix of #36891 
