### PR TITLE
[omg] Avoid MSVC miscompile (v1.65.x backport)

### DIFF
--- a/src/core/lib/resource_quota/arena.h
+++ b/src/core/lib/resource_quota/arena.h
@@ -94,8 +94,13 @@ class ArenaContextTraits : public BaseArenaContextTraits {
 };
 
 template <typename T>
-const uint16_t ArenaContextTraits<T>::id_ = BaseArenaContextTraits::MakeId(
-    [](void* ptr) { ArenaContextType<T>::Destroy(static_cast<T*>(ptr)); });
+void DestroyArenaContext(void* p) {
+  ArenaContextType<T>::Destroy(static_cast<T*>(p));
+}
+
+template <typename T>
+const uint16_t ArenaContextTraits<T>::id_ =
+    BaseArenaContextTraits::MakeId(DestroyArenaContext<T>);
 
 template <typename T, typename A, typename B>
 struct IfArray {
@@ -283,6 +288,7 @@ class Arena final : public RefCounted<Arena, NonPolymorphicRefCount,
       ArenaContextType<T>::Destroy(static_cast<T*>(slot));
     }
     slot = context;
+    DCHECK_EQ(GetContext<T>(), context);
   }
 
  private:


### PR DESCRIPTION
Backport of #36893 to v1.65.x.
---
Seems MSVC has trouble compiling this statically initialized lambda in a template; crash goes away when I split it out to be a named function instead