### PR TITLE
fix: Remove unused -GCC_WARN_INHIBIT_ALL_WARNINGS flag

### DIFF
--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -106,7 +106,7 @@ Pod::Spec.new do |s|
 
   # We don't need to inhibit all warnings; only -Wno-shorten-64-to-32. But Cocoapods' linter doesn't
   # want that for some reason.
-  s.compiler_flags = '-DOPENSSL_NO_ASM', '-GCC_WARN_INHIBIT_ALL_WARNINGS', '-w', '-DBORINGSSL_PREFIX=GRPC'
+  s.compiler_flags = '-DOPENSSL_NO_ASM', '-w', '-DBORINGSSL_PREFIX=GRPC'
   s.requires_arc = false
 
   # Like many other C libraries, BoringSSL has its public headers under `include/<libname>/` and its

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -137,7 +137,7 @@
 
     # We don't need to inhibit all warnings; only -Wno-shorten-64-to-32. But Cocoapods' linter doesn't
     # want that for some reason.
-    s.compiler_flags = '-DOPENSSL_NO_ASM', '-GCC_WARN_INHIBIT_ALL_WARNINGS', '-w', '-DBORINGSSL_PREFIX=GRPC'
+    s.compiler_flags = '-DOPENSSL_NO_ASM', '-w', '-DBORINGSSL_PREFIX=GRPC'
     s.requires_arc = false
 
     # Like many other C libraries, BoringSSL has its public headers under `include/<libname>/` and its


### PR DESCRIPTION
This flag was being ignored in clang in Xcode 15 and below, but is now an error in Xcode 16 and above.

