### PR TITLE
[ObjC] default GRPC_IOS_EVENT_ENGINE_CLIENT to 0

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -273,7 +273,7 @@
 #define GPR_CPU_IPHONE 1
 #define GRPC_CFSTREAM 1
 #ifndef GRPC_IOS_EVENT_ENGINE_CLIENT
-#define GRPC_IOS_EVENT_ENGINE_CLIENT 1
+#define GRPC_IOS_EVENT_ENGINE_CLIENT 0
 #endif /* GRPC_IOS_EVENT_ENGINE_CLIENT */
 /* the c-ares resolver isn't safe to enable on iOS */
 #define GRPC_ARES 0

--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -346,6 +346,7 @@ grpc_objc_testing_library(
 grpc_objc_testing_library(
     name = "EventEngineUnitTests-lib",
     srcs = ["EventEngineTests/CFEventEngineUnitTests.mm"],
+    defines = ["GRPC_IOS_EVENT_ENGINE_CLIENT=1"],
     deps = [
         "//src/core:cf_event_engine",
         "//test/core/event_engine/cf:cf_engine_unit_test_lib",

--- a/test/core/event_engine/test_suite/BUILD
+++ b/test/core/event_engine/test_suite/BUILD
@@ -118,6 +118,7 @@ grpc_cc_test(
 grpc_cc_test(
     name = "cf_event_engine_test",
     srcs = ["cf_event_engine_test.cc"],
+    copts = ["-DGRPC_IOS_EVENT_ENGINE_CLIENT=1"],
     tags = [
         "no_linux",
         "no_windows",

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -142,6 +142,7 @@ objc_event_engine_bazel_tests/bazel_wrapper \
   --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
   "${BAZEL_REMOTE_CACHE_ARGS[@]}" \
   $BAZEL_FLAGS \
+  --cxxopt=-DGRPC_IOS_EVENT_ENGINE_CLIENT=1 \
   --test_env=GRPC_EXPERIMENTS=event_engine_client \
   --test_env=GRPC_VERBOSITY=debug --test_env=GRPC_TRACE=event_engine,api \
   "${OBJC_TEST_ENV_ARGS[@]}" \


### PR DESCRIPTION
This partially revert #36785 which may be causing gmap crashes