### PR TITLE
[promises]: fix UB on uninitialized bool

### DIFF
--- a/src/core/lib/promise/pipe.h
+++ b/src/core/lib/promise/pipe.h
@@ -61,9 +61,9 @@ struct Pipe;
 template <typename T>
 class NextResult final {
  public:
-  NextResult() : center_(nullptr) {}
+  NextResult() : center_(nullptr), cancelled_(false) {}
   explicit NextResult(RefCountedPtr<pipe_detail::Center<T>> center)
-      : center_(std::move(center)) {
+      : center_(std::move(center)), cancelled_(false) {
     CHECK(center_ != nullptr);
   }
   explicit NextResult(bool cancelled)


### PR DESCRIPTION
Add the missing initializations in the constructors of 'NextResult' as the std doesn't provide it for primitive types.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

