### PR TITLE
[resource_quota] Reduce frequency of time polls in the first 10 seconds of execution

### DIFF
--- a/src/core/lib/resource_quota/periodic_update.cc
+++ b/src/core/lib/resource_quota/periodic_update.cc
@@ -56,8 +56,9 @@ bool PeriodicUpdate::MaybeEndPeriod(absl::FunctionRef<void(Duration)> f) {
     // Store the remainder left. Note that updates_remaining_ may have been
     // decremented by another thread whilst we performed the above calculations:
     // we simply discard those decrements.
-    updates_remaining_.store(better_guess - expected_updates_per_period_,
-                             std::memory_order_release);
+    auto remaining = better_guess - expected_updates_per_period_;
+    expected_updates_per_period_ = better_guess;
+    updates_remaining_.store(remaining, std::memory_order_release);
     // Not quite done, return, try for longer.
     return false;
   }

--- a/test/core/resource_quota/periodic_update_test.cc
+++ b/test/core/resource_quota/periodic_update_test.cc
@@ -78,7 +78,35 @@ TEST(PeriodicUpdateTest, SimpleTest) {
   }
 }
 
-TEST(PeriodicUpdate, ThreadTest) {
+TEST(PeriodicUpdateTest, NoSpin) {
+  // Ensure that we do not poll the time every update... even initially
+  class NowCounter : public Timestamp::ScopedSource {
+   public:
+    Timestamp Now() override {
+      ++n_;
+      return previous()->Now();
+    }
+
+    int now_calls() const { return n_; }
+
+   private:
+    int n_ = 0;
+  };
+  NowCounter counter;
+  PeriodicUpdate upd(Duration::Seconds(5));
+  while (!upd.Tick([](Duration d) { EXPECT_GE(d, Duration::Seconds(5)); })) {
+  }
+  const int initial_now_calls = counter.now_calls();
+  EXPECT_GT(initial_now_calls, 2);
+  EXPECT_LT(initial_now_calls, 100);
+  while (!upd.Tick([](Duration d) { EXPECT_GE(d, Duration::Seconds(5)); })) {
+  }
+  const int second_round_calls = counter.now_calls() - initial_now_calls;
+  EXPECT_GE(second_round_calls, 1);
+  EXPECT_LE(second_round_calls, initial_now_calls);
+}
+
+TEST(PeriodicUpdateTest, ThreadTest) {
   std::unique_ptr<PeriodicUpdate> upd;
   std::atomic<int> count(0);
   Timestamp start;


### PR DESCRIPTION
I noticed that we were unconditionally checking the timer during the first time period. I've added a test to ensure that we no longer do, and improved the code to fix it.