### PR TITLE
[optimization] Add support for `[[clang:always_inline]]` and similar attributes

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -746,6 +746,17 @@ extern void gpr_unreachable_code(const char* reason, const char* file,
 #endif
 #endif /* GPR_ATTRIBUTE_NOINLINE */
 
+#ifndef GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION
+#if GPR_HAS_CPP_ATTRIBUTE(clang::always_inline)
+#define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION [[clang::always_inline]]
+#elif GPR_HAS_ATTRIBUTE(always_inline)
+#define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION __attribute__((always_inline))
+#else
+// TODO(ctiller): add __forceinline for MSVC
+#define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION
+#endif
+#endif /* GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION */
+
 #ifndef GPR_NO_UNIQUE_ADDRESS
 #if GPR_HAS_CPP_ATTRIBUTE(no_unique_address)
 #define GPR_NO_UNIQUE_ADDRESS [[no_unique_address]]


### PR DESCRIPTION
We can demonstrably do a better job than compiler heuristics for large chunks of call-v3, so give ourselves that lever.