### PR TITLE
[optimization] Always inline `Construct` and `Destruct`

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -747,12 +747,17 @@ extern void gpr_unreachable_code(const char* reason, const char* file,
 #endif /* GPR_ATTRIBUTE_NOINLINE */
 
 #ifndef GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION
+#ifdef __cplusplus
 #if GPR_HAS_CPP_ATTRIBUTE(clang::always_inline)
 #define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION [[clang::always_inline]]
 #elif GPR_HAS_ATTRIBUTE(always_inline)
 #define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION __attribute__((always_inline))
 #else
 // TODO(ctiller): add __forceinline for MSVC
+#define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION
+#endif
+#else
+// Disable for C code
 #define GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION
 #endif
 #endif /* GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION */

--- a/src/core/lib/gprpp/construct_destruct.h
+++ b/src/core/lib/gprpp/construct_destruct.h
@@ -24,14 +24,14 @@ namespace grpc_core {
 
 // Call the destructor of p without having to name the type of p.
 template <typename T>
-void Destruct(T* p) {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void Destruct(T* p) {
   p->~T();
 }
 
 // Call the constructor of p without having to name the type of p and forward
 // any arguments
 template <typename T, typename... Args>
-void Construct(T* p, Args&&... args) {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void Construct(T* p, Args&&... args) {
   new (p) T(std::forward<Args>(args)...);
 }
 


### PR DESCRIPTION
These are helpers to make it slightly easier to spell some kinds of code... and should never ever generate a function body.

(that said, I've seen them do so... fixing now)