### PR TITLE
[Gpr_To_Absl_Logging] Remove custom logger from php.

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -336,7 +336,6 @@ all possible values of the `grpc.grpc.trace` option, please check
 ```
 grpc.grpc_verbosity=debug
 grpc.grpc_trace=all,-polling,-polling_api,-pollable_refcount,-timer,-timer_check
-grpc.log_filename=/var/log/grpc.log
 ```
 
 > Make sure the log file above is writable, by doing the following:

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -90,8 +90,6 @@ ZEND_GET_MODULE(grpc)
                      grpc_verbosity, zend_grpc_globals, grpc_globals)
    STD_PHP_INI_ENTRY("grpc.grpc_trace", NULL, PHP_INI_SYSTEM, OnUpdateString,
                      grpc_trace, zend_grpc_globals, grpc_globals)
-   STD_PHP_INI_ENTRY("grpc.log_filename", NULL, PHP_INI_SYSTEM, OnUpdateString,
-                     log_filename, zend_grpc_globals, grpc_globals)
    PHP_INI_END()
 /* }}} */
 
@@ -249,41 +247,6 @@ void apply_ini_settings(TSRMLS_D) {
   }
 }
 
-// static void custom_logger(gpr_log_func_args* args) {
-//   TSRMLS_FETCH();
-
-//   const char* final_slash;
-//   const char* display_file;
-//   char* prefix;
-//   char* final;
-//   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
-
-//   final_slash = strrchr(args->file, '/');
-//   if (final_slash) {
-//     display_file = final_slash + 1;
-//   } else {
-//     display_file = args->file;
-//   }
-
-//   FILE *fp = fopen(GRPC_G(log_filename), "ab");
-//   if (!fp) {
-//     return;
-//   }
-
-//   gpr_asprintf(&prefix, "%s%" PRId64 ".%09" PRId32 " %s:%d]",
-//                gpr_log_severity_string(args->severity), now.tv_sec,
-//                now.tv_nsec, display_file, args->line);
-
-//   gpr_asprintf(&final, "%-60s %s\n", prefix, args->message);
-
-//   fprintf(fp, "%s", final);
-//   fclose(fp);
-//   gpr_free(prefix);
-//   gpr_free(final);
-// }
-
-/* {{{ PHP_MINIT_FUNCTION
- */
 PHP_MINIT_FUNCTION(grpc) {
   REGISTER_INI_ENTRIES();
 
@@ -613,7 +576,6 @@ static PHP_GINIT_FUNCTION(grpc) {
   grpc_globals->poll_strategy = NULL;
   grpc_globals->grpc_verbosity = NULL;
   grpc_globals->grpc_trace = NULL;
-  grpc_globals->log_filename = NULL;
 }
 /* }}} */
 

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -596,9 +596,6 @@ PHP_MINFO_FUNCTION(grpc) {
 PHP_RINIT_FUNCTION(grpc) {
   if (!GRPC_G(initialized)) {
     apply_ini_settings(TSRMLS_C);
-    if (GRPC_G(log_filename)) {
-      gpr_set_log_function(custom_logger);
-    }
     grpc_init();
     register_fork_handlers();
     grpc_php_init_completion_queue(TSRMLS_C);

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -249,38 +249,38 @@ void apply_ini_settings(TSRMLS_D) {
   }
 }
 
-static void custom_logger(gpr_log_func_args* args) {
-  TSRMLS_FETCH();
+// static void custom_logger(gpr_log_func_args* args) {
+//   TSRMLS_FETCH();
 
-  const char* final_slash;
-  const char* display_file;
-  char* prefix;
-  char* final;
-  gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
+//   const char* final_slash;
+//   const char* display_file;
+//   char* prefix;
+//   char* final;
+//   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
 
-  final_slash = strrchr(args->file, '/');
-  if (final_slash) {
-    display_file = final_slash + 1;
-  } else {
-    display_file = args->file;
-  }
+//   final_slash = strrchr(args->file, '/');
+//   if (final_slash) {
+//     display_file = final_slash + 1;
+//   } else {
+//     display_file = args->file;
+//   }
 
-  FILE *fp = fopen(GRPC_G(log_filename), "ab");
-  if (!fp) {
-    return;
-  }
+//   FILE *fp = fopen(GRPC_G(log_filename), "ab");
+//   if (!fp) {
+//     return;
+//   }
 
-  gpr_asprintf(&prefix, "%s%" PRId64 ".%09" PRId32 " %s:%d]",
-               gpr_log_severity_string(args->severity), now.tv_sec,
-               now.tv_nsec, display_file, args->line);
+//   gpr_asprintf(&prefix, "%s%" PRId64 ".%09" PRId32 " %s:%d]",
+//                gpr_log_severity_string(args->severity), now.tv_sec,
+//                now.tv_nsec, display_file, args->line);
 
-  gpr_asprintf(&final, "%-60s %s\n", prefix, args->message);
+//   gpr_asprintf(&final, "%-60s %s\n", prefix, args->message);
 
-  fprintf(fp, "%s", final);
-  fclose(fp);
-  gpr_free(prefix);
-  gpr_free(final);
-}
+//   fprintf(fp, "%s", final);
+//   fclose(fp);
+//   gpr_free(prefix);
+//   gpr_free(final);
+// }
 
 /* {{{ PHP_MINIT_FUNCTION
  */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -247,6 +247,9 @@ void apply_ini_settings(TSRMLS_D) {
   }
 }
 
+
+/* {{{ PHP_MINIT_FUNCTION
+ */
 PHP_MINIT_FUNCTION(grpc) {
   REGISTER_INI_ENTRIES();
 

--- a/tools/run_tests/sanity/banned_functions.py
+++ b/tools/run_tests/sanity/banned_functions.py
@@ -45,7 +45,6 @@ BANNED_EXCEPT = {
         "./src/core/util/log.cc",
         "./src/core/util/posix/log.cc",
         "./src/core/util/windows/log.cc",
-        "./src/php/ext/grpc/php_grpc.c",
     ],
     "gpr_log(": [
         "./include/grpc/support/log.h",
@@ -257,14 +256,12 @@ BANNED_EXCEPT = {
         "./src/core/util/log.cc",
         "./src/core/util/posix/log.cc",
         "./src/core/util/windows/log.cc",
-        "./src/php/ext/grpc/php_grpc.c",
         "./test/core/end2end/tests/no_logging.cc",
         "./test/cpp/interop/stress_test.cc",
     ],
     "gpr_set_log_function(": [
         "./include/grpc/support/log.h",
         "./src/core/util/log.cc",
-        "./src/php/ext/grpc/php_grpc.c",
         "./test/core/end2end/tests/no_logging.cc",
         "./test/cpp/interop/stress_test.cc",
     ],

--- a/tools/run_tests/sanity/banned_functions.py
+++ b/tools/run_tests/sanity/banned_functions.py
@@ -34,7 +34,6 @@ BANNED_EXCEPT = {
         "./src/core/util/log.cc",
         "./src/core/util/posix/log.cc",
         "./src/core/util/windows/log.cc",
-        "./src/php/ext/grpc/php_grpc.c",
         "./src/ruby/ext/grpc/rb_grpc_imports.generated.c",
         "./src/ruby/ext/grpc/rb_grpc_imports.generated.h",
         "./test/core/end2end/tests/no_logging.cc",


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Remove custom logger from php. Not supported anymore.
While I am writing a custom absl LogSink to fix the issue in the next Pull Request,
I wanted to know if not having this LogSink is a release blocker or not. 