### PR TITLE
[fuzzer] Fix mock endpoint ownership bug

### DIFF
--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -58,8 +58,11 @@ class ClientFuzzer final : public BasicFuzzer {
   explicit ClientFuzzer(const fuzzer_input::Msg& msg)
       : BasicFuzzer(msg.event_engine_actions()) {
     ExecCtx exec_ctx;
-    UpdateMinimumRunTime(
-        ScheduleReads(msg.network_input()[0], mock_endpoint_, engine().get()));
+    UpdateMinimumRunTime(ScheduleReads(
+        msg.network_input()[0],
+        grpc_event_engine::experimental::grpc_mock_endpoint_get_control(
+            mock_endpoint_),
+        engine().get()));
     ChannelArgs args =
         CoreConfiguration::Get()
             .channel_args_preconditioning()

--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -56,20 +56,20 @@ namespace testing {
 class ClientFuzzer final : public BasicFuzzer {
  public:
   explicit ClientFuzzer(const fuzzer_input::Msg& msg)
-      : BasicFuzzer(msg.event_engine_actions()) {
+      : BasicFuzzer(msg.event_engine_actions()),
+        mock_endpoint_control_(
+            grpc_event_engine::experimental::MockEndpointControl::Create(
+                engine())) {
     ExecCtx exec_ctx;
-    UpdateMinimumRunTime(ScheduleReads(
-        msg.network_input()[0],
-        grpc_event_engine::experimental::grpc_mock_endpoint_get_control(
-            mock_endpoint_),
-        engine().get()));
+    UpdateMinimumRunTime(ScheduleReads(msg.network_input()[0],
+                                       mock_endpoint_control_, engine().get()));
     ChannelArgs args =
         CoreConfiguration::Get()
             .channel_args_preconditioning()
             .PreconditionChannelArgs(nullptr)
             .SetIfUnset(GRPC_ARG_DEFAULT_AUTHORITY, "test-authority");
-    Transport* transport =
-        grpc_create_chttp2_transport(args, mock_endpoint_, true);
+    Transport* transport = grpc_create_chttp2_transport(
+        args, mock_endpoint_control_->TakeCEndpoint(), true);
     channel_ = ChannelCreate("test-target", args, GRPC_CLIENT_DIRECT_CHANNEL,
                              transport)
                    ->release()
@@ -94,7 +94,8 @@ class ClientFuzzer final : public BasicFuzzer {
   grpc_server* server() override { return nullptr; }
   grpc_channel* channel() override { return channel_; }
 
-  grpc_endpoint* mock_endpoint_ = grpc_mock_endpoint_create(engine());
+  std::shared_ptr<grpc_event_engine::experimental::MockEndpointControl>
+      mock_endpoint_control_;
   grpc_channel* channel_ = nullptr;
 };
 

--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -57,19 +57,19 @@ class ClientFuzzer final : public BasicFuzzer {
  public:
   explicit ClientFuzzer(const fuzzer_input::Msg& msg)
       : BasicFuzzer(msg.event_engine_actions()),
-        mock_endpoint_control_(
+        mock_endpoint_controller_(
             grpc_event_engine::experimental::MockEndpointController::Create(
                 engine())) {
     ExecCtx exec_ctx;
-    UpdateMinimumRunTime(ScheduleReads(msg.network_input()[0],
-                                       mock_endpoint_control_, engine().get()));
+    UpdateMinimumRunTime(ScheduleReads(
+        msg.network_input()[0], mock_endpoint_controller_, engine().get()));
     ChannelArgs args =
         CoreConfiguration::Get()
             .channel_args_preconditioning()
             .PreconditionChannelArgs(nullptr)
             .SetIfUnset(GRPC_ARG_DEFAULT_AUTHORITY, "test-authority");
     Transport* transport = grpc_create_chttp2_transport(
-        args, mock_endpoint_control_->TakeCEndpoint(), true);
+        args, mock_endpoint_controller_->TakeCEndpoint(), true);
     channel_ = ChannelCreate("test-target", args, GRPC_CLIENT_DIRECT_CHANNEL,
                              transport)
                    ->release()
@@ -95,7 +95,7 @@ class ClientFuzzer final : public BasicFuzzer {
   grpc_channel* channel() override { return channel_; }
 
   std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
-      mock_endpoint_control_;
+      mock_endpoint_controller_;
   grpc_channel* channel_ = nullptr;
 };
 

--- a/test/core/end2end/fuzzers/client_fuzzer.cc
+++ b/test/core/end2end/fuzzers/client_fuzzer.cc
@@ -58,7 +58,7 @@ class ClientFuzzer final : public BasicFuzzer {
   explicit ClientFuzzer(const fuzzer_input::Msg& msg)
       : BasicFuzzer(msg.event_engine_actions()),
         mock_endpoint_control_(
-            grpc_event_engine::experimental::MockEndpointControl::Create(
+            grpc_event_engine::experimental::MockEndpointController::Create(
                 engine())) {
     ExecCtx exec_ctx;
     UpdateMinimumRunTime(ScheduleReads(msg.network_input()[0],
@@ -94,7 +94,7 @@ class ClientFuzzer final : public BasicFuzzer {
   grpc_server* server() override { return nullptr; }
   grpc_channel* channel() override { return channel_; }
 
-  std::shared_ptr<grpc_event_engine::experimental::MockEndpointControl>
+  std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
       mock_endpoint_control_;
   grpc_channel* channel_ = nullptr;
 };

--- a/test/core/end2end/fuzzers/client_fuzzer_corpus/4908841560506368
+++ b/test/core/end2end/fuzzers/client_fuzzer_corpus/4908841560506368
@@ -1,0 +1,12 @@
+network_input {
+  input_segments {
+    segments {
+      chaotic_good {
+      }
+    }
+  }
+}
+api_actions {
+  close_channel {
+  }
+}

--- a/test/core/end2end/fuzzers/network_input.cc
+++ b/test/core/end2end/fuzzers/network_input.cc
@@ -384,7 +384,7 @@ std::vector<QueuedRead> MakeSchedule(
 
 Duration ScheduleReads(
     const fuzzer_input::NetworkInput& network_input,
-    std::shared_ptr<grpc_event_engine::experimental::MockEndpointControl>
+    std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
         mock_endpoint_control,
     grpc_event_engine::experimental::FuzzingEventEngine* event_engine) {
   int delay = 0;

--- a/test/core/end2end/fuzzers/network_input.h
+++ b/test/core/end2end/fuzzers/network_input.h
@@ -26,7 +26,7 @@ namespace grpc_core {
 
 Duration ScheduleReads(
     const fuzzer_input::NetworkInput& network_input,
-    std::shared_ptr<grpc_event_engine::experimental::MockEndpointControl>
+    std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
         mock_endpoint_control,
     grpc_event_engine::experimental::FuzzingEventEngine* event_engine);
 

--- a/test/core/end2end/fuzzers/network_input.h
+++ b/test/core/end2end/fuzzers/network_input.h
@@ -27,7 +27,7 @@ namespace grpc_core {
 Duration ScheduleReads(
     const fuzzer_input::NetworkInput& network_input,
     std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
-        mock_endpoint_control,
+        mock_endpoint_controller,
     grpc_event_engine::experimental::FuzzingEventEngine* event_engine);
 
 Duration ScheduleConnection(

--- a/test/core/end2end/fuzzers/network_input.h
+++ b/test/core/end2end/fuzzers/network_input.h
@@ -20,12 +20,14 @@
 #include "test/core/end2end/fuzzers/fuzzer_input.pb.h"
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h"
 #include "test/core/test_util/fuzzing_channel_args.h"
+#include "test/core/test_util/mock_endpoint.h"
 
 namespace grpc_core {
 
 Duration ScheduleReads(
     const fuzzer_input::NetworkInput& network_input,
-    grpc_endpoint* mock_endpoint,
+    std::shared_ptr<grpc_event_engine::experimental::MockEndpointControl>
+        mock_endpoint_control,
     grpc_event_engine::experimental::FuzzingEventEngine* event_engine);
 
 Duration ScheduleConnection(

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -68,7 +68,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
     auto engine = GetDefaultEventEngine();
     auto mock_endpoint_control =
-        grpc_event_engine::experimental::MockEndpointControl::Create(engine);
+        grpc_event_engine::experimental::MockEndpointController::Create(engine);
     mock_endpoint_control->TriggerReadEvent(
         grpc_event_engine::experimental::Slice::FromCopiedBuffer(
             reinterpret_cast<const char*>(data), size));

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -24,7 +24,6 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/event_engine/default_event_engine.h"
-#include "src/core/lib/gprpp/crash.h"
 #include "src/core/lib/gprpp/notification.h"
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/core/lib/security/security_connector/security_connector.h"

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -67,12 +67,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     grpc_core::ExecCtx exec_ctx;
 
     auto engine = GetDefaultEventEngine();
-    auto mock_endpoint_control =
+    auto mock_endpoint_controller =
         grpc_event_engine::experimental::MockEndpointController::Create(engine);
-    mock_endpoint_control->TriggerReadEvent(
+    mock_endpoint_controller->TriggerReadEvent(
         grpc_event_engine::experimental::Slice::FromCopiedBuffer(
             reinterpret_cast<const char*>(data), size));
-    mock_endpoint_control->NoMoreReads();
+    mock_endpoint_controller->NoMoreReads();
 
     // Load key pair and establish server SSL credentials.
     std::string ca_cert = grpc_core::testing::GetFileContents(CA_CERT_PATH);
@@ -98,7 +98,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     auto channel_args =
         grpc_core::ChannelArgs().SetObject<EventEngine>(std::move(engine));
     sc->add_handshakers(channel_args, nullptr, handshake_mgr.get());
-    handshake_mgr->DoHandshake(mock_endpoint_control->TakeCEndpoint(),
+    handshake_mgr->DoHandshake(mock_endpoint_controller->TakeCEndpoint(),
                                channel_args, deadline, nullptr /* acceptor */,
                                on_handshake_done, &state);
     grpc_core::ExecCtx::Get()->Flush();

--- a/test/core/test_util/mock_endpoint.cc
+++ b/test/core/test_util/mock_endpoint.cc
@@ -30,17 +30,19 @@
 #include <grpc/support/sync.h>
 
 #include "src/core/lib/event_engine/tcp_socket_utils.h"
+#include "src/core/lib/gprpp/down_cast.h"
 #include "src/core/lib/iomgr/event_engine_shims/endpoint.h"
 
 namespace grpc_event_engine {
 namespace experimental {
 
 MockEndpoint::MockEndpoint(std::shared_ptr<EventEngine> engine)
-    : engine_(std::move(engine)),
+    : endpoint_control_(
+          std::make_shared<MockEndpointControl>(std::move(engine))),
       peer_addr_(URIToResolvedAddress("ipv4:127.0.0.1:12345").value()),
       local_addr_(URIToResolvedAddress("ipv4:127.0.0.1:6789").value()) {}
 
-MockEndpoint::~MockEndpoint() {
+MockEndpointControl::~MockEndpointControl() {
   grpc_core::MutexLock lock(&mu_);
   if (on_read_) {
     engine_->Run([cb = std::move(on_read_)]() mutable {
@@ -50,7 +52,7 @@ MockEndpoint::~MockEndpoint() {
   }
 }
 
-void MockEndpoint::TriggerReadEvent(Slice read_data) {
+void MockEndpointControl::TriggerReadEvent(Slice read_data) {
   grpc_core::MutexLock lock(&mu_);
   CHECK(!reads_done_)
       << "Cannot trigger a read event after NoMoreReads has been called.";
@@ -65,14 +67,14 @@ void MockEndpoint::TriggerReadEvent(Slice read_data) {
   }
 }
 
-void MockEndpoint::NoMoreReads() {
+void MockEndpointControl::NoMoreReads() {
   grpc_core::MutexLock lock(&mu_);
   CHECK(!std::exchange(reads_done_, true))
       << "NoMoreReads() can only be called once";
 }
 
-bool MockEndpoint::Read(absl::AnyInvocable<void(absl::Status)> on_read,
-                        SliceBuffer* buffer, const ReadArgs* /* args */) {
+void MockEndpointControl::Read(absl::AnyInvocable<void(absl::Status)> on_read,
+                               SliceBuffer* buffer) {
   grpc_core::MutexLock lock(&mu_);
   if (read_buffer_.Count() > 0) {
     CHECK(buffer->Count() == 0);
@@ -87,6 +89,11 @@ bool MockEndpoint::Read(absl::AnyInvocable<void(absl::Status)> on_read,
     on_read_ = std::move(on_read);
     on_read_slice_buffer_ = buffer;
   }
+}
+
+bool MockEndpoint::Read(absl::AnyInvocable<void(absl::Status)> on_read,
+                        SliceBuffer* buffer, const ReadArgs* /* args */) {
+  endpoint_control_->Read(std::move(on_read), buffer);
   return false;
 }
 
@@ -94,7 +101,7 @@ bool MockEndpoint::Write(absl::AnyInvocable<void(absl::Status)> on_writable,
                          SliceBuffer* data, const WriteArgs* /* args */) {
   // No-op implementation. Nothing was using it.
   data->Clear();
-  engine_->Run(
+  endpoint_control_->engine()->Run(
       [cb = std::move(on_writable)]() mutable { cb(absl::OkStatus()); });
   return false;
 }
@@ -107,6 +114,13 @@ const EventEngine::ResolvedAddress& MockEndpoint::GetLocalAddress() const {
   return local_addr_;
 }
 
+std::shared_ptr<MockEndpointControl> grpc_mock_endpoint_get_control(
+    grpc_endpoint* ep) {
+  return grpc_core::DownCast<MockEndpoint*>(
+             grpc_get_wrapped_event_engine_endpoint(ep))
+      ->endpoint_control();
+}
+
 }  // namespace experimental
 }  // namespace grpc_event_engine
 
@@ -115,19 +129,4 @@ grpc_endpoint* grpc_mock_endpoint_create(
   return grpc_event_engine_endpoint_create(
       std::make_unique<grpc_event_engine::experimental::MockEndpoint>(
           std::move(engine)));
-}
-
-void grpc_mock_endpoint_put_read(grpc_endpoint* ep, grpc_slice slice) {
-  grpc_event_engine::experimental::Slice s(slice);
-  static_cast<grpc_event_engine::experimental::MockEndpoint*>(
-      grpc_event_engine::experimental::grpc_get_wrapped_event_engine_endpoint(
-          ep))
-      ->TriggerReadEvent(std::move(s));
-}
-
-void grpc_mock_endpoint_finish_put_reads(grpc_endpoint* ep) {
-  static_cast<grpc_event_engine::experimental::MockEndpoint*>(
-      grpc_event_engine::experimental::grpc_get_wrapped_event_engine_endpoint(
-          ep))
-      ->NoMoreReads();
 }

--- a/test/core/test_util/mock_endpoint.h
+++ b/test/core/test_util/mock_endpoint.h
@@ -34,14 +34,14 @@ namespace experimental {
 // This helps avoid shared ownership issus. The endpoint itself may destroyed
 // while a fuzzer is still attempting to use it (e.g., the transport is closed,
 // and a fuzzer still wants to schedule reads).
-class MockEndpointControl
-    : public std::enable_shared_from_this<MockEndpointControl> {
+class MockEndpointController
+    : public std::enable_shared_from_this<MockEndpointController> {
  public:
   // Factory method ensures this class is always a shared_ptr.
-  static std::shared_ptr<MockEndpointControl> Create(
+  static std::shared_ptr<MockEndpointController> Create(
       std::shared_ptr<EventEngine> engine);
 
-  ~MockEndpointControl();
+  ~MockEndpointController();
 
   // ---- mock methods ----
   void TriggerReadEvent(Slice read_data);
@@ -55,7 +55,7 @@ class MockEndpointControl
   EventEngine* engine() { return engine_.get(); }
 
  private:
-  explicit MockEndpointControl(std::shared_ptr<EventEngine> engine);
+  explicit MockEndpointController(std::shared_ptr<EventEngine> engine);
 
   std::shared_ptr<EventEngine> engine_;
   grpc_core::Mutex mu_;
@@ -72,11 +72,7 @@ class MockEndpoint : public EventEngine::Endpoint {
   ~MockEndpoint() override = default;
 
   // ---- mock methods ----
-  // Get a reffed-added MockEndpointControl object.
-  std::shared_ptr<MockEndpointControl> endpoint_control() {
-    return endpoint_control_;
-  }
-  void SetController(std::shared_ptr<MockEndpointControl> endpoint_control) {
+  void SetController(std::shared_ptr<MockEndpointController> endpoint_control) {
     endpoint_control_ = std::move(endpoint_control);
   }
 
@@ -89,13 +85,10 @@ class MockEndpoint : public EventEngine::Endpoint {
   const EventEngine::ResolvedAddress& GetLocalAddress() const override;
 
  private:
-  std::shared_ptr<MockEndpointControl> endpoint_control_;
+  std::shared_ptr<MockEndpointController> endpoint_control_;
   EventEngine::ResolvedAddress peer_addr_;
   EventEngine::ResolvedAddress local_addr_;
 };
-
-std::shared_ptr<MockEndpointControl> grpc_mock_endpoint_get_control(
-    grpc_endpoint* ep);
 
 }  // namespace experimental
 }  // namespace grpc_event_engine

--- a/test/core/transport/chttp2/ping_configuration_test.cc
+++ b/test/core/transport/chttp2/ping_configuration_test.cc
@@ -29,7 +29,6 @@
 #include "src/core/lib/event_engine/default_event_engine.h"
 #include "src/core/lib/experiments/config.h"
 #include "src/core/lib/gprpp/time.h"
-#include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/resource_quota/resource_quota.h"
 #include "test/core/test_util/mock_endpoint.h"

--- a/test/core/transport/chttp2/ping_configuration_test.cc
+++ b/test/core/transport/chttp2/ping_configuration_test.cc
@@ -42,15 +42,15 @@ class ConfigurationTest : public ::testing::Test {
  protected:
   ConfigurationTest() {
     auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
-    mock_endpoint_control_ =
+    mock_endpoint_controller_ =
         grpc_event_engine::experimental::MockEndpointController::Create(engine);
-    mock_endpoint_control_->NoMoreReads();
+    mock_endpoint_controller_->NoMoreReads();
     args_ = args_.SetObject(ResourceQuota::Default());
     args_ = args_.SetObject(std::move(engine));
   }
 
   std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
-      mock_endpoint_control_;
+      mock_endpoint_controller_;
   ChannelArgs args_;
 };
 
@@ -58,7 +58,8 @@ TEST_F(ConfigurationTest, ClientKeepaliveDefaults) {
   ExecCtx exec_ctx;
   grpc_chttp2_transport* t =
       reinterpret_cast<grpc_chttp2_transport*>(grpc_create_chttp2_transport(
-          args_, mock_endpoint_control_->TakeCEndpoint(), /*is_client=*/true));
+          args_, mock_endpoint_controller_->TakeCEndpoint(),
+          /*is_client=*/true));
   EXPECT_EQ(t->keepalive_time, Duration::Infinity());
   EXPECT_EQ(t->keepalive_timeout, Duration::Infinity());
   EXPECT_EQ(t->keepalive_permit_without_calls, false);
@@ -74,7 +75,8 @@ TEST_F(ConfigurationTest, ClientKeepaliveExplicitArgs) {
   args_ = args_.Set(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 3);
   grpc_chttp2_transport* t =
       reinterpret_cast<grpc_chttp2_transport*>(grpc_create_chttp2_transport(
-          args_, mock_endpoint_control_->TakeCEndpoint(), /*is_client=*/true));
+          args_, mock_endpoint_controller_->TakeCEndpoint(),
+          /*is_client=*/true));
   EXPECT_EQ(t->keepalive_time, Duration::Seconds(20));
   EXPECT_EQ(t->keepalive_timeout, Duration::Seconds(10));
   EXPECT_EQ(t->keepalive_permit_without_calls, true);
@@ -86,7 +88,8 @@ TEST_F(ConfigurationTest, ServerKeepaliveDefaults) {
   ExecCtx exec_ctx;
   grpc_chttp2_transport* t =
       reinterpret_cast<grpc_chttp2_transport*>(grpc_create_chttp2_transport(
-          args_, mock_endpoint_control_->TakeCEndpoint(), /*is_client=*/false));
+          args_, mock_endpoint_controller_->TakeCEndpoint(),
+          /*is_client=*/false));
   EXPECT_EQ(t->keepalive_time, Duration::Hours(2));
   EXPECT_EQ(t->keepalive_timeout, Duration::Seconds(20));
   EXPECT_EQ(t->keepalive_permit_without_calls, false);
@@ -109,7 +112,8 @@ TEST_F(ConfigurationTest, ServerKeepaliveExplicitArgs) {
   args_ = args_.Set(GRPC_ARG_HTTP2_MAX_PING_STRIKES, 0);
   grpc_chttp2_transport* t =
       reinterpret_cast<grpc_chttp2_transport*>(grpc_create_chttp2_transport(
-          args_, mock_endpoint_control_->TakeCEndpoint(), /*is_client=*/false));
+          args_, mock_endpoint_controller_->TakeCEndpoint(),
+          /*is_client=*/false));
   EXPECT_EQ(t->keepalive_time, Duration::Seconds(20));
   EXPECT_EQ(t->keepalive_timeout, Duration::Seconds(10));
   EXPECT_EQ(t->keepalive_permit_without_calls, true);
@@ -137,7 +141,8 @@ TEST_F(ConfigurationTest, ModifyClientDefaults) {
   // which does not override the defaults.
   grpc_chttp2_transport* t =
       reinterpret_cast<grpc_chttp2_transport*>(grpc_create_chttp2_transport(
-          args_, mock_endpoint_control_->TakeCEndpoint(), /*is_client=*/true));
+          args_, mock_endpoint_controller_->TakeCEndpoint(),
+          /*is_client=*/true));
   EXPECT_EQ(t->keepalive_time, Duration::Seconds(20));
   EXPECT_EQ(t->keepalive_timeout, Duration::Seconds(10));
   EXPECT_EQ(t->keepalive_permit_without_calls, true);
@@ -163,7 +168,8 @@ TEST_F(ConfigurationTest, ModifyServerDefaults) {
   // which does not override the defaults.
   grpc_chttp2_transport* t =
       reinterpret_cast<grpc_chttp2_transport*>(grpc_create_chttp2_transport(
-          args_, mock_endpoint_control_->TakeCEndpoint(), /*is_client=*/false));
+          args_, mock_endpoint_controller_->TakeCEndpoint(),
+          /*is_client=*/false));
   EXPECT_EQ(t->keepalive_time, Duration::Seconds(20));
   EXPECT_EQ(t->keepalive_timeout, Duration::Seconds(10));
   EXPECT_EQ(t->keepalive_permit_without_calls, true);

--- a/test/core/transport/chttp2/ping_configuration_test.cc
+++ b/test/core/transport/chttp2/ping_configuration_test.cc
@@ -43,13 +43,13 @@ class ConfigurationTest : public ::testing::Test {
   ConfigurationTest() {
     auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
     mock_endpoint_control_ =
-        grpc_event_engine::experimental::MockEndpointControl::Create(engine);
+        grpc_event_engine::experimental::MockEndpointController::Create(engine);
     mock_endpoint_control_->NoMoreReads();
     args_ = args_.SetObject(ResourceQuota::Default());
     args_ = args_.SetObject(std::move(engine));
   }
 
-  std::shared_ptr<grpc_event_engine::experimental::MockEndpointControl>
+  std::shared_ptr<grpc_event_engine::experimental::MockEndpointController>
       mock_endpoint_control_;
   ChannelArgs args_;
 };

--- a/test/core/transport/chttp2/ping_configuration_test.cc
+++ b/test/core/transport/chttp2/ping_configuration_test.cc
@@ -43,7 +43,9 @@ class ConfigurationTest : public ::testing::Test {
   ConfigurationTest() {
     auto engine = grpc_event_engine::experimental::GetDefaultEventEngine();
     mock_endpoint_ = grpc_mock_endpoint_create(engine);
-    grpc_mock_endpoint_finish_put_reads(mock_endpoint_);
+    grpc_event_engine::experimental::grpc_mock_endpoint_get_control(
+        mock_endpoint_)
+        ->NoMoreReads();
     args_ = args_.SetObject(ResourceQuota::Default());
     args_ = args_.SetObject(std::move(engine));
   }


### PR DESCRIPTION
In the client fuzzer, some valid fuzzing scenarios would close the transport (thus deleting the endpoint), while the fuzzer mechanics still attempted to read/write to that endpoint. There was an inherent ownership problem, where both the transport and the fuzzer logic expected to own the endpoint lifetime.

This PR ensures that the transport owns the endpoint, and the fuzzer logic owns an object that can write to some shared endpoint state. This shared object can outlive the endpoint.