### PR TITLE
[context] Forcibly inline fast paths

### DIFF
--- a/src/core/lib/gprpp/down_cast.h
+++ b/src/core/lib/gprpp/down_cast.h
@@ -26,7 +26,7 @@
 namespace grpc_core {
 
 template <typename To, typename From>
-inline To DownCast(From* f) {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION To DownCast(From* f) {
   static_assert(
       std::is_base_of<From, typename std::remove_pointer<To>::type>::value,
       "DownCast requires a base-to-derived relationship");
@@ -40,7 +40,7 @@ inline To DownCast(From* f) {
 }
 
 template <typename To, typename From>
-inline To DownCast(From& f) {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION To DownCast(From& f) {
   return *DownCast<typename std::remove_reference<To>::type*>(&f);
 }
 

--- a/src/core/lib/promise/context.h
+++ b/src/core/lib/promise/context.h
@@ -62,7 +62,7 @@ class ThreadLocalContext : public ContextType<T> {
   ThreadLocalContext(const ThreadLocalContext&) = delete;
   ThreadLocalContext& operator=(const ThreadLocalContext&) = delete;
 
-  static T* get() { return current_; }
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION static T* get() { return current_; }
 
  private:
   T* const old_;
@@ -83,7 +83,7 @@ class Context<T, absl::void_t<typename ContextSubclass<T>::Base>>
     : public Context<typename ContextSubclass<T>::Base> {
  public:
   using Context<typename ContextSubclass<T>::Base>::Context;
-  static T* get() {
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION static T* get() {
     return DownCast<T*>(Context<typename ContextSubclass<T>::Base>::get());
   }
 };
@@ -107,26 +107,26 @@ class WithContext {
 
 // Return true if a context of type T is currently active.
 template <typename T>
-bool HasContext() {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION bool HasContext() {
   return promise_detail::Context<T>::get() != nullptr;
 }
 
 // Retrieve the current value of a context, or abort if the value is unset.
 template <typename T>
-T* GetContext() {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION T* GetContext() {
   auto* p = promise_detail::Context<T>::get();
-  CHECK_NE(p, nullptr);
+  DCHECK_NE(p, nullptr);
   return p;
 }
 
 // Retrieve the current value of a context, or nullptr if the value is unset.
 template <typename T>
-T* MaybeGetContext() {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION T* MaybeGetContext() {
   return promise_detail::Context<T>::get();
 }
 
 template <typename T>
-void SetContext(T* p) {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void SetContext(T* p) {
   promise_detail::Context<T>::set(p);
 }
 

--- a/src/core/lib/resource_quota/arena.h
+++ b/src/core/lib/resource_quota/arena.h
@@ -278,7 +278,7 @@ class Arena final : public RefCounted<Arena, NonPolymorphicRefCount,
   // for modern promise-based code -- however legacy filter stack based code
   // often needs to access these directly.
   template <typename T>
-  T* GetContext() {
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION T* GetContext() {
     return static_cast<T*>(
         contexts()[arena_detail::ArenaContextTraits<T>::id()]);
   }
@@ -339,7 +339,9 @@ class Arena final : public RefCounted<Arena, NonPolymorphicRefCount,
 
   void* AllocZone(size_t size);
   void Destroy() const;
-  void** contexts() { return reinterpret_cast<void**>(this + 1); }
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void** contexts() {
+    return reinterpret_cast<void**>(this + 1);
+  }
 
   // Keep track of the total used size. We use this in our call sizing
   // hysteresis.

--- a/src/core/lib/resource_quota/arena.h
+++ b/src/core/lib/resource_quota/arena.h
@@ -87,14 +87,14 @@ class BaseArenaContextTraits {
 template <typename T>
 class ArenaContextTraits : public BaseArenaContextTraits {
  public:
-  static uint16_t id() { return id_; }
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION static uint16_t id() { return id_; }
 
  private:
   static const uint16_t id_;
 };
 
 template <typename T>
-void DestroyArenaContext(void* p) {
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void DestroyArenaContext(void* p) {
   ArenaContextType<T>::Destroy(static_cast<T*>(p));
 }
 
@@ -371,8 +371,12 @@ namespace promise_detail {
 template <typename T>
 class Context<T, absl::void_t<decltype(ArenaContextType<T>::Destroy)>> {
  public:
-  static T* get() { return GetContext<Arena>()->GetContext<T>(); }
-  static void set(T* value) { GetContext<Arena>()->SetContext(value); }
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION static T* get() {
+    return GetContext<Arena>()->GetContext<T>();
+  }
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION static void set(T* value) {
+    GetContext<Arena>()->SetContext(value);
+  }
 };
 
 }  // namespace promise_detail


### PR DESCRIPTION
When building #36946 I noticed a bunch of places where `GetContext<>` was not inlined. This change forcibly inlines paths that we need to be, and additionally lowers the `CHECK` in `GetContext` to be a `DCHECK` as this comparison was using the bulk of the time in a very hot function in the stack.