### PR TITLE
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -23,6 +23,7 @@
 #include "absl/base/attributes.h"
 #include "absl/functional/function_ref.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
@@ -211,8 +212,8 @@ void BaseCallData::CapturedBatch::ResumeWith(Flusher* releaser) {
   if (refcnt == 0) {
     // refcnt==0 ==> cancelled
     if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-      gpr_log(GPR_INFO, "%sRESUME BATCH REQUEST CANCELLED",
-              releaser->call()->DebugTag().c_str());
+      LOG(INFO) << releaser->call()->DebugTag()
+                << "RESUME BATCH REQUEST CANCELLED";
     }
     return;
   }
@@ -267,8 +268,8 @@ BaseCallData::Flusher::~Flusher() {
     BaseCallData* call =
         static_cast<BaseCallData*>(batch->handler_private.extra_arg);
     if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-      gpr_log(GPR_INFO, "FLUSHER:forward batch via closure: %s",
-              grpc_transport_stream_op_batch_string(batch, false).c_str());
+      LOG(INFO) << "FLUSHER:forward batch via closure: "
+                << grpc_transport_stream_op_batch_string(batch, false);
     }
     grpc_call_next_op(call->elem(), batch);
     GRPC_CALL_STACK_UNREF(call->call_stack(), "flusher_batch");
@@ -279,9 +280,8 @@ BaseCallData::Flusher::~Flusher() {
       batch->is_traced = true;
     }
     if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-      gpr_log(
-          GPR_INFO, "FLUSHER:queue batch to forward in closure: %s",
-          grpc_transport_stream_op_batch_string(release_[i], false).c_str());
+      LOG(INFO) << "FLUSHER:queue batch to forward in closure: "
+                << grpc_transport_stream_op_batch_string(release_[i], false);
     }
     batch->handler_private.extra_arg = call_;
     GRPC_CLOSURE_INIT(&batch->handler_private.closure, call_next_op, batch,
@@ -292,8 +292,8 @@ BaseCallData::Flusher::~Flusher() {
   }
   call_closures_.RunClosuresWithoutYielding(call_->call_combiner());
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "FLUSHER:forward batch: %s",
-            grpc_transport_stream_op_batch_string(release_[0], false).c_str());
+    LOG(INFO) << "FLUSHER:forward batch: "
+              << grpc_transport_stream_op_batch_string(release_[0], false);
   }
   if (call_->call() != nullptr && call_->call()->traced()) {
     release_[0]->is_traced = true;
@@ -333,8 +333,8 @@ const char* BaseCallData::SendMessage::StateString(State state) {
 
 void BaseCallData::SendMessage::StartOp(CapturedBatch batch) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s SendMessage.StartOp st=%s", base_->LogTag().c_str(),
-            StateString(state_));
+    LOG(INFO) << base_->LogTag()
+              << " SendMessage.StartOp st=" << StateString(state_);
   }
   switch (state_) {
     case State::kInitial:
@@ -361,8 +361,8 @@ void BaseCallData::SendMessage::StartOp(CapturedBatch batch) {
 template <typename T>
 void BaseCallData::SendMessage::GotPipe(T* pipe_end) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s SendMessage.GotPipe st=%s", base_->LogTag().c_str(),
-            StateString(state_));
+    LOG(INFO) << base_->LogTag()
+              << " SendMessage.GotPipe st=" << StateString(state_);
   }
   CHECK_NE(pipe_end, nullptr);
   switch (state_) {
@@ -409,9 +409,9 @@ bool BaseCallData::SendMessage::IsIdle() const {
 void BaseCallData::SendMessage::OnComplete(absl::Status status) {
   Flusher flusher(base_);
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s SendMessage.OnComplete st=%s status=%s",
-            base_->LogTag().c_str(), StateString(state_),
-            status.ToString().c_str());
+    LOG(INFO) << base_->LogTag()
+              << " SendMessage.OnComplete st=" << StateString(state_)
+              << " status=" << status;
   }
   switch (state_) {
     case State::kInitial:
@@ -440,9 +440,9 @@ void BaseCallData::SendMessage::OnComplete(absl::Status status) {
 void BaseCallData::SendMessage::Done(const ServerMetadata& metadata,
                                      Flusher* flusher) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s SendMessage.Done st=%s md=%s",
-            base_->LogTag().c_str(), StateString(state_),
-            metadata.DebugString().c_str());
+    LOG(INFO) << base_->LogTag()
+              << " SendMessage.Done st=" << StateString(state_)
+              << " md=" << metadata.DebugString();
   }
   switch (state_) {
     case State::kCancelled:
@@ -483,11 +483,11 @@ void BaseCallData::SendMessage::Done(const ServerMetadata& metadata,
 void BaseCallData::SendMessage::WakeInsideCombiner(Flusher* flusher,
                                                    bool allow_push_to_pipe) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s SendMessage.WakeInsideCombiner st=%s%s",
-            base_->LogTag().c_str(), StateString(state_),
-            state_ == State::kBatchCompleted
-                ? absl::StrCat(" status=", completed_status_.ToString()).c_str()
-                : "");
+    LOG(INFO) << base_->LogTag()
+              << " SendMessage.WakeInsideCombiner st=" << StateString(state_)
+              << (state_ == State::kBatchCompleted
+                      ? absl::StrCat(" status=", completed_status_.ToString())
+                      : "");
   }
   switch (state_) {
     case State::kInitial:
@@ -517,9 +517,10 @@ void BaseCallData::SendMessage::WakeInsideCombiner(Flusher* flusher,
       auto r_push = (*push_)();
       if (auto* p = r_push.value_if_ready()) {
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO,
-                  "%s SendMessage.WakeInsideCombiner push complete, result=%s",
-                  base_->LogTag().c_str(), *p ? "true" : "false");
+          LOG(INFO) << base_->LogTag()
+                    << " SendMessage.WakeInsideCombiner push complete, "
+                       "result="
+                    << (*p ? "true" : "false");
         }
         // We haven't pulled through yet, so this certainly shouldn't succeed.
         CHECK(!*p);
@@ -531,10 +532,10 @@ void BaseCallData::SendMessage::WakeInsideCombiner(Flusher* flusher,
       auto r_next = (*next_)();
       if (auto* p = r_next.value_if_ready()) {
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO,
-                  "%s SendMessage.WakeInsideCombiner next complete, "
-                  "result.has_value=%s",
-                  base_->LogTag().c_str(), p->has_value() ? "true" : "false");
+          LOG(INFO) << base_->LogTag()
+                    << " SendMessage.WakeInsideCombiner next complete, "
+                       "result.has_value="
+                    << (p->has_value() ? "true" : "false");
         }
         if (p->has_value()) {
           batch_->payload->send_message.send_message->Swap((**p)->payload());
@@ -616,8 +617,8 @@ const char* BaseCallData::ReceiveMessage::StateString(State state) {
 
 void BaseCallData::ReceiveMessage::StartOp(CapturedBatch& batch) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ReceiveMessage.StartOp st=%s",
-            base_->LogTag().c_str(), StateString(state_));
+    LOG(INFO) << base_->LogTag()
+              << " ReceiveMessage.StartOp st=" << StateString(state_);
   }
   switch (state_) {
     case State::kInitial:
@@ -657,8 +658,8 @@ void BaseCallData::ReceiveMessage::StartOp(CapturedBatch& batch) {
 template <typename T>
 void BaseCallData::ReceiveMessage::GotPipe(T* pipe_end) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ReceiveMessage.GotPipe st=%s",
-            base_->LogTag().c_str(), StateString(state_));
+    LOG(INFO) << base_->LogTag()
+              << " ReceiveMessage.GotPipe st=" << StateString(state_);
   }
   switch (state_) {
     case State::kInitial:
@@ -693,9 +694,9 @@ void BaseCallData::ReceiveMessage::GotPipe(T* pipe_end) {
 
 void BaseCallData::ReceiveMessage::OnComplete(absl::Status status) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ReceiveMessage.OnComplete st=%s status=%s",
-            base_->LogTag().c_str(), StateString(state_),
-            status.ToString().c_str());
+    LOG(INFO) << base_->LogTag()
+              << " ReceiveMessage.OnComplete st=" << StateString(state_)
+              << " status=" << status;
   }
   switch (state_) {
     case State::kInitial:
@@ -734,9 +735,9 @@ void BaseCallData::ReceiveMessage::OnComplete(absl::Status status) {
 void BaseCallData::ReceiveMessage::Done(const ServerMetadata& metadata,
                                         Flusher* flusher) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ReceiveMessage.Done st=%s md=%s",
-            base_->LogTag().c_str(), StateString(state_),
-            metadata.DebugString().c_str());
+    LOG(INFO) << base_->LogTag()
+              << " ReceiveMessage.Done st=" << StateString(state_)
+              << " md=" << metadata.DebugString();
   }
   switch (state_) {
     case State::kInitial:
@@ -793,12 +794,11 @@ void BaseCallData::ReceiveMessage::Done(const ServerMetadata& metadata,
 void BaseCallData::ReceiveMessage::WakeInsideCombiner(Flusher* flusher,
                                                       bool allow_push_to_pipe) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO,
-            "%s ReceiveMessage.WakeInsideCombiner st=%s push?=%s next?=%s "
-            "allow_push_to_pipe=%s",
-            base_->LogTag().c_str(), StateString(state_),
-            push_.has_value() ? "yes" : "no", next_.has_value() ? "yes" : "no",
-            allow_push_to_pipe ? "yes" : "no");
+    LOG(INFO) << base_->LogTag()
+              << " ReceiveMessage.WakeInsideCombiner st=" << StateString(state_)
+              << " push?=" << (push_.has_value() ? "yes" : "no")
+              << " next?=" << (next_.has_value() ? "yes" : "no")
+              << " allow_push_to_pipe=" << (allow_push_to_pipe ? "yes" : "no");
   }
   switch (state_) {
     case State::kInitial:
@@ -855,9 +855,9 @@ void BaseCallData::ReceiveMessage::WakeInsideCombiner(Flusher* flusher,
       auto r_push = (*push_)();
       if (auto* p = r_push.value_if_ready()) {
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO,
-                  "%s ReceiveMessage.WakeInsideCombiner push complete: %s",
-                  base_->LogTag().c_str(), *p ? "true" : "false");
+          LOG(INFO) << base_->LogTag()
+                    << " ReceiveMessage.WakeInsideCombiner push complete: "
+                    << (*p ? "true" : "false");
         }
         // We haven't pulled through yet, so this certainly shouldn't succeed.
         CHECK(!*p);
@@ -886,12 +886,10 @@ void BaseCallData::ReceiveMessage::WakeInsideCombiner(Flusher* flusher,
               "recv_message");
         }
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO,
-                  "%s ReceiveMessage.WakeInsideCombiner next complete: %s "
-                  "new_state=%s",
-                  base_->LogTag().c_str(),
-                  p->has_value() ? "got message" : "end of stream",
-                  StateString(state_));
+          LOG(INFO) << base_->LogTag()
+                    << " ReceiveMessage.WakeInsideCombiner next complete: "
+                    << (p->has_value() ? "got message" : "end of stream")
+                    << " new_state=" << StateString(state_);
         }
       }
       if (state_ != State::kPulledFromPipe &&
@@ -905,9 +903,8 @@ void BaseCallData::ReceiveMessage::WakeInsideCombiner(Flusher* flusher,
       CHECK(push_.has_value());
       if ((*push_)().ready()) {
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO,
-                  "%s ReceiveMessage.WakeInsideCombiner push complete",
-                  base_->LogTag().c_str());
+          LOG(INFO) << base_->LogTag()
+                    << " ReceiveMessage.WakeInsideCombiner push complete";
         }
         if (state_ == State::kCompletedWhilePulledFromPipe) {
           interceptor()->Push()->Close();
@@ -1021,8 +1018,8 @@ class ClientCallData::PollContext {
   void Run() {
     DCHECK(HasContext<Arena>());
     if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-      gpr_log(GPR_INFO, "%s ClientCallData.PollContext.Run %s",
-              self_->LogTag().c_str(), self_->DebugString().c_str());
+      LOG(INFO) << self_->LogTag() << " ClientCallData.PollContext.Run "
+                << self_->DebugString();
     }
     CHECK(have_scoped_activity_);
     repoll_ = false;
@@ -1105,14 +1102,13 @@ class ClientCallData::PollContext {
         // Poll the promise once since we're waiting for it.
         Poll<ServerMetadataHandle> poll = self_->promise_();
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO, "%s ClientCallData.PollContext.Run: poll=%s; %s",
-                  self_->LogTag().c_str(),
-                  PollToString(poll,
-                               [](const ServerMetadataHandle& h) {
-                                 return h->DebugString();
-                               })
-                      .c_str(),
-                  self_->DebugString().c_str());
+          LOG(INFO) << self_->LogTag()
+                    << " ClientCallData.PollContext.Run: poll="
+                    << PollToString(poll,
+                                    [](const ServerMetadataHandle& h) {
+                                      return h->DebugString();
+                                    })
+                    << "; " << self_->DebugString();
         }
         if (auto* r = poll.value_if_ready()) {
           auto md = std::move(*r);
@@ -1385,8 +1381,7 @@ void ClientCallData::StartBatch(grpc_transport_stream_op_batch* b) {
   Flusher flusher(this);
 
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s StartBatch %s", LogTag().c_str(),
-            DebugString().c_str());
+    LOG(INFO) << LogTag() << " StartBatch " << DebugString();
   }
 
   // If this is a cancel stream, cancel anything we have pending and propagate
@@ -1509,8 +1504,7 @@ void ClientCallData::StartBatch(grpc_transport_stream_op_batch* b) {
 // Handle cancellation.
 void ClientCallData::Cancel(grpc_error_handle error, Flusher* flusher) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s Cancel error=%s", LogTag().c_str(),
-            error.ToString().c_str());
+    LOG(INFO) << LogTag() << " Cancel error=" << error.ToString();
   }
   // Track the latest reason for cancellation.
   cancelled_error_ = error;
@@ -1589,10 +1583,9 @@ void ClientCallData::StartPromise(Flusher* flusher) {
 
 void ClientCallData::RecvInitialMetadataReady(grpc_error_handle error) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO,
-            "%s ClientCallData.RecvInitialMetadataReady %s error:%s md:%s",
-            LogTag().c_str(), DebugString().c_str(), error.ToString().c_str(),
-            recv_initial_metadata_->metadata->DebugString().c_str());
+    LOG(INFO) << LogTag() << " ClientCallData.RecvInitialMetadataReady "
+              << DebugString() << " error:" << error.ToString()
+              << " md:" << recv_initial_metadata_->metadata->DebugString();
   }
   ScopedContext context(this);
   Flusher flusher(this);
@@ -1673,8 +1666,8 @@ void ClientCallData::HookRecvTrailingMetadata(CapturedBatch batch) {
 ArenaPromise<ServerMetadataHandle> ClientCallData::MakeNextPromise(
     CallArgs call_args) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ClientCallData.MakeNextPromise %s", LogTag().c_str(),
-            DebugString().c_str());
+    LOG(INFO) << LogTag() << " ClientCallData.MakeNextPromise "
+              << DebugString();
   }
   CHECK_NE(poll_ctx_, nullptr);
   CHECK(send_initial_state_ == SendInitialState::kQueued);
@@ -1736,8 +1729,8 @@ ArenaPromise<ServerMetadataHandle> ClientCallData::MakeNextPromise(
 // application.
 Poll<ServerMetadataHandle> ClientCallData::PollTrailingMetadata() {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ClientCallData.PollTrailingMetadata %s",
-            LogTag().c_str(), DebugString().c_str());
+    LOG(INFO) << LogTag() << " ClientCallData.PollTrailingMetadata "
+              << DebugString();
   }
   CHECK_NE(poll_ctx_, nullptr);
   if (send_initial_state_ == SendInitialState::kQueued) {
@@ -1787,12 +1780,10 @@ void ClientCallData::RecvTrailingMetadataReadyCallback(
 void ClientCallData::RecvTrailingMetadataReady(grpc_error_handle error) {
   Flusher flusher(this);
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO,
-            "%s ClientCallData.RecvTrailingMetadataReady "
-            "recv_trailing_state=%s error=%s md=%s",
-            LogTag().c_str(), StateString(recv_trailing_state_),
-            error.ToString().c_str(),
-            recv_trailing_metadata_->DebugString().c_str());
+    LOG(INFO) << LogTag() << " ClientCallData.RecvTrailingMetadataReady "
+              << "recv_trailing_state=" << StateString(recv_trailing_state_)
+              << " error=" << error
+              << " md=" << recv_trailing_metadata_->DebugString();
   }
   // If we were cancelled prior to receiving this callback, we should simply
   // forward the callback up with the same error.
@@ -2002,8 +1993,7 @@ ServerCallData::ServerCallData(grpc_call_element* elem,
 
 ServerCallData::~ServerCallData() {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s ~ServerCallData %s", LogTag().c_str(),
-            DebugString().c_str());
+    LOG(INFO) << LogTag() << " ~ServerCallData " << DebugString();
   }
   if (send_initial_metadata_ != nullptr) {
     send_initial_metadata_->~SendInitialMetadata();
@@ -2030,8 +2020,7 @@ void ServerCallData::StartBatch(grpc_transport_stream_op_batch* b) {
   bool wake = false;
 
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s StartBatch: %s", LogTag().c_str(),
-            DebugString().c_str());
+    LOG(INFO) << LogTag() << " StartBatch: " << DebugString();
   }
 
   // If this is a cancel stream, cancel anything we have pending and
@@ -2164,15 +2153,13 @@ void ServerCallData::StartBatch(grpc_transport_stream_op_batch* b) {
 void ServerCallData::Completed(grpc_error_handle error,
                                bool tarpit_cancellation, Flusher* flusher) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(
-        GPR_DEBUG,
-        "%sServerCallData::Completed: send_trailing_state=%s "
-        "send_initial_state=%s error=%s",
-        LogTag().c_str(), StateString(send_trailing_state_),
-        send_initial_metadata_ == nullptr
-            ? "null"
-            : SendInitialMetadata::StateString(send_initial_metadata_->state),
-        error.ToString().c_str());
+    VLOG(2) << LogTag() << "ServerCallData::Completed: send_trailing_state="
+            << StateString(send_trailing_state_) << " send_initial_state="
+            << (send_initial_metadata_ == nullptr
+                    ? "null"
+                    : SendInitialMetadata::StateString(
+                          send_initial_metadata_->state))
+            << " error=" << error;
   }
   // Track the latest reason for cancellation.
   cancelled_error_ = error;
@@ -2290,8 +2277,8 @@ ArenaPromise<ServerMetadataHandle> ServerCallData::MakeNextPromise(
 // stack.
 Poll<ServerMetadataHandle> ServerCallData::PollTrailingMetadata() {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s PollTrailingMetadata: %s", LogTag().c_str(),
-            StateString(send_trailing_state_));
+    LOG(INFO) << LogTag()
+              << " PollTrailingMetadata: " << StateString(send_trailing_state_);
   }
   switch (send_trailing_state_) {
     case SendTrailingState::kInitial:
@@ -2321,9 +2308,8 @@ void ServerCallData::RecvTrailingMetadataReadyCallback(
 
 void ServerCallData::RecvTrailingMetadataReady(grpc_error_handle error) {
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s: RecvTrailingMetadataReady error=%s md=%s",
-            LogTag().c_str(), error.ToString().c_str(),
-            recv_trailing_metadata_->DebugString().c_str());
+    LOG(INFO) << LogTag() << ": RecvTrailingMetadataReady error=" << error
+              << " md=" << recv_trailing_metadata_->DebugString();
   }
   Flusher flusher(this);
   PollContext poll_ctx(this, &flusher);
@@ -2341,8 +2327,7 @@ void ServerCallData::RecvInitialMetadataReadyCallback(void* arg,
 void ServerCallData::RecvInitialMetadataReady(grpc_error_handle error) {
   Flusher flusher(this);
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s: RecvInitialMetadataReady %s", LogTag().c_str(),
-            error.ToString().c_str());
+    LOG(INFO) << LogTag() << ": RecvInitialMetadataReady " << error;
   }
   CHECK(recv_initial_state_ == RecvInitialState::kForwarded);
   // If there was an error we just propagate that through
@@ -2406,8 +2391,7 @@ std::string ServerCallData::DebugString() const {
 void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
   PollContext poll_ctx(this, flusher);
   if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-    gpr_log(GPR_INFO, "%s: WakeInsideCombiner %s", LogTag().c_str(),
-            DebugString().c_str());
+    LOG(INFO) << LogTag() << ": WakeInsideCombiner " << DebugString();
   }
   poll_ctx.ClearRepoll();
   if (send_initial_metadata_ != nullptr) {
@@ -2429,13 +2413,11 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
     if (send_initial_metadata_->metadata_push_.has_value()) {
       if ((*send_initial_metadata_->metadata_push_)().ready()) {
         if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-          gpr_log(GPR_INFO, "%s: WakeInsideCombiner: metadata_push done",
-                  LogTag().c_str());
+          LOG(INFO) << LogTag() << ": WakeInsideCombiner: metadata_push done";
         }
         send_initial_metadata_->metadata_push_.reset();
       } else if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-        gpr_log(GPR_INFO, "%s: WakeInsideCombiner: metadata_push pending",
-                LogTag().c_str());
+        LOG(INFO) << LogTag() << ": WakeInsideCombiner: metadata_push pending";
       }
     }
   }
@@ -2452,12 +2434,9 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
         send_initial_metadata_ == nullptr ||
             send_initial_metadata_->state == SendInitialMetadata::kForwarded);
     if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-      gpr_log(GPR_DEBUG,
-              "%s: After send_message WakeInsideCombiner %s is_idle=%s "
-              "is_forwarded=%s",
-              LogTag().c_str(), DebugString().c_str(),
-              send_message()->IsIdle() ? "true" : "false",
-              send_message()->IsForwarded() ? "true" : "false");
+      VLOG(2) << LogTag() << ": After send_message WakeInsideCombiner "
+              << DebugString() << " is_idle=" << send_message()->IsIdle()
+              << " is_forwarded=" << send_message()->IsForwarded();
     }
     if (send_trailing_state_ == SendTrailingState::kQueuedBehindSendMessage &&
         (send_message()->IsIdle() ||
@@ -2481,19 +2460,19 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
     Poll<ServerMetadataHandle> poll;
     poll = promise_();
     if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-      gpr_log(
-          GPR_INFO,
-          "%s: WakeInsideCombiner poll=%s; send_initial_metadata=%s "
-          "send_trailing_metadata=%s",
-          LogTag().c_str(),
-          PollToString(
-              poll,
-              [](const ServerMetadataHandle& h) { return h->DebugString(); })
-              .c_str(),
-          send_initial_metadata_ == nullptr
-              ? "null"
-              : SendInitialMetadata::StateString(send_initial_metadata_->state),
-          StateString(send_trailing_state_));
+      LOG(INFO) << LogTag() << ": WakeInsideCombiner poll="
+                << PollToString(poll,
+                                [](const ServerMetadataHandle& h) {
+                                  return h->DebugString();
+                                })
+                       .c_str()
+                << "; send_initial_metadata="
+                << (send_initial_metadata_ == nullptr
+                        ? "null"
+                        : SendInitialMetadata::StateString(
+                              send_initial_metadata_->state))
+                << " send_trailing_metadata="
+                << StateString(send_trailing_state_);
     }
     if (send_initial_metadata_ != nullptr &&
         send_initial_metadata_->state ==
@@ -2501,12 +2480,12 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
       CHECK(send_initial_metadata_->metadata_next_.has_value());
       auto p = (*send_initial_metadata_->metadata_next_)();
       if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-        gpr_log(GPR_INFO,
-                "%s: WakeInsideCombiner send_initial_metadata poll=%s",
-                LogTag().c_str(),
-                PollToString(p, [](const NextResult<ServerMetadataHandle>& h) {
-                  return (*h)->DebugString();
-                }).c_str());
+        LOG(INFO)
+            << LogTag() << ": WakeInsideCombiner send_initial_metadata "
+            << "poll="
+            << PollToString(p, [](const NextResult<ServerMetadataHandle>& h) {
+                 return (*h)->DebugString();
+               }).c_str();
       }
       if (auto* nr = p.value_if_ready()) {
         ServerMetadataHandle md = std::move(nr->value());

--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -2480,12 +2480,12 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
       CHECK(send_initial_metadata_->metadata_next_.has_value());
       auto p = (*send_initial_metadata_->metadata_next_)();
       if (GRPC_TRACE_FLAG_ENABLED(channel)) {
-        LOG(INFO)
-            << LogTag() << ": WakeInsideCombiner send_initial_metadata "
-            << "poll="
-            << PollToString(p, [](const NextResult<ServerMetadataHandle>& h) {
-                 return (*h)->DebugString();
-               }).c_str();
+        LOG(INFO) << LogTag()
+                  << ": WakeInsideCombiner send_initial_metadata poll="
+                  << PollToString(
+                         p, [](const NextResult<ServerMetadataHandle>& h) {
+                           return (*h)->DebugString();
+                         });
       }
       if (auto* nr = p.value_if_ready()) {
         ServerMetadataHandle md = std::move(nr->value());

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -30,7 +30,6 @@
 #include "absl/strings/strip.h"
 
 #include <grpc/grpc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/config/config_vars.h"
@@ -41,7 +40,7 @@ int grpc_tracer_set_enabled(const char* name, int enabled);
 namespace grpc_core {
 namespace {
 void LogAllTracers() {
-  gpr_log(GPR_DEBUG, "available tracers:");
+  VLOG(2) << "available tracers:";
   for (const auto& name : GetAllTraceFlags()) {
     LOG(INFO) << "  " << name.first;
   }

--- a/src/core/lib/experiments/config.cc
+++ b/src/core/lib/experiments/config.cc
@@ -24,12 +24,12 @@
 
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/config/config_vars.h"
@@ -137,8 +137,7 @@ GPR_ATTRIBUTE_NOINLINE Experiments LoadExperimentsFromConfigVariableInner() {
     // If not found log an error, but don't take any other action.
     // Allows us an easy path to disabling experiments.
     if (!found) {
-      gpr_log(GPR_ERROR, "Unknown experiment: %s",
-              std::string(experiment).c_str());
+      LOG(ERROR) << "Unknown experiment: " << experiment;
     }
   }
   for (size_t i = 0; i < kNumExperiments; i++) {
@@ -227,19 +226,20 @@ void PrintExperimentsList() {
   }
   if (experiment_status.empty()) {
     if (!defaulted_on_experiments.empty()) {
-      gpr_log(GPR_INFO, "gRPC experiments enabled: %s",
-              absl::StrJoin(defaulted_on_experiments, ", ").c_str());
+      LOG(INFO) << "gRPC experiments enabled: "
+                << absl::StrJoin(defaulted_on_experiments, ", ");
     }
   } else {
     if (defaulted_on_experiments.empty()) {
-      gpr_log(GPR_INFO, "gRPC experiments: %s",
-              absl::StrJoin(experiment_status, ", ", absl::PairFormatter(":"))
-                  .c_str());
+      LOG(INFO) << "gRPC experiments: "
+                << absl::StrJoin(experiment_status, ", ",
+                                 absl::PairFormatter(":"));
     } else {
-      gpr_log(GPR_INFO, "gRPC experiments: %s; default-enabled: %s",
-              absl::StrJoin(experiment_status, ", ", absl::PairFormatter(":"))
-                  .c_str(),
-              absl::StrJoin(defaulted_on_experiments, ", ").c_str());
+      LOG(INFO) << "gRPC experiments: "
+                << absl::StrJoin(experiment_status, ", ",
+                                 absl::PairFormatter(":"))
+                << "; default-enabled: "
+                << absl::StrJoin(defaulted_on_experiments, ", ");
     }
   }
 }
@@ -256,8 +256,8 @@ void ForceEnableExperiment(absl::string_view experiment, bool enable) {
     }
     return;
   }
-  gpr_log(GPR_INFO, "gRPC EXPERIMENT %s not found to force %s",
-          std::string(experiment).c_str(), enable ? "enable" : "disable");
+  LOG(INFO) << "gRPC EXPERIMENT " << experiment << " not found to force "
+            << (enable ? "enable" : "disable");
 }
 
 void RegisterExperimentConstraintsValidator(

--- a/tools/run_tests/sanity/banned_functions.py
+++ b/tools/run_tests/sanity/banned_functions.py
@@ -95,7 +95,6 @@ BANNED_EXCEPT = {
         "./src/core/handshaker/http_connect/http_proxy_mapper.cc",
         "./src/core/handshaker/security/secure_endpoint.cc",
         "./src/core/lib/channel/channel_stack.cc",
-        "./src/core/lib/debug/trace.cc",
         "./src/core/lib/event_engine/ares_resolver.h",
         "./src/core/lib/event_engine/cf_engine/cf_engine.cc",
         "./src/core/lib/event_engine/posix_engine/posix_engine.cc",

--- a/tools/run_tests/sanity/banned_functions.py
+++ b/tools/run_tests/sanity/banned_functions.py
@@ -95,7 +95,6 @@ BANNED_EXCEPT = {
         "./src/core/handshaker/http_connect/http_proxy_mapper.cc",
         "./src/core/handshaker/security/secure_endpoint.cc",
         "./src/core/lib/channel/channel_stack.cc",
-        "./src/core/lib/channel/promise_based_filter.cc",
         "./src/core/lib/debug/trace.cc",
         "./src/core/lib/event_engine/ares_resolver.h",
         "./src/core/lib/event_engine/cf_engine/cf_engine.cc",


### PR DESCRIPTION
[grpc][Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.