### PR TITLE
[Gpr_To_Absl_Logging] Fixing bugs  (#36961)

### DIFF
--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -28,15 +28,10 @@
 extern "C" {
 #endif
 
-/** GPR log API.
-
-   Usage (within grpc):
-
-   int argument1 = 3;
-   char* argument2 = "hello";
-   gpr_log(GPR_DEBUG, "format string %d", argument1);
-   gpr_log(GPR_INFO, "hello world");
-   gpr_log(GPR_ERROR, "%d %s!!", argument1, argument2); */
+/**
+ * Logging functions in this file are deprecated.
+ * Please use absl ABSL_LOG instead.
+ */
 
 /** The severity of a log message - use the #defines below when calling into
    gpr_log to additionally supply file and line data */
@@ -65,7 +60,7 @@ GPRAPI void gpr_log_message(const char* file, int line,
                             gpr_log_severity severity, const char* message);
 
 /** Set global log verbosity */
-GPRAPI void gpr_set_log_verbosity(gpr_log_severity min_severity_to_print);
+GPRAPI void gpr_set_log_verbosity(gpr_log_severity deprecated_setting);
 
 GPRAPI void gpr_log_verbosity_init(void);
 
@@ -83,7 +78,7 @@ typedef struct gpr_log_func_args gpr_log_func_args;
 
 typedef void (*gpr_log_func)(gpr_log_func_args* args);
 
-GPRAPI void gpr_set_log_function(gpr_log_func func);
+GPRAPI void gpr_set_log_function(gpr_log_func deprecated_setting);
 
 GPRAPI void gpr_assertion_failed(const char* filename, int line,
                                  const char* message) GPR_ATTRIBUTE_NORETURN;

--- a/src/core/util/log.cc
+++ b/src/core/util/log.cc
@@ -35,14 +35,9 @@
 #include "src/core/lib/gprpp/crash.h"
 #include "src/core/util/string.h"
 
-static constexpr gpr_atm GPR_LOG_SEVERITY_UNSET = GPR_LOG_SEVERITY_ERROR + 10;
-static constexpr gpr_atm GPR_LOG_SEVERITY_NONE = GPR_LOG_SEVERITY_ERROR + 11;
-
 void gpr_default_log(gpr_log_func_args* args);
 void gpr_platform_log(gpr_log_func_args* args);
 static gpr_atm g_log_func = reinterpret_cast<gpr_atm>(gpr_default_log);
-static gpr_atm g_min_severity_to_print = GPR_LOG_SEVERITY_UNSET;
-static gpr_atm g_min_severity_to_print_stacktrace = GPR_LOG_SEVERITY_UNSET;
 
 void gpr_unreachable_code(const char* reason, const char* file, int line) {
   grpc_core::Crash(absl::StrCat("UNREACHABLE CODE: ", reason),
@@ -67,10 +62,22 @@ const char* gpr_log_severity_string(gpr_log_severity severity) {
 }
 
 int gpr_should_log(gpr_log_severity severity) {
-  return static_cast<gpr_atm>(severity) >=
-                 gpr_atm_no_barrier_load(&g_min_severity_to_print)
-             ? 1
-             : 0;
+  switch (severity) {
+    case GPR_LOG_SEVERITY_ERROR:
+      return absl::MinLogLevel() <= absl::LogSeverityAtLeast::kError;
+    case GPR_LOG_SEVERITY_INFO:
+      // There is no documentation about how expensive or inexpensive
+      // MinLogLevel is. We could have saved this in a static const variable.
+      // But decided against it just in case anyone programatically sets absl
+      // min log level settings after this has been initialized.
+      // Same holds for VLOG_IS_ON(2).
+      return absl::MinLogLevel() <= absl::LogSeverityAtLeast::kInfo;
+    case GPR_LOG_SEVERITY_DEBUG:
+      return VLOG_IS_ON(2);
+    default:
+      DLOG(ERROR) << "Invalid gpr_log_severity.";
+      return true;
+  }
 }
 
 void gpr_default_log(gpr_log_func_args* args) {
@@ -107,25 +114,21 @@ void gpr_log_message(const char* file, int line, gpr_log_severity severity,
   reinterpret_cast<gpr_log_func>(gpr_atm_no_barrier_load(&g_log_func))(&lfargs);
 }
 
-void gpr_set_log_verbosity(gpr_log_severity min_severity_to_print) {
-  gpr_atm_no_barrier_store(&g_min_severity_to_print,
-                           (gpr_atm)min_severity_to_print);
+void gpr_set_log_verbosity(
+    [[maybe_unused]] gpr_log_severity deprecated_setting) {
+  LOG(ERROR)
+      << "This will not be set. Please set this via absl log level settings.";
 }
 
-static gpr_atm parse_log_severity(absl::string_view str, gpr_atm error_value) {
-  if (absl::EqualsIgnoreCase(str, "DEBUG")) return GPR_LOG_SEVERITY_DEBUG;
-  if (absl::EqualsIgnoreCase(str, "INFO")) return GPR_LOG_SEVERITY_INFO;
-  if (absl::EqualsIgnoreCase(str, "ERROR")) return GPR_LOG_SEVERITY_ERROR;
-  if (absl::EqualsIgnoreCase(str, "NONE")) return GPR_LOG_SEVERITY_NONE;
-  return error_value;
-}
-
-void gpr_to_absl_verbosity_setting_init(void) {
+void gpr_log_verbosity_init(void) {
 // This is enabled in Github only.
 // This ifndef is converted to ifdef internally by copybara.
 // Internally grpc verbosity is managed using absl settings.
 // So internally we avoid setting it like this.
 #ifndef GRPC_VERBOSITY_MACRO
+  // SetMinLogLevel sets the value for the entire binary, not just gRPC.
+  // This setting will change things for other libraries/code that is unrelated
+  // to grpc.
   absl::string_view verbosity = grpc_core::ConfigVars::Get().Verbosity();
   DVLOG(2) << "Log verbosity: " << verbosity;
   if (absl::EqualsIgnoreCase(verbosity, "INFO")) {
@@ -147,52 +150,16 @@ void gpr_to_absl_verbosity_setting_init(void) {
     absl::SetVLogLevel("*grpc*/*", -1);
     absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
   } else if (verbosity.empty()) {
-    // Do not set absl::MinLogLevel if verbosity has not been set. Note that the
-    // default gRPC min log severity that is printed will still be ERROR.
+    // Do not alter absl settings if GRPC_VERBOSITY flag is not set.
   } else {
     LOG(ERROR) << "Unknown log verbosity: " << verbosity;
   }
 #endif  // GRPC_VERBOSITY_MACRO
 }
 
-void gpr_log_verbosity_init() {
-  // init verbosity when it hasn't been set
-  if ((gpr_atm_no_barrier_load(&g_min_severity_to_print)) ==
-      GPR_LOG_SEVERITY_UNSET) {
-    auto verbosity = grpc_core::ConfigVars::Get().Verbosity();
-    gpr_atm min_severity_to_print = GPR_LOG_SEVERITY_ERROR;
-    if (!verbosity.empty()) {
-      min_severity_to_print =
-          parse_log_severity(verbosity, min_severity_to_print);
-    }
-    gpr_atm_no_barrier_store(&g_min_severity_to_print, min_severity_to_print);
-  }
-  // init stacktrace_minloglevel when it hasn't been set
-  if ((gpr_atm_no_barrier_load(&g_min_severity_to_print_stacktrace)) ==
-      GPR_LOG_SEVERITY_UNSET) {
-    auto stacktrace_minloglevel =
-        grpc_core::ConfigVars::Get().StacktraceMinloglevel();
-    gpr_atm min_severity_to_print_stacktrace = GPR_LOG_SEVERITY_NONE;
-    if (!stacktrace_minloglevel.empty()) {
-      min_severity_to_print_stacktrace = parse_log_severity(
-          stacktrace_minloglevel, min_severity_to_print_stacktrace);
-    }
-    gpr_atm_no_barrier_store(&g_min_severity_to_print_stacktrace,
-                             min_severity_to_print_stacktrace);
-  }
-  gpr_to_absl_verbosity_setting_init();
-}
-
-void gpr_set_log_function(gpr_log_func f) {
+void gpr_set_log_function([[maybe_unused]] gpr_log_func deprecated_setting) {
   LOG(ERROR)
-      << "This function is in the process of being deprecated. Your "
-         "gpr_log_func will not work as expected. This is because only few "
-         "instances of gpr_log remain in our code base. All instances of "
-         "gpr_log will log via this custom function. Many of the gpr_log "
-         "statements have been converted to ABSL_LOG statements. These will "
-         "log to the default absl log sink. The gpr_set_log_function function "
-         "will be deleted in the next gRPC release. We strongly advice against "
-         "using this function. You may create a new absl LogSink with similar "
+      << "This function is deprecated. This function will be deleted in the "
+         "next gRPC release. You may create a new absl LogSink with similar "
          "functionality. gRFC: https://github.com/grpc/proposal/pull/425 ";
-  gpr_atm_no_barrier_store(&g_log_func, (gpr_atm)(f ? f : gpr_default_log));
 }

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -747,13 +747,13 @@ extern gpr_should_log_type gpr_should_log_import;
 typedef void(*gpr_log_message_type)(const char* file, int line, gpr_log_severity severity, const char* message);
 extern gpr_log_message_type gpr_log_message_import;
 #define gpr_log_message gpr_log_message_import
-typedef void(*gpr_set_log_verbosity_type)(gpr_log_severity min_severity_to_print);
+typedef void(*gpr_set_log_verbosity_type)(gpr_log_severity deprecated_setting);
 extern gpr_set_log_verbosity_type gpr_set_log_verbosity_import;
 #define gpr_set_log_verbosity gpr_set_log_verbosity_import
 typedef void(*gpr_log_verbosity_init_type)(void);
 extern gpr_log_verbosity_init_type gpr_log_verbosity_init_import;
 #define gpr_log_verbosity_init gpr_log_verbosity_init_import
-typedef void(*gpr_set_log_function_type)(gpr_log_func func);
+typedef void(*gpr_set_log_function_type)(gpr_log_func deprecated_setting);
 extern gpr_set_log_function_type gpr_set_log_function_import;
 #define gpr_set_log_function gpr_set_log_function_import
 typedef void(*gpr_assertion_failed_type)(const char* filename, int line, const char* message);

--- a/test/core/end2end/tests/no_logging.cc
+++ b/test/core/end2end/tests/no_logging.cc
@@ -38,7 +38,8 @@
 void gpr_default_log(gpr_log_func_args* args);
 
 namespace grpc_core {
-
+// This test is currently broken.
+// The whole test will be re-written as a part of gpr to absl log conversion.
 class Verifier {
  public:
   Verifier() {
@@ -54,9 +55,11 @@ class Verifier {
     }
     grpc_tracer_set_enabled("all", 0);
     grpc_set_absl_verbosity_debug();
+    // This is broken. Replace with an absl log sink.
     gpr_set_log_function(DispatchLog);
   }
   ~Verifier() {
+    // This is broken. Replace with an absl log sink.
     gpr_set_log_function(gpr_default_log);
     saved_trace_flags_.Restore();
     gpr_set_log_verbosity(saved_severity_);


### PR DESCRIPTION
Backport #36961 to v1.65.x

### Problem 1

Context :
gpr_log() internally calls gpr_log_message() .
gpr_log_message() may either call gpr_default_log() or a user provided logging function. gpr_default_log() uses absl LOG. This is the default. Most users will log this way. For the small percentage of users who have customized the logging function, gpr_log will log to custom this function.

Problem :
We have converted half the instances of gpr_log to absl LOG(). For users who use the defaults - there will be no issue. For the users who use a customized logging function
1. All the absl LOGs will log to the absl log sink.
2. All the gpr_log statements will log via this user provided function. This is in-consistent behaviour and will cause confusion and difficulty in debugging.

Solution:
All logs should go to the same sink.
So we decided to make gpr_set_log_function a no op in this release. The function will be deleted in the next release.
https://github.com/grpc/proposal/pull/425

### Problem 2

Context :
gpr_should_log is used to avoid computing expensive stuff for logging if the log is not going to be visible.

Problem :
gpr_should_log was referencing the GRPC_VERBOSITY flag and values set by gpr_set_log_verbosity . However, actual logging happens based on the absl settings. This is incorrect. Because if the old settings are not honoured, they should not be checked and no decision in code should be made based on settings which are not going to get used.

Solution :
Given the above changes in Problem 1, since all custom logging is disabled, all logging from gRPC with honour the absl LOG settings. Hence we modified the gpr_should_log function to refer to absl settings.

### Problem 3

We still have the issue of php using a custom log sink. We will address this in a separate PR.

### Problem 4

Tests related to test/core/end2end/tests/no_logging.cc are broken . These will be fixed in another PR.

Closes #36961

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/36961 from tanvi-jagtap:fix_gpr_should_log 70c3224af16ba14ce9f1b58fa659d69fa8278eb3 PiperOrigin-RevId: 645096418

