### PR TITLE
[benchmark] Add an opinionated macro for gRPC benchmark targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,8 +895,12 @@ if(gRPC_BUILD_TESTS)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_c bm_client_channel)
   endif()
-  add_dependencies(buildtests_c bm_experiments)
-  add_dependencies(buildtests_c bm_http_client_filter)
+  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
+    add_dependencies(buildtests_c bm_experiments)
+  endif()
+  if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
+    add_dependencies(buildtests_c bm_http_client_filter)
+  endif()
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_c bm_party)
   endif()
@@ -5940,81 +5944,82 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
 endif()
 endif()
 if(gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
 
-add_executable(bm_experiments
-  test/core/experiments/bm_experiments.cc
-)
-if(WIN32 AND MSVC)
-  if(BUILD_SHARED_LIBS)
-    target_compile_definitions(bm_experiments
-    PRIVATE
-      "GPR_DLL_IMPORTS"
-      "GRPC_DLL_IMPORTS"
-      "GRPCXX_DLL_IMPORTS"
-    )
+  add_executable(bm_experiments
+    test/core/experiments/bm_experiments.cc
+  )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(bm_experiments
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
   endif()
+  target_compile_features(bm_experiments PUBLIC cxx_std_14)
+  target_include_directories(bm_experiments
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+      ${_gRPC_RE2_INCLUDE_DIR}
+      ${_gRPC_SSL_INCLUDE_DIR}
+      ${_gRPC_UPB_GENERATED_DIR}
+      ${_gRPC_UPB_GRPC_GENERATED_DIR}
+      ${_gRPC_UPB_INCLUDE_DIR}
+      ${_gRPC_XXHASH_INCLUDE_DIR}
+      ${_gRPC_ZLIB_INCLUDE_DIR}
+  )
+
+  target_link_libraries(bm_experiments
+    ${_gRPC_ALLTARGETS_LIBRARIES}
+    ${_gRPC_BENCHMARK_LIBRARIES}
+    grpc_test_util
+  )
+
+
 endif()
-target_compile_features(bm_experiments PUBLIC cxx_std_14)
-target_include_directories(bm_experiments
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-)
-
-target_link_libraries(bm_experiments
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  absl::btree
-  ${_gRPC_BENCHMARK_LIBRARIES}
-  grpc++
-  grpc_test_util
-)
-
-
 endif()
 if(gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
 
-add_executable(bm_http_client_filter
-  test/core/filters/bm_http_client_filter.cc
-)
-if(WIN32 AND MSVC)
-  if(BUILD_SHARED_LIBS)
-    target_compile_definitions(bm_http_client_filter
-    PRIVATE
-      "GPR_DLL_IMPORTS"
-      "GRPC_DLL_IMPORTS"
-    )
+  add_executable(bm_http_client_filter
+    test/core/filters/bm_http_client_filter.cc
+  )
+  if(WIN32 AND MSVC)
+    if(BUILD_SHARED_LIBS)
+      target_compile_definitions(bm_http_client_filter
+      PRIVATE
+        "GPR_DLL_IMPORTS"
+        "GRPC_DLL_IMPORTS"
+      )
+    endif()
   endif()
+  target_compile_features(bm_http_client_filter PUBLIC cxx_std_14)
+  target_include_directories(bm_http_client_filter
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+      ${_gRPC_RE2_INCLUDE_DIR}
+      ${_gRPC_SSL_INCLUDE_DIR}
+      ${_gRPC_UPB_GENERATED_DIR}
+      ${_gRPC_UPB_GRPC_GENERATED_DIR}
+      ${_gRPC_UPB_INCLUDE_DIR}
+      ${_gRPC_XXHASH_INCLUDE_DIR}
+      ${_gRPC_ZLIB_INCLUDE_DIR}
+  )
+
+  target_link_libraries(bm_http_client_filter
+    ${_gRPC_ALLTARGETS_LIBRARIES}
+    ${_gRPC_BENCHMARK_LIBRARIES}
+    grpc
+  )
+
+
 endif()
-target_compile_features(bm_http_client_filter PUBLIC cxx_std_14)
-target_include_directories(bm_http_client_filter
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-)
-
-target_link_libraries(bm_http_client_filter
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  ${_gRPC_BENCHMARK_LIBRARIES}
-  grpc
-)
-
-
 endif()
 if(gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5188,12 +5188,16 @@ targets:
   src:
   - test/core/experiments/bm_experiments.cc
   deps:
-  - absl/container:btree
   - benchmark
-  - grpc++
   - grpc_test_util
+  args:
+  - --benchmark_min_time=0.001s
   benchmark: true
   defaults: benchmark
+  platforms:
+  - linux
+  - posix
+  uses_polling: false
 - name: bm_http_client_filter
   build: test
   language: c
@@ -5208,6 +5212,9 @@ targets:
   - --benchmark_min_time=0.001s
   benchmark: true
   defaults: benchmark
+  platforms:
+  - linux
+  - posix
   uses_polling: false
 - name: bm_party
   build: test
@@ -5290,6 +5297,8 @@ targets:
   - absl/types:span
   - benchmark
   - gpr
+  args:
+  - --benchmark_min_time=0.001s
   benchmark: true
   defaults: benchmark
   platforms:
@@ -13756,6 +13765,8 @@ targets:
   - gtest
   - benchmark
   - grpc_test_util
+  args:
+  - --benchmark_min_time=0.001s
   benchmark: true
   defaults: benchmark
   platforms:

--- a/test/core/call/BUILD
+++ b/test/core/call/BUILD
@@ -14,7 +14,7 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 load("//test/core/call/yodel:grpc_yodel_test.bzl", "grpc_yodel_simple_test")
-load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 grpc_package(name = "test/core/call")
 
@@ -79,17 +79,9 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_client_call",
-    size = "small",
     srcs = ["bm_client_call.cc"],
-    args = grpc_benchmark_args(),
-    external_deps = ["benchmark"],
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
-    uses_polling = False,
     deps = [
         "//:grpc",
         "//src/core:default_event_engine",

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -14,7 +14,7 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
 load("//test/core/call/yodel:grpc_yodel_test.bzl", "grpc_yodel_simple_test")
-load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 grpc_package(name = "test/core/client_channel")
 
@@ -118,17 +118,9 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_client_channel",
-    size = "small",
     srcs = ["bm_client_channel.cc"],
-    args = grpc_benchmark_args(),
-    external_deps = ["benchmark"],
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
-    uses_polling = False,
     deps = [
         "//:grpc",
         "//src/core:default_event_engine",

--- a/test/core/event_engine/posix/BUILD
+++ b/test/core/event_engine/posix/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 licenses(["notice"])
 
@@ -109,20 +110,13 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "lock_free_event_test",
     srcs = ["lock_free_event_test.cc"],
     external_deps = [
-        "benchmark",
         "gtest",
     ],
-    language = "C++",
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
     uses_event_engine = True,
-    uses_polling = False,
     deps = [
         "//src/core:posix_event_engine",
         "//src/core:posix_event_engine_closure",

--- a/test/core/experiments/BUILD
+++ b/test/core/experiments/BUILD
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 grpc_package(name = "test/core/experiments")
 
@@ -31,16 +32,10 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_experiments",
     srcs = ["bm_experiments.cc"],
-    external_deps = [
-        "benchmark",
-        "absl/container:btree",
-    ],
     deps = [
-        "//:grpc++",
-        "//src/core:channel_args",
         "//src/core:experiments",
         "//test/core/test_util:grpc_test_util",
     ],

--- a/test/core/filters/BUILD
+++ b/test/core/filters/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
-load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 licenses(["notice"])
 
@@ -120,13 +120,9 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_http_client_filter",
-    size = "small",
     srcs = ["bm_http_client_filter.cc"],
-    args = grpc_benchmark_args(),
-    external_deps = ["benchmark"],
-    uses_polling = False,
     deps = [
         "//:grpc",
         "//src/core:default_event_engine",

--- a/test/core/load_balancing/BUILD
+++ b/test/core/load_balancing/BUILD
@@ -18,6 +18,7 @@ load(
     "grpc_cc_test",
     "grpc_package",
 )
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 grpc_package(name = "test/core/load_balancing")
 
@@ -194,21 +195,14 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "static_stride_scheduler_benchmark",
     srcs = ["static_stride_scheduler_benchmark.cc"],
     external_deps = [
         "absl/algorithm:container",
         "absl/log:check",
-        "benchmark",
-    ],
-    language = "C++",
-    tags = [
-        "no_mac",
-        "no_windows",
     ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [
         "//src/core:no_destruct",
         "//src/core:static_stride_scheduler",

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -14,7 +14,7 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 load("//test/core/test_util:grpc_fuzzer.bzl", "grpc_proto_fuzzer")
-load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 licenses(["notice"])
 
@@ -686,17 +686,9 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_party",
-    size = "small",
     srcs = ["bm_party.cc"],
-    args = grpc_benchmark_args(),
-    external_deps = ["benchmark"],
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
-    uses_polling = False,
     deps = [
         "//:grpc",
         "//src/core:1999",

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -14,7 +14,7 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 load("//test/core/call/yodel:grpc_yodel_test.bzl", "grpc_yodel_simple_test")
-load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 licenses(["notice"])
 
@@ -226,17 +226,9 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_call_spine",
-    size = "small",
     srcs = ["bm_call_spine.cc"],
-    args = grpc_benchmark_args(),
-    external_deps = ["benchmark"],
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
-    uses_polling = False,
     deps = [
         ":call_spine_benchmarks",
         "//:grpc",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -306,7 +306,6 @@ grpc_cc_benchmark(
 grpc_cc_benchmark(
     name = "bm_opencensus_plugin",
     srcs = ["bm_opencensus_plugin.cc"],
-    language = "C++",
     deps = [
         ":helpers_secure",
         "//:grpc_opencensus_plugin",
@@ -345,7 +344,7 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_callback_unary_ping_pong",
     size = "large",
     srcs = [
@@ -373,7 +372,7 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_callback_streaming_ping_pong",
     srcs = [
         "bm_callback_streaming_ping_pong.cc",
@@ -386,7 +385,7 @@ grpc_cc_test(
 )
 
 # TODO(hork): Generalize this for other work queue implementations
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_basic_work_queue",
     srcs = ["bm_basic_work_queue.cc"],
     external_deps = [
@@ -396,7 +395,6 @@ grpc_cc_test(
         "manual",
         "notap",
     ],
-    uses_event_engine = False,
     deps = [
         "//:gpr",
         "//src/core:common_event_engine_closures",

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -13,26 +13,22 @@
 # limitations under the License.
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
-load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_benchmark_args")
+load("//test/cpp/microbenchmarks:grpc_benchmark_config.bzl", "grpc_cc_benchmark")
 
 licenses(["notice"])
 
 grpc_package(name = "test/cpp/microbenchmarks")
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "noop-benchmark",
     srcs = ["noop-benchmark.cc"],
-    external_deps = [
-        "benchmark",
-    ],
     deps = ["//test/core/test_util:grpc_test_util"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_channel_args",
     srcs = ["bm_channel_args.cc"],
     external_deps = [
-        "benchmark",
         "absl/container:btree",
     ],
     deps = [
@@ -42,11 +38,10 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_rng",
     srcs = ["bm_rng.cc"],
     external_deps = [
-        "benchmark",
         "absl/container:btree",
     ],
     deps = [
@@ -56,46 +51,33 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_exec_ctx",
     srcs = ["bm_exec_ctx.cc"],
-    args = grpc_benchmark_args(),
-    external_deps = [
-        "benchmark",
-    ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_event_engine_run",
-    size = "small",
     srcs = ["bm_event_engine_run.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
         "absl/debugging:leak_check",
-        "benchmark",
     ],
-    uses_polling = False,
     deps = [
         ":helpers",
         "//src/core:common_event_engine_closures",
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_thread_pool",
-    size = "small",
     srcs = ["bm_thread_pool.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
-        "benchmark",
     ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [
         ":helpers",
         "//src/core:common_event_engine_closures",
@@ -147,27 +129,19 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_closure",
     srcs = ["bm_closure.cc"],
-    args = grpc_benchmark_args(),
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
     deps = [
         ":helpers",
         "//src/core:closure",
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_huffman_decode",
     srcs = ["bm_huffman_decode.cc"],
-    args = grpc_benchmark_args(),
     tags = [
-        "no_mac",
-        "no_windows",
         "nomsan",
         "notsan",
         "noubsan",
@@ -178,36 +152,25 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_alarm",
     srcs = ["bm_alarm.cc"],
-    args = grpc_benchmark_args(),
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_arena",
-    size = "large",
     srcs = ["bm_arena.cc"],
-    args = grpc_benchmark_args(),
     tags = [
-        "no_mac",
-        "no_windows",
         "notsan",
     ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_byte_buffer",
     srcs = ["bm_byte_buffer.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
     ],
@@ -216,50 +179,36 @@ grpc_cc_test(
         "no_windows",
     ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_channel",
     srcs = ["bm_channel.cc"],
-    args = grpc_benchmark_args(),
     tags = [
         "no_mac",
         "no_windows",
     ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_cq",
     srcs = ["bm_cq.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
-    ],
-    tags = [
-        "no_mac",
-        "no_windows",
     ],
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_cq_multiple_threads",
     srcs = ["bm_cq_multiple_threads.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
     ],
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [":helpers"],
 )
 
@@ -279,18 +228,13 @@ grpc_cc_library(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_fullstack_streaming_ping_pong",
     size = "large",
     srcs = [
         "bm_fullstack_streaming_ping_pong.cc",
     ],
-    args = grpc_benchmark_args(),
     flaky = True,
-    tags = [
-        "no_mac",  # to emulate "excluded_poll_engines: poll"
-        "no_windows",
-    ],
     deps = [":fullstack_streaming_ping_pong_h"],
 )
 
@@ -306,15 +250,10 @@ grpc_cc_library(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_fullstack_streaming_pump",
     srcs = [
         "bm_fullstack_streaming_pump.cc",
-    ],
-    args = grpc_benchmark_args(),
-    tags = [
-        "no_mac",  # to emulate "excluded_poll_engines: poll"
-        "no_windows",
     ],
     deps = [":fullstack_streaming_pump_h"],
 )
@@ -331,30 +270,19 @@ grpc_cc_library(
     deps = [":helpers_secure"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_fullstack_unary_ping_pong",
     size = "large",
     srcs = [
         "bm_fullstack_unary_ping_pong.cc",
     ],
-    args = grpc_benchmark_args(),
-    tags = [
-        "no_mac",  # to emulate "excluded_poll_engines: poll"
-        "no_windows",
-    ],
     deps = [":fullstack_unary_ping_pong_h"],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_fullstack_unary_ping_pong_chaotic_good",
-    size = "large",
     srcs = [
         "bm_fullstack_unary_ping_pong_chaotic_good.cc",
-    ],
-    args = grpc_benchmark_args(),
-    tags = [
-        "no_mac",  # to emulate "excluded_poll_engines: poll"
-        "no_windows",
     ],
     deps = [
         ":fullstack_unary_ping_pong_h",
@@ -362,29 +290,22 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_chttp2_hpack",
     srcs = ["bm_chttp2_hpack.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
     ],
-    tags = [
-        "no_mac",
-        "no_windows",
-    ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [
         ":helpers",
         "//src/core:slice",
     ],
 )
 
-grpc_cc_test(
+grpc_cc_benchmark(
     name = "bm_opencensus_plugin",
     srcs = ["bm_opencensus_plugin.cc"],
-    args = grpc_benchmark_args(),
     language = "C++",
     deps = [
         ":helpers_secure",
@@ -430,11 +351,8 @@ grpc_cc_test(
     srcs = [
         "bm_callback_unary_ping_pong.cc",
     ],
-    args = grpc_benchmark_args(),
     tags = [
         "manual",
-        "no_mac",
-        "no_windows",
         "notap",
     ],
     deps = [":callback_unary_ping_pong_h"],
@@ -457,15 +375,11 @@ grpc_cc_library(
 
 grpc_cc_test(
     name = "bm_callback_streaming_ping_pong",
-    size = "large",
     srcs = [
         "bm_callback_streaming_ping_pong.cc",
     ],
-    args = grpc_benchmark_args(),
     tags = [
         "manual",
-        "no_mac",
-        "no_windows",
         "notap",
     ],
     deps = [":callback_streaming_ping_pong_h"],
@@ -475,18 +389,14 @@ grpc_cc_test(
 grpc_cc_test(
     name = "bm_basic_work_queue",
     srcs = ["bm_basic_work_queue.cc"],
-    args = grpc_benchmark_args(),
     external_deps = [
         "absl/log:check",
-        "benchmark",
     ],
     tags = [
         "manual",
-        "no_windows",
         "notap",
     ],
     uses_event_engine = False,
-    uses_polling = False,
     deps = [
         "//:gpr",
         "//src/core:common_event_engine_closures",

--- a/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
+++ b/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
@@ -13,6 +13,46 @@
 # limitations under the License.
 """Configuration macros for grpc microbenchmarking"""
 
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test")
+
 def grpc_benchmark_args():
     """Command line arguments for running a microbenchmark as a test"""
     return ["--benchmark_min_time=0.001s"]
+
+def grpc_cc_benchmark(name, external_deps = [], tags = [], uses_polling = False, uses_event_engine = False, **kwargs):
+    """Base rule for gRPC benchmarks.
+
+    This is an opinionated configuration for gRPC benchmarks.
+
+    We disable uses_polling, uses_event_engine by default so that we minimize
+    unnecessary uses of CI time.
+
+    Similarly, we disable running on Windows, Mac to save testing time there
+    (our principle target for performance work is Linux).
+
+    linkstatic is enabled always: this is the configuration real binaries use, and
+    it affects performance, so we should use it on our benchmarks too!
+
+    Args:
+        name: base name of the test
+        external_deps: per grpc_cc_test
+        tags: per grpc_cc_test
+        uses_polling: per grpc_cc_test, but defaulted False
+        uses_event_engine: per grpc_cc_test, but defaulted False
+        **kwargs: per grpc_cc_test
+
+    Returns:
+        A list of dictionaries containing modified values of name, srcs, deps, tags, and args.
+    """
+    grpc_cc_test(
+        name = name,
+        args = grpc_benchmark_args(),
+        external_deps = ["benchmark"] + external_deps,
+        tags = tags + ["no_mac", "no_windows"],
+        uses_polling = uses_polling,
+        uses_event_engine = uses_event_engine,
+        # cc_binary defaults to 1, and we are interested in performance
+        # for that, so duplicate that setting here.
+        linkstatic = 1,
+        **kwargs
+    )

--- a/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
+++ b/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
@@ -40,9 +40,6 @@ def grpc_cc_benchmark(name, external_deps = [], tags = [], uses_polling = False,
         uses_polling: per grpc_cc_test, but defaulted False
         uses_event_engine: per grpc_cc_test, but defaulted False
         **kwargs: per grpc_cc_test
-
-    Returns:
-        A list of dictionaries containing modified values of name, srcs, deps, tags, and args.
     """
     grpc_cc_test(
         name = name,

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -68,13 +68,13 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001s"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
-      "mac",
-      "posix",
-      "windows"
+      "posix"
     ],
     "cpu_cost": 1.0,
     "exclude_configs": [],
@@ -85,11 +85,9 @@
     "name": "bm_experiments",
     "platforms": [
       "linux",
-      "mac",
-      "posix",
-      "windows"
+      "posix"
     ],
-    "uses_polling": true
+    "uses_polling": false
   },
   {
     "args": [
@@ -98,9 +96,7 @@
     "benchmark": true,
     "ci_platforms": [
       "linux",
-      "mac",
-      "posix",
-      "windows"
+      "posix"
     ],
     "cpu_cost": 1.0,
     "exclude_configs": [],
@@ -111,9 +107,7 @@
     "name": "bm_http_client_filter",
     "platforms": [
       "linux",
-      "mac",
-      "posix",
-      "windows"
+      "posix"
     ],
     "uses_polling": false
   },
@@ -208,7 +202,9 @@
     "uses_polling": true
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001s"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",
@@ -5842,7 +5838,9 @@
     "uses_polling": false
   },
   {
-    "args": [],
+    "args": [
+      "--benchmark_min_time=0.001s"
+    ],
     "benchmark": true,
     "ci_platforms": [
       "linux",


### PR DESCRIPTION
As we've learned what configuration is needed for our benchmarks the settings have been growing more and more bespoke for each binary. Try to consolidate that into some useful defaults.

Also ensure we always `linkstatic=1`. `cc_binary` defaults to this, so it's reasonable to assume that's the performance our customers see. It also deeply impacts performance for small microbenchmarks, and so enabling it gives us more apples:apples, and saves chasing things that don't matter.