### PR TITLE
[alts] Remove duplicate declaration of AltsServerCredentials.

### DIFF
--- a/include/grpcpp/security/server_credentials.h
+++ b/include/grpcpp/security/server_credentials.h
@@ -116,9 +116,6 @@ std::shared_ptr<ServerCredentials> AltsServerCredentials(
     const AltsServerCredentialsOptions& options);
 
 /// Builds Local ServerCredentials.
-std::shared_ptr<ServerCredentials> AltsServerCredentials(
-    const AltsServerCredentialsOptions& options);
-
 std::shared_ptr<ServerCredentials> LocalServerCredentials(
     grpc_local_connect_type type);
 


### PR DESCRIPTION
It looks like this duplicate was accidentally added several years ago during a revert of a revert.
