### PR TITLE
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -50,7 +50,6 @@
 
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
@@ -619,7 +618,7 @@ static void tcp_drop_uncovered_then_handle_write(void* arg /* grpc_tcp */,
 static void done_poller(void* bp, grpc_error_handle /*error_ignored*/) {
   backup_poller* p = static_cast<backup_poller*>(bp);
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "BACKUP_POLLER:%p destroy", p);
+    LOG(INFO) << "BACKUP_POLLER:" << p << " destroy";
   }
   grpc_pollset_destroy(BACKUP_POLLER_POLLSET(p));
   gpr_free(p);
@@ -628,7 +627,7 @@ static void done_poller(void* bp, grpc_error_handle /*error_ignored*/) {
 static void run_poller(void* bp, grpc_error_handle /*error_ignored*/) {
   backup_poller* p = static_cast<backup_poller*>(bp);
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "BACKUP_POLLER:%p run", p);
+    LOG(INFO) << "BACKUP_POLLER:" << p << " run";
   }
   gpr_mu_lock(p->pollset_mu);
   grpc_core::Timestamp deadline =
@@ -645,7 +644,7 @@ static void run_poller(void* bp, grpc_error_handle /*error_ignored*/) {
     g_uncovered_notifications_pending = 0;
     g_backup_poller_mu->Unlock();
     if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-      gpr_log(GPR_INFO, "BACKUP_POLLER:%p shutdown", p);
+      LOG(INFO) << "BACKUP_POLLER:" << p << " shutdown";
     }
     grpc_pollset_shutdown(BACKUP_POLLER_POLLSET(p),
                           GRPC_CLOSURE_INIT(&p->run_poller, done_poller, p,
@@ -653,7 +652,7 @@ static void run_poller(void* bp, grpc_error_handle /*error_ignored*/) {
   } else {
     g_backup_poller_mu->Unlock();
     if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-      gpr_log(GPR_INFO, "BACKUP_POLLER:%p reschedule", p);
+      LOG(INFO) << "BACKUP_POLLER:" << p << " reschedule";
     }
     grpc_core::Executor::Run(&p->run_poller, absl::OkStatus(),
                              grpc_core::ExecutorType::DEFAULT,
@@ -670,8 +669,8 @@ static void drop_uncovered(grpc_tcp* /*tcp*/) {
   g_backup_poller_mu->Unlock();
   CHECK_GT(old_count, 1);
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "BACKUP_POLLER:%p uncover cnt %d->%d", p, old_count,
-            old_count - 1);
+    LOG(INFO) << "BACKUP_POLLER:" << p << " uncover cnt " << old_count << "->"
+              << old_count - 1;
   }
 }
 
@@ -694,7 +693,7 @@ static void cover_self(grpc_tcp* tcp) {
     grpc_pollset_init(BACKUP_POLLER_POLLSET(p), &p->pollset_mu);
     g_backup_poller_mu->Unlock();
     if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-      gpr_log(GPR_INFO, "BACKUP_POLLER:%p create", p);
+      LOG(INFO) << "BACKUP_POLLER:" << p << " create";
     }
     grpc_core::Executor::Run(
         GRPC_CLOSURE_INIT(&p->run_poller, run_poller, p, nullptr),
@@ -706,22 +705,22 @@ static void cover_self(grpc_tcp* tcp) {
     g_backup_poller_mu->Unlock();
   }
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "BACKUP_POLLER:%p add %p cnt %d->%d", p, tcp,
-            old_count - 1, old_count);
+    LOG(INFO) << "BACKUP_POLLER:" << p << " add " << tcp << " cnt "
+              << old_count - 1 << "->" << old_count;
   }
   grpc_pollset_add_fd(BACKUP_POLLER_POLLSET(p), tcp->em_fd);
 }
 
 static void notify_on_read(grpc_tcp* tcp) {
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p notify_on_read", tcp);
+    LOG(INFO) << "TCP:" << tcp << " notify_on_read";
   }
   grpc_fd_notify_on_read(tcp->em_fd, &tcp->read_done_closure);
 }
 
 static void notify_on_write(grpc_tcp* tcp) {
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p notify_on_write", tcp);
+    LOG(INFO) << "TCP:" << tcp << " notify_on_write";
   }
   if (!grpc_event_engine_run_in_background()) {
     cover_self(tcp);
@@ -732,8 +731,8 @@ static void notify_on_write(grpc_tcp* tcp) {
 static void tcp_drop_uncovered_then_handle_write(void* arg,
                                                  grpc_error_handle error) {
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p got_write: %s", arg,
-            grpc_core::StatusToString(error).c_str());
+    LOG(INFO) << "TCP:" << arg
+              << " got_write: " << grpc_core::StatusToString(error);
   }
   drop_uncovered(static_cast<grpc_tcp*>(arg));
   tcp_handle_write(arg, error);
@@ -852,10 +851,11 @@ static void tcp_trace_read(grpc_tcp* tcp, grpc_error_handle error)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(tcp->read_mu) {
   grpc_closure* cb = tcp->read_cb;
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p call_cb %p %p:%p", tcp, cb, cb->cb, cb->cb_arg);
+    LOG(INFO) << "TCP:" << tcp << " call_cb " << cb << " " << cb->cb << ":"
+              << cb->cb_arg;
     size_t i;
-    gpr_log(GPR_INFO, "READ %p (peer=%s) error=%s", tcp,
-            tcp->peer_string.c_str(), grpc_core::StatusToString(error).c_str());
+    LOG(INFO) << "READ " << tcp << " (peer=" << tcp->peer_string.c_str()
+              << ") error=" << grpc_core::StatusToString(error);
     if (ABSL_VLOG_IS_ON(2)) {
       for (i = 0; i < tcp->incoming_buffer->count; i++) {
         char* dump = grpc_dump_slice(tcp->incoming_buffer->slices[i],
@@ -903,10 +903,8 @@ static void update_rcvlowat(grpc_tcp* tcp)
   }
   if (setsockopt(tcp->fd, SOL_SOCKET, SO_RCVLOWAT, &remaining,
                  sizeof(remaining)) != 0) {
-    gpr_log(GPR_ERROR, "%s",
-            absl::StrCat("Cannot set SO_RCVLOWAT on fd=", tcp->fd,
-                         " err=", grpc_core::StrError(errno).c_str())
-                .c_str());
+    LOG(ERROR) << "Cannot set SO_RCVLOWAT on fd=" << tcp->fd
+               << " err=" << grpc_core::StrError(errno);
     return;
   }
   tcp->set_rcvlowat = remaining;
@@ -917,7 +915,7 @@ static void update_rcvlowat(grpc_tcp* tcp)
 static bool tcp_do_read(grpc_tcp* tcp, grpc_error_handle* error)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(tcp->read_mu) {
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p do_read", tcp);
+    LOG(INFO) << "TCP:" << tcp << " do_read";
   }
   struct msghdr msg;
   struct iovec iov[MAX_READ_IOVEC];
@@ -1130,8 +1128,7 @@ static void maybe_make_read_slices(grpc_tcp* tcp)
 static void tcp_handle_read(void* arg /* grpc_tcp */, grpc_error_handle error) {
   grpc_tcp* tcp = static_cast<grpc_tcp*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p got_read: %s", tcp,
-            grpc_core::StatusToString(error).c_str());
+    LOG(INFO) << "TCP:" << tcp << " got_read: " << error;
   }
   tcp->read_mu.Lock();
   grpc_error_handle tcp_read_error;
@@ -1471,9 +1468,8 @@ static bool process_errors(grpc_tcp* tcp) {
         // Got a control message that is not a timestamp or zerocopy. Don't know
         // how to handle this.
         if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-          gpr_log(GPR_INFO,
-                  "unknown control message cmsg_level:%d cmsg_type:%d",
-                  cmsg->cmsg_level, cmsg->cmsg_type);
+          LOG(INFO) << "unknown control message cmsg_level:" << cmsg->cmsg_level
+                    << " cmsg_type:" << cmsg->cmsg_type;
         }
         return processed_err;
       }
@@ -1488,8 +1484,7 @@ static void tcp_handle_error(void* arg /* grpc_tcp */,
                              grpc_error_handle error) {
   grpc_tcp* tcp = static_cast<grpc_tcp*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    gpr_log(GPR_INFO, "TCP:%p got_error: %s", tcp,
-            grpc_core::StatusToString(error).c_str());
+    LOG(INFO) << "TCP:" << tcp << " got_error: " << error;
   }
 
   if (!error.ok() ||
@@ -1847,7 +1842,8 @@ static void tcp_write(grpc_endpoint* ep, grpc_slice_buffer* buf,
     size_t i;
 
     for (i = 0; i < buf->count; i++) {
-      gpr_log(GPR_INFO, "WRITE %p (peer=%s)", tcp, tcp->peer_string.c_str());
+      LOG(INFO) << "WRITE " << tcp << " (peer=" << tcp->peer_string.c_str()
+                << ")";
       if (ABSL_VLOG_IS_ON(2)) {
         char* data =
             grpc_dump_slice(buf->slices[i], GPR_DUMP_HEX | GPR_DUMP_ASCII);
@@ -2030,7 +2026,7 @@ grpc_endpoint* grpc_tcp_create(grpc_fd* em_fd,
   if (setsockopt(tcp->fd, SOL_TCP, TCP_INQ, &one, sizeof(one)) == 0) {
     tcp->inq_capable = true;
   } else {
-    gpr_log(GPR_DEBUG, "cannot set inq fd=%d errno=%d", tcp->fd, errno);
+    VLOG(2) << "cannot set inq fd=" << tcp->fd << " errno=" << errno;
     tcp->inq_capable = false;
   }
 #else

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -854,7 +854,7 @@ static void tcp_trace_read(grpc_tcp* tcp, grpc_error_handle error)
     LOG(INFO) << "TCP:" << tcp << " call_cb " << cb << " " << cb->cb << ":"
               << cb->cb_arg;
     size_t i;
-    LOG(INFO) << "READ " << tcp << " (peer=" << tcp->peer_string.c_str()
+    LOG(INFO) << "READ " << tcp << " (peer=" << tcp->peer_string
               << ") error=" << grpc_core::StatusToString(error);
     if (ABSL_VLOG_IS_ON(2)) {
       for (i = 0; i < tcp->incoming_buffer->count; i++) {
@@ -1128,7 +1128,8 @@ static void maybe_make_read_slices(grpc_tcp* tcp)
 static void tcp_handle_read(void* arg /* grpc_tcp */, grpc_error_handle error) {
   grpc_tcp* tcp = static_cast<grpc_tcp*>(arg);
   if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-    LOG(INFO) << "TCP:" << tcp << " got_read: " << error;
+    LOG(INFO) << "TCP:" << tcp
+              << " got_read: " << grpc_core::StatusToString(error);
   }
   tcp->read_mu.Lock();
   grpc_error_handle tcp_read_error;
@@ -1842,8 +1843,7 @@ static void tcp_write(grpc_endpoint* ep, grpc_slice_buffer* buf,
     size_t i;
 
     for (i = 0; i < buf->count; i++) {
-      LOG(INFO) << "WRITE " << tcp << " (peer=" << tcp->peer_string.c_str()
-                << ")";
+      LOG(INFO) << "WRITE " << tcp << " (peer=" << tcp->peer_string << ")";
       if (ABSL_VLOG_IS_ON(2)) {
         char* data =
             grpc_dump_slice(buf->slices[i], GPR_DUMP_HEX | GPR_DUMP_ASCII);

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -44,6 +44,7 @@
 #include <string>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -51,7 +52,6 @@
 #include <grpc/event_engine/endpoint_config.h>
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -438,8 +438,7 @@ static void on_read(void* arg, grpc_error_handle err) {
                       &(addr.len)) < 0) {
         auto listener_addr_uri = grpc_sockaddr_to_uri(&sp->addr);
         LOG(ERROR) << "Failed getpeername: " << grpc_core::StrError(errno)
-                   << ". Dropping the connection, and continuing "
-                   << "to listen on "
+                   << ". Dropping the connection, and continuing to listen on "
                    << (listener_addr_uri.ok() ? *listener_addr_uri
                                               : "<unknown>")
                    << ":" << sp->port;
@@ -543,11 +542,13 @@ static grpc_error_handle add_wildcard_addrs_to_server(grpc_tcp_server* s,
   if (*out_port > 0) {
     if (!v6_err.ok()) {
       LOG(INFO) << "Failed to add :: listener, "
-                << "the environment may not support IPv6: " << v6_err;
+                << "the environment may not support IPv6: "
+                << grpc_core::StatusToString(v6_err);
     }
     if (!v4_err.ok()) {
       LOG(INFO) << "Failed to add 0.0.0.0 listener, "
-                << "the environment may not support IPv4: " << v4_err;
+                << "the environment may not support IPv4: "
+                << grpc_core::StatusToString(v4_err);
     }
     return absl::OkStatus();
   } else {

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -165,22 +165,21 @@ static grpc_error_handle CreateEventEngineListener(
                       ->GetWrappedFd();
               if (getpeername(fd, reinterpret_cast<struct sockaddr*>(addr.addr),
                               &(addr.len)) < 0) {
-                gpr_log(GPR_ERROR, "Failed getpeername: %s",
-                        grpc_core::StrError(errno).c_str());
+                LOG(ERROR) << "Failed getpeername: "
+                           << grpc_core::StrError(errno);
                 close(fd);
                 return;
               }
               (void)grpc_set_socket_no_sigpipe_if_possible(fd);
               auto addr_uri = grpc_sockaddr_to_uri(&addr);
               if (!addr_uri.ok()) {
-                gpr_log(GPR_ERROR, "Invalid address: %s",
-                        addr_uri.status().ToString().c_str());
+                LOG(ERROR) << "Invalid address: "
+                           << addr_uri.status().ToString();
                 return;
               }
               if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-                gpr_log(GPR_INFO,
-                        "SERVER_CONNECT: incoming external connection: %s",
-                        addr_uri->c_str());
+                LOG(INFO) << "SERVER_CONNECT: incoming external connection: "
+                          << addr_uri->c_str();
               }
             }
             read_notifier_pollset =
@@ -410,8 +409,7 @@ static void on_read(void* arg, grpc_error_handle err) {
       }
       gpr_mu_lock(&sp->server->mu);
       if (!sp->server->shutdown_listeners) {
-        gpr_log(GPR_ERROR, "Failed accept4: %s",
-                grpc_core::StrError(errno).c_str());
+        LOG(ERROR) << "Failed accept4: " << grpc_core::StrError(errno);
       } else {
         // if we have shutdown listeners, accept4 could fail, and we
         // needn't notify users
@@ -424,10 +422,8 @@ static void on_read(void* arg, grpc_error_handle err) {
       int64_t dropped_connections_count =
           num_dropped_connections.fetch_add(1, std::memory_order_relaxed) + 1;
       if (dropped_connections_count % 1000 == 1) {
-        gpr_log(GPR_INFO,
-                "Dropped >= %" PRId64
-                " new connection attempts due to high memory pressure",
-                dropped_connections_count);
+        LOG(INFO) << "Dropped >= " << dropped_connections_count
+                  << " new connection attempts due to high memory pressure";
       }
       close(fd);
       continue;
@@ -441,13 +437,12 @@ static void on_read(void* arg, grpc_error_handle err) {
       if (getpeername(fd, reinterpret_cast<struct sockaddr*>(addr.addr),
                       &(addr.len)) < 0) {
         auto listener_addr_uri = grpc_sockaddr_to_uri(&sp->addr);
-        gpr_log(
-            GPR_ERROR,
-            "Failed getpeername: %s. Dropping the connection, and continuing "
-            "to listen on %s:%d.",
-            grpc_core::StrError(errno).c_str(),
-            listener_addr_uri.ok() ? listener_addr_uri->c_str() : "<unknown>",
-            sp->port);
+        LOG(ERROR) << "Failed getpeername: " << grpc_core::StrError(errno)
+                   << ". Dropping the connection, and continuing "
+                   << "to listen on "
+                   << (listener_addr_uri.ok() ? *listener_addr_uri
+                                              : "<unknown>")
+                   << ":" << sp->port;
         close(fd);
         continue;
       }
@@ -463,13 +458,11 @@ static void on_read(void* arg, grpc_error_handle err) {
 
     auto addr_uri = grpc_sockaddr_to_uri(&addr);
     if (!addr_uri.ok()) {
-      gpr_log(GPR_ERROR, "Invalid address: %s",
-              addr_uri.status().ToString().c_str());
+      LOG(ERROR) << "Invalid address: " << addr_uri.status();
       goto error;
     }
     if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-      gpr_log(GPR_INFO, "SERVER_CONNECT: incoming connection: %s",
-              addr_uri->c_str());
+      LOG(INFO) << "SERVER_CONNECT: incoming connection: " << *addr_uri;
     }
 
     std::string name = absl::StrCat("tcp-server-connection:", addr_uri.value());
@@ -549,16 +542,12 @@ static grpc_error_handle add_wildcard_addrs_to_server(grpc_tcp_server* s,
   }
   if (*out_port > 0) {
     if (!v6_err.ok()) {
-      gpr_log(GPR_INFO,
-              "Failed to add :: listener, "
-              "the environment may not support IPv6: %s",
-              grpc_core::StatusToString(v6_err).c_str());
+      LOG(INFO) << "Failed to add :: listener, "
+                << "the environment may not support IPv6: " << v6_err;
     }
     if (!v4_err.ok()) {
-      gpr_log(GPR_INFO,
-              "Failed to add 0.0.0.0 listener, "
-              "the environment may not support IPv4: %s",
-              grpc_core::StatusToString(v4_err).c_str());
+      LOG(INFO) << "Failed to add 0.0.0.0 listener, "
+                << "the environment may not support IPv4: " << v4_err;
     }
     return absl::OkStatus();
   } else {
@@ -916,21 +905,19 @@ class ExternalConnectionHandler : public grpc_core::TcpServerFdHandler {
 
     if (getpeername(fd, reinterpret_cast<struct sockaddr*>(addr.addr),
                     &(addr.len)) < 0) {
-      gpr_log(GPR_ERROR, "Failed getpeername: %s",
-              grpc_core::StrError(errno).c_str());
+      LOG(ERROR) << "Failed getpeername: " << grpc_core::StrError(errno);
       close(fd);
       return;
     }
     (void)grpc_set_socket_no_sigpipe_if_possible(fd);
     auto addr_uri = grpc_sockaddr_to_uri(&addr);
     if (!addr_uri.ok()) {
-      gpr_log(GPR_ERROR, "Invalid address: %s",
-              addr_uri.status().ToString().c_str());
+      LOG(ERROR) << "Invalid address: " << addr_uri.status();
       return;
     }
     if (GRPC_TRACE_FLAG_ENABLED(tcp)) {
-      gpr_log(GPR_INFO, "SERVER_CONNECT: incoming external connection: %s",
-              addr_uri->c_str());
+      LOG(INFO) << "SERVER_CONNECT: incoming external connection: "
+                << *addr_uri;
     }
     std::string name = absl::StrCat("tcp-server-connection:", addr_uri.value());
     grpc_fd* fdobj = grpc_fd_create(fd, name.c_str(), true);


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
