### PR TITLE
[channel_init] Add grpc_init/shutdown to one test that sometimes needs it

### DIFF
--- a/test/core/surface/channel_init_test.cc
+++ b/test/core/surface/channel_init_test.cc
@@ -317,6 +317,7 @@ const NoInterceptor TestFilter1::Call::OnServerToClientMessage;
 const NoInterceptor TestFilter1::Call::OnFinalize;
 
 TEST(ChannelInitTest, CanCreateFilterWithCall) {
+  grpc::testing::TestGrpcScope g;
   ChannelInit::Builder b;
   b.RegisterFilter<TestFilter1>(GRPC_CLIENT_CHANNEL);
   auto init = b.Build();


### PR DESCRIPTION
This test very occasionally needs to have gRPC initialized, so adding the init/shutdown scope just where it's needed.