### PR TITLE
[tracing] Fix ERROR logging on Windows

### DIFF
--- a/src/core/lib/debug/trace_impl.h
+++ b/src/core/lib/debug/trace_impl.h
@@ -25,6 +25,10 @@
 
 #include <grpc/support/port_platform.h>
 
+#ifdef _WIN32
+#undef ERROR
+#endif
+
 void grpc_tracer_init();
 void grpc_tracer_shutdown(void);
 


### PR DESCRIPTION
See compilation errors for https://github.com/grpc/grpc/pull/37058/commits/67334ab421f4c9028c510522a22f7c6de32ee713

Windows headers do `#define ERROR 0`, which breaks abseil logging.