### PR TITLE
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/lib/event_engine/cf_engine/cf_engine.cc
+++ b/src/core/lib/event_engine/cf_engine/cf_engine.cc
@@ -21,6 +21,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 
 #include <grpc/support/cpu.h>
 
@@ -64,9 +65,9 @@ CFEventEngine::~CFEventEngine() {
     grpc_core::MutexLock lock(&task_mu_);
     if (GRPC_TRACE_FLAG_ENABLED(event_engine)) {
       for (auto handle : known_handles_) {
-        gpr_log(GPR_ERROR,
-                "CFEventEngine:%p uncleared TaskHandle at shutdown:%s", this,
-                HandleToString(handle).c_str());
+        LOG(ERROR) << "CFEventEngine:" << this
+                   << " uncleared TaskHandle at shutdown:"
+                   << HandleToString(handle);
       }
     }
     CHECK(GPR_LIKELY(known_handles_.empty()));

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -35,7 +35,6 @@
 #include <grpc/event_engine/memory_allocator.h>
 #include <grpc/event_engine/slice_buffer.h>
 #include <grpc/support/cpu.h>
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/debug/trace.h"
@@ -451,11 +450,9 @@ PosixEventEngine::~PosixEventEngine() {
     grpc_core::MutexLock lock(&mu_);
     if (GRPC_TRACE_FLAG_ENABLED(event_engine)) {
       for (auto handle : known_handles_) {
-        gpr_log(GPR_ERROR,
-                "(event_engine) PosixEventEngine:%p uncleared "
-                "TaskHandle at "
-                "shutdown:%s",
-                this, HandleToString(handle).c_str());
+        LOG(ERROR) << "(event_engine) PosixEventEngine:" << this
+                   << " uncleared TaskHandle at shutdown:"
+                   << HandleToString(handle);
       }
     }
     CHECK(GPR_LIKELY(known_handles_.empty()));

--- a/src/core/lib/event_engine/posix_engine/timer_manager.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.cc
@@ -22,10 +22,10 @@
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/time.h>
 
@@ -102,10 +102,9 @@ void TimerManager::TimerInit(Timer* timer, grpc_core::Timestamp deadline,
   if (GRPC_TRACE_FLAG_ENABLED(timer)) {
     grpc_core::MutexLock lock(&mu_);
     if (shutdown_) {
-      gpr_log(GPR_ERROR,
-              "WARNING: TimerManager::%p: scheduling Closure::%p after "
-              "TimerManager has been shut down.",
-              this, closure);
+      LOG(ERROR) << "WARNING: TimerManager::" << this
+                 << ": scheduling Closure::" << closure
+                 << " after TimerManager has been shut down.";
     }
   }
   timer_list_->TimerInit(timer, deadline, closure);
@@ -120,7 +119,7 @@ void TimerManager::Shutdown() {
     grpc_core::MutexLock lock(&mu_);
     if (shutdown_) return;
     if (GRPC_TRACE_FLAG_ENABLED(timer)) {
-      gpr_log(GPR_DEBUG, "TimerManager::%p shutting down", this);
+      VLOG(2) << "TimerManager::" << this << " shutting down";
     }
     shutdown_ = true;
     // Wait on the main loop to exit.
@@ -128,7 +127,7 @@ void TimerManager::Shutdown() {
   }
   main_loop_exit_signal_->WaitForNotification();
   if (GRPC_TRACE_FLAG_ENABLED(timer)) {
-    gpr_log(GPR_DEBUG, "TimerManager::%p shutdown complete", this);
+    VLOG(2) << "TimerManager::" << this << " shutdown complete";
   }
 }
 
@@ -146,7 +145,7 @@ void TimerManager::RestartPostFork() {
   grpc_core::MutexLock lock(&mu_);
   CHECK(GPR_LIKELY(shutdown_));
   if (GRPC_TRACE_FLAG_ENABLED(timer)) {
-    gpr_log(GPR_DEBUG, "TimerManager::%p restarting after shutdown", this);
+    VLOG(2) << "TimerManager::" << this << " restarting after shutdown";
   }
   shutdown_ = false;
   main_loop_exit_signal_.emplace();

--- a/src/core/lib/event_engine/windows/windows_endpoint.cc
+++ b/src/core/lib/event_engine/windows/windows_endpoint.cc
@@ -18,6 +18,7 @@
 #include "absl/cleanup/cleanup.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_format.h"
 
@@ -41,8 +42,7 @@ constexpr int kMaxWSABUFCount = 16;
 void DumpSliceBuffer(SliceBuffer* buffer, absl::string_view context_string) {
   for (size_t i = 0; i < buffer->Count(); i++) {
     auto str = buffer->MutableSliceAt(i).as_string_view();
-    gpr_log(GPR_INFO, "%s: %.*s", context_string.data(), str.length(),
-            str.data());
+    LOG(INFO) << context_string << ": " << str;
   }
 }
 
@@ -160,8 +160,8 @@ bool WindowsEndpoint::Write(absl::AnyInvocable<void(absl::Status)> on_writable,
   if (GRPC_TRACE_FLAG_ENABLED(event_engine_endpoint_data)) {
     for (size_t i = 0; i < data->Count(); i++) {
       auto str = data->RefSlice(i).as_string_view();
-      gpr_log(GPR_INFO, "WindowsEndpoint::%p WRITE (peer=%s): %.*s", this,
-              peer_address_string_.c_str(), str.length(), str.data());
+      LOG(INFO) << "WindowsEndpoint::" << this
+                << " WRITE (peer=" << peer_address_string_ << "): " << str;
     }
   }
   CHECK(data->Count() <= UINT_MAX);

--- a/src/core/lib/event_engine/windows/windows_engine.cc
+++ b/src/core/lib/event_engine/windows/windows_engine.cc
@@ -218,10 +218,9 @@ WindowsEventEngine::~WindowsEventEngine() {
     if (!known_handles_.empty()) {
       if (GRPC_TRACE_FLAG_ENABLED(event_engine)) {
         for (auto handle : known_handles_) {
-          gpr_log(GPR_ERROR,
-                  "WindowsEventEngine:%p uncleared TaskHandle at shutdown:%s",
-                  this,
-                  HandleToString<EventEngine::TaskHandle>(handle).c_str());
+          LOG(ERROR) << "WindowsEventEngine:" << this
+                     << " uncleared TaskHandle at shutdown:"
+                     << HandleToString<EventEngine::TaskHandle>(handle);
         }
       }
       // Allow a small grace period for timers to be run before shutting down.


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
