### PR TITLE
[thready_tsan] Enable thready_tsan on all microbenchmarks

### DIFF
--- a/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
+++ b/test/cpp/microbenchmarks/grpc_benchmark_config.bzl
@@ -45,7 +45,7 @@ def grpc_cc_benchmark(name, external_deps = [], tags = [], uses_polling = False,
         name = name,
         args = grpc_benchmark_args(),
         external_deps = ["benchmark"] + external_deps,
-        tags = tags + ["no_mac", "no_windows"],
+        tags = tags + ["no_mac", "no_windows", "thready_tsan"],
         uses_polling = uses_polling,
         uses_event_engine = uses_event_engine,
         # cc_binary defaults to 1, and we are interested in performance


### PR DESCRIPTION
These are great little canaries for threading issues, let's leverage them.