### PR TITLE
[grpc_trace] protect some log statements behind trace flags (#36956)

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -356,7 +356,8 @@ Epoll1Poller::Epoll1Poller(Scheduler* scheduler)
   wakeup_fd_ = *CreateWakeupFd();
   CHECK(wakeup_fd_ != nullptr);
   CHECK_GE(g_epoll_set_.epfd, 0);
-  LOG(INFO) << "grpc epoll fd: " << g_epoll_set_.epfd;
+  GRPC_TRACE_LOG(event_engine_poller, INFO)
+      << "grpc epoll fd: " << g_epoll_set_.epfd;
   struct epoll_event ev;
   ev.events = static_cast<uint32_t>(EPOLLIN | EPOLLET);
   ev.data.ptr = wakeup_fd_.get();

--- a/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/posix_engine/tcp_socket_utils.cc
@@ -627,12 +627,15 @@ void PosixSocketWrapper::TrySetSocketTcpUserTimeout(
     // if it is available.
     if (g_socket_supports_tcp_user_timeout.load() == 0) {
       if (0 != getsockopt(fd_, IPPROTO_TCP, TCP_USER_TIMEOUT, &newval, &len)) {
+        // This log is intentionally not protected behind a flag, so that users
+        // know that TCP_USER_TIMEOUT is not being used.
         LOG(INFO) << "TCP_USER_TIMEOUT is not available. TCP_USER_TIMEOUT "
                      "won't be used thereafter";
         g_socket_supports_tcp_user_timeout.store(-1);
       } else {
-        LOG(INFO) << "TCP_USER_TIMEOUT is available. TCP_USER_TIMEOUT will be "
-                     "used thereafter";
+        GRPC_TRACE_LOG(tcp, INFO)
+            << "TCP_USER_TIMEOUT is available. TCP_USER_TIMEOUT will be "
+               "used thereafter";
         g_socket_supports_tcp_user_timeout.store(1);
       }
     }

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -122,7 +122,7 @@ static bool epoll_set_init() {
     return false;
   }
 
-  gpr_log(GPR_INFO, "grpc epoll fd: %d", g_epoll_set.epfd);
+  GRPC_TRACE_LOG(polling, INFO) << "grpc epoll fd: " << g_epoll_set.epfd;
   gpr_atm_no_barrier_store(&g_epoll_set.num_events, 0);
   gpr_atm_no_barrier_store(&g_epoll_set.cursor, 0);
   return true;


### PR DESCRIPTION
Backport #36956 to 1.65

