### PR TITLE
[test-flake] Increase Ruby run_tests.py timeout to 20 minutes

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -905,7 +905,7 @@ class RubyLanguage(object):
         tests = [
             self.config.job_spec(
                 ["tools/run_tests/helper_scripts/run_ruby.sh"],
-                timeout_seconds=10 * 60,
+                timeout_seconds=20 * 60,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS,
             )
         ]


### PR DESCRIPTION
![7zfxqBLsQo8ciuq](https://github.com/grpc/grpc/assets/11674202/ceccb042-1b02-4199-9db8-3a82f7ef54c0)

Curiously, some of the Ruby sub-tests job were given a 20-minute timeout, while the main `run_ruby.sh` job was given a 10-minute timeout. All the current flakes have the `run_ruby.sh` job timeout at 10 minutes. So this PR tries to increase that limit to 20-minute to see if that helps.

```
GRPC::GenericService::Dsl
  can be included in new classes

GRPC::GenericService
  #underscore
    should convert CamelCase to underscore separated
  including it
    adds a class method, rpc
    adds rpc descs using the added class method, #rpc
    give subclasses access to #rpc_descs
    adds a default service name
    adds a default service name to subclasses
    adds the specified service name
    adds the specified service name to subclasses
  #include
    raises if #rpc is missing an arg
    is ok for services that expect the default {un,}marshal methods
    is ok for services that override the default {un,}marshal methods
    when #rpc args are incorrect
      raises if an arg does not have the marshal or unmarshal methods
      raises if a type arg only has the marshal method
      raises if a type arg only has the unmarshal method
  #rpc_stub_class
    generates a client class that defines any of the rpc methods
    the generated instances
I0000 00:00:1719872817.473215   21463 rb_grpc.c:331] GRPC_RUBY: grpc_ruby_init_threads g_bg_thread_init_done=1
      can be instanciated with just a hostname and credentials
I0000 00:00:1719872817.481099   21463 rb_grpc.c:331] GRPC_RUBY: grpc_ruby_init_threads g_bg_thread_init_done=1
      has the methods defined in the service

Finished in 0.83804 seconds (files took 0.51661 seconds to load)
150 examples, 0 failures

Coverage report generated for idiomatic, wrapper to /var/local/git/grpc/coverage. 1001 / 1110 LOC (90.18%) covered.

2024-07-01 22:36:20,441 TIMEOUT: tools/run_tests/helper_scripts/run_ruby.sh [pid=18527, time=604.5sec]
2024-07-01 22:36:20,442 FAILED: tools/run_tests/helper_scripts/run_ruby.sh
```