### PR TITLE
[promise] Remove support for moving-from an already started sequence or join

### DIFF
--- a/src/core/lib/promise/detail/join_state.h
+++ b/src/core/lib/promise/detail/join_state.h
@@ -67,16 +67,9 @@ struct JoinState<Traits, P0, P1> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -182,21 +175,10 @@ struct JoinState<Traits, P0, P1, P2> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -339,26 +321,11 @@ struct JoinState<Traits, P0, P1, P2, P3> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
-    if (ready.is_set(3)) {
-      Construct(&result3, std::move(other.result3));
-    } else {
-      Construct(&promise3, std::move(other.promise3));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
+    Construct(&promise3, std::move(other.promise3));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -537,31 +504,12 @@ struct JoinState<Traits, P0, P1, P2, P3, P4> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
-    if (ready.is_set(3)) {
-      Construct(&result3, std::move(other.result3));
-    } else {
-      Construct(&promise3, std::move(other.promise3));
-    }
-    if (ready.is_set(4)) {
-      Construct(&result4, std::move(other.result4));
-    } else {
-      Construct(&promise4, std::move(other.promise4));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
+    Construct(&promise3, std::move(other.promise3));
+    Construct(&promise4, std::move(other.promise4));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -776,36 +724,13 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
-    if (ready.is_set(3)) {
-      Construct(&result3, std::move(other.result3));
-    } else {
-      Construct(&promise3, std::move(other.promise3));
-    }
-    if (ready.is_set(4)) {
-      Construct(&result4, std::move(other.result4));
-    } else {
-      Construct(&promise4, std::move(other.promise4));
-    }
-    if (ready.is_set(5)) {
-      Construct(&result5, std::move(other.result5));
-    } else {
-      Construct(&promise5, std::move(other.promise5));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
+    Construct(&promise3, std::move(other.promise3));
+    Construct(&promise4, std::move(other.promise4));
+    Construct(&promise5, std::move(other.promise5));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -1056,41 +981,14 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5, P6> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
-    if (ready.is_set(3)) {
-      Construct(&result3, std::move(other.result3));
-    } else {
-      Construct(&promise3, std::move(other.promise3));
-    }
-    if (ready.is_set(4)) {
-      Construct(&result4, std::move(other.result4));
-    } else {
-      Construct(&promise4, std::move(other.promise4));
-    }
-    if (ready.is_set(5)) {
-      Construct(&result5, std::move(other.result5));
-    } else {
-      Construct(&promise5, std::move(other.promise5));
-    }
-    if (ready.is_set(6)) {
-      Construct(&result6, std::move(other.result6));
-    } else {
-      Construct(&promise6, std::move(other.promise6));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
+    Construct(&promise3, std::move(other.promise3));
+    Construct(&promise4, std::move(other.promise4));
+    Construct(&promise5, std::move(other.promise5));
+    Construct(&promise6, std::move(other.promise6));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -1377,46 +1275,15 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5, P6, P7> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
-    if (ready.is_set(3)) {
-      Construct(&result3, std::move(other.result3));
-    } else {
-      Construct(&promise3, std::move(other.promise3));
-    }
-    if (ready.is_set(4)) {
-      Construct(&result4, std::move(other.result4));
-    } else {
-      Construct(&promise4, std::move(other.promise4));
-    }
-    if (ready.is_set(5)) {
-      Construct(&result5, std::move(other.result5));
-    } else {
-      Construct(&promise5, std::move(other.promise5));
-    }
-    if (ready.is_set(6)) {
-      Construct(&result6, std::move(other.result6));
-    } else {
-      Construct(&promise6, std::move(other.promise6));
-    }
-    if (ready.is_set(7)) {
-      Construct(&result7, std::move(other.result7));
-    } else {
-      Construct(&promise7, std::move(other.promise7));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
+    Construct(&promise3, std::move(other.promise3));
+    Construct(&promise4, std::move(other.promise4));
+    Construct(&promise5, std::move(other.promise5));
+    Construct(&promise6, std::move(other.promise6));
+    Construct(&promise7, std::move(other.promise7));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {
@@ -1738,51 +1605,16 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5, P6, P7, P8> {
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
       : ready(other.ready) {
-    if (ready.is_set(0)) {
-      Construct(&result0, std::move(other.result0));
-    } else {
-      Construct(&promise0, std::move(other.promise0));
-    }
-    if (ready.is_set(1)) {
-      Construct(&result1, std::move(other.result1));
-    } else {
-      Construct(&promise1, std::move(other.promise1));
-    }
-    if (ready.is_set(2)) {
-      Construct(&result2, std::move(other.result2));
-    } else {
-      Construct(&promise2, std::move(other.promise2));
-    }
-    if (ready.is_set(3)) {
-      Construct(&result3, std::move(other.result3));
-    } else {
-      Construct(&promise3, std::move(other.promise3));
-    }
-    if (ready.is_set(4)) {
-      Construct(&result4, std::move(other.result4));
-    } else {
-      Construct(&promise4, std::move(other.promise4));
-    }
-    if (ready.is_set(5)) {
-      Construct(&result5, std::move(other.result5));
-    } else {
-      Construct(&promise5, std::move(other.promise5));
-    }
-    if (ready.is_set(6)) {
-      Construct(&result6, std::move(other.result6));
-    } else {
-      Construct(&promise6, std::move(other.promise6));
-    }
-    if (ready.is_set(7)) {
-      Construct(&result7, std::move(other.result7));
-    } else {
-      Construct(&promise7, std::move(other.promise7));
-    }
-    if (ready.is_set(8)) {
-      Construct(&result8, std::move(other.result8));
-    } else {
-      Construct(&promise8, std::move(other.promise8));
-    }
+    DCHECK(ready.none());
+    Construct(&promise0, std::move(other.promise0));
+    Construct(&promise1, std::move(other.promise1));
+    Construct(&promise2, std::move(other.promise2));
+    Construct(&promise3, std::move(other.promise3));
+    Construct(&promise4, std::move(other.promise4));
+    Construct(&promise5, std::move(other.promise5));
+    Construct(&promise6, std::move(other.promise6));
+    Construct(&promise7, std::move(other.promise7));
+    Construct(&promise8, std::move(other.promise8));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {
     if (ready.is_set(0)) {

--- a/src/core/lib/promise/detail/join_state.h
+++ b/src/core/lib/promise/detail/join_state.h
@@ -65,9 +65,8 @@ struct JoinState<Traits, P0, P1> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
   }
@@ -173,9 +172,8 @@ struct JoinState<Traits, P0, P1, P2> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));
@@ -319,9 +317,8 @@ struct JoinState<Traits, P0, P1, P2, P3> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));
@@ -502,9 +499,8 @@ struct JoinState<Traits, P0, P1, P2, P3, P4> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));
@@ -722,9 +718,8 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));
@@ -979,9 +974,8 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5, P6> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));
@@ -1273,9 +1267,8 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5, P6, P7> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));
@@ -1603,9 +1596,8 @@ struct JoinState<Traits, P0, P1, P2, P3, P4, P5, P6, P7, P8> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept
-      : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
     Construct(&promise0, std::move(other.promise0));
     Construct(&promise1, std::move(other.promise1));
     Construct(&promise2, std::move(other.promise2));

--- a/src/core/lib/promise/detail/seq_state.h
+++ b/src/core/lib/promise/detail/seq_state.h
@@ -122,23 +122,15 @@ struct SeqState<Traits, P, F0> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.next_factory, other.prior.next_factory);
   }
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -259,7 +251,7 @@ struct SeqState<Traits, P, F0, F1> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.next_factory, other.prior.prior.next_factory);
     Construct(&prior.next_factory, other.prior.next_factory);
@@ -267,23 +259,10 @@ struct SeqState<Traits, P, F0, F1> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail1:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -455,7 +434,7 @@ struct SeqState<Traits, P, F0, F1, F2> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.next_factory,
               other.prior.prior.prior.next_factory);
@@ -465,30 +444,12 @@ struct SeqState<Traits, P, F0, F1, F2> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail1:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail2:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -710,7 +671,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.next_factory);
@@ -722,37 +683,14 @@ struct SeqState<Traits, P, F0, F1, F2, F3> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail1:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail2:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail3:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -1033,7 +971,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.prior.next_factory);
@@ -1047,45 +985,16 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail1:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail2:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail3:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail4:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -1420,7 +1329,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.prior.prior.next_factory);
@@ -1436,55 +1345,19 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail1:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail2:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail3:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail4:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail5:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -1873,7 +1746,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.prior.prior.prior.next_factory);
@@ -1891,65 +1764,23 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail6;
-      case State::kState7:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
             other.prior.prior.prior.prior.prior.prior.prior.next_factory));
-  tail1:
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail2:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail3:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail4:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail5:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail6:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -2394,7 +2225,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
@@ -2415,75 +2246,26 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
-                          .current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail6;
-      case State::kState7:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail7;
-      case State::kState8:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .next_factory));
-  tail1:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
             other.prior.prior.prior.prior.prior.prior.prior.next_factory));
-  tail2:
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail3:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail4:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail5:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail6:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail7:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -2989,7 +2771,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
@@ -3014,86 +2796,30 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
-                          .current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail6;
-      case State::kState7:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail7;
-      case State::kState8:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail8;
-      case State::kState9:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.prior.prior.prior
                       .next_factory));
-  tail1:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .next_factory));
-  tail2:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
             other.prior.prior.prior.prior.prior.prior.prior.next_factory));
-  tail3:
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail4:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail5:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail6:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail7:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail8:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -3660,7 +3386,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
@@ -3689,97 +3415,34 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
-                          .current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail6;
-      case State::kState7:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail7;
-      case State::kState8:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail8;
-      case State::kState9:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail9;
-      case State::kState10:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .prior.prior.next_factory));
-  tail1:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.prior.prior.prior
                       .next_factory));
-  tail2:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .next_factory));
-  tail3:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
             other.prior.prior.prior.prior.prior.prior.prior.next_factory));
-  tail4:
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail5:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail6:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail7:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail8:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail9:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -4408,7 +4071,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
@@ -4441,108 +4104,38 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
-                          .current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail6;
-      case State::kState7:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail7;
-      case State::kState8:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail8;
-      case State::kState9:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail9;
-      case State::kState10:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail10;
-      case State::kState11:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .prior.prior.prior.next_factory));
-  tail1:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .prior.prior.next_factory));
-  tail2:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.prior.prior.prior
                       .next_factory));
-  tail3:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .next_factory));
-  tail4:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
             other.prior.prior.prior.prior.prior.prior.prior.next_factory));
-  tail5:
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail6:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail7:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail8:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail9:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail10:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =
@@ -5235,7 +4828,7 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11> {
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&prior.current_promise, other.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .prior.next_factory,
@@ -5272,120 +4865,42 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11> {
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
-    switch (state) {
-      case State::kState0:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
-                 .prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
-                          .prior.prior.prior.prior.current_promise));
-        goto tail0;
-      case State::kState1:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.prior.prior.current_promise));
-        goto tail1;
-      case State::kState2:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.prior.current_promise));
-        goto tail2;
-      case State::kState3:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior
-                       .current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .prior.prior.current_promise));
-        goto tail3;
-      case State::kState4:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
-                          .current_promise));
-        goto tail4;
-      case State::kState5:
-        Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.prior.prior.prior
-                                .current_promise));
-        goto tail5;
-      case State::kState6:
-        Construct(
-            &prior.prior.prior.prior.prior.prior.current_promise,
-            std::move(
-                other.prior.prior.prior.prior.prior.prior.current_promise));
-        goto tail6;
-      case State::kState7:
-        Construct(
-            &prior.prior.prior.prior.prior.current_promise,
-            std::move(other.prior.prior.prior.prior.prior.current_promise));
-        goto tail7;
-      case State::kState8:
-        Construct(&prior.prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.prior.current_promise));
-        goto tail8;
-      case State::kState9:
-        Construct(&prior.prior.prior.current_promise,
-                  std::move(other.prior.prior.prior.current_promise));
-        goto tail9;
-      case State::kState10:
-        Construct(&prior.prior.current_promise,
-                  std::move(other.prior.prior.current_promise));
-        goto tail10;
-      case State::kState11:
-        Construct(&prior.current_promise,
-                  std::move(other.prior.current_promise));
-        goto tail11;
-      case State::kState12:
-        Construct(&current_promise, std::move(other.current_promise));
-        return;
-    }
-  tail0:
+    DCHECK(state == State::kState0);
+    Construct(&prior.current_promise, std::move(other.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .prior.prior.prior.prior.next_factory));
-  tail1:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .prior.prior.prior.next_factory));
-  tail2:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .prior.prior.next_factory));
-  tail3:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.prior.prior.prior
                       .next_factory));
-  tail4:
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .next_factory));
-  tail5:
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
             other.prior.prior.prior.prior.prior.prior.prior.next_factory));
-  tail6:
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
-  tail7:
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
-  tail8:
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
-  tail9:
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
-  tail10:
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
-  tail11:
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState& operator=(SeqState&& other) =

--- a/src/core/lib/promise/detail/seq_state.h
+++ b/src/core/lib/promise/detail/seq_state.h
@@ -252,7 +252,7 @@ struct SeqState<Traits, P, F0, F1> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.current_promise, other.prior.prior.current_promise);
     Construct(&prior.prior.next_factory, other.prior.prior.next_factory);
     Construct(&prior.next_factory, other.prior.next_factory);
   }
@@ -260,7 +260,8 @@ struct SeqState<Traits, P, F0, F1> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.current_promise,
+              std::move(other.prior.prior.current_promise));
     Construct(&prior.prior.next_factory,
               std::move(other.prior.prior.next_factory));
     Construct(&prior.next_factory, std::move(other.prior.next_factory));
@@ -435,7 +436,8 @@ struct SeqState<Traits, P, F0, F1, F2> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.current_promise,
+              other.prior.prior.prior.current_promise);
     Construct(&prior.prior.prior.next_factory,
               other.prior.prior.prior.next_factory);
     Construct(&prior.prior.next_factory, other.prior.prior.next_factory);
@@ -445,7 +447,8 @@ struct SeqState<Traits, P, F0, F1, F2> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.current_promise,
+              std::move(other.prior.prior.prior.current_promise));
     Construct(&prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.next_factory));
     Construct(&prior.prior.next_factory,
@@ -672,7 +675,8 @@ struct SeqState<Traits, P, F0, F1, F2, F3> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.current_promise,
+              other.prior.prior.prior.prior.current_promise);
     Construct(&prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.next_factory);
     Construct(&prior.prior.prior.next_factory,
@@ -684,7 +688,8 @@ struct SeqState<Traits, P, F0, F1, F2, F3> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.prior.current_promise,
+              std::move(other.prior.prior.prior.prior.current_promise));
     Construct(&prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.next_factory));
     Construct(&prior.prior.prior.next_factory,
@@ -972,7 +977,8 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.prior.current_promise,
+              other.prior.prior.prior.prior.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.prior.next_factory);
     Construct(&prior.prior.prior.prior.next_factory,
@@ -986,7 +992,8 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.prior.prior.current_promise,
+              std::move(other.prior.prior.prior.prior.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.next_factory));
     Construct(&prior.prior.prior.prior.next_factory,
@@ -1330,7 +1337,8 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.prior.prior.current_promise,
+              other.prior.prior.prior.prior.prior.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.prior.prior.next_factory);
     Construct(&prior.prior.prior.prior.prior.next_factory,
@@ -1346,7 +1354,9 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(
+        &prior.prior.prior.prior.prior.prior.current_promise,
+        std::move(other.prior.prior.prior.prior.prior.prior.current_promise));
     Construct(
         &prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.next_factory));
@@ -1747,7 +1757,8 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.prior.prior.prior.current_promise,
+              other.prior.prior.prior.prior.prior.prior.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.next_factory,
               other.prior.prior.prior.prior.prior.prior.prior.next_factory);
     Construct(&prior.prior.prior.prior.prior.prior.next_factory,
@@ -1765,7 +1776,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(
+        &prior.prior.prior.prior.prior.prior.prior.current_promise,
+        std::move(
+            other.prior.prior.prior.prior.prior.prior.prior.current_promise));
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(
@@ -2226,7 +2240,9 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(
+        &prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
+        other.prior.prior.prior.prior.prior.prior.prior.prior.current_promise);
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         other.prior.prior.prior.prior.prior.prior.prior.prior.next_factory);
@@ -2247,7 +2263,9 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
+              std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
+                            .current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
                             .next_factory));
@@ -2772,7 +2790,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(
+        &prior.prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
+        other.prior.prior.prior.prior.prior.prior.prior.prior.prior
+            .current_promise);
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         other.prior.prior.prior.prior.prior.prior.prior.prior.prior
@@ -2797,7 +2818,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(
+        &prior.prior.prior.prior.prior.prior.prior.prior.prior.current_promise,
+        std::move(other.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                      .current_promise));
     Construct(
         &prior.prior.prior.prior.prior.prior.prior.prior.prior.next_factory,
         std::move(other.prior.prior.prior.prior.prior.prior.prior.prior.prior
@@ -3387,7 +3411,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                   .current_promise,
+              other.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                  .current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               other.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
@@ -3416,7 +3443,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                   .current_promise,
+              std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
+                            .prior.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
@@ -4072,7 +4102,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                   .current_promise,
+              other.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                  .prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               other.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
@@ -4105,7 +4138,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                   .current_promise,
+              std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
+                            .prior.prior.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
@@ -4829,7 +4865,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, other.prior.current_promise);
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                   .prior.current_promise,
+              other.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                  .prior.prior.current_promise);
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .prior.next_factory,
               other.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
@@ -4866,7 +4905,10 @@ struct SeqState<Traits, P, F0, F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11> {
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept
       : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&prior.current_promise, std::move(other.prior.current_promise));
+    Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
+                   .prior.current_promise,
+              std::move(other.prior.prior.prior.prior.prior.prior.prior.prior
+                            .prior.prior.prior.prior.current_promise));
     Construct(&prior.prior.prior.prior.prior.prior.prior.prior.prior.prior.prior
                    .prior.next_factory,
               std::move(other.prior.prior.prior.prior.prior.prior.prior.prior

--- a/tools/codegen/core/gen_join.py
+++ b/tools/codegen/core/gen_join.py
@@ -46,8 +46,8 @@ struct JoinState<Traits, ${",".join(f"P{i}" for i in range(0,n))}> {
   }
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
-  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept : ready(other.ready) {
-    DCHECK(ready.none());
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept {
+    DCHECK(other.ready.none());
 % for i in range(0,n):
     Construct(&promise${i}, std::move(other.promise${i}));
 % endfor

--- a/tools/codegen/core/gen_join.py
+++ b/tools/codegen/core/gen_join.py
@@ -47,12 +47,9 @@ struct JoinState<Traits, ${",".join(f"P{i}" for i in range(0,n))}> {
   JoinState& operator=(const JoinState& other) = delete;
   JoinState& operator=(JoinState&& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION JoinState(JoinState&& other) noexcept : ready(other.ready) {
+    DCHECK(ready.none());
 % for i in range(0,n):
-    if (ready.is_set(${i})) {
-      Construct(&result${i}, std::move(other.result${i}));
-    } else {
-      Construct(&promise${i}, std::move(other.promise${i}));
-    }
+    Construct(&promise${i}, std::move(other.promise${i}));
 % endfor
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION ~JoinState() {

--- a/tools/codegen/core/gen_seq.py
+++ b/tools/codegen/core/gen_seq.py
@@ -110,7 +110,7 @@ tail${i}:
 % endfor
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept : state(other.state), whence(other.whence) {
-    CHECK(state == State::kState0);
+    DCHECK(state == State::kState0);
     Construct(&${"prior."*(n-1-i)}current_promise,
             other.${"prior."*(n-1-i)}current_promise);
 % for i in range(0,n-1):
@@ -120,19 +120,10 @@ tail${i}:
   }
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept : state(other.state), whence(other.whence) {
-    switch (state) {
+    DCHECK(state == State::kState0);
+    Construct(&${"prior."*(n-1-i)}current_promise,
+              std::move(other.${"prior."*(n-1-i)}current_promise));
 % for i in range(0,n-1):
-     case State::kState${i}:
-      Construct(&${"prior."*(n-1-i)}current_promise,
-                std::move(other.${"prior."*(n-1-i)}current_promise));
-      goto tail${i};
-% endfor
-     case State::kState${n-1}:
-      Construct(&current_promise, std::move(other.current_promise));
-      return;
-    }
-% for i in range(0,n-1):
-tail${i}:
     Construct(&${"prior."*(n-1-i)}next_factory,
               std::move(other.${"prior."*(n-1-i)}next_factory));
 % endfor

--- a/tools/codegen/core/gen_seq.py
+++ b/tools/codegen/core/gen_seq.py
@@ -111,8 +111,8 @@ tail${i}:
   }
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(const SeqState& other) noexcept : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&${"prior."*(n-1-i)}current_promise,
-            other.${"prior."*(n-1-i)}current_promise);
+    Construct(&${"prior."*(n-1)}current_promise,
+            other.${"prior."*(n-1)}current_promise);
 % for i in range(0,n-1):
     Construct(&${"prior."*(n-1-i)}next_factory,
               other.${"prior."*(n-1-i)}next_factory);
@@ -121,8 +121,8 @@ tail${i}:
   SeqState& operator=(const SeqState& other) = delete;
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION SeqState(SeqState&& other) noexcept : state(other.state), whence(other.whence) {
     DCHECK(state == State::kState0);
-    Construct(&${"prior."*(n-1-i)}current_promise,
-              std::move(other.${"prior."*(n-1-i)}current_promise));
+    Construct(&${"prior."*(n-1)}current_promise,
+              std::move(other.${"prior."*(n-1)}current_promise));
 % for i in range(0,n-1):
     Construct(&${"prior."*(n-1-i)}next_factory,
               std::move(other.${"prior."*(n-1-i)}next_factory));


### PR DESCRIPTION
I added this support about a year ago experimentally, but we don't need it. Removing it results in much simpler codegen.