### PR TITLE
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/lib/event_engine/ares_resolver.h
+++ b/src/core/lib/event_engine/ares_resolver.h
@@ -47,11 +47,12 @@
 namespace grpc_event_engine {
 namespace experimental {
 
-#define GRPC_ARES_RESOLVER_TRACE_LOG(format, ...)                              \
-  do {                                                                         \
-    if (GRPC_TRACE_FLAG_ENABLED(cares_resolver)) {                             \
-      gpr_log(GPR_INFO, "(EventEngine c-ares resolver) " format, __VA_ARGS__); \
-    }                                                                          \
+#define GRPC_ARES_RESOLVER_TRACE_LOG(format, ...)        \
+  do {                                                   \
+    if (GRPC_TRACE_FLAG_ENABLED(cares_resolver)) {       \
+      LOG(INFO) << "(EventEngine c-ares resolver) "      \
+                << absl::StrFormat(format, __VA_ARGS__); \
+    }                                                    \
   } while (0)
 
 class AresResolver : public RefCountedDNSResolverInterface {


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
