### PR TITLE
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/ext/filters/backend_metrics/backend_metric_filter.cc
+++ b/src/core/ext/filters/backend_metrics/backend_metric_filter.cc
@@ -24,13 +24,13 @@
 #include <memory>
 #include <utility>
 
+#include "absl/log/log.h"
 #include "absl/strings/string_view.h"
 #include "upb/base/string_view.h"
 #include "upb/mem/arena.hpp"
 #include "xds/data/orca/v3/orca_load_report.upb.h"
 
 #include <grpc/impl/channel_arg_names.h>
-#include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/promise_based_filter.h"
@@ -129,20 +129,20 @@ void BackendMetricFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
   auto* ctx = MaybeGetContext<BackendMetricProvider>();
   if (ctx == nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric_filter)) {
-      gpr_log(GPR_INFO, "[%p] No BackendMetricProvider.", this);
+      LOG(INFO) << "[" << this << "] No BackendMetricProvider.";
     }
     return;
   }
   absl::optional<std::string> serialized = MaybeSerializeBackendMetrics(ctx);
   if (serialized.has_value() && !serialized->empty()) {
     if (GRPC_TRACE_FLAG_ENABLED(backend_metric_filter)) {
-      gpr_log(GPR_INFO, "[%p] Backend metrics serialized. size: %" PRIuPTR,
-              this, serialized->size());
+      LOG(INFO) << "[" << this
+                << "] Backend metrics serialized. size: " << serialized->size();
     }
     md.Set(EndpointLoadMetricsBinMetadata(),
            Slice::FromCopiedString(std::move(*serialized)));
   } else if (GRPC_TRACE_FLAG_ENABLED(backend_metric_filter)) {
-    gpr_log(GPR_INFO, "[%p] No backend metrics.", this);
+    LOG(INFO) << "[" << this << "] No backend metrics.";
   }
 }
 

--- a/src/core/ext/filters/fault_injection/fault_injection_filter.cc
+++ b/src/core/ext/filters/fault_injection/fault_injection_filter.cc
@@ -27,6 +27,7 @@
 #include <type_traits>
 #include <utility>
 
+#include "absl/log/log.h"
 #include "absl/meta/type_traits.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -36,7 +37,6 @@
 #include "absl/types/optional.h"
 
 #include <grpc/status.h>
-#include <grpc/support/log.h>
 
 #include "src/core/ext/filters/fault_injection/fault_injection_service_config_parser.h"
 #include "src/core/lib/channel/channel_stack.h"
@@ -151,8 +151,8 @@ ArenaPromise<absl::Status> FaultInjectionFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, FaultInjectionFilter* filter) {
   auto decision = filter->MakeInjectionDecision(md);
   if (GRPC_TRACE_FLAG_ENABLED(fault_injection_filter)) {
-    gpr_log(GPR_INFO, "chand=%p: Fault injection triggered %s", this,
-            decision.ToString().c_str());
+    LOG(INFO) << "chand=" << this << ": Fault injection triggered "
+              << decision.ToString();
   }
   auto delay = decision.DelayUntil();
   return TrySeq(Sleep(delay), [decision = std::move(decision)]() {

--- a/src/core/ext/filters/http/message_compress/compression_filter.cc
+++ b/src/core/ext/filters/http/message_compress/compression_filter.cc
@@ -32,7 +32,6 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/impl/compression_types.h>
-#include <grpc/support/log.h>
 
 #include "src/core/ext/filters/message_size/message_size_filter.h"
 #include "src/core/lib/channel/channel_args.h"
@@ -104,9 +103,8 @@ ChannelCompression::ChannelCompression(const ChannelArgs& args)
                                          &name)) {
       name = "<unknown>";
     }
-    gpr_log(GPR_ERROR,
-            "default compression algorithm %s not enabled: switching to none",
-            name);
+    LOG(ERROR) << "default compression algorithm " << name
+               << " not enabled: switching to none";
     default_compression_algorithm_ = GRPC_COMPRESS_NONE;
   }
 }
@@ -114,8 +112,8 @@ ChannelCompression::ChannelCompression(const ChannelArgs& args)
 MessageHandle ChannelCompression::CompressMessage(
     MessageHandle message, grpc_compression_algorithm algorithm) const {
   if (GRPC_TRACE_FLAG_ENABLED(compression)) {
-    gpr_log(GPR_INFO, "CompressMessage: len=%" PRIdPTR " alg=%d flags=%d",
-            message->payload()->Length(), algorithm, message->flags());
+    LOG(INFO) << "CompressMessage: len=" << message->payload()->Length()
+              << " alg=" << algorithm << " flags=" << message->flags();
   }
   auto* call_tracer = MaybeGetContext<CallTracerInterface>();
   if (call_tracer != nullptr) {
@@ -144,10 +142,9 @@ MessageHandle ChannelCompression::CompressMessage(
       const float savings_ratio = 1.0f - static_cast<float>(after_size) /
                                              static_cast<float>(before_size);
       CHECK(grpc_compression_algorithm_name(algorithm, &algo_name));
-      gpr_log(GPR_INFO,
-              "Compressed[%s] %" PRIuPTR " bytes vs. %" PRIuPTR
-              " bytes (%.2f%% savings)",
-              algo_name, before_size, after_size, 100 * savings_ratio);
+      LOG(INFO) << "Compressed[" << algo_name << "] " << before_size
+                << " bytes vs. " << after_size << " bytes ("
+                << 100 * savings_ratio << "% savings)";
     }
     tmp.Swap(payload);
     flags |= GRPC_WRITE_INTERNAL_COMPRESS;
@@ -158,10 +155,9 @@ MessageHandle ChannelCompression::CompressMessage(
     if (GRPC_TRACE_FLAG_ENABLED(compression)) {
       const char* algo_name;
       CHECK(grpc_compression_algorithm_name(algorithm, &algo_name));
-      gpr_log(GPR_INFO,
-              "Algorithm '%s' enabled but decided not to compress. Input size: "
-              "%" PRIuPTR,
-              algo_name, payload->Length());
+      LOG(INFO) << "Algorithm '" << algo_name
+                << "' enabled but decided not to compress. Input size: "
+                << payload->Length();
     }
   }
   return message;
@@ -170,9 +166,9 @@ MessageHandle ChannelCompression::CompressMessage(
 absl::StatusOr<MessageHandle> ChannelCompression::DecompressMessage(
     bool is_client, MessageHandle message, DecompressArgs args) const {
   if (GRPC_TRACE_FLAG_ENABLED(compression)) {
-    gpr_log(GPR_INFO, "DecompressMessage: len=%" PRIdPTR " max=%d alg=%d",
-            message->payload()->Length(),
-            args.max_recv_message_length.value_or(-1), args.algorithm);
+    LOG(INFO) << "DecompressMessage: len=" << message->payload()->Length()
+              << " max=" << args.max_recv_message_length.value_or(-1)
+              << " alg=" << args.algorithm;
   }
   auto* call_tracer = MaybeGetContext<CallTracerInterface>();
   if (call_tracer != nullptr) {

--- a/src/core/ext/filters/http/message_compress/compression_filter.cc
+++ b/src/core/ext/filters/http/message_compress/compression_filter.cc
@@ -142,9 +142,10 @@ MessageHandle ChannelCompression::CompressMessage(
       const float savings_ratio = 1.0f - static_cast<float>(after_size) /
                                              static_cast<float>(before_size);
       CHECK(grpc_compression_algorithm_name(algorithm, &algo_name));
-      LOG(INFO) << "Compressed[" << algo_name << "] " << before_size
-                << " bytes vs. " << after_size << " bytes ("
-                << 100 * savings_ratio << "% savings)";
+      LOG(INFO) << absl::StrFormat(
+          "Compressed[%s] %" PRIuPTR " bytes vs. %" PRIuPTR
+          " bytes (%.2f%% savings)",
+          algo_name, before_size, after_size, 100 * savings_ratio);
     }
     tmp.Swap(payload);
     flags |= GRPC_WRITE_INTERNAL_COMPRESS;

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -25,12 +25,12 @@
 #include <utility>
 
 #include "absl/base/attributes.h"
+#include "absl/log/log.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/status.h>
-#include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_stack.h"
@@ -140,8 +140,8 @@ ServerMetadataHandle HttpServerFilter::Call::OnClientInitialMetadata(
 
 void HttpServerFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
   if (GRPC_TRACE_FLAG_ENABLED(call)) {
-    gpr_log(GPR_INFO, "%s[http-server] Write metadata",
-            GetContext<Activity>()->DebugTag().c_str());
+    LOG(INFO) << GetContext<Activity>()->DebugTag()
+              << "[http-server] Write metadata";
   }
   FilterOutgoingMetadata(&md);
   md.Set(HttpStatusMetadata(), 200);

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
@@ -41,7 +42,6 @@
 #include <grpc/grpc_security.h>
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/status.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
 #include "src/core/ext/filters/load_reporting/registered_opencensus_objects.h"
@@ -103,26 +103,23 @@ std::string GetCensusSafeClientIpString(
   // Find the client URI string.
   const Slice* client_uri_slice = initial_metadata.get_pointer(PeerString());
   if (client_uri_slice == nullptr) {
-    gpr_log(GPR_ERROR,
-            "Unable to extract client URI string (peer string) from gRPC "
-            "metadata.");
+    LOG(ERROR) << "Unable to extract client URI string (peer string) from gRPC "
+                  "metadata.";
     return "";
   }
   absl::StatusOr<URI> client_uri =
       URI::Parse(client_uri_slice->as_string_view());
   if (!client_uri.ok()) {
-    gpr_log(GPR_ERROR,
-            "Unable to parse the client URI string (peer string) to a client "
-            "URI. Error: %s",
-            client_uri.status().ToString().c_str());
+    LOG(ERROR) << "Unable to parse the client URI string (peer string) to a "
+                  "client URI. Error: "
+               << client_uri.status();
     return "";
   }
   // Parse the client URI into grpc_resolved_address.
   grpc_resolved_address resolved_address;
   bool success = grpc_parse_uri(*client_uri, &resolved_address);
   if (!success) {
-    gpr_log(GPR_ERROR,
-            "Unable to parse client URI into a grpc_resolved_address.");
+    LOG(ERROR) << "Unable to parse client URI into a grpc_resolved_address.";
     return "";
   }
   // Convert the socket address in the grpc_resolved_address into a hex string

--- a/src/core/ext/filters/logging/logging_filter.cc
+++ b/src/core/ext/filters/logging/logging_filter.cc
@@ -46,7 +46,6 @@
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/slice.h>
 #include <grpc/status.h>
-#include <grpc/support/log.h>
 
 #include "src/core/client_channel/client_channel_filter.h"
 #include "src/core/ext/filters/logging/logging_sink.h"
@@ -106,11 +105,9 @@ class MetadataEncoder {
     }
     uint64_t mdentry_len = key.length() + value.length();
     if (mdentry_len > log_len_) {
-      gpr_log(
-          GPR_DEBUG,
-          "Skipped metadata key because of max metadata logging bytes %" PRIu64
-          " (current) vs %" PRIu64 " (max less already accounted metadata)",
-          mdentry_len, log_len_);
+      VLOG(2) << "Skipped metadata key because of max metadata logging bytes "
+              << mdentry_len << " (current) vs " << log_len_
+              << " (max less already accounted metadata)";
       truncated_ = true;
       return;
     }

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -23,11 +23,11 @@
 #include <functional>
 #include <utility>
 
+#include "absl/log/log.h"
 #include "absl/strings/str_format.h"
 
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/status.h>
-#include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_stack.h"
@@ -160,9 +160,9 @@ ServerMetadataHandle CheckPayload(const Message& msg,
                                   bool is_client, bool is_send) {
   if (!max_length.has_value()) return nullptr;
   if (GRPC_TRACE_FLAG_ENABLED(call)) {
-    gpr_log(GPR_INFO, "%s[message_size] %s len:%" PRIdPTR " max:%d",
-            GetContext<Activity>()->DebugTag().c_str(),
-            is_send ? "send" : "recv", msg.payload()->Length(), *max_length);
+    LOG(INFO) << GetContext<Activity>()->DebugTag() << "[message_size] "
+              << (is_send ? "send" : "recv")
+              << " len:" << msg.payload()->Length() << " max:" << *max_length;
   }
   if (msg.payload()->Length() <= *max_length) return nullptr;
   auto r = Arena::MakePooled<ServerMetadata>();


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
