### PR TITLE
[CSM] Increase CPP PSM CSM timeout to 180min (v1.65.x backport)

### DIFF
--- a/tools/internal_ci/linux/psm-csm.cfg
+++ b/tools/internal_ci/linux/psm-csm.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
Backport of #37154 to v1.65.x.
---
Pyhton timeout was already set to 240min:
https://github.com/grpc/grpc/blob/3e8cdb9f396f290cc8725fe9e6180c37542d9e40/tools/internal_ci/linux/psm-csm-python.cfg#L19
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

