### PR TITLE
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -594,6 +594,7 @@ grpc_cc_library(
     external_deps = [
         "absl/base:core_headers",
         "absl/log:check",
+        "absl/log:log",
         "absl/strings",
         "absl/strings:str_format",
     ],

--- a/src/core/lib/promise/for_each.h
+++ b/src/core/lib/promise/for_each.h
@@ -173,15 +173,14 @@ class ForEach {
 
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION Poll<Result> PollReaderNext() {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%s PollReaderNext", DebugTag().c_str());
+      LOG(INFO) << DebugTag() << " PollReaderNext";
     }
     auto r = reader_next_();
     if (auto* p = r.value_if_ready()) {
       switch (NextValueTraits<ReaderResult>::Type(*p)) {
         case NextValueType::kValue: {
           if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-            gpr_log(GPR_INFO, "%s PollReaderNext: got value",
-                    DebugTag().c_str());
+            LOG(INFO) << DebugTag() << " PollReaderNext: got value";
           }
           Destruct(&reader_next_);
           auto action = action_factory_.Make(
@@ -192,15 +191,13 @@ class ForEach {
         }
         case NextValueType::kEndOfStream: {
           if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-            gpr_log(GPR_INFO, "%s PollReaderNext: got end of stream",
-                    DebugTag().c_str());
+            LOG(INFO) << DebugTag() << " PollReaderNext: got end of stream";
           }
           return Done<Result>::Make(false);
         }
         case NextValueType::kError: {
           if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-            gpr_log(GPR_INFO, "%s PollReaderNext: got error",
-                    DebugTag().c_str());
+            LOG(INFO) << DebugTag() << " PollReaderNext: got error";
           }
           return Done<Result>::Make(true);
         }
@@ -211,7 +208,7 @@ class ForEach {
 
   Poll<Result> PollAction() {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%s PollAction", DebugTag().c_str());
+      LOG(INFO) << DebugTag() << " PollAction";
     }
     auto r = in_action_.promise();
     if (auto* p = r.value_if_ready()) {

--- a/src/core/lib/promise/for_each.h
+++ b/src/core/lib/promise/for_each.h
@@ -21,10 +21,10 @@
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/debug/trace.h"

--- a/src/core/lib/promise/inter_activity_latch.h
+++ b/src/core/lib/promise/inter_activity_latch.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 
 #include <grpc/support/port_platform.h>

--- a/src/core/lib/promise/inter_activity_latch.h
+++ b/src/core/lib/promise/inter_activity_latch.h
@@ -22,7 +22,6 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/strings/str_cat.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/debug/trace.h"
@@ -46,8 +45,7 @@ class InterActivityLatch {
     return [this]() -> Poll<T> {
       MutexLock lock(&mu_);
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_INFO, "%sPollWait %s", DebugTag().c_str(),
-                StateString().c_str());
+        LOG(INFO) << DebugTag() << "PollWait " << StateString();
       }
       if (is_set_) {
         return std::move(value_);
@@ -62,7 +60,7 @@ class InterActivityLatch {
   void Set(T value) {
     MutexLock lock(&mu_);
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%sSet %s", DebugTag().c_str(), StateString().c_str());
+      LOG(INFO) << DebugTag() << "Set " << StateString();
     }
     is_set_ = true;
     value_ = std::move(value);
@@ -104,8 +102,7 @@ class InterActivityLatch<void> {
     return [this]() -> Poll<Empty> {
       MutexLock lock(&mu_);
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_INFO, "%sPollWait %s", DebugTag().c_str(),
-                StateString().c_str());
+        LOG(INFO) << DebugTag() << "PollWait " << StateString();
       }
       if (is_set_) {
         return Empty{};
@@ -120,7 +117,7 @@ class InterActivityLatch<void> {
   void Set() {
     MutexLock lock(&mu_);
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%sSet %s", DebugTag().c_str(), StateString().c_str());
+      LOG(INFO) << DebugTag() << "Set " << StateString();
     }
     is_set_ = true;
     waiters_.WakeupAsync();

--- a/src/core/lib/promise/interceptor_list.h
+++ b/src/core/lib/promise/interceptor_list.h
@@ -23,11 +23,11 @@
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/optional.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/gprpp/construct_destruct.h"

--- a/src/core/lib/promise/interceptor_list.h
+++ b/src/core/lib/promise/interceptor_list.h
@@ -88,8 +88,8 @@ class InterceptorList {
     RunPromise(size_t memory_required, Map** factory, absl::optional<T> value) {
       if (!value.has_value() || *factory == nullptr) {
         if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-          gpr_log(GPR_DEBUG,
-                  "InterceptorList::RunPromise[%p]: create immediate", this);
+          VLOG(2) << "InterceptorList::RunPromise[" << this
+                  << "]: create immediate";
         }
         is_immediately_resolved_ = true;
         Construct(&result_, std::move(value));
@@ -101,16 +101,15 @@ class InterceptorList {
         async_resolution_.current_factory = *factory;
         async_resolution_.first_factory = factory;
         if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-          gpr_log(GPR_DEBUG,
-                  "InterceptorList::RunPromise[%p]: create async; mem=%p", this,
-                  async_resolution_.space.get());
+          VLOG(2) << "InterceptorList::RunPromise[" << this
+                  << "]: create async; mem=" << async_resolution_.space.get();
         }
       }
     }
 
     ~RunPromise() {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_DEBUG, "InterceptorList::RunPromise[%p]: destroy", this);
+        VLOG(2) << "InterceptorList::RunPromise[" << this << "]: destroy";
       }
       if (is_immediately_resolved_) {
         Destruct(&result_);
@@ -129,8 +128,8 @@ class InterceptorList {
     RunPromise(RunPromise&& other) noexcept
         : is_immediately_resolved_(other.is_immediately_resolved_) {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_DEBUG, "InterceptorList::RunPromise[%p]: move from %p",
-                this, &other);
+        VLOG(2) << "InterceptorList::RunPromise[" << this << "]: move from "
+                << &other;
       }
       if (is_immediately_resolved_) {
         Construct(&result_, std::move(other.result_));
@@ -143,8 +142,8 @@ class InterceptorList {
 
     Poll<absl::optional<T>> operator()() {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_DEBUG, "InterceptorList::RunPromise[%p]: %s", this,
-                DebugString().c_str());
+        VLOG(2) << "InterceptorList::RunPromise[" << this
+                << "]: " << DebugString();
       }
       if (is_immediately_resolved_) return std::move(result_);
       while (true) {
@@ -161,8 +160,8 @@ class InterceptorList {
               async_resolution_.current_factory->next();
           if (!p->has_value()) async_resolution_.current_factory = nullptr;
           if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-            gpr_log(GPR_DEBUG, "InterceptorList::RunPromise[%p]: %s", this,
-                    DebugString().c_str());
+            VLOG(2) << "InterceptorList::RunPromise[" << this
+                    << "]: " << DebugString();
           }
           if (async_resolution_.current_factory == nullptr) {
             return std::move(*p);

--- a/src/core/lib/promise/latch.h
+++ b/src/core/lib/promise/latch.h
@@ -22,9 +22,9 @@
 #include <utility>
 
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_cat.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/debug/trace.h"
@@ -68,8 +68,7 @@ class Latch {
 #endif
     return [this]() -> Poll<T> {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_INFO, "%sWait %s", DebugTag().c_str(),
-                StateString().c_str());
+        LOG(INFO) << DebugTag() << "Wait " << StateString();
       }
       if (has_value_) {
         return std::move(value_);
@@ -87,8 +86,7 @@ class Latch {
 #endif
     return [this]() -> Poll<T> {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_INFO, "%sWaitAndCopy %s", DebugTag().c_str(),
-                StateString().c_str());
+        LOG(INFO) << DebugTag() << "WaitAndCopy " << StateString();
       }
       if (has_value_) {
         return value_;
@@ -101,7 +99,7 @@ class Latch {
   // Set the value of the latch. Can only be called once.
   void Set(T value) {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%sSet %s", DebugTag().c_str(), StateString().c_str());
+      LOG(INFO) << DebugTag() << "Set " << StateString();
     }
     DCHECK(!has_value_);
     value_ = std::move(value);
@@ -164,8 +162,7 @@ class Latch<void> {
 #endif
     return [this]() -> Poll<Empty> {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_INFO, "%sPollWait %s", DebugTag().c_str(),
-                StateString().c_str());
+        LOG(INFO) << DebugTag() << "PollWait " << StateString();
       }
       if (is_set_) {
         return Empty{};
@@ -178,7 +175,7 @@ class Latch<void> {
   // Set the latch. Can only be called once.
   void Set() {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%sSet %s", DebugTag().c_str(), StateString().c_str());
+      LOG(INFO) << DebugTag() << "Set " << StateString();
     }
     DCHECK(!is_set_);
     is_set_ = true;
@@ -227,8 +224,7 @@ class ExternallyObservableLatch<void> {
   auto Wait() {
     return [this]() -> Poll<Empty> {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_INFO, "%sPollWait %s", DebugTag().c_str(),
-                StateString().c_str());
+        LOG(INFO) << DebugTag() << "PollWait " << StateString();
       }
       if (IsSet()) {
         return Empty{};
@@ -241,7 +237,7 @@ class ExternallyObservableLatch<void> {
   // Set the latch.
   void Set() {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%sSet %s", DebugTag().c_str(), StateString().c_str());
+      LOG(INFO) << DebugTag() << "Set " << StateString();
     }
     is_set_.store(true, std::memory_order_relaxed);
     waiter_.Wake();
@@ -251,8 +247,7 @@ class ExternallyObservableLatch<void> {
 
   void Reset() {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%sReset %s", DebugTag().c_str(),
-              StateString().c_str());
+      LOG(INFO) << DebugTag() << "Reset " << StateString();
     }
     is_set_.store(false, std::memory_order_relaxed);
   }

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -287,16 +287,14 @@ bool Party::RunOneParticipant(int i) {
   auto* participant = participants_[i].load(std::memory_order_acquire);
   if (participant == nullptr) {
     if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-      gpr_log(GPR_INFO, "%s[party] wakeup %d already complete",
-              DebugTag().c_str(), i);
+      LOG(INFO) << DebugTag() << "[party] wakeup " << i << " already complete";
     }
     return false;
   }
   absl::string_view name;
   if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
     name = participant->name();
-    gpr_log(GPR_INFO, "%s[%s] begin job %d", DebugTag().c_str(),
-            std::string(name).c_str(), i);
+    LOG(INFO) << DebugTag() << "[" << name << "] begin job " << i;
   }
   // Poll the participant.
   currently_polling_ = i;
@@ -304,13 +302,12 @@ bool Party::RunOneParticipant(int i) {
   currently_polling_ = kNotPolling;
   if (done) {
     if (!name.empty()) {
-      gpr_log(GPR_INFO, "%s[%s] end poll and finish job %d", DebugTag().c_str(),
-              std::string(name).c_str(), i);
+      LOG(INFO) << DebugTag() << "[" << name << "] end poll and finish job "
+                << i;
     }
     participants_[i].store(nullptr, std::memory_order_relaxed);
   } else if (!name.empty()) {
-    gpr_log(GPR_INFO, "%s[%s] end poll", DebugTag().c_str(),
-            std::string(name).c_str());
+    LOG(INFO) << DebugTag() << "[" << name << "] end poll";
   }
   return done;
 }
@@ -320,11 +317,9 @@ void Party::AddParticipants(Participant** participants, size_t count) {
                                                        count](size_t* slots) {
     for (size_t i = 0; i < count; i++) {
       if (GRPC_TRACE_FLAG_ENABLED(party_state)) {
-        gpr_log(GPR_INFO,
-                "Party %p                 AddParticipant: %s @ %" PRIdPTR
-                " [participant=%p]",
-                &sync_, std::string(participants[i]->name()).c_str(), slots[i],
-                participants[i]);
+        LOG(INFO) << "Party " << &sync_ << "                 AddParticipant: "
+                  << participants[i]->name() << " @ " << slots[i]
+                  << " [participant=" << participants[i] << "]";
       }
       participants_[slots[i]].store(participants[i], std::memory_order_release);
     }

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -18,9 +18,9 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/str_format.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/event_engine/event_engine_context.h"

--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -25,10 +25,10 @@
 #include "absl/base/attributes.h"
 #include "absl/base/thread_annotations.h"
 #include "absl/log/check.h"
+#include "absl/log/log.h"
 #include "absl/strings/string_view.h"
 
 #include <grpc/event_engine/event_engine.h>
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/debug/trace.h"

--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -227,8 +227,8 @@ class PartySyncUsingAtomics {
                       DebugLocation loc = {}) {
     if (GRPC_TRACE_FLAG_ENABLED(party_state)) {
       LOG(INFO).AtLocation(loc.file(), loc.line())
-          << "Party " << this << " " << op << ": " << prev_state << " -> "
-          << new_state;
+          << absl::StrFormat("Party %p %30s: %016" PRIx64 " -> %016" PRIx64,
+                             this, op, prev_state, new_state);
     }
   }
 

--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -226,9 +226,9 @@ class PartySyncUsingAtomics {
   void LogStateChange(const char* op, uint64_t prev_state, uint64_t new_state,
                       DebugLocation loc = {}) {
     if (GRPC_TRACE_FLAG_ENABLED(party_state)) {
-      gpr_log(loc.file(), loc.line(), GPR_LOG_SEVERITY_INFO,
-              "Party %p %30s: %016" PRIx64 " -> %016" PRIx64, this, op,
-              prev_state, new_state);
+      LOG(INFO).AtLocation(loc.file(), loc.line())
+          << "Party " << this << " " << op << ": " << prev_state << " -> "
+          << new_state;
     }
   }
 

--- a/src/core/lib/promise/pipe.h
+++ b/src/core/lib/promise/pipe.h
@@ -636,8 +636,8 @@ class Push {
   Poll<bool> operator()() {
     if (center_ == nullptr) {
       if (GRPC_TRACE_FLAG_ENABLED(promise_primitives)) {
-        gpr_log(GPR_DEBUG, "%s Pipe push has a null center",
-                GetContext<Activity>()->DebugTag().c_str());
+        VLOG(2) << GetContext<Activity>()->DebugTag()
+                << " Pipe push has a null center";
       }
       return false;
     }

--- a/src/core/lib/promise/pipe.h
+++ b/src/core/lib/promise/pipe.h
@@ -28,7 +28,6 @@
 #include "absl/types/optional.h"
 #include "absl/types/variant.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/gprpp/debug_location.h"


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Migrating from gpr to absl logging - gpr_log
In this CL we are migrating from gRPCs own gpr logging mechanism to absl logging mechanism. The intention is to deprecate gpr_log in the future.

We have the following mapping

1. gpr_log(GPR_INFO,...) -> LOG(INFO)
2. gpr_log(GPR_ERROR,...) -> LOG(ERROR)
3. gpr_log(GPR_DEBUG,...) -> VLOG(2)

Reviewers need to check :

1. If the above mapping is correct.
2. The content of the log is as before.
gpr_log format strings did not use string_view or std::string . absl LOG accepts these. So there will be some elimination of string_view and std::string related conversions. This is expected.
