### PR TITLE
[Ruby] add ruby distrib test with protobuf 3.25

### DIFF
--- a/test/distrib/ruby/run_distrib_test.sh
+++ b/test/distrib/ruby/run_distrib_test.sh
@@ -25,6 +25,8 @@ function die {
 ARCH="$1"
 PLATFORM="$2"
 PACKAGE_TYPE="$3"
+PROTOBUF_VERSION="$4"
+
 echo "$EXTERNAL_GIT_ROOT"
 GRPC_VERSION="$(ruby -e 'require ENV["EXTERNAL_GIT_ROOT"] + "/src/ruby/lib/grpc/version.rb"; puts GRPC::VERSION')"
 if [[ "$PACKAGE_TYPE" == "source" ]]; then
@@ -45,6 +47,10 @@ if [[ "$(ls "${GEM_SOURCE}/gems" | grep -c grpc)" != 1 ]]; then
 fi;
 gem install builder
 gem generate_index --directory "${GEM_SOURCE}"
+
+if [[ -n "$PROTOBUF_VERSION" ]]; then
+  bundle add google-protobuf --version "~> $PROTOBUF_VERSION"
+fi;
 
 bundle install
 

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -220,6 +220,7 @@ class RubyDistribTest(object):
         ruby_version=None,
         source=False,
         presubmit=False,
+        protobuf_version="",
     ):
         self.package_type = "binary"
         if source:
@@ -231,10 +232,13 @@ class RubyDistribTest(object):
             ruby_version or "unspecified",
             self.package_type,
         )
+        if not protobuf_version == "":
+            self.name += "_protobuf_%s" % protobuf_version
         self.platform = platform
         self.arch = arch
         self.docker_suffix = docker_suffix
         self.ruby_version = ruby_version
+        self.protobuf_version = protobuf_version
         self.labels = ["distribtest", "ruby", platform, arch, docker_suffix]
         if presubmit:
             self.labels.append("presubmit")
@@ -261,8 +265,13 @@ class RubyDistribTest(object):
         return create_docker_jobspec(
             self.name,
             dockerfile_name,
-            "test/distrib/ruby/run_distrib_test.sh %s %s %s"
-            % (arch_to_gem_arch[self.arch], self.platform, self.package_type),
+            "test/distrib/ruby/run_distrib_test.sh %s %s %s %s"
+            % (
+                arch_to_gem_arch[self.arch],
+                self.platform,
+                self.package_type,
+                self.protobuf_version,
+            ),
             copy_rel_path="test/distrib",
         )
 
@@ -484,6 +493,14 @@ def targets():
         ),
         RubyDistribTest(
             "linux", "x64", "debian11", ruby_version="ruby_3_3", presubmit=True
+        ),
+        RubyDistribTest(
+            "linux",
+            "x64",
+            "debian11",
+            ruby_version="ruby_3_3",
+            protobuf_version="3.25",
+            presubmit=True,
         ),
         RubyDistribTest("linux", "x64", "centos7"),
         RubyDistribTest("linux", "x64", "ubuntu2004"),


### PR DESCRIPTION
Add distrib test with protobuf 3.25

https://btx.cloud.google.com/invocations/3bbd9817-4f69-4ae6-b70b-77fac674c6be/targets/github%2Fgrpc%2Fdistribtests;config=default/tests