### PR TITLE
Fix Typos In Docs & Code Comments

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -61,5 +61,5 @@ of extra logs.
 Log noise could consume a lot of resources. We recommend tuning settings for production systems very carefully.
 *	Avoid using GRPC_VERBOSITY flag. This has been deprecated. If this value of this flag is anything other than "ERROR" or "NONE" it will cause log noise.
 *	Always avoid setting --v and --vmodule to anything other than -1 for production systems.
-*	Avoid setting --minloglevel=0 for production systems. Anyting greater than 0 should be fine.
+*	Avoid setting --minloglevel=0 for production systems. Anything greater than 0 should be fine.
 *   If setting this does not eliminate your log noise, look for instances of functions `--v`, `--vmodule`, `absl::SetVLogLevel` and `absl::SetMinLogLevel` in your entire codebase and any libraries/components/configs that you may be using.

--- a/examples/android/helloworld/gradlew.bat
+++ b/examples/android/helloworld/gradlew.bat
@@ -46,7 +46,7 @@ echo location of your Java installation.
 goto fail
 
 :init
-@rem Get command-line arguments, handling Windowz variants
+@rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
 if "%@eval[2+2]" == "4" goto 4NT_args

--- a/examples/cpp/auth/README.md
+++ b/examples/cpp/auth/README.md
@@ -7,7 +7,7 @@ communication security. In the example, we show how to set up a server
 authenticated SSL connection to transmit RPC.
 
 We provide `grpc::SslServerCredentials` and `grpc::SslCredentials` types
-to use SSL conections.
+to use SSL connections.
 
 In our example, we use the public/private keys created ahead: 
 * "localhost.crt" contains the server certificate (public key). 

--- a/examples/cpp/csm/README.md
+++ b/examples/cpp/csm/README.md
@@ -5,7 +5,7 @@ This CSM example builds on the [Hello World Example](https://github.com/grpc/grp
 ## Configuration
 
 The client takes the following command-line arguments -
-* target - By default, the client tries to connect to the xDS "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overriden to change the target.
+* target - By default, the client tries to connect to the xDS "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overridden to change the target.
 * cookie_name - session affinity cookie name. Defaults to "GSSA"
 * delay_s - delay (in seconds) between the RPCs. Default value is 5
 

--- a/examples/cpp/deadline/README.md
+++ b/examples/cpp/deadline/README.md
@@ -22,7 +22,7 @@ $ ./client
 
 To simulate the test scenario, the test server implements following functionalities:
 - Response Delay: The server intentionally delays its response for `delay` request messages to induce timeout conditions.
-- Deadline Propagation: Upon receiving a request with the `[propagate me]` prefix, the server forwards it back to itselt.
+- Deadline Propagation: Upon receiving a request with the `[propagate me]` prefix, the server forwards it back to itself.
   This simulates the propagation of deadlines within the system.
 
 If things go smoothly, you will see the client output:

--- a/examples/cpp/generic_api/greeter_server.cc
+++ b/examples/cpp/generic_api/greeter_server.cc
@@ -55,7 +55,7 @@ class GreeterServiceImpl final : public CallbackGenericService {
       // Let the SayHello reactor handle this now on.
       return new SayHelloReactor();
     } else {
-      // Forward this to the implementation of the base calss returning
+      // Forward this to the implementation of the base class returning
       // UNIMPLEMENTED.
       return CallbackGenericService::CreateReactor(context);
     }

--- a/examples/cpp/helloworld/greeter_async_server.cc
+++ b/examples/cpp/helloworld/greeter_async_server.cc
@@ -77,7 +77,7 @@ class ServerImpl final {
   }
 
  private:
-  // Class encompasing the state and logic needed to serve a request.
+  // Class encompassing the state and logic needed to serve a request.
   class CallData {
    public:
     // Take in the "service" instance (in this case representing an asynchronous

--- a/examples/cpp/xds/README.md
+++ b/examples/cpp/xds/README.md
@@ -5,7 +5,7 @@ This xDS example builds on the [Hello World Example](https://github.com/grpc/grp
 ## Configuration
 
 The client takes two command-line arguments -
-* target - By default, the client tries to connect to the xDS "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overriden to change the target.
+* target - By default, the client tries to connect to the xDS "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overridden to change the target.
 * secure - Bool value, defaults to true. When this is set, [XdsCredentials](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md) will be used with a fallback on `InsecureChannelCredentials`. If unset, `InsecureChannelCredentials` will be used.
 
 The server takes three command-line arguments -

--- a/examples/php/Helloworld/GreeterStub.php
+++ b/examples/php/Helloworld/GreeterStub.php
@@ -27,7 +27,7 @@ class GreeterStub {
      * Sends a greeting
      * @param \Helloworld\HelloRequest $request client request
      * @param \Grpc\ServerContext $context server request context
-     * @return \Helloworld\HelloReply for response data, null if if error occured
+     * @return \Helloworld\HelloReply for response data, null if if error occurred
      *     initial metadata (if any) and status (if not ok) should be set to $context
      */
     public function SayHello(

--- a/examples/php/route_guide/Routeguide/RouteGuideStub.php
+++ b/examples/php/route_guide/Routeguide/RouteGuideStub.php
@@ -32,7 +32,7 @@ class RouteGuideStub {
      * position.
      * @param \Routeguide\Point $request client request
      * @param \Grpc\ServerContext $context server request context
-     * @return \Routeguide\Feature for response data, null if if error occured
+     * @return \Routeguide\Feature for response data, null if if error occurred
      *     initial metadata (if any) and status (if not ok) should be set to $context
      */
     public function GetFeature(

--- a/examples/php/route_guide/Routeguide/RouteGuideStub.php
+++ b/examples/php/route_guide/Routeguide/RouteGuideStub.php
@@ -71,7 +71,7 @@ class RouteGuideStub {
      * RouteSummary when traversal is completed.
      * @param \Grpc\ServerCallReader $reader read client request data of \Routeguide\Point
      * @param \Grpc\ServerContext $context server request context
-     * @return \Routeguide\RouteSummary for response data, null if if error occured
+     * @return \Routeguide\RouteSummary for response data, null if if error occurred
      *     initial metadata (if any) and status (if not ok) should be set to $context
      */
     public function RecordRoute(

--- a/examples/python/observability/csm/BUILD.bazel
+++ b/examples/python/observability/csm/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 
-# TODO(xuanwn): Instaed of using Bazel build, we should pip install all dependencies
+# TODO(xuanwn): Instead of using Bazel build, we should pip install all dependencies
 # once we have a released version of grpcio-csm-observability.
 
 py_binary(

--- a/examples/python/observability/csm/README.md
+++ b/examples/python/observability/csm/README.md
@@ -5,7 +5,7 @@ This CSM example builds on the [Python xDS Example](https://github.com/grpc/grpc
 ## Configuration
 
 The client takes the following command-line arguments -
-* `--target` - By default, the client tries to connect to the target "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overriden to change the target.
+* `--target` - By default, the client tries to connect to the target "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overridden to change the target.
 * `--secure_mode` - Whether to use xDS to retrieve server credentials. Default value is False.
 * `--prometheus_endpoint` - Endpoint used for prometheus. Default value is localhost:9464.
 

--- a/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
+++ b/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py
@@ -52,7 +52,7 @@ class Greeter(helloworld_pb2_grpc.GreeterServicer):
         starting_up_server()
 
         # Initial metadata will be send back immediately after calling send_initial_metadata.
-        print("sending inital metadata back")
+        print("sending initial metadata back")
         servicer_context.send_initial_metadata(_INITIAL_METADATA)
 
         # Time for server to process the request.

--- a/examples/python/xds/README.md
+++ b/examples/python/xds/README.md
@@ -28,7 +28,7 @@ python server.py
 1. Set up xDS configuration.
 
 After configuring your xDS server to track the gRPC server we just started,
-create a bootstrap file as desribed in [gRFC A27](https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md):
+create a bootstrap file as described in [gRFC A27](https://github.com/grpc/proposal/blob/master/A27-xds-global-load-balancing.md):
 
 ```
 {


### PR DESCRIPTION
There are several typos in files within the ./examples/* directory, so just a PR to fix them

