### PR TITLE
[Log] Fix VLOG_IS_ON error

### DIFF
--- a/src/core/util/log.cc
+++ b/src/core/util/log.cc
@@ -53,10 +53,10 @@ int gpr_should_log(gpr_log_severity severity) {
       // MinLogLevel is. We could have saved this in a static const variable.
       // But decided against it just in case anyone programatically sets absl
       // min log level settings after this has been initialized.
-      // Same holds for VLOG_IS_ON(2).
+      // Same holds for ABSL_VLOG_IS_ON(2).
       return absl::MinLogLevel() <= absl::LogSeverityAtLeast::kInfo;
     case GPR_LOG_SEVERITY_DEBUG:
-      return VLOG_IS_ON(2);
+      return ABSL_VLOG_IS_ON(2);
     default:
       DLOG(ERROR) << "Invalid gpr_log_severity.";
       return true;


### PR DESCRIPTION
It appears that `VLOG_IS_ON` is internal only and `ABSL_VLOG_IS_ON` is supposed to be used. 
This is required to fix recent failures of [prod:grpc/core/master/linux/grpc_build_abseil-cpp_at_head](https://fusion2.corp.google.com/ci;ids=1930537984/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_build_abseil-cpp_at_head/activity/db615bdd-a42b-4462-9911-c6185165223c/summary).

Error excerpt;
```
/var/local/git/grpc/src/core/util/log.cc: In function int gpr_should_log(gpr_log_severity):
/[var/local/git/grpc/src/core/util/log.cc:59](https://cs.corp.google.com/piper///depot/google3/var/local/git/grpc/src/core/util/log.cc?l=59&ws&snapshot=0):14: error: VLOG_IS_ON was not declared in this scope; did you mean VLOG_FIRST_N?
   59 |       return VLOG_IS_ON(2);
      |              ^~~~~~~~~~
      |              VLOG_FIRST_N
```