### PR TITLE
[interop] Add 1.63.3, 1.64.1 and 1.65.0 releases of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -300,8 +300,9 @@ LANG_RELEASE_MATRIX = {
             ("v1.60.1", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.61.2", ReleaseInfo(runtimes=["go1.19"])),
             ("v1.62.2", ReleaseInfo(runtimes=["go1.19"])),
-            ("v1.63.2", ReleaseInfo(runtimes=["go1.19"])),
-            ("v1.64.0", ReleaseInfo()),
+            ("v1.63.3", ReleaseInfo()),
+            ("v1.64.1", ReleaseInfo()),
+            ("v1.65.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```bash
gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.x
DIGEST        TAGS                                         TIMESTAMP
4468f7609ae0  infrastructure-public-image-v1.63.3,v1.63.3  2024-07-09T16:34:13 
995c94eb26a5  infrastructure-public-image-v1.64.1,v1.64.1  2024-07-09T16:31:20 
32d250831313  infrastructure-public-image-v1.65.0,v1.65.0  2024-07-09T14:47:02 
a67512984d72  infrastructure-public-image-v1.64.0,v1.64.0  2024-06-05T10:11:11 
```

Adhoc Interop Matrix passes: https://source.cloud.google.com/results/invocations/eb5c0e87-737d-46e8-acd8-b1e7bf6078c9