### PR TITLE
[Release] Fix opentelemetry deps version conflict (v1.65.x backport)

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -33,7 +33,7 @@ opentelemetry-resourcedetector-gcp==1.6.0a0
 opentelemetry-exporter-prometheus==0.46b0
 prometheus_client==0.20.0
 Deprecated==1.2.14
-opentelemetry-semantic-conventions==0.42b0
+opentelemetry-semantic-conventions==0.46b0
 typing-extensions==4.9.0
 pyasn1-modules==0.3.0
 zipp==3.17.0


### PR DESCRIPTION
Backport of #37098 to v1.65.x.
---
`opentelemetry-sdk==1.25.0` depends on `opentelemetry-semantic-conventions==0.46b0`

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

