### PR TITLE
[TSI] Print cert verification status on handshake failure

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1659,7 +1659,7 @@ static tsi_result ssl_handshaker_do_handshake(tsi_ssl_handshaker* impl,
         long verify_result = SSL_get_verify_result(impl->ssl);
         std::string verify_result_str;
         if (verify_result != X509_V_OK) {
-          const char * verify_err = X509_verify_cert_error_string(verify_result);
+          const char* verify_err = X509_verify_cert_error_string(verify_result);
           verify_result_str = absl::StrCat(": ", verify_err);
         }
         LOG(ERROR) << "Handshake failed with fatal error "

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1659,8 +1659,7 @@ static tsi_result ssl_handshaker_do_handshake(tsi_ssl_handshaker* impl,
         long verify_result = SSL_get_verify_result(impl->ssl);
         std::string verify_result_str;
         if (verify_result != X509_V_OK) {
-          const char * verify_err =
-            X509_verify_cert_error_string(verify_result);
+          const char * verify_err = X509_verify_cert_error_string(verify_result);
           verify_result_str = absl::StrCat(": ", verify_err);
         }
         LOG(ERROR) << "Handshake failed with fatal error "

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -858,7 +858,9 @@ std::string XdsEnd2endTest::MakeTlsHandshakeFailureRegex(
       "(Failed to connect to remote host: )?"
       // Tls handshake failure
       "Tls handshake failed \\(TSI_PROTOCOL_FAILURE\\): SSL_ERROR_SSL: "
-      "error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED");
+      "error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED"
+      // Detailed reason for certificate verify failure
+      "(: .*)?");
 }
 
 grpc_core::PemKeyCertPairList XdsEnd2endTest::ReadTlsIdentityPair(


### PR DESCRIPTION
Certificate verification can fail for more than 50 different reasons. Simplify troubleshooting by including the reason in the error message.
