### PR TITLE
[Ruby] Increased ruby build timeout to 20min

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -911,7 +911,7 @@ class RubyLanguage(object):
         tests = [
             self.config.job_spec(
                 ["tools/run_tests/helper_scripts/run_ruby.sh"],
-                timeout_seconds=10 * 60,
+                timeout_seconds=20 * 60,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS,
             )
         ]


### PR DESCRIPTION
Ruby tests have been flaky for a while on Linux. All I looked at failed with timeout during the build step which has 10 minutes timeout which sounds tight. So I'm increasing this to mitigate this problem.