### PR TITLE
[CI] Removed python test from protobuf_at_head test

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -51,6 +51,8 @@ case "$SUBMODULE_NAME" in
     ;;
   protobuf)
     BAZEL_DEP_NAME="com_google_protobuf"
+    # TODO(xuanwang-amos): Remove the following once python test gets fixed for protobuf-at-head test.
+    EXTRA_EXCLUDE_FILTER="python"
     ;;
 esac
 if [ -z "$BAZEL_DEP_NAME" ]
@@ -88,4 +90,4 @@ tools/buildgen/generate_projects.sh
 git add -A
 git -c user.name='foo' -c user.email='foo@google.com' commit -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg --inner_jobs 16 -j 2 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg $EXTRA_EXCLUDE_FILTER --inner_jobs 16 -j 2 --internal_ci --build_only


### PR DESCRIPTION
[prod:grpc/core/master/linux/grpc_build_protobuf_at_head](https://fusion2.corp.google.com/ci;ids=1930537984/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_build_protobuf_at_head/activity/fcb4763a-a8d8-4259-a4f0-2d0b73dbe9e7/summary) has been failing due to the timeout of `run_tests_python_linux_opt_native_buildonly`. (e.g. [log](https://btx.cloud.google.com/invocations/fcb4763a-a8d8-4259-a4f0-2d0b73dbe9e7/targets/github%2Fgrpc%2Ftoplevel_run_tests_invocations%2Frun_tests_python_linux_opt_native_buildonly;config=default/tests)) It's unclear why this failed at this point so let's disable Python in this test for now so that we can enable the alert on this `grpc_build_protobuf_at_head` to know whether the lastest protobuf is working with gRPC.