### PR TITLE
[Test] Increase registered callback's duration to avoid flakyness

### DIFF
--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -1919,7 +1919,7 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
         reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
-      grpc_core::Duration::Milliseconds(10) * grpc_test_slowdown_factor(),
+      grpc_core::Duration::Milliseconds(50) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
   int report_count_2 = 0;
   int64_t int_value_2 = 1;
@@ -1936,9 +1936,9 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
         reporter.Report(double_gauge_handle, double_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
-      grpc_core::Duration::Milliseconds(10) * grpc_test_slowdown_factor(),
+      grpc_core::Duration::Milliseconds(50) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
-  constexpr int kIterations = 100;
+  constexpr int kIterations = 50;
   MetricsCollectorThread collector{
       this,
       grpc_core::Duration::Milliseconds(100) * grpc_test_slowdown_factor(),
@@ -1956,8 +1956,8 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
       data = collector.Stop();
   // Verify that data is incremental without duplications (cached
   // values).
-  EXPECT_GE(report_count_1, kIterations);
-  EXPECT_GE(report_count_2, kIterations);
+  EXPECT_EQ(report_count_1, kIterations);
+  EXPECT_EQ(report_count_2, kIterations);
   EXPECT_EQ(data[kInt64CallbackGaugeMetric].size(),
             data[kDoubleCallbackGaugeMetric].size());
   // Verify labels.

--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -1956,8 +1956,8 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
       data = collector.Stop();
   // Verify that data is incremental without duplications (cached
   // values).
-  EXPECT_EQ(report_count_1, kIterations);
-  EXPECT_EQ(report_count_2, kIterations);
+  EXPECT_GE(report_count_1, kIterations);
+  EXPECT_GE(report_count_2, kIterations);
   EXPECT_EQ(data[kInt64CallbackGaugeMetric].size(),
             data[kDoubleCallbackGaugeMetric].size());
   // Verify labels.


### PR DESCRIPTION
Previously the registered callback's duration is set too low (10ms) that 2 different OTel callbacks get called from OTel consecutively would trigger the registered callback again, making the test flaky.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

