### PR TITLE
[Python Interop] Add signal handler to python interop client and server (v1.65.x backport)

### DIFF
--- a/src/python/grpcio_tests/tests/fork/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/fork/BUILD.bazel
@@ -16,6 +16,10 @@ load("//bazel:cython_library.bzl", "pyx_library")
 pyx_library(
     name = "native_debug",
     srcs = ["native_debug.pyx"],
+    visibility = [
+        "//src/python/grpcio_tests/tests/observability:__subpackages__",
+        "//src/python/grpcio_tests/tests_py3_only/interop:__subpackages__",
+    ],
     deps = ["@com_google_absl//absl/debugging:failure_signal_handler"],
 )
 

--- a/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests_py3_only/interop/BUILD.bazel
@@ -28,6 +28,7 @@ py_binary(
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_admin/grpc_admin",
         "//src/python/grpcio_channelz/grpc_channelz/v1:grpc_channelz",
+        "//src/python/grpcio_tests/tests/fork:native_debug",
         requirement("opentelemetry-exporter-prometheus"),
     ],
 )
@@ -46,6 +47,7 @@ py_binary(
         "//src/python/grpcio_csm_observability/grpc_csm_observability:csm_observability",
         "//src/python/grpcio_health_checking/grpc_health/v1:grpc_health",
         "//src/python/grpcio_reflection/grpc_reflection/v1alpha:grpc_reflection",
+        "//src/python/grpcio_tests/tests/fork:native_debug",
         requirement("opentelemetry-exporter-prometheus"),
     ],
 )

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_client.py
@@ -45,6 +45,9 @@ from src.proto.grpc.testing import empty_pb2
 from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2
 from src.proto.grpc.testing import test_pb2_grpc
+from src.python.grpcio_tests.tests.fork import native_debug
+
+native_debug.install_failure_signal_handler()
 
 logger = logging.getLogger()
 console_handler = logging.StreamHandler()

--- a/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server.py
+++ b/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server.py
@@ -39,6 +39,9 @@ from src.proto.grpc.testing import empty_pb2
 from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2
 from src.proto.grpc.testing import test_pb2_grpc
+from src.python.grpcio_tests.tests.fork import native_debug
+
+native_debug.install_failure_signal_handler()
 
 # NOTE: This interop server is not fully compatible with all xDS interop tests.
 #  It currently only implements enough functionality to pass the xDS security


### PR DESCRIPTION
Backport of #37241 to v1.65.x.
---
Tested by manually introduce a segfault, able to see the backtrace:

![Screenshot 2024-07-17 at 12 53 45 PM](https://github.com/user-attachments/assets/069e79ac-f215-4964-8b91-bd7a9e64ebfe)

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

