### PR TITLE
[ObjC] Skip 0-length slices when writing to CFWriteStream (#37246)

### DIFF
--- a/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
+++ b/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
@@ -331,6 +331,10 @@ void CFStreamEndpointImpl::DoWrite(
   size_t total_written_size = 0;
   for (size_t i = 0; i < data->Count(); i++) {
     auto slice = data->RefSlice(i);
+    if (slice.size() == 0) {
+      continue;
+    }
+
     size_t written_size =
         CFWriteStreamWrite(cf_write_stream_, slice.begin(), slice.size());
 


### PR DESCRIPTION
#37246 

