### PR TITLE
Fix use-of-uninitialized-value in gRPC

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -358,7 +358,7 @@ Epoll1Poller::Epoll1Poller(Scheduler* scheduler)
   CHECK_GE(g_epoll_set_.epfd, 0);
   GRPC_TRACE_LOG(event_engine_poller, INFO)
       << "grpc epoll fd: " << g_epoll_set_.epfd;
-  struct epoll_event ev;
+  struct epoll_event ev{};
   ev.events = static_cast<uint32_t>(EPOLLIN | EPOLLET);
   ev.data.ptr = wakeup_fd_.get();
   CHECK(epoll_ctl(g_epoll_set_.epfd, EPOLL_CTL_ADD, wakeup_fd_->ReadFd(),

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -358,7 +358,7 @@ Epoll1Poller::Epoll1Poller(Scheduler* scheduler)
   CHECK_GE(g_epoll_set_.epfd, 0);
   GRPC_TRACE_LOG(event_engine_poller, INFO)
       << "grpc epoll fd: " << g_epoll_set_.epfd;
-  struct epoll_event ev{};
+  struct epoll_event ev {};
   ev.events = static_cast<uint32_t>(EPOLLIN | EPOLLET);
   ev.data.ptr = wakeup_fd_.get();
   CHECK(epoll_ctl(g_epoll_set_.epfd, EPOLL_CTL_ADD, wakeup_fd_->ReadFd(),

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.h
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.h
@@ -102,17 +102,17 @@ class Epoll1Poller : public PosixEventPoller {
   friend class Epoll1EventHandle;
 #ifdef GRPC_LINUX_EPOLL
   struct EpollSet {
-    int epfd;
+    int epfd = -1;
 
     // The epoll_events after the last call to epoll_wait()
-    struct epoll_event events[MAX_EPOLL_EVENTS];
+    struct epoll_event events[MAX_EPOLL_EVENTS]{};
 
     // The number of epoll_events after the last call to epoll_wait()
-    int num_events;
+    int num_events = 0;
 
     // Index of the first event in epoll_events that has to be processed. This
     // field is only valid if num_events > 0
-    int cursor;
+    int cursor = 0;
   };
 #else
   struct EpollSet {};


### PR DESCRIPTION
ClickHouse is an analytical database which has grpc import/export functionality.

Testing with msan builds found a uninitialized-value in grpc.

Downstream bug report: https://github.com/ClickHouse/ClickHouse/issues/66525

I am not the author of the fix, I am merely contributing the fix back to grpc.
- https://github.com/ClickHouse/ClickHouse/pull/66509
- https://github.com/ClickHouse/grpc/pull/41

ClickHouse currently uses grpc 1.59.x ([here](https://github.com/ClickHouse/grpc/commits/ClickHouse/v1.59.2/)), I forward-ported the fix to `master`.