### PR TITLE
[Build] Reviving Gcc-7 test

### DIFF
--- a/tools/bazelify_tests/test/portability_tests.bzl
+++ b/tools/bazelify_tests/test/portability_tests.bzl
@@ -53,7 +53,8 @@ def generate_run_tests_portability_tests(name):
     # C and C++ under different compilers
     for language in ["c", "c++"]:
         compiler_configs = [
-            ["gcc_7", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
+            # Some gRPC tests have an issue with gcc-7 so gcc-7 portability test won't build any gRPC tests
+            ["gcc_7", "--cmake_configure_extra_args=-DgRPC_BUILD_TESTS=OFF", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
             ["gcc_8", "", "tools/dockerfile/test/cxx_gcc_8_x64.current_version"],
             ["gcc_12_cxx20", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_12_x64.current_version"],
             ["gcc10.2_openssl102", "--cmake_configure_extra_args=-DgRPC_SSL_PROVIDER=package", "tools/dockerfile/test/cxx_debian11_openssl102_x64.current_version"],

--- a/tools/bazelify_tests/test/portability_tests.bzl
+++ b/tools/bazelify_tests/test/portability_tests.bzl
@@ -53,8 +53,7 @@ def generate_run_tests_portability_tests(name):
     # C and C++ under different compilers
     for language in ["c", "c++"]:
         compiler_configs = [
-            # TODO(https://github.com/grpc/grpc/issues/36751): Replace gcc_8 with gcc_7 once it's fixed.
-            # ["gcc_7", "", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
+            ["gcc_7", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
             ["gcc_8", "", "tools/dockerfile/test/cxx_gcc_8_x64.current_version"],
             ["gcc_12_cxx20", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_12_x64.current_version"],
             ["gcc10.2_openssl102", "--cmake_configure_extra_args=-DgRPC_SSL_PROVIDER=package", "tools/dockerfile/test/cxx_debian11_openssl102_x64.current_version"],

--- a/tools/run_tests/helper_scripts/build_cxx.sh
+++ b/tools/run_tests/helper_scripts/build_cxx.sh
@@ -46,5 +46,10 @@ else
 cmake -DgRPC_BUILD_GRPCPP_OTEL_PLUGIN=ON -DgRPC_ABSL_PROVIDER=package -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE="${MSBUILD_CONFIG}" -DCMAKE_INSTALL_PREFIX="${INSTALL_PATH}" "$@" ../..
 fi
 
+if [[ "$@" =~ "-DgRPC_BUILD_TESTS=OFF" ]]; then
+# Just build grpc++ target when gRPC_BUILD_TESTS is OFF (This is a temporary mitigation for gcc 7. Remove this once gcc 7 is removed from the supported compilers)
+make -j"${GRPC_RUN_TESTS_JOBS}" "grpc++"
+else
 # GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX will be set to either "c" or "cxx"
 make -j"${GRPC_RUN_TESTS_JOBS}" "buildtests_${GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX}" "tools_${GRPC_RUN_TESTS_CXX_LANGUAGE_SUFFIX}"
+fi

--- a/tools/run_tests/helper_scripts/build_cxx.sh
+++ b/tools/run_tests/helper_scripts/build_cxx.sh
@@ -46,7 +46,7 @@ else
 cmake -DgRPC_BUILD_GRPCPP_OTEL_PLUGIN=ON -DgRPC_ABSL_PROVIDER=package -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE="${MSBUILD_CONFIG}" -DCMAKE_INSTALL_PREFIX="${INSTALL_PATH}" "$@" ../..
 fi
 
-if [[ "$@" =~ "-DgRPC_BUILD_TESTS=OFF" ]]; then
+if [[ "$*" =~ "-DgRPC_BUILD_TESTS=OFF" ]]; then
 # Just build grpc++ target when gRPC_BUILD_TESTS is OFF (This is a temporary mitigation for gcc 7. Remove this once gcc 7 is removed from the supported compilers)
 make -j"${GRPC_RUN_TESTS_JOBS}" "grpc++"
 else


### PR DESCRIPTION
The oldest gcc version that gRPC supports as of today is gcc 7 but gcc 7 has an issue with template supports that gRPC already picked up. Recently we managed to fix it in gRPC library code but we still have some in our test code. Given that it's not easy to fix since it requires many trial error approach to find a way to satisfy gcc 7 and eventually gcc 7 will be dropped from our supported compilers, let's have this mitigation where just main grpc++ target is being tested for gcc 7 so that users can use grpc with it without having to fix this hairy issue.

Fixes https://github.com/grpc/grpc/issues/36751