### PR TITLE
[test] Remove deprecated flag from run_tests* scripts

### DIFF
--- a/tools/internal_ci/linux/arm64/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests_arm64 linux csharp --inner_jobs 4 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests_arm64 linux csharp --inner_jobs 4 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/arm64/grpc_basictests_php.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_basictests_php.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests_arm64 linux php7 --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests_arm64 linux php7 --inner_jobs 16 -j 2 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/arm64/grpc_basictests_python.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_basictests_python.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests_arm64 linux python --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests_arm64 linux python --inner_jobs 16 -j 2 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/arm64/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_basictests_ruby.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests_arm64 linux ruby --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests_arm64 linux ruby --inner_jobs 16 -j 2 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_c_cpp_dbg.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_c_cpp_dbg.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux corelang dbg --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux corelang dbg --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_c_cpp_opt.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_c_cpp_opt.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux corelang opt --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux corelang opt --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux csharp --inner_jobs 4 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux csharp --inner_jobs 4 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_php.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_php.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux php7 --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux php7 --inner_jobs 16 -j 2 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_python.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_python.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux python --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux python --inner_jobs 16 -j 2 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_ruby.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux ruby --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux ruby --inner_jobs 16 -j 2 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -90,4 +90,4 @@ tools/buildgen/generate_projects.sh
 git add -A
 git -c user.name='foo' -c user.email='foo@google.com' commit -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg $EXTRA_EXCLUDE_FILTER --inner_jobs 16 -j 2 --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg $EXTRA_EXCLUDE_FILTER --inner_jobs 16 -j 2 --build_only

--- a/tools/internal_ci/linux/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/grpc_clang_tidy.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_interop_alts.cfg
+++ b/tools/internal_ci/linux/grpc_interop_alts.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all -s all --use_docker --transport_security alts --internal_ci -t -j 12 --bq_result_table interop_results"
+  value: "-l all -s all --use_docker --transport_security alts -t -j 12 --bq_result_table interop_results"
 }

--- a/tools/internal_ci/linux/grpc_interop_tocloud.cfg
+++ b/tools/internal_ci/linux/grpc_interop_tocloud.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all -s all --use_docker --http2_interop --internal_ci -t -j 8 --bq_result_table interop_results"
+  value: "-l all -s all --use_docker --http2_interop -t -j 8 --bq_result_table interop_results"
 }

--- a/tools/internal_ci/linux/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/grpc_interop_toprod.cfg
@@ -26,7 +26,7 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker --internal_ci -t -j 8 --bq_result_table interop_results"
+  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker -t -j 8 --bq_result_table interop_results"
 }
 
 before_action {

--- a/tools/internal_ci/linux/grpc_portability.cfg
+++ b/tools/internal_ci/linux/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f portability linux --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_pull_request_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_pull_request_sanity.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity opt --inner_jobs 16 -j 1 "
+  value: "-f basictests linux sanity opt --inner_jobs 16 -j 1"
 }

--- a/tools/internal_ci/linux/grpc_pull_request_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_pull_request_sanity.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity opt --inner_jobs 16 -j 1 --internal_ci"
+  value: "-f basictests linux sanity opt --inner_jobs 16 -j 1 "
 }

--- a/tools/internal_ci/linux/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_sanity.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux sanity --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux csharp --inner_jobs 4 -j 1 --internal_ci --max_time=3600"
+  value: "-f basictests linux csharp --inner_jobs 4 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_php.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_php.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux php7 --inner_jobs 16 -j 2 --internal_ci --max_time=3600"
+  value: "-f basictests linux php7 --inner_jobs 16 -j 2 --max_time=3600"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_python.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_python.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux python --inner_jobs 16 -j 2 --internal_ci --max_time=3600"
+  value: "-f basictests linux python --inner_jobs 16 -j 2 --max_time=3600"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_ruby.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux ruby --inner_jobs 16 -j 2 --internal_ci --max_time=3600"
+  value: "-f basictests linux ruby --inner_jobs 16 -j 2 --max_time=3600"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 --internal_ci"
+  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 "
 }

--- a/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_clang_tidy.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1 "
+  value: "-f basictests linux clang-tidy --inner_jobs 32 -j 1"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity --inner_jobs 16 -j 1 --internal_ci"
+  value: "-f basictests linux sanity --inner_jobs 16 -j 1
 }

--- a/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity --inner_jobs 16 -j 1
+  value: "-f basictests linux sanity --inner_jobs 16 -j 1"
 }

--- a/tools/internal_ci/linux/sanitizer/grpc_c_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_asan.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c asan --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f c asan --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/sanitizer/grpc_c_msan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_msan.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c msan --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f c msan --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/sanitizer/grpc_c_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_tsan.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c tsan --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f c tsan --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/sanitizer/grpc_c_ubsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_ubsan.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c ubsan --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f c ubsan --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c++ asan --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f c++ asan --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c++ tsan --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f c++ tsan --inner_jobs 16 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_asan.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c asan --inner_jobs 16 -j 1 --internal_ci --max_time=3600"
+  value: "-f c asan --inner_jobs 16 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_msan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_msan.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c msan --inner_jobs 16 -j 1 --internal_ci --max_time=3600"
+  value: "-f c msan --inner_jobs 16 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_tsan.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c tsan --inner_jobs 16 -j 1 --internal_ci --max_time=3600"
+  value: "-f c tsan --inner_jobs 16 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_ubsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_ubsan.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c ubsan --inner_jobs 16 -j 1 --internal_ci --max_time=3600"
+  value: "-f c ubsan --inner_jobs 16 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_asan.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c++ asan --inner_jobs 16 -j 1 --internal_ci --max_time=3600"
+  value: "-f c++ asan --inner_jobs 16 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_tsan.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f c++ tsan --inner_jobs 16 -j 1 --internal_ci --max_time=3600"
+  value: "-f c++ tsan --inner_jobs 16 -j 1 --max_time=3600"
 }

--- a/tools/internal_ci/macos/grpc_basictests_c_cpp_dbg.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_c_cpp_dbg.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos corelang dbg --internal_ci -j 4 --inner_jobs 8 --bq_result_table aggregate_results"
+  value: "-f basictests macos corelang dbg -j 4 --inner_jobs 8 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_basictests_c_cpp_opt.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_c_cpp_opt.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos corelang opt --internal_ci -j 4 --inner_jobs 8 --bq_result_table aggregate_results"
+  value: "-f basictests macos corelang opt -j 4 --inner_jobs 8 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_basictests_cpp_ios.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_cpp_ios.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r ios-cpp-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r ios-cpp-test-.*"
 }

--- a/tools/internal_ci/macos/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_csharp.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos csharp --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos csharp -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_basictests_objc_examples.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_objc_examples.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r ios-buildtest-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r ios-buildtest-.*"
 }

--- a/tools/internal_ci/macos/grpc_basictests_objc_ios.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_objc_ios.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r ios-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r ios-test-.*"
 }

--- a/tools/internal_ci/macos/grpc_basictests_objc_mac.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_objc_mac.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r mac-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r mac-test-.*"
 }

--- a/tools/internal_ci/macos/grpc_basictests_objc_tvos.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_objc_tvos.cfg
@@ -27,6 +27,6 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r tvos-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --bq_result_table aggregate_results --extra_args -r tvos-test-.*"
 }
 

--- a/tools/internal_ci/macos/grpc_basictests_php.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_php.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos php7 --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos php7 -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_basictests_python.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_python.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos python --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos python -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_ruby.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos ruby --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos ruby -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -42,7 +42,7 @@ tools/run_tests/run_interop_tests.py -l c++ \
     --prod_servers default gateway_v4 \
     --service_account_key_file="${KOKORO_KEYSTORE_DIR}/73836_interop_to_prod_tests_service_account_key" \
     --default_service_account="interop-to-prod-tests@grpc-testing.iam.gserviceaccount.com" \
-    --skip_compute_engine_creds --internal_ci -t -j 4 || FAILED="true"
+    --skip_compute_engine_creds -t -j 4 || FAILED="true"
 
 if [ "$FAILED" != "" ]
 then

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_c_cpp_dbg.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_c_cpp_dbg.cfg
@@ -28,5 +28,5 @@ action {
 env_vars {
   key: "RUN_TESTS_FLAGS"
   # on pull requests, only run the "dbg" configuration due to CI resource constraints
-  value: "-f basictests macos corelang dbg --internal_ci -j 4 --inner_jobs 8 --max_time=3600"
+  value: "-f basictests macos corelang dbg -j 4 --inner_jobs 8 --max_time=3600"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_cpp_ios.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_cpp_ios.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --extra_args -r ios-cpp-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --extra_args -r ios-cpp-test-.*"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_csharp.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos csharp --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
+  value: "-f basictests macos csharp -j 1 --inner_jobs 4 --max_time=3600"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_objc_examples.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_objc_examples.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --extra_args -r ios-buildtest-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --extra_args -r ios-buildtest-.*"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_objc_ios.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_objc_ios.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --extra_args -r ios-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --extra_args -r ios-test-.*"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_objc_mac.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_objc_mac.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --extra_args -r mac-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --extra_args -r mac-test-.*"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_objc_tvos.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_objc_tvos.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos objc opt --internal_ci -j 1 --inner_jobs 4 --extra_args -r tvos-test-.*"
+  value: "-f basictests macos objc opt -j 1 --inner_jobs 4 --extra_args -r tvos-test-.*"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_php.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_php.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos php7 --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
+  value: "-f basictests macos php7 -j 1 --inner_jobs 4 --max_time=3600"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_python.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_python.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos python --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
+  value: "-f basictests macos python -j 1 --inner_jobs 4 --max_time=3600"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_ruby.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos ruby --internal_ci -j 1 --inner_jobs 4 --max_time=3600"
+  value: "-f basictests macos ruby obs 4 --max_time=3600"
 }

--- a/tools/internal_ci/windows/grpc_basictests_c.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_c.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows c -j 1 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests windows c -j 1 --inner_jobs 8 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows csharp -j 1 --inner_jobs 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests windows csharp -j 1 --inner_jobs 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_basictests_python.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_python.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows python -j 1 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests windows python -j 1 --inner_jobs 8 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_portability.cfg
+++ b/tools/internal_ci/windows/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 4 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
+  value: "-f portability windows -j 4 --inner_jobs 8 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/windows/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows c++ -j 4 --inner_jobs 8 --internal_ci --build_only"
+  value: "-f portability windows c++ -j 4 --inner_jobs 8 --build_only"
 }

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_c.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_c.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows c -j 1 --inner_jobs 8 --internal_ci --max_time=3600"
+  value: "-f basictests windows c -j 1 --inner_jobs 8 --max_time=3600"
 }

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_csharp.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_csharp.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows csharp -j 1 --inner_jobs 8 --internal_ci --max_time=3600"
+  value: "-f basictests windows csharp -j 1 --inner_jobs 8 --max_time=3600"
 }

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_python.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_python.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests windows python -j 1 --inner_jobs 8 --internal_ci --max_time=5400"
+  value: "-f basictests windows python -j 1 --inner_jobs 8 --max_time=5400"
 }

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1425,16 +1425,6 @@ argp.add_argument(
     help="Skip auth tests requiring access to compute engine credentials.",
 )
 argp.add_argument(
-    "--internal_ci",
-    default=False,
-    action="store_const",
-    const=True,
-    help=(
-        "(Deprecated, has no effect) Put reports into subdirectories to improve"
-        " presentation of results by Internal CI."
-    ),
-)
-argp.add_argument(
     "--bq_result_table",
     default="",
     type=str,

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -532,16 +532,6 @@ if __name__ == "__main__":
         + "(other tests will be skipped)",
     )
     argp.add_argument(
-        "--internal_ci",
-        default=False,
-        action="store_const",
-        const=True,
-        help=(
-            "(Deprecated, has no effect) Put reports into subdirectories to"
-            " improve presentation of results by Kokoro."
-        ),
-    )
-    argp.add_argument(
         "--bq_result_table",
         default="",
         type=str,


### PR DESCRIPTION
`--internal_ci` has been deprecated and unused for 6 years. https://github.com/grpc/grpc/pull/16635