### PR TITLE
[Backport] 1.65.x: Cherry-pick 

### DIFF
--- a/src/core/util/log.cc
+++ b/src/core/util/log.cc
@@ -70,10 +70,10 @@ int gpr_should_log(gpr_log_severity severity) {
       // MinLogLevel is. We could have saved this in a static const variable.
       // But decided against it just in case anyone programatically sets absl
       // min log level settings after this has been initialized.
-      // Same holds for VLOG_IS_ON(2).
+      // Same holds for ABSL_VLOG_IS_ON(2).
       return absl::MinLogLevel() <= absl::LogSeverityAtLeast::kInfo;
     case GPR_LOG_SEVERITY_DEBUG:
-      return VLOG_IS_ON(2);
+      return ABSL_VLOG_IS_ON(2);
     default:
       DLOG(ERROR) << "Invalid gpr_log_severity.";
       return true;


### PR DESCRIPTION
gRPC 1.65 doesn't build with the upcoming Abseil release and this can be resolved by cherry-picking  https://github.com/grpc/grpc/pull/37183