### PR TITLE
[StatsPlugin] Some more benchmarks and fixes

### DIFF
--- a/test/core/test_util/fake_stats_plugin.h
+++ b/test/core/test_util/fake_stats_plugin.h
@@ -225,8 +225,8 @@ class FakeStatsPlugin : public StatsPlugin {
                 descriptor) {
           if (!use_disabled_by_default_metrics &&
               !descriptor.enable_by_default) {
-            LOG(INFO) << "FakeStatsPlugin[" << this
-                      << "]: skipping disabled metric: " << descriptor.name;
+            VLOG(2) << "FakeStatsPlugin[" << this
+                    << "]: skipping disabled metric: " << descriptor.name;
             return;
           }
           switch (descriptor.instrument_type) {
@@ -300,12 +300,11 @@ class FakeStatsPlugin : public StatsPlugin {
     // just ignore it here. This would also prevent us from having to lock the
     // GlobalInstrumentsRegistry everytime a metric is recorded. But this is not
     // a concern for now.
-    LOG(INFO) << "FakeStatsPlugin[" << this
-              << "]::AddCounter(index=" << handle.index << ", value=(uint64)"
-              << value << ", label_values={"
-              << absl::StrJoin(label_values, ", ")
-              << "}, optional_label_values={"
-              << absl::StrJoin(optional_values, ", ") << "}";
+    VLOG(2) << "FakeStatsPlugin[" << this
+            << "]::AddCounter(index=" << handle.index << ", value=(uint64)"
+            << value << ", label_values={" << absl::StrJoin(label_values, ", ")
+            << "}, optional_label_values={"
+            << absl::StrJoin(optional_values, ", ") << "}";
     MutexLock lock(&mu_);
     auto iter = uint64_counters_.find(handle.index);
     if (iter == uint64_counters_.end()) return;
@@ -315,12 +314,11 @@ class FakeStatsPlugin : public StatsPlugin {
       GlobalInstrumentsRegistry::GlobalInstrumentHandle handle, double value,
       absl::Span<const absl::string_view> label_values,
       absl::Span<const absl::string_view> optional_values) override {
-    LOG(INFO) << "FakeStatsPlugin[" << this
-              << "]::AddCounter(index=" << handle.index
-              << ", value(double)=" << value << ", label_values={"
-              << absl::StrJoin(label_values, ", ")
-              << "}, optional_label_values={"
-              << absl::StrJoin(optional_values, ", ") << "}";
+    VLOG(2) << "FakeStatsPlugin[" << this
+            << "]::AddCounter(index=" << handle.index
+            << ", value(double)=" << value << ", label_values={"
+            << absl::StrJoin(label_values, ", ") << "}, optional_label_values={"
+            << absl::StrJoin(optional_values, ", ") << "}";
     MutexLock lock(&mu_);
     auto iter = double_counters_.find(handle.index);
     if (iter == double_counters_.end()) return;
@@ -330,12 +328,11 @@ class FakeStatsPlugin : public StatsPlugin {
       GlobalInstrumentsRegistry::GlobalInstrumentHandle handle, uint64_t value,
       absl::Span<const absl::string_view> label_values,
       absl::Span<const absl::string_view> optional_values) override {
-    LOG(INFO) << "FakeStatsPlugin[" << this
-              << "]::RecordHistogram(index=" << handle.index
-              << ", value=(uint64)" << value << ", label_values={"
-              << absl::StrJoin(label_values, ", ")
-              << "}, optional_label_values={"
-              << absl::StrJoin(optional_values, ", ") << "}";
+    VLOG(2) << "FakeStatsPlugin[" << this
+            << "]::RecordHistogram(index=" << handle.index << ", value=(uint64)"
+            << value << ", label_values={" << absl::StrJoin(label_values, ", ")
+            << "}, optional_label_values={"
+            << absl::StrJoin(optional_values, ", ") << "}";
     MutexLock lock(&mu_);
     auto iter = uint64_histograms_.find(handle.index);
     if (iter == uint64_histograms_.end()) return;
@@ -345,25 +342,24 @@ class FakeStatsPlugin : public StatsPlugin {
       GlobalInstrumentsRegistry::GlobalInstrumentHandle handle, double value,
       absl::Span<const absl::string_view> label_values,
       absl::Span<const absl::string_view> optional_values) override {
-    LOG(INFO) << "FakeStatsPlugin[" << this
-              << "]::RecordHistogram(index=" << handle.index
-              << ", value=(double)" << value << ", label_values={"
-              << absl::StrJoin(label_values, ", ")
-              << "}, optional_label_values={"
-              << absl::StrJoin(optional_values, ", ") << "}";
+    VLOG(2) << "FakeStatsPlugin[" << this
+            << "]::RecordHistogram(index=" << handle.index << ", value=(double)"
+            << value << ", label_values={" << absl::StrJoin(label_values, ", ")
+            << "}, optional_label_values={"
+            << absl::StrJoin(optional_values, ", ") << "}";
     MutexLock lock(&mu_);
     auto iter = double_histograms_.find(handle.index);
     if (iter == double_histograms_.end()) return;
     iter->second.Record(value, label_values, optional_values);
   }
   void AddCallback(RegisteredMetricCallback* callback) override {
-    LOG(INFO) << "FakeStatsPlugin[" << this << "]::AddCallback(" << callback
-              << ")";
+    VLOG(2) << "FakeStatsPlugin[" << this << "]::AddCallback(" << callback
+            << ")";
     callbacks_.insert(callback);
   }
   void RemoveCallback(RegisteredMetricCallback* callback) override {
-    LOG(INFO) << "FakeStatsPlugin[" << this << "]::RemoveCallback(" << callback
-              << ")";
+    VLOG(2) << "FakeStatsPlugin[" << this << "]::RemoveCallback(" << callback
+            << ")";
     callbacks_.erase(callback);
   }
 
@@ -428,12 +424,12 @@ class FakeStatsPlugin : public StatsPlugin {
     return iter->second.GetValues(label_values, optional_values);
   }
   void TriggerCallbacks() {
-    LOG(INFO) << "FakeStatsPlugin[" << this << "]::TriggerCallbacks(): START";
+    VLOG(2) << "FakeStatsPlugin[" << this << "]::TriggerCallbacks(): START";
     Reporter reporter(*this);
     for (auto* callback : callbacks_) {
       callback->Run(reporter);
     }
-    LOG(INFO) << "FakeStatsPlugin[" << this << "]::TriggerCallbacks(): END";
+    VLOG(2) << "FakeStatsPlugin[" << this << "]::TriggerCallbacks(): END";
   }
   absl::optional<int64_t> GetInt64CallbackGaugeValue(
       GlobalInstrumentsRegistry::GlobalInstrumentHandle handle,
@@ -467,12 +463,12 @@ class FakeStatsPlugin : public StatsPlugin {
         GlobalInstrumentsRegistry::GlobalInstrumentHandle handle, int64_t value,
         absl::Span<const absl::string_view> label_values,
         absl::Span<const absl::string_view> optional_values) override {
-      LOG(INFO) << "FakeStatsPlugin[" << this
-                << "]::Reporter::Report(index=" << handle.index
-                << ", value=(int64_t)" << value << ", label_values={"
-                << absl::StrJoin(label_values, ", ")
-                << "}, optional_label_values={"
-                << absl::StrJoin(optional_values, ", ") << "}";
+      VLOG(2) << "FakeStatsPlugin[" << this
+              << "]::Reporter::Report(index=" << handle.index
+              << ", value=(int64_t)" << value << ", label_values={"
+              << absl::StrJoin(label_values, ", ")
+              << "}, optional_label_values={"
+              << absl::StrJoin(optional_values, ", ") << "}";
       MutexLock lock(&plugin_.callback_mu_);
       auto iter = plugin_.int64_callback_gauges_.find(handle.index);
       if (iter == plugin_.int64_callback_gauges_.end()) return;
@@ -483,12 +479,12 @@ class FakeStatsPlugin : public StatsPlugin {
         GlobalInstrumentsRegistry::GlobalInstrumentHandle handle, double value,
         absl::Span<const absl::string_view> label_values,
         absl::Span<const absl::string_view> optional_values) override {
-      LOG(INFO) << "FakeStatsPlugin[" << this
-                << "]::Reporter::Report(index=" << handle.index
-                << ", value=(double)" << value << ", label_values={"
-                << absl::StrJoin(label_values, ", ")
-                << "}, optional_label_values={"
-                << absl::StrJoin(optional_values, ", ") << "}";
+      VLOG(2) << "FakeStatsPlugin[" << this
+              << "]::Reporter::Report(index=" << handle.index
+              << ", value=(double)" << value << ", label_values={"
+              << absl::StrJoin(label_values, ", ")
+              << "}, optional_label_values={"
+              << absl::StrJoin(optional_values, ", ") << "}";
       MutexLock lock(&plugin_.callback_mu_);
       auto iter = plugin_.double_callback_gauges_.find(handle.index);
       if (iter == plugin_.double_callback_gauges_.end()) return;


### PR DESCRIPTION
```
-------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations
-------------------------------------------------------------------------------------
BM_AddCounterWithFakeStatsPlugin                 36.9 ns         36.9 ns     18606645
BM_AddCounterWithLabelsWithFakeStatsPlugin        407 ns          407 ns      1712866
BM_AddCounterWithOTelPlugin                      46.6 ns         46.6 ns     15022711
BM_AddCounterWithLabelsWithOTelPlugin             142 ns          142 ns      4957733
BM_AddCounterWithNoPlugin                       0.313 ns        0.313 ns   1000000000
BM_AddCounterWithLabelsWithNoPlugin              1.96 ns         1.96 ns    356217818
```