### PR TITLE
Remove win32 handling on grpc_ares_init

### DIFF
--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -1180,10 +1180,6 @@ static void grpc_cancel_ares_request_impl(grpc_ares_request* r) {
 void (*grpc_cancel_ares_request)(grpc_ares_request* r) =
     grpc_cancel_ares_request_impl;
 
-// ares_library_init and ares_library_cleanup are currently no-op except under
-// Windows. Calling them may cause race conditions when other parts of the
-// binary calls these functions concurrently.
-#ifdef GPR_WINDOWS
 grpc_error_handle grpc_ares_init(void) {
   int status = ares_library_init(ARES_LIB_INIT_ALL);
   if (status != ARES_SUCCESS) {
@@ -1194,9 +1190,5 @@ grpc_error_handle grpc_ares_init(void) {
 }
 
 void grpc_ares_cleanup(void) { ares_library_cleanup(); }
-#else
-grpc_error_handle grpc_ares_init(void) { return absl::OkStatus(); }
-void grpc_ares_cleanup(void) {}
-#endif  // GPR_WINDOWS
 
 #endif  // GRPC_ARES == 1

--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -55,7 +55,6 @@
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
-#include <grpc/support/sync.h>
 
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
@@ -1180,10 +1179,8 @@ static void grpc_cancel_ares_request_impl(grpc_ares_request* r) {
 
 void (*grpc_cancel_ares_request)(grpc_ares_request* r) =
     grpc_cancel_ares_request_impl;
-grpc_core::Mutex ares_setup_mu_;
 
 grpc_error_handle grpc_ares_init(void) {
-  grpc_core::MutexLock lock(&ares_setup_mu_);
   int status = ares_library_init(ARES_LIB_INIT_ALL);
   if (status != ARES_SUCCESS) {
     return GRPC_ERROR_CREATE(
@@ -1192,9 +1189,6 @@ grpc_error_handle grpc_ares_init(void) {
   return absl::OkStatus();
 }
 
-void grpc_ares_cleanup(void) {
-  ares_library_cleanup();
-  grpc_core::MutexLock lock(&ares_setup_mu_);
-}
+void grpc_ares_cleanup(void) { ares_library_cleanup(); }
 
 #endif  // GRPC_ARES == 1


### PR DESCRIPTION
Purpose: Fix TSAN caused by early call to ares_library_cleanup while gRPC is still using ares

`ares_library_init` and `ares_library_cleanup` is not required to be called on non-windows. But if other library is calling these functions, then it will potentially introduce data race. Some example that I encounter: [Curl](https://github.com/curl/curl/blob/abdf612221db39f31abde0ef211bad28e272dde0/lib/asyn-ares.c#L152) calling `ares_library_cleanup` when gRPC is still processing request.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

