### PR TITLE
[release] Bump Ruby artifact build timeout: 1h30m -> 2h

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -270,7 +270,7 @@ class RubyArtifact:
                 self.gem_platform,
             ],
             use_workspace=True,
-            timeout_seconds=90 * 60,
+            timeout_seconds=120 * 60,
             environ=environ,
         )
 


### PR DESCRIPTION
The Ruby artifact build is timing out at 1hr30m, specifically `build_artifact.ruby_native_gem_linux_aarch64-linux` in the `tools/internal_ci/linux/grpc_distribtests_ruby.sh` job. Most of the other Ruby builds take around 1hr15m, so the build time is increasing regardless.

@stanley-cheung this should probably be investigated. In the meantime, to hopefully unblock the v1.66 release, let's increase the build timeout.