### PR TITLE
[ruby] refactor flaky test and expose cancel_with_status

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -620,6 +620,8 @@ module GRPC
     # @param metadata [Hash] metadata to be sent to the server. If a value is
     # a list, multiple metadata for its key are sent
     def start_call(metadata = {})
+      # TODO(apolcyn): we should cancel and clean up the call in case this
+      # send initial MD op fails.
       merge_metadata_to_send(metadata) && send_initial_metadata
     end
 

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -44,8 +44,8 @@ module GRPC
     include Core::CallOps
     extend Forwardable
     attr_reader :deadline, :metadata_sent, :metadata_to_send, :peer, :peer_cert
-    def_delegators :@call, :cancel, :metadata, :write_flag, :write_flag=,
-                   :trailing_metadata, :status
+    def_delegators :@call, :cancel, :cancel_with_status, :metadata,
+                   :write_flag, :write_flag=, :trailing_metadata, :status
 
     # client_invoke begins a client invocation.
     #
@@ -665,9 +665,9 @@ module GRPC
 
     # Operation limits access to an ActiveCall's methods for use as
     # a Operation on the client.
-    Operation = view_class(:cancel, :cancelled?, :deadline, :execute,
-                           :metadata, :status, :start_call, :wait, :write_flag,
-                           :write_flag=, :trailing_metadata)
+    Operation = view_class(:cancel, :cancel_with_status, :cancelled?, :deadline,
+                           :execute, :metadata, :status, :start_call, :wait,
+                           :write_flag, :write_flag=, :trailing_metadata)
 
     # InterceptableView further limits access to an ActiveCall's methods
     # for use in interceptors on the client, exposing only the deadline

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -667,6 +667,7 @@ module GRPC
 
     # Operation limits access to an ActiveCall's methods for use as
     # a Operation on the client.
+    # TODO(apolcyn): expose peer getter
     Operation = view_class(:cancel, :cancel_with_status, :cancelled?, :deadline,
                            :execute, :metadata, :status, :start_call, :wait,
                            :write_flag, :write_flag=, :trailing_metadata)

--- a/src/ruby/spec/call_spec.rb
+++ b/src/ruby/spec/call_spec.rb
@@ -90,88 +90,101 @@ describe GRPC::Core::Call do
 
   describe '#status' do
     it 'can save the status and read it back' do
-      call = make_test_call
-      sts = Struct::Status.new(OK, 'OK')
-      expect { call.status = sts }.not_to raise_error
-      expect(call.status).to eq(sts)
+      make_test_call do |call|
+        sts = Struct::Status.new(OK, 'OK')
+        expect { call.status = sts }.not_to raise_error
+        expect(call.status).to eq(sts)
+      end
     end
 
     it 'must be set to a status' do
-      call = make_test_call
-      bad_sts = Object.new
-      expect { call.status = bad_sts }.to raise_error(TypeError)
+      make_test_call do |call|
+        bad_sts = Object.new
+        expect { call.status = bad_sts }.to raise_error(TypeError)
+      end
     end
 
     it 'can be set to nil' do
-      call = make_test_call
-      expect { call.status = nil }.not_to raise_error
+      make_test_call do |call|
+        expect { call.status = nil }.not_to raise_error
+      end
     end
   end
 
   describe '#metadata' do
     it 'can save the metadata hash and read it back' do
-      call = make_test_call
-      md = { 'k1' => 'v1',  'k2' => 'v2' }
-      expect { call.metadata = md }.not_to raise_error
-      expect(call.metadata).to be(md)
+      make_test_call do |call|
+        md = { 'k1' => 'v1',  'k2' => 'v2' }
+        expect { call.metadata = md }.not_to raise_error
+        expect(call.metadata).to be(md)
+      end
     end
 
     it 'must be set with a hash' do
-      call = make_test_call
-      bad_md = Object.new
-      expect { call.metadata = bad_md }.to raise_error(TypeError)
+      make_test_call do |call|
+        bad_md = Object.new
+        expect { call.metadata = bad_md }.to raise_error(TypeError)
+      end
     end
 
     it 'can be set to nil' do
-      call = make_test_call
-      expect { call.metadata = nil }.not_to raise_error
+      make_test_call do |call|
+        expect { call.metadata = nil }.not_to raise_error
+      end
     end
   end
 
   describe '#set_credentials!' do
     it 'can set a valid CallCredentials object' do
-      call = make_test_call
-      auth_proc = proc { { 'plugin_key' => 'plugin_value' } }
-      creds = GRPC::Core::CallCredentials.new auth_proc
-      expect { call.set_credentials! creds }.not_to raise_error
+      make_test_call do |call|
+        auth_proc = proc { { 'plugin_key' => 'plugin_value' } }
+        creds = GRPC::Core::CallCredentials.new auth_proc
+        expect { call.set_credentials! creds }.not_to raise_error
+      end
     end
   end
 
   describe '#cancel' do
     it 'completes ok' do
-      call = make_test_call
-      expect { call.cancel }.not_to raise_error
+      make_test_call do |call|
+        expect { call.cancel }.not_to raise_error
+      end
     end
 
     it 'completes ok when the call is closed' do
-      call = make_test_call
-      call.close
-      expect { call.cancel }.not_to raise_error
+      make_test_call do |call|
+        call.close
+        expect { call.cancel }.not_to raise_error
+      end
     end
   end
 
   describe '#cancel_with_status' do
     it 'completes ok' do
-      call = make_test_call
-      expect do
-        call.cancel_with_status(0, 'test status')
-      end.not_to raise_error
-      expect do
-        call.cancel_with_status(0, nil)
-      end.to raise_error(TypeError)
+      make_test_call do |call|
+        expect do
+          call.cancel_with_status(0, 'test status')
+        end.not_to raise_error
+        expect do
+          call.cancel_with_status(0, nil)
+        end.to raise_error(TypeError)
+      end
     end
 
     it 'completes ok when the call is closed' do
-      call = make_test_call
-      call.close
-      expect do
-        call.cancel_with_status(0, 'test status')
-      end.not_to raise_error
+      make_test_call do |call|
+        call.close
+        expect do
+          call.cancel_with_status(0, 'test status')
+        end.not_to raise_error
+      end
     end
   end
 
-  def make_test_call
-    @ch.create_call(nil, nil, 'phony_method', nil, deadline)
+  def make_test_call(&blk)
+    call = @ch.create_call(nil, nil, 'phony_method', nil, deadline)
+    yield call
+    call.close
   end
 
   def deadline

--- a/src/ruby/spec/call_spec.rb
+++ b/src/ruby/spec/call_spec.rb
@@ -181,7 +181,7 @@ describe GRPC::Core::Call do
     end
   end
 
-  def make_test_call(&blk)
+  def make_test_call
     call = @ch.create_call(nil, nil, 'phony_method', nil, deadline)
     yield call
     call.close

--- a/src/ruby/spec/channel_spec.rb
+++ b/src/ruby/spec/channel_spec.rb
@@ -118,7 +118,8 @@ describe GRPC::Core::Channel do
       deadline = Time.now + 5
 
       blk = proc do
-        ch.create_call(nil, nil, 'phony_method', nil, deadline)
+        call = ch.create_call(nil, nil, 'phony_method', nil, deadline)
+        call.close
       end
       expect(&blk).to_not raise_error
     end
@@ -132,8 +133,9 @@ describe GRPC::Core::Channel do
 
       deadline = Time.now + 5
       blk = proc do
-        ch.create_call(nil, nil, 'phony_method', nil, deadline)
+        call = ch.create_call(nil, nil, 'phony_method', nil, deadline)
         STDERR.puts "#{Time.now}: created call"
+        call.close
       end
       expect(&blk).to raise_error(RuntimeError)
       STDERR.puts "#{Time.now}: finished: raises an error if called on a closed channel"

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -48,243 +48,243 @@ shared_examples 'basic GRPC message delivery is OK' do
   include_context 'setup: tags'
 
   context 'the test channel' do
-    it 'should have a target' do
-      expect(@ch.target).to be_a(String)
-    end
+    #it 'should have a target' do
+    #  expect(@ch.target).to be_a(String)
+    #end
   end
 
   context 'a client call' do
-    it 'should have a peer' do
-      expect(new_client_call.peer).to be_a(String)
-    end
+    #it 'should have a peer' do
+    #  expect(new_client_call.peer).to be_a(String)
+    #end
   end
 
-  it 'calls have peer info' do
-    call = new_client_call
-    expect(call.peer).to be_a(String)
-  end
+  #it 'calls have peer info' do
+  #  call = new_client_call
+  #  expect(call.peer).to be_a(String)
+  #end
 
-  it 'servers receive requests from clients and can respond' do
-    call = new_client_call
-    server_call = nil
+  #it 'servers receive requests from clients and can respond' do
+  #  call = new_client_call
+  #  server_call = nil
 
-    server_thread = Thread.new do
-      server_call = server_allows_client_to_proceed
-    end
+  #  server_thread = Thread.new do
+  #    server_call = server_allows_client_to_proceed
+  #  end
 
-    client_ops = {
-      CallOps::SEND_INITIAL_METADATA => {},
-      CallOps::SEND_MESSAGE => sent_message,
-      CallOps::SEND_CLOSE_FROM_CLIENT => nil
-    }
-    client_batch = call.run_batch(client_ops)
-    expect(client_batch.send_metadata).to be true
-    expect(client_batch.send_message).to be true
-    expect(client_batch.send_close).to be true
+  #  client_ops = {
+  #    CallOps::SEND_INITIAL_METADATA => {},
+  #    CallOps::SEND_MESSAGE => sent_message,
+  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
+  #  }
+  #  client_batch = call.run_batch(client_ops)
+  #  expect(client_batch.send_metadata).to be true
+  #  expect(client_batch.send_message).to be true
+  #  expect(client_batch.send_close).to be true
 
-    # confirm the server can read the inbound message
-    server_thread.join
-    server_ops = {
-      CallOps::RECV_MESSAGE => nil
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.message).to eq(sent_message)
-    server_ops = {
-      CallOps::RECV_CLOSE_ON_SERVER => nil,
-      CallOps::SEND_STATUS_FROM_SERVER => ok_status
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.send_close).to be true
-    expect(server_batch.send_status).to be true
+  #  # confirm the server can read the inbound message
+  #  server_thread.join
+  #  server_ops = {
+  #    CallOps::RECV_MESSAGE => nil
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.message).to eq(sent_message)
+  #  server_ops = {
+  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
+  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.send_close).to be true
+  #  expect(server_batch.send_status).to be true
 
-    # finish the call
-    final_client_batch = call.run_batch(
-      CallOps::RECV_INITIAL_METADATA => nil,
-      CallOps::RECV_STATUS_ON_CLIENT => nil)
-    expect(final_client_batch.metadata).to eq({})
-    expect(final_client_batch.status.code).to eq(0)
-  end
+  #  # finish the call
+  #  final_client_batch = call.run_batch(
+  #    CallOps::RECV_INITIAL_METADATA => nil,
+  #    CallOps::RECV_STATUS_ON_CLIENT => nil)
+  #  expect(final_client_batch.metadata).to eq({})
+  #  expect(final_client_batch.status.code).to eq(0)
+  #end
 
-  it 'responses written by servers are received by the client' do
-    call = new_client_call
-    server_call = nil
+  #it 'responses written by servers are received by the client' do
+  #  call = new_client_call
+  #  server_call = nil
 
-    server_thread = Thread.new do
-      server_call = server_allows_client_to_proceed
-    end
+  #  server_thread = Thread.new do
+  #    server_call = server_allows_client_to_proceed
+  #  end
 
-    client_ops = {
-      CallOps::SEND_INITIAL_METADATA => {},
-      CallOps::SEND_MESSAGE => sent_message,
-      CallOps::SEND_CLOSE_FROM_CLIENT => nil
-    }
-    client_batch = call.run_batch(client_ops)
-    expect(client_batch.send_metadata).to be true
-    expect(client_batch.send_message).to be true
-    expect(client_batch.send_close).to be true
+  #  client_ops = {
+  #    CallOps::SEND_INITIAL_METADATA => {},
+  #    CallOps::SEND_MESSAGE => sent_message,
+  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
+  #  }
+  #  client_batch = call.run_batch(client_ops)
+  #  expect(client_batch.send_metadata).to be true
+  #  expect(client_batch.send_message).to be true
+  #  expect(client_batch.send_close).to be true
 
-    # confirm the server can read the inbound message
-    server_thread.join
-    server_ops = {
-      CallOps::RECV_MESSAGE => nil
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.message).to eq(sent_message)
-    server_ops = {
-      CallOps::RECV_CLOSE_ON_SERVER => nil,
-      CallOps::SEND_MESSAGE => reply_text,
-      CallOps::SEND_STATUS_FROM_SERVER => ok_status
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.send_close).to be true
-    expect(server_batch.send_message).to be true
-    expect(server_batch.send_status).to be true
+  #  # confirm the server can read the inbound message
+  #  server_thread.join
+  #  server_ops = {
+  #    CallOps::RECV_MESSAGE => nil
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.message).to eq(sent_message)
+  #  server_ops = {
+  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
+  #    CallOps::SEND_MESSAGE => reply_text,
+  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.send_close).to be true
+  #  expect(server_batch.send_message).to be true
+  #  expect(server_batch.send_status).to be true
 
-    # finish the call
-    final_client_batch = call.run_batch(
-      CallOps::RECV_INITIAL_METADATA => nil,
-      CallOps::RECV_MESSAGE => nil,
-      CallOps::RECV_STATUS_ON_CLIENT => nil)
-    expect(final_client_batch.metadata).to eq({})
-    expect(final_client_batch.message).to eq(reply_text)
-    expect(final_client_batch.status.code).to eq(0)
-  end
+  #  # finish the call
+  #  final_client_batch = call.run_batch(
+  #    CallOps::RECV_INITIAL_METADATA => nil,
+  #    CallOps::RECV_MESSAGE => nil,
+  #    CallOps::RECV_STATUS_ON_CLIENT => nil)
+  #  expect(final_client_batch.metadata).to eq({})
+  #  expect(final_client_batch.message).to eq(reply_text)
+  #  expect(final_client_batch.status.code).to eq(0)
+  #end
 
-  it 'compressed messages can be sent and received' do
-    call = new_client_call
-    server_call = nil
-    long_request_str = '0' * 2000
-    long_response_str = '1' * 2000
-    md = { 'grpc-internal-encoding-request' => 'gzip' }
+  #it 'compressed messages can be sent and received' do
+  #  call = new_client_call
+  #  server_call = nil
+  #  long_request_str = '0' * 2000
+  #  long_response_str = '1' * 2000
+  #  md = { 'grpc-internal-encoding-request' => 'gzip' }
 
-    server_thread = Thread.new do
-      server_call = server_allows_client_to_proceed(md)
-    end
+  #  server_thread = Thread.new do
+  #    server_call = server_allows_client_to_proceed(md)
+  #  end
 
-    client_ops = {
-      CallOps::SEND_INITIAL_METADATA => md,
-      CallOps::SEND_MESSAGE => long_request_str,
-      CallOps::SEND_CLOSE_FROM_CLIENT => nil
-    }
-    client_batch = call.run_batch(client_ops)
-    expect(client_batch.send_metadata).to be true
-    expect(client_batch.send_message).to be true
-    expect(client_batch.send_close).to be true
+  #  client_ops = {
+  #    CallOps::SEND_INITIAL_METADATA => md,
+  #    CallOps::SEND_MESSAGE => long_request_str,
+  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
+  #  }
+  #  client_batch = call.run_batch(client_ops)
+  #  expect(client_batch.send_metadata).to be true
+  #  expect(client_batch.send_message).to be true
+  #  expect(client_batch.send_close).to be true
 
-    # confirm the server can read the inbound message
-    server_thread.join
-    server_ops = {
-      CallOps::RECV_MESSAGE => nil
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.message).to eq(long_request_str)
-    server_ops = {
-      CallOps::RECV_CLOSE_ON_SERVER => nil,
-      CallOps::SEND_MESSAGE => long_response_str,
-      CallOps::SEND_STATUS_FROM_SERVER => ok_status
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.send_close).to be true
-    expect(server_batch.send_message).to be true
-    expect(server_batch.send_status).to be true
+  #  # confirm the server can read the inbound message
+  #  server_thread.join
+  #  server_ops = {
+  #    CallOps::RECV_MESSAGE => nil
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.message).to eq(long_request_str)
+  #  server_ops = {
+  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
+  #    CallOps::SEND_MESSAGE => long_response_str,
+  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.send_close).to be true
+  #  expect(server_batch.send_message).to be true
+  #  expect(server_batch.send_status).to be true
 
-    client_ops = {
-      CallOps::RECV_INITIAL_METADATA => nil,
-      CallOps::RECV_MESSAGE => nil,
-      CallOps::RECV_STATUS_ON_CLIENT => nil
-    }
-    final_client_batch = call.run_batch(client_ops)
-    expect(final_client_batch.metadata).to eq({})
-    expect(final_client_batch.message).to eq long_response_str
-    expect(final_client_batch.status.code).to eq(0)
-  end
+  #  client_ops = {
+  #    CallOps::RECV_INITIAL_METADATA => nil,
+  #    CallOps::RECV_MESSAGE => nil,
+  #    CallOps::RECV_STATUS_ON_CLIENT => nil
+  #  }
+  #  final_client_batch = call.run_batch(client_ops)
+  #  expect(final_client_batch.metadata).to eq({})
+  #  expect(final_client_batch.message).to eq long_response_str
+  #  expect(final_client_batch.status.code).to eq(0)
+  #end
 
-  it 'servers can ignore a client write and send a status' do
-    call = new_client_call
-    server_call = nil
+  #it 'servers can ignore a client write and send a status' do
+  #  call = new_client_call
+  #  server_call = nil
 
-    server_thread = Thread.new do
-      server_call = server_allows_client_to_proceed
-    end
+  #  server_thread = Thread.new do
+  #    server_call = server_allows_client_to_proceed
+  #  end
 
-    client_ops = {
-      CallOps::SEND_INITIAL_METADATA => {},
-      CallOps::SEND_MESSAGE => sent_message,
-      CallOps::SEND_CLOSE_FROM_CLIENT => nil
-    }
-    client_batch = call.run_batch(client_ops)
-    expect(client_batch.send_metadata).to be true
-    expect(client_batch.send_message).to be true
-    expect(client_batch.send_close).to be true
+  #  client_ops = {
+  #    CallOps::SEND_INITIAL_METADATA => {},
+  #    CallOps::SEND_MESSAGE => sent_message,
+  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
+  #  }
+  #  client_batch = call.run_batch(client_ops)
+  #  expect(client_batch.send_metadata).to be true
+  #  expect(client_batch.send_message).to be true
+  #  expect(client_batch.send_close).to be true
 
-    # confirm the server can read the inbound message
-    the_status = Struct::Status.new(StatusCodes::OK, 'OK')
-    server_thread.join
-    server_ops = {
-      CallOps::SEND_STATUS_FROM_SERVER => the_status
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.message).to eq nil
-    expect(server_batch.send_status).to be true
+  #  # confirm the server can read the inbound message
+  #  the_status = Struct::Status.new(StatusCodes::OK, 'OK')
+  #  server_thread.join
+  #  server_ops = {
+  #    CallOps::SEND_STATUS_FROM_SERVER => the_status
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.message).to eq nil
+  #  expect(server_batch.send_status).to be true
 
-    final_client_batch = call.run_batch(
-      CallOps::RECV_INITIAL_METADATA => nil,
-      CallOps::RECV_STATUS_ON_CLIENT => nil)
-    expect(final_client_batch.metadata).to eq({})
-    expect(final_client_batch.status.code).to eq(0)
-  end
+  #  final_client_batch = call.run_batch(
+  #    CallOps::RECV_INITIAL_METADATA => nil,
+  #    CallOps::RECV_STATUS_ON_CLIENT => nil)
+  #  expect(final_client_batch.metadata).to eq({})
+  #  expect(final_client_batch.status.code).to eq(0)
+  #end
 
-  it 'completes calls by sending status to client and server' do
-    call = new_client_call
-    server_call = nil
+  #it 'completes calls by sending status to client and server' do
+  #  call = new_client_call
+  #  server_call = nil
 
-    server_thread = Thread.new do
-      server_call = server_allows_client_to_proceed
-    end
+  #  server_thread = Thread.new do
+  #    server_call = server_allows_client_to_proceed
+  #  end
 
-    client_ops = {
-      CallOps::SEND_INITIAL_METADATA => {},
-      CallOps::SEND_MESSAGE => sent_message
-    }
-    client_batch = call.run_batch(client_ops)
-    expect(client_batch.send_metadata).to be true
-    expect(client_batch.send_message).to be true
+  #  client_ops = {
+  #    CallOps::SEND_INITIAL_METADATA => {},
+  #    CallOps::SEND_MESSAGE => sent_message
+  #  }
+  #  client_batch = call.run_batch(client_ops)
+  #  expect(client_batch.send_metadata).to be true
+  #  expect(client_batch.send_message).to be true
 
-    # confirm the server can read the inbound message and respond
-    the_status = Struct::Status.new(StatusCodes::OK, 'OK', {})
-    server_thread.join
-    server_ops = {
-      CallOps::RECV_MESSAGE => nil
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.message).to eq sent_message
-    server_ops = {
-      CallOps::SEND_MESSAGE => reply_text,
-      CallOps::SEND_STATUS_FROM_SERVER => the_status
-    }
-    server_batch = server_call.run_batch(server_ops)
-    expect(server_batch.send_status).to be true
-    expect(server_batch.send_message).to be true
+  #  # confirm the server can read the inbound message and respond
+  #  the_status = Struct::Status.new(StatusCodes::OK, 'OK', {})
+  #  server_thread.join
+  #  server_ops = {
+  #    CallOps::RECV_MESSAGE => nil
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.message).to eq sent_message
+  #  server_ops = {
+  #    CallOps::SEND_MESSAGE => reply_text,
+  #    CallOps::SEND_STATUS_FROM_SERVER => the_status
+  #  }
+  #  server_batch = server_call.run_batch(server_ops)
+  #  expect(server_batch.send_status).to be true
+  #  expect(server_batch.send_message).to be true
 
-    # confirm the client can receive the server response and status.
-    client_ops = {
-      CallOps::SEND_CLOSE_FROM_CLIENT => nil,
-      CallOps::RECV_INITIAL_METADATA => nil,
-      CallOps::RECV_MESSAGE => nil,
-      CallOps::RECV_STATUS_ON_CLIENT => nil
-    }
-    final_client_batch = call.run_batch(client_ops)
-    expect(final_client_batch.send_close).to be true
-    expect(final_client_batch.message).to eq reply_text
-    expect(final_client_batch.status).to eq the_status
+  #  # confirm the client can receive the server response and status.
+  #  client_ops = {
+  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil,
+  #    CallOps::RECV_INITIAL_METADATA => nil,
+  #    CallOps::RECV_MESSAGE => nil,
+  #    CallOps::RECV_STATUS_ON_CLIENT => nil
+  #  }
+  #  final_client_batch = call.run_batch(client_ops)
+  #  expect(final_client_batch.send_close).to be true
+  #  expect(final_client_batch.message).to eq reply_text
+  #  expect(final_client_batch.status).to eq the_status
 
-    # confirm the server can receive the client close.
-    server_ops = {
-      CallOps::RECV_CLOSE_ON_SERVER => nil
-    }
-    final_server_batch = server_call.run_batch(server_ops)
-    expect(final_server_batch.send_close).to be true
-  end
+  #  # confirm the server can receive the client close.
+  #  server_ops = {
+  #    CallOps::RECV_CLOSE_ON_SERVER => nil
+  #  }
+  #  final_server_batch = server_call.run_batch(server_ops)
+  #  expect(final_server_batch.send_close).to be true
+  #end
 
   def client_cancel_test(cancel_proc, expected_code,
                          expected_details)
@@ -321,26 +321,26 @@ shared_examples 'basic GRPC message delivery is OK' do
     expect(client_batch.status.details).to eq expected_details
   end
 
-  it 'clients can cancel a call on the server' do
-    expected_code = StatusCodes::CANCELLED
-    expected_details = 'CANCELLED'
-    cancel_proc = proc { |call| call.cancel }
-    client_cancel_test(cancel_proc, expected_code, expected_details)
-  end
+  #it 'clients can cancel a call on the server' do
+  #  expected_code = StatusCodes::CANCELLED
+  #  expected_details = 'CANCELLED'
+  #  cancel_proc = proc { |call| call.cancel }
+  #  client_cancel_test(cancel_proc, expected_code, expected_details)
+  #end
 
-  it 'cancel_with_status unknown status' do
-    code = StatusCodes::UNKNOWN
-    details = 'test unknown reason'
-    cancel_proc = proc { |call| call.cancel_with_status(code, details) }
-    client_cancel_test(cancel_proc, code, details)
-  end
+  #it 'cancel_with_status unknown status' do
+  #  code = StatusCodes::UNKNOWN
+  #  details = 'test unknown reason'
+  #  cancel_proc = proc { |call| call.cancel_with_status(code, details) }
+  #  client_cancel_test(cancel_proc, code, details)
+  #end
 
-  it 'cancel_with_status unknown status' do
-    code = StatusCodes::FAILED_PRECONDITION
-    details = 'test failed precondition reason'
-    cancel_proc = proc { |call| call.cancel_with_status(code, details) }
-    client_cancel_test(cancel_proc, code, details)
-  end
+  #it 'cancel_with_status unknown status' do
+  #  code = StatusCodes::FAILED_PRECONDITION
+  #  details = 'test failed precondition reason'
+  #  cancel_proc = proc { |call| call.cancel_with_status(code, details) }
+  #  client_cancel_test(cancel_proc, code, details)
+  #end
 end
 
 shared_examples 'GRPC metadata delivery works OK' do
@@ -362,57 +362,57 @@ shared_examples 'GRPC metadata delivery works OK' do
       @bad_keys << { 1 => 'a value' }
     end
 
-    it 'raises an exception if a metadata key is invalid' do
-      @bad_keys.each do |md|
-        call = new_client_call
-        client_ops = {
-          CallOps::SEND_INITIAL_METADATA => md
-        }
-        blk = proc do
-          call.run_batch(client_ops)
-        end
-        expect(&blk).to raise_error
-      end
-    end
+    #it 'raises an exception if a metadata key is invalid' do
+    #  @bad_keys.each do |md|
+    #    call = new_client_call
+    #    client_ops = {
+    #      CallOps::SEND_INITIAL_METADATA => md
+    #    }
+    #    blk = proc do
+    #      call.run_batch(client_ops)
+    #    end
+    #    expect(&blk).to raise_error
+    #  end
+    #end
 
-    it 'sends all the metadata pairs when keys and values are valid' do
-      @valid_metadata.each do |md|
-        recvd_rpc = nil
-        rcv_thread = Thread.new do
-          recvd_rpc = @server.request_call
-        end
+    #it 'sends all the metadata pairs when keys and values are valid' do
+    #  @valid_metadata.each do |md|
+    #    recvd_rpc = nil
+    #    rcv_thread = Thread.new do
+    #      recvd_rpc = @server.request_call
+    #    end
 
-        call = new_client_call
-        client_ops = {
-          CallOps::SEND_INITIAL_METADATA => md,
-          CallOps::SEND_CLOSE_FROM_CLIENT => nil
-        }
-        client_batch = call.run_batch(client_ops)
-        expect(client_batch.send_metadata).to be true
+    #    call = new_client_call
+    #    client_ops = {
+    #      CallOps::SEND_INITIAL_METADATA => md,
+    #      CallOps::SEND_CLOSE_FROM_CLIENT => nil
+    #    }
+    #    client_batch = call.run_batch(client_ops)
+    #    expect(client_batch.send_metadata).to be true
 
-        # confirm the server can receive the client metadata
-        rcv_thread.join
-        expect(recvd_rpc).to_not eq nil
-        recvd_md = recvd_rpc.metadata
-        replace_symbols = Hash[md.each_pair.collect { |x, y| [x.to_s, y] }]
-        expect(recvd_md).to eq(recvd_md.merge(replace_symbols))
+    #    # confirm the server can receive the client metadata
+    #    rcv_thread.join
+    #    expect(recvd_rpc).to_not eq nil
+    #    recvd_md = recvd_rpc.metadata
+    #    replace_symbols = Hash[md.each_pair.collect { |x, y| [x.to_s, y] }]
+    #    expect(recvd_md).to eq(recvd_md.merge(replace_symbols))
 
-        # finish the call
-        final_server_batch = recvd_rpc.call.run_batch(
-          CallOps::RECV_CLOSE_ON_SERVER => nil,
-          CallOps::SEND_INITIAL_METADATA => nil,
-          CallOps::SEND_STATUS_FROM_SERVER => ok_status)
-        expect(final_server_batch.send_close).to be(true)
-        expect(final_server_batch.send_metadata).to be(true)
-        expect(final_server_batch.send_status).to be(true)
+    #    # finish the call
+    #    final_server_batch = recvd_rpc.call.run_batch(
+    #      CallOps::RECV_CLOSE_ON_SERVER => nil,
+    #      CallOps::SEND_INITIAL_METADATA => nil,
+    #      CallOps::SEND_STATUS_FROM_SERVER => ok_status)
+    #    expect(final_server_batch.send_close).to be(true)
+    #    expect(final_server_batch.send_metadata).to be(true)
+    #    expect(final_server_batch.send_status).to be(true)
 
-        final_client_batch = call.run_batch(
-          CallOps::RECV_INITIAL_METADATA => nil,
-          CallOps::RECV_STATUS_ON_CLIENT => nil)
-        expect(final_client_batch.metadata).to eq({})
-        expect(final_client_batch.status.code).to eq(0)
-      end
-    end
+    #    final_client_batch = call.run_batch(
+    #      CallOps::RECV_INITIAL_METADATA => nil,
+    #      CallOps::RECV_STATUS_ON_CLIENT => nil)
+    #    expect(final_client_batch.metadata).to eq({})
+    #    expect(final_client_batch.status.code).to eq(0)
+    #  end
+    #end
   end
 
   describe 'from server => client' do
@@ -431,123 +431,123 @@ shared_examples 'GRPC metadata delivery works OK' do
       @bad_keys << { 1 => 'a value' }
     end
 
-    it 'raises an exception if a metadata key is invalid' do
-      @bad_keys.each do |md|
-        recvd_rpc = nil
-        rcv_thread = Thread.new do
-          recvd_rpc = @server.request_call
-        end
+    #it 'raises an exception if a metadata key is invalid' do
+    #  @bad_keys.each do |md|
+    #    recvd_rpc = nil
+    #    rcv_thread = Thread.new do
+    #      recvd_rpc = @server.request_call
+    #    end
 
-        call = new_client_call
-        # client signals that it's done sending metadata to allow server to
-        # respond
-        client_ops = {
-          CallOps::SEND_INITIAL_METADATA => nil
-        }
-        call.run_batch(client_ops)
+    #    call = new_client_call
+    #    # client signals that it's done sending metadata to allow server to
+    #    # respond
+    #    client_ops = {
+    #      CallOps::SEND_INITIAL_METADATA => nil
+    #    }
+    #    call.run_batch(client_ops)
 
-        # server gets the invocation
-        rcv_thread.join
-        expect(recvd_rpc).to_not eq nil
-        server_ops = {
-          CallOps::SEND_INITIAL_METADATA => md
-        }
-        blk = proc do
-          recvd_rpc.call.run_batch(server_ops)
-        end
-        expect(&blk).to raise_error
+    #    # server gets the invocation
+    #    rcv_thread.join
+    #    expect(recvd_rpc).to_not eq nil
+    #    server_ops = {
+    #      CallOps::SEND_INITIAL_METADATA => md
+    #    }
+    #    blk = proc do
+    #      recvd_rpc.call.run_batch(server_ops)
+    #    end
+    #    expect(&blk).to raise_error
 
-        # cancel the call so the server can shut down immediately
-        call.cancel
-      end
-    end
+    #    # cancel the call so the server can shut down immediately
+    #    call.cancel
+    #  end
+    #end
 
-    it 'sends an empty hash if no metadata is added' do
-      recvd_rpc = nil
-      rcv_thread = Thread.new do
-        recvd_rpc = @server.request_call
-      end
+    #it 'sends an empty hash if no metadata is added' do
+    #  recvd_rpc = nil
+    #  rcv_thread = Thread.new do
+    #    recvd_rpc = @server.request_call
+    #  end
 
-      call = new_client_call
-      # client signals that it's done sending metadata to allow server to
-      # respond
-      client_ops = {
-        CallOps::SEND_INITIAL_METADATA => nil,
-        CallOps::SEND_CLOSE_FROM_CLIENT => nil
-      }
-      client_batch = call.run_batch(client_ops)
-      expect(client_batch.send_metadata).to be true
-      expect(client_batch.send_close).to be true
+    #  call = new_client_call
+    #  # client signals that it's done sending metadata to allow server to
+    #  # respond
+    #  client_ops = {
+    #    CallOps::SEND_INITIAL_METADATA => nil,
+    #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
+    #  }
+    #  client_batch = call.run_batch(client_ops)
+    #  expect(client_batch.send_metadata).to be true
+    #  expect(client_batch.send_close).to be true
 
-      # server gets the invocation but sends no metadata back
-      rcv_thread.join
-      expect(recvd_rpc).to_not eq nil
-      server_call = recvd_rpc.call
-      server_ops = {
-        # receive close and send status to finish the call
-        CallOps::RECV_CLOSE_ON_SERVER => nil,
-        CallOps::SEND_INITIAL_METADATA => nil,
-        CallOps::SEND_STATUS_FROM_SERVER => ok_status
-      }
-      srv_batch = server_call.run_batch(server_ops)
-      expect(srv_batch.send_close).to be true
-      expect(srv_batch.send_metadata).to be true
-      expect(srv_batch.send_status).to be true
+    #  # server gets the invocation but sends no metadata back
+    #  rcv_thread.join
+    #  expect(recvd_rpc).to_not eq nil
+    #  server_call = recvd_rpc.call
+    #  server_ops = {
+    #    # receive close and send status to finish the call
+    #    CallOps::RECV_CLOSE_ON_SERVER => nil,
+    #    CallOps::SEND_INITIAL_METADATA => nil,
+    #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
+    #  }
+    #  srv_batch = server_call.run_batch(server_ops)
+    #  expect(srv_batch.send_close).to be true
+    #  expect(srv_batch.send_metadata).to be true
+    #  expect(srv_batch.send_status).to be true
 
-      # client receives nothing as expected
-      client_ops = {
-        CallOps::RECV_INITIAL_METADATA => nil,
-        # receive status to finish the call
-        CallOps::RECV_STATUS_ON_CLIENT => nil
-      }
-      final_client_batch = call.run_batch(client_ops)
-      expect(final_client_batch.metadata).to eq({})
-      expect(final_client_batch.status.code).to eq(0)
-    end
+    #  # client receives nothing as expected
+    #  client_ops = {
+    #    CallOps::RECV_INITIAL_METADATA => nil,
+    #    # receive status to finish the call
+    #    CallOps::RECV_STATUS_ON_CLIENT => nil
+    #  }
+    #  final_client_batch = call.run_batch(client_ops)
+    #  expect(final_client_batch.metadata).to eq({})
+    #  expect(final_client_batch.status.code).to eq(0)
+    #end
 
-    it 'sends all the pairs when keys and values are valid' do
-      @valid_metadata.each do |md|
-        recvd_rpc = nil
-        rcv_thread = Thread.new do
-          recvd_rpc = @server.request_call
-        end
+    #it 'sends all the pairs when keys and values are valid' do
+    #  @valid_metadata.each do |md|
+    #    recvd_rpc = nil
+    #    rcv_thread = Thread.new do
+    #      recvd_rpc = @server.request_call
+    #    end
 
-        call = new_client_call
-        # client signals that it's done sending metadata to allow server to
-        # respond
-        client_ops = {
-          CallOps::SEND_INITIAL_METADATA => nil,
-          CallOps::SEND_CLOSE_FROM_CLIENT => nil
-        }
-        client_batch = call.run_batch(client_ops)
-        expect(client_batch.send_metadata).to be true
-        expect(client_batch.send_close).to be true
+    #    call = new_client_call
+    #    # client signals that it's done sending metadata to allow server to
+    #    # respond
+    #    client_ops = {
+    #      CallOps::SEND_INITIAL_METADATA => nil,
+    #      CallOps::SEND_CLOSE_FROM_CLIENT => nil
+    #    }
+    #    client_batch = call.run_batch(client_ops)
+    #    expect(client_batch.send_metadata).to be true
+    #    expect(client_batch.send_close).to be true
 
-        # server gets the invocation but sends no metadata back
-        rcv_thread.join
-        expect(recvd_rpc).to_not eq nil
-        server_call = recvd_rpc.call
-        server_ops = {
-          CallOps::RECV_CLOSE_ON_SERVER => nil,
-          CallOps::SEND_INITIAL_METADATA => md,
-          CallOps::SEND_STATUS_FROM_SERVER => ok_status
-        }
-        srv_batch = server_call.run_batch(server_ops)
-        expect(srv_batch.send_close).to be true
-        expect(srv_batch.send_metadata).to be true
-        expect(srv_batch.send_status).to be true
+    #    # server gets the invocation but sends no metadata back
+    #    rcv_thread.join
+    #    expect(recvd_rpc).to_not eq nil
+    #    server_call = recvd_rpc.call
+    #    server_ops = {
+    #      CallOps::RECV_CLOSE_ON_SERVER => nil,
+    #      CallOps::SEND_INITIAL_METADATA => md,
+    #      CallOps::SEND_STATUS_FROM_SERVER => ok_status
+    #    }
+    #    srv_batch = server_call.run_batch(server_ops)
+    #    expect(srv_batch.send_close).to be true
+    #    expect(srv_batch.send_metadata).to be true
+    #    expect(srv_batch.send_status).to be true
 
-        # client receives nothing as expected
-        client_ops = {
-          CallOps::RECV_INITIAL_METADATA => nil,
-          CallOps::RECV_STATUS_ON_CLIENT => nil
-        }
-        final_client_batch = call.run_batch(client_ops)
-        replace_symbols = Hash[md.each_pair.collect { |x, y| [x.to_s, y] }]
-        expect(final_client_batch.metadata).to eq(replace_symbols)
-        expect(final_client_batch.status.code).to eq(0)
-      end
-    end
+    #    # client receives nothing as expected
+    #    client_ops = {
+    #      CallOps::RECV_INITIAL_METADATA => nil,
+    #      CallOps::RECV_STATUS_ON_CLIENT => nil
+    #    }
+    #    final_client_batch = call.run_batch(client_ops)
+    #    replace_symbols = Hash[md.each_pair.collect { |x, y| [x.to_s, y] }]
+    #    expect(final_client_batch.metadata).to eq(replace_symbols)
+    #    expect(final_client_batch.status.code).to eq(0)
+    #  end
+    #end
   end
 end
 
@@ -596,8 +596,10 @@ describe 'the secure http client/server' do
   end
 
   after(:example) do
+    p "BEGIN SERVER SHUTDOWN"
     @server.shutdown_and_notify(deadline)
     @server.close
+    p "END SERVER SHUTDOWN"
   end
 
   it_behaves_like 'basic GRPC message delivery is OK' do
@@ -623,7 +625,7 @@ describe 'the secure http client/server' do
     end
 
     call = new_client_call
-    call.set_credentials! call_creds
+    #call.set_credentials! call_creds
 
     client_batch = call.run_batch(
       CallOps::SEND_INITIAL_METADATA => initial_md,
@@ -636,7 +638,7 @@ describe 'the secure http client/server' do
     expect(recvd_rpc).to_not eq nil
     recvd_md = recvd_rpc.metadata
     replace_symbols = Hash[expected_md.each_pair.collect { |x, y| [x.to_s, y] }]
-    expect(recvd_md).to eq(recvd_md.merge(replace_symbols))
+    #expect(recvd_md).to eq(recvd_md.merge(replace_symbols))
 
     credentials_update_test_finish_call(call, recvd_rpc.call)
   end
@@ -649,28 +651,30 @@ describe 'the secure http client/server' do
     expect(final_server_batch.send_close).to be(true)
     expect(final_server_batch.send_metadata).to be(true)
     expect(final_server_batch.send_status).to be(true)
+    server_call.close
 
     final_client_batch = client_call.run_batch(
       CallOps::RECV_INITIAL_METADATA => nil,
       CallOps::RECV_STATUS_ON_CLIENT => nil)
     expect(final_client_batch.metadata).to eq({})
     expect(final_client_batch.status.code).to eq(0)
+    client_call.close
   end
 
   it 'modifies metadata with CallCredentials' do
     credentials_update_test('k1' => 'updated-v1')
   end
 
-  it 'modifies large metadata with CallCredentials' do
-    val_array = %w(
-      '00000000000000000000000000000000000000000000000000000000000000',
-      '11111111111111111111111111111111111111111111111111111111111111',
-    )
-    md = {
-      k3: val_array,
-      k4: '0000000000000000000000000000000000000000000000000000000000',
-      keeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeey5: 'v1'
-    }
-    credentials_update_test(md)
-  end
+  #it 'modifies large metadata with CallCredentials' do
+  #  val_array = %w(
+  #    '00000000000000000000000000000000000000000000000000000000000000',
+  #    '11111111111111111111111111111111111111111111111111111111111111',
+  #  )
+  #  md = {
+  #    k3: val_array,
+  #    k4: '0000000000000000000000000000000000000000000000000000000000',
+  #    keeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeey5: 'v1'
+  #  }
+  #  credentials_update_test(md)
+  #end
 end

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -48,156 +48,34 @@ shared_examples 'basic GRPC message delivery is OK' do
   include_context 'setup: tags'
 
   context 'the test channel' do
-    #it 'should have a target' do
-    #  expect(@ch.target).to be_a(String)
-    #end
+    it 'should have a target' do
+      expect(@ch.target).to be_a(String)
+    end
   end
 
-  context 'a client call' do
-    #it 'should have a peer' do
-    #  expect(new_client_call.peer).to be_a(String)
-    #end
+  it 'unary calls work' do
+    run_services_on_server(@server, services: [EchoService]) do
+      call = @stub.an_rpc(EchoMsg.new, return_op: true)
+      expect(call.execute).to be_a(EchoMsg)
+      # exercise the peer method
+      expect(call.peer).to be_a(String)
+    end
   end
 
-  #it 'calls have peer info' do
-  #  call = new_client_call
-  #  expect(call.peer).to be_a(String)
-  #end
-
-  #it 'simple unary calls work' do
-  #  call = new_client_call
-  #  server_call = nil
-
-  #  server_thread = Thread.new do
-  #    server_call = server_allows_client_to_proceed
-  #  end
-
-  #  client_ops = {
-  #    CallOps::SEND_INITIAL_METADATA => {},
-  #    CallOps::SEND_MESSAGE => sent_message,
-  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
-  #  }
-  #  client_batch = call.run_batch(client_ops)
-  #  expect(client_batch.send_metadata).to be true
-  #  expect(client_batch.send_message).to be true
-  #  expect(client_batch.send_close).to be true
-
-  #  # confirm the server can read the inbound message
-  #  server_thread.join
-  #  server_ops = {
-  #    CallOps::RECV_MESSAGE => nil
-  #  }
-  #  server_batch = server_call.run_batch(server_ops)
-  #  expect(server_batch.message).to eq(sent_message)
-  #  server_ops = {
-  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
-  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
-  #  }
-  #  server_batch = server_call.run_batch(server_ops)
-  #  expect(server_batch.send_close).to be true
-  #  expect(server_batch.send_status).to be true
-
-  #  # finish the call
-  #  final_client_batch = call.run_batch(
-  #    CallOps::RECV_INITIAL_METADATA => nil,
-  #    CallOps::RECV_STATUS_ON_CLIENT => nil)
-  #  expect(final_client_batch.metadata).to eq({})
-  #  expect(final_client_batch.status.code).to eq(0)
-  #end
-
-  #it 'responses written by servers are received by the client' do
-  #  call = new_client_call
-  #  server_call = nil
-
-  #  server_thread = Thread.new do
-  #    server_call = server_allows_client_to_proceed
-  #  end
-
-  #  client_ops = {
-  #    CallOps::SEND_INITIAL_METADATA => {},
-  #    CallOps::SEND_MESSAGE => sent_message,
-  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
-  #  }
-  #  client_batch = call.run_batch(client_ops)
-  #  expect(client_batch.send_metadata).to be true
-  #  expect(client_batch.send_message).to be true
-  #  expect(client_batch.send_close).to be true
-
-  #  # confirm the server can read the inbound message
-  #  server_thread.join
-  #  server_ops = {
-  #    CallOps::RECV_MESSAGE => nil
-  #  }
-  #  server_batch = server_call.run_batch(server_ops)
-  #  expect(server_batch.message).to eq(sent_message)
-  #  server_ops = {
-  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
-  #    CallOps::SEND_MESSAGE => reply_text,
-  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
-  #  }
-  #  server_batch = server_call.run_batch(server_ops)
-  #  expect(server_batch.send_close).to be true
-  #  expect(server_batch.send_message).to be true
-  #  expect(server_batch.send_status).to be true
-
-  #  # finish the call
-  #  final_client_batch = call.run_batch(
-  #    CallOps::RECV_INITIAL_METADATA => nil,
-  #    CallOps::RECV_MESSAGE => nil,
-  #    CallOps::RECV_STATUS_ON_CLIENT => nil)
-  #  expect(final_client_batch.metadata).to eq({})
-  #  expect(final_client_batch.message).to eq(reply_text)
-  #  expect(final_client_batch.status.code).to eq(0)
-  #end
-
-  #it 'compressed messages can be sent and received' do
-  #  call = new_client_call
-  #  server_call = nil
-  #  long_request_str = '0' * 2000
-  #  long_response_str = '1' * 2000
-  #  md = { 'grpc-internal-encoding-request' => 'gzip' }
-
-  #  server_thread = Thread.new do
-  #    server_call = server_allows_client_to_proceed(md)
-  #  end
-
-  #  client_ops = {
-  #    CallOps::SEND_INITIAL_METADATA => md,
-  #    CallOps::SEND_MESSAGE => long_request_str,
-  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil
-  #  }
-  #  client_batch = call.run_batch(client_ops)
-  #  expect(client_batch.send_metadata).to be true
-  #  expect(client_batch.send_message).to be true
-  #  expect(client_batch.send_close).to be true
-
-  #  # confirm the server can read the inbound message
-  #  server_thread.join
-  #  server_ops = {
-  #    CallOps::RECV_MESSAGE => nil
-  #  }
-  #  server_batch = server_call.run_batch(server_ops)
-  #  expect(server_batch.message).to eq(long_request_str)
-  #  server_ops = {
-  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
-  #    CallOps::SEND_MESSAGE => long_response_str,
-  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status
-  #  }
-  #  server_batch = server_call.run_batch(server_ops)
-  #  expect(server_batch.send_close).to be true
-  #  expect(server_batch.send_message).to be true
-  #  expect(server_batch.send_status).to be true
-
-  #  client_ops = {
-  #    CallOps::RECV_INITIAL_METADATA => nil,
-  #    CallOps::RECV_MESSAGE => nil,
-  #    CallOps::RECV_STATUS_ON_CLIENT => nil
-  #  }
-  #  final_client_batch = call.run_batch(client_ops)
-  #  expect(final_client_batch.metadata).to eq({})
-  #  expect(final_client_batch.message).to eq long_response_str
-  #  expect(final_client_batch.status.code).to eq(0)
-  #end
+  it 'unary calls work when enabling compression' do
+    run_services_on_server(@server, services: [EchoService]) do
+      long_request_str = '0' * 2000
+      md = { 'grpc-internal-encoding-request' => 'gzip' }
+      call = @stub.an_rpc(EchoMsg.new(msg: long_request_str),
+                          return_op: true,
+                          metadata: md)
+      response = call.execute
+      expect(response).to be_a(EchoMsg)
+      expect(response.msg).to eq(long_request_str)
+      # exercise the peer method
+      expect(call.peer).to be_a(String)
+    end
+  end
 
   #it 'servers can ignore a client write and send a status' do
   #  call = new_client_call

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -16,26 +16,8 @@ require 'spec_helper'
 
 include GRPC::Core
 
-shared_context 'setup: tags' do
-  let(:sent_message) { 'sent message' }
-  let(:reply_text) { 'the reply' }
-
-  def deadline
-    Time.now + 5
-  end
-
-  def new_client_call
-    @ch.create_call(nil, nil, '/method', nil, deadline)
-  end
-
-  def ok_status
-    Struct::Status.new(StatusCodes::OK, 'OK')
-  end
-end
-
 shared_examples 'basic GRPC message delivery is OK' do
   include GRPC::Core
-  include_context 'setup: tags'
 
   context 'the test channel' do
     it 'should have a target' do
@@ -107,8 +89,6 @@ shared_examples 'basic GRPC message delivery is OK' do
 end
 
 shared_examples 'GRPC metadata delivery works OK' do
-  include_context 'setup: tags'
-
   describe 'from client => server' do
     before(:example) do
       n = 7  # arbitrary number of metadata
@@ -251,8 +231,6 @@ describe 'the http client/server' do
 end
 
 describe 'the secure http client/server' do
-  include_context 'setup: tags'
-
   def load_test_certs
     test_root = File.join(File.dirname(__FILE__), 'testdata')
     files = ['ca.pem', 'server1.key', 'server1.pem']

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -66,27 +66,21 @@ shared_examples 'basic GRPC message delivery is OK' do
   def client_cancel_test(cancel_proc, expected_code,
                          expected_details)
     call = @stub.an_rpc(EchoMsg.new, return_op: true)
-    p "RUN SERVICES BEGIN"
     run_services_on_server(@server, services: [EchoService]) do
       # start the call, but don't send a message yet
       call.start_call
       # cancel the call
-      p "CANCEL CALL BEGIN"
       cancel_proc.call(call)
-      p "CANCEL CALL END"
       # check the client's status
       failed = false
       begin
-        p "EXECUTE BEGIN"
         call.execute
-        p "EXECUTE END"
       rescue GRPC::BadStatus => e
         failed = true
         expect(e.code).to be expected_code
         expect(e.details).to eq expected_details
       end
       expect(failed).to be(true)
-    p "RUN SERVICES END"
     end
   end
 
@@ -308,12 +302,6 @@ describe 'the http client/server' do
     @stub = EchoStub.new(
       "0.0.0.0:#{server_port}", nil, channel_override: @ch)
   end
-
-#  after(:example) do
-#    @ch.close
-#    @server.shutdown_and_notify(deadline)
-#    @server.close
-#  end
 
   it_behaves_like 'basic GRPC message delivery is OK' do
   end

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -64,7 +64,7 @@ shared_examples 'basic GRPC message delivery is OK' do
   #  expect(call.peer).to be_a(String)
   #end
 
-  #it 'servers receive requests from clients and can respond' do
+  #it 'simple unary calls work' do
   #  call = new_client_call
   #  server_call = nil
 
@@ -594,10 +594,12 @@ describe 'the secure http client/server' do
         Channel::SSL_TARGET => 'foo.test.google.fr'
       }
     }
+    args = { Channel::SSL_TARGET => 'foo.test.google.fr' }
+    @ch = Channel.new(
+      "0.0.0.0:#{server_port}", args,
+      GRPC::Core::ChannelCredentials.new(certs[0], nil, nil))
     @stub = EchoStub.new(
-      "0.0.0.0:#{server_port}",
-      GRPC::Core::ChannelCredentials.new(certs[0], nil, nil),
-      **client_opts)
+      "0.0.0.0:#{server_port}", nil, channel_override: @ch)
   end
 
   it_behaves_like 'basic GRPC message delivery is OK' do
@@ -605,52 +607,6 @@ describe 'the secure http client/server' do
 
   it_behaves_like 'GRPC metadata delivery works OK' do
   end
-
-  #def credentials_update_test(creds_update_md)
-  #  auth_proc = proc { creds_update_md }
-
-
-  #  recvd_rpc = nil
-  #  rcv_thread = Thread.new do
-  #    recvd_rpc = @server.request_call
-  #  end
-
-  #  call = new_client_call
-  #  #call.set_credentials! call_creds
-
-  #  client_batch = call.run_batch(
-  #    CallOps::SEND_INITIAL_METADATA => initial_md,
-  #    CallOps::SEND_CLOSE_FROM_CLIENT => nil)
-  #  expect(client_batch.send_metadata).to be true
-  #  expect(client_batch.send_close).to be true
-
-  #  # confirm the server can receive the client metadata
-  #  rcv_thread.join
-  #  expect(recvd_rpc).to_not eq nil
-  #  recvd_md = recvd_rpc.metadata
-  #  replace_symbols = Hash[expected_md.each_pair.collect { |x, y| [x.to_s, y] }]
-  #  #expect(recvd_md).to eq(recvd_md.merge(replace_symbols))
-
-  #  credentials_update_test_finish_call(call, recvd_rpc.call)
-  #end
-
-  #def credentials_update_test_finish_call(client_call, server_call)
-  #  final_server_batch = server_call.run_batch(
-  #    CallOps::RECV_CLOSE_ON_SERVER => nil,
-  #    CallOps::SEND_INITIAL_METADATA => nil,
-  #    CallOps::SEND_STATUS_FROM_SERVER => ok_status)
-  #  expect(final_server_batch.send_close).to be(true)
-  #  expect(final_server_batch.send_metadata).to be(true)
-  #  expect(final_server_batch.send_status).to be(true)
-  #  server_call.close
-
-  #  final_client_batch = client_call.run_batch(
-  #    CallOps::RECV_INITIAL_METADATA => nil,
-  #    CallOps::RECV_STATUS_ON_CLIENT => nil)
-  #  expect(final_client_batch.metadata).to eq({})
-  #  expect(final_client_batch.status.code).to eq(0)
-  #  client_call.close
-  #end
 
   it 'modifies metadata with CallCredentials' do
     # create call creds

--- a/src/ruby/spec/support/services.rb
+++ b/src/ruby/spec/support/services.rb
@@ -51,7 +51,7 @@ class EchoService
 
   def an_rpc(req, call)
     GRPC.logger.info('echo service received a request')
-    on_call_started.call(call) unless on_call_started.nil?
+    on_call_started&.call(call)
     call.output_metadata.update(@trailing_metadata)
     @received_md << call.metadata unless call.metadata.nil?
     req

--- a/src/ruby/spec/support/services.rb
+++ b/src/ruby/spec/support/services.rb
@@ -41,14 +41,17 @@ class EchoService
   rpc :a_bidi_rpc, stream(EchoMsg), stream(EchoMsg)
   rpc :a_client_streaming_rpc_unimplemented, stream(EchoMsg), EchoMsg
   attr_reader :received_md
+  attr_accessor :on_call_started
 
   def initialize(**kw)
     @trailing_metadata = kw
     @received_md = []
+    @on_call_started = nil
   end
 
   def an_rpc(req, call)
     GRPC.logger.info('echo service received a request')
+    on_call_started.call(call) unless on_call_started.nil?
     call.output_metadata.update(@trailing_metadata)
     @received_md << call.metadata unless call.metadata.nil?
     req


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/37234

Following up on the problem described in https://github.com/grpc/grpc/pull/36903, there are a number of paths in `client_server_spec.rb` and a few other tests where client call objects can leak due to RPC lifecycles not being properly completed, leading to a thread not terminating.

Some of the tests (which don't use the surface-level grpc-ruby APIs), are changed to manually terminate calls where necessary. If an RPC is not manually closed, then we rely on garbage collection to unref it. If GC doesn't happen before ruby process shutdown initiates, then still-live calls can prevent a thread from terminating. `client_server_spec.rb` is updated to use surface level APIs, which manages call lifecycles correctly (this also improves the test's fidelity).

While we're here: expose `cancel_with_status` on call operations. This was only accidentally private so far. The test refactoring caught it.
