### PR TITLE
[Bazel] Updated bazel-skylib

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -23,10 +23,10 @@ def grpc_deps():
     if "platforms" not in native.existing_rules():
         http_archive(
             name = "platforms",
-            sha256 = "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74",
+            sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
-                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
             ],
         )
 
@@ -168,10 +168,10 @@ def grpc_deps():
         http_archive(
             name = "bazel_skylib",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
             ],
-            sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+            sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
         )
 
     if "bazel_compdb" not in native.existing_rules():

--- a/tools/remote_build/include/rbe_remote_execution.bazelrc
+++ b/tools/remote_build/include/rbe_remote_execution.bazelrc
@@ -20,11 +20,8 @@ import %workspace%/tools/remote_build/include/rbe_base_config.bazelrc
 # configure backend for remote execution
 build --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
-build --spawn_strategy=remote
-build --strategy=Javac=remote
-build --strategy=Closure=remote
-build --genrule_strategy=remote
-build --remote_timeout=7200  # very large value to avoid problems like https://github.com/grpc/grpc/issues/20777
+# Very large value to avoid problems like https://github.com/grpc/grpc/issues/20777
+build --remote_timeout=7200
 
 # In the remote execution environment, each test gets its own docker containers
 # and port server won't be available.


### PR DESCRIPTION
It appears that gRPC needs to upgrade bazel-skylib to 1.7.x or later to have the latest protobuf 
(Context: https://github.com/protocolbuffers/protobuf/issues/17687)

Two minor things are done
- Removed `--spawn_strategy=remote` to resolve errors related to https://github.com/bazelbuild/bazel/issues/7480
- Upgraded `bazelbuild/platforms` to 0.0.10