### PR TITLE
[OTel] Fix deadlocks when adding and removing callbacks

### DIFF
--- a/src/core/load_balancing/rls/rls.cc
+++ b/src/core/load_balancing/rls/rls.cc
@@ -787,7 +787,7 @@ class RlsLb final : public LoadBalancingPolicy {
   std::map<std::string /*target*/, ChildPolicyWrapper*> child_policy_map_;
 
   // Must be after mu_, so that it is destroyed before mu_.
-  std::unique_ptr<RegisteredMetricCallback> registered_metric_callback_;
+  OrphanablePtr<RegisteredMetricCallback> registered_metric_callback_;
 };
 
 //
@@ -1935,9 +1935,11 @@ RlsLb::RlsLb(Args args)
       cache_(this),
       registered_metric_callback_(
           channel_control_helper()->GetStatsPluginGroup().RegisterCallback(
-              [this](CallbackMetricReporter& reporter) {
-                MutexLock lock(&mu_);
-                cache_.ReportMetricsLocked(reporter);
+              [rls_lb = RefAsSubclass<RlsLb>(DEBUG_LOCATION,
+                                             "RlsLB Metric Callback")](
+                  CallbackMetricReporter& reporter) {
+                MutexLock lock(&rls_lb->mu_);
+                rls_lb->cache_.ReportMetricsLocked(reporter);
               },
               Duration::Seconds(5), kMetricCacheSize, kMetricCacheEntries)) {
   if (GRPC_TRACE_FLAG_ENABLED(rls_lb)) {

--- a/src/core/telemetry/metrics.cc
+++ b/src/core/telemetry/metrics.cc
@@ -90,14 +90,15 @@ RegisteredMetricCallback::RegisteredMetricCallback(
       metrics_(std::move(metrics)),
       min_interval_(min_interval) {
   for (auto& state : stats_plugin_group_.plugins_state_) {
-    state.plugin->AddCallback(this);
+    state.plugin->AddCallback(Ref());
   }
 }
 
-RegisteredMetricCallback::~RegisteredMetricCallback() {
+void RegisteredMetricCallback::Orphan() {
   for (auto& state : stats_plugin_group_.plugins_state_) {
-    state.plugin->RemoveCallback(this);
+    state.plugin->RemoveCallback(Ref());
   }
+  Unref(DEBUG_LOCATION, "RegisteredMetricCallback::Orphan");
 }
 
 void GlobalStatsPluginRegistry::StatsPluginGroup::AddClientCallTracers(

--- a/src/core/xds/grpc/xds_client_grpc.cc
+++ b/src/core/xds/grpc/xds_client_grpc.cc
@@ -313,8 +313,10 @@ GrpcXdsClient::GrpcXdsClient(
               .certificate_providers())),
       stats_plugin_group_(GetStatsPluginGroupForKey(key_)),
       registered_metric_callback_(stats_plugin_group_.RegisterCallback(
-          [this](CallbackMetricReporter& reporter) {
-            ReportCallbackMetrics(reporter);
+          [xds_client = WeakRefAsSubclass<GrpcXdsClient>(
+               DEBUG_LOCATION, "GrpcXdsClient Metric Callback")](
+              CallbackMetricReporter& reporter) {
+            xds_client->ReportCallbackMetrics(reporter);
           },
           Duration::Seconds(5), kMetricConnected, kMetricResources)) {}
 

--- a/src/core/xds/grpc/xds_client_grpc.h
+++ b/src/core/xds/grpc/xds_client_grpc.h
@@ -93,7 +93,7 @@ class GrpcXdsClient final : public XdsClient {
   std::string key_;
   OrphanablePtr<CertificateProviderStore> certificate_provider_store_;
   GlobalStatsPluginRegistry::StatsPluginGroup stats_plugin_group_;
-  std::unique_ptr<RegisteredMetricCallback> registered_metric_callback_;
+  OrphanablePtr<RegisteredMetricCallback> registered_metric_callback_;
 };
 
 namespace internal {

--- a/src/cpp/ext/otel/BUILD
+++ b/src/cpp/ext/otel/BUILD
@@ -75,6 +75,7 @@ grpc_cc_library(
         "//src/core:channel_fwd",
         "//src/core:channel_stack_type",
         "//src/core:context",
+        "//src/core:default_event_engine",
         "//src/core:error",
         "//src/core:experiments",
         "//src/core:match",

--- a/src/cpp/ext/otel/otel_plugin.h
+++ b/src/cpp/ext/otel/otel_plugin.h
@@ -478,6 +478,10 @@ class OpenTelemetryPluginImpl
     //               x
     // instrument2 ----- RegisteredMetricCallback2
     // One instrument can be registered by multiple callbacks.
+    // Note that we are not holding a ref on the callback here since we expect
+    // the callback owner to be holding a ref while it is needed. Once the
+    // callback is removed by the owner, we get and maintain weak refs while we
+    // actually remove the callback from our structures.
     absl::flat_hash_map<grpc_core::RegisteredMetricCallback*, Cache> caches
         ABSL_GUARDED_BY(ot_plugin->mu_);
     OpenTelemetryPluginImpl* ot_plugin;

--- a/test/core/test_util/fake_stats_plugin.h
+++ b/test/core/test_util/fake_stats_plugin.h
@@ -352,15 +352,16 @@ class FakeStatsPlugin : public StatsPlugin {
     if (iter == double_histograms_.end()) return;
     iter->second.Record(value, label_values, optional_values);
   }
-  void AddCallback(RegisteredMetricCallback* callback) override {
-    VLOG(2) << "FakeStatsPlugin[" << this << "]::AddCallback(" << callback
+  void AddCallback(RefCountedPtr<RegisteredMetricCallback> callback) override {
+    VLOG(2) << "FakeStatsPlugin[" << this << "]::AddCallback(" << callback.get()
             << ")";
-    callbacks_.insert(callback);
+    callbacks_.insert(callback.get());
   }
-  void RemoveCallback(RegisteredMetricCallback* callback) override {
-    VLOG(2) << "FakeStatsPlugin[" << this << "]::RemoveCallback(" << callback
-            << ")";
-    callbacks_.erase(callback);
+  void RemoveCallback(
+      RefCountedPtr<RegisteredMetricCallback> callback) override {
+    VLOG(2) << "FakeStatsPlugin[" << this << "]::RemoveCallback("
+            << callback.get() << ")";
+    callbacks_.erase(callback.get());
   }
 
   ClientCallTracer* GetClientCallTracer(

--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -1784,7 +1784,7 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
         reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
-      grpc_core::Duration::Milliseconds(100) * grpc_test_slowdown_factor(),
+      grpc_core::Duration::Milliseconds(200) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
   int report_count_2 = 0;
   int64_t int_value_2 = 1;
@@ -1801,11 +1801,11 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
         reporter.Report(double_gauge_handle, double_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
-      grpc_core::Duration::Milliseconds(100) * grpc_test_slowdown_factor(),
+      grpc_core::Duration::Milliseconds(200) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
   constexpr int kIterations = 100;
   MetricsCollectorThread collector{
-      this, grpc_core::Duration::Milliseconds(10) * grpc_test_slowdown_factor(),
+      this, grpc_core::Duration::Milliseconds(50) * grpc_test_slowdown_factor(),
       kIterations,
       [&](const absl::flat_hash_map<
           std::string,

--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -1775,14 +1775,10 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_1 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_1;
-        reporter.Report(integer_gauge_handle, int_value_1, kLabelValuesSet1,
+        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_1, kLabelValuesSet1,
+        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
       },
       grpc_core::Duration::Milliseconds(200) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
@@ -1792,12 +1788,8 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_2 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_2;
-        reporter.Report(integer_gauge_handle, int_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(integer_gauge_handle, int_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(double_gauge_handle, double_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
@@ -1821,8 +1813,6 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   // Verify that data is incremental with duplications (cached values).
   EXPECT_LT(report_count_1, kIterations);
   EXPECT_LT(report_count_2, kIterations);
-  EXPECT_EQ(data[kInt64CallbackGaugeMetric].size(),
-            data[kDoubleCallbackGaugeMetric].size());
   // Verify labels.
   ASSERT_THAT(
       data,
@@ -1910,14 +1900,10 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_1 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_1;
-        reporter.Report(integer_gauge_handle, int_value_1, kLabelValuesSet1,
+        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_1, kLabelValuesSet1,
+        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
       },
       grpc_core::Duration::Milliseconds(50) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
@@ -1927,12 +1913,8 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_2 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_2;
-        reporter.Report(integer_gauge_handle, int_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(integer_gauge_handle, int_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(double_gauge_handle, double_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
@@ -1958,8 +1940,6 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   // values).
   EXPECT_EQ(report_count_1, kIterations);
   EXPECT_EQ(report_count_2, kIterations);
-  EXPECT_EQ(data[kInt64CallbackGaugeMetric].size(),
-            data[kDoubleCallbackGaugeMetric].size());
   // Verify labels.
   ASSERT_THAT(
       data,


### PR DESCRIPTION
Internal bug: b/357864682

There are two bugs being fixed here -

Bug 1 - A lock ordering inversion was noticed with the following stacks -

```
[mutex.cc : 1418] RAW: Potential Mutex deadlock:                                                         
        @ 0x564f4ce62fe5 absl::lts_20240116::DebugOnlyDeadlockCheck()
        @ 0x564f4ce632dc absl::lts_20240116::Mutex::Lock()                                                 
        @ 0x564f4be5886c absl::lts_20240116::MutexLock::MutexLock()                                        
        @ 0x564f4be968c5 grpc::internal::OpenTelemetryPluginImpl::RemoveCallback()                        
        @ 0x564f4cd097b8 grpc_core::RegisteredMetricCallback::~RegisteredMetricCallback()                 
        @ 0x564f4c1f1216 std::default_delete<>::operator()()                                              
        @ 0x564f4c1f157f std::__uniq_ptr_impl<>::reset()                                                  
        @ 0x564f4c1ee967 std::unique_ptr<>::reset()                                                        
        @ 0x564f4c352f44 grpc_core::GrpcXdsClient::Orphaned()                                            
        @ 0x564f4c25dad1 grpc_core::DualRefCounted<>::Unref()                                             
        @ 0x564f4c4653ed grpc_core::RefCountedPtr<>::reset()                                               
        @ 0x564f4c463c73 grpc_core::XdsClusterDropStats::~XdsClusterDropStats()                           
        @ 0x564f4c463d02 grpc_core::XdsClusterDropStats::~XdsClusterDropStats()                           
        @ 0x564f4c25efa9 grpc_core::UnrefDelete::operator()<>()                                           
        @ 0x564f4c25d5f0 grpc_core::RefCounted<>::Unref()                                                 
        @ 0x564f4c25c2d9 grpc_core::RefCountedPtr<>::~RefCountedPtr()                                     
        @ 0x564f4c25b1d8 grpc_core::(anonymous namespace)::XdsClusterImplLb::Picker::~Picker()            
        @ 0x564f4c25b240 grpc_core::(anonymous namespace)::XdsClusterImplLb::Picker::~Picker()            
        @ 0x564f4c12c71a grpc_core::UnrefDelete::operator()<>()                                           
        @ 0x564f4c1292ac grpc_core::DualRefCounted<>::WeakUnref()                                         
        @ 0x564f4c124fb8 grpc_core::DualRefCounted<>::Unref()                                             
        @ 0x564f4c11f029 grpc_core::RefCountedPtr<>::~RefCountedPtr()                                     
        @ 0x564f4c14e958 grpc_core::(anonymous namespace)::OutlierDetectionLb::Picker::~Picker()          
        @ 0x564f4c14e980 grpc_core::(anonymous namespace)::OutlierDetectionLb::Picker::~Picker()          
        @ 0x564f4c12c71a grpc_core::UnrefDelete::operator()<>()                                           
        @ 0x564f4c1292ac grpc_core::DualRefCounted<>::WeakUnref()                                         
        @ 0x564f4c124fb8 grpc_core::DualRefCounted<>::Unref()                                             
        @ 0x564f4c11f029 grpc_core::RefCountedPtr<>::~RefCountedPtr()                                     
        @ 0x564f4c26bafc std::pair<>::~pair()                                                             
        @ 0x564f4c26bb28 __gnu_cxx::new_allocator<>::destroy<>()                                          
        @ 0x564f4c26b88f std::allocator_traits<>::destroy<>()                                             
        @ 0x564f4c26b297 std::_Rb_tree<>::_M_destroy_node()                                               
        @ 0x564f4c26abfb std::_Rb_tree<>::_M_drop_node()                                                  
        @ 0x564f4c26a926 std::_Rb_tree<>::_M_erase()                                                      
        @ 0x564f4c26a6f0 std::_Rb_tree<>::~_Rb_tree()                                                     
        @ 0x564f4c26a62a std::map<>::~map()                                                               
        @ 0x564f4c2691a4 grpc_core::(anonymous namespace)::XdsClusterManagerLb::ClusterPicker::~ClusterPicker()                                                                                                     
        @ 0x564f4c2691cc grpc_core::(anonymous namespace)::XdsClusterManagerLb::ClusterPicker::~ClusterPicker()                                                                                                     
        @ 0x564f4c12c71a grpc_core::UnrefDelete::operator()<>()                                           
        @ 0x564f4c1292ac grpc_core::DualRefCounted<>::WeakUnref()
                                                                                                                                                                                                                   
[mutex.cc : 1428] RAW: Acquiring absl::Mutex 0x564f4f22ad40 while holding  0x7f939834bb70; a cycle in the historical lock ordering graph has been observed                                                          
[mutex.cc : 1432] RAW: Cycle:                       
[mutex.cc : 1446] RAW: mutex@0x564f4f22ad40 stack:                                                                                                                                                                    
        @ 0x564f4ce62fe5 absl::lts_20240116::DebugOnlyDeadlockCheck()                                    
        @ 0x564f4ce632dc absl::lts_20240116::Mutex::Lock()                                               
        @ 0x564f4be5886c absl::lts_20240116::MutexLock::MutexLock()            
        @ 0x564f4be96124 grpc::internal::OpenTelemetryPluginImpl::AddCallback()         
        @ 0x564f4cd096f0 grpc_core::RegisteredMetricCallback::RegisteredMetricCallback()                   
        @ 0x564f4c1f111b std::make_unique<>()                                                            
        @ 0x564f4c3564b0 grpc_core::GlobalStatsPluginRegistry::StatsPluginGroup::RegisterCallback<>()
        @ 0x564f4c352dea grpc_core::GrpcXdsClient::GrpcXdsClient()                                       
        @ 0x564f4c355bc6 grpc_core::MakeRefCounted<>()                                               
        @ 0x564f4c3525f2 grpc_core::GrpcXdsClient::GetOrCreate()                     
        @ 0x564f4c28f8f8 grpc_core::(anonymous namespace)::XdsResolver::StartLocked()                  
        @ 0x564f4c2f5f82 grpc_core::(anonymous namespace)::GoogleCloud2ProdResolver::StartXdsResolver()
        @ 0x564f4c2f515d grpc_core::(anonymous namespace)::GoogleCloud2ProdResolver::ZoneQueryDone()                                                                                                               
        @ 0x564f4c2f496b grpc_core::(anonymous namespace)::GoogleCloud2ProdResolver::StartLocked()::{lambda()#1}::operator()()::{lambda()#1}::operator()()                                                          
        @ 0x564f4c2f80f6 std::__invoke_impl<>()                                                                                                                                                                    
        @ 0x564f4c2f7b9d _ZSt10__invoke_rIvRZZN9grpc_core12_GLOBAL__N_124GoogleCloud2ProdResolver11StartLockedEvENUlNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN4absl12lts_202401168StatusOrIS8_EEE_clES8_SC_EUlvE_J...
        @ 0x564f4c2f748c std::_Function_handler<>::_M_invoke()                                           
        @ 0x564f4b8ad682 std::function<>::operator()()                                                                                                                                                                                                                                                                                                                                                                                  
        @ 0x564f4cd1c6bf grpc_core::WorkSerializer::LegacyWorkSerializer::Run()
        @ 0x564f4cd1dae4 grpc_core::WorkSerializer::Run()
        @ 0x564f4c2f4b0b grpc_core::(anonymous namespace)::GoogleCloud2ProdResolver::StartLocked()::{lambda()#1}::operator()()                                                                                     
        @ 0x564f4c2f8dc7 absl::lts_20240116::base_internal::Callable::Invoke<>()
        @ 0x564f4c2f8cb8 absl::lts_20240116::base_internal::invoke<>()                                                                                                                                                
        @ 0x564f4c2f8b16 absl::lts_20240116::internal_any_invocable::InvokeR<>()
        @ 0x564f4c2f8a0c absl::lts_20240116::internal_any_invocable::LocalInvoker<>()
        @ 0x564f4c2fb88d absl::lts_20240116::internal_any_invocable::Impl<>::operator()()
        @ 0x564f4c2fb1f3 grpc_core::GcpMetadataQuery::OnDone()                       
        @ 0x564f4cd75a72 exec_ctx_run()                                                                    
        @ 0x564f4cd75ba9 grpc_core::ExecCtx::Flush()          
        @ 0x564f4cc8ee1d end_worker()  
        @ 0x564f4cc8f304 pollset_work()                                                                    
        @ 0x564f4cc5dcaf pollset_work()
        @ 0x564f4cc69220 grpc_pollset_work()
        @ 0x564f4cbe7733 cq_pluck()    
        @ 0x564f4cbe7ad5 grpc_completion_queue_pluck                                                     
        @ 0x564f4bc61d96 grpc::CompletionQueue::Pluck()                                                  
        @ 0x564f4bfdb055 grpc::ClientReader<>::ClientReader<>()
        @ 0x564f4bfd6035 grpc::internal::ClientReaderFactory<>::Create<>()
        @ 0x564f4bfc322b google::storage::v2::Storage::Stub::ReadObjectRaw()
        @ 0x564f4bf9934b google::storage::v2::Storage::Stub::ReadObject() 
                                                                                                           
[mutex.cc : 1446] RAW: mutex@0x7f939834bb70 stack:                                                         
        @ 0x564f4ce62fe5 absl::lts_20240116::DebugOnlyDeadlockCheck()                                    
        @ 0x564f4ce632dc absl::lts_20240116::Mutex::Lock()                                               
        @ 0x564f4be5886c absl::lts_20240116::MutexLock::MutexLock()  
        @ 0x564f4c1ce9eb grpc_core::(anonymous namespace)::RlsLb::RlsLb()::{lambda()#1}::operator()()
        @ 0x564f4c1e794c absl::lts_20240116::base_internal::Callable::Invoke<>()
        @ 0x564f4c1e72c1 absl::lts_20240116::base_internal::invoke<>()                               
        @ 0x564f4c1e6af1 absl::lts_20240116::internal_any_invocable::InvokeR<>()
        @ 0x564f4c1e5d6c absl::lts_20240116::internal_any_invocable::LocalInvoker<>()
        @ 0x564f4be9d0c8 absl::lts_20240116::internal_any_invocable::Impl<>::operator()()
        @ 0x564f4be9b4ff grpc_core::RegisteredMetricCallback::Run()                  
        @ 0x564f4bea07ae grpc::internal::OpenTelemetryPluginImpl::CallbackGaugeState<>::CallbackGaugeCallback()                                                                                                    
        @ 0x564f4bf844de opentelemetry::v1::sdk::metrics::ObservableRegistry::Observe()
        @ 0x564f4bf56529 opentelemetry::v1::sdk::metrics::Meter::Collect()                                                                                                                                            
        @ 0x564f4bf8c1d5 opentelemetry::v1::sdk::metrics::MetricCollector::Collect()::{lambda()#1}::operator()()                                                                                                   
        @ 0x564f4bf8c5ac opentelemetry::v1::nostd::function_ref<>::BindTo<>()::{lambda()#1}::operator()()                                                                                                          
        @ 0x564f4bf8c5e8 opentelemetry::v1::nostd::function_ref<>::BindTo<>()::{lambda()#1}::_FUN()                                                                                                                   
        @ 0x564f4bf7604d opentelemetry::v1::nostd::function_ref<>::operator()()                                                                                                                                       
        @ 0x564f4bf74ad9 opentelemetry::v1::sdk::metrics::MeterContext::ForEachMeter()             
        @ 0x564f4bf8c457 opentelemetry::v1::sdk::metrics::MetricCollector::Collect()
        @ 0x564f4bf4a7fe opentelemetry::v1::sdk::metrics::MetricReader::Collect()     
        @ 0x564f4bed5e24 opentelemetry::v1::exporter::metrics::PrometheusCollector::Collect()
        @ 0x564f4bef004f prometheus::detail::CollectMetrics()                    
        @ 0x564f4beec26d prometheus::detail::MetricsHandler::handleGet()                     
        @ 0x564f4bf1cd8b CivetServer::requestHandler()       
        @ 0x564f4bf35e7b handle_request                                                                    
        @ 0x564f4bf29534 handle_request_stat_log                                                           
        @ 0x564f4bf39b3f process_new_connection
        @ 0x564f4bf3a448 worker_thread_run      
        @ 0x564f4bf3a57f worker_thread         
        @ 0x7f93e9137ea7 start_thread     
                                                                                                           
[mutex.cc : 1454] RAW: dying due to potential deadlock                                                   
Aborted    
```

From the stack, it looks like we are ending up holding a lock to the RlsLB policy while removing a callback from the gRPC OpenTelemetry plugin, which is a lock ordering inversion. The expected order is `OpenTelemetry` -> `gRPC OpenTelemetry plugin` -> gRPC Component like `RLS`/`xDSClient`.

Bug 2 - We are adding and removing callbacks on the OpenTelemetry Async Instruments without synchronization. This opens us to races where we have an `AddCallback` and `RemoveCallback` operation happening at the same time. The correct result after these operations is to still have a callback registered with OpenTelemetry at the end, but the two operations could race and we could just decide to remove the `OpenTelemetry` callback.

Changes -
* We add and remove callbacks from the gRPC OpenTelemetry plugin asynchronously using EventEngine. This allows to be safe and avoid deadlocks even if the callback owner adds/removes a callback while holding a lock.
* To make this async operation work, we now need `RegisteredMetricCallback` to be internally refcounted so that we can hold on to the callback even after the owner has released it. Additionally, to make sure that the callbacks are valid while we actually remove the callback, we need the callbacks to hold a ref to the callback owner.
* To fix Bug 2, we are just deciding to not remove OpenTelemetry callbacks immediately, and instead delay this to plugin destruction time.

Verified that the deadlock goes away with this fix.

In an upcoming PR, I am also going to change the gRPC OpenTelemetry plugin to release its mutex before the callbacks are invoked. That would save a lot of contention.
