### PR TITLE
Use /usr/bin/base64 to decode because some Darwin users use GNU base64

### DIFF
--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -173,10 +173,11 @@ Pod::Spec.new do |s|
     # /src/boringssl/boringssl_prefix_symbols.h. Here we decode the content and inject the header to
     # the correct location in BoringSSL.
     case "$(uname)" in
-      Darwin) opts="" ;;
-           *) opts="--ignore-garbage" ;;
+      Darwin) opts=""; BASE64_BIN=/usr/bin/base64 ;;
+      *) opts="--ignore-garbage"; BASE64_BIN=base64 ;;
     esac
-    base64 --decode $opts <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
+
+    "$BASE64_BIN" --decode $opts <<EOF | gunzip > src/include/openssl/boringssl_prefix_symbols.h
       H4sICAAAAAAC/2JvcmluZ3NzbF9wcmVmaXhfc3ltYm9scy5oALS9XXPbuJaofT+/wnXm5kzVrpnY6WRn
       v3eKrXQ0cWxvSenpzA2LkiCLOxSpEJRj968/AEmJ+FgL5FrwW7VrpmPpeRYFgPgiCPzXf108ikJUaS02
       F6uX8z+SVVllxaOUeXKoxDZ7TnYi3YjqP+XuoiwuPjafLha3F+tyv8/q/+/i8v36w+btZnWZbq/ebNfr
@@ -696,7 +697,7 @@ Pod::Spec.new do |s|
     EOF
 
     # PrivacyInfo.xcprivacy is not part of BoringSSL repo, inject it during pod installation
-    base64 --decode $opts <<EOF | gunzip > src/PrivacyInfo.xcprivacy
+    "$BASE64_BIN" --decode $opts <<EOF | gunzip > src/PrivacyInfo.xcprivacy
       H4sICAAAAAAC/1ByaXZhY3lJbmZvLnhjcHJpdmFjeQCFUU1PwjAYPo9fUXtnr7uoMWMEN0iWEFykHDw2
       3Ss2dGvTNuD+vUWdk4hya54+n3nT6VujyB6tk7qd0CS+pgRboWvZbid0wxbjOzrNRulV8Ziz52pOjJLO
       k2rzsCxzQscAM2MUAhSsINWyXDMSPADmK0roq/fmHuBwOMT8yIqFbo5EB5XVBq3vlsFsHARx7WsaYj7d


### PR DESCRIPTION
When you have `coreutils` brew package installed, `base64` is usually going to be the coreutils version rather than macos system version at /usr/bin/base64. This causes package installation to fail with a pretty cryptic error message.

This seems to trip people up fairly often, see:

- https://stackoverflow.com/questions/72499392/pod-install-in-flutter-ios-project-gives-base64-invalid-input/72500565#72500565
- https://stackoverflow.com/questions/61603856/flutter-boringssl-grpc-unable-to-install
- https://github.com/grpc/grpc/issues/32489
- me, the last hour or so pulling hair and scratching head

It seems like this script is fundamentally assuming we are using the system-provided `base64` command anyway which is fair enough, so I think it makes sense to just call it directly.