### PR TITLE
[ruby] fix typo in ruby macos run_tests flags

### DIFF
--- a/tools/internal_ci/macos/pull_request/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_ruby.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos ruby obs 4 --max_time=3600"
+  value: "-f basictests macos ruby -j 1 --inner_jobs 4 --max_time=3600"
 }


### PR DESCRIPTION
[https://github.com/grpc/grpc/pull/37261](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2Fgrpc%2Fgrpc%2Fpull%2F37261) seems to have left a typo in this config.

This should fix the remaining ruby macos pull request failures

