### PR TITLE
[ruby] backport "reduce ruby gpr_log invocations from INFO to DEBUG" #37426 to v1.66.x

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -809,7 +809,7 @@ struct call_run_batch_args {
 };
 
 static void cancel_call_unblock_func(void* arg) {
-  gpr_log(GPR_INFO, "GRPC_RUBY: cancel_call_unblock_func");
+  gpr_log(GPR_DEBUG, "GRPC_RUBY: cancel_call_unblock_func");
   grpc_call* call = (grpc_call*)arg;
   grpc_call_cancel(call, NULL);
 }

--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -112,7 +112,7 @@ static VALUE grpc_rb_call_credentials_callback_rescue(VALUE args,
   VALUE rb_exception_info =
       rb_funcall(exception_object, rb_intern("inspect"), 0);
   (void)args;
-  gpr_log(GPR_INFO,
+  gpr_log(GPR_DEBUG,
           "GRPC_RUBY call credentials callback failed, exception inspect:|%s| "
           "backtrace:|%s|",
           StringValueCStr(rb_exception_info), StringValueCStr(backtrace_str));

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -328,7 +328,7 @@ static void grpc_ruby_init_threads() {
   // in gpr_once_init. In general, it appears to be unsafe to call
   // into the ruby library while holding a non-ruby mutex, because a gil yield
   // could end up trying to lock onto that same mutex and deadlocking.
-  gpr_log(GPR_INFO,
+  gpr_log(GPR_DEBUG,
           "GRPC_RUBY: grpc_ruby_init_threads g_bg_thread_init_done=%d",
           g_bg_thread_init_done);
   rb_mutex_lock(g_bg_thread_init_rb_mu);

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -68,7 +68,7 @@ static void grpc_rb_server_shutdown_and_notify_internal(grpc_rb_server* server,
           server->queue, tag, gpr_inf_future(GPR_CLOCK_REALTIME), NULL, NULL);
     }
     if (ev.type != GRPC_OP_COMPLETE) {
-      gpr_log(GPR_INFO,
+      gpr_log(GPR_DEBUG,
               "GRPC_RUBY: bad grpc_server_shutdown_and_notify result:%d",
               ev.type);
     }
@@ -192,7 +192,7 @@ struct server_request_call_args {
 
 static void shutdown_server_unblock_func(void* arg) {
   grpc_rb_server* server = (grpc_rb_server*)arg;
-  gpr_log(GPR_INFO, "GRPC_RUBY: shutdown_server_unblock_func");
+  gpr_log(GPR_DEBUG, "GRPC_RUBY: shutdown_server_unblock_func");
   GRPC_RUBY_ASSERT(server->wrapped != NULL);
   grpc_event event;
   void* tag = &event;
@@ -202,7 +202,7 @@ static void shutdown_server_unblock_func(void* arg) {
   // cancelled all calls.
   event = grpc_completion_queue_pluck(server->queue, tag,
                                       gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-  gpr_log(GPR_INFO,
+  gpr_log(GPR_DEBUG,
           "GRPC_RUBY: shutdown_server_unblock_func pluck event.type: %d "
           "event.success: %d",
           event.type, event.success);


### PR DESCRIPTION
Remove log spam.

Since recently, GPR_INFO started logging by default.

Closes #37426

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/37426 from apolcyn:fix_stuff 5ac5a3812479b84dd4dda8dcd5a3a2b92c2ffd94 PiperOrigin-RevId: 661119953




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

