### PR TITLE
Fix minor typos

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -170,7 +170,7 @@ def grpc_cc_library(
       srcs: The source files.
       public_hdrs: The public headers.
       hdrs: The headers.
-      external_deps: External depdendencies to be resolved.
+      external_deps: External dependencies to be resolved.
       defines: Build defines to use.
       deps: cc_library deps.
       select_deps: deps included conditionally.
@@ -529,7 +529,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         exec_properties: A dictionary of strings that will be added to the
             exec_properties of a platform selected for this target.
         shard_count: The number of shards for this test.
@@ -660,7 +660,7 @@ def grpc_sh_test(name, srcs = [], args = [], data = [], uses_polling = True, siz
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         exec_properties: A dictionary of strings that will be added to the
             exec_properties of a platform selected for this target.
         shard_count: The number of shards for this test.

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -37,13 +37,13 @@ def well_known_proto_libs():
     return ["@com_google_protobuf//:" + b for b in _WELL_KNOWN_PROTOS_BASE]
 
 def is_well_known(label):
-    # Bazel surfaces labels as their undelying identity, even if they are referenced
+    # Bazel surfaces labels as their underlying identity, even if they are referenced
     # via aliases. Bazel also does not currently provide a way to find the real label
     # underlying an alias. So the implementation detail that the WKTs present at the
     # top level of the protobuf repo are actually backed by targets in the
     # //src/google/protobuf package leaks through here.
     # We include both the alias path and the underlying path to be resilient to
-    # reversions of this change as well as for continuing compatiblity with repos
+    # reversions of this change as well as for continuing compatibility with repos
     # that happen to pull in older versions of protobuf.
     all_wkt_targets = (["@com_google_protobuf//:" + b for b in _WELL_KNOWN_PROTOS_BASE] +
                        ["@com_google_protobuf//src/google/protobuf:" + b for b in _WELL_KNOWN_PROTOS_BASE])

--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -60,7 +60,7 @@ some configuration as environment variables that can be set.
   - NONE - won't log any.
   GRPC_VERBOSITY will set verbosity of absl logging. 
   - If the external application sets some other verbosity, then whatever is set later will be honoured. 
-  - If nothing is set as GRPC_VERBOSITY, then the setting of the exernal application will be honoured.
+  - If nothing is set as GRPC_VERBOSITY, then the setting of the external application will be honoured.
   - If nothing is set by the external application also, the default set by absl will be honoured.
 <!-- END_OPEN_SOURCE_DOCUMENTATION -->
 

--- a/doc/grpc_xds_bootstrap_format.md
+++ b/doc/grpc_xds_bootstrap_format.md
@@ -8,7 +8,7 @@ gRPC expects the xDS bootstrap configuration to be specified as a JSON string.
 The xDS bootstrap file location may be specified using the environment variable
 `GRPC_XDS_BOOTSTRAP`.  Alternatively, the bootstrap file contents may be
 specified using the environment variable `GRPC_XDS_BOOTSTRAP_CONFIG`.  If both
-are specified, the former takes precendence.
+are specified, the former takes precedence.
 
 The xDS client inside of gRPC parses the bootstrap configuration specified by
 one of the above means when it is created to configure itself.

--- a/doc/service_config.md
+++ b/doc/service_config.md
@@ -48,7 +48,7 @@ name, will return both the resolved addresses and the service config.
 
 The name resolver returns the service config to the gRPC client in JSON form.
 Individual resolver implementations determine where and in what format the
-service config is stored.  If the resolver implemention obtains the
+service config is stored.  If the resolver implementation obtains the
 service config in protobuf form, it must convert it to JSON.
 Alternatively, a resolver implementation may obtain the service config
 already in JSON form, in which case it may return it directly.  Or it

--- a/doc/xds-test-descriptions.md
+++ b/doc/xds-test-descriptions.md
@@ -640,17 +640,17 @@ There are four sub-tests:
 1. `app_timeout_exceeded`
    1. Test client configured to send UnaryCall RPCs with a 1s application
       timeout, and metadata of `rpc-behavior: sleep-2`.
-   1. Test driver asserts client recieves ~100% status `DEADLINE_EXCEEDED`.
+   1. Test driver asserts client receives ~100% status `DEADLINE_EXCEEDED`.
 1. `timeout_not_exceeded`
    1. Test client configured to send UnaryCall RPCs with the default
       application timeout (20 seconds), and no metadata.
-   1. Test driver asserts client recieves ~100% status `OK`.
+   1. Test driver asserts client receives ~100% status `OK`.
 1. `timeout_exceeded` (executed with the below test case)
 1. `timeout_different_route`
    1. Test client configured to send UnaryCall RPCs and EmptyCall RPCs with
       the default application timeout (20 seconds), and metadata of
       `rpc-behavior: sleep-4`.
-   1. Test driver asserts client recieves ~100% status `OK` for EmptyCall
+   1. Test driver asserts client receives ~100% status `OK` for EmptyCall
       and ~100% status `DEADLINE_EXCEEDED` for UnaryCall.
 
 ### api_listener

--- a/examples/cpp/xds/README.md
+++ b/examples/cpp/xds/README.md
@@ -10,7 +10,7 @@ The client takes two command-line arguments -
 
 The server takes three command-line arguments -
 * port - Port on which the Hello World service is run. Defaults to 50051.
-* mantenance_port - If secure mode is used (see below), the [Admin](https://github.com/grpc/proposal/blob/master/A38-admin-interface-api.md) service is exposed on this port. If secure mode is not used, `maintenance_port` is unused, and the Admin service is just exposed on `port`. Defaults to 50052.
+* maintenance_port - If secure mode is used (see below), the [Admin](https://github.com/grpc/proposal/blob/master/A38-admin-interface-api.md) service is exposed on this port. If secure mode is not used, `maintenance_port` is unused, and the Admin service is just exposed on `port`. Defaults to 50052.
 * secure - Bool value, defaults to true. When this is set, [XdsServerCredentials](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md) will be used with a fallback on `InsecureServerCredentials`. If unset, `InsecureServerCredentials` will be used.
 
 ## Running the example

--- a/include/grpc/credentials.h
+++ b/include/grpc/credentials.h
@@ -103,7 +103,7 @@ GRPCAPI grpc_call_credentials* grpc_sts_credentials_create(
 /** Context that can be used by metadata credentials plugin in order to create
    auth related metadata. */
 typedef struct {
-  /** The fully qualifed service url. */
+  /** The fully qualified service url. */
   const char* service_url;
 
   /** The method name of the RPC being called (not fully qualified).

--- a/include/grpc/event_engine/README.md
+++ b/include/grpc/event_engine/README.md
@@ -23,7 +23,7 @@ thresholds. To enable this feature, the memory allocation of read/write buffers
 within an EventEngine must be acquired in the form of Slices from
 SliceAllocators. This is covered more fully in the gRFC and code.
 
-### Documentating expectations around callback execution
+### Documenting expectations around callback execution
 Some callbacks may be expensive to run. EventEngines should decide on and
 document whether callback execution might block polling operations. This way,
 application developers can plan accordingly (e.g., run their expensive callbacks

--- a/include/grpc/event_engine/internal/slice_cast.h
+++ b/include/grpc/event_engine/internal/slice_cast.h
@@ -24,7 +24,7 @@ namespace internal {
 // with `SliceCast`. Both ways need to be declared (i.e. if
 // SliceCastable<A,B> exists, you should declare
 // SliceCastable<B,A> too).
-// The type has no members, it's just the existance of the specialization that
+// The type has no members, it's just the existence of the specialization that
 // unlocks SliceCast usage for a type pair.
 template <typename Result, typename T>
 struct SliceCastable;

--- a/include/grpc/grpc_crl_provider.h
+++ b/include/grpc/grpc_crl_provider.h
@@ -82,7 +82,7 @@ absl::StatusOr<std::shared_ptr<CrlProvider>> CreateDirectoryReloaderCrlProvider(
 }  // namespace experimental
 }  // namespace grpc_core
 
-// TODO(gtcooke94) - Mark with api macro when all wrapped langauges support C++
+// TODO(gtcooke94) - Mark with api macro when all wrapped languages support C++
 // in core APIs
 /**
  * EXPERIMENTAL API - Subject to change

--- a/include/grpc/impl/channel_arg_names.h
+++ b/include/grpc/impl/channel_arg_names.h
@@ -259,7 +259,7 @@
    issued by the tcp_write(). By default, this is set to 4. */
 #define GRPC_ARG_TCP_TX_ZEROCOPY_MAX_SIMULT_SENDS \
   "grpc.experimental.tcp_tx_zerocopy_max_simultaneous_sends"
-/* Overrides the TCP socket recieve buffer size, SO_RCVBUF. */
+/* Overrides the TCP socket receive buffer size, SO_RCVBUF. */
 #define GRPC_ARG_TCP_RECEIVE_BUFFER_SIZE "grpc.tcp_receive_buffer_size"
 /* Timeout in milliseconds to use for calls to the grpclb load balancer.
    If 0 or unset, the balancer calls will have no deadline. */

--- a/include/grpcpp/ext/call_metric_recorder.h
+++ b/include/grpcpp/ext/call_metric_recorder.h
@@ -33,7 +33,7 @@ namespace experimental {
 
 /// Records call metrics for the purpose of load balancing.
 /// During an RPC, call \a ServerContext::ExperimentalGetCallMetricRecorder()
-/// method to retrive the recorder for the current call.
+/// method to retrieve the recorder for the current call.
 class CallMetricRecorder {
  public:
   virtual ~CallMetricRecorder() = default;

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -247,7 +247,7 @@ class MetadataCredentialsPlugin {
   /// Type of credentials this plugin is implementing.
   virtual const char* GetType() const { return ""; }
 
-  /// Gets the auth metatada produced by this plugin.
+  /// Gets the auth metadata produced by this plugin.
   /// The fully qualified method name is:
   /// service_url + "/" + method_name.
   /// The channel_auth_context contains (among other things), the identity of
@@ -295,7 +295,7 @@ grpc::Status StsCredentialsOptionsFromJson(const std::string& json_string,
 
 /// Creates STS credentials options from the $STS_CREDENTIALS environment
 /// variable. This environment variable points to the path of a JSON file
-/// comforming to the schema described above.
+/// conforming to the schema described above.
 grpc::Status StsCredentialsOptionsFromEnv(StsCredentialsOptions* options);
 
 std::shared_ptr<CallCredentials> StsCredentials(

--- a/include/grpcpp/server_builder.h
+++ b/include/grpcpp/server_builder.h
@@ -297,7 +297,7 @@ class ServerBuilder {
 
     // Creates a passive listener for Server Endpoint injection.
     ///
-    /// \a PasiveListener lets applications provide pre-established connections
+    /// \a PassiveListener lets applications provide pre-established connections
     /// to gRPC Servers. The server will behave as if it accepted the connection
     /// itself on its own listening addresses.
     ///

--- a/include/grpcpp/support/byte_buffer.h
+++ b/include/grpcpp/support/byte_buffer.h
@@ -59,7 +59,7 @@ class GrpcByteBufferPeer;
 /// A sequence of bytes.
 class ByteBuffer final {
  public:
-  /// Constuct an empty buffer.
+  /// Construct an empty buffer.
   ByteBuffer() : buffer_(nullptr) {}
 
   /// Construct buffer from \a slices, of which there are \a nslices.

--- a/include/grpcpp/support/config.h
+++ b/include/grpcpp/support/config.h
@@ -35,7 +35,7 @@ namespace grpc {
 
 // Using grpc::string and grpc::to_string is discouraged in favor of
 // std::string and std::to_string. This is only for legacy code using
-// them explictly.
+// them explicitly.
 using std::string;     // deprecated // NOLINT(misc-unused-using-decls)
 using std::to_string;  // deprecated // NOLINT(misc-unused-using-decls)
 

--- a/include/grpcpp/support/interceptor.h
+++ b/include/grpcpp/support/interceptor.h
@@ -133,7 +133,7 @@ class InterceptorBatchMethods {
   /// means that the payload would be available in the serialized form only
   /// unless an interceptor replaces the payload with ModifySendMessage.
 
-  /// Returns a modifable ByteBuffer holding the serialized form of the message
+  /// Returns a modifiable ByteBuffer holding the serialized form of the message
   /// that is going to be sent. Valid for PRE_SEND_MESSAGE interceptions.
   /// A return value of nullptr indicates that this ByteBuffer is not valid.
   virtual ByteBuffer* GetSerializedSendMessage() = 0;

--- a/templates/tools/dockerfile/ccache_old.include
+++ b/templates/tools/dockerfile/ccache_old.include
@@ -1,5 +1,5 @@
 #=================
-# Install ccache (use slighly older release of ccache that works older compilers and cmake)
+# Install ccache (use slightly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/templates/tools/dockerfile/ccache_old.include
+++ b/templates/tools/dockerfile/ccache_old.include
@@ -1,5 +1,5 @@
 #=================
-# Install ccache (use slightly older release of ccache that works older compilers and cmake)
+# Install ccache (use slighly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/templates/tools/doxygen/Doxyfile.base
+++ b/templates/tools/doxygen/Doxyfile.base
@@ -1407,7 +1407,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #
@@ -1982,7 +1982,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/templates/tools/doxygen/Doxyfile.objc.include
+++ b/templates/tools/doxygen/Doxyfile.objc.include
@@ -1438,7 +1438,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #
@@ -2013,7 +2013,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/bazelify_tests/build_defs.bzl
+++ b/tools/bazelify_tests/build_defs.bzl
@@ -114,7 +114,7 @@ def grpc_run_tests_harness_test(name, args = [], data = [], size = "medium", tim
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         flaky: Whether this test is flaky.
         docker_image_version: The docker .current_version file to use for docker containerization.
         use_login_shell: If True, the run_tests.py command will run under a login shell.
@@ -163,7 +163,7 @@ def grpc_run_bazel_distribtest_test(name, args = [], data = [], size = "medium",
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         flaky: Whether this test is flaky.
         docker_image_version: The docker .current_version file to use for docker containerization.
     """
@@ -193,7 +193,7 @@ def grpc_run_cpp_distribtest_test(name, args = [], data = [], size = "medium", t
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         flaky: Whether this test is flaky.
         docker_image_version: The docker .current_version file to use for docker containerization.
     """
@@ -225,7 +225,7 @@ def grpc_run_simple_command_test(name, args = [], data = [], size = "medium", ti
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         flaky: Whether this test is flaky.
         docker_image_version: The docker .current_version file to use for docker containerization.
     """
@@ -260,10 +260,10 @@ def grpc_build_artifact_task(name, timeout = None, artifact_deps = [], tags = []
         artifact_deps: List of dependencies on artifacts built by another grpc_build_artifact_task.
         tags: The tags for the target.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         flaky: Whether this artifact build is flaky.
         docker_image_version: The docker .current_version file to use for docker containerization.
-        build_script: The script that builds the aritfacts.
+        build_script: The script that builds the artifacts.
     """
 
     out_exitcode_file = str(name + "_exit_code")
@@ -284,7 +284,7 @@ def grpc_build_artifact_task(name, timeout = None, artifact_deps = [], tags = []
 
     cmd = "$(location //tools/bazelify_tests:grpc_build_artifact_task.sh) $(location //tools/bazelify_tests:grpc_repo_archive_with_submodules.tar.gz) $(location " + build_script + ") $(location " + out_exitcode_file + ") $(location " + out_build_log + ") $(location " + out_archive_name + ")"
 
-    # for each artifact task we depends on, use the correponding tar.gz as extra src and pass its location as an extra cmdline arg.
+    # for each artifact task we depends on, use the corresponding tar.gz as extra src and pass its location as an extra cmdline arg.
     for dep in artifact_deps:
         dep_archive_name = str(dep + ".tar.gz")
         cmd = cmd + " $(location " + dep_archive_name + ")"
@@ -324,7 +324,7 @@ def grpc_run_distribtest_test(name, artifact_deps = [], size = "medium", timeout
         timeout: The test timeout.
         tags: The tags for the test.
         exec_compatible_with: A list of constraint values that must be
-            satisifed for the platform.
+            satisfied for the platform.
         flaky: Whether this test is flaky.
         docker_image_version: The docker .current_version file to use for docker containerization.
         build_script: The script that runs the test.
@@ -341,7 +341,7 @@ def grpc_run_distribtest_test(name, artifact_deps = [], size = "medium", timeout
         "$(location " + build_script + ")",
     ]
 
-    # for each artifact task we depends on, use the correponding tar.gz as extra data item and pass its location as an extra arg.
+    # for each artifact task we depends on, use the corresponding tar.gz as extra data item and pass its location as an extra arg.
     for dep in artifact_deps:
         dep_archive_name = str(dep + ".tar.gz")
         args.append("$(location " + dep_archive_name + ")")

--- a/tools/bazelify_tests/grpc_repo_archive.sh
+++ b/tools/bazelify_tests/grpc_repo_archive.sh
@@ -50,7 +50,7 @@ then
   exit 1
 fi
 
-GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS=$(grep ^STABLE_GRPC_UNCOMMITED_PATCH_CHECKSUM bazel-out/stable-status.txt | cut -d' ' -f2)
+GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS=$(grep ^STABLE_GRPC_UNCOMMITTED_PATCH_CHECKSUM bazel-out/stable-status.txt | cut -d' ' -f2)
 GRPC_GIT_WORKSPACE_DIRTY_FROM_STABLE_STATUS=$(grep ^STABLE_GRPC_GIT_WORKSPACE_DIRTY bazel-out/stable-status.txt | cut -d' ' -f2)
 
 pushd ${ORIGINAL_BAZEL_WORKSPACE_ROOT} >/dev/null
@@ -65,11 +65,11 @@ fi
 mkdir -p ${ARCHIVES_DIR}/grpc
 git archive --format="${ARCHIVE_FORMAT}" HEAD >"${ARCHIVES_DIR}/grpc/$(git rev-parse HEAD).${ARCHIVE_FORMAT}"
 
-if [ "${GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS}" != "" ]
+if [ "${GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS}" != "" ]
 then
-  git diff HEAD >"${ARCHIVES_DIR}/grpc/grpc_uncommited_${GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS}.patch"
+  git diff HEAD >"${ARCHIVES_DIR}/grpc/grpc_uncommited_${GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS}.patch"
   # check that the actual checksum of the patch file is what we expect it to be
-  echo "${GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS} ${ARCHIVES_DIR}/grpc/grpc_uncommited_${GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS}.patch" | sha256sum --quiet --check
+  echo "${GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS} ${ARCHIVES_DIR}/grpc/grpc_uncommited_${GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS}.patch" | sha256sum --quiet --check
 fi
 
 # produce archive for each submodule 
@@ -82,10 +82,10 @@ mkdir grpc
 tar -xopf "${ARCHIVES_DIR}/grpc/${GRPC_GIT_COMMIT_FROM_STABLE_STATUS}.${ARCHIVE_FORMAT}" -C grpc
 
 # apply the patch
-if [ "${GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS}" != "" ]
+if [ "${GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS}" != "" ]
 then
   pushd grpc >/dev/null
-  patch --quiet -p1 <"${ARCHIVES_DIR}/grpc/grpc_uncommited_${GRPC_UNCOMMITED_PATCH_CHECKSUM_FROM_STABLE_STATUS}.patch"
+  patch --quiet -p1 <"${ARCHIVES_DIR}/grpc/grpc_uncommited_${GRPC_UNCOMMITTED_PATCH_CHECKSUM_FROM_STABLE_STATUS}.patch"
   popd >/dev/null
 fi
 

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -72,7 +72,7 @@ grpc_run_tests_harness_test(
     ],
     docker_image_version = "tools/dockerfile/test/ruby_debian11_x64.current_version",
     prepare_script = ":prepare_ruby.sh",
-    use_login_shell = True,  # ruby's docker image uses RVM which wierdly requires login shell
+    use_login_shell = True,  # ruby's docker image uses RVM which weirdly requires login shell
 )
 
 grpc_run_tests_harness_test(
@@ -83,7 +83,7 @@ grpc_run_tests_harness_test(
     ],
     docker_image_version = "tools/dockerfile/test/ruby_debian11_x64.current_version",
     prepare_script = ":prepare_ruby.sh",
-    use_login_shell = True,  # ruby's docker image uses RVM which wierdly requires login shell
+    use_login_shell = True,  # ruby's docker image uses RVM which weirdly requires login shell
 )
 
 # PHP

--- a/tools/bazelify_tests/workspace_status_cmd.sh
+++ b/tools/bazelify_tests/workspace_status_cmd.sh
@@ -28,7 +28,7 @@ then
   echo "STABLE_GRPC_GIT_WORKSPACE_DIRTY false"
 else
   echo "STABLE_GRPC_GIT_WORKSPACE_DIRTY true"
-  echo "STABLE_GRPC_UNCOMMITED_PATCH_CHECKSUM $(git diff HEAD | sha256sum | cut -f1 -d' ')"
+  echo "STABLE_GRPC_UNCOMMITTED_PATCH_CHECKSUM $(git diff HEAD | sha256sum | cut -f1 -d' ')"
 fi
 
 # Since only --workspace_status_command is allowed by bazel, also include

--- a/tools/buildgen/plugins/transitive_dependencies.py
+++ b/tools/buildgen/plugins/transitive_dependencies.py
@@ -37,9 +37,9 @@ def transitive_deps(lib_map, node):
                 if next_node:
                     recursive_helper(next_node)
                 else:
-                    # For some deps, the corrensponding library entry doesn't exist,
+                    # For some deps, the corresponding library entry doesn't exist,
                     # but we still want to preserve the dependency so that the build
-                    # system can provide custom handling for that depdendency.
+                    # system can provide custom handling for that dependency.
                     result.append(dep)
         if node is not start:
             result.insert(0, node["name"])

--- a/tools/codegen/core/gen_huffman_decompressor.cc
+++ b/tools/codegen/core/gen_huffman_decompressor.cc
@@ -148,7 +148,7 @@ SymSet AllSyms() {
   return syms;
 }
 
-// What whould we do after reading a set of bits?
+// What would we do after reading a set of bits?
 struct ReadActions {
   // Emit these symbols
   std::vector<int> emit;

--- a/tools/distrib/check_protobuf_pod_version.sh
+++ b/tools/distrib/check_protobuf_pod_version.sh
@@ -23,7 +23,7 @@ pushd third_party/protobuf
 version1=$(git describe --tags | cut -f 1 -d'-')
 v1=${version1:1}
 # Protobuf has recently changed the versioning of the release branches/tags
-# and the same release commit can be tagged with mutliple tag names
+# and the same release commit can be tagged with multiple tag names
 # (e.g. v3.21.12 is also tagged as v21.12), which ultimately confuses
 # the output of "git describe --tags" and makes it non-deterministic.
 # The hack below converts the version number to always become 3.x.y

--- a/tools/distrib/fix_build_deps.py
+++ b/tools/distrib/fix_build_deps.py
@@ -488,7 +488,7 @@ if args.whats_left:
     )
 
 
-# Keeps track of all possible sets of dependencies that could satify the
+# Keeps track of all possible sets of dependencies that could satisfy the
 # problem. (models the list monad in Haskell!)
 class Choices:
     def __init__(self, library, substitutions):

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -133,7 +133,7 @@ class BuildExt(build_ext.build_ext):
         #   behavior in gcc and clang. The clang doesn't take --stdc++11
         #   flags but gcc does. Since the setuptools of Python only support
         #   all C or all C++ compilation, the mix of C and C++ will crash.
-        #   *By default*, macOS and FreBSD use clang and Linux use gcc
+        #   *By default*, macOS and FreeBSD use clang and Linux use gcc
         #
         #   If we are not using a permissive compiler that's OK with being
         #   passed wrong std flags, swap out compile function by adding a filter

--- a/tools/distrib/python/xds_protos/build.py
+++ b/tools/distrib/python/xds_protos/build.py
@@ -56,7 +56,7 @@ EXCLUDE_PROTO_PACKAGES_LIST = tuple(
     )
 )
 
-# Compute the pathes
+# Compute the paths
 WORK_DIR = os.path.dirname(os.path.abspath(__file__))
 GRPC_ROOT = os.path.abspath(os.path.join(WORK_DIR, "..", "..", "..", ".."))
 ENVOY_API_PROTO_ROOT = os.path.join(GRPC_ROOT, "third_party", "envoy-api")

--- a/tools/docker_runners/examples/concurrent_bazel.sh
+++ b/tools/docker_runners/examples/concurrent_bazel.sh
@@ -34,7 +34,7 @@ cd "$(dirname "$0")/../../.."
 # use the default docker image used for bazel builds
 export DOCKERFILE_DIR=tools/dockerfile/test/bazel
 
-# Bazel RBE uses application default credentials from localhost to authenticate with RBE servers. Use a trick to make the credentails accessible from inside the docker container."
+# Bazel RBE uses application default credentials from localhost to authenticate with RBE servers. Use a trick to make the credentials accessible from inside the docker container."
 APPLICATION_DEFAULT_CREDENTIALS_DIR="$HOME/.config/gcloud"
 export DOCKER_EXTRA_ARGS="-v=${APPLICATION_DEFAULT_CREDENTIALS_DIR}:/application_default_credentials:ro -e=GOOGLE_APPLICATION_CREDENTIALS=/application_default_credentials/application_default_credentials.json"
 

--- a/tools/docker_runners/examples/coredump_in_docker.sh
+++ b/tools/docker_runners/examples/coredump_in_docker.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")/../../.."
 # To use the correct docker image for your experiments,
 # note that every invocation of run_tests.py with "--use_docker"
 # prints the docker image used as a debug message at the end of the run.
-# This is expecially important when --compiler/--arch params are
+# This is especially important when --compiler/--arch params are
 # use, since they usually influence with docker image will be used
 # by run_tests.py
 export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64

--- a/tools/docker_runners/examples/gdb_in_docker.sh
+++ b/tools/docker_runners/examples/gdb_in_docker.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")/../../.."
 # To use the correct docker image for your experiments,
 # note that every invocation of run_tests.py with "--use_docker"
 # prints the docker image used as a debug message at the end of the run.
-# This is expecially important when --compiler/--arch params are
+# This is especially important when --compiler/--arch params are
 # use, since they usually influence with docker image will be used
 # by run_tests.py
 export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64

--- a/tools/docker_runners/examples/run_tests_c_in_docker.sh
+++ b/tools/docker_runners/examples/run_tests_c_in_docker.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")/../../.."
 # To use the correct docker image for your experiments,
 # note that every invocation of run_tests.py with "--use_docker"
 # prints the docker image used as a debug message at the end of the run.
-# This is expecially important when --compiler/--arch params are
+# This is especially important when --compiler/--arch params are
 # use, since they usually influence with docker image will be used
 # by run_tests.py
 export DOCKERFILE_DIR=tools/dockerfile/test/cxx_debian11_x64

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -37,7 +37,7 @@ cd -
 # $ gcloud auth login
 
 # Various check that the environment is setup correctly.
-# The enviroment checks are skipped when running as a sanity check on CI.
+# The environment checks are skipped when running as a sanity check on CI.
 if [ "${CHECK_MODE}" == "" ]
 then
   # Check that docker is installed and sudoless docker works.
@@ -178,7 +178,7 @@ do
   then
     echo "Running 'docker build' for ${DOCKER_IMAGE_NAME}"
     echo "=========="
-    # Buliding a docker image with two tags;
+    # Building a docker image with two tags;
     # - one for image identification based on Dockerfile hash
     # - one to exclude it from the GCP Vulnerability Scanner
     docker build \

--- a/tools/dockerfile/test/cxx_gcc_7_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_7_x64/Dockerfile
@@ -58,7 +58,7 @@ RUN python3 -m pip install twisted
 RUN apt-get update && apt-get install -y cmake && apt-get clean
 
 #=================
-# Install ccache (use slighly older release of ccache that works older compilers and cmake)
+# Install ccache (use slightly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/tools/dockerfile/test/cxx_gcc_7_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_7_x64/Dockerfile
@@ -58,7 +58,7 @@ RUN python3 -m pip install twisted
 RUN apt-get update && apt-get install -y cmake && apt-get clean
 
 #=================
-# Install ccache (use slightly older release of ccache that works older compilers and cmake)
+# Install ccache (use slighly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/tools/dockerfile/test/cxx_gcc_8_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_8_x64/Dockerfile
@@ -58,7 +58,7 @@ RUN python3 -m pip install twisted
 RUN apt-get update && apt-get install -y cmake && apt-get clean
 
 #=================
-# Install ccache (use slighly older release of ccache that works older compilers and cmake)
+# Install ccache (use slightly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/tools/dockerfile/test/cxx_gcc_8_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_8_x64/Dockerfile
@@ -58,7 +58,7 @@ RUN python3 -m pip install twisted
 RUN apt-get update && apt-get install -y cmake && apt-get clean
 
 #=================
-# Install ccache (use slightly older release of ccache that works older compilers and cmake)
+# Install ccache (use slighly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/tools/doxygen/Doxyfile.c++
+++ b/tools/doxygen/Doxyfile.c++
@@ -1736,7 +1736,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.c++
+++ b/tools/doxygen/Doxyfile.c++
@@ -2311,7 +2311,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -3742,7 +3742,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -4317,7 +4317,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/doxygen/Doxyfile.core
+++ b/tools/doxygen/Doxyfile.core
@@ -1535,7 +1535,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.core
+++ b/tools/doxygen/Doxyfile.core
@@ -2110,7 +2110,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -3460,7 +3460,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -4035,7 +4035,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/doxygen/Doxyfile.objc
+++ b/tools/doxygen/Doxyfile.objc
@@ -1486,7 +1486,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.objc
+++ b/tools/doxygen/Doxyfile.objc
@@ -2061,7 +2061,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/doxygen/Doxyfile.objc.internal
+++ b/tools/doxygen/Doxyfile.objc.internal
@@ -1513,7 +1513,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.objc.internal
+++ b/tools/doxygen/Doxyfile.objc.internal
@@ -2088,7 +2088,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/doxygen/Doxyfile.php
+++ b/tools/doxygen/Doxyfile.php
@@ -1473,7 +1473,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/tools/doxygen/Doxyfile.php
+++ b/tools/doxygen/Doxyfile.php
@@ -2048,7 +2048,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = GRPC_FINAL= GRPC_OVERIDE=
+PREDEFINED             = GRPC_FINAL= GRPC_OVERRIDE=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/tools/internal_ci/macos/grpc_ios_binary_size.sh
+++ b/tools/internal_ci/macos/grpc_ios_binary_size.sh
@@ -32,7 +32,7 @@ then
   # running on PR, generate size diff
   DIFF_BASE="origin/${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}"
 else
-  # running as continous build, only generate numbers for the current revision
+  # running as continuous build, only generate numbers for the current revision
   DIFF_BASE=""
 fi
 

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -41,7 +41,7 @@ ruby --version
 # log gem versions for easier debugging if things go wrong
 gem list || true
 
-# avoid polluting the global gem diretory
+# avoid polluting the global gem directory
 # by configuring "bundle install" to install all the gems
 # into a project-local directory
 export BUNDLE_PATH=bundle_local_gems

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -321,7 +321,7 @@ class CXXLanguage(Language):
         )
 
         # Scenario was added in https://github.com/grpc/grpc/pull/12987, but its purpose is unclear
-        # (beyond excercising some params that other scenarios don't)
+        # (beyond exercising some params that other scenarios don't)
         yield _ping_pong_scenario(
             "cpp_protobuf_async_unary_75Kqps_600channel_60Krpcs_300Breq_50Bresp",
             rpc_type="UNARY",

--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -310,7 +310,7 @@ if __name__ == "__main__":
                             "test_target": action["id"]["targetId"],
                             "test_class_name": "N/A",
                             "test_case": "N/A",
-                            "result": "UNPARSEABLE",
+                            "result": "UNPARSABLE",
                             "timestamp": "N/A",
                         },
                     }

--- a/tools/run_tests/run_grpclb_interop_tests.py
+++ b/tools/run_tests/run_grpclb_interop_tests.py
@@ -554,7 +554,7 @@ def wait_until_dns_server_is_up(dns_server_ip):
         time.sleep(0.1)
     raise Exception(
         "Failed to reach DNS server over TCP and/or UDP. "
-        "Exitting without running tests."
+        "Exiting without running tests."
     )
 
 

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -447,7 +447,7 @@ def create_scenarios(
                     if custom_server_lang and custom_client_lang:
                         raise Exception(
                             "Cannot set both custom CLIENT_LANGUAGE and"
-                            " SERVER_LANGUAGEin the same scenario"
+                            " SERVER_LANGUAGE in the same scenario"
                         )
                     if custom_server_lang:
                         if not workers_by_lang.get(custom_server_lang, []):
@@ -528,7 +528,7 @@ profile_output_files = []
 # Note the base names of perf text reports are used when creating and processing
 # perf data. The scenario name uniqifies the output name in the final
 # perf reports directory.
-# Alos, the perf profiles need to be fetched and processed after each scenario
+# Also, the perf profiles need to be fetched and processed after each scenario
 # in order to avoid clobbering the output files.
 def run_collect_perf_profile_jobs(
     hosts_and_base_names, scenario_name, flame_graph_reports

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -320,7 +320,7 @@ class CLanguage(object):
             self._cmake_architecture_windows = (
                 "x64" if self.args.arch == "x64" else "Win32"
             )
-            # when builing with Ninja, the VS common tools need to be activated first
+            # when building with Ninja, the VS common tools need to be activated first
             self._activate_vs_tools_windows = activate_vs_tools
             # "x64_x86" means create 32bit binaries, but use 64bit toolkit to secure more memory for the build
             self._vs_tools_architecture_windows = (

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -123,7 +123,7 @@ def parse_test_cases(arg):
             test_cases = test_cases.union([arg])
     if not all([test_case in all_test_cases for test_case in test_cases]):
         raise Exception("Failed to parse test cases %s" % arg)
-    # Perserve order.
+    # Preserve order.
     return [x for x in all_test_cases if x in test_cases]
 
 
@@ -2179,7 +2179,7 @@ def test_circuit_breaking(
     """
     Since backend service circuit_breakers configuration cannot be unset,
     which causes trouble for restoring validate_for_proxy flag in target
-    proxy/global forwarding rule. This test uses dedicated backend sevices.
+    proxy/global forwarding rule. This test uses dedicated backend services.
     The url_map and backend services undergoes the following state changes:
 
     Before test:


### PR DESCRIPTION
Just thought I'd contribute some typo fixes I stumbled upon. Nothing controversial (hopefully), just 74 simple fixes.

Use the following command to get a quick and dirty summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the top typos are:
* satisifed (8)
* uncommited (7)
* tranparent (7)
* expecially (3)
* recieves (3)
* correponding (2)
* slighly (2)
* wierdly (2)