### PR TITLE
Remove the link for `compat_check_pypi`

### DIFF
--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -1,12 +1,7 @@
 gRPC Python
 ===========
 
-|compat_check_pypi|
-
 Package for gRPC Python.
-
-.. |compat_check_pypi| image:: https://python-compatibility-tools.appspot.com/one_badge_image?package=grpcio
-   :target: https://python-compatibility-tools.appspot.com/one_badge_target?package=grpcio
 
 Supported Python Versions
 -------------------------


### PR DESCRIPTION
It seems that [python-compatibility-tools.appspot.com ](https://python-compatibility-tools.appspot.com/)doesn't work now. And, cloud-opensource-python is archived already.
https://github.com/GoogleCloudPlatform/cloud-opensource-python

