### PR TITLE
[Python Distrib] Change warning to RuntimeError for version incompatibility (v1.66.x backport)

### DIFF
--- a/examples/python/helloworld/helloworld_pb2_grpc.py
+++ b/examples/python/helloworld/helloworld_pb2_grpc.py
@@ -5,10 +5,8 @@ import warnings
 
 import helloworld_pb2 as helloworld__pb2
 
-GRPC_GENERATED_VERSION = '1.66.0.dev0'
+GRPC_GENERATED_VERSION = '1.67.0.dev0'
 GRPC_VERSION = grpc.__version__
-EXPECTED_ERROR_RELEASE = '1.66.0'
-SCHEDULED_RELEASE_DATE = 'August 6, 2024'
 _version_not_supported = False
 
 try:
@@ -18,15 +16,12 @@ except ImportError:
     _version_not_supported = True
 
 if _version_not_supported:
-    warnings.warn(
+    raise RuntimeError(
         f'The grpc package installed is at version {GRPC_VERSION},'
         + f' but the generated code in helloworld_pb2_grpc.py depends on'
         + f' grpcio>={GRPC_GENERATED_VERSION}.'
         + f' Please upgrade your grpc module to grpcio>={GRPC_GENERATED_VERSION}'
         + f' or downgrade your generated code using grpcio-tools<={GRPC_VERSION}.'
-        + f' This warning will become an error in {EXPECTED_ERROR_RELEASE},'
-        + f' scheduled for release on {SCHEDULED_RELEASE_DATE}.',
-        RuntimeWarning
     )
 
 

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -744,8 +744,6 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
       var["ToolsVersion"] = config.grpc_tools_version;
       out->Print(var, "\nGRPC_GENERATED_VERSION = '$ToolsVersion$'\n");
       out->Print("GRPC_VERSION = grpc.__version__\n");
-      out->Print("EXPECTED_ERROR_RELEASE = '1.66.0'\n");
-      out->Print("SCHEDULED_RELEASE_DATE = 'August 6, 2024'\n");
       out->Print("_version_not_supported = False\n\n");
       out->Print("try:\n");
       {
@@ -763,7 +761,7 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
       out->Print("\nif _version_not_supported:\n");
       {
         IndentScope raii_warning_indent(out);
-        out->Print("warnings.warn(\n");
+        out->Print("raise RuntimeError(\n");
         {
           IndentScope raii_warning_string_indent(out);
           std::string filename_without_ext = file->filename_without_ext();
@@ -779,11 +777,7 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
               "+ f' Please upgrade your grpc module to "
               "grpcio>={GRPC_GENERATED_VERSION}'\n"
               "+ f' or downgrade your generated code using "
-              "grpcio-tools<={GRPC_VERSION}.'\n"
-              "+ f' This warning will become an error in "
-              "{EXPECTED_ERROR_RELEASE},'\n"
-              "+ f' scheduled for release on {SCHEDULED_RELEASE_DATE}.',\n"
-              "RuntimeWarning\n");
+              "grpcio-tools<={GRPC_VERSION}.'\n");
         }
         out->Print(")\n");
       }


### PR DESCRIPTION
Backport of #37466 to v1.66.x.
---




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

