### PR TITLE
[OTel C++] Simplify tests

### DIFF
--- a/test/cpp/ext/otel/otel_plugin_test.cc
+++ b/test/cpp/ext/otel/otel_plugin_test.cc
@@ -1775,14 +1775,11 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_1 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_1;
-        reporter.Report(integer_gauge_handle, int_value_1, kLabelValuesSet1,
+        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_1, kLabelValuesSet1,
+        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
+        ;
       },
       grpc_core::Duration::Milliseconds(100) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
@@ -1792,12 +1789,8 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_2 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_2;
-        reporter.Report(integer_gauge_handle, int_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(integer_gauge_handle, int_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(double_gauge_handle, double_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },
@@ -1910,14 +1903,10 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_1 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_1;
-        reporter.Report(integer_gauge_handle, int_value_1, kLabelValuesSet1,
+        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(integer_gauge_handle, int_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_1, kLabelValuesSet1,
+        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet1,
                         kOptionalLabelValuesSet1);
-        reporter.Report(double_gauge_handle, double_value_1++, kLabelValuesSet2,
-                        kOptionalLabelValuesSet2);
       },
       grpc_core::Duration::Milliseconds(50) * grpc_test_slowdown_factor(),
       integer_gauge_handle, double_gauge_handle);
@@ -1927,12 +1916,8 @@ TEST_F(OpenTelemetryPluginCallbackMetricsTest,
   auto registered_metric_callback_2 = stats_plugins.RegisterCallback(
       [&](grpc_core::CallbackMetricReporter& reporter) {
         ++report_count_2;
-        reporter.Report(integer_gauge_handle, int_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(integer_gauge_handle, int_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
-        reporter.Report(double_gauge_handle, double_value_2, kLabelValuesSet1,
-                        kOptionalLabelValuesSet1);
         reporter.Report(double_gauge_handle, double_value_2++, kLabelValuesSet2,
                         kOptionalLabelValuesSet2);
       },


### PR DESCRIPTION
It is hard to reason about tests if multiple callbacks record values for the same metrics with the same label sets.