### PR TITLE
[Gpr_To_Absl_Logging] Remove logging header from example and test/cpp folder

### DIFF
--- a/examples/cpp/helloworld/greeter_async_client.cc
+++ b/examples/cpp/helloworld/greeter_async_client.cc
@@ -24,7 +24,6 @@
 #include "absl/flags/parse.h"
 #include "absl/log/check.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
 
 #ifdef BAZEL_BUILD

--- a/examples/cpp/helloworld/greeter_async_client2.cc
+++ b/examples/cpp/helloworld/greeter_async_client2.cc
@@ -25,7 +25,6 @@
 #include "absl/flags/parse.h"
 #include "absl/log/check.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
 
 #ifdef BAZEL_BUILD

--- a/examples/cpp/helloworld/greeter_async_server.cc
+++ b/examples/cpp/helloworld/greeter_async_server.cc
@@ -26,7 +26,6 @@
 #include "absl/log/check.h"
 #include "absl/strings/str_format.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
 
 #ifdef BAZEL_BUILD

--- a/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
+++ b/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
@@ -27,7 +27,6 @@
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>

--- a/test/cpp/end2end/client_crash_test.cc
+++ b/test/cpp/end2end/client_crash_test.cc
@@ -22,7 +22,6 @@
 #include "absl/memory/memory.h"
 
 #include <grpc/grpc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -37,7 +37,6 @@
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/atm.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -37,7 +37,6 @@
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/test/cpp/end2end/health_service_end2end_test.cc
+++ b/test/cpp/end2end/health_service_end2end_test.cc
@@ -24,7 +24,6 @@
 #include <gtest/gtest.h>
 
 #include <grpc/grpc.h>
-#include <grpc/support/log.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>

--- a/test/cpp/end2end/raw_end2end_test.cc
+++ b/test/cpp/end2end/raw_end2end_test.cc
@@ -26,7 +26,6 @@
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/test/cpp/end2end/server_early_return_test.cc
+++ b/test/cpp/end2end/server_early_return_test.cc
@@ -20,7 +20,6 @@
 
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/test/cpp/end2end/time_change_test.cc
+++ b/test/cpp/end2end/time_change_test.cc
@@ -26,7 +26,6 @@
 #include "absl/memory/memory.h"
 
 #include <grpc/grpc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>

--- a/test/cpp/interop/metrics_client.cc
+++ b/test/cpp/interop/metrics_client.cc
@@ -21,7 +21,6 @@
 
 #include "absl/flags/flag.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
 
 #include "src/core/lib/gprpp/crash.h"

--- a/test/cpp/microbenchmarks/bm_basic_work_queue.cc
+++ b/test/cpp/microbenchmarks/bm_basic_work_queue.cc
@@ -18,7 +18,6 @@
 #include "absl/log/check.h"
 
 #include <grpc/event_engine/event_engine.h>
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/event_engine/common_closures.h"

--- a/test/cpp/microbenchmarks/bm_cq.cc
+++ b/test/cpp/microbenchmarks/bm_cq.cc
@@ -24,7 +24,6 @@
 #include "absl/log/check.h"
 
 #include <grpc/grpc.h>
-#include <grpc/support/log.h>
 #include <grpcpp/completion_queue.h>
 #include <grpcpp/impl/grpc_library.h>
 

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -32,7 +32,6 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
 #include "src/core/lib/channel/channel_args.h"

--- a/test/cpp/qps/benchmark_config.cc
+++ b/test/cpp/qps/benchmark_config.cc
@@ -21,7 +21,6 @@
 #include "absl/flags/flag.h"
 #include "absl/log/check.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 

--- a/test/cpp/util/channel_trace_proto_helper.cc
+++ b/test/cpp/util/channel_trace_proto_helper.cc
@@ -21,7 +21,6 @@
 #include <gtest/gtest.h>
 
 #include <grpc/grpc.h>
-#include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 #include <grpcpp/impl/codegen/config_protobuf.h>
 #include <grpcpp/support/config.h>

--- a/test/cpp/util/cli_call.cc
+++ b/test/cpp/util/cli_call.cc
@@ -26,7 +26,6 @@
 
 #include <grpc/grpc.h>
 #include <grpc/slice.h>
-#include <grpc/support/log.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/support/byte_buffer.h>

--- a/test/cpp/util/cli_credentials.cc
+++ b/test/cpp/util/cli_credentials.cc
@@ -22,7 +22,6 @@
 #include "absl/log/log.h"
 
 #include <grpc/slice.h>
-#include <grpc/support/log.h>
 #include <grpcpp/support/slice.h>
 
 #include "src/core/lib/gprpp/crash.h"

--- a/test/cpp/util/create_test_channel.cc
+++ b/test/cpp/util/create_test_channel.cc
@@ -21,7 +21,6 @@
 #include "absl/flags/flag.h"
 #include "absl/log/check.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 

--- a/test/cpp/util/metrics_server.cc
+++ b/test/cpp/util/metrics_server.cc
@@ -20,7 +20,6 @@
 
 #include "absl/log/log.h"
 
-#include <grpc/support/log.h>
 #include <grpcpp/server.h>
 #include <grpcpp/server_builder.h>
 

--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -29,7 +29,6 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 
-#include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpcpp/security/server_credentials.h>
 

--- a/test/cpp/util/windows/manifest_file.cc
+++ b/test/cpp/util/windows/manifest_file.cc
@@ -29,7 +29,6 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 
-
 #include "src/core/lib/gprpp/crash.h"
 
 namespace grpc {

--- a/test/cpp/util/windows/manifest_file.cc
+++ b/test/cpp/util/windows/manifest_file.cc
@@ -29,7 +29,6 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 
-#include <grpc/support/log.h>
 
 #include "src/core/lib/gprpp/crash.h"
 


### PR DESCRIPTION
[Gpr_To_Absl_Logging] Remove logging header from example and test/cpp folder