### PR TITLE
[dualstack] enable EDS dualstack support by default (backport to 1.66.x)

### DIFF
--- a/src/core/xds/grpc/xds_endpoint_parser.cc
+++ b/src/core/xds/grpc/xds_endpoint_parser.cc
@@ -61,10 +61,10 @@ namespace grpc_core {
 
 namespace {
 
-// TODO(roth): Remove this once dualstack support is stable.
+// TODO(roth): Remove this after 1.67 is released.
 bool XdsDualstackEndpointsEnabled() {
   auto value = GetEnv("GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
-  if (!value.has_value()) return false;
+  if (!value.has_value()) return true;
   bool parsed_value;
   bool parse_succeeded = gpr_parse_bool_value(value->c_str(), &parsed_value);
   return parse_succeeded && parsed_value;

--- a/test/core/xds/xds_endpoint_resource_type_test.cc
+++ b/test/core/xds/xds_endpoint_resource_type_test.cc
@@ -487,8 +487,6 @@ TEST_F(XdsEndpointTest, MissingAddress) {
 }
 
 TEST_F(XdsEndpointTest, MultipleAddressesPerEndpoint) {
-  testing::ScopedExperimentalEnvVar env(
-      "GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
   ClusterLoadAssignment cla;
   cla.set_cluster_name("foo");
   auto* locality = cla.add_endpoints();
@@ -543,8 +541,6 @@ TEST_F(XdsEndpointTest, MultipleAddressesPerEndpoint) {
 }
 
 TEST_F(XdsEndpointTest, AdditionalAddressesMissingAddress) {
-  testing::ScopedExperimentalEnvVar env(
-      "GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
   ClusterLoadAssignment cla;
   cla.set_cluster_name("foo");
   auto* locality = cla.add_endpoints();
@@ -575,8 +571,6 @@ TEST_F(XdsEndpointTest, AdditionalAddressesMissingAddress) {
 }
 
 TEST_F(XdsEndpointTest, AdditionalAddressesMissingSocketAddress) {
-  testing::ScopedExperimentalEnvVar env(
-      "GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
   ClusterLoadAssignment cla;
   cla.set_cluster_name("foo");
   auto* locality = cla.add_endpoints();
@@ -608,8 +602,6 @@ TEST_F(XdsEndpointTest, AdditionalAddressesMissingSocketAddress) {
 }
 
 TEST_F(XdsEndpointTest, AdditionalAddressesInvalidPort) {
-  testing::ScopedExperimentalEnvVar env(
-      "GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
   ClusterLoadAssignment cla;
   cla.set_cluster_name("foo");
   auto* locality = cla.add_endpoints();
@@ -645,8 +637,6 @@ TEST_F(XdsEndpointTest, AdditionalAddressesInvalidPort) {
 }
 
 TEST_F(XdsEndpointTest, AdditionalAddressesInvalidAddress) {
-  testing::ScopedExperimentalEnvVar env(
-      "GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
   ClusterLoadAssignment cla;
   cla.set_cluster_name("foo");
   auto* locality = cla.add_endpoints();
@@ -681,7 +671,9 @@ TEST_F(XdsEndpointTest, AdditionalAddressesInvalidAddress) {
       << decode_result.resource.status();
 }
 
-TEST_F(XdsEndpointTest, IgnoresMultipleAddressesPerEndpointWhenNotEnabled) {
+TEST_F(XdsEndpointTest, IgnoresMultipleAddressesPerEndpointWhenDisabled) {
+  testing::ScopedEnvVar env("GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS",
+                            "false");
   ClusterLoadAssignment cla;
   cla.set_cluster_name("foo");
   auto* locality = cla.add_endpoints();

--- a/test/cpp/end2end/xds/xds_override_host_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_override_host_end2end_test.cc
@@ -703,8 +703,6 @@ TEST_P(OverrideHostTest, TTLSetsMaxAge) {
 }
 
 TEST_P(OverrideHostTest, MultipleAddressesPerEndpoint) {
-  grpc_core::testing::ScopedExperimentalEnvVar env(
-      "GRPC_EXPERIMENTAL_XDS_DUALSTACK_ENDPOINTS");
   // Create 3 backends, but leave backend 0 unstarted.
   CreateBackends(3);
   StartBackend(1);


### PR DESCRIPTION
Backports #37545 to 1.66.x.