### PR TITLE
[benchmark] Move CI images to artifact registry.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -34,8 +34,8 @@ GRPC_NODE_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
-# This is to ensure we can push and pull images from gcr.io. We do not
-# necessarily need it to run load tests, but will need it when we employ
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
 # pre-built images in the optimization.
 gcloud auth configure-docker
 
@@ -59,7 +59,7 @@ else
 fi
 # END differentiate experimental configuration from master configuration.
 CLOUD_LOGGING_URL="https://source.cloud.google.com/results/invocations/${KOKORO_BUILD_ID}"
-PREBUILT_IMAGE_PREFIX="gcr.io/grpc-testing/e2etest/prebuilt/${LOAD_TEST_PREFIX}"
+PREBUILT_IMAGE_PREFIX="us-docker.pkg.dev/grpc-testing/e2etest-prebuilt"
 UNIQUE_IDENTIFIER="$(date +%Y%m%d%H%M%S)"
 ROOT_DIRECTORY_OF_DOCKERFILES="../test-infra/containers/pre_built_workers/"
 # Head of the workspace checked out by Kokoro.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
@@ -57,7 +57,7 @@ BIGQUERY_TABLE_8CORE=e2e_benchmark_cxx_experiments.results_8core
 BIGQUERY_TABLE_32CORE=e2e_benchmark_cxx_experiments.results_32core
 # END differentiate experimental configuration from master configuration.
 CLOUD_LOGGING_URL="https://source.cloud.google.com/results/invocations/${KOKORO_BUILD_ID}"
-PREBUILT_IMAGE_PREFIX="gcr.io/grpc-testing/e2etest/prebuilt/cxx_experiment/${LOAD_TEST_PREFIX}"
+PREBUILT_IMAGE_PREFIX="us-docker.pkg.dev/grpc-testing/e2etest-prebuilt"
 UNIQUE_IDENTIFIER="cxx-experiment-$(date +%Y%m%d%H%M%S)"
 ROOT_DIRECTORY_OF_DOCKERFILES="../test-infra/containers/pre_built_workers/"
 # Head of the workspace checked out by Kokoro.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -34,8 +34,8 @@ GRPC_NODE_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
-# This is to ensure we can push and pull images from gcr.io. We do not
-# necessarily need it to run load tests, but will need it when we employ
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
 # pre-built images in the optimization.
 gcloud auth configure-docker
 
@@ -54,7 +54,7 @@ BIGQUERY_TABLE_8CORE=e2e_benchmarks.experimental_results
 BIGQUERY_TABLE_32CORE=e2e_benchmarks.experimental_results_32core
 # END differentiate experimental configuration from master configuration.
 CLOUD_LOGGING_URL="https://source.cloud.google.com/results/invocations/${KOKORO_BUILD_ID}"
-PREBUILT_IMAGE_PREFIX="gcr.io/grpc-testing/e2etest/prebuilt/${LOAD_TEST_PREFIX}"
+PREBUILT_IMAGE_PREFIX="us-docker.pkg.dev/grpc-testing/e2etest-prebuilt"
 UNIQUE_IDENTIFIER="$(date +%Y%m%d%H%M%S)"
 ROOT_DIRECTORY_OF_DOCKERFILES="../test-infra/containers/pre_built_workers/"
 # Head of the workspace checked out by Kokoro.

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -19,8 +19,8 @@ cd "$(dirname "$0")/../../.."
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-# This is to ensure we can push and pull images from gcr.io. We do not
-# necessarily need it to run load tests, but will need it when we employ
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
 # pre-built images in the optimization.
 gcloud auth configure-docker
 
@@ -38,7 +38,7 @@ fi
 BIGQUERY_TABLE_8CORE=e2e_benchmarks.psm_experimental_results_8core
 # END differentiate experimental configuration from master configuration.
 CLOUD_LOGGING_URL="https://source.cloud.google.com/results/invocations/${KOKORO_BUILD_ID}"
-PREBUILT_IMAGE_PREFIX="gcr.io/grpc-testing/e2etest/prebuilt/${LOAD_TEST_PREFIX}"
+PREBUILT_IMAGE_PREFIX="us-docker.pkg.dev/grpc-testing/e2etest-prebuilt"
 UNIQUE_IDENTIFIER="$(date +%Y%m%d%H%M%S)"
 ROOT_DIRECTORY_OF_DOCKERFILES="../test-infra/containers/pre_built_workers/"
 # Head of the workspace checked out by Kokoro.


### PR DESCRIPTION
This change moves the location for the prebuilt images used in gRPC OSS benchmarks from GCR to Artifact Registry.

Images are all saved to the same repo, instead of being organized by a prefix (`kokoro`, `kokoro-test`, 
`cxx_experiment/kokoro-test`, etc.).


