### PR TITLE
[log] Fix logging for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2874,6 +2874,7 @@ target_link_libraries(grpc_test_util
   absl::failure_signal_handler
   absl::stacktrace
   absl::symbolize
+  absl::log_initialize
   grpc
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2940,6 +2940,7 @@ target_link_libraries(grpc_test_util_unsecure
   absl::failure_signal_handler
   absl::stacktrace
   absl::symbolize
+  absl::log_initialize
   grpc_unsecure
 )
 if(_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2118,6 +2118,7 @@ libs:
   - absl/debugging:failure_signal_handler
   - absl/debugging:stacktrace
   - absl/debugging:symbolize
+  - absl/log:initialize
   - grpc
 - name: grpc_test_util_unsecure
   build: private

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2147,6 +2147,7 @@ libs:
   - absl/debugging:failure_signal_handler
   - absl/debugging:stacktrace
   - absl/debugging:symbolize
+  - absl/log:initialize
   - grpc_unsecure
 - name: grpc_unsecure
   build: all

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -121,6 +121,7 @@ grpc_cc_library(
         "absl/debugging:failure_signal_handler",
         "absl/log:check",
         "absl/log:globals",
+        "absl/log:initialize",
         "absl/log:log",
         "absl/status",
         "absl/status:statusor",

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -169,6 +169,7 @@ grpc_cc_library(
     external_deps = [
         "absl/debugging:failure_signal_handler",
         "absl/log:check",
+        "absl/log:initialize",
         "absl/log:log",
         "absl/status",
         "absl/status:statusor",

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -124,7 +124,10 @@ void ParseTestArgs(int* argc, char** argv) {
   }
 }
 
+// grpc-oss-only-begin
 std::once_flag log_flag;
+// grpc-oss-only-end
+
 }  // namespace
 
 void grpc_test_init(int* argc, char** argv) {

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -128,10 +128,12 @@ std::once_flag log_flag;
 }  // namespace
 
 void grpc_test_init(int* argc, char** argv) {
+  // grpc-oss-only-begin
   std::call_once(log_flag, []() { absl::InitializeLog(); });
   absl::SetGlobalVLogLevel(2);
   absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
   absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  // grpc-oss-only-end
   gpr_log_verbosity_init();
   ParseTestArgs(argc, argv);
   grpc_core::testing::InitializeStackTracer(argv[0]);

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -125,10 +125,10 @@ void ParseTestArgs(int* argc, char** argv) {
 
 void grpc_test_init(int* argc, char** argv) {
   absl::InitializeLog();
-  gpr_log_verbosity_init();
   absl::SetGlobalVLogLevel(2);
   absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
   absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  gpr_log_verbosity_init();
   ParseTestArgs(argc, argv);
   grpc_core::testing::InitializeStackTracer(argv[0]);
   absl::FailureSignalHandlerOptions options;

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -23,6 +23,7 @@
 
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/log/globals.h"
+#include "absl/log/initialize.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
@@ -123,7 +124,11 @@ void ParseTestArgs(int* argc, char** argv) {
 }  // namespace
 
 void grpc_test_init(int* argc, char** argv) {
+  absl::InitializeLog();
   gpr_log_verbosity_init();
+  absl::SetGlobalVLogLevel(2);
+  absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
   ParseTestArgs(argc, argv);
   grpc_core::testing::InitializeStackTracer(argv[0]);
   absl::FailureSignalHandlerOptions options;

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -21,6 +21,8 @@
 #include <inttypes.h>
 #include <stdlib.h>
 
+#include <mutex>
+
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/log/globals.h"
 #include "absl/log/initialize.h"
@@ -121,10 +123,12 @@ void ParseTestArgs(int* argc, char** argv) {
     ++i;
   }
 }
+
+std::once_flag log_flag;
 }  // namespace
 
 void grpc_test_init(int* argc, char** argv) {
-  absl::InitializeLog();
+  std::call_once(log_flag, []() { absl::InitializeLog(); });
   absl::SetGlobalVLogLevel(2);
   absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
   absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);


### PR DESCRIPTION
This will fix timestamps on logs and show all `VLOG(2)` logs on tests by default.

Currently, timestamps on logs are shown as - 
```
I0000 00:00:1724385276.681936 1894892 config.cc:262] gRPC experiments enabled: call_tracer_in_transport, event_engine_dns, event_engine_listener, monitoring_experiment, pick_first_new, trace_record_callops, work_serializer_clears_time_cache
```
After invoking `absl::InitializeLog()`, this gets fixed to - 
```
I0823 03:55:53.993928 1895644 config.cc:262] gRPC experiments enabled: call_tracer_in_transport, event_engine_dns, event_engine_listener, monitoring_experiment, pick_first_new, trace_record_callops, work_serializer_clears_time_cache
```