### PR TITLE
[benchmark] Set up auth for artifact registry.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -34,16 +34,6 @@ GRPC_NODE_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
-gcloud auth configure-docker
-
-# Connect to benchmarks-prod2 cluster.
-gcloud config set project grpc-testing
-gcloud container clusters get-credentials benchmarks-prod2 \
-  --zone us-central1-b --project grpc-testing
-
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
 # BEGIN differentiate experimental configuration from master configuration.
@@ -82,6 +72,16 @@ WORKER_POOL_8CORE=workers-c2-8core-ci
 WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
+
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
+# pre-built images in the optimization.
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+
+# Connect to benchmarks-prod2 cluster.
+gcloud config set project grpc-testing
+gcloud container clusters get-credentials benchmarks-prod2 \
+  --zone us-central1-b --project grpc-testing
 
 # Clone test-infra repository and build all tools.
 mkdir ../test-infra

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
@@ -35,16 +35,6 @@ GRPC_CORE_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
-# This is to ensure we can push and pull images from gcr.io. We do not
-# necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
-gcloud auth configure-docker
-
-# Connect to benchmarks-prod2 cluster.
-gcloud config set project grpc-testing
-gcloud container clusters get-credentials benchmarks-prod2 \
-  --zone us-central1-b --project grpc-testing
-
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
 # BEGIN differentiate experimental configuration from master configuration.
@@ -76,6 +66,16 @@ WORKER_POOL_8CORE=workers-c2-8core-ci
 WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
+
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
+# pre-built images in the optimization.
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+
+# Connect to benchmarks-prod2 cluster.
+gcloud config set project grpc-testing
+gcloud container clusters get-credentials benchmarks-prod2 \
+  --zone us-central1-b --project grpc-testing
 
 # Clone test-infra repository and build all tools.
 mkdir ../test-infra

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -34,16 +34,6 @@ GRPC_NODE_GITREF=master
 TEST_INFRA_REPO=grpc/test-infra
 TEST_INFRA_GITREF=master
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
-gcloud auth configure-docker
-
-# Connect to benchmarks-prod2 cluster.
-gcloud config set project grpc-testing
-gcloud container clusters get-credentials benchmarks-prod2 \
-  --zone us-central1-b --project grpc-testing
-
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
 # BEGIN differentiate experimental configuration from master configuration.
@@ -77,6 +67,16 @@ WORKER_POOL_8CORE=workers-c2-8core-ci
 WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
+
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
+# pre-built images in the optimization.
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+
+# Connect to benchmarks-prod2 cluster.
+gcloud config set project grpc-testing
+gcloud container clusters get-credentials benchmarks-prod2 \
+  --zone us-central1-b --project grpc-testing
 
 # Clone test-infra repository and build all tools.
 mkdir ../test-infra

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -19,16 +19,6 @@ cd "$(dirname "$0")/../../.."
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
-gcloud auth configure-docker
-
-# Connect to benchmarks-prod2 cluster.
-gcloud config set project grpc-testing
-gcloud container clusters get-credentials psm-benchmarks-performance \
-  --zone us-central1-b --project grpc-testing
-
 # Set up environment variables.
 LOAD_TEST_PREFIX="${KOKORO_BUILD_INITIATOR}"
 # BEGIN differentiate experimental configuration from master configuration.
@@ -55,6 +45,16 @@ DRIVER_POOL=drivers-ci
 WORKER_POOL_8CORE=workers-c2-8core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
+
+# This is to ensure we can push and pull images from Artifact Registry. We do
+# not necessarily need it to run load tests, but will need it when we employ
+# pre-built images in the optimization.
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+
+# Connect to benchmarks-prod2 cluster.
+gcloud config set project grpc-testing
+gcloud container clusters get-credentials psm-benchmarks-performance \
+  --zone us-central1-b --project grpc-testing
 
 # Clone test-infra repository and build all tools.
 pushd ..


### PR DESCRIPTION
Artifact Registry requires the registry as an argument for `gcloud auth configure-docker`.