### PR TITLE
[interop] Add v1.66.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -305,6 +305,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.63.3", ReleaseInfo()),
             ("v1.64.1", ReleaseInfo()),
             ("v1.65.0", ReleaseInfo()),
+            ("v1.66.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```bash
$ GO_VERSION='1.x'
$ RELEASE_VERSION='1.66.0'

$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_"$GO_VERSION" | grep "$RELEASE_VERSION" 
a8f2a7268e7c  infrastructure-public-image-v1.66.0,v1.66.0                                                                                                                                                                                  2024-08-28T15:27:01  CRITICAL=5,HIGH=62,LOW=334,MEDIUM=136
```