### PR TITLE
[CI] Upgrade pytype to 2024.4.11

### DIFF
--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -18,17 +18,9 @@
 
   <%include file="../../apt_get_basic.include"/>
 
-  # Install Python 3.7 from source (and installed as a default python3)
-  # (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
-  RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev ${'\\'}
-                              libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev
-  RUN curl -O https://www.python.org/ftp/python/3.7.17/Python-3.7.17.tar.xz && ${'\\'}
-  tar -xf Python-3.7.17.tar.xz && ${'\\'}
-  cd Python-3.7.17 && ${'\\'}
-  ./configure && ${'\\'}
-  make -j 4 && ${'\\'}
-  make install
-  RUN curl https://bootstrap.pypa.io/pip/3.7/get-pip.py | python3
+  RUN apt update && apt install -y python3 python3-pip && apt-get clean
+  RUN mkdir -p ~/.config/pip
+  RUN echo "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
 
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../run_tests_addons.include"/>
@@ -46,10 +38,10 @@
   # otherwise clang-tidy will report missing <gtest/gtest.h> header
   RUN apt-get update && apt-get install -y libgtest-dev && apt-get clean
 
-  RUN python3 -m pip install simplejson mako virtualenv==16.7.9 lxml six
+  RUN python3 -m pip install simplejson mako virtualenv lxml six
 
   # Upgrade Python's YAML library
-  RUN python3 -m pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
+  RUN python3 -m pip install --upgrade --ignore-installed PyYAML
 
   # Install prerequisites for the clang-tidy script
   RUN apt-get update && apt-get install -y jq git && apt-get clean

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -113,5 +113,5 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/test/rbe_ubuntu2004.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rbe_ubuntu2004@sha256:b3eb1a17b7b091e3c5648a803076b2c40601242ff91c04d55997af6641305f68",
     "tools/dockerfile/test/ruby_debian11_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_debian11_arm64@sha256:d2e79919b2e2d4cc36a29682ecb5170641df4fb506cfb453978ffdeb8a841bd9",
     "tools/dockerfile/test/ruby_debian11_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/ruby_debian11_x64@sha256:6e8b4696ba0661f11a31ed0992a94d2efcd889a018f57160f0e2fb62963f3593",
-    "tools/dockerfile/test/sanity.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/sanity@sha256:4fb77e7130e10934e65ec0657e286a8ca5850e9a25441dabe2174b3cb6a56180",
+    "tools/dockerfile/test/sanity.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/sanity@sha256:a1f685b401a4d43d34b4aec588ad37439c69c8d7236fe2cf5754604dedbf6357",
 }

--- a/tools/distrib/check_pytype.sh
+++ b/tools/distrib/check_pytype.sh
@@ -15,5 +15,5 @@
 
 JOBS=$(nproc) || JOBS=4
 # TODO(xuanwn): update pytype version
-python3 -m pip install pytype==2019.11.27
+python3 -m pip install pytype==2024.4.11
 python3 -m pytype --keep-going -j "$JOBS" --strict-import --config "setup.cfg"

--- a/tools/dockerfile/test/sanity.current_version
+++ b/tools/dockerfile/test/sanity.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:0006a2ed3aca736f842b3e1bf758cb6ab621922d@sha256:4fb77e7130e10934e65ec0657e286a8ca5850e9a25441dabe2174b3cb6a56180
+us-docker.pkg.dev/grpc-testing/testing-images-public/sanity:9fbf104d71fd53fbe8924f7ab216657c729b04be@sha256:a1f685b401a4d43d34b4aec588ad37439c69c8d7236fe2cf5754604dedbf6357

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -63,17 +63,9 @@ RUN git config --global protocol.file.allow always
 
 
 
-# Install Python 3.7 from source (and installed as a default python3)
-# (Bullseye comes with Python 3.9 which isn't supported by pytype yet)
-RUN apt update && apt install -y build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
-                            libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev
-RUN curl -O https://www.python.org/ftp/python/3.7.17/Python-3.7.17.tar.xz && \
-tar -xf Python-3.7.17.tar.xz && \
-cd Python-3.7.17 && \
-./configure && \
-make -j 4 && \
-make install
-RUN curl https://bootstrap.pypa.io/pip/3.7/get-pip.py | python3
+RUN apt update && apt install -y python3 python3-pip && apt-get clean
+RUN mkdir -p ~/.config/pip
+RUN echo "[global]\nbreak-system-packages = true" > ~/.config/pip/pip.conf
 
 # Google Cloud Platform API libraries
 # These are needed for uploading test results to BigQuery (e.g. by tools/run_tests scripts)
@@ -96,10 +88,10 @@ RUN apt-get update && apt-get install -y \
 # otherwise clang-tidy will report missing <gtest/gtest.h> header
 RUN apt-get update && apt-get install -y libgtest-dev && apt-get clean
 
-RUN python3 -m pip install simplejson mako virtualenv==16.7.9 lxml six
+RUN python3 -m pip install simplejson mako virtualenv lxml six
 
 # Upgrade Python's YAML library
-RUN python3 -m pip install --upgrade --ignore-installed PyYAML==5.4.1 --user
+RUN python3 -m pip install --upgrade --ignore-installed PyYAML
 
 # Install prerequisites for the clang-tidy script
 RUN apt-get update && apt-get install -y jq git && apt-get clean


### PR DESCRIPTION
`pytype==2019.11.27` supports Python up to 3.7 which is now deprecated so let's upgrade this to 2024. Also this allows some clean-up in Dockerfile.