### PR TITLE
[benchmark] Support GCR and Artifact Registry.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -76,8 +76,8 @@ LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifac
 # This is to ensure we can push and pull images from GCR and Artifact Registry.
 # We do not necessarily need it to run load tests, but will need it when we
 # employ pre-built images in the optimization.
-gcloud auth configure-docker
-gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+gcloud auth configure-docker --quiet
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}" --quiet
 
 # Connect to benchmarks-prod2 cluster.
 gcloud config set project grpc-testing

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -73,9 +73,10 @@ WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
+# This is to ensure we can push and pull images from GCR and Artifact Registry.
+# We do not necessarily need it to run load tests, but will need it when we
+# employ pre-built images in the optimization.
+gcloud auth configure-docker
 gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
 
 # Connect to benchmarks-prod2 cluster.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
@@ -67,9 +67,10 @@ WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
+# This is to ensure we can push and pull images from GCR and Artifact Registry.
+# We do not necessarily need it to run load tests, but will need it when we
+# employ pre-built images in the optimization.
+gcloud auth configure-docker
 gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
 
 # Connect to benchmarks-prod2 cluster.

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_cxx_experiments_framework.sh
@@ -70,8 +70,8 @@ LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifac
 # This is to ensure we can push and pull images from GCR and Artifact Registry.
 # We do not necessarily need it to run load tests, but will need it when we
 # employ pre-built images in the optimization.
-gcloud auth configure-docker
-gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+gcloud auth configure-docker --quiet
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}" --quiet
 
 # Connect to benchmarks-prod2 cluster.
 gcloud config set project grpc-testing

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -71,8 +71,8 @@ LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifac
 # This is to ensure we can push and pull images from GCR and Artifact Registry.
 # We do not necessarily need it to run load tests, but will need it when we
 # employ pre-built images in the optimization.
-gcloud auth configure-docker
-gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+gcloud auth configure-docker --quiet
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}" --quiet
 
 # Connect to benchmarks-prod2 cluster.
 gcloud config set project grpc-testing

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -68,9 +68,10 @@ WORKER_POOL_32CORE=workers-c2-30core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
+# This is to ensure we can push and pull images from GCR and Artifact Registry.
+# We do not necessarily need it to run load tests, but will need it when we
+# employ pre-built images in the optimization.
+gcloud auth configure-docker
 gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
 
 # Connect to benchmarks-prod2 cluster.

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -46,9 +46,10 @@ WORKER_POOL_8CORE=workers-c2-8core-ci
 # Prefix for log URLs in cnsviewer.
 LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifacts/${KOKORO_BUILD_ARTIFACTS_SUBDIR}/github/grpc/"
 
-# This is to ensure we can push and pull images from Artifact Registry. We do
-# not necessarily need it to run load tests, but will need it when we employ
-# pre-built images in the optimization.
+# This is to ensure we can push and pull images from GCR and Artifact Registry.
+# We do not necessarily need it to run load tests, but will need it when we
+# employ pre-built images in the optimization.
+gcloud auth configure-docker
 gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
 
 # Connect to benchmarks-prod2 cluster.

--- a/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_psm_performance_gke_experiment.sh
@@ -49,8 +49,8 @@ LOG_URL_PREFIX="http://cnsviewer/placer/prod/home/kokoro-dedicated/build_artifac
 # This is to ensure we can push and pull images from GCR and Artifact Registry.
 # We do not necessarily need it to run load tests, but will need it when we
 # employ pre-built images in the optimization.
-gcloud auth configure-docker
-gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}"
+gcloud auth configure-docker --quiet
+gcloud auth configure-docker "${PREBUILT_IMAGE_PREFIX%%/*}" --quiet
 
 # Connect to benchmarks-prod2 cluster.
 gcloud config set project grpc-testing


### PR DESCRIPTION
We have base images that still need to be migrated (for instance, from marketplace.gcr.io). This change restores support for GCR, to be maintained until all images are migrated.

