### PR TITLE
[CI] A bit update on clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -79,7 +79,6 @@ Checks: '-*,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
   -bugprone-not-null-terminated-result,
-  -bugprone-optional-value-conversion,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,
   -bugprone-sizeof-expression,
@@ -87,11 +86,9 @@ Checks: '-*,
   -bugprone-too-small-loop-variable,
   -bugprone-unchecked-optional-access,
   -bugprone-unused-local-non-trivial-variable,
-  -bugprone-unused-return-value,
   google-*,
   -google-readability-casting,
   -google-runtime-int,
-  -google-runtime-references,
   performance-*,
   -performance-avoid-endl,
   -performance-enum-size,
@@ -133,6 +130,7 @@ Checks: '-*,
   modernize-use-noexcept,
   modernize-use-nullptr,
   modernize-use-override,
+  modernize-use-starts-ends-with,
   modernize-use-transparent-functors,
   readability-braces-around-statements,
   readability-const-return-type,
@@ -142,13 +140,13 @@ Checks: '-*,
   readability-duplicate-include,
   readability-function-size,
   readability-inconsistent-declaration-parameter-name,
+  readability-math-missing-parentheses,
   readability-misleading-indentation,
   readability-misplaced-array-index,
   readability-redundant-access-specifiers,
   readability-redundant-control-flow,
   readability-redundant-function-ptr-dereference,
   readability-redundant-smartptr-get,
-  -readability-redundant-string-cstr,
   readability-redundant-string-init,
   readability-simplify-boolean-expr,
   readability-static-definition-in-anonymous-namespace,
@@ -156,13 +154,13 @@ Checks: '-*,
   readability-uniqueptr-delete-release'
 WarningsAsErrors: '*'
 CheckOptions:
-  - key:    readability-function-size.StatementThreshold
+  - key:    bugprone-unused-return-value.AllowCastToVoid
+    value:  true
+  - key:    readability-braces-around-statements.ShortStatementLines
     value:  '450'
+  - key:    readability-simplify-boolean-expr.SimplifyDeMorgan
+    value:  false
   - key:    modernize-make-unique.MakeSmartPtrFunction
     value:  'absl::make_unique'
   - key:    modernize-make-unique.MakeSmartPtrFunctionHeader
     value:  'absl/memory/memory.h'
-  - key:    readability-braces-around-statements.ShortStatementLines
-    value:  1
-  - key:    readability-simplify-boolean-expr.SimplifyDeMorgan
-    value:  false

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -188,12 +188,12 @@ ClientMessageSizeFilter::Call::Call(ClientMessageSizeFilter* filter)
     if (config_from_call_context->max_send_size().has_value() &&
         (!max_send_size.has_value() ||
          *config_from_call_context->max_send_size() < *max_send_size)) {
-      max_send_size = *config_from_call_context->max_send_size();
+      max_send_size = config_from_call_context->max_send_size();
     }
     if (config_from_call_context->max_recv_size().has_value() &&
         (!max_recv_size.has_value() ||
          *config_from_call_context->max_recv_size() < *max_recv_size)) {
-      max_recv_size = *config_from_call_context->max_recv_size();
+      max_recv_size = config_from_call_context->max_recv_size();
     }
     limits_ = MessageSizeParsedConfig(max_send_size, max_recv_size);
   }

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -111,8 +111,8 @@ class LoggingInterceptor : public experimental::Interceptor {
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = pair.first.find("testkey") == 0 &&
-                pair.second.find("testvalue") == 0;
+        found = pair.first.starts_with("testkey") &&
+                pair.second.starts_with("testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);


### PR DESCRIPTION
Revived clang-tidy flags I had to disable while doing https://github.com/grpc/grpc/pull/37593 and sorted the configuration values.