### PR TITLE
[Ruby] Reduce log when starting a server

### DIFF
--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1794,8 +1794,8 @@ void grpc_server_register_completion_queue(grpc_server* server,
   CHECK(!reserved);
   auto cq_type = grpc_get_cq_completion_type(cq);
   if (cq_type != GRPC_CQ_NEXT && cq_type != GRPC_CQ_CALLBACK) {
-    LOG(INFO) << "Completion queue of type " << static_cast<int>(cq_type)
-              << " is being registered as a server-completion-queue";
+    VLOG(2) << "Completion queue of type " << static_cast<int>(cq_type)
+            << " is being registered as a server-completion-queue";
     // Ideally we should log an error and abort but ruby-wrapped-language API
     // calls grpc_completion_queue_pluck() on server completion queues
   }


### PR DESCRIPTION
Since v1.65.0, GRPC always outputs the following log when starting a server.

```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1724995922.684820  513990 server.cc:1797] Completion queue of type 1 is being registered as a server-completion-queue
```

According to the e7e38da237 and comment, it seems that this log always outputs when using Ruby.
So I changed it to use `VLOG` as same as #37296.



