### PR TITLE
[examples/cpp/route_guide] client and server cmdlines can't parse --db_path argument

### DIFF
--- a/examples/cpp/route_guide/helper.cc
+++ b/examples/cpp/route_guide/helper.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
 #include "absl/log/log.h"
 
 #ifdef BAZEL_BUILD
@@ -43,6 +44,8 @@ ABSL_FLAG(std::string, db_path, "route_guide_db.json", "Path to db file");
 namespace routeguide {
 
 std::string GetDbFileContent(int argc, char** argv) {
+  // Command-line flags should be parsed at startup
+  absl::ParseCommandLine(argc, argv);
   std::string db_path = absl::GetFlag(FLAGS_db_path);
   std::ifstream db_file(db_path);
   if (!db_file.is_open()) {


### PR DESCRIPTION

Executing client and server commandlines with --db_path=path/to/route_guide_db.json, it always gets default value "route_guide_db.json" in ABSL_FLAG. So both of client and server are aborted because of
`helper.cc:49] Failed to open route_guide_db.json Aborted`
We need to call `absl::ParseCommandLine` during start up before `absl::GetFlag`.

