### PR TITLE
TLS Auth example: Make response message print properly

### DIFF
--- a/examples/python/auth/tls_client.py
+++ b/examples/python/auth/tls_client.py
@@ -37,7 +37,7 @@ def send_rpc(stub):
         _LOGGER.error("Received error: %s", rpc_error)
         return rpc_error
     else:
-        _LOGGER.info("Received message: %s", response)
+        _LOGGER.info("Received message: %s", response.message)
         return response
 
 


### PR DESCRIPTION
Logging "response" would result in incorrect output without the actual message, or sometimes no output at all. The program needs to log "response.message" to print the message properly.

Output before change: 

```
$ python .\tls_client.py
INFO:__main__:Received message: message: ""
```

Fixed output:
```
$ python .\tls_client.py
INFO:__main__:Received message: Hello, you!
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

