### PR TITLE
[ObjC] bump _OBJC_RUNTESTS_TIMEOUT to 4h

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -34,7 +34,7 @@ _DEFAULT_RUNTESTS_TIMEOUT = 1 * 60 * 60
 _CPP_RUNTESTS_TIMEOUT = 4 * 60 * 60
 
 # Set timeout high for ObjC for Cocoapods to install pods
-_OBJC_RUNTESTS_TIMEOUT = 2 * 60 * 60
+_OBJC_RUNTESTS_TIMEOUT = 4 * 60 * 60
 
 # Number of jobs assigned to each run_tests.py instance
 _DEFAULT_INNER_JOBS = 2


### PR DESCRIPTION
Objc tests timeout while build is still going on:
https://btx.cloud.google.com/invocations/ee44a388-de6c-402d-8704-248f798633c9/targets

Double the timeout to see if things improve.