### PR TITLE
[ObjC] disable iomgr cfstream test

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1164,15 +1164,16 @@ class ObjCLanguage(object):
 
         # TODO(jtattermusch): move the test out of the test/core/iomgr/CFStreamTests directory?
         # How does one add the cfstream dependency in bazel?
-        out.append(
-            self.config.job_spec(
-                ["test/core/iomgr/ios/CFStreamTests/build_and_run_tests.sh"],
-                timeout_seconds=60 * 60,
-                shortname="ios-test-cfstream-tests",
-                cpu_cost=1e6,
-                environ=_FORCE_ENVIRON_FOR_WRAPPERS,
-            )
-        )
+        # Disabled due to flakiness and being replaced with event engine
+        # out.append(
+        #     self.config.job_spec(
+        #         ["test/core/iomgr/ios/CFStreamTests/build_and_run_tests.sh"],
+        #         timeout_seconds=60 * 60,
+        #         shortname="ios-test-cfstream-tests",
+        #         cpu_cost=1e6,
+        #         environ=_FORCE_ENVIRON_FOR_WRAPPERS,
+        #     )
+        # )
         return sorted(out)
 
     def pre_build_steps(self):


### PR DESCRIPTION
This is flaky in CI, and is being replaced by the new implementation with event engine, disabling this test.
Will clean them up after all have switched to event engine.