### PR TITLE
[ruby] add a sanity check to load grpc in a child process before most ruby tests

### DIFF
--- a/src/ruby/end2end/bad_usage_fork_test.rb
+++ b/src/ruby/end2end/bad_usage_fork_test.rb
@@ -24,6 +24,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/call_credentials_returning_bad_metadata_doesnt_kill_background_thread_test.rb
+++ b/src/ruby/end2end/call_credentials_returning_bad_metadata_doesnt_kill_background_thread_test.rb
@@ -21,6 +21,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/call_credentials_timeout_test.rb
+++ b/src/ruby/end2end/call_credentials_timeout_test.rb
@@ -21,6 +21,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/errors_load_before_grpc_lib_test.rb
+++ b/src/ruby/end2end/errors_load_before_grpc_lib_test.rb
@@ -18,6 +18,8 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
+require 'sanity_check_dlopen'
+
 def check_to_status(error)
   my_status = error.to_status
   fail('GRPC BadStatus#to_status not expected to return nil') if my_status.nil?

--- a/src/ruby/end2end/errors_load_before_grpc_lib_test.rb
+++ b/src/ruby/end2end/errors_load_before_grpc_lib_test.rb
@@ -18,7 +18,7 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
-require 'sanity_check_dlopen'
+require_relative './sanity_check_dlopen'
 
 def check_to_status(error)
   my_status = error.to_status

--- a/src/ruby/end2end/fork_test.rb
+++ b/src/ruby/end2end/fork_test.rb
@@ -24,6 +24,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/load_grpc_with_gc_stress_test.rb
+++ b/src/ruby/end2end/load_grpc_with_gc_stress_test.rb
@@ -21,6 +21,8 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
+
 GC.stress = 0x04
 
 require 'grpc'

--- a/src/ruby/end2end/logger_load_before_grpc_lib_test.rb
+++ b/src/ruby/end2end/logger_load_before_grpc_lib_test.rb
@@ -18,7 +18,7 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
-require 'sanity_check_dlopen'
+require_relative './sanity_check_dlopen'
 
 def main
   fail('GRPC constant loaded before expected') if Object.const_defined?(:GRPC)

--- a/src/ruby/end2end/logger_load_before_grpc_lib_test.rb
+++ b/src/ruby/end2end/logger_load_before_grpc_lib_test.rb
@@ -18,6 +18,8 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
+require 'sanity_check_dlopen'
+
 def main
   fail('GRPC constant loaded before expected') if Object.const_defined?(:GRPC)
   require 'grpc/logconfig'

--- a/src/ruby/end2end/prefork_postfork_loop_test.rb
+++ b/src/ruby/end2end/prefork_postfork_loop_test.rb
@@ -24,6 +24,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/prefork_without_using_grpc_test.rb
+++ b/src/ruby/end2end/prefork_without_using_grpc_test.rb
@@ -24,6 +24,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Some tests are flaking by failing to dlopen grpc. Perform a sanity check.
+pid = fork do
+  STDERR.puts "==== sanity check require grpc in child process BEGIN ====="
+  require 'grpc'
+  STDERR.puts "==== sanity check require grpc in child process DONE ====="
+end
+Process.wait pid
+if $?.success?
+  STDERR.puts "==== sanity check require grpc in child process SUCCESS ====="
+else
+  raise "==== sanity check require grpc in child process FAILED exit code #{$?.exitstatus} ====="
+end

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -40,5 +40,5 @@ pid = fork do
   STDERR.puts "==== sanity check child process DONE ===="
 end
 Process.wait pid
-raise "==== sanity check require grpc in child process FAILED exit code #{$CHILD_STATUS.exitstatus} =====" unless $CHILD_STATUS.success?
+raise "==== sanity check require grpc in child process FAILED exit code #{$CHILD_STATUS} =====" unless $CHILD_STATUS.to_i.zero?
 STDERR.puts "==== sanity check require grpc in child process SUCCESS ====="

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -65,6 +65,6 @@ pid = fork do
   dump("/proc/#{Process.pid}/status")
   STDERR.puts "==== sanity check child process DONE ===="
 end
-child_pid, status = Process.wait2(pid)
+_, status = Process.wait2(pid)
 fail "sanity check require grpc in child process FAILED exit code #{status.exitstatus}" unless status.success?
 STDERR.puts "==== sanity check require grpc in child process SUCCESS ====="

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -16,9 +16,28 @@
 
 # Some tests are flaking by failing to dlopen grpc. Perform a sanity check.
 pid = fork do
+  STDERR.puts "==== sanity check child process BEGIN ===="
+  def dump(file_path)
+    STDERR.puts "==== dump file: #{file_path} BEGIN ===="
+    begin
+      File.open(file_path, 'r') do |file|
+      file.each_line do |line|
+        puts line
+      end
+    end
+    rescue => e
+      STDERR.puts "Error reading file: #{file_path} error: |#{e}|"
+    end
+    STDERR.puts "==== dump file: #{file_path} DONE ===="
+  end
+  dump("/proc/#{Process.pid}/limits")
+  dump("/proc/#{Process.pid}/status")
   STDERR.puts "==== sanity check require grpc in child process BEGIN ====="
   require 'grpc'
   STDERR.puts "==== sanity check require grpc in child process DONE ====="
+  dump("/proc/#{Process.pid}/limits")
+  dump("/proc/#{Process.pid}/status")
+  STDERR.puts "==== sanity check child process DONE ===="
 end
 Process.wait pid
 if $?.success?

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -19,14 +19,14 @@ pid = fork do
   STDERR.puts "==== sanity check child process BEGIN ===="
   def dump(file_path)
     STDERR.puts "==== dump file: #{file_path} BEGIN ===="
-    begin
+    if File.exist?(file_path)
       File.open(file_path, 'r') do |file|
-      file.each_line do |line|
-        puts line
+        file.each_line do |line|
+          puts line
+        end
       end
-    end
-    rescue => e
-      STDERR.puts "Error reading file: #{file_path} error: |#{e}|"
+    else
+      STDERR.puts "file: #{file_path} does not exist"
     end
     STDERR.puts "==== dump file: #{file_path} DONE ===="
   end
@@ -40,8 +40,5 @@ pid = fork do
   STDERR.puts "==== sanity check child process DONE ===="
 end
 Process.wait pid
-if $?.success?
-  STDERR.puts "==== sanity check require grpc in child process SUCCESS ====="
-else
-  raise "==== sanity check require grpc in child process FAILED exit code #{$?.exitstatus} ====="
-end
+raise "==== sanity check require grpc in child process FAILED exit code #{$CHILD_STATUS.exitstatus} =====" unless $CHILD_STATUS.success?
+STDERR.puts "==== sanity check require grpc in child process SUCCESS ====="

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -14,7 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Some tests are flaking by failing to dlopen grpc. Perform a sanity check.
+# Some tests are flaking by failing to dlopen grpc. Perform some sanity checks.
+this_dir = File.expand_path(File.dirname(__FILE__))
+grpc_bin_dir = File.join(File.join(File.dirname(this_dir), 'lib'), 'grpc')
+grpc_c_so_path = File.join(grpc_bin_dir, 'grpc_c.so')
+grpc_c_sha256_path = File.join(grpc_bin_dir, 'grpc_c_sha256')
+
+require 'digest'
+
+# first try to detect corruption b/t the build and now
+actual_sha256 = Digest::SHA256.file(grpc_c_so_path).hexdigest
+expected_sha256 = File.read(grpc_c_sha256_path).chomp
+raise "detected corruption in #{grpc_c_so_path}: sha256: |#{actual_sha256}| != expected sha256: |#{expected_sha256}|" if actual_sha256 != expected_sha256
+STDERR.puts "verified sha256 of #{grpc_c_so_path}"
+
+# sanity check that we can load grpc in a child process, log things like available
+# memory on the off chance we might be low.
 pid = fork do
   STDERR.puts "==== sanity check child process BEGIN ===="
   def dump(file_path)

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -17,6 +17,7 @@
 # Some tests are flaking by failing to dlopen grpc. Perform some sanity checks.
 this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_bin_dir = File.join(File.join(File.dirname(this_dir), 'lib'), 'grpc')
+grpc_c_sha256_path = File.join(grpc_bin_dir, 'grpc_c_sha256')
 grpc_c_so_path = if RUBY_PLATFORM =~ /darwin/
                    File.join(grpc_bin_dir, 'grpc_c.bundle')
                  else

--- a/src/ruby/end2end/sanity_check_dlopen.rb
+++ b/src/ruby/end2end/sanity_check_dlopen.rb
@@ -17,8 +17,11 @@
 # Some tests are flaking by failing to dlopen grpc. Perform some sanity checks.
 this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_bin_dir = File.join(File.join(File.dirname(this_dir), 'lib'), 'grpc')
-grpc_c_so_path = File.join(grpc_bin_dir, 'grpc_c.so')
-grpc_c_sha256_path = File.join(grpc_bin_dir, 'grpc_c_sha256')
+grpc_c_so_path = if RUBY_PLATFORM =~ /darwin/
+                   File.join(grpc_bin_dir, 'grpc_c.bundle')
+                 else
+                   File.join(grpc_bin_dir, 'grpc_c.so')
+                 end
 
 require 'digest'
 

--- a/src/ruby/end2end/secure_fork_test.rb
+++ b/src/ruby/end2end/secure_fork_test.rb
@@ -24,6 +24,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/simple_fork_test.rb
+++ b/src/ruby/end2end/simple_fork_test.rb
@@ -24,6 +24,7 @@ $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 $LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
 $LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
 
+require 'sanity_check_dlopen'
 require 'grpc'
 require 'end2end_common'
 

--- a/src/ruby/end2end/status_codes_load_before_grpc_lib_test.rb
+++ b/src/ruby/end2end/status_codes_load_before_grpc_lib_test.rb
@@ -18,7 +18,7 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
-require 'sanity_check_dlopen'
+require_relative './sanity_check_dlopen'
 
 def main
   fail('GRPC constant loaded before expected') if Object.const_defined?(:GRPC)

--- a/src/ruby/end2end/status_codes_load_before_grpc_lib_test.rb
+++ b/src/ruby/end2end/status_codes_load_before_grpc_lib_test.rb
@@ -18,6 +18,8 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
+require 'sanity_check_dlopen'
+
 def main
   fail('GRPC constant loaded before expected') if Object.const_defined?(:GRPC)
   require 'grpc/core/status_codes'

--- a/tools/run_tests/helper_scripts/build_ruby.sh
+++ b/tools/run_tests/helper_scripts/build_ruby.sh
@@ -36,14 +36,15 @@ if [ "$SYSTEM" == "Darwin" ]; then
 fi
 bundle exec rake compile
 
-# log some debug info about the binary
-ls -l src/ruby/lib/grpc/grpc_c.so
-file src/ruby/lib/grpc/grpc_c.so
-# Save some info about the binary to verify later at test runtime, in order
+# Log stuff and save a hash of the binary verify later at test runtime, in order
 # to detect corruption.
 if [ "$SYSTEM" == "Darwin" ]; then
-  shasum -a 256 src/ruby/lib/grpc/grpc_c.so | awk '{print $1}' > src/ruby/lib/grpc/grpc_c_sha256
+  ls -l src/ruby/lib/grpc/grpc_c.bundle
+  file src/ruby/lib/grpc/grpc_c.bundle
+  shasum -a 256 src/ruby/lib/grpc/grpc_c.bundle | awk '{print $1}' > src/ruby/lib/grpc/grpc_c_sha256
 else
+  ls -l src/ruby/lib/grpc/grpc_c.so
+  file src/ruby/lib/grpc/grpc_c.so
   sha256sum src/ruby/lib/grpc/grpc_c.so | awk '{print $1}' > src/ruby/lib/grpc/grpc_c_sha256
 fi
 

--- a/tools/run_tests/helper_scripts/build_ruby.sh
+++ b/tools/run_tests/helper_scripts/build_ruby.sh
@@ -36,6 +36,17 @@ if [ "$SYSTEM" == "Darwin" ]; then
 fi
 bundle exec rake compile
 
+# log some debug info about the binary
+ls -l src/ruby/lib/grpc/grpc_c.so
+file src/ruby/lib/grpc/grpc_c.so
+# Save some info about the binary to verify later at test runtime, in order
+# to detect corruption.
+if [ "$SYSTEM" == "Darwin" ]; then
+  shasum -a 256 src/ruby/lib/grpc/grpc_c.so | awk '{print $1}' > src/ruby/lib/grpc/grpc_c_sha256
+else
+  sha256sum src/ruby/lib/grpc/grpc_c.so | awk '{print $1}' > src/ruby/lib/grpc/grpc_c_sha256
+fi
+
 # build grpc_ruby_plugin
 mkdir -p cmake/build
 pushd cmake/build


### PR DESCRIPTION
To try to get more info about these dlopen flakes
