### PR TITLE
[Python Aio] Fix test_cancel_after_done_writing

### DIFF
--- a/src/python/grpcio_tests/tests_aio/unit/call_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/call_test.py
@@ -817,7 +817,6 @@ class TestStreamStreamCall(_MulticallableTestMixin, AioTestBase):
         await call.done_writing()
 
         # Cancels the RPC
-        self.assertFalse(call.done())
         self.assertFalse(call.cancelled())
         self.assertTrue(call.cancel())
         self.assertTrue(call.cancelled())


### PR DESCRIPTION
This test is flaky, example failure: https://fusion2.corp.google.com/invocations/31bcd70f-650d-40be-8ec4-6fafc3cd3724, error message:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.9/unittest/case.py", line 593, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/var/local/git/grpc/src/python/grpcio_tests/tests_aio/unit/_test_base.py", line 31, in wrapper
    return loop.run_until_complete(f(*args, **kwargs))
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/var/local/git/grpc/src/python/grpcio_tests/tests_aio/unit/call_test.py", line 820, in test_cancel_after_done_writing
    self.assertFalse(call.done())
  File "/usr/lib/python3.9/unittest/case.py", line 676, in assertFalse
    raise self.failureException(msg)
AssertionError: True is not false
```

We're expecting call to NOT finish immediately after `await call.done_writing()` which is not correct.
* `call.done_writing()` only notifies server that the client is done sending messages, while `call.done()` checks if the RPC call itself has finished.

Thus removing assert check for `call.done()`.

 
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

