### PR TITLE
[XdsEnabledServerTest] Wait on serving status to change

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -833,12 +833,16 @@ class XdsEnabledServerTest : public XdsEnd2endTest {
 TEST_P(XdsEnabledServerTest, Basic) {
   DoSetUp();
   backends_[0]->Start();
+  backends_[0]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK);
   WaitForBackend(DEBUG_LOCATION, 0);
 }
 
 TEST_P(XdsEnabledServerTest, ListenerDeletionIgnored) {
   DoSetUp(MakeBootstrapBuilder().SetIgnoreResourceDeletion());
   backends_[0]->Start();
+  backends_[0]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK);
   WaitForBackend(DEBUG_LOCATION, 0);
   // Check that we ACKed.
   // TODO(roth): There may be multiple entries in the resource state response


### PR DESCRIPTION
Fixes flakes in xds_end2end_test for XdsEnabledServerTest where the updates for the control plane were not applied in time. The change here waits for the server to notify that the serving status is OK before sending RPCs.

Flakes fixed are of the kind - https://btx.cloud.google.com/invocations/3b8f68a9-268c-4ad9-81dd-8a099a871537/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_end2end_test@poller%3Dpoll;shard=32;config=f78d0de70f525043d29a05fb7a78970999e04b7f8a87d8c4e974688bf7616998/log