### PR TITLE
[flake] Fix tsan error surfaced by grpc_lb_end2end_test

### DIFF
--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -2518,9 +2518,10 @@ ClientChannelFilter::LoadBalancedCall::PickSubchannel(bool was_queued) {
   // updated before we queue it.
   // We need to unref pickers in the WorkSerializer.
   std::vector<RefCountedPtr<LoadBalancingPolicy::SubchannelPicker>> pickers;
-  auto cleanup = absl::MakeCleanup([&]() {
+  auto cleanup = absl::MakeCleanup([work_serializer = chand_->work_serializer_,
+                                    &pickers]() {
     if (IsWorkSerializerDispatchEnabled()) return;
-    chand_->work_serializer_->Run(
+    work_serializer->Run(
         [pickers = std::move(pickers)]() mutable {
           for (auto& picker : pickers) {
             picker.reset(DEBUG_LOCATION, "PickSubchannel");


### PR DESCRIPTION
Pretty sure that the `LoadBalancedCall` instance is getting dropped before return on *some* path through `PickSubchannel`, although it's unclear to me which and it's hard to tell with this implementation.

Ensure that such an event cannot cause a crash by holding a ref to the object we need and calling through that.

This will be marginally worse performance per pick for now, but once work serializer dispatch lands everywhere the additional ref will disappear.