### PR TITLE
Fix readme

### DIFF
--- a/examples/cpp/interceptors/README.md
+++ b/examples/cpp/interceptors/README.md
@@ -15,11 +15,11 @@ On the server-side, a very simple logging interceptor is added that simply logs 
 To run the server -
 
 ```
-$ tools/bazel run examples/cpp/interceptors:server
+$ tools/bazel run examples/cpp/interceptors:keyvaluestore_server
 ```
 
 To run the client (on a different terminal) -
 
 ```
-$ tools/bazel run examples/cpp/interceptors:client
+$ tools/bazel run examples/cpp/interceptors:keyvaluestore_client
 ```


### PR DESCRIPTION
Corrects bazel run command in README.
It does not match the bazel command in the BUILD file.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

