### PR TITLE
[interop] Add v1.66.2 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -305,7 +305,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.63.3", ReleaseInfo()),
             ("v1.64.1", ReleaseInfo()),
             ("v1.65.0", ReleaseInfo()),
-            ("v1.66.0", ReleaseInfo()),
+            ("v1.66.2", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```sh
$ GO_VERSION='go1.x'
$ RELEASE_VERSION='1.66.0'

$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_"$GO_VERSION" | grep "$RELEASE_VERSION"
2c1cef2d5aa5  infrastructure-public-image-v1.66.2,v1.66.2
```