### PR TITLE
[chttp2] Improve logging for parse errors

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2730,6 +2730,8 @@ static void read_action_parse_loop_locked(
       }
     }
     if (errors[1] != absl::OkStatus()) {
+      GRPC_CHTTP2_LOG_PARSE_ERROR()
+          << "Failed parsing HTTP/2: " << errors[1].message();
       errors[2] = try_http_parsing(t.get());
       error = GRPC_ERROR_CREATE_REFERENCING("Failed parsing HTTP/2", errors,
                                             GPR_ARRAY_SIZE(errors));

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -928,4 +928,26 @@ void schedule_bdp_ping_locked(
 
 uint32_t grpc_chttp2_min_read_progress_size(grpc_chttp2_transport* t);
 
+namespace grpc_core {
+
+inline bool ShouldLogParseError() {
+  if (GRPC_TRACE_FLAG_ENABLED(http)) return true;
+  static constexpr uint64_t kLogInterval = Duration::Seconds(1).millis();
+  static std::atomic<uint64_t> last_log_time{0};
+  const uint64_t now = Timestamp::Now().milliseconds_after_process_epoch();
+  uint64_t last = last_log_time.load(std::memory_order_relaxed);
+  while (last == 0 || now >= last + kLogInterval) {
+    if (last_log_time.compare_exchange_weak(last, now,
+                                            std::memory_order_relaxed)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace grpc_core
+
+#define GRPC_CHTTP2_LOG_PARSE_ERROR() \
+  LOG_IF(ERROR, grpc_core::ShouldLogParseError())
+
 #endif  // GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_INTERNAL_H

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -451,7 +451,7 @@ static grpc_error_handle init_frame_parser(grpc_chttp2_transport* t,
     case GRPC_CHTTP2_FRAME_GOAWAY:
       return init_goaway_parser(t);
     default:
-      GRPC_TRACE_LOG(http, ERROR)
+      GRPC_CHTTP2_LOG_PARSE_ERROR()
           << "Unknown frame type "
           << absl::StrFormat("%02x", t->incoming_frame_type);
       return init_non_header_skip_frame_parser(t);
@@ -883,7 +883,7 @@ static grpc_error_handle parse_frame_slice(grpc_chttp2_transport* t,
   if (GPR_LIKELY(err.ok())) {
     return err;
   }
-  GRPC_TRACE_LOG(http, ERROR)
+  GRPC_CHTTP2_LOG_PARSE_ERROR()
       << "INCOMING[" << t << ";" << s << "]: Parse failed with " << err;
   if (grpc_error_get_int(err, grpc_core::StatusIntProperty::kStreamId,
                          &unused)) {


### PR DESCRIPTION
Currently http2 parse errors are silent; increase verbosity by printing at most one per second (unless tracing, and then print them all).