### PR TITLE
[Python test] Fix gcf permission denied error

### DIFF
--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -45,8 +45,6 @@ trap cleanup SIGINT SIGTERM EXIT
 
 # Deploy
 
-gcloud config get account
-
 DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated --no-gen2)
 HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 

--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -45,8 +45,7 @@ trap cleanup SIGINT SIGTERM EXIT
 
 # Deploy
 
-gcloud functions add-iam-policy-binding ${FUNCTION_NAME} --region=us-central1 --member=allUsers --role=roles/cloudfunctions.invoker
-DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated)
+DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated --no-gen2)
 HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 
 # Send Requests

--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -44,7 +44,10 @@ function cleanup() {
 trap cleanup SIGINT SIGTERM EXIT
 
 # Deploy
-DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated)
+
+gcloud config get account
+
+DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated --no-gen2)
 HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 
 # Send Requests

--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -45,7 +45,8 @@ trap cleanup SIGINT SIGTERM EXIT
 
 # Deploy
 
-DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated --no-gen2)
+gcloud functions add-iam-policy-binding ${FUNCTION_NAME} --region=us-central1 --member=allUsers --role=roles/cloudfunctions.invoker
+DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated)
 HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 
 # Send Requests


### PR DESCRIPTION
`grpc_distribtests_gcp_python` test is [failing with permission error](https://fusion2.corp.google.com/ci;ids=1930537984/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_distribtests_gcp_python/activity/2c6d57dd-f504-4834-9fd6-845db47ede01/log):
```
ERROR: (gcloud.functions.deploy) ResponseError: status=[403], code=[Ok], message=[Permission 'run.services.setIamPolicy' denied on resource 'projects/grpc-testing/locations/us-central1/services/grpc-gcf-distribtest-3cd3cc11-1a8f-4b88-9c3b-220f0bdf9fdc' (or resource may not exist).]
```

In the logs, looks like we're creating gen2 functions by default:
```
As of this Cloud SDK release, new functions will be deployed as 2nd gen  functions by default. This is equivalent to currently deploying new  with the --gen2 flag. Existing 1st gen functions will not be impacted and will continue to deploy as 1st gen functions.
```

Since we don't need functions provided by gen2 functions and use `--no-gen2` fixed the permission issue, we're adding `--no-gen2` flag to our test.

### Test:
* Passed manually run: http://sponge/e52ffb74-5a12-4e67-9f95-4638390ef57c


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

