### PR TITLE
[ruby] reduce an INFO log to DEBUG (backport https://github.com/grpc/grpc/pull/37633)

### DIFF
--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1794,8 +1794,8 @@ void grpc_server_register_completion_queue(grpc_server* server,
   CHECK(!reserved);
   auto cq_type = grpc_get_cq_completion_type(cq);
   if (cq_type != GRPC_CQ_NEXT && cq_type != GRPC_CQ_CALLBACK) {
-    LOG(DEBUG) << "Completion queue of type " << static_cast<int>(cq_type)
-               << " is being registered as a server-completion-queue";
+    VLOG(2) << "Completion queue of type " << static_cast<int>(cq_type)
+            << " is being registered as a server-completion-queue";
     // Ideally we should log an error and abort but ruby-wrapped-language API
     // calls grpc_completion_queue_pluck() on server completion queues
   }

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1794,8 +1794,8 @@ void grpc_server_register_completion_queue(grpc_server* server,
   CHECK(!reserved);
   auto cq_type = grpc_get_cq_completion_type(cq);
   if (cq_type != GRPC_CQ_NEXT && cq_type != GRPC_CQ_CALLBACK) {
-    LOG(INFO) << "Completion queue of type " << static_cast<int>(cq_type)
-              << " is being registered as a server-completion-queue";
+    LOG(DEBUG) << "Completion queue of type " << static_cast<int>(cq_type)
+               << " is being registered as a server-completion-queue";
     // Ideally we should log an error and abort but ruby-wrapped-language API
     // calls grpc_completion_queue_pluck() on server completion queues
   }


### PR DESCRIPTION
Backport https://github.com/grpc/grpc/pull/37633 to 1.67

Note https://github.com/grpc/grpc/pull/37633 is not yet merged b/c of the master branch freeze. Merging on 1.67 with the idea that https://github.com/grpc/grpc/pull/37633 will merge as soon as the master branch is unfrozen.
