### PR TITLE
[Build] Minimum version of MSVC is now 2022

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -55,7 +55,7 @@ installed by `brew` is being used:
 ## Windows
 
 To prepare for cmake + Microsoft Visual C++ compiler build
-- Install Visual Studio 2019 or later (Visual C++ compiler will be used).
+- Install Visual Studio 2022 or later (Visual C++ compiler will be used).
 - Install [Git](https://git-scm.com/).
 - Install [CMake](https://cmake.org/download/).
 - Install [nasm](https://www.nasm.us/) and add it to `PATH` (`choco install nasm`) - *required by boringssl*
@@ -132,7 +132,7 @@ $ make
 
 If you want to build shared libraries (`.so` files), run `cmake` with `-DBUILD_SHARED_LIBS=ON`.
 
-### Windows, Using Visual Studio 2019 or later
+### Windows, Using Visual Studio 2022 or later
 
 When using the "Visual Studio" generator,
 cmake will generate a solution (`grpc.sln`) that contains a VS project for
@@ -143,7 +143,7 @@ you will be able to browse and build the code.
 > @rem Run from grpc directory after cloning the repo with --recursive or updating submodules.
 > md .build
 > cd .build
-> cmake .. -G "Visual Studio 16 2019"
+> cmake .. -G "Visual Studio 17 2022"
 > cmake --build . --config Release
 ```
 

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -31,7 +31,7 @@ Therefore, gRPC supports several major build systems, which should satisfy most 
 | Operating System | Architectures | Versions | Support Level |
 |------------------|---------------|----------|---------------|
 | Linux - Debian, Ubuntu, CentOS | x86, x64      | clang 7+, GCC 7.3+     | Officially Supported |
-| Windows 10+                    | x86, x64      | Visual Studio 2019+    | Officially Supported |
+| Windows 10+                    | x86, x64      | Visual Studio 2022+    | Officially Supported |
 | MacOS                          | x64, ARM64    | XCode 12+              | Officially Supported |
 | Linux - Others                 | x86, x64      | clang 7+, GCC 7.3+     | Best Effort          |
 | Linux                          | ARM64         |                        | Best Effort          |

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -31,7 +31,7 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
-set VS_GENERATOR="Visual Studio 16 2019"
+set VS_GENERATOR="Visual Studio 17 2022"
 @rem TODO(jtattermusch): switch to x64 build (will require pulling a x64 build of openssl)
 set VS_ARCHITECTURE="Win32"
 

--- a/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
@@ -28,7 +28,7 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
-set VS_GENERATOR="Visual Studio 16 2019"
+set VS_GENERATOR="Visual Studio 17 2022"
 @rem TODO(jtattermusch): switch to x64 build (will require pulling a x64 build of openssl)
 set VS_ARCHITECTURE="Win32"
 

--- a/test/distrib/cpp/run_distrib_test_cmake_for_dll.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_for_dll.bat
@@ -31,7 +31,7 @@ set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 
 @rem TODO(jtattermusch): add support for GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS env variable
 
-set VS_GENERATOR="Visual Studio 16 2019"
+set VS_GENERATOR="Visual Studio 17 2022"
 @rem TODO(jtattermusch): switch to x64 build (will require pulling a x64 build of openssl)
 set VS_ARCHITECTURE="Win32"
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -283,9 +283,7 @@ class CLanguage(object):
                 [
                     "default",
                     "cmake",
-                    "cmake_ninja_vs2019",
                     "cmake_ninja_vs2022",
-                    "cmake_vs2019",
                     "cmake_vs2022",
                 ],
             )
@@ -293,19 +291,13 @@ class CLanguage(object):
 
             activate_vs_tools = ""
             if (
-                self.args.compiler == "cmake_ninja_vs2019"
+                self.args.compiler == "cmake_ninja_vs2022"
                 or self.args.compiler == "cmake"
                 or self.args.compiler == "default"
             ):
                 # cmake + ninja build is the default because it is faster and supports boringssl assembly optimizations
-                # the compiler used is exactly the same as for cmake_vs2017
-                cmake_generator = "Ninja"
-                activate_vs_tools = "2019"
-            elif self.args.compiler == "cmake_ninja_vs2022":
                 cmake_generator = "Ninja"
                 activate_vs_tools = "2022"
-            elif self.args.compiler == "cmake_vs2019":
-                cmake_generator = "Visual Studio 16 2019"
             elif self.args.compiler == "cmake_vs2022":
                 cmake_generator = "Visual Studio 17 2022"
             else:
@@ -1698,9 +1690,7 @@ argp.add_argument(
         "all_the_cpythons",
         "coreclr",
         "cmake",
-        "cmake_ninja_vs2019",
         "cmake_ninja_vs2022",
-        "cmake_vs2019",
         "cmake_vs2022",
         "mono",
     ],

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -383,7 +383,7 @@ def _create_portability_test_jobs(
         configs=["dbg"],
         platforms=["windows"],
         arch="default",
-        compiler="cmake_ninja_vs2019",
+        compiler="cmake_ninja_vs2022",
         labels=["portability", "corelang"],
         extra_args=extra_args,
         inner_jobs=inner_jobs,


### PR DESCRIPTION
Per https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md, we can require msvc 2022 or later.