### PR TITLE
[port_sharing_e2e_test] Fix flakiness due to dualstack

### DIFF
--- a/test/cpp/end2end/port_sharing_end2end_test.cc
+++ b/test/cpp/end2end/port_sharing_end2end_test.cc
@@ -38,6 +38,7 @@
 
 #include "src/core/lib/gprpp/crash.h"
 #include "src/core/lib/gprpp/env.h"
+#include "src/core/lib/gprpp/host_port.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/pollset.h"
@@ -46,6 +47,7 @@
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/test_util/port.h"
+#include "test/core/test_util/resolve_localhost_ip46.h"
 #include "test/core/test_util/test_config.h"
 #include "test/core/test_util/test_tcp_server.h"
 #include "test/cpp/end2end/test_service_impl.h"
@@ -96,9 +98,11 @@ class TestTcpServer {
       : shutdown_(false),
         queue_data_(false),
         port_(grpc_pick_unused_port_or_die()) {
-    std::ostringstream server_address;
-    server_address << "localhost:" << port_;
-    address_ = server_address.str();
+    grpc_init();  // needed by LocalIpAndPort()
+    // This test does not do well with multiple connection attempts at the same
+    // time to the same tcp server, so use the local IP address instead of
+    // "localhost" which can result in two connections (ipv4 and ipv6).
+    address_ = grpc_core::LocalIpAndPort(port_);
     test_tcp_server_init(&tcp_server_, &TestTcpServer::OnConnect, this);
     GRPC_CLOSURE_INIT(&on_fd_released_, &TestTcpServer::OnFdReleased, this,
                       grpc_schedule_on_exec_ctx);
@@ -108,6 +112,7 @@ class TestTcpServer {
     running_thread_.join();
     test_tcp_server_destroy(&tcp_server_);
     grpc_recycle_unused_port(port_);
+    grpc_shutdown();
   }
 
   // Read some data before handing off the connection.
@@ -168,7 +173,7 @@ class TestTcpServer {
     grpc_tcp_destroy_and_release_fd(tcp, &fd_, &on_fd_released_);
   }
 
-  void OnFdReleased(grpc_error_handle err) {
+  void OnFdReleased(const absl::Status& err) {
     EXPECT_EQ(absl::OkStatus(), err);
     experimental::ExternalConnectionAcceptor::NewConnectionParameters p;
     p.listener_fd = listener_fd_;


### PR DESCRIPTION
From the logs, we could see multiple connections being created by the client. 
https://btx.cloud.google.com/invocations/2da963a2-b6e7-4002-8a39-fbb7ca0febd2/targets/%2F%2Ftest%2Fcpp%2Fend2end:port_sharing_end2end_test@poller%3Dpoll;config=73d114f34497fe815dc9359619f4998ad393f9a101551e59d2a81873570c0afd/log

One for ipv4 and one for ipv6. This is probably due to the changes from the dualstack design, but this test is not equipped to handle multiple connections. A simple fix would be to just use the ip address instead of "localhost".