### PR TITLE
[resource-quota] Fix periodic_update_test flake

### DIFF
--- a/src/core/lib/gprpp/time.h
+++ b/src/core/lib/gprpp/time.h
@@ -296,6 +296,14 @@ class Duration {
   int64_t millis_;
 };
 
+inline std::ostream& operator<<(std::ostream& out, const Duration& d) {
+  return out << d.ToString();
+}
+
+inline std::ostream& operator<<(std::ostream& out, const Timestamp& d) {
+  return out << d.ToString();
+}
+
 inline Duration operator+(Duration lhs, Duration rhs) {
   return Duration::Milliseconds(
       time_detail::MillisAdd(lhs.millis(), rhs.millis()));

--- a/src/core/lib/resource_quota/periodic_update.cc
+++ b/src/core/lib/resource_quota/periodic_update.cc
@@ -68,8 +68,8 @@ bool PeriodicUpdate::MaybeEndPeriod(absl::FunctionRef<void(Duration)> f) {
   expected_updates_per_period_ =
       period_.seconds() * expected_updates_per_period_ / time_so_far.seconds();
   if (expected_updates_per_period_ < 1) expected_updates_per_period_ = 1;
-  period_start_ = now;
   f(time_so_far);
+  period_start_ = Timestamp::Now();
   updates_remaining_.store(expected_updates_per_period_,
                            std::memory_order_release);
   return true;


### PR DESCRIPTION
The timer wasn't taking into account the time for one update, which is necessary to get predictable behavior
