### PR TITLE
[Build] Bumped the minimum version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 
 set(PACKAGE_NAME          "grpc")
 set(PACKAGE_VERSION       "1.68.0-dev")

--- a/examples/android/helloworld/app/CMakeLists.txt
+++ b/examples/android/helloworld/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 set(helloworld_PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(helloworld_GRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")

--- a/examples/cpp/auth/CMakeLists.txt
+++ b/examples/cpp/auth/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Cancellation C CXX)
 

--- a/examples/cpp/cancellation/CMakeLists.txt
+++ b/examples/cpp/cancellation/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Cancellation C CXX)
 

--- a/examples/cpp/cmake/common.cmake
+++ b/examples/cpp/cmake/common.cmake
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building route_guide.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 if(MSVC)
   add_definitions(-D_WIN32_WINNT=0x600)

--- a/examples/cpp/compression/CMakeLists.txt
+++ b/examples/cpp/compression/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Compression C CXX)
 

--- a/examples/cpp/deadline/CMakeLists.txt
+++ b/examples/cpp/deadline/CMakeLists.txt
@@ -16,7 +16,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building this example.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Deadline C CXX)
 

--- a/examples/cpp/error_details/CMakeLists.txt
+++ b/examples/cpp/error_details/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(ErrorDetails C CXX)
 

--- a/examples/cpp/error_handling/CMakeLists.txt
+++ b/examples/cpp/error_handling/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(ErrorHandling C CXX)
 

--- a/examples/cpp/flow_control/CMakeLists.txt
+++ b/examples/cpp/flow_control/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building example.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/generic_api/CMakeLists.txt
+++ b/examples/cpp/generic_api/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(GenericAPI C CXX)
 

--- a/examples/cpp/health/CMakeLists.txt
+++ b/examples/cpp/health/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -20,7 +20,7 @@
 # including the "helloworld" project itself.
 # See https://blog.kitware.com/cmake-superbuilds-git-submodules/
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 # Project
 project(HelloWorld-SuperBuild C CXX)

--- a/examples/cpp/interceptors/CMakeLists.txt
+++ b/examples/cpp/interceptors/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(KeyValueStore C CXX)
 

--- a/examples/cpp/keepalive/CMakeLists.txt
+++ b/examples/cpp/keepalive/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/load_balancing/CMakeLists.txt
+++ b/examples/cpp/load_balancing/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(LoadBalancing C CXX)
 

--- a/examples/cpp/metadata/CMakeLists.txt
+++ b/examples/cpp/metadata/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Metadata C CXX)
 

--- a/examples/cpp/multiplex/CMakeLists.txt
+++ b/examples/cpp/multiplex/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Multiplex C CXX)
 

--- a/examples/cpp/otel/CMakeLists.txt
+++ b/examples/cpp/otel/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 
 project(grpc_opentelemetry_example C CXX)
 

--- a/examples/cpp/otel/codelab/CMakeLists.txt
+++ b/examples/cpp/otel/codelab/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 
 project(grpc_opentelemetry_example C CXX)
 

--- a/examples/cpp/otel/ostream/CMakeLists.txt
+++ b/examples/cpp/otel/ostream/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16)
 
 project(grpc_opentelemetry_example C CXX)
 

--- a/examples/cpp/retry/CMakeLists.txt
+++ b/examples/cpp/retry/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building retry.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(Retry C CXX)
 

--- a/examples/cpp/route_guide/CMakeLists.txt
+++ b/examples/cpp/route_guide/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building route_guide.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(RouteGuide C CXX)
 

--- a/examples/cpp/wait_for_ready/CMakeLists.txt
+++ b/examples/cpp/wait_for_ready/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 project(HelloWorld C CXX)
 

--- a/src/android/test/interop/app/CMakeLists.txt
+++ b/src/android/test/interop/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 
 set(PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(gRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -107,7 +107,7 @@ also sets up an `add_subdirectory()` rule for you. This causes gRPC to be
 built as part of your project.
 
 ```cmake
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.16)
 project(my_project)
 
 include(FetchContent)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -275,7 +275,7 @@
         protobuf_gen_files.add(src)
   %>
 
-  cmake_minimum_required(VERSION 3.13)
+  cmake_minimum_required(VERSION 3.16)
 
   set(PACKAGE_NAME          "grpc")
   set(PACKAGE_VERSION       "${settings.cpp_version}")


### PR DESCRIPTION
Per https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md, the minimum version of cmake to support is 3.16 so let's change our cmake builds' requirements accordingly.