### PR TITLE
[ChannelIdleFilter] Use different error messages for idleness and max connection age

### DIFF
--- a/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
+++ b/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.cc
@@ -207,7 +207,7 @@ void LegacyMaxAgeFilter::PostInit() {
           // OnDone -- close the connection if the promise completed
           // successfully.
           // (if it did not, it was cancelled)
-          if (status.ok()) CloseChannel();
+          if (status.ok()) CloseChannel("max connection age");
         },
         std::move(arena)));
   }
@@ -273,16 +273,16 @@ void LegacyChannelIdleFilter::StartIdleTimer() {
   activity_.Set(MakeActivity(
       std::move(promise), ExecCtxWakeupScheduler{},
       [channel_stack, this](absl::Status status) {
-        if (status.ok()) CloseChannel();
+        if (status.ok()) CloseChannel("connection idle");
       },
       std::move(arena)));
 }
 
-void LegacyChannelIdleFilter::CloseChannel() {
+void LegacyChannelIdleFilter::CloseChannel(absl::string_view reason) {
   auto* op = grpc_make_transport_op(nullptr);
   op->disconnect_with_error = grpc_error_set_int(
-      GRPC_ERROR_CREATE("enter idle"),
-      StatusIntProperty::ChannelConnectivityState, GRPC_CHANNEL_IDLE);
+      GRPC_ERROR_CREATE(reason), StatusIntProperty::ChannelConnectivityState,
+      GRPC_CHANNEL_IDLE);
   // Pass the transport op down to the channel stack.
   auto* elem = grpc_channel_stack_element(channel_stack_, 0);
   elem->filter->start_transport_op(elem, op);

--- a/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.h
+++ b/src/core/ext/filters/channel_idle/legacy_channel_idle_filter.h
@@ -69,7 +69,7 @@ class LegacyChannelIdleFilter : public ChannelFilter {
   grpc_channel_stack* channel_stack() { return channel_stack_; };
 
   virtual void Shutdown();
-  void CloseChannel();
+  void CloseChannel(absl::string_view reason);
 
   void IncreaseCallCount();
   void DecreaseCallCount();

--- a/test/core/end2end/tests/max_connection_age.cc
+++ b/test/core/end2end/tests/max_connection_age.cc
@@ -20,6 +20,7 @@
 
 #include <memory>
 
+#include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 
 #include <grpc/impl/channel_arg_names.h>
@@ -109,6 +110,8 @@ CORE_END2END_TEST(Http2Test, MaxAgeForciblyClose) {
   // The connection should be closed immediately after the max age grace period,
   // the in-progress RPC should fail.
   EXPECT_EQ(server_status.status(), GRPC_STATUS_UNAVAILABLE);
+  EXPECT_THAT(server_status.message(),
+              ::testing::MatchesRegex("max connection age"));
 }
 
 CORE_END2END_TEST(Http2Test, MaxAgeGracefullyClose) {

--- a/test/core/end2end/tests/max_connection_age.cc
+++ b/test/core/end2end/tests/max_connection_age.cc
@@ -20,7 +20,7 @@
 
 #include <memory>
 
-#include "gmock/gmock-matchers.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include <grpc/impl/channel_arg_names.h>


### PR DESCRIPTION
Without this, we see GOAWAYs with "enter idle" irrespective of the reason being idleness or max connection age.