### PR TITLE
[xds_core_e2e_test] ensure server is serving before starting client

### DIFF
--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -1060,7 +1060,7 @@ TEST_P(XdsFederationTest, FederationServer) {
       "xdstp://xds.example.com/envoy.config.listener.v3.Listener"
       "client/%s?client_listener_resource_name_template_not_in_use");
   InitClient(builder);
-  CreateAndStartBackends(2, /*xds_enabled=*/true);
+  CreateBackends(2, /*xds_enabled=*/true);
   // Eds for new authority balancer.
   EdsResourceArgs args =
       EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});
@@ -1099,6 +1099,13 @@ TEST_P(XdsFederationTest, FederationServer) {
                                      new_server_route_config,
                                      ServerHcmAccessor());
   }
+  // Start backends and wait for them to start serving.
+  StartAllBackends();
+  for (const auto& backend : backends_) {
+    ASSERT_TRUE(backend->notifier()->WaitOnServingStatusChange(
+        grpc_core::LocalIpAndPort(backend->port()), grpc::StatusCode::OK));
+  }
+  // Make sure everything works.
   WaitForAllBackends(DEBUG_LOCATION);
 }
 


### PR DESCRIPTION
This fixes the following flake:

https://btx.cloud.google.com/invocations/f3618072-5634-4bf2-a3ba-d25e725fe871/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_core_end2end_test@poller%3Dpoll;config=f78d0de70f525043d29a05fb7a78970999e04b7f8a87d8c4e974688bf7616998/tests