### PR TITLE
[flake] Fix chaotic good no_logging flake

### DIFF
--- a/src/core/ext/transport/chaotic_good/server/chaotic_good_server.h
+++ b/src/core/ext/transport/chaotic_good/server/chaotic_good_server.h
@@ -111,7 +111,7 @@ class ChaoticGoodServerListener final : public Server::ListenerInterface {
     };
 
    private:
-    void Done(absl::optional<absl::string_view> error = absl::nullopt);
+    void Done();
     void NewConnectionID();
     RefCountedPtr<Arena> arena_ = SimpleArenaAllocator()->MakeArena();
     const RefCountedPtr<ChaoticGoodServerListener> listener_;


### PR DESCRIPTION
Move the problematic log to be a trace log (not needed for general workflows), and take the opportunity to clean up a few other errors to log every n seconds -- because we principally need the signal that it's happening, not every occurrence.