### PR TITLE
[flake] Fix flake in connection_refused_test

### DIFF
--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -86,7 +86,8 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
   chan = grpc_channel_create(addr.c_str(), creds, args);
   grpc_channel_credentials_release(creds);
   grpc_slice host = grpc_slice_from_static_string("nonexistant");
-  gpr_timespec deadline = grpc_timeout_seconds_to_deadline(2);
+  gpr_timespec deadline =
+      grpc_timeout_seconds_to_deadline(wait_for_ready ? 2 : 600);
   call =
       grpc_channel_create_call(chan, nullptr, GRPC_PROPAGATE_DEFAULTS, cq,
                                grpc_slice_from_static_string("/service/method"),


### PR DESCRIPTION
Increase deadline in the case that we don't expect a deadline to hit (it expired too early in https://btx.cloud.google.com/invocations/55447722-0454-44b4-bd96-9f1604d8e02c/targets/%2F%2Ftest%2Fcore%2Fend2end:connection_refused_test;config=213e6770efdd9d7e0a9867560d39d4ea0067b835bad2334b239f96b3b6b502ba/log, but two seconds is actually kind of tight here).