### PR TITLE
[xds_cluster_e2e_test] fix flake in DropConfigUpdate test

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -1107,15 +1107,13 @@ TEST_P(EdsTest, DropConfigUpdate) {
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
   // Wait until backend 1 sees traffic, so that we know the client has
   // seen the update.
-  WaitForBackend(
-      DEBUG_LOCATION, 1,
-      [&](const RpcResult& result) {
-        if (!result.status.ok()) {
-          EXPECT_EQ(result.status.error_code(), StatusCode::UNAVAILABLE);
-          EXPECT_THAT(result.status.error_message(),
-                      ::testing::StartsWith(kStatusMessageDropPrefix));
-        }
-      });
+  WaitForBackend(DEBUG_LOCATION, 1, [&](const RpcResult& result) {
+    if (!result.status.ok()) {
+      EXPECT_EQ(result.status.error_code(), StatusCode::UNAVAILABLE);
+      EXPECT_THAT(result.status.error_message(),
+                  ::testing::StartsWith(kStatusMessageDropPrefix));
+    }
+  });
   // Send kNumRpcsBoth RPCs and count the drops.
   LOG(INFO) << "========= BEFORE SECOND BATCH ==========";
   num_drops = SendRpcsAndCountFailuresWithMessage(DEBUG_LOCATION, kNumRpcsBoth,


### PR DESCRIPTION
Changed test to add a new backend, as a more reliable method for determining when the client has seen the update.  This fixes flakes like the following:

https://btx.cloud.google.com/invocations/d4267c2a-3557-4e09-8439-d7f24637a5ba/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_end2end_test@poller%3Dpoll;config=c4ae5af353698403518bd66f686ce4f7f10d865e4cdcccbb7036582cbc9fa7d6/tests