### PR TITLE
[xds_cluster_e2e_test] remove unnecessary check for EDS response state

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -1563,8 +1563,6 @@ TEST_P(FailoverTest, MoveAllLocalitiesInCurrentPriorityToHigherPriority) {
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
   // When backend 2 gets traffic, we know the second update has been seen.
   WaitForBackend(DEBUG_LOCATION, 2);
-  // The xDS server got at least 1 response.
-  EXPECT_TRUE(balancer_->ads_service()->eds_response_state().has_value());
 }
 
 // This tests a bug triggered by the xds_cluster_resolver policy reusing


### PR DESCRIPTION
This check wasn't actually adding any value in the test, and we've seen a couple of flakes like the following:

https://btx.cloud.google.com/invocations/c814e411-7589-4cbf-b907-6be55ff55f0e/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_cluster_end2end_test@poller%3Depoll1;config=56f5b09615e325097b100b58c41171656571290519a83c5d89a6067ef0283d46/tests