### PR TITLE
[test] Handle no server in GracefulServerShutdown

### DIFF
--- a/test/core/end2end/tests/graceful_server_shutdown.cc
+++ b/test/core/end2end/tests/graceful_server_shutdown.cc
@@ -42,7 +42,6 @@ CORE_END2END_TEST(Http2Test, GracefulServerShutdown) {
   Expect(101, Maybe{&got_server});
   Step();
   if (got_server) {
-    LOG(ERROR) << "Got server";
     // shutdown and destroy the server
     ShutdownServerAndNotify(200);
     Step();


### PR DESCRIPTION
Trying to replicate a flake fix in https://github.com/yashykt/grpc/blob/master/test/core/end2end/tests/max_connection_age.cc