### PR TITLE
[party] Fix use after free in tracer

### DIFF
--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -394,7 +394,7 @@ class Party : public Activity, private Wakeable {
       const char* op, uint64_t prev_state, uint64_t new_state,
       DebugLocation loc = {}) {
     GRPC_TRACE_LOG(party_state, INFO).AtLocation(loc.file(), loc.line())
-        << DebugTag() << " " << op << " "
+        << this << " " << op << " "
         << absl::StrFormat("%016" PRIx64 " -> %016" PRIx64, prev_state,
                            new_state);
   }


### PR DESCRIPTION
It's possible for `LogStateChange` to be called after the party is destroyed (one thread calls Unref, which calls LogStateChange after the atomic op; another calls Unref concurrently, frees the last ref, deletes the object)

Consequently, it's not safe to call `DebugTag()` here - remove that.