### PR TITLE
[Python test] Add log to print test start time and duration

### DIFF
--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -301,6 +301,14 @@ class TerminalResult(CoverageResult):
             + _Colors.END
         )
 
+    def startTest(self, test):
+        """See unittest.TestResult.startTest."""
+        super(TerminalResult, self).startTest(test)
+        self.out.write(
+            _Colors.FAIL + "[{}]START         {}\n".format(test.id(), datetime.datetime.now()) + _Colors.END
+        )
+        self.out.flush()
+
     def stopTestRun(self):
         """See unittest.TestResult.stopTestRun."""
         super(TerminalResult, self).stopTestRun()
@@ -311,7 +319,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addError."""
         super(TerminalResult, self).addError(test, err)
         self.out.write(
-            _Colors.FAIL + "ERROR         {}\n".format(test.id()) + _Colors.END
+            _Colors.FAIL + "[{}]ERROR         {}\n".format(test.id(), datetime.datetime.now()) + _Colors.END
         )
         self.out.flush()
 
@@ -319,7 +327,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addFailure."""
         super(TerminalResult, self).addFailure(test, err)
         self.out.write(
-            _Colors.FAIL + "FAILURE       {}\n".format(test.id()) + _Colors.END
+            _Colors.FAIL + "[{}]FAILURE       {}\n".format(test.id()) + _Colors.END
         )
         self.out.flush()
 

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -291,6 +291,7 @@ class TerminalResult(CoverageResult):
         """
         super(TerminalResult, self).__init__(id_map=id_map)
         self.out = out
+        self.start_time = None
 
     def startTestRun(self):
         """See unittest.TestResult.startTestRun."""
@@ -304,11 +305,10 @@ class TerminalResult(CoverageResult):
     def startTest(self, test):
         """See unittest.TestResult.startTest."""
         super(TerminalResult, self).startTest(test)
+        self.start_time = datetime.datetime.now()
         self.out.write(
             _Colors.INFO
-            + " [{}]START         {}\n".format(
-                datetime.datetime.now(), test.id()
-            )
+            + " [{}]START         {}\n".format(self.start_time, test.id())
             + _Colors.END
         )
         self.out.flush()
@@ -346,11 +346,16 @@ class TerminalResult(CoverageResult):
     def addSuccess(self, test):
         """See unittest.TestResult.addSuccess."""
         super(TerminalResult, self).addSuccess(test)
+        end_time = datetime.datetime.now()
+        duration = end_time - self.start_time
         self.out.write(
             _Colors.OK
-            + " [{}]SUCCESS       {}\n".format(
-                datetime.datetime.now(), test.id()
-            )
+            + " [{}]SUCCESS       {}\n".format(end_time, test.id())
+            + _Colors.END
+        )
+        self.out.write(
+            _Colors.OK
+            + " {} Took:       {}\n".format(test.id(), duration)
             + _Colors.END
         )
         self.out.flush()

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -297,7 +297,7 @@ class TerminalResult(CoverageResult):
         super(TerminalResult, self).startTestRun()
         self.out.write(
             _Colors.HEADER
-            + "[{}]Testing gRPC Python...\n".format(datetime.datetime.now())
+            + " [{}]Testing gRPC Python...\n".format(datetime.datetime.now())
             + _Colors.END
         )
 
@@ -305,7 +305,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.startTest."""
         super(TerminalResult, self).startTest(test)
         self.out.write(
-            _Colors.FAIL + "[{}]START         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.FAIL + " [{}]START         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 
@@ -319,7 +319,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addError."""
         super(TerminalResult, self).addError(test, err)
         self.out.write(
-            _Colors.FAIL + "[{}]ERROR         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.FAIL + " [{}]ERROR         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 
@@ -327,7 +327,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addFailure."""
         super(TerminalResult, self).addFailure(test, err)
         self.out.write(
-            _Colors.FAIL + "[{}]FAILURE       {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.FAIL + " [{}]FAILURE       {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 
@@ -336,7 +336,7 @@ class TerminalResult(CoverageResult):
         super(TerminalResult, self).addSuccess(test)
         self.out.write(
             _Colors.OK
-            + "[{}]SUCCESS       {}\n".format(
+            + " [{}]SUCCESS       {}\n".format(
                 datetime.datetime.now(), test.id()
             )
             + _Colors.END

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -326,7 +326,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]ERROR         {}[{}s]\n".format(
+            + " [{}]ERROR         {}[Took {}s]\n".format(
                 datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
@@ -340,7 +340,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]FAILURE       {}[{}s]\n".format(
+            + " [{}]FAILURE       {}[Took {}s]\n".format(
                 datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
@@ -354,7 +354,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.OK
-            + " [{}]SUCCESS       {}[{}s]\n".format(
+            + " [{}]SUCCESS       {}[Took {}s]\n".format(
                 end_time, test.id(), duration
             )
             + _Colors.END

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -326,7 +326,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]ERROR         {}[Took {}s]\n".format(
+            + " [{}]ERROR         {}[Duration: {}s]\n".format(
                 datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
@@ -340,7 +340,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]FAILURE       {}[Took {}s]\n".format(
+            + " [{}]FAILURE       {}[Duration: {}]\n".format(
                 datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
@@ -354,7 +354,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.OK
-            + " [{}]SUCCESS       {}[Took {}s]\n".format(
+            + " [{}]SUCCESS       {}[Duration: {}s]\n".format(
                 end_time, test.id(), duration
             )
             + _Colors.END

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -326,7 +326,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]ERROR         {}[Duration: {}s]\n".format(
+            + " [{}]ERROR         {}[Duration: {}]\n".format(
                 datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
@@ -354,7 +354,7 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.OK
-            + " [{}]SUCCESS       {}[Duration: {}s]\n".format(
+            + " [{}]SUCCESS       {}[Duration: {}]\n".format(
                 end_time, test.id(), duration
             )
             + _Colors.END

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -327,7 +327,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addFailure."""
         super(TerminalResult, self).addFailure(test, err)
         self.out.write(
-            _Colors.FAIL + "[{}]FAILURE       {}\n".format(test.id()) + _Colors.END
+            _Colors.FAIL + "[{}]FAILURE       {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -305,7 +305,11 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.startTest."""
         super(TerminalResult, self).startTest(test)
         self.out.write(
-            _Colors.INFO + " [{}]START         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.INFO
+            + " [{}]START         {}\n".format(
+                datetime.datetime.now(), test.id()
+            )
+            + _Colors.END
         )
         self.out.flush()
 
@@ -319,7 +323,11 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addError."""
         super(TerminalResult, self).addError(test, err)
         self.out.write(
-            _Colors.FAIL + " [{}]ERROR         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.FAIL
+            + " [{}]ERROR         {}\n".format(
+                datetime.datetime.now(), test.id()
+            )
+            + _Colors.END
         )
         self.out.flush()
 
@@ -327,7 +335,11 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addFailure."""
         super(TerminalResult, self).addFailure(test, err)
         self.out.write(
-            _Colors.FAIL + " [{}]FAILURE       {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.FAIL
+            + " [{}]FAILURE       {}\n".format(
+                datetime.datetime.now(), test.id()
+            )
+            + _Colors.END
         )
         self.out.flush()
 

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -305,7 +305,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.startTest."""
         super(TerminalResult, self).startTest(test)
         self.out.write(
-            _Colors.FAIL + " [{}]START         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
+            _Colors.INFO + " [{}]START         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -322,10 +322,12 @@ class TerminalResult(CoverageResult):
     def addError(self, test, err):
         """See unittest.TestResult.addError."""
         super(TerminalResult, self).addError(test, err)
+        end_time = datetime.datetime.now()
+        duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]ERROR         {}\n".format(
-                datetime.datetime.now(), test.id()
+            + " [{}]ERROR         {}[{}s]\n".format(
+                datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
         )
@@ -334,10 +336,12 @@ class TerminalResult(CoverageResult):
     def addFailure(self, test, err):
         """See unittest.TestResult.addFailure."""
         super(TerminalResult, self).addFailure(test, err)
+        end_time = datetime.datetime.now()
+        duration = end_time - self.start_time
         self.out.write(
             _Colors.FAIL
-            + " [{}]FAILURE       {}\n".format(
-                datetime.datetime.now(), test.id()
+            + " [{}]FAILURE       {}[{}s]\n".format(
+                datetime.datetime.now(), test.id(), duration
             )
             + _Colors.END
         )
@@ -350,12 +354,9 @@ class TerminalResult(CoverageResult):
         duration = end_time - self.start_time
         self.out.write(
             _Colors.OK
-            + " [{}]SUCCESS       {}\n".format(end_time, test.id())
-            + _Colors.END
-        )
-        self.out.write(
-            _Colors.OK
-            + " {} Took:       {}\n".format(test.id(), duration)
+            + " [{}]SUCCESS       {}[{}s]\n".format(
+                end_time, test.id(), duration
+            )
             + _Colors.END
         )
         self.out.flush()

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -305,7 +305,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.startTest."""
         super(TerminalResult, self).startTest(test)
         self.out.write(
-            _Colors.FAIL + "[{}]START         {}\n".format(test.id(), datetime.datetime.now()) + _Colors.END
+            _Colors.FAIL + "[{}]START         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 
@@ -319,7 +319,7 @@ class TerminalResult(CoverageResult):
         """See unittest.TestResult.addError."""
         super(TerminalResult, self).addError(test, err)
         self.out.write(
-            _Colors.FAIL + "[{}]ERROR         {}\n".format(test.id(), datetime.datetime.now()) + _Colors.END
+            _Colors.FAIL + "[{}]ERROR         {}\n".format(datetime.datetime.now(), test.id()) + _Colors.END
         )
         self.out.flush()
 

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -291,7 +291,6 @@ class MetadataFlagsTest(unittest.TestCase):
 
         if not unhandled_exceptions.empty():
             raise unhandled_exceptions.get(True)
-        self.assertEqual(1, 2)
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -229,7 +229,6 @@ class MetadataFlagsTest(unittest.TestCase):
                 self.check_connection_does_failfast(
                     perform_call, channel, wait_for_ready=False
                 )
-        self.assertEqual(1, 2)
 
     def test_call_wait_for_ready_enabled(self):
         # To test the wait mechanism, Python thread is required to make

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -229,6 +229,7 @@ class MetadataFlagsTest(unittest.TestCase):
                 self.check_connection_does_failfast(
                     perform_call, channel, wait_for_ready=False
                 )
+        self.assertEqual(1, 2)
 
     def test_call_wait_for_ready_enabled(self):
         # To test the wait mechanism, Python thread is required to make

--- a/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_flags_test.py
@@ -291,6 +291,7 @@ class MetadataFlagsTest(unittest.TestCase):
 
         if not unhandled_exceptions.empty():
             raise unhandled_exceptions.get(True)
+        self.assertEqual(1, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some of our tests failed because RPC was canceled by server, error message:
```
I0000 00:00:1726598495.788119   64528 chttp2_transport.cc:1182] ipv4:127.0.0.1:41825: Got goaway [2] err=UNAVAILABLE:GOAWAY received; Error code: 2; Debug Text: Cancelling all calls {grpc_status:14, http2_error:2, created_time:"2024-09-17T18:41:35.78810597+00:00"}
```

It's possible that the request waited too long to be processed and thus canceled by server (default maximum time gRPC server allows a request to be received by the server but not handled is `30s`, controlled by `grpc.server_max_unrequested_time_in_server`).

This PR will print the test start/finish time so we know if we should increase `grpc.server_max_unrequested_time_in_server` time.

Example before change:
```
Testing gRPC Python...
SUCCESS       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_default
Running       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_disabled
SUCCESS       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_disabled
Running       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_enabled
```

Example after change:
```
 [2024-09-20 18:32:15.228947]Testing gRPC Python...
 [2024-09-20 18:32:15.237855]START         tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_default
 [2024-09-20 18:32:15.265477]SUCCESS       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_default[Duration: 0:00:00.027622s]
Running       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_disabled
 [2024-09-20 18:32:15.278142]START         tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_disabled
 [2024-09-20 18:32:15.316065]FAILURE       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_disabled[Duration: 0:00:00.037911]
Running       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_enabled
 [2024-09-20 18:32:15.328680]START         tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_enabled
 [2024-09-20 18:32:16.938745]SUCCESS       tests.unit._metadata_flags_test.MetadataFlagsTest.test_call_wait_for_ready_enabled[Duration: 0:00:01.610065s]
```

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

