### PR TITLE
Don't grab GIL from C-Core during shutdown

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -66,13 +66,6 @@ cdef int _get_metadata(void *state,
   return 0  # Asynchronous return
 
 
-cdef extern from "<mutex>" namespace "std" nogil:
-  cdef cppclass mutex:
-    mutex()
-    void lock()
-    void unlock()
-
-
 # Protects access to GIL from _destroy() and to g_shutting_down.
 cdef mutex g_shutdown_mu
 cdef int g_shutting_down = 0


### PR DESCRIPTION
MetadataPluginCallCredentials passes a function pointer to C-core to be called during destruction. This function grabs GIL which may race between GIL destruction during process shutdown. Since GIL destruction happens after Python's exit handlers, we cana mark that Python is shutting down from an exit handler and don't grab GIL in this function afterwards using a C mutex.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

