### PR TITLE
[EventEngine] Stop testing iomgr servers in core end2end tests

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -72,7 +72,6 @@ EXPERIMENTS = {
             ],
             "core_end2end_test": [
                 "event_engine_client",
-                "event_engine_listener",
             ],
             "cpp_lb_end2end_test": [
                 "pick_first_new",
@@ -161,9 +160,6 @@ EXPERIMENTS = {
         "on": {
             "cancel_ares_query_test": [
                 "event_engine_dns",
-            ],
-            "core_end2end_test": [
-                "event_engine_listener",
             ],
             "cpp_lb_end2end_test": [
                 "pick_first_new",

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -81,7 +81,7 @@
   description: Use EventEngine listeners instead of iomgr's grpc_tcp_server
   expiry: 2025/03/01
   owner: vigneshbabu@google.com
-  test_tags: ["core_end2end_test", "event_engine_listener_test"]
+  test_tags: ["event_engine_listener_test"]
   uses_polling: true
 - name: free_large_allocator
   description: If set, return all free bytes from a "big" allocator


### PR DESCRIPTION
The `//test/core/end2end:.*@experiment=no_event_engine_listener` tests aren't terribly valuable in OSS anymore. They test iomgr's tcp_server code, and the `event_engine_listener` experiment has been enabled on all platforms in OSS for nearly 1 year.

We run ~750k `no_event_engine_listener` tests every day. This will free up a fair amount of test resources.