### PR TITLE
Change the arg name used by XDS client example to indicate secure mode.

### DIFF
--- a/examples/cpp/xds/README.md
+++ b/examples/cpp/xds/README.md
@@ -6,7 +6,7 @@ This xDS example builds on the [Hello World Example](https://github.com/grpc/grp
 
 The client takes two command-line arguments -
 * target - By default, the client tries to connect to the xDS "xds:///helloworld:50051" and gRPC would use xDS to resolve this target and connect to the server backend. This can be overridden to change the target.
-* secure - Bool value, defaults to true. When this is set, [XdsCredentials](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md) will be used with a fallback on `InsecureChannelCredentials`. If unset, `InsecureChannelCredentials` will be used.
+* xds-creds - Bool value, defaults to true. When this is set, [XdsCredentials](https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md) will be used with a fallback on `InsecureChannelCredentials`. If unset, `InsecureChannelCredentials` will be used.
 
 The server takes three command-line arguments -
 * port - Port on which the Hello World service is run. Defaults to 50051.

--- a/examples/cpp/xds/xds_greeter_client.cc
+++ b/examples/cpp/xds/xds_greeter_client.cc
@@ -34,7 +34,7 @@
 #endif
 
 ABSL_FLAG(std::string, target, "xds:///helloworld:50051", "Target string");
-ABSL_FLAG(bool, secure, true, "Secure mode");
+ABSL_FLAG(bool, xds_creds, true, "Secure mode");
 
 using grpc::Channel;
 using grpc::ClientContext;
@@ -98,7 +98,7 @@ int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
   GreeterClient greeter(grpc::CreateChannel(
       absl::GetFlag(FLAGS_target),
-      absl::GetFlag(FLAGS_secure)
+      absl::GetFlag(FLAGS_xds_creds)
           ? grpc::XdsCredentials(grpc::InsecureChannelCredentials())
           : grpc::InsecureChannelCredentials()));
   std::string user("world");


### PR DESCRIPTION
Change flag used by the xds client example from --secure to --xds-creds. This woul
d be consistent with the [user guide](https://cloud.google.com/service-mesh/docs/service-routing/security-proxyless-setup#c++_2) where it says to use --xds-creds. It would also make it consistnt with other language examples -x the [Python example xds client](https://github.com/grpc/grpc/blob/master/examples/python/xds/client.py#L47) and the [Java example xds client](https://github.com/grpc/grpc-java/blob/master/examples/example-xds/src/main/java/io/grpc/examples/helloworldxds/XdsHelloWorldClient.java#L74) .