### PR TITLE
[doc] Clarify client callback API comments

### DIFF
--- a/include/grpcpp/support/client_callback.h
+++ b/include/grpcpp/support/client_callback.h
@@ -325,21 +325,20 @@ class ClientBidiReactor : public internal::ClientReactor {
   /// call of OnReadDone or OnDone.
   ///
   /// \param[in] ok Was the initial metadata read successfully? If false, no
-  ///               new read/write operation will succeed, and any further
-  ///               Start* operations should not be called.
+  ///               new read/write operation will succeed.
   virtual void OnReadInitialMetadataDone(bool /*ok*/) {}
 
   /// Notifies the application that a StartRead operation completed.
   ///
   /// \param[in] ok Was it successful? If false, no new read/write operation
-  ///               will succeed, and any further Start* should not be called.
+  ///               will succeed.
   virtual void OnReadDone(bool /*ok*/) {}
 
   /// Notifies the application that a StartWrite or StartWriteLast operation
   /// completed.
   ///
   /// \param[in] ok Was it successful? If false, no new read/write operation
-  ///               will succeed, and any further Start* should not be called.
+  ///               will succeed.
   virtual void OnWriteDone(bool /*ok*/) {}
 
   /// Notifies the application that a StartWritesDone operation completed. Note


### PR DESCRIPTION
Comments say users "should not" call Start* methods after notification callbacks are called with false, but users may still call so it's close to 'not recommended'. But it's less confusing to remove it altogether.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

