### PR TITLE
[Backport 1.66.x] increased timeout for armv7 artifact build to 2 hours (#37807)

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -160,7 +160,7 @@ class PythonArtifact:
                 ),
                 "tools/run_tests/artifacts/build_artifact_python.sh",
                 environ=environ,
-                timeout_seconds=60 * 60,
+                timeout_seconds=60 * 60 * 2,
             )
         elif "manylinux" in self.platform:
             if self.arch == "x86":


### PR DESCRIPTION
Building armv7 artifacts after adding Python 3.13 is failing with a timeout. Hence increasing timeout to 2 hours.