### PR TITLE
[Chttp2Server] Remove unnecessary ExecCtx Flush

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -783,15 +783,11 @@ Chttp2ServerListener::Chttp2ServerListener(
 }
 
 Chttp2ServerListener::~Chttp2ServerListener() {
-  // Flush queued work before destroying handshaker factory, since that
-  // may do a synchronous unref.
-  ExecCtx::Get()->Flush();
   if (passive_listener_ != nullptr) {
     passive_listener_->ListenerDestroyed();
   }
   if (on_destroy_done_ != nullptr) {
     ExecCtx::Run(DEBUG_LOCATION, on_destroy_done_, absl::OkStatus());
-    ExecCtx::Get()->Flush();
   }
 }
 


### PR DESCRIPTION
This seems to be a vestige from around 8 years ago. The code has changed a lot since then, and this makes no sense anymore.

(Making this change separately to be safe.)