### PR TITLE
[PH2][NewFile][ClassStructure] Add new files

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -7621,6 +7621,64 @@ grpc_cc_library(
     ],
 )
 
+# TODO(tjagtap) : [PH2_TODO] Remove unused includes after class is ready
+grpc_cc_library(
+    name = "grpc_transport_http2_client_connector",
+    srcs = [
+        "ext/transport/chttp2/client/http2_connector.cc",
+    ],
+    hdrs = [
+        "ext/transport/chttp2/client/http2_connector.h",
+    ],
+    external_deps = [
+        "absl/base:core_headers",
+        "absl/log:check",
+        "absl/log:log",
+        "absl/status",
+        "absl/status:statusor",
+        "absl/strings:str_format",
+        "absl/types:optional",
+    ],
+    language = "c++",
+    deps = [
+        "channel_args",
+        "channel_args_endpoint_config",
+        "channel_args_preconditioning",
+        "channel_stack_type",
+        "closure",
+        "error",
+        "error_utils",
+        "grpc_insecure_credentials",
+        "handshaker_registry",
+        "resolved_address",
+        "status_helper",
+        "subchannel_connector",
+        "tcp_connect_handshaker",
+        "time",
+        "unique_type_name",
+        "//:channel",
+        "//:channel_arg_names",
+        "//:channel_create",
+        "//:channelz",
+        "//:config",
+        "//:debug_location",
+        "//:exec_ctx",
+        "//:gpr",
+        "//:grpc_base",
+        "//:grpc_client_channel",
+        "//:grpc_public_hdrs",
+        "//:grpc_resolver",
+        "//:grpc_security_base",
+        "//:grpc_trace",
+        "//:grpc_transport_chttp2",
+        "//:handshaker",
+        "//:iomgr",
+        "//:orphanable",
+        "//:ref_counted_ptr",
+        "//:sockaddr_utils",
+    ],
+)
+
 grpc_cc_library(
     name = "grpc_transport_chttp2_server",
     srcs = [

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -7629,7 +7629,9 @@ grpc_cc_library(
     hdrs = [
         "ext/transport/chttp2/client/http2_connector.h",
     ],
-    external_deps = [],
+    external_deps = [
+        "absl/base:core_headers",
+    ],
     language = "c++",
     deps = [],
 )

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -7621,7 +7621,7 @@ grpc_cc_library(
     ],
 )
 
-# TODO(tjagtap) : [PH2_TODO] Remove unused includes after class is ready
+# TODO(tjagtap) : [PH2_TODO][P1] Remove unused includes after class is ready
 grpc_cc_library(
     name = "grpc_transport_http2_client_connector",
     srcs = [

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -7621,7 +7621,6 @@ grpc_cc_library(
     ],
 )
 
-# TODO(tjagtap) : [PH2_TODO][P1] Remove unused includes after class is ready
 grpc_cc_library(
     name = "grpc_transport_http2_client_connector",
     srcs = [
@@ -7630,53 +7629,9 @@ grpc_cc_library(
     hdrs = [
         "ext/transport/chttp2/client/http2_connector.h",
     ],
-    external_deps = [
-        "absl/base:core_headers",
-        "absl/log:check",
-        "absl/log:log",
-        "absl/status",
-        "absl/status:statusor",
-        "absl/strings:str_format",
-        "absl/types:optional",
-    ],
+    external_deps = [],
     language = "c++",
-    deps = [
-        "channel_args",
-        "channel_args_endpoint_config",
-        "channel_args_preconditioning",
-        "channel_stack_type",
-        "closure",
-        "error",
-        "error_utils",
-        "grpc_insecure_credentials",
-        "handshaker_registry",
-        "resolved_address",
-        "status_helper",
-        "subchannel_connector",
-        "tcp_connect_handshaker",
-        "time",
-        "unique_type_name",
-        "//:channel",
-        "//:channel_arg_names",
-        "//:channel_create",
-        "//:channelz",
-        "//:config",
-        "//:debug_location",
-        "//:exec_ctx",
-        "//:gpr",
-        "//:grpc_base",
-        "//:grpc_client_channel",
-        "//:grpc_public_hdrs",
-        "//:grpc_resolver",
-        "//:grpc_security_base",
-        "//:grpc_trace",
-        "//:grpc_transport_chttp2",
-        "//:handshaker",
-        "//:iomgr",
-        "//:orphanable",
-        "//:ref_counted_ptr",
-        "//:sockaddr_utils",
-    ],
+    deps = [],
 )
 
 grpc_cc_library(

--- a/src/core/ext/transport/chttp2/client/http2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/http2_connector.cc
@@ -89,6 +89,10 @@ namespace http {
 
 using ::grpc_event_engine::experimental::EventEngine;
 
+// Experimental : All code in this file will undergo large scale changes in the
+// coming year. Do not use unless you know transports well enough.
+// TODO(tjagtap) : [PH2_TODO][P2] : Remove comment when code is ready
+
 void Http2Connector::Connect(const Args& args, Result* result,
                              grpc_closure* notify) {}
 

--- a/src/core/ext/transport/chttp2/client/http2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/http2_connector.cc
@@ -1,0 +1,104 @@
+//
+//
+// Copyright 2024 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <stdint.h>
+
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_format.h"
+
+#include <grpc/grpc.h>
+#include <grpc/grpc_posix.h>
+#include <grpc/impl/channel_arg_names.h>
+#include <grpc/slice_buffer.h>
+#include <grpc/status.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/port_platform.h>
+#include <grpc/support/sync.h>
+
+#include "src/core/channelz/channelz.h"
+#include "src/core/client_channel/client_channel_factory.h"
+#include "src/core/client_channel/client_channel_filter.h"
+#include "src/core/client_channel/connector.h"
+#include "src/core/client_channel/subchannel.h"
+#include "src/core/ext/transport/chttp2/client/chttp2_connector.h"
+#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
+#include "src/core/handshaker/handshaker.h"
+#include "src/core/handshaker/handshaker_registry.h"
+#include "src/core/handshaker/tcp_connect/tcp_connect_handshaker.h"
+#include "src/core/lib/address_utils/sockaddr_utils.h"
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/channel/channel_args_preconditioning.h"
+#include "src/core/lib/config/core_configuration.h"
+#include "src/core/lib/debug/trace.h"
+#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
+#include "src/core/lib/iomgr/endpoint.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/resolved_address.h"
+#include "src/core/lib/security/credentials/credentials.h"
+#include "src/core/lib/security/credentials/insecure/insecure_credentials.h"
+#include "src/core/lib/security/security_connector/security_connector.h"
+#include "src/core/lib/surface/channel.h"
+#include "src/core/lib/surface/channel_create.h"
+#include "src/core/lib/surface/channel_stack_type.h"
+#include "src/core/lib/transport/error_utils.h"
+#include "src/core/lib/transport/transport.h"
+#include "src/core/resolver/resolver_registry.h"
+#include "src/core/util/debug_location.h"
+#include "src/core/util/orphanable.h"
+#include "src/core/util/status_helper.h"
+#include "src/core/util/time.h"
+#include "src/core/util/unique_type_name.h"
+
+#ifdef GPR_SUPPORT_CHANNELS_FROM_FD
+
+#include <fcntl.h>
+
+#include "src/core/lib/iomgr/ev_posix.h"
+#include "src/core/lib/iomgr/tcp_client_posix.h"
+
+#endif  // GPR_SUPPORT_CHANNELS_FROM_FD
+
+// TODO(tjagtap) : [PH2_TODO] Remove unused includes after class is ready
+
+namespace grpc_core {
+namespace http {
+
+using ::grpc_event_engine::experimental::EventEngine;
+
+void Http2Connector::Connect(const Args& args, Result* result,
+                             grpc_closure* notify) {}
+
+void Http2Connector::Shutdown(grpc_error_handle error) {}
+
+void Chttp2Connector::OnHandshakeDone(absl::StatusOr<HandshakerArgs*> result) {}
+
+void Chttp2Connector::OnReceiveSettings(void* arg, grpc_error_handle error) {}
+
+void Chttp2Connector::OnTimeout() {}
+
+void Chttp2Connector::MaybeNotify(grpc_error_handle error) {}
+
+}  // namespace http
+}  // namespace grpc_core

--- a/src/core/ext/transport/chttp2/client/http2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/http2_connector.cc
@@ -80,7 +80,9 @@
 
 #endif  // GPR_SUPPORT_CHANNELS_FROM_FD
 
-// TODO(tjagtap) : [PH2_TODO] Remove unused includes after class is ready
+// TODO(tjagtap) : [PH2_TODO][P1] Remove unused includes after class is ready.
+// Compiler whining about missing includes when we are iterating over the code
+// is a huge time sink.
 
 namespace grpc_core {
 namespace http {

--- a/src/core/ext/transport/chttp2/client/http2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/http2_connector.cc
@@ -16,73 +16,26 @@
 //
 //
 
+#include "src/core/ext/transport/chttp2/client/http2_connector.h"
+
 #include <stdint.h>
 
 #include <string>
 #include <type_traits>
 #include <utility>
 
-#include "absl/log/check.h"
-#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 
 #include <grpc/grpc.h>
-#include <grpc/grpc_posix.h>
-#include <grpc/impl/channel_arg_names.h>
 #include <grpc/slice_buffer.h>
 #include <grpc/status.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/sync.h>
 
-#include "src/core/channelz/channelz.h"
-#include "src/core/client_channel/client_channel_factory.h"
-#include "src/core/client_channel/client_channel_filter.h"
-#include "src/core/client_channel/connector.h"
-#include "src/core/client_channel/subchannel.h"
-#include "src/core/ext/transport/chttp2/client/chttp2_connector.h"
-#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
-#include "src/core/handshaker/handshaker.h"
-#include "src/core/handshaker/handshaker_registry.h"
-#include "src/core/handshaker/tcp_connect/tcp_connect_handshaker.h"
-#include "src/core/lib/address_utils/sockaddr_utils.h"
-#include "src/core/lib/channel/channel_args.h"
-#include "src/core/lib/channel/channel_args_preconditioning.h"
-#include "src/core/lib/config/core_configuration.h"
-#include "src/core/lib/debug/trace.h"
-#include "src/core/lib/event_engine/channel_args_endpoint_config.h"
-#include "src/core/lib/iomgr/endpoint.h"
-#include "src/core/lib/iomgr/exec_ctx.h"
-#include "src/core/lib/iomgr/resolved_address.h"
-#include "src/core/lib/security/credentials/credentials.h"
-#include "src/core/lib/security/credentials/insecure/insecure_credentials.h"
-#include "src/core/lib/security/security_connector/security_connector.h"
-#include "src/core/lib/surface/channel.h"
-#include "src/core/lib/surface/channel_create.h"
-#include "src/core/lib/surface/channel_stack_type.h"
-#include "src/core/lib/transport/error_utils.h"
-#include "src/core/lib/transport/transport.h"
-#include "src/core/resolver/resolver_registry.h"
-#include "src/core/util/debug_location.h"
-#include "src/core/util/orphanable.h"
-#include "src/core/util/status_helper.h"
-#include "src/core/util/time.h"
-#include "src/core/util/unique_type_name.h"
-
-#ifdef GPR_SUPPORT_CHANNELS_FROM_FD
-
-#include <fcntl.h>
-
-#include "src/core/lib/iomgr/ev_posix.h"
-#include "src/core/lib/iomgr/tcp_client_posix.h"
-
-#endif  // GPR_SUPPORT_CHANNELS_FROM_FD
-
 // TODO(tjagtap) : [PH2_TODO][P1] Remove unused includes after class is ready.
-// Compiler whining about missing includes when we are iterating over the code
-// is a huge time sink.
 
 namespace grpc_core {
 namespace http {

--- a/src/core/ext/transport/chttp2/client/http2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/http2_connector.cc
@@ -94,13 +94,13 @@ void Http2Connector::Connect(const Args& args, Result* result,
 
 void Http2Connector::Shutdown(grpc_error_handle error) {}
 
-void Chttp2Connector::OnHandshakeDone(absl::StatusOr<HandshakerArgs*> result) {}
+void Http2Connector::OnHandshakeDone(absl::StatusOr<HandshakerArgs*> result) {}
 
-void Chttp2Connector::OnReceiveSettings(void* arg, grpc_error_handle error) {}
+void Http2Connector::OnReceiveSettings(void* arg, grpc_error_handle error) {}
 
-void Chttp2Connector::OnTimeout() {}
+void Http2Connector::OnTimeout() {}
 
-void Chttp2Connector::MaybeNotify(grpc_error_handle error) {}
+void Http2Connector::MaybeNotify(grpc_error_handle error) {}
 
 }  // namespace http
 }  // namespace grpc_core

--- a/src/core/ext/transport/chttp2/client/http2_connector.h
+++ b/src/core/ext/transport/chttp2/client/http2_connector.h
@@ -49,6 +49,8 @@ class Http2Connector : public SubchannelConnector {
   void OnHandshakeDone(absl::StatusOr<HandshakerArgs*> result);
   static void OnReceiveSettings(void* arg, grpc_error_handle error);
   void OnTimeout() ABSL_LOCKS_EXCLUDED(mu_);
+
+  Mutex mu_;
 };
 
 }  // namespace http

--- a/src/core/ext/transport/chttp2/client/http2_connector.h
+++ b/src/core/ext/transport/chttp2/client/http2_connector.h
@@ -34,8 +34,6 @@
 #include "src/core/util/sync.h"
 
 // TODO(tjagtap) : [PH2_TODO][P1] Remove unused includes after class is ready.
-// Compiler whining about missing includes when we are iterating over the code
-// is a huge time sink.
 
 namespace grpc_core {
 namespace http {

--- a/src/core/ext/transport/chttp2/client/http2_connector.h
+++ b/src/core/ext/transport/chttp2/client/http2_connector.h
@@ -40,6 +40,9 @@
 namespace grpc_core {
 namespace http {
 
+// Experimental : All code in this file will undergo large scale changes in the
+// coming year. Do not use unless you know transports well enough.
+// TODO(tjagtap) : [PH2_TODO][P2] : Remove comment when code is ready
 class Http2Connector : public SubchannelConnector {
  public:
   void Connect(const Args& args, Result* result, grpc_closure* notify) override;

--- a/src/core/ext/transport/chttp2/client/http2_connector.h
+++ b/src/core/ext/transport/chttp2/client/http2_connector.h
@@ -1,0 +1,54 @@
+//
+//
+// Copyright 2024 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#ifndef GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_CLIENT_HTTP2_CONNECTOR_H
+#define GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_CLIENT_HTTP2_CONNECTOR_H
+
+#include "absl/base/thread_annotations.h"
+#include "absl/types/optional.h"
+
+#include <grpc/event_engine/event_engine.h>
+#include <grpc/support/port_platform.h>
+
+#include "src/core/client_channel/connector.h"
+#include "src/core/handshaker/handshaker.h"
+#include "src/core/lib/iomgr/closure.h"
+#include "src/core/lib/iomgr/endpoint.h"
+#include "src/core/lib/iomgr/error.h"
+#include "src/core/util/ref_counted_ptr.h"
+#include "src/core/util/sync.h"
+
+namespace grpc_core {
+namespace http {
+
+// TODO(tjagtap) : [PH2_TODO] Remove unused includes after class is ready
+class Http2Connector : public SubchannelConnector {
+ public:
+  void Connect(const Args& args, Result* result, grpc_closure* notify) override;
+  void Shutdown(grpc_error_handle error) override;
+
+ private:
+  void OnHandshakeDone(absl::StatusOr<HandshakerArgs*> result);
+  static void OnReceiveSettings(void* arg, grpc_error_handle error);
+  void OnTimeout() ABSL_LOCKS_EXCLUDED(mu_);
+};
+
+}  // namespace http
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_CLIENT_HTTP2_CONNECTOR_H

--- a/src/core/ext/transport/chttp2/client/http2_connector.h
+++ b/src/core/ext/transport/chttp2/client/http2_connector.h
@@ -33,10 +33,13 @@
 #include "src/core/util/ref_counted_ptr.h"
 #include "src/core/util/sync.h"
 
+// TODO(tjagtap) : [PH2_TODO][P1] Remove unused includes after class is ready.
+// Compiler whining about missing includes when we are iterating over the code
+// is a huge time sink.
+
 namespace grpc_core {
 namespace http {
 
-// TODO(tjagtap) : [PH2_TODO] Remove unused includes after class is ready
 class Http2Connector : public SubchannelConnector {
  public:
   void Connect(const Args& args, Result* result, grpc_closure* notify) override;


### PR DESCRIPTION
Created two new files for the new http2 promise based transport

Chose to create it in the same folder as chttp2 because sharing code will be easier. And after 1.5 years only one of the 2 transports will remain. Classes, files and functions belonging to the batch based transport will have string chttp2. But classes, files and functions belonging to promise based transport will have http as the string. They will also be in namespace http. Which is new. 
```
Copied
ext/transport/chttp2/client/chttp2_connector.cc to
ext/transport/chttp2/client/http2_connector.cc

Copied
ext/transport/chttp2/client/chttp2_connector.h to
ext/transport/chttp2/client/http2_connector.h
```

Kept the Skeleton functions which will be used for the new transport. 

Added to the build file too. 