### PR TITLE
Document that Deserialize implementations are responsible for freeing the ByteBuffer

### DIFF
--- a/include/grpcpp/impl/serialization_traits.h
+++ b/include/grpcpp/impl/serialization_traits.h
@@ -49,7 +49,8 @@ namespace grpc {
 ///
 /// Deserialize is required to convert buffer into the message stored at
 /// msg. max_receive_message_size is passed in as a bound on the maximum
-/// number of message bytes Deserialize should accept.
+/// number of message bytes Deserialize should accept. Deserialize implementations
+/// are responsible for freeing the ByteBuffer by calling buffer->Clear().
 ///
 /// Both functions return a Status, allowing them to explain what went
 /// wrong if required.


### PR DESCRIPTION
After building out a custom `Deserialize` function in our gRPC implementation, we ran ASAN and found that we were leaking on every Read call due to not freeing the `ByteBuffer`. It isn't currently obvious from the documentation that it is the implementer's responsibility to free the `ByteBuffer`, and so I've just added a sentence clarifying that in the docstring. Please let me know if I have missed a spot where this is already documented. Thanks all!