### PR TITLE
[generic API] add separate targets for cq generic stub/service (#36447)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2962,6 +2962,18 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "generic_stub",
+    hdrs = [
+        "include/grpcpp/generic/generic_stub.h",
+    ],
+    language = "c++",
+    visibility = ["@grpc:public"],
+    deps = [
+        "generic_stub_internal",
+    ],
+)
+
+grpc_cc_library(
     name = "generic_stub_callback",
     hdrs = [
         "include/grpcpp/generic/generic_stub_callback.h",
@@ -2970,6 +2982,18 @@ grpc_cc_library(
     visibility = ["@grpc:public"],
     deps = [
         "generic_stub_internal",
+    ],
+)
+
+grpc_cc_library(
+    name = "async_generic_service",
+    hdrs = [
+        "include/grpcpp/generic/async_generic_service.h",
+    ],
+    language = "c++",
+    visibility = ["@grpc:public"],
+    deps = [
+        "grpc++_public_hdrs",
     ],
 )
 


### PR DESCRIPTION
This allows to restrict CQ based generic stub/service use.

See https://github.com/grpc/proposal/pull/426




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

