### PR TITLE
examples/cpp/route_guide add missing command line parsing

### DIFF
--- a/examples/cpp/route_guide/BUILD
+++ b/examples/cpp/route_guide/BUILD
@@ -39,6 +39,7 @@ cc_binary(
         ":route_guide_helper",
         "//:grpc++",
         "//examples/protos:route_guide",
+        "@com_google_absl//absl/flags:parse",
     ],
 )
 
@@ -53,6 +54,7 @@ cc_binary(
         ":route_guide_helper",
         "//:grpc++",
         "//examples/protos:route_guide",
+        "@com_google_absl//absl/flags:parse",
     ],
 )
 

--- a/examples/cpp/route_guide/Makefile
+++ b/examples/cpp/route_guide/Makefile
@@ -25,7 +25,7 @@ PROTOBUF_UTF8_RANGE_LINK_LIBS = -lutf8_validity
 HOST_SYSTEM = $(shell uname | cut -f 1 -d_)
 SYSTEM ?= $(HOST_SYSTEM)
 CXX = g++
-CPPFLAGS += `pkg-config --cflags protobuf grpc`
+CPPFLAGS += `pkg-config --cflags protobuf grpc absl_flags absl_flags_parse`
 CXXFLAGS += -std=c++17
 ifeq ($(SYSTEM),Darwin)
 LDFLAGS += -L/usr/local/lib `pkg-config --libs --static protobuf grpc++ $(PROTOBUF_ABSL_DEPS)`\
@@ -35,7 +35,7 @@ LDFLAGS += -L/usr/local/lib `pkg-config --libs --static protobuf grpc++ $(PROTOB
            -lgrpc++_reflection\
            -ldl
 else
-LDFLAGS += -L/usr/local/lib `pkg-config --libs --static protobuf grpc++ $(PROTOBUF_ABSL_DEPS)`\
+LDFLAGS += -L/usr/local/lib `pkg-config --libs --static protobuf grpc++ absl_flags absl_flags_parse $(PROTOBUF_ABSL_DEPS)`\
            $(PROTOBUF_UTF8_RANGE_LINK_LIBS) \
            -pthread\
            -Wl,--no-as-needed -lgrpc++_reflection -Wl,--as-needed\

--- a/examples/cpp/route_guide/route_guide_client.cc
+++ b/examples/cpp/route_guide/route_guide_client.cc
@@ -29,6 +29,7 @@
 #include <string>
 #include <thread>
 
+#include "absl/flags/parse.h"
 #include "helper.h"
 #ifdef BAZEL_BUILD
 #include "examples/protos/route_guide.grpc.pb.h"
@@ -216,6 +217,7 @@ class RouteGuideClient {
 };
 
 int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
   // Expect only arg: --db_path=path/to/route_guide_db.json.
   std::string db = routeguide::GetDbFileContent(argc, argv);
   RouteGuideClient guide(

--- a/examples/cpp/route_guide/route_guide_server.cc
+++ b/examples/cpp/route_guide/route_guide_server.cc
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 
+#include "absl/flags/parse.h"
 #include "helper.h"
 #ifdef BAZEL_BUILD
 #include "examples/protos/route_guide.grpc.pb.h"
@@ -182,6 +183,7 @@ void RunServer(const std::string& db_path) {
 }
 
 int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
   // Expect only arg: --db_path=path/to/route_guide_db.json.
   std::string db = routeguide::GetDbFileContent(argc, argv);
   RunServer(db);


### PR DESCRIPTION
The gRPC basic turorial says to call the following command to run the server `./route_guide_server --db_path=path/to/route_guide_db.json`

But the server and client do not parse command line arguments and they always use default value `route_guide_db.json`. Thus the example only works if we run it from `examples/cpp/route_guide` dir. Otherwise we get the following error: `helper.cc:49] Failed to open route_guide_db.json
Aborted (core dumped)`

Add
`absl::ParseCommandLine(argc, argv);`
to both server and client `main` similar to `route_guide_callback_server.cc`