### PR TITLE
[call-v3] Add state machinery for flow control

### DIFF
--- a/test/core/transport/call_state_test.cc
+++ b/test/core/transport/call_state_test.cc
@@ -300,6 +300,39 @@ TEST(CallStateTest, ReceiveTrailingMetadataAfterMessageRead) {
   EXPECT_THAT(state.PollServerTrailingMetadataAvailable(), IsReady());
 }
 
+TEST(CallStateTest, CanWaitForPullClientMessage) {
+  StrictMock<MockActivity> activity;
+  activity.Activate();
+  CallState state;
+  state.Start();
+  EXPECT_THAT(state.PollPullClientToServerMessageStarted(), IsPending());
+  state.BeginPullClientInitialMetadata();
+  EXPECT_THAT(state.PollPullClientToServerMessageStarted(), IsPending());
+  // TODO(ctiller): consider adding another wakeup set to CallState to eliminate
+  // this wakeup (trade memory for cpu)
+  EXPECT_WAKEUP(activity, state.FinishPullClientInitialMetadata());
+  EXPECT_THAT(state.PollPullClientToServerMessageStarted(), IsPending());
+  EXPECT_WAKEUP(activity, state.PollPullClientToServerMessageAvailable());
+  EXPECT_THAT(state.PollPullClientToServerMessageStarted(), IsReady(Success{}));
+}
+
+TEST(CallStateTest, CanWaitForPullServerMessage) {
+  StrictMock<MockActivity> activity;
+  activity.Activate();
+  CallState state;
+  state.Start();
+  EXPECT_THAT(state.PollPullServerToClientMessageStarted(), IsPending());
+  state.PushServerInitialMetadata();
+  EXPECT_THAT(state.PollPullServerToClientMessageStarted(), IsPending());
+  EXPECT_WAKEUP(
+      activity,
+      EXPECT_THAT(state.PollPullServerInitialMetadataAvailable(), IsReady()));
+  state.FinishPullServerInitialMetadata();
+  EXPECT_THAT(state.PollPullServerToClientMessageStarted(), IsPending());
+  EXPECT_WAKEUP(activity, state.PollPullServerToClientMessageAvailable());
+  EXPECT_THAT(state.PollPullServerToClientMessageStarted(), IsReady(Success{}));
+}
+
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
So far missing for HTTP/2 style flow control has been a primitive to query whether there's a receiver for flow control data at the other end of the message pipes.

Here I'm updating the state machine accessors to accommodate that functionality.

No new states were needed.

Whilst here, document the current member functions on `CallState`.