### PR TITLE
[XdsE2ETest] Enable tracers

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -3507,6 +3507,8 @@ int main(int argc, char** argv) {
   // updates from all the subchannels's FDs.
   grpc_core::ConfigVars::Overrides overrides;
   overrides.client_channel_backup_poll_interval_ms = 1;
+  overrides.trace =
+      "call,channel,client_channel,client_channel_call,client_channel_lb_call";
   grpc_core::ConfigVars::SetOverrides(overrides);
 #if TARGET_OS_IPHONE
   // Workaround Apple CFStream bug

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -3508,7 +3508,8 @@ int main(int argc, char** argv) {
   grpc_core::ConfigVars::Overrides overrides;
   overrides.client_channel_backup_poll_interval_ms = 1;
   overrides.trace =
-      "call,channel,client_channel,client_channel_call,client_channel_lb_call";
+      "call,channel,client_channel,client_channel_call,client_channel_lb_call,"
+      "handshaker";
   grpc_core::ConfigVars::SetOverrides(overrides);
 #if TARGET_OS_IPHONE
   // Workaround Apple CFStream bug


### PR DESCRIPTION
I'm unable to reproduce some of the flakiness here. Enabling tracers to get more information.