### PR TITLE
Add basic typing support for python code compiler

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -549,10 +549,13 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
       method_dict["ResponseModuleAndClass"] = response_module_and_class;
       method_dict["InputTypeName"] = server_request_type;
       method_dict["OutputTypeName"] = server_response_type;
-      method_dict["AsyncFuncPrefix"] = render_async ? "async " : "";
 
       out->Print("\n");
-      out->Print(method_dict, "$AsyncFuncPrefix$def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.ServicerContext) -> $OutputTypeName$:\n");
+      if (render_async) {
+        out->Print(method_dict, "async def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.aio.ServicerContext[$InputTypeName$, $OutputTypeName$]) -> $OutputTypeName$:\n");
+      } else {
+        out->Print(method_dict, "def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.ServicerContext) -> $OutputTypeName$:\n");
+      }
       {
         IndentScope raii_method_indent(out);
         StringVector method_comments = method->GetAllComments();

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -466,10 +466,15 @@ bool PrivateGenerator::PrintStub(
           out->Print(method_dict, "self.$Method$ = cast(\n");
           IndentScope raii_first_attribute_indent(out);
           if (render_async) {
-            out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$[\n");
-            out->Print(method_dict, "    $RequestModuleAndClass$,\n");
-            out->Print(method_dict, "    $ResponseModuleAndClass$,\n");
-            out->Print(method_dict, "],\n");
+            if (method->ClientStreaming()) {
+              // there is no proper generic typing for Stream*MultiCallable available yet
+              out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$,");
+            } else {
+              out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$[\n");
+              out->Print(method_dict, "    $RequestModuleAndClass$,\n");
+              out->Print(method_dict, "    $ResponseModuleAndClass$,\n");
+              out->Print(method_dict, "],\n");
+            }
           } else {
             out->Print(method_dict, "grpc.$MultiCallableReturnType$,\n");
           }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -406,17 +406,20 @@ bool PrivateGenerator::PrintBetaStubFactory(
 
 bool PrivateGenerator::PrintStub(
     const std::string& package_qualified_service_name,
-    const grpc_generator::Service* service, grpc_generator::Printer* out) {
+    const grpc_generator::Service* service, grpc_generator::Printer* out,
+    const bool render_async) {
   StringMap dict;
   dict["Service"] = service->name();
+  dict["AsyncPostfix"] = render_async ? "Async" : "";
+  dict["ChannelClass"] = render_async ? "grpc.aio.Channel" : "grpc.Channel";
   out->Print("\n\n");
-  out->Print(dict, "class $Service$Stub:\n");
+  out->Print(dict, "class $Service$Stub$AsyncPostfix$:\n");
   {
     IndentScope raii_class_indent(out);
     StringVector service_comments = service->GetAllComments();
     PrintAllComments(service_comments, out);
     out->Print("\n");
-    out->Print("def __init__(self, channel):\n");
+    out->Print(dict, "def __init__(self, channel: $ChannelClass$):\n");
     {
       IndentScope raii_init_indent(out);
       out->Print("\"\"\"Constructor.\n");
@@ -446,27 +449,47 @@ bool PrivateGenerator::PrintStub(
                 config.prefixes_to_filter)) {
           return false;
         }
+
+        std::string client_request_type =
+            std::string(method->ClientStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + request_module_and_class +
+            std::string(method->ClientStreaming() ? "]" : "");
+        std::string client_response_type =
+            std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + response_module_and_class +
+            std::string(method->ServerStreaming() ? "]" : "");
+
         StringMap method_dict;
         method_dict["Method"] = method->name();
         method_dict["MultiCallableConstructor"] = multi_callable_constructor;
-        out->Print(method_dict,
-                   "self.$Method$ = channel.$MultiCallableConstructor$(\n");
         {
           method_dict["PackageQualifiedService"] =
               package_qualified_service_name;
           method_dict["RequestModuleAndClass"] = request_module_and_class;
           method_dict["ResponseModuleAndClass"] = response_module_and_class;
+          method_dict["ClientRequestType"] = client_request_type;
+          method_dict["ClientResponseType"] = client_response_type;
+          out->Print(method_dict, "self.$Method$ = cast(\n");
           IndentScope raii_first_attribute_indent(out);
-          IndentScope raii_second_attribute_indent(out);
-          out->Print(method_dict, "'/$PackageQualifiedService$/$Method$',\n");
-          out->Print(method_dict,
-                     "request_serializer=$RequestModuleAndClass$."
-                     "SerializeToString,\n");
-          out->Print(
-              method_dict,
-              "response_deserializer=$ResponseModuleAndClass$.FromString,\n");
-          out->Print("_registered_method=True)\n");
+          out->Print(method_dict, "Callable[\n");
+          out->Print(method_dict, "    [$ClientRequestType$],\n");
+          out->Print(method_dict, "    $ClientResponseType$,\n");
+          out->Print(method_dict, "],\n");
+          out->Print(method_dict, "channel.$MultiCallableConstructor$(\n");
+
+          {
+            IndentScope raii_second_attribute_indent(out);
+
+            out->Print(method_dict, "'/$PackageQualifiedService$/$Method$',\n");
+            out->Print(method_dict,
+                      "request_serializer=$RequestModuleAndClass$."
+                      "SerializeToString,\n");
+            out->Print(
+                method_dict,
+                "response_deserializer=$ResponseModuleAndClass$.FromString,\n");
+            out->Print("_registered_method=True,\n");
+          }
+          out->Print(")\n");
         }
+        out->Print(")\n");
       }
     }
   }
@@ -474,11 +497,14 @@ bool PrivateGenerator::PrintStub(
 }
 
 bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
-                                     grpc_generator::Printer* out) {
+                                     grpc_generator::Printer* out,
+                                     const bool render_async) {
   StringMap service_dict;
   service_dict["Service"] = service->name();
+  service_dict["AsyncPostfix"] = render_async ? "Async" : "";
+  service_dict["ChannelClass"] = render_async ? "grpc.aio.Channel" : "grpc.Channel";
   out->Print("\n\n");
-  out->Print(service_dict, "class $Service$Servicer:\n");
+  out->Print(service_dict, "class $Service$Servicer$AsyncPostfix$:\n");
   {
     IndentScope raii_class_indent(out);
     StringVector service_comments = service->GetAllComments();
@@ -490,8 +516,33 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
       StringMap method_dict;
       method_dict["Method"] = method->name();
       method_dict["ArgName"] = arg_name;
+
+      // get request and response types
+      std::string request_module_and_class;
+      method->get_module_and_message_path_input(
+            &request_module_and_class, generator_file_name,
+            generate_in_pb2_grpc, config.import_prefix,
+            config.prefixes_to_filter);
+      
+      std::string response_module_and_class;
+      method->get_module_and_message_path_output(
+              &response_module_and_class, generator_file_name,
+              generate_in_pb2_grpc, config.import_prefix,
+              config.prefixes_to_filter);
+
+      std::string server_request_type =
+          std::string(method->ClientStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + request_module_and_class +
+          std::string(method->ClientStreaming() ? "]" : "");
+      std::string server_response_type =
+          std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + response_module_and_class +
+          std::string(method->ServerStreaming() ? "]" : "");
+
+      method_dict["InputTypeName"] = server_request_type;
+      method_dict["OutputTypeName"] = server_response_type;
+      method_dict["AsyncFuncPrefix"] = render_async ? "async " : "";
+
       out->Print("\n");
-      out->Print(method_dict, "def $Method$(self, $ArgName$, context):\n");
+      out->Print(method_dict, "$AsyncFuncPrefix$def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.ServicerContext) -> $OutputTypeName$:\n");
       {
         IndentScope raii_method_indent(out);
         StringVector method_comments = method->GetAllComments();
@@ -507,12 +558,15 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
 
 bool PrivateGenerator::PrintAddServicerToServer(
     const std::string& package_qualified_service_name,
-    const grpc_generator::Service* service, grpc_generator::Printer* out) {
+    const grpc_generator::Service* service, grpc_generator::Printer* out,
+    const bool render_async) {
   StringMap service_dict;
   service_dict["Service"] = service->name();
+  service_dict["AsyncPostfix"] = render_async ? "Async" : "";
+  service_dict["ServerClass"] = render_async ? "grpc.aio.Server" : "grpc.Server";
   out->Print("\n\n");
   out->Print(service_dict,
-             "def add_$Service$Servicer_to_server(servicer, server):\n");
+             "def add_$Service$Servicer$AsyncPostfix$_to_server(servicer: $Service$Servicer$AsyncPostfix$, server: $ServerClass$) -> None:\n");
   {
     IndentScope raii_class_indent(out);
     out->Print("rpc_method_handlers = {\n");
@@ -689,6 +743,8 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
   StringMap var;
   var["Package"] = config.grpc_package_root;
   out->Print(var, "import $Package$\n");
+  out->Print(var, "from typing import AsyncIterator, Iterator, cast\n");
+  out->Print(var, "from collections.abc import Callable\n");
   if (config.grpc_tools_version.size() > 0) {
     out->Print(var, "import warnings\n");
   }
@@ -790,10 +846,14 @@ bool PrivateGenerator::PrintGAServices(grpc_generator::Printer* out) {
   for (int i = 0; i < file->service_count(); ++i) {
     auto service = file->service(i);
     std::string package_qualified_service_name = package + service->name();
-    if (!(PrintStub(package_qualified_service_name, service.get(), out) &&
-          PrintServicer(service.get(), out) &&
+    if (!(PrintStub(package_qualified_service_name, service.get(), out, false) && 
+          PrintStub(package_qualified_service_name, service.get(), out, true) &&
+          PrintServicer(service.get(), out, false) &&
+          PrintServicer(service.get(), out, true) &&
           PrintAddServicerToServer(package_qualified_service_name,
-                                   service.get(), out) &&
+                                   service.get(), out, false) &&
+          PrintAddServicerToServer(package_qualified_service_name,
+                                   service.get(), out, true) &&
           PrintServiceClass(package_qualified_service_name, service.get(),
                             out))) {
       return false;

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -454,8 +454,8 @@ bool PrivateGenerator::PrintStub(
             std::string(method->ClientStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + request_module_and_class +
             std::string(method->ClientStreaming() ? "]" : "");
         std::string client_response_type =
-            std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + response_module_and_class +
-            std::string(method->ServerStreaming() ? "]" : "");
+            std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : (render_async ? "Coroutine[Any, Any, " : "")) + response_module_and_class +
+            std::string(method->ServerStreaming() ? "]" : (render_async ? "]" : ""));
 
         StringMap method_dict;
         method_dict["Method"] = method->name();
@@ -537,6 +537,7 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
           std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + response_module_and_class +
           std::string(method->ServerStreaming() ? "]" : "");
 
+      method_dict["ResponseModuleAndClass"] = response_module_and_class;
       method_dict["InputTypeName"] = server_request_type;
       method_dict["OutputTypeName"] = server_response_type;
       method_dict["AsyncFuncPrefix"] = render_async ? "async " : "";
@@ -550,6 +551,9 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
         out->Print("context.set_code(grpc.StatusCode.UNIMPLEMENTED)\n");
         out->Print("context.set_details('Method not implemented!')\n");
         out->Print("raise NotImplementedError('Method not implemented!')\n");
+        if (method->ServerStreaming()) {
+          out->Print(method_dict, "yield $ResponseModuleAndClass$()\n");
+        }
       }
     }
   }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -468,7 +468,7 @@ bool PrivateGenerator::PrintStub(
           if (render_async) {
             if (method->ClientStreaming()) {
               // there is no proper generic typing for Stream*MultiCallable available yet
-              out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$,");
+              out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$,\n");
             } else {
               out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$[\n");
               out->Print(method_dict, "    $RequestModuleAndClass$,\n");

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -437,7 +437,8 @@ bool PrivateGenerator::PrintStub(
             std::string(method->ServerStreaming() ? "stream" : "unary");
         std::string multi_callable_return_type =
             std::string(method->ClientStreaming() ? "Stream" : "Unary") +
-            std::string(method->ServerStreaming() ? "Stream" : "Unary") + "MultiCallable";
+            std::string(method->ServerStreaming() ? "Stream" : "Unary") +
+            "MultiCallable";
         std::string request_module_and_class;
         if (!method->get_module_and_message_path_input(
                 &request_module_and_class, generator_file_name,
@@ -479,8 +480,8 @@ bool PrivateGenerator::PrintStub(
 
             out->Print(method_dict, "'/$PackageQualifiedService$/$Method$',\n");
             out->Print(method_dict,
-                      "request_serializer=$RequestModuleAndClass$."
-                      "SerializeToString,\n");
+                       "request_serializer=$RequestModuleAndClass$."
+                       "SerializeToString,\n");
             out->Print(
                 method_dict,
                 "response_deserializer=$ResponseModuleAndClass$.FromString,\n");
@@ -501,7 +502,8 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
   StringMap service_dict;
   service_dict["Service"] = service->name();
   service_dict["AsyncPostfix"] = render_async ? "Async" : "";
-  service_dict["ChannelClass"] = render_async ? "grpc.aio.Channel" : "grpc.Channel";
+  service_dict["ChannelClass"] =
+      render_async ? "grpc.aio.Channel" : "grpc.Channel";
   out->Print("\n\n");
   out->Print(service_dict, "class $Service$Servicer$AsyncPostfix$:\n");
   {
@@ -514,7 +516,8 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
     {
       IndentScope raii_method_indent(out);
       out->Print(service_dict,
-             "add_$Service$Servicer$AsyncPostfix$_to_server(servicer=self, server=server)\n");
+                 "add_$Service$Servicer$AsyncPostfix$_to_server(servicer=self, "
+                 "server=server)\n");
     }
 
     for (int i = 0; i < service->method_count(); ++i) {
@@ -528,21 +531,25 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
       // get request and response types
       std::string request_module_and_class;
       method->get_module_and_message_path_input(
-            &request_module_and_class, generator_file_name,
-            generate_in_pb2_grpc, config.import_prefix,
-            config.prefixes_to_filter);
-      
+          &request_module_and_class, generator_file_name, generate_in_pb2_grpc,
+          config.import_prefix, config.prefixes_to_filter);
+
       std::string response_module_and_class;
       method->get_module_and_message_path_output(
-              &response_module_and_class, generator_file_name,
-              generate_in_pb2_grpc, config.import_prefix,
-              config.prefixes_to_filter);
+          &response_module_and_class, generator_file_name, generate_in_pb2_grpc,
+          config.import_prefix, config.prefixes_to_filter);
 
       std::string server_request_type =
-          std::string(method->ClientStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + request_module_and_class +
+          std::string(method->ClientStreaming()
+                          ? (render_async ? "AsyncIterator[" : "Iterator[")
+                          : "") +
+          request_module_and_class +
           std::string(method->ClientStreaming() ? "]" : "");
       std::string server_response_type =
-          std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + response_module_and_class +
+          std::string(method->ServerStreaming()
+                          ? (render_async ? "AsyncIterator[" : "Iterator[")
+                          : "") +
+          response_module_and_class +
           std::string(method->ServerStreaming() ? "]" : "");
 
       method_dict["RequestModuleAndClass"] = request_module_and_class;
@@ -552,9 +559,14 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
 
       out->Print("\n");
       if (render_async) {
-        out->Print(method_dict, "async def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.aio.ServicerContext[$RequestModuleAndClass$, $ResponseModuleAndClass$]) -> $OutputTypeName$:\n");
+        out->Print(method_dict,
+                   "async def $Method$(self, $ArgName$: $InputTypeName$, "
+                   "context: grpc.aio.ServicerContext[$RequestModuleAndClass$, "
+                   "$ResponseModuleAndClass$]) -> $OutputTypeName$:\n");
       } else {
-        out->Print(method_dict, "def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.ServicerContext) -> $OutputTypeName$:\n");
+        out->Print(method_dict,
+                   "def $Method$(self, $ArgName$: $InputTypeName$, context: "
+                   "grpc.ServicerContext) -> $OutputTypeName$:\n");
       }
       {
         IndentScope raii_method_indent(out);
@@ -579,10 +591,13 @@ bool PrivateGenerator::PrintAddServicerToServer(
   StringMap service_dict;
   service_dict["Service"] = service->name();
   service_dict["AsyncPostfix"] = render_async ? "Async" : "";
-  service_dict["ServerClass"] = render_async ? "grpc.aio.Server" : "grpc.Server";
+  service_dict["ServerClass"] =
+      render_async ? "grpc.aio.Server" : "grpc.Server";
   out->Print("\n\n");
-  out->Print(service_dict,
-             "def add_$Service$Servicer$AsyncPostfix$_to_server(servicer: $Service$Servicer$AsyncPostfix$, server: $ServerClass$) -> None:\n");
+  out->Print(
+      service_dict,
+      "def add_$Service$Servicer$AsyncPostfix$_to_server(servicer: "
+      "$Service$Servicer$AsyncPostfix$, server: $ServerClass$) -> None:\n");
   {
     IndentScope raii_class_indent(out);
     out->Print("rpc_method_handlers = {\n");
@@ -760,7 +775,9 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
   var["Package"] = config.grpc_package_root;
   out->Print(var, "import $Package$\n");
   out->Print(var, "import $Package$.aio\n");
-  out->Print(var, "from typing import Any, AsyncIterator, Iterator, Coroutine, cast\n");
+  out->Print(
+      var,
+      "from typing import Any, AsyncIterator, Iterator, Coroutine, cast\n");
   out->Print(var, "from collections.abc import Callable\n");
   if (config.grpc_tools_version.size() > 0) {
     out->Print(var, "import warnings\n");
@@ -863,7 +880,8 @@ bool PrivateGenerator::PrintGAServices(grpc_generator::Printer* out) {
   for (int i = 0; i < file->service_count(); ++i) {
     auto service = file->service(i);
     std::string package_qualified_service_name = package + service->name();
-    if (!(PrintStub(package_qualified_service_name, service.get(), out, false) && 
+    if (!(PrintStub(package_qualified_service_name, service.get(), out,
+                    false) &&
           PrintStub(package_qualified_service_name, service.get(), out, true) &&
           PrintServicer(service.get(), out, false) &&
           PrintServicer(service.get(), out, true) &&

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -747,7 +747,8 @@ bool PrivateGenerator::PrintPreamble(grpc_generator::Printer* out) {
   StringMap var;
   var["Package"] = config.grpc_package_root;
   out->Print(var, "import $Package$\n");
-  out->Print(var, "from typing import AsyncIterator, Iterator, cast\n");
+  out->Print(var, "import $Package$.aio\n");
+  out->Print(var, "from typing import Any, AsyncIterator, Iterator, Coroutine, cast\n");
   out->Print(var, "from collections.abc import Callable\n");
   if (config.grpc_tools_version.size() > 0) {
     out->Print(var, "import warnings\n");

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -546,13 +546,14 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
           std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + response_module_and_class +
           std::string(method->ServerStreaming() ? "]" : "");
 
+      method_dict["RequestModuleAndClass"] = request_module_and_class;
       method_dict["ResponseModuleAndClass"] = response_module_and_class;
       method_dict["InputTypeName"] = server_request_type;
       method_dict["OutputTypeName"] = server_response_type;
 
       out->Print("\n");
       if (render_async) {
-        out->Print(method_dict, "async def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.aio.ServicerContext[$InputTypeName$, $OutputTypeName$]) -> $OutputTypeName$:\n");
+        out->Print(method_dict, "async def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.aio.ServicerContext[$RequestModuleAndClass$, $ResponseModuleAndClass$]) -> $OutputTypeName$:\n");
       } else {
         out->Print(method_dict, "def $Method$(self, $ArgName$: $InputTypeName$, context: grpc.ServicerContext) -> $OutputTypeName$:\n");
       }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -509,6 +509,15 @@ bool PrivateGenerator::PrintServicer(const grpc_generator::Service* service,
     IndentScope raii_class_indent(out);
     StringVector service_comments = service->GetAllComments();
     PrintAllComments(service_comments, out);
+
+    out->Print("\n");
+    out->Print("def add_to_server(self, server: grpc.aio.Server) -> None:\n");
+    {
+      IndentScope raii_method_indent(out);
+      out->Print(service_dict,
+             "add_$Service$Servicer$AsyncPostfix$_to_server(servicer=self, server=server)\n");
+    }
+
     for (int i = 0; i < service->method_count(); ++i) {
       auto method = service->method(i);
       std::string arg_name =

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -427,7 +427,7 @@ bool PrivateGenerator::PrintStub(
       out->Print("Args:\n");
       {
         IndentScope raii_args_indent(out);
-        out->Print("channel: A grpc.Channel.\n");
+        out->Print(dict, "channel: A $ChannelClass$.\n");
       }
       out->Print("\"\"\"\n");
       for (int i = 0; i < service->method_count(); ++i) {
@@ -435,6 +435,9 @@ bool PrivateGenerator::PrintStub(
         std::string multi_callable_constructor =
             std::string(method->ClientStreaming() ? "stream" : "unary") + "_" +
             std::string(method->ServerStreaming() ? "stream" : "unary");
+        std::string multi_callable_return_type =
+            std::string(method->ClientStreaming() ? "Stream" : "Unary") +
+            std::string(method->ServerStreaming() ? "Stream" : "Unary") + "MultiCallable";
         std::string request_module_and_class;
         if (!method->get_module_and_message_path_input(
                 &request_module_and_class, generator_file_name,
@@ -450,29 +453,25 @@ bool PrivateGenerator::PrintStub(
           return false;
         }
 
-        std::string client_request_type =
-            std::string(method->ClientStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : "") + request_module_and_class +
-            std::string(method->ClientStreaming() ? "]" : "");
-        std::string client_response_type =
-            std::string(method->ServerStreaming() ? (render_async ? "AsyncIterator[" : "Iterator[") : (render_async ? "Coroutine[Any, Any, " : "")) + response_module_and_class +
-            std::string(method->ServerStreaming() ? "]" : (render_async ? "]" : ""));
-
         StringMap method_dict;
         method_dict["Method"] = method->name();
         method_dict["MultiCallableConstructor"] = multi_callable_constructor;
+        method_dict["MultiCallableReturnType"] = multi_callable_return_type;
         {
           method_dict["PackageQualifiedService"] =
               package_qualified_service_name;
           method_dict["RequestModuleAndClass"] = request_module_and_class;
           method_dict["ResponseModuleAndClass"] = response_module_and_class;
-          method_dict["ClientRequestType"] = client_request_type;
-          method_dict["ClientResponseType"] = client_response_type;
           out->Print(method_dict, "self.$Method$ = cast(\n");
           IndentScope raii_first_attribute_indent(out);
-          out->Print(method_dict, "Callable[\n");
-          out->Print(method_dict, "    [$ClientRequestType$],\n");
-          out->Print(method_dict, "    $ClientResponseType$,\n");
-          out->Print(method_dict, "],\n");
+          if (render_async) {
+            out->Print(method_dict, "grpc.aio.$MultiCallableReturnType$[\n");
+            out->Print(method_dict, "    $RequestModuleAndClass$,\n");
+            out->Print(method_dict, "    $ResponseModuleAndClass$,\n");
+            out->Print(method_dict, "],\n");
+          } else {
+            out->Print(method_dict, "grpc.$MultiCallableReturnType$,\n");
+          }
           out->Print(method_dict, "channel.$MultiCallableConstructor$(\n");
 
           {

--- a/src/compiler/python_private_generator.h
+++ b/src/compiler/python_private_generator.h
@@ -52,12 +52,15 @@ struct PrivateGenerator {
 
   bool PrintAddServicerToServer(
       const std::string& package_qualified_service_name,
-      const grpc_generator::Service* service, grpc_generator::Printer* out);
+      const grpc_generator::Service* service, grpc_generator::Printer* out,
+      const bool render_async);
   bool PrintServicer(const grpc_generator::Service* service,
-                     grpc_generator::Printer* out);
+                     grpc_generator::Printer* out,
+                     const bool render_async);
   bool PrintStub(const std::string& package_qualified_service_name,
                  const grpc_generator::Service* service,
-                 grpc_generator::Printer* out);
+                 grpc_generator::Printer* out,
+                 const bool render_async);
 
   bool PrintServiceClass(const std::string& package_qualified_service_name,
                          const grpc_generator::Service* service,

--- a/src/compiler/python_private_generator.h
+++ b/src/compiler/python_private_generator.h
@@ -55,12 +55,10 @@ struct PrivateGenerator {
       const grpc_generator::Service* service, grpc_generator::Printer* out,
       const bool render_async);
   bool PrintServicer(const grpc_generator::Service* service,
-                     grpc_generator::Printer* out,
-                     const bool render_async);
+                     grpc_generator::Printer* out, const bool render_async);
   bool PrintStub(const std::string& package_qualified_service_name,
                  const grpc_generator::Service* service,
-                 grpc_generator::Printer* out,
-                 const bool render_async);
+                 grpc_generator::Printer* out, const bool render_async);
 
   bool PrintServiceClass(const std::string& package_qualified_service_name,
                          const grpc_generator::Service* service,


### PR DESCRIPTION
This PR adds basic typing to Python code compiler and adds asyncio specialities (returning AsyncIterator, async method stubs, proper parameter variants for grpc.aio.Server, ...) when using grpc.aio variants.

This is a very straightforward implementation and a quickfix which works perfectly well for my own purposes. If it's not intended to modify python code to include typing information directly but rather generate separate pyi files, please don't hesitate to say so.

There already [exists an issue for this topic](https://github.com/grpc/grpc/issues/29041#issuecomment-2258058076), which says that a release of probably the same feature is ready soon. Since there was no reply in a while I jumped in and tried my best. Maybe there'll be an update on this as well.

Sorry for not updating the python examples section, I didn't manage to find out where to auto-generate the example files (compile the existing proto-files to Python stubs and servicers). If there's documentation on how to do it, I'm happy to do this as well.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->
