### PR TITLE
[Python Bazel] Revert Cython upgrade

### DIFF
--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -38,9 +38,9 @@ def grpc_python_deps():
         http_archive(
             name = "cython",
             build_file = "@com_github_grpc_grpc//third_party:cython.BUILD",
-            sha256 = "2ec7d66d23d6da2328fb24f5c1bec6c63a59ec2e91027766ab904f417e1078aa",
-            strip_prefix = "cython-3.0.11",
+            sha256 = "a2da56cc22be823acf49741b9aa3aa116d4f07fa8e8b35a3cb08b8447b37c607",
+            strip_prefix = "cython-0.29.35",
             urls = [
-                "https://github.com/cython/cython/archive/3.0.11.tar.gz",
+                "https://github.com/cython/cython/archive/0.29.35.tar.gz",
             ],
         )


### PR DESCRIPTION
We're seeing some Bazel tests timing out due to this upgrade, revert this for now until we resolved the issue.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

