### PR TITLE
[chaotic-good] Don't add new streams after transport closed

### DIFF
--- a/src/core/ext/transport/chaotic_good/server_transport.h
+++ b/src/core/ext/transport/chaotic_good/server_transport.h
@@ -143,6 +143,7 @@ class ChaoticGoodServerTransport final : public ServerTransport {
   Mutex mu_;
   // Map of stream incoming server frames, key is stream_id.
   StreamMap stream_map_ ABSL_GUARDED_BY(mu_);
+  bool aborted_with_error_ ABSL_GUARDED_BY(mu_) = false;
   uint32_t last_seen_new_stream_id_ = 0;
   RefCountedPtr<Party> party_;
   ConnectivityStateTracker state_tracker_ ABSL_GUARDED_BY(mu_){


### PR DESCRIPTION
Prior to this change events could conspire such that newly read streams got added after the AbortWithError() code ran, and so those calls would be orphaned in the transport forever - continuing to hold a ref.