### PR TITLE
[latent_see] Move latent_see to be behind a build define, not a config

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -29,6 +29,11 @@ package(
     ],
 )
 
+config_setting(
+    name = "enable_latent_see",
+    values = {"define": "GRPC_ENABLE_LATENT_SEE=1"},
+)
+
 # This is needed as a transitionary mechanism to build the src/core targets in
 # the top-level BUILD file that have not yet been moved here. Should go away
 # once the transition is complete.
@@ -153,6 +158,10 @@ grpc_cc_library(
         "ring_buffer",
         "//:gpr",
     ],
+    defines=select({
+        ":enable_latent_see": ["GRPC_ENABLE_LATENT_SEE"],
+        "//conditions:default": [],
+    }),
 )
 
 grpc_cc_library(

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -146,6 +146,10 @@ grpc_cc_library(
     hdrs = [
         "util/latent_see.h",
     ],
+    defines = select({
+        ":enable_latent_see": ["GRPC_ENABLE_LATENT_SEE"],
+        "//conditions:default": [],
+    }),
     external_deps = [
         "absl/base:core_headers",
         "absl/functional:any_invocable",
@@ -158,10 +162,6 @@ grpc_cc_library(
         "ring_buffer",
         "//:gpr",
     ],
-    defines=select({
-        ":enable_latent_see": ["GRPC_ENABLE_LATENT_SEE"],
-        "//conditions:default": [],
-    }),
 )
 
 grpc_cc_library(

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -35,8 +35,6 @@ build --define=use_fast_cpp_protos=true
 build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
 
-build:latent_see --copt=-DGRPC_ENABLE_LATENT_SEE
-
 build:dbg --compilation_mode=dbg
 
 # Dynamic link cause issues like: `dyld: malformed mach-o: load commands size (59272) > 32768`


### PR DESCRIPTION
This will allow latent_see to be used with different build configurations in the future (and eventually perhaps defaulted on for some CI runs to aid postmortem debugging of test failures)
