### PR TITLE
Adding `noexcept` to void return Cython functions as required by Cython 3.x upgrade

### DIFF
--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -38,9 +38,9 @@ def grpc_python_deps():
         http_archive(
             name = "cython",
             build_file = "@com_github_grpc_grpc//third_party:cython.BUILD",
-            sha256 = "a2da56cc22be823acf49741b9aa3aa116d4f07fa8e8b35a3cb08b8447b37c607",
-            strip_prefix = "cython-0.29.35",
+            sha256 = "2ec7d66d23d6da2328fb24f5c1bec6c63a59ec2e91027766ab904f417e1078aa",
+            strip_prefix = "cython-3.0.11",
             urls = [
-                "https://github.com/cython/cython/archive/0.29.35.tar.gz",
+                "https://github.com/cython/cython/archive/3.0.11.tar.gz",
             ],
         )

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -48,5 +48,5 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef object _write_socket   # socket.socket
     cdef dict _loops            # Mapping[asyncio.AbstractLoop, _BoundEventLoop]
 
-    cdef void _poll(self) noexcept nogil
+    cdef void _poll(self) nogil
     cdef shutdown(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
@@ -94,7 +94,7 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
         else:
             self._loops[loop] = _BoundEventLoop(loop, self._read_socket, self._handle_events)
 
-    cdef void _poll(self) noexcept nogil:
+    cdef void _poll(self) nogil:
         cdef grpc_event event
         cdef CallbackContext *context
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -28,7 +28,7 @@ cdef int _get_metadata(
     size_t *num_creds_md, grpc_status_code *status,
     const char **error_details) except -1 with gil
 
-cdef void _destroy(void *state) noexcept with gil
+cdef void _destroy(void *state) noexcept nogil
 
 
 cdef class MetadataPluginCallCredentials(CallCredentials):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -26,9 +26,9 @@ cdef int _get_metadata(
     grpc_credentials_plugin_metadata_cb cb, void *user_data,
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t *num_creds_md, grpc_status_code *status,
-    const char **error_details) except * with gil
+    const char **error_details) except -1 with gil
 
-cdef void _destroy(void *state) except * with gil
+cdef void _destroy(void *state) noexcept with gil
 
 
 cdef class MetadataPluginCallCredentials(CallCredentials):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -42,7 +42,7 @@ cdef int _get_metadata(void *state,
                        grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
                        size_t *num_creds_md,
                        grpc_status_code *status,
-                       const char **error_details) except * with gil:
+                       const char **error_details) except -1 with gil:
   cdef size_t metadata_count
   cdef grpc_metadata *c_metadata
   def callback(metadata, grpc_status_code status, bytes error_details):
@@ -77,7 +77,7 @@ cdef int g_shutting_down = 0
 # GIL destruction during process shutdown. Since GIL destruction happens after
 # Python's exit handlers, we mark that Python is shutting down from an exit
 # handler and don't grab GIL in this function afterwards using a C mutex.
-cdef void _destroy(void *state) nogil:
+cdef void _destroy(void *state) noexcept nogil:
   global g_shutdown_mu
   global g_shutting_down
   g_shutdown_mu.lock()
@@ -101,7 +101,7 @@ def _maybe_register_shutdown_handler():
   g_shutdown_handler_registered = True
   atexit.register(_on_shutdown)
 
-cdef void _on_shutdown() nogil:
+cdef void _on_shutdown() noexcept nogil:
   global g_shutdown_mu
   global g_shutting_down
   # Wait for up to ~2s if C-core is still cleaning up.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pxd.pxi
@@ -14,8 +14,8 @@
 
 
 cdef bytes _slice_bytes(grpc_slice slice)
-cdef grpc_slice _copy_slice(grpc_slice slice) nogil
-cdef grpc_slice _slice_from_bytes(bytes value) nogil
+cdef grpc_slice _copy_slice(grpc_slice slice) noexcept nogil
+cdef grpc_slice _slice_from_bytes(bytes value) noexcept nogil
 
 
 cdef class CallDetails:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
@@ -18,12 +18,12 @@ cdef bytes _slice_bytes(grpc_slice slice):
   cdef size_t length = grpc_slice_length(slice)
   return (<const char *>start)[:length]
 
-cdef grpc_slice _copy_slice(grpc_slice slice) nogil:
+cdef grpc_slice _copy_slice(grpc_slice slice) noexcept nogil:
   cdef void *start = grpc_slice_start_ptr(slice)
   cdef size_t length = grpc_slice_length(slice)
   return grpc_slice_from_copied_buffer(<const char *>start, length)
 
-cdef grpc_slice _slice_from_bytes(bytes value) nogil:
+cdef grpc_slice _slice_from_bytes(bytes value) noexcept nogil:
   cdef const char *value_ptr
   cdef size_t length
   with gil:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
@@ -14,4 +14,4 @@
 
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
-    char **pem_root_certs) nogil
+    char **pem_root_certs) noexcept nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
@@ -18,7 +18,7 @@ import pkgutil
 
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
-    char **pem_root_certs) nogil:
+    char **pem_root_certs) noexcept nogil:
   with gil:
     pkg = __name__
     if pkg.endswith('.cygrpc'):

--- a/tools/distrib/python/grpcio_tools/grpc_tools/_protoc_compiler.pyx
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/_protoc_compiler.pyx
@@ -43,12 +43,12 @@ cdef extern from "grpc_tools/main.h" namespace "grpc_tools":
                         vector[string]* include_path,
                         vector[pair[string, string]]* files_out,
                         vector[cProtocError]* errors,
-                        vector[cProtocWarning]* wrnings) nogil except +
+                        vector[cProtocWarning]* wrnings) except + nogil
   int protoc_get_services(char* protobuf_path, char* version,
                           vector[string]* include_path,
                           vector[pair[string, string]]* files_out,
                           vector[cProtocError]* errors,
-                          vector[cProtocWarning]* wrnings) nogil except +
+                          vector[cProtocWarning]* wrnings) except + nogil
 
 def run_main(list args not None):
   cdef char **argv = <char **>stdlib.malloc(len(args)*sizeof(char *))


### PR DESCRIPTION
Follow up from #37917 to add `noexcept` to multiple Cython functions using `nogil` with a `void` return type.
Below are the performance hints that were encountered as part of the Cython translation which are solved by this PR:
![Screenshot 2024-10-15 8 24 29 AM](https://github.com/user-attachments/assets/6f0a20ca-2f15-462f-acee-8b447da228cf)

The below performance hint still exists, and is not resolved. 
![Screenshot 2024-10-11 6 32 56 PM](https://github.com/user-attachments/assets/6b58acd0-64b8-474b-9406-fb27cda75963)
This is because `noexcept` expects that the function doesn't raise an exception, or a raised exception is just displayed as a warning and not propagated. But `_poll` raises an `AssertionError` at `QUEUE_TIMEOUT`, and hence cannot use `noexcept` with `_poll`.

As [PR 37917](https://github.com/grpc/grpc/pull/37917) and this PR now solves the Cython Asyncio test timeouts caused by Cython upgrade, this PR also reverts the Bazel Cython downgrade PR #37884

### Testing for timeout
Tested using `bazel test -c dbg --runs_per_test=3000 --test_timeout=10 "//examples/python/auth:_auth_example_test"`
```
//examples/python/auth:_auth_example_test                                PASSED in 4.6s
  Stats over 3000 runs: max = 4.6s, min = 2.6s, avg = 3.2s, dev = 0.2s
```