### PR TITLE
[CI] Disallowed std::string_view

### DIFF
--- a/tools/run_tests/sanity/cpp_banned_constructs.sh
+++ b/tools/run_tests/sanity/cpp_banned_constructs.sh
@@ -24,7 +24,7 @@ cd "$(dirname "$0")/../../.."
 #
 
 grep -EIrn \
-    'std::(mutex|condition_variable|lock_guard|unique_lock|thread)' \
+    '\bstd::(mutex|condition_variable|lock_guard|unique_lock|thread|string_view)' \
     include/grpc include/grpcpp src/core src/cpp | \
     grep -Ev 'include/grpcpp/impl/sync.h|src/core/util/work_serializer.cc' | \
     diff - /dev/null


### PR DESCRIPTION
`std::string_view` is not allowed to use per Google C++ style guide. This test will prevent us from accidentally using it after C++17 upgrade. 