### PR TITLE
[benchmark] Remove redundant callback benchmarks

### DIFF
--- a/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
+++ b/test/cpp/microbenchmarks/bm_callback_streaming_ping_pong.cc
@@ -58,14 +58,6 @@ BENCHMARK_TEMPLATE(BM_CallbackBidiStreaming, MinInProcess, NoOpMutator,
                    NoOpMutator)
     ->Apply(StreamingPingPongArgs);
 
-// Streaming with different message number
-BENCHMARK_TEMPLATE(BM_CallbackBidiStreaming, InProcess, NoOpMutator,
-                   NoOpMutator)
-    ->Apply(StreamingPingPongArgs);
-BENCHMARK_TEMPLATE(BM_CallbackBidiStreaming, MinInProcess, NoOpMutator,
-                   NoOpMutator)
-    ->Apply(StreamingPingPongArgs);
-
 // Client context with different metadata
 BENCHMARK_TEMPLATE(BM_CallbackBidiStreaming, InProcess,
                    Client_AddMetadata<RandomBinaryMetadata<10>, 1>, NoOpMutator)


### PR DESCRIPTION
In https://github.com/grpc/grpc/pull/37077, the "different message size" benchmarks were made identical to the benchmarks defined on the lines above them.