### PR TITLE
[ConfigFetcher] Set HTTP2 error to NO_ERROR to do graceful GOAWAYs

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -627,8 +627,10 @@ void Chttp2ServerListener::ActiveConnection::SendGoAway() {
   }
   if (transport != nullptr) {
     grpc_transport_op* op = grpc_make_transport_op(nullptr);
-    op->goaway_error =
-        GRPC_ERROR_CREATE("Server is stopping to serve requests.");
+    // Set an HTTP2 error of NO_ERROR to do graceful GOAWAYs.
+    op->goaway_error = grpc_error_set_int(
+        GRPC_ERROR_CREATE("Server is stopping to serve requests."),
+        StatusIntProperty::kHttp2Error, GRPC_HTTP2_NO_ERROR);
     transport->PerformOp(op);
   }
 }


### PR DESCRIPTION
We were not doing graceful GOAWAYs earlier where we -
* send a GOAWAY with max stream ID
* send PING to wait for RTT
* Finally, send a GOAWAY with last stream max ID to make sure that the peer has seen the first GOAWAY frame, and any RPCs started before receiving the first GOAWAY frame are handled.

Without explicitly setting the HTTP2 error to "NO_ERROR", we were instead sending a final GOAWAY frame with an "UNKNOWN_ERROR".

Sample test failure : https://btx.cloud.google.com/invocations/041cafcd-334b-42dd-a797-cfd03c53048e/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_end2end_test@poller%3Dpoll;config=f78d0de70f525043d29a05fb7a78970999e04b7f8a87d8c4e974688bf7616998/log
