### PR TITLE
[XdsCoreE2ETest] Use wait_for_ready on RPCs to wait for xds enabled servers to be serving

### DIFF
--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -1060,10 +1060,6 @@ TEST_P(XdsFederationTest, FederationServer) {
       "client/%s?client_listener_resource_name_template_not_in_use");
   InitClient(builder);
   CreateBackends(2, /*xds_enabled=*/true);
-  ASSERT_TRUE(backends_[0]->notifier()->WaitOnServingStatusChange(
-      grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK));
-  ASSERT_TRUE(backends_[1]->notifier()->WaitOnServingStatusChange(
-      grpc_core::LocalIpAndPort(backends_[1]->port()), grpc::StatusCode::OK));
   // Eds for new authority balancer.
   EdsResourceArgs args =
       EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});

--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -1060,6 +1060,10 @@ TEST_P(XdsFederationTest, FederationServer) {
       "client/%s?client_listener_resource_name_template_not_in_use");
   InitClient(builder);
   CreateBackends(2, /*xds_enabled=*/true);
+  ASSERT_TRUE(backends_[0]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK));
+  ASSERT_TRUE(backends_[1]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[1]->port()), grpc::StatusCode::OK));
   // Eds for new authority balancer.
   EdsResourceArgs args =
       EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});
@@ -1247,6 +1251,8 @@ TEST_P(XdsMetricsTest, MetricValues) {
   const std::string kTarget = absl::StrCat("xds:", kServerName);
   const std::string kXdsServer = absl::StrCat("localhost:", balancer_->port());
   CreateAndStartBackends(1, /*xds_enabled=*/true);
+  ASSERT_TRUE(backends_[0]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK));
   EdsResourceArgs args =
       EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
@@ -1424,6 +1430,10 @@ TEST_P(XdsFederationLoadReportingTest, FederationMultipleLoadReportingTest) {
                        kNewListenerTemplate);
   InitClient(builder);
   CreateAndStartBackends(2, /*xds_enabled=*/true);
+  ASSERT_TRUE(backends_[0]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK));
+  ASSERT_TRUE(backends_[1]->notifier()->WaitOnServingStatusChange(
+      grpc_core::LocalIpAndPort(backends_[1]->port()), grpc::StatusCode::OK));
   // Eds for 2 balancers to ensure RPCs sent using current stub go to backend 0
   // and RPCs sent using the new stub go to backend 1.
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends(0, 1)}});


### PR DESCRIPTION
Fix flakes where RPCs fail due to the xds enabled server not being ready.

Sample flake - https://btx.cloud.google.com/invocations/74aca4dd-d5d6-43a4-89e3-08c1aed688e0/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_core_end2end_test@poller%3Dpoll;config=f78d0de70f525043d29a05fb7a78970999e04b7f8a87d8c4e974688bf7616998/log