### PR TITLE
updated default run_tests max version to py313

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -867,7 +867,7 @@ class PythonLanguage(object):
                 # Default set tested on master. Test oldest and newest.
                 return (
                     python38_config,
-                    python312_config,
+                    python313_config,
                 )
         elif args.compiler == "python3.8":
             return (python38_config,)


### PR DESCRIPTION
The default versions to run tests on master using `run_tests.py` are usually set to min and max supported Python versions. Looks like I missed updating the max version to Python 3.13 when adding support recently