### PR TITLE
[EE] Prevent crash when address can't be resolved

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
@@ -107,8 +107,11 @@ class PosixEngineListenerImpl
     }
     ListenerSocketsContainer::ListenerSocket& Socket() { return socket_; }
     ~AsyncConnectionAcceptor() {
-      // If uds socket, unlink it so that the corresponding file is deleted.
-      UnlinkIfUnixDomainSocket(*socket_.sock.LocalAddress());
+      auto maybe_address = socket_.sock.LocalAddress();
+      if (maybe_address.ok()) {
+        // If uds socket, unlink it so that the corresponding file is deleted.
+        UnlinkIfUnixDomainSocket(*maybe_address);
+      }
       handle_->OrphanHandle(nullptr, nullptr, "");
       delete notify_on_accept_;
     }

--- a/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine_listener.h
@@ -107,10 +107,10 @@ class PosixEngineListenerImpl
     }
     ListenerSocketsContainer::ListenerSocket& Socket() { return socket_; }
     ~AsyncConnectionAcceptor() {
-      auto maybe_address = socket_.sock.LocalAddress();
-      if (maybe_address.ok()) {
+      auto address = socket_.sock.LocalAddress();
+      if (address.ok()) {
         // If uds socket, unlink it so that the corresponding file is deleted.
-        UnlinkIfUnixDomainSocket(*maybe_address);
+        UnlinkIfUnixDomainSocket(*address);
       }
       handle_->OrphanHandle(nullptr, nullptr, "");
       delete notify_on_accept_;


### PR DESCRIPTION
I hit this crash working on fork support but there's a chance it happens if the file descriptor becomes bad for some other reason.