### PR TITLE
[alts] ALTS server handshaker should return early if there is no handshake data.

### DIFF
--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -482,7 +482,7 @@ static tsi_result alts_tsi_handshaker_continue_handshaker_next(
 
 struct alts_tsi_handshaker_continue_handshaker_next_args {
   alts_tsi_handshaker* handshaker;
-  std::unique_ptr<unsigned char> received_bytes;
+  unsigned char* received_bytes;
   size_t received_bytes_size;
   tsi_handshaker_on_next_done_cb cb;
   void* user_data;
@@ -507,13 +507,13 @@ static void alts_tsi_handshaker_create_channel(
   grpc_channel_credentials_release(creds);
   tsi_result continue_next_result =
       alts_tsi_handshaker_continue_handshaker_next(
-          handshaker, next_args->received_bytes.get(),
-          next_args->received_bytes_size, next_args->cb, next_args->user_data,
-          next_args->error);
+          handshaker, next_args->received_bytes, next_args->received_bytes_size,
+          next_args->cb, next_args->user_data, next_args->error);
   if (continue_next_result != TSI_OK) {
     next_args->cb(continue_next_result, next_args->user_data, nullptr, 0,
                   nullptr);
   }
+  gpr_free(next_args->received_bytes);
   delete next_args;
 }
 
@@ -536,7 +536,11 @@ static tsi_result handshaker_next(
       if (error != nullptr) *error = "handshake shutdown";
       return TSI_HANDSHAKE_SHUTDOWN;
     }
+    if (!handshaker->is_client && received_bytes_size == 0) {
+      return TSI_INCOMPLETE_DATA;
+    }
   }
+
   if (handshaker->channel == nullptr && !handshaker->use_dedicated_cq) {
     alts_tsi_handshaker_continue_handshaker_next_args* args =
         new alts_tsi_handshaker_continue_handshaker_next_args();
@@ -545,9 +549,9 @@ static tsi_result handshaker_next(
     args->received_bytes_size = received_bytes_size;
     args->error = error;
     if (received_bytes_size > 0) {
-      args->received_bytes = std::unique_ptr<unsigned char>(
-          static_cast<unsigned char*>(gpr_zalloc(received_bytes_size)));
-      memcpy(args->received_bytes.get(), received_bytes, received_bytes_size);
+      args->received_bytes =
+          static_cast<unsigned char*>(gpr_zalloc(received_bytes_size));
+      memcpy(args->received_bytes, received_bytes, received_bytes_size);
     }
     args->cb = cb;
     args->user_data = user_data;

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -536,11 +536,11 @@ static tsi_result handshaker_next(
       if (error != nullptr) *error = "handshake shutdown";
       return TSI_HANDSHAKE_SHUTDOWN;
     }
-    if (!handshaker->is_client && received_bytes_size == 0) {
-      return TSI_INCOMPLETE_DATA;
-    }
   }
 
+  if (!handshaker->is_client && received_bytes_size == 0) {
+    return TSI_INCOMPLETE_DATA;
+  }
   if (handshaker->channel == nullptr && !handshaker->use_dedicated_cq) {
     alts_tsi_handshaker_continue_handshaker_next_args* args =
         new alts_tsi_handshaker_continue_handshaker_next_args();

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -709,11 +709,8 @@ TEST(AltsTsiHandshakerTest, CheckHandshakerNextFailure) {
   tsi_handshaker* server_handshaker =
       create_test_handshaker(false /* is_client */);
   // Client start.
-  ASSERT_EQ(tsi_handshaker_next(
-                client_handshaker,
-                (const unsigned char*)ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES,
-                strlen(ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES), nullptr, nullptr,
-                nullptr, check_must_not_be_called, nullptr),
+  ASSERT_EQ(tsi_handshaker_next(client_handshaker, nullptr, 0, nullptr, nullptr,
+                                nullptr, check_must_not_be_called, nullptr),
             TSI_INTERNAL_ERROR);
   // Server start.
   ASSERT_EQ(tsi_handshaker_next(

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -535,14 +535,15 @@ static tsi_result mock_server_start(alts_handshaker_client* client,
   }
   alts_handshaker_client_check_fields_for_testing(
       client, on_server_start_success_cb, nullptr, true, nullptr);
-  grpc_slice slice = grpc_empty_slice();
-  EXPECT_EQ(grpc_slice_cmp(*bytes_received, slice), 0);
+  EXPECT_EQ(memcmp(GRPC_SLICE_START_PTR(*bytes_received),
+                   ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES,
+                   GRPC_SLICE_LENGTH(*bytes_received)),
+            0);
   // Populate handshaker response for server_start request.
   grpc_byte_buffer** recv_buffer_ptr =
       alts_handshaker_client_get_recv_buffer_addr_for_testing(client);
   *recv_buffer_ptr = generate_handshaker_response(SERVER_START);
   cb_event = client;
-  grpc_slice_unref(slice);
   signal(&caller_to_tsi_notification);
   return TSI_OK;
 }
@@ -655,8 +656,11 @@ static void check_handshaker_next_success() {
             TSI_ASYNC);
   wait(&tsi_to_caller_notification);
   // Server start.
-  ASSERT_EQ(tsi_handshaker_next(server_handshaker, nullptr, 0, nullptr, nullptr,
-                                nullptr, on_server_start_success_cb, nullptr),
+  ASSERT_EQ(tsi_handshaker_next(
+                server_handshaker,
+                (const unsigned char*)ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES,
+                strlen(ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES), nullptr, nullptr,
+                nullptr, on_server_start_success_cb, nullptr),
             TSI_ASYNC);
   wait(&tsi_to_caller_notification);
   // Server next.
@@ -705,12 +709,18 @@ TEST(AltsTsiHandshakerTest, CheckHandshakerNextFailure) {
   tsi_handshaker* server_handshaker =
       create_test_handshaker(false /* is_client */);
   // Client start.
-  ASSERT_EQ(tsi_handshaker_next(client_handshaker, nullptr, 0, nullptr, nullptr,
-                                nullptr, check_must_not_be_called, nullptr),
+  ASSERT_EQ(tsi_handshaker_next(
+                client_handshaker,
+                (const unsigned char*)ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES,
+                strlen(ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES), nullptr, nullptr,
+                nullptr, check_must_not_be_called, nullptr),
             TSI_INTERNAL_ERROR);
   // Server start.
-  ASSERT_EQ(tsi_handshaker_next(server_handshaker, nullptr, 0, nullptr, nullptr,
-                                nullptr, check_must_not_be_called, nullptr),
+  ASSERT_EQ(tsi_handshaker_next(
+                server_handshaker,
+                (const unsigned char*)ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES,
+                strlen(ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES), nullptr, nullptr,
+                nullptr, check_must_not_be_called, nullptr),
             TSI_INTERNAL_ERROR);
   // Server next.
   ASSERT_EQ(tsi_handshaker_next(
@@ -729,6 +739,18 @@ TEST(AltsTsiHandshakerTest, CheckHandshakerNextFailure) {
   // Cleanup.
   run_tsi_handshaker_destroy_with_exec_ctx(server_handshaker);
   run_tsi_handshaker_destroy_with_exec_ctx(client_handshaker);
+}
+
+TEST(AltsTsiHandshakerTest, CheckHandshakerNextIncomplete) {
+  should_handshaker_client_api_succeed = false;
+  tsi_handshaker* server_handshaker =
+      create_test_handshaker(false /* is_client */);
+  // Server start.
+  ASSERT_EQ(tsi_handshaker_next(server_handshaker, nullptr, 0, nullptr, nullptr,
+                                nullptr, check_must_not_be_called, nullptr),
+            TSI_INCOMPLETE_DATA);
+  // Cleanup.
+  run_tsi_handshaker_destroy_with_exec_ctx(server_handshaker);
 }
 
 static void on_invalid_input_cb(tsi_result status, void* user_data,


### PR DESCRIPTION
Porting from #37829.

This ensures that we wait to create the stream to the handshaker service until handshake frames arrive from the client. Without this change, a TCP connection to the ALTS server triggers the stream to the handshaker service to be created, even if no handshake frames have arrived from the client. This waste resources and can potentially trigger the ALTS server to freeze up, because there is a cap on the number of concurrent ALTS handshakes that a server can perform.