### PR TITLE
Changed Bazel/Workspace to use @com_google_protobuf//python/dist:syst…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -75,7 +75,7 @@ load("@grpc_python_dependencies//:requirements.bzl", "install_deps")
 
 install_deps()
 
-load("@com_google_protobuf//bazel:system_python.bzl", "system_python")
+load("@com_google_protobuf//python/dist:system_python.bzl", "system_python")
 
 system_python(
     name = "system_python",


### PR DESCRIPTION
To address the upcoming breaking change; https://engdoc.corp.google.com/eng/doc/devguide/proto/news/2024-10-02.md?cl=head#python-remove-alias
