### PR TITLE
[Windows] Hack to prewarm cache (`GetAdaptersAddresses`) for core_end2end_tests

### DIFF
--- a/test/core/end2end/end2end_tests.cc
+++ b/test/core/end2end/end2end_tests.cc
@@ -64,6 +64,7 @@ Slice RandomBinarySlice(size_t length) {
 void CoreEnd2endTest::SetUp() {
   CoreConfiguration::Reset();
   initialized_ = false;
+  grpc_prewarm_os_for_tests();
 }
 
 void CoreEnd2endTest::TearDown() {

--- a/test/core/end2end/end2end_tests.cc
+++ b/test/core/end2end/end2end_tests.cc
@@ -22,10 +22,6 @@
 #include <regex>
 #include <tuple>
 
-#ifdef GPR_WINDOWS
-#include <iphlpapi.h>
-#endif
-
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/memory/memory.h"
@@ -68,20 +64,6 @@ Slice RandomBinarySlice(size_t length) {
 void CoreEnd2endTest::SetUp() {
   CoreConfiguration::Reset();
   initialized_ = false;
-#ifdef GPR_WINDOWS
-  // On Windows RBE, c-ares' ares_init_options which internally calls
-  // GetAdaptersAddresses sometimes take >20s to return causing tests to
-  // timeout. This is a hack to prewarm the cache by calling that function
-  // here.
-#define IPAA_INITIAL_BUF_SZ 15 * 1024
-  ULONG AddrFlags = 0;
-  ULONG Bufsz = IPAA_INITIAL_BUF_SZ;
-  ULONG ReqBufsz = IPAA_INITIAL_BUF_SZ;
-  IP_ADAPTER_ADDRESSES* ipaa;
-  ipaa = static_cast<IP_ADAPTER_ADDRESSES*>(malloc(Bufsz));
-  GetAdaptersAddresses(AF_UNSPEC, AddrFlags, NULL, ipaa, &ReqBufsz);
-  free(ipaa);
-#endif
 }
 
 void CoreEnd2endTest::TearDown() {

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -56,8 +56,10 @@ static unsigned seed(void) { return (unsigned)_getpid(); }
 #endif
 
 #ifdef GPR_WINDOWS
+// clang-format off
 #include <winsock2.h>
 #include <iphlpapi.h>
+// clang-format on
 #endif
 
 int64_t grpc_test_sanitizer_slowdown_factor() {

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -55,6 +55,11 @@ static unsigned seed(void) { return static_cast<unsigned>(getpid()); }
 static unsigned seed(void) { return (unsigned)_getpid(); }
 #endif
 
+#ifdef GPR_WINDOWS
+#include <winsock2.h>
+#include <iphlpapi.h>
+#endif
+
 int64_t grpc_test_sanitizer_slowdown_factor() {
   int64_t sanitizer_multiplier = 1;
   if (BuiltUnderValgrind()) {
@@ -171,6 +176,23 @@ bool grpc_wait_until_shutdown(int64_t time_s) {
 void grpc_disable_all_absl_logs() {
   absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
   absl::SetVLogLevel("*grpc*/*", -1);
+}
+
+void grpc_prewarm_os_for_tests() {
+#ifdef GPR_WINDOWS
+  // On Windows RBE, c-ares' ares_init_options which internally calls
+  // GetAdaptersAddresses sometimes take >20s to return causing tests to
+  // timeout. This is a hack to prewarm the cache by calling that function
+  // here.
+#define IPAA_INITIAL_BUF_SZ 15 * 1024
+  ULONG AddrFlags = 0;
+  ULONG Bufsz = IPAA_INITIAL_BUF_SZ;
+  ULONG ReqBufsz = IPAA_INITIAL_BUF_SZ;
+  IP_ADAPTER_ADDRESSES* ipaa;
+  ipaa = static_cast<IP_ADAPTER_ADDRESSES*>(malloc(Bufsz));
+  GetAdaptersAddresses(AF_UNSPEC, AddrFlags, NULL, ipaa, &ReqBufsz);
+  free(ipaa);
+#endif
 }
 
 namespace grpc {

--- a/test/core/test_util/test_config.cc
+++ b/test/core/test_util/test_config.cc
@@ -185,7 +185,7 @@ void grpc_prewarm_os_for_tests() {
   // On Windows RBE, c-ares' ares_init_options which internally calls
   // GetAdaptersAddresses sometimes take >20s to return causing tests to
   // timeout. This is a hack to prewarm the cache by calling that function
-  // here.
+  // during test setup.
 #define IPAA_INITIAL_BUF_SZ 15 * 1024
   ULONG AddrFlags = 0;
   ULONG Bufsz = IPAA_INITIAL_BUF_SZ;

--- a/test/core/test_util/test_config.h
+++ b/test/core/test_util/test_config.h
@@ -51,6 +51,9 @@ bool grpc_wait_until_shutdown(int64_t time_s);
 // Sets absl verbosity via SetMinLogLevel and SetVLogLevel
 void grpc_set_absl_verbosity_debug(void);
 
+// Hacks to reduce the effect of OS on test results.
+void grpc_prewarm_os_for_tests(void);
+
 namespace grpc {
 namespace testing {
 


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

