### PR TITLE
[test] Disable //test/core/end2end/... on Windows

### DIFF
--- a/test/core/end2end/end2end_tests.cc
+++ b/test/core/end2end/end2end_tests.cc
@@ -56,6 +56,7 @@ Slice RandomBinarySlice(size_t length) {
   std::vector<uint8_t> output;
   output.resize(length);
   for (i = 0; i < length; ++i) {
+
     output[i] = rand();
   }
   return Slice::FromCopiedBuffer(output);
@@ -65,17 +66,17 @@ void CoreEnd2endTest::SetUp() {
   CoreConfiguration::Reset();
   initialized_ = false;
   grpc_prewarm_os_for_tests();
+#ifdef GPR_WINDOWS
+  GTEST_SKIP() << "Disabled on Windows due to high flake rate";
+#endif
 }
 
 void CoreEnd2endTest::TearDown() {
   const bool do_shutdown = fixture_ != nullptr;
   std::shared_ptr<grpc_event_engine::experimental::EventEngine> ee;
-// TODO(hork): locate the windows leak so we can enable end2end experiments.
-#ifndef GPR_WINDOWS
   if (grpc_is_initialized()) {
     ee = grpc_event_engine::experimental::GetDefaultEventEngine();
   }
-#endif
   ShutdownAndDestroyClient();
   ShutdownAndDestroyServer();
   cq_verifier_.reset();


### PR DESCRIPTION
This will disable the jobs in both bazel and cmake builds, which is necessary for our CI to remain happy. These end2end tests were enabled on Windows at some point without any notice (they had been intentionally disabled for a while), but the RBE jobs have been silently failing for 7 months, so it's unclear when that happened.

These failures still need to be examined so we can re-enable these tests.