### PR TITLE
[test] Increase timeout for windows portability tests

### DIFF
--- a/tools/internal_ci/windows/grpc_portability.cfg
+++ b/tools/internal_ci/windows/grpc_portability.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 300
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -31,7 +31,7 @@ os.chdir(_ROOT)
 _DEFAULT_RUNTESTS_TIMEOUT = 1 * 60 * 60
 
 # C/C++ tests can take long time
-_CPP_RUNTESTS_TIMEOUT = 4 * 60 * 60
+_CPP_RUNTESTS_TIMEOUT = 6 * 60 * 60
 
 # Set timeout high for ObjC for Cocoapods to install pods
 _OBJC_RUNTESTS_TIMEOUT = 4 * 60 * 60


### PR DESCRIPTION
It's not obvious to me what the reason for the increase in test time is, but it seems that we were already at ~3hr45min earlier and now we are timing out at 4 hours. Increasing to 6 hours.