### PR TITLE
[Backport] Adding `noexcept` to required Cython functions to fix potential deadlocks coming from Cython 3.x upgrade

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -48,5 +48,5 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef object _write_socket   # socket.socket
     cdef dict _loops            # Mapping[asyncio.AbstractLoop, _BoundEventLoop]
 
-    cdef void _poll(self) noexcept nogil
+    cdef void _poll(self) nogil
     cdef shutdown(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -23,7 +23,7 @@ IF UNAME_SYSNAME == "Windows":
         int win_socket_send "send" (WIN_SOCKET s, const char *buf, int len, int flags)
 
 
-cdef void _unified_socket_write(int fd) nogil
+cdef void _unified_socket_write(int fd) noexcept nogil
 
 
 cdef class BaseCompletionQueue:
@@ -48,5 +48,5 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef object _write_socket   # socket.socket
     cdef dict _loops            # Mapping[asyncio.AbstractLoop, _BoundEventLoop]
 
-    cdef void _poll(self) nogil
+    cdef void _poll(self) noexcept nogil
     cdef shutdown(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
@@ -22,12 +22,12 @@ cdef float _POLL_AWAKE_INTERVAL_S = 0.2
 cdef bint _has_fd_monitoring = True
 
 IF UNAME_SYSNAME == "Windows":
-    cdef void _unified_socket_write(int fd) nogil:
+    cdef void _unified_socket_write(int fd) noexcept nogil:
         win_socket_send(<WIN_SOCKET>fd, b"1", 1, 0)
 ELSE:
     from posix cimport unistd
 
-    cdef void _unified_socket_write(int fd) nogil:
+    cdef void _unified_socket_write(int fd) noexcept nogil:
         unistd.write(fd, b"1", 1)
 
 
@@ -94,7 +94,7 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
         else:
             self._loops[loop] = _BoundEventLoop(loop, self._read_socket, self._handle_events)
 
-    cdef void _poll(self) nogil:
+    cdef void _poll(self) noexcept nogil:
         cdef grpc_event event
         cdef CallbackContext *context
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
@@ -94,7 +94,7 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
         else:
             self._loops[loop] = _BoundEventLoop(loop, self._read_socket, self._handle_events)
 
-    cdef void _poll(self) noexcept nogil:
+    cdef void _poll(self) nogil:
         cdef grpc_event event
         cdef CallbackContext *context
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -26,9 +26,9 @@ cdef int _get_metadata(
     grpc_credentials_plugin_metadata_cb cb, void *user_data,
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t *num_creds_md, grpc_status_code *status,
-    const char **error_details) except * with gil
+    const char **error_details) except -1 with gil
 
-cdef void _destroy(void *state) except * with gil
+cdef void _destroy(void *state) noexcept nogil
 
 
 cdef class MetadataPluginCallCredentials(CallCredentials):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 
 def _spawn_callback_in_thread(cb_func, args):
   t = ForkManagedThread(target=cb_func, args=args)
@@ -131,6 +132,7 @@ cdef class MetadataPluginCallCredentials(CallCredentials):
     c_metadata_plugin.state = <void *>self._metadata_plugin
     c_metadata_plugin.type = self._name
     cpython.Py_INCREF(self._metadata_plugin)
+    _maybe_register_shutdown_handler()
     fork_handlers_and_grpc_init()
     # TODO(yihuazhang): Expose min_security_level via the Python API so that
     # applications can decide what minimum security level their plugins require.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -41,7 +41,7 @@ cdef int _get_metadata(void *state,
                        grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
                        size_t *num_creds_md,
                        grpc_status_code *status,
-                       const char **error_details) except * with gil:
+                       const char **error_details) except -1 with gil:
   cdef size_t metadata_count
   cdef grpc_metadata *c_metadata
   def callback(metadata, grpc_status_code status, bytes error_details):
@@ -65,10 +65,58 @@ cdef int _get_metadata(void *state,
   return 0  # Asynchronous return
 
 
-cdef void _destroy(void *state) except * with gil:
-  cpython.Py_DECREF(<object>state)
+# Protects access to GIL from _destroy() and to g_shutting_down.
+# Do NOT hold this while holding GIL to prevent a deadlock.
+cdef mutex g_shutdown_mu
+# Number of C-core clean up calls in progress. Set to -1 when Python is shutting
+# down.
+cdef int g_shutting_down = 0
+
+# This is called by C-core when the plugin is destroyed, which may race between
+# GIL destruction during process shutdown. Since GIL destruction happens after
+# Python's exit handlers, we mark that Python is shutting down from an exit
+# handler and don't grab GIL in this function afterwards using a C mutex.
+cdef void _destroy(void *state) noexcept nogil:
+  global g_shutdown_mu
+  global g_shutting_down
+  g_shutdown_mu.lock()
+  if g_shutting_down > -1:
+    g_shutting_down += 1
+    g_shutdown_mu.unlock()
+    with gil:
+      cpython.Py_DECREF(<object>state)
+    g_shutdown_mu.lock()
+    g_shutting_down -= 1
+  g_shutdown_mu.unlock()
   grpc_shutdown()
 
+
+g_shutdown_handler_registered = False
+
+def _maybe_register_shutdown_handler():
+  global g_shutdown_handler_registered
+  if g_shutdown_handler_registered:
+    return
+  g_shutdown_handler_registered = True
+  atexit.register(_on_shutdown)
+
+cdef void _on_shutdown() noexcept nogil:
+  global g_shutdown_mu
+  global g_shutting_down
+  # Wait for up to ~2s if C-core is still cleaning up.
+  cdef int wait_ms = 10
+  while wait_ms < 1500:
+    g_shutdown_mu.lock()
+    if g_shutting_down == 0:
+      g_shutting_down = -1
+      g_shutdown_mu.unlock()
+      return
+    g_shutdown_mu.unlock()
+    with gil:
+      time.sleep(wait_ms / 1000)
+    wait_ms = wait_ms * 2
+  with gil:
+    _LOGGER.error('Timed out waiting for C-core clean-up')
 
 cdef class MetadataPluginCallCredentials(CallCredentials):
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pxd.pxi
@@ -14,8 +14,8 @@
 
 
 cdef bytes _slice_bytes(grpc_slice slice)
-cdef grpc_slice _copy_slice(grpc_slice slice) nogil
-cdef grpc_slice _slice_from_bytes(bytes value) nogil
+cdef grpc_slice _copy_slice(grpc_slice slice) noexcept nogil
+cdef grpc_slice _slice_from_bytes(bytes value) noexcept nogil
 
 
 cdef class CallDetails:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
@@ -18,12 +18,12 @@ cdef bytes _slice_bytes(grpc_slice slice):
   cdef size_t length = grpc_slice_length(slice)
   return (<const char *>start)[:length]
 
-cdef grpc_slice _copy_slice(grpc_slice slice) nogil:
+cdef grpc_slice _copy_slice(grpc_slice slice) noexcept nogil:
   cdef void *start = grpc_slice_start_ptr(slice)
   cdef size_t length = grpc_slice_length(slice)
   return grpc_slice_from_copied_buffer(<const char *>start, length)
 
-cdef grpc_slice _slice_from_bytes(bytes value) nogil:
+cdef grpc_slice _slice_from_bytes(bytes value) noexcept nogil:
   cdef const char *value_ptr
   cdef size_t length
   with gil:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
@@ -14,4 +14,4 @@
 
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
-    char **pem_root_certs) nogil
+    char **pem_root_certs) noexcept nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
@@ -18,7 +18,7 @@ import pkgutil
 
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
-    char **pem_root_certs) nogil:
+    char **pem_root_certs) noexcept nogil:
   with gil:
     pkg = __name__
     if pkg.endswith('.cygrpc'):

--- a/tools/distrib/python/grpcio_tools/grpc_tools/_protoc_compiler.pyx
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/_protoc_compiler.pyx
@@ -43,12 +43,12 @@ cdef extern from "grpc_tools/main.h" namespace "grpc_tools":
                         vector[string]* include_path,
                         vector[pair[string, string]]* files_out,
                         vector[cProtocError]* errors,
-                        vector[cProtocWarning]* wrnings) nogil except +
+                        vector[cProtocWarning]* wrnings) except + nogil
   int protoc_get_services(char* protobuf_path, char* version,
                           vector[string]* include_path,
                           vector[pair[string, string]]* files_out,
                           vector[cProtocError]* errors,
-                          vector[cProtocWarning]* wrnings) nogil except +
+                          vector[cProtocWarning]* wrnings) except + nogil
 
 def run_main(list args not None):
   cdef char **argv = <char **>stdlib.malloc(len(args)*sizeof(char *))


### PR DESCRIPTION
This Backport PR, backports 3 PRs from the master branch:
 - #37784 
 - #37917 
 - #37922 

#37917 and #37922 are backported to fix a potential deadlock that was introduced after Cython was upgraded to v3.x. The file [credentials.pyx.pxi](https://github.com/grpc/grpc/compare/v1.67.x...sreenithi:grpc:v1.67.x?expand=1#diff-9ae05cb62d5bf7b9c01e31854a83a1e8d450d3cea608ace3a32598fb028224f6) changed in #37922 was dependent on a change from #37784  and hence required backporting it too.
