### PR TITLE
[xDS gcp_authn filter] remove upper bound for cache size

### DIFF
--- a/src/core/xds/grpc/xds_http_gcp_authn_filter.cc
+++ b/src/core/xds/grpc/xds_http_gcp_authn_filter.cc
@@ -69,9 +69,9 @@ Json::Object ValidateFilterConfig(
           envoy_extensions_filters_http_gcp_authn_v3_TokenCacheConfig_cache_size(
               cache_config))
           .value_or(10);
-  if (cache_size == 0 || cache_size >= INT64_MAX) {
+  if (cache_size == 0) {
     ValidationErrors::ScopedField field(errors, ".cache_config.cache_size");
-    errors->AddError("must be in the range (0, INT64_MAX)");
+    errors->AddError("must be greater than 0");
   }
   config["cache_size"] = Json::FromNumber(cache_size);
   return config;

--- a/test/core/xds/xds_http_filters_test.cc
+++ b/test/core/xds/xds_http_filters_test.cc
@@ -1574,25 +1574,7 @@ TEST_F(XdsGcpAuthnFilterTest, GenerateFilterConfigCacheSizeZero) {
             "field:http_filter.value["
             "envoy.extensions.filters.http.gcp_authn.v3.GcpAuthnFilterConfig]"
             ".cache_config.cache_size "
-            "error:must be in the range (0, INT64_MAX)]")
-      << status;
-}
-
-TEST_F(XdsGcpAuthnFilterTest, GenerateFilterConfigCacheSizeTooBig) {
-  GcpAuthnFilterConfig proto;
-  proto.mutable_cache_config()->mutable_cache_size()->set_value(INT64_MAX);
-  XdsExtension extension = MakeXdsExtension(proto);
-  auto config = filter_->GenerateFilterConfig("langley", decode_context_,
-                                              std::move(extension), &errors_);
-  absl::Status status = errors_.status(absl::StatusCode::kInvalidArgument,
-                                       "errors validating filter config");
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_EQ(status.message(),
-            "errors validating filter config: ["
-            "field:http_filter.value["
-            "envoy.extensions.filters.http.gcp_authn.v3.GcpAuthnFilterConfig]"
-            ".cache_config.cache_size "
-            "error:must be in the range (0, INT64_MAX)]")
+            "error:must be greater than 0]")
       << status;
 }
 


### PR DESCRIPTION
As per discussion in https://github.com/grpc/proposal/pull/438#discussion_r1813247252.