### PR TITLE
[XdsClient] Add missing authority to XdsClient metrics scope

### DIFF
--- a/include/grpc/support/metrics.h
+++ b/include/grpc/support/metrics.h
@@ -24,7 +24,11 @@ namespace grpc_core {
 namespace experimental {
 
 // Configuration (scope) for a specific client channel to be used for stats
-// plugins.
+// plugins. For some components like XdsClient where the same XdsClient instance
+// can be shared across multiple channels that share the same target name but
+// have different default authority and channel arguments, the component uses
+// the configuration from the first channel that uses this XdsClient instance to
+// determine StatsPluginChannelScope.
 class StatsPluginChannelScope {
  public:
   StatsPluginChannelScope(

--- a/src/core/xds/grpc/xds_client_grpc.cc
+++ b/src/core/xds/grpc/xds_client_grpc.cc
@@ -232,7 +232,7 @@ GetStatsPluginGroupForKeyAndChannelArgs(absl::string_view key,
     return GlobalStatsPluginRegistry::GetStatsPluginsForServer(channel_args);
   }
   grpc_event_engine::experimental::ChannelArgsEndpointConfig endpoint_config(
-      ChannelArgs{channel_args});
+      channel_args);
   std::string authority =
       channel_args.GetOwnedString(GRPC_ARG_DEFAULT_AUTHORITY)
           .value_or(

--- a/src/core/xds/grpc/xds_client_grpc.cc
+++ b/src/core/xds/grpc/xds_client_grpc.cc
@@ -232,7 +232,7 @@ GetStatsPluginGroupForKeyAndChannelArgs(absl::string_view key,
     return GlobalStatsPluginRegistry::GetStatsPluginsForServer(channel_args);
   }
   grpc_event_engine::experimental::ChannelArgsEndpointConfig endpoint_config(
-      ChannelArgs{});
+      ChannelArgs{channel_args});
   std::string authority =
       channel_args.GetOwnedString(GRPC_ARG_DEFAULT_AUTHORITY)
           .value_or(
@@ -250,11 +250,6 @@ absl::StatusOr<RefCountedPtr<GrpcXdsClient>> GrpcXdsClient::GetOrCreate(
   // instance for the channel or server instead of using the global instance.
   absl::optional<absl::string_view> bootstrap_config = args.GetString(
       GRPC_ARG_TEST_ONLY_DO_NOT_USE_IN_PROD_XDS_BOOTSTRAP_CONFIG);
-  std::string channel_default_authority =
-      args.GetOwnedString(GRPC_ARG_DEFAULT_AUTHORITY)
-          .value_or(
-              CoreConfiguration::Get().resolver_registry().GetDefaultAuthority(
-                  key));
   if (bootstrap_config.has_value()) {
     auto bootstrap = GrpcXdsBootstrap::Create(*bootstrap_config);
     if (!bootstrap.ok()) return bootstrap.status();

--- a/src/core/xds/grpc/xds_client_grpc.h
+++ b/src/core/xds/grpc/xds_client_grpc.h
@@ -63,7 +63,8 @@ class GrpcXdsClient final : public XdsClient {
   GrpcXdsClient(absl::string_view key,
                 std::shared_ptr<GrpcXdsBootstrap> bootstrap,
                 const ChannelArgs& args,
-                RefCountedPtr<XdsTransportFactory> transport_factory);
+                RefCountedPtr<XdsTransportFactory> transport_factory,
+                GlobalStatsPluginRegistry::StatsPluginGroup stats_plugin_group);
 
   // Helpers for encoding the XdsClient object in channel args.
   static absl::string_view ChannelArgName() {

--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -1122,10 +1122,16 @@ class XdsMetricsTest : public XdsEnd2endTest {
                 [](const grpc_core::experimental::StatsPluginChannelScope&
                        scope) {
                   return scope.target() == absl::StrCat("xds:", kServerName) &&
-                         scope.default_authority() == kServerName;
+                         scope.default_authority() == kServerName &&
+                         scope.experimental_args().GetString("test_only.arg") ==
+                             "test_only.value";
                 })
             .BuildAndRegister();
-    InitClient();
+    ChannelArguments args;
+    args.SetString("test_only.arg", "test_only.value");
+    InitClient(/*builder=*/absl::nullopt, /*lb_expected_authority=*/"",
+               /*xds_resource_does_not_exist_timeout_ms=*/0,
+               /*balancer_authority_override=*/"", /*args=*/&args);
   }
 
   std::shared_ptr<grpc_core::FakeStatsPlugin> stats_plugin_;

--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -1115,9 +1115,16 @@ TEST_P(XdsFederationTest, FederationServer) {
 class XdsMetricsTest : public XdsEnd2endTest {
  protected:
   void SetUp() override {
-    stats_plugin_ = grpc_core::FakeStatsPluginBuilder()
-                        .UseDisabledByDefaultMetrics(true)
-                        .BuildAndRegister();
+    stats_plugin_ =
+        grpc_core::FakeStatsPluginBuilder()
+            .UseDisabledByDefaultMetrics(true)
+            .SetChannelFilter(
+                [](const grpc_core::experimental::StatsPluginChannelScope&
+                       scope) {
+                  return scope.target() == absl::StrCat("xds:", kServerName) &&
+                         scope.default_authority() == kServerName;
+                })
+            .BuildAndRegister();
     InitClient();
   }
 


### PR DESCRIPTION
Fix for b/365993761.

Noticed that XdsClient metrics were not being reported due to authority not being properly set. 

This solution is not perfect since channels created later can possibly use a different authority, so preferring to use the default authority from the first channel.