### PR TITLE
Remove unused definition of ResolvedAddrToUnixPathIfPossible

### DIFF
--- a/src/core/lib/event_engine/tcp_socket_utils.cc
+++ b/src/core/lib/event_engine/tcp_socket_utils.cc
@@ -141,12 +141,6 @@ absl::StatusOr<std::string> ResolvedAddrToUriUnixIfPossible(
   return uri->ToString();
 }
 #else
-
-absl::StatusOr<std::string> ResolvedAddrToUnixPathIfPossible(
-    const EventEngine::ResolvedAddress* /*resolved_addr*/) {
-  return absl::InvalidArgumentError("Unix socket is not supported.");
-}
-
 absl::StatusOr<std::string> ResolvedAddrToUriUnixIfPossible(
     const EventEngine::ResolvedAddress* /*resolved_addr*/) {
   return absl::InvalidArgumentError("Unix socket is not supported.");


### PR DESCRIPTION
ResolvedAddrToUnixPathIfPossible is only called when GRPC_HAVE_UNIX_SOCKET is defined, so there's no need to define that function when it isn't.