### PR TITLE
Fix tools typos

### DIFF
--- a/tools/bazelify_tests/grpc_build_artifact_task.sh
+++ b/tools/bazelify_tests/grpc_build_artifact_task.sh
@@ -54,7 +54,7 @@ SCRIPT_EXIT_CODE=0
 ../"${BUILD_SCRIPT}" >"../${SCRIPT_LOG_FILE}" 2>&1  || SCRIPT_EXIT_CODE="$?"
 
 # Store build script's exitcode in a file.
-# Note that the build atifacts task will terminate with success even when
+# Note that the build artifacts task will terminate with success even when
 # there was an error building the artifacts.
 # The error status (an associated log) will be reported by an associated
 # bazel test.

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -296,7 +296,7 @@ def _extract_sources(bazel_rule: BuildMetadata) -> List[str]:
 def _extract_deps(
     bazel_rule: BuildMetadata, bazel_rules: BuildDict
 ) -> List[str]:
-    """Gets list of deps from from a bazel rule"""
+    """Gets list of deps from a bazel rule"""
     deps = set(bazel_rule["deps"])
     for src in bazel_rule["srcs"]:
         if (
@@ -495,7 +495,7 @@ def _compute_transitive_metadata(
                 )
     # This item is a "visited" flag
     bazel_rule["_PROCESSING_DONE"] = True
-    # Following items are described in the docstinrg.
+    # Following items are described in the docstring.
     bazel_rule["_TRANSITIVE_DEPS"] = list(sorted(transitive_deps))
     bazel_rule["_COLLAPSED_DEPS"] = list(sorted(collapsed_deps))
     bazel_rule["_COLLAPSED_SRCS"] = list(sorted(collapsed_srcs))
@@ -539,7 +539,7 @@ def update_test_metadata_with_transitive_metadata(
 ) -> None:
     """Patches test build metadata with transitive metadata."""
     for lib_name, lib_dict in list(all_extra_metadata.items()):
-        # Skip if it isn't not an test
+        # Skip if it isn't a test
         if (
             lib_dict.get("build") != "test"
             and lib_dict.get("build") != "plugin_test"
@@ -713,7 +713,7 @@ def _generate_build_metadata(
     # Rename targets marked with "_RENAME" extra metadata.
     # This is mostly a cosmetic change to ensure that we end up with build.yaml target
     # names we're used to from the past (and also to avoid too long target names).
-    # The rename step needs to be made after we're done with most of processing logic
+    # The rename step needs to be made after we're done with most processing logic
     # otherwise the already-renamed libraries will have different names than expected
     for lib_name in lib_names:
         to_name = build_extra_metadata.get(lib_name, {}).get("_RENAME", None)

--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -97,7 +97,7 @@ def isCompileTarget(target, args):
 def modifyCompileCommand(target, args):
     cc, options = target["command"].split(" ", 1)
 
-    # Workaround for bazel added C++14 options, those doesn't affect build itself but
+    # Workaround for bazel added C++14 options, those don't affect the build itself but
     # clang-tidy will misinterpret them.
     options = options.replace("-std=c++0x ", "")
     options = options.replace("-std=c++14 ", "")

--- a/tools/distrib/python/grpcio_tools/_parallel_compile_patch.py
+++ b/tools/distrib/python/grpcio_tools/_parallel_compile_patch.py
@@ -18,7 +18,7 @@
 # instead. This file can be regenerated from the template by running
 # `tools/buildgen/generate_projects.sh`.
 
-"""Patches the compile() to allow enable parallel compilation of C/C++.
+"""Patches compile() to enable parallel compilation of C/C++.
 
 build_ext has lots of C/C++ files and normally them one by one.
 Enabling parallel build helps a lot.

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -191,7 +191,7 @@ if EXTRA_ENV_LINK_ARGS is None:
     # This is needed for protobuf/main.cc
     if "win32" in sys.platform:
         EXTRA_ENV_LINK_ARGS += " Shell32.lib"
-    # NOTE(rbellevi): Clang on Mac OS will make all static symbols (both
+    # NOTE(rbellevi): Clang on MacOS will make all static symbols (both
     # variables and objects) global weak symbols. When a process loads the
     # protobuf wheel's shared object library before loading *this* C extension,
     # the runtime linker will prefer the protobuf module's version of symbols.

--- a/tools/distrib/python/xds_protos/envoy/service/rate_limit_quota/v3/rlqs_pb2_grpc.py
+++ b/tools/distrib/python/xds_protos/envoy/service/rate_limit_quota/v3/rlqs_pb2_grpc.py
@@ -8,7 +8,7 @@ from envoy.service.rate_limit_quota.v3 import rlqs_pb2 as envoy_dot_service_dot_
 class RateLimitQuotaServiceStub(object):
     """[#protodoc-title: Rate Limit Quota Service (RLQS)]
 
-    The Rate Limit Quota Service (RLQS) is a Envoy global rate limiting service that allows to
+    The Rate Limit Quota Service (RLQS) is an Envoy global rate limiting service that allows to
     delegate rate limit decisions to a remote service. The service will aggregate the usage reports
     from multiple data plane instances, and distribute Rate Limit Assignments to each instance
     based on its business logic. The logic is outside of the scope of the protocol API.
@@ -61,7 +61,7 @@ class RateLimitQuotaServiceStub(object):
 class RateLimitQuotaServiceServicer(object):
     """[#protodoc-title: Rate Limit Quota Service (RLQS)]
 
-    The Rate Limit Quota Service (RLQS) is a Envoy global rate limiting service that allows to
+    The Rate Limit Quota Service (RLQS) is an Envoy global rate limiting service that allows to
     delegate rate limit decisions to a remote service. The service will aggregate the usage reports
     from multiple data plane instances, and distribute Rate Limit Assignments to each instance
     based on its business logic. The logic is outside of the scope of the protocol API.
@@ -124,7 +124,7 @@ def add_RateLimitQuotaServiceServicer_to_server(servicer, server):
 class RateLimitQuotaService(object):
     """[#protodoc-title: Rate Limit Quota Service (RLQS)]
 
-    The Rate Limit Quota Service (RLQS) is a Envoy global rate limiting service that allows to
+    The Rate Limit Quota Service (RLQS) is an Envoy global rate limiting service that allows to
     delegate rate limit decisions to a remote service. The service will aggregate the usage reports
     from multiple data plane instances, and distribute Rate Limit Assignments to each instance
     based on its business logic. The logic is outside of the scope of the protocol API.

--- a/tools/dockerfile/README.md
+++ b/tools/dockerfile/README.md
@@ -26,7 +26,7 @@ as follows:
 us-docker.pkg.dev/grpc-testing/testing-images-public/cxx_debian11_x64:[CURRENT_CHECKSUM]@sha256:[CURRENT_SHA256_DIGEST]
 ```
 This info can be passed directly to `docker run` command to get an environment
-that's identical what what we use when testing on CI.
+that's identical to what we use when testing on CI.
 
 ## Updating the images
 

--- a/tools/dockerfile/grpc_artifact_python_linux_armv7/install_python_for_wheel_crosscompilation.sh
+++ b/tools/dockerfile/grpc_artifact_python_linux_armv7/install_python_for_wheel_crosscompilation.sh
@@ -17,7 +17,7 @@ set -ex
 
 # ARGUMENTS
 # $1 - python version in "3.X.Y" format
-# $2 - python tags (as in manylinx images) e.g. "/opt/python/cp37-cp37m"
+# $2 - python tags (as in manylinux images) e.g. "/opt/python/cp37-cp37m"
 PYTHON_VERSION="$1"
 PYTHON_RELEASE="$2"
 PYTHON_PREFIX="$3"

--- a/tools/dockerfile/test/cxx_gcc_7_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_7_x64/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -sSL -o cmake-linux.sh https://github.com/Kitware/CMake/releases/downlo
     && rm cmake-linux.sh
 
 #=================
-# Install ccache (use slighly older release of ccache that works older compilers and cmake)
+# Install ccache (use slightly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/tools/dockerfile/test/cxx_gcc_8_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_gcc_8_x64/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -sSL -o cmake-linux.sh https://github.com/Kitware/CMake/releases/downlo
     && rm cmake-linux.sh
 
 #=================
-# Install ccache (use slighly older release of ccache that works older compilers and cmake)
+# Install ccache (use slightly older release of ccache that works older compilers and cmake)
 
 # Install ccache from source since ccache 3.x packaged with most linux distributions
 # does not support Redis backend for caching.

--- a/tools/doxygen/Doxyfile.php
+++ b/tools/doxygen/Doxyfile.php
@@ -66,7 +66,7 @@ OUTPUT_DIRECTORY       = doc/ref/php
 # directories (in 2 levels) under the output directory of each output format and
 # will distribute the generated files over these directories. Enabling this
 # option can be useful when feeding doxygen a huge amount of source files, where
-# putting all generated files in the same directory would otherwise causes
+# putting all generated files in the same directory would otherwise cause
 # performance problems for the file system.
 # The default value is: NO.
 
@@ -450,7 +450,7 @@ EXTRACT_LOCAL_METHODS  = NO
 # If this flag is set to YES, the members of anonymous namespaces will be
 # extracted and appear in the documentation as a namespace called
 # 'anonymous_namespace{file}', where file will be replaced with the base name of
-# the file that contains the anonymous namespace. By default anonymous namespace
+# the file that contains the anonymous namespace. By default anonymous namespaces
 # are hidden.
 # The default value is: NO.
 

--- a/tools/http2_interop/testsuite.go
+++ b/tools/http2_interop/testsuite.go
@@ -26,7 +26,7 @@ import (
 // This means the name of the test case is lost, so we need to grab a copy of pc before.
 func Report(t testing.TB) {
 	// If the goroutine panics, Fatal()s, or Skip()s, the function name is at the 3rd callstack
-	// layer.  On success, its at 1st.  Since it's hard to check which happened, just try both.
+	// layer.  On success, it's at 1st.  Since it's hard to check which happened, just try both.
 	pcs := make([]uintptr, 10)
 	total := runtime.Callers(1, pcs)
 	var name string

--- a/tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
+++ b/tools/internal_ci/helper_scripts/check_python_artifacts_size.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Checks if any of the Python artifacts exceeds a certern size limit since
+# Checks if any of the Python artifacts exceeds a certain size limit since
 # Pypi has a per-file size limit.
 
 set -ex

--- a/tools/internal_ci/helper_scripts/prepare_qemu_rc
+++ b/tools/internal_ci/helper_scripts/prepare_qemu_rc
@@ -33,5 +33,5 @@ cat /proc/sys/fs/binfmt_misc/qemu-aarch64
 # to install qemu-user-static with the right flags.
 docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset --credential yes --persistent yes
 
-# Print current qemu reqistration to make sure everything is setup correctly.
+# Print current qemu registration to make sure everything is setup correctly.
 cat /proc/sys/fs/binfmt_misc/qemu-aarch64

--- a/tools/internal_ci/linux/grpc_distribtests_ruby.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_ruby.sh
@@ -32,7 +32,7 @@ source tools/internal_ci/helper_scripts/prepare_ccache_rc
 # Build all ruby linux artifacts (this step actually builds all the native and source gems)
 tools/run_tests/task_runner.py -f artifact linux ruby ${TASK_RUNNER_EXTRA_FILTERS} -j 6 --inner_jobs 6 -x build_artifacts/sponge_log.xml || FAILED="true"
 
-# Ruby "build_package" step is basically just a passthough for the "grpc" gems, so it's enough to just
+# Ruby "build_package" step is basically just a passthrough for the "grpc" gems, so it's enough to just
 # copy the native gems directly to the "distribtests" step and skip the "build_package" phase entirely.
 # Note that by skipping the "build_package" step, we are also skipping the build of "grpc-tools" gem
 # but that's fine since the distribtests only test the "grpc" native gems.

--- a/tools/internal_ci/linux/grpc_sample_fuzzers_failure_explanation.txt
+++ b/tools/internal_ci/linux/grpc_sample_fuzzers_failure_explanation.txt
@@ -5,7 +5,7 @@
 *******************************************************************************
 
 
-HEY THIS TEST IS FAILING AND I DONT KNOW HOW TO REPRODUCE IT??
+HEY THIS TEST IS FAILING AND I DON'T KNOW HOW TO REPRODUCE IT??
 
 At the point when this file was authored, I had no idea how to get the crash
 artifacts out of bazel/the fuzzer/kokoro/somewhere and onto your machine.

--- a/tools/internal_ci/macos/grpc_distribtests_php.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_php.sh
@@ -27,7 +27,7 @@ source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 # Build all PHP macos artifacts
 tools/run_tests/task_runner.py -f artifact macos php ${TASK_RUNNER_EXTRA_FILTERS} -j 4 -x build_artifacts/sponge_log.xml || FAILED="true"
 
-# PHP's "build_package" step is basically just a passthough, so the build artifacts can be used
+# PHP's "build_package" step is basically just a passthrough, so the build artifacts can be used
 # directly by the "distribtests" step (and we skip the "build_package" phase entirely on mac).
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.

--- a/tools/interop_matrix/README.md
+++ b/tools/interop_matrix/README.md
@@ -5,7 +5,7 @@ This directory contains scripts that facilitate building and running gRPC intero
 The setup builds gRPC docker images for each language/runtime and upload it to Artifact Registry (AR). These images, encapsulating gRPC stack
 from specific releases/tag, are used to test version compatibility between gRPC release versions.
 
-## Step-by-step instructions for adding a AR docker image for a new release for compatibility test
+## Step-by-step instructions for adding an AR docker image for a new release for compatibility test
 
 We have continuous nightly test setup to test gRPC backward compatibility between old clients and latest server.
 When a gRPC developer creates a new gRPC release, s/he is also responsible to add the just-released gRPC client to the nightly test.

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -233,7 +233,7 @@ def build_all_images_for_release(lang, release):
     build_jobs = []
 
     env = {}
-    # If we not using current tree or the sibling for grpc stack, do checkout.
+    # If we're not using current tree or the sibling for grpc stack, do checkout.
     stack_base = ""
     if args.git_checkout:
         stack_base = checkout_grpc_stack(lang, release)

--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -160,7 +160,7 @@ def _read_test_cases_file(lang, runtime, release):
         testcases_file = "%s__master" % lang
 
     # For csharp, the testcases file used depends on the runtime
-    # TODO(jtattermusch): remove this odd specialcase
+    # TODO(jtattermusch): remove this odd special case
     if lang == "csharp" and runtime == "csharpcoreclr":
         testcases_file = testcases_file.replace("csharp_", "csharpcoreclr_")
 

--- a/tools/release/release_notes.py
+++ b/tools/release/release_notes.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Generate draft and release notes in Markdown from Github PRs.
+"""Generate draft and release notes in Markdown from GitHub PRs.
 
 You'll need a github API token to avoid being rate-limited. See
 https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
@@ -168,7 +168,7 @@ def get_pr_titles(gitLogs):
     print(prlist_merge_pr)
     print("\n")
 
-    # PRs using Github's squash & merge feature
+    # PRs using GitHub's squash & merge feature
     match_sq = "^([a-fA-F0-9]+) .*\(#(\d+)\)$"
     matches = re.findall(match_sq, gitLogs, re.MULTILINE)
     if matches:

--- a/tools/release/update_supported_bazel_versions.sh
+++ b/tools/release/update_supported_bazel_versions.sh
@@ -20,7 +20,7 @@
 
 # This script selects the latest patch release of the two most recent major
 # versions of Bazel. If you want to include other versions in the set of
-# supported versions, then you will need to manually edit the ifle.
+# supported versions, then you will need to manually edit the file.
 
 set -xeuo pipefail
 

--- a/tools/release/verify_python_release.py
+++ b/tools/release/verify_python_release.py
@@ -71,7 +71,7 @@ def _get_local_artifacts():
 def _get_remote_artifacts_for_package(package, version):
     """Get a list of artifacts based on PyPi's json metadata.
 
-    Note that this data will not updated immediately after upload. In my
+    Note that this data will not be updated immediately after upload. In my
     experience, it has taken a minute on average to be fresh.
     """
     artifacts = set()

--- a/tools/run_tests/README.md
+++ b/tools/run_tests/README.md
@@ -39,7 +39,7 @@ See [end-to-end benchmarking documentation](/tools/run_tests/peformance/README.m
 
 # Artifacts & Packages (task_runner.py)
 
-A generalized framework for running predefined tasks based on their labels. We use this to building binary artifacts & distrib packages and testing them)
+A generalized framework for running predefined tasks based on their labels. We use this to build binary artifacts & distrib packages and testing them.
 
 ###### Example
 `tools/run_tests/task_runner.py -f python artifact linux x64` (build tasks with labels `python`, `artifact`, `linux`, and `x64`)

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -72,7 +72,7 @@ if [ "$AUDITWHEEL_ARCH" == "armv7l" ]
 then
   # when crosscompiling for arm, --plat-name needs to be set explicitly
   # to end up with correctly named wheel file
-  # our dockcross-based docker image onveniently provides the value in the AUDITWHEEL_PLAT env
+  # our dockcross-based docker image conveniently provides the value in the AUDITWHEEL_PLAT env
   WHEEL_PLAT_NAME_FLAG="--plat-name=$AUDITWHEEL_PLAT"
 
   # override the value of EXT_SUFFIX to make sure the crosscompiled .so files in the wheel have the correct filename suffix

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -120,7 +120,7 @@ class CSharpDistribTest(object):
         return []
 
     def build_jobspec(self, inner_jobs=None):
-        del inner_jobs  # arg unused as there is little opportunity for parallelizing whats inside the distribtests
+        del inner_jobs  # arg unused as there is little opportunity for parallelizing what's inside the distribtests
         if self.platform == "linux":
             return create_docker_jobspec(
                 self.name,

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -28,7 +28,7 @@ cd -
 # DOCKERFILE_DIR - Directory in which Dockerfile file is located.
 # OUTPUT_DIR - (optional) Directory under the git repo root that will be copied from inside docker container after finishing.
 # DOCKER_RUN_SCRIPT - (optional) Script to run under docker (relative to grpc repo root). If specified, the cmdline args
-#     passed on the commadline (a.k.a. $@) will be interpreted as extra args to pass to the "docker run" command.
+#     passed on the commandline (a.k.a. $@) will be interpreted as extra args to pass to the "docker run" command.
 #     If DOCKER_RUN_SCRIPT is not set, $@ will be interpreted as the command and args to run under the docker container.
 
 # The exact docker image to use and its version is determined by the corresponding .current_version file

--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -317,7 +317,7 @@ This approach is much more involved than using the gRPC OSS benchmarks framework
 
 In general the benchmark workers and driver build scripts expect
 [linux_performance_worker_init.sh](../../gce/linux_performance_worker_init.sh)
-to have been ran already.
+to have been run already.
 
 ### To run benchmarks locally:
 

--- a/tools/run_tests/performance/bq_upload_result.py
+++ b/tools/run_tests/performance/bq_upload_result.py
@@ -236,7 +236,7 @@ def _populate_metadata_from_file(scenario_result, test_metadata_file):
 
         annotations = test_metadata.get("annotations", {})
 
-        # if use kubectl apply ..., kubectl will append current configuration to
+        # if using kubectl apply ..., kubectl will append current configuration to
         # annotation, the field is deleted since it includes a lot of irrelevant
         # information
         if "kubectl.kubernetes.io/last-applied-configuration" in annotations:

--- a/tools/run_tests/performance/build_performance_php7.sh
+++ b/tools/run_tests/performance/build_performance_php7.sh
@@ -19,7 +19,7 @@ cd "$(dirname "$0")/../../.."
 CONFIG=${CONFIG:-opt}
 python tools/run_tests/run_tests.py -l php7 -c "$CONFIG" --build_only -j 8
 
-# Set up all dependences needed for PHP QPS test
+# Set up all dependencies needed for PHP QPS test
 cd src/php/tests/qps
 composer install
 # Install protobuf C-extension for php

--- a/tools/run_tests/performance/loadtest_examples.sh
+++ b/tools/run_tests/performance/loadtest_examples.sh
@@ -130,7 +130,7 @@ prebuilt_example() {
     echo "Created example: ${outputdir}/${outputfile}"
 }
 
-# PSM basic examples are intended to be runnable with only subsituding the
+# PSM basic examples are intended to be runnable with only substituting the
 # xds-server and sidecar images, so substitution keys for xds-server and 
 # sidecar images are kept. 
 psm_basic_example() {

--- a/tools/run_tests/performance/run_worker_csharp.sh
+++ b/tools/run_tests/performance/run_worker_csharp.sh
@@ -17,7 +17,7 @@ set -ex
 
 cd "$(dirname "$0")/../../.."
 
-# needed to correctly locate testca
+# needed to correctly locate testcase
 cd src/csharp/Grpc.IntegrationTesting.QpsWorker/bin/Release/netcoreapp3.1
 
 dotnet exec Grpc.IntegrationTesting.QpsWorker.dll "$@"

--- a/tools/run_tests/python_utils/bazel_report_helper.py
+++ b/tools/run_tests/python_utils/bazel_report_helper.py
@@ -87,7 +87,7 @@ def _generate_junit_report_string(
             % bazel_invocation_url
         )
     else:
-        # The failure output will be displayes in both resultstore UI and sponge when clicking on the failing testcase.
+        # The failure output will be displayed in both resultstore UI and sponge when clicking on the failing testcase.
         test_output_tag = (
             '<failure message="Failure">FAILED. See bazel invocation results'
             " here: %s</failure>" % bazel_invocation_url

--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -131,7 +131,7 @@ cronet_restricted_ports = [
 
 
 def can_connect(port):
-    # this test is only really useful on unices where SO_REUSE_PORT is available
+    # this test is only really useful on Unixes where SO_REUSE_PORT is available
     # so on Windows, where this test is expensive, skip it
     if platform.system() == "Windows":
         return False

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -526,7 +526,7 @@ profile_output_files = []
 
 # Collect perf text reports and flamegraphs if perf_cmd was used
 # Note the base names of perf text reports are used when creating and processing
-# perf data. The scenario name uniqifies the output name in the final
+# perf data. The scenario name uniquifies the output name in the final
 # perf reports directory.
 # Also, the perf profiles need to be fetched and processed after each scenario
 # in order to avoid clobbering the output files.

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -194,7 +194,7 @@ def _check_arch(arch, supported_archs):
 
 
 def _is_use_docker_child():
-    """Returns True if running running as a --use_docker child."""
+    """Returns True if running as a --use_docker child."""
     return True if os.getenv("DOCKER_RUN_SCRIPT_COMMAND") else False
 
 
@@ -1509,7 +1509,7 @@ def _build_and_run(
                 )
             )
         )
-        # When running on travis, we want out test runs to be as similar as possible
+        # When running on travis, we want our test runs to be as similar as possible
         # for reproducibility purposes.
         if args.travis and args.max_time <= 0:
             massaged_one_run = sorted(one_run, key=lambda x: x.cpu_cost)

--- a/tools/run_tests/run_xds_tests.py
+++ b/tools/run_tests/run_xds_tests.py
@@ -1436,7 +1436,7 @@ def test_api_listener(
         )
         if not gcp.service_port:
             raise Exception(
-                "Faied to find a valid port for the forwarding rule"
+                "Failed to find a valid port for the forwarding rule"
             )
         potential_ip_addresses = []
         max_attempts = 10
@@ -2870,7 +2870,7 @@ def test_csds(gcp, original_backend_service, instance_group, server_uri):
                 ok = False
             finally:
                 if ok:
-                    # Successfully fetched xDS config, and they looks good.
+                    # Successfully fetched xDS config, and it looks good.
                     logger.info("success")
                     return
         logger.info("test_csds attempt %d failed", cnt)


### PR DESCRIPTION
Continuation of #37541 but focused on tools.

FYI, typos are:
* atifacts
* building
* certern
* commadline
* dependences
* displayes
* docstinrg
* doesn
* faied
* ifle
* manylinx
* onveniently
* passthough
* reqistration
* slighly
* subsituding
* testca
* unices
* uniqifies