### PR TITLE
[ObjC] remove CLANG_CXX_LANGUAGE_STANDARD from podspecs

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -68,7 +68,6 @@ Pod::Spec.new do |s|
     # build.
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
   }
 
   s.libraries = 'c++'

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -88,7 +88,6 @@ Pod::Spec.new do |s|
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
     'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
     'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
   }
 
   s.default_subspecs = 'Interface', 'Implementation'

--- a/gRPC-ProtoRPC.podspec
+++ b/gRPC-ProtoRPC.podspec
@@ -85,6 +85,5 @@ Pod::Spec.new do |s|
     # This is needed by all pods that depend on gRPC-RxLibrary:
     'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
     'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
   }
 end

--- a/gRPC-RxLibrary.podspec
+++ b/gRPC-RxLibrary.podspec
@@ -67,6 +67,5 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
   }
 end

--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -42,7 +42,6 @@ Pod::Spec.new do |s|
     # This is needed by all pods that depend on gRPC-RxLibrary:
     'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
     'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
   }
 
   s.ios.deployment_target = '11.0'

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -152,7 +152,6 @@
       # build.
       'USE_HEADERMAP' => 'NO',
       'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     }
 
     s.libraries = 'c++'

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -164,7 +164,6 @@
       'ALWAYS_SEARCH_USER_PATHS' => 'NO',
       'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     }
 
     s.default_subspecs = 'Interface', 'Implementation'

--- a/templates/gRPC-ProtoRPC.podspec.template
+++ b/templates/gRPC-ProtoRPC.podspec.template
@@ -87,6 +87,5 @@
       # This is needed by all pods that depend on gRPC-RxLibrary:
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     }
   end

--- a/templates/gRPC-RxLibrary.podspec.template
+++ b/templates/gRPC-RxLibrary.podspec.template
@@ -69,6 +69,5 @@
 
     s.pod_target_xcconfig = {
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     }
   end

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -44,7 +44,6 @@
       # This is needed by all pods that depend on gRPC-RxLibrary:
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
     }
 
     s.ios.deployment_target = '11.0'

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -99,7 +99,7 @@ then
   # cocoapods
   export LANG=en_US.UTF-8
   # use "sudo" to avoid permission error on kokoro monterey image
-  time sudo gem install cocoapods --version 1.15.2 --no-document --user-install
+  time sudo gem install cocoapods --version 1.16.1 --no-document --user-install
   # pre-fetch cocoapods master repo's most recent commit only
   mkdir -p ~/.cocoapods/repos
   time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master


### PR DESCRIPTION
This conflicts with defaults and cause build errors like https://github.com/firebase/firebase-ios-sdk/pull/13989

