### PR TITLE
[EventEngine] Add stronger wording on Endpoint::Read contract

### DIFF
--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -196,7 +196,10 @@ class EventEngine : public std::enable_shared_from_this<EventEngine>,
     /// caller must ensure that the callback has access to the buffer when it
     /// executes. Ownership of the buffer is not transferred. Either an error is
     /// passed to the callback (like socket closed), or valid data is available
-    /// in the buffer, but never both at the same time.
+    /// in the buffer, but never both at the same time. Implementations that
+    /// receive valid data must not throw that data away - that is, if valid
+    /// data is received on the underlying endpoint, a callback will be made
+    /// with that data available and an ok status.
     ///
     /// There can be at most one outstanding read per Endpoint at any given
     /// time. An outstanding read is one in which the \a on_read callback has

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -194,9 +194,9 @@ class EventEngine : public std::enable_shared_from_this<EventEngine>,
     /// on_read callback is not executed. Otherwise it returns false and the \a
     /// on_read callback executes asynchronously when the read completes. The
     /// caller must ensure that the callback has access to the buffer when it
-    /// executes. Ownership of the buffer is not transferred. Valid slices *may*
-    /// be placed into the buffer even if the callback is invoked with a non-OK
-    /// Status.
+    /// executes. Ownership of the buffer is not transferred. Either an error is
+    /// passed to the callback (like socket closed), or valid data is available
+    /// in the buffer, but never both at the same time.
     ///
     /// There can be at most one outstanding read per Endpoint at any given
     /// time. An outstanding read is one in which the \a on_read callback has


### PR DESCRIPTION
tl;dr: If data is received on the underlying endpoint, it must never be discarded.