### PR TITLE
[XdsE2ETest] Fix MtlsWithAggregateCluster to gracefully switch

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -808,7 +808,7 @@ TEST_P(XdsSecurityTest, MtlsWithAggregateCluster) {
   EXPECT_EQ(backends_[0]->backend_service()->last_peer_identity(),
             authenticated_identity_);
   // Now stop backend 0 and wait for backend 1.
-  ShutdownBackend(0);
+  backends_[0]->StopListeningAndSendGoaways();
   WaitForBackend(DEBUG_LOCATION, 1);
   // Make sure the backend saw the right client identity.
   EXPECT_EQ(backends_[1]->backend_service()->last_peer_identity(),


### PR DESCRIPTION
Fix for flakes like https://btx.cloud.google.com/invocations/f12c8322-287a-4333-b2db-0ba14711546d/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_end2end_test@poller%3Depoll1;config=f78d0de70f525043d29a05fb7a78970999e04b7f8a87d8c4e974688bf7616998/tests

The `Shutdown` method is not graceful. For graceful shutdown, we should instead stop listening and send goaways. 
