### PR TITLE
[PHP] remove PersistentChannelTest.testInitHelper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6524,6 +6524,7 @@ target_link_libraries(activity_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -9182,6 +9183,7 @@ target_link_libraries(call_state_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -14229,6 +14231,7 @@ target_link_libraries(exec_ctx_wakeup_scheduler_test
   upb_wire_lib
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -18509,6 +18512,7 @@ target_link_libraries(inter_activity_pipe_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -19393,6 +19397,7 @@ target_link_libraries(latch_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -20877,6 +20882,7 @@ target_link_libraries(mpsc_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -21380,6 +21386,7 @@ target_link_libraries(observable_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -23257,6 +23264,7 @@ target_link_libraries(promise_mutex_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor
@@ -33052,6 +33060,7 @@ target_link_libraries(wait_for_callback_test
   gtest
   absl::config
   absl::flat_hash_map
+  absl::function_ref
   absl::hash
   absl::type_traits
   absl::statusor

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -5255,6 +5255,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -6586,6 +6587,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -9848,6 +9850,7 @@ targets:
   - upb_wire_lib
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -12000,6 +12003,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -12564,6 +12568,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -13385,6 +13390,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -13699,6 +13705,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -14620,6 +14627,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor
@@ -20488,6 +20496,7 @@ targets:
   - gtest
   - absl/base:config
   - absl/container:flat_hash_map
+  - absl/functional:function_ref
   - absl/hash:hash
   - absl/meta:type_traits
   - absl/status:statusor

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -51,14 +51,6 @@ class PersistentChannelTest extends \PHPUnit\Framework\TestCase
       $state == GRPC\CHANNEL_TRANSIENT_FAILURE);
   }
 
-  public function testInitHelper()
-  {
-      // PersistentList is not empty at the beginning of the tests
-      // because phpunit will cache the channels created by other test
-      // files.
-  }
-
-
   public function testChannelNotPersist()
   {
       $this->channel1 = new Grpc\Channel('localhost:1', ['force_new' => true]);


### PR DESCRIPTION
Basic Tests PHP MacOS  fails with
```
There was 1 risky test:

1) PersistentChannelTest::testInitHelper
This test did not perform any assertions

/[Volumes/BuildData/tmpfs/altsrc/github/grpc/workspace_php8_macos_dbg_native/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php:54](https://cs.corp.google.com/piper///depot/google3/Volumes/BuildData/tmpfs/altsrc/github/grpc/workspace_php8_macos_dbg_native/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php?l=54&ws&snapshot=0)

OK, but incomplete, skipped, or risky tests!
Tests: 20, Assertions: 84, Risky: 1.
```