### PR TITLE
[Test] Remove unnecessary cmake 3.16 installation

### DIFF
--- a/test/distrib/cpp/run_distrib_test_cmake_fetchcontent.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_fetchcontent.sh
@@ -21,12 +21,6 @@ grpc_dir=$(pwd)
 # Install openssl (to use instead of boringssl)
 apt-get update && apt-get install -y libssl-dev
 
-# Install CMake 3.16
-apt-get update && apt-get install -y wget
-wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.16.1/cmake-3.16.1-Linux-x86_64.sh
-sh cmake-linux.sh -- --skip-license --prefix=/usr
-rm cmake-linux.sh
-
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}
 

--- a/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
@@ -20,12 +20,6 @@ cd "$(dirname "$0")/../../.."
 # Install openssl (to use instead of boringssl)
 apt-get update && apt-get install -y libssl-dev
 
-# Install CMake 3.16
-apt-get update && apt-get install -y wget
-wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.16.1/cmake-3.16.1-Linux-x86_64.sh
-sh cmake-linux.sh -- --skip-license --prefix=/usr
-rm cmake-linux.sh
-
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}
 


### PR DESCRIPTION
gRPC requires at least CMake 3.16 or later so the test script no longer needs to install CMake 3.16.