### PR TITLE
[http-proxy] Add a log message sampling HTTP proxy connect failures

### DIFF
--- a/src/core/handshaker/http_connect/http_connect_handshaker.cc
+++ b/src/core/handshaker/http_connect/http_connect_handshaker.cc
@@ -107,6 +107,12 @@ void HttpConnectHandshaker::HandshakeFailedLocked(absl::Status error) {
     // own error.
     error = GRPC_ERROR_CREATE("Handshaker shutdown");
   }
+  std::string peer_string = "[unknown]";
+  if (args_ != nullptr && args_->endpoint != nullptr) {
+    peer_string = grpc_endpoint_get_peer(args_->endpoint.get());
+  }
+  LOG_EVERY_N_SEC(ERROR, 1)
+      << "HTTP proxy handshake with " << peer_string << " failed: " << error;
   // Invoke callback.
   FinishLocked(std::move(error));
 }

--- a/src/core/handshaker/http_connect/http_connect_handshaker.cc
+++ b/src/core/handshaker/http_connect/http_connect_handshaker.cc
@@ -109,7 +109,7 @@ void HttpConnectHandshaker::HandshakeFailedLocked(absl::Status error) {
   }
   std::string peer_string = "[unknown]";
   if (args_ != nullptr && args_->endpoint != nullptr) {
-    peer_string = grpc_endpoint_get_peer(args_->endpoint.get());
+    peer_string = std::string(grpc_endpoint_get_peer(args_->endpoint.get()));
   }
   LOG_EVERY_N_SEC(ERROR, 1)
       << "HTTP proxy handshake with " << peer_string << " failed: " << error;

--- a/src/core/handshaker/http_connect/http_connect_handshaker.cc
+++ b/src/core/handshaker/http_connect/http_connect_handshaker.cc
@@ -107,9 +107,9 @@ void HttpConnectHandshaker::HandshakeFailedLocked(absl::Status error) {
     // own error.
     error = GRPC_ERROR_CREATE("Handshaker shutdown");
   }
-  std::string peer_string = "[unknown]";
+  absl::string_view peer_string = "[unknown]";
   if (args_ != nullptr && args_->endpoint != nullptr) {
-    peer_string = std::string(grpc_endpoint_get_peer(args_->endpoint.get()));
+    peer_string = grpc_endpoint_get_peer(args_->endpoint.get());
   }
   LOG_EVERY_N_SEC(ERROR, 1)
       << "HTTP proxy handshake with " << peer_string << " failed: " << error;


### PR DESCRIPTION
We've got a customer that's seeing some failures right now and are stuck debugging because we don't have sufficient log visibility.