### PR TITLE
[PHP] Fix flaky MacOS tests

### DIFF
--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -64,18 +64,6 @@ class TimevalTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('Grpc\Timeval', get_class($this->time));
     }
 
-    public function testConstructorWithFloat()
-    {
-        if (version_compare(PHP_VERSION, '8.1.0') >= 0) {
-            $this->markTestSkipped('implicit float to int cast deprecated in 8.1+');
-        }
-        $this->time = new Grpc\Timeval(123.456);
-        $this->assertNotNull($this->time);
-        $this->assertSame('Grpc\Timeval', get_class($this->time));
-        $timeFromInt = new Grpc\Timeval(123);
-        $this->assertSame(0, Grpc\Timeval::compare($this->time, $timeFromInt));
-    }
-
     public function testConstructorWithBigInt()
     {
         $this->time = new Grpc\Timeval(7200000000); // > 2^32


### PR DESCRIPTION
This fixes b/323916594. In some flaky cases, a skipped test seems to be causing an unnecessary segfault at the test shutdown. This test is no longer relevant in newer version of PHP. It had been skipped for a while already.