### PR TITLE
[c-ares] Fix inverted length check in GrpcPolledFdWindows

### DIFF
--- a/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
+++ b/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
@@ -79,7 +79,7 @@ grpc_slice FlattenIovec(const struct iovec* iov, int iov_count) {
 // instantiated at the top of the virtual socket function callstack.
 class WSAErrorContext {
  public:
-  explicit WSAErrorContext() {};
+  explicit WSAErrorContext(){};
 
   ~WSAErrorContext() {
     if (error_ != 0) {
@@ -224,7 +224,7 @@ class GrpcPolledFdWindows : public GrpcPolledFd {
     // c-ares overloads this recv_from virtual socket function to receive
     // data on both UDP and TCP sockets, and from is nullptr for TCP.
     if (from != nullptr) {
-      CHECK(*from_len <= recv_from_source_addr_len_);
+      CHECK(*from_len >= recv_from_source_addr_len_);
       memcpy(from, &recv_from_source_addr_, recv_from_source_addr_len_);
       *from_len = recv_from_source_addr_len_;
     }

--- a/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
+++ b/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
@@ -224,6 +224,7 @@ class GrpcPolledFdWindows : public GrpcPolledFd {
     // c-ares overloads this recv_from virtual socket function to receive
     // data on both UDP and TCP sockets, and from is nullptr for TCP.
     if (from != nullptr) {
+      CHECK(recv_from_source_addr_len_ != 0);
       CHECK(*from_len >= recv_from_source_addr_len_);
       memcpy(from, &recv_from_source_addr_, recv_from_source_addr_len_);
       *from_len = recv_from_source_addr_len_;
@@ -301,7 +302,7 @@ class GrpcPolledFdWindows : public GrpcPolledFd {
     WSABUF buffer;
     buffer.buf = reinterpret_cast<char*>(GRPC_SLICE_START_PTR(read_buf_));
     buffer.len = GRPC_SLICE_LENGTH(read_buf_);
-    recv_from_source_addr_len_ = sizeof(recv_from_source_addr_);
+    recv_from_source_addr_len_ = 0;
     DWORD flags = 0;
     winsocket_->NotifyOnRead(&outer_read_closure_);
     if (WSARecvFrom(winsocket_->raw_socket(), &buffer, 1, nullptr, &flags,

--- a/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
+++ b/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
@@ -79,7 +79,7 @@ grpc_slice FlattenIovec(const struct iovec* iov, int iov_count) {
 // instantiated at the top of the virtual socket function callstack.
 class WSAErrorContext {
  public:
-  explicit WSAErrorContext(){};
+  explicit WSAErrorContext() {};
 
   ~WSAErrorContext() {
     if (error_ != 0) {

--- a/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
+++ b/src/core/lib/event_engine/windows/grpc_polled_fd_windows.cc
@@ -79,7 +79,7 @@ grpc_slice FlattenIovec(const struct iovec* iov, int iov_count) {
 // instantiated at the top of the virtual socket function callstack.
 class WSAErrorContext {
  public:
-  explicit WSAErrorContext() {};
+  explicit WSAErrorContext(){};
 
   ~WSAErrorContext() {
     if (error_ != 0) {
@@ -224,7 +224,6 @@ class GrpcPolledFdWindows : public GrpcPolledFd {
     // c-ares overloads this recv_from virtual socket function to receive
     // data on both UDP and TCP sockets, and from is nullptr for TCP.
     if (from != nullptr) {
-      CHECK(recv_from_source_addr_len_ != 0);
       CHECK(*from_len >= recv_from_source_addr_len_);
       memcpy(from, &recv_from_source_addr_, recv_from_source_addr_len_);
       *from_len = recv_from_source_addr_len_;
@@ -302,7 +301,7 @@ class GrpcPolledFdWindows : public GrpcPolledFd {
     WSABUF buffer;
     buffer.buf = reinterpret_cast<char*>(GRPC_SLICE_START_PTR(read_buf_));
     buffer.len = GRPC_SLICE_LENGTH(read_buf_);
-    recv_from_source_addr_len_ = 0;
+    recv_from_source_addr_len_ = sizeof(recv_from_source_addr_);
     DWORD flags = 0;
     winsocket_->NotifyOnRead(&outer_read_closure_);
     if (WSARecvFrom(winsocket_->raw_socket(), &buffer, 1, nullptr, &flags,

--- a/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -69,7 +69,7 @@ namespace {
 // instantiated at the top of the virtual socket function callstack.
 class WSAErrorContext final {
  public:
-  explicit WSAErrorContext() {};
+  explicit WSAErrorContext(){};
 
   ~WSAErrorContext() {
     if (error_ != 0) {
@@ -183,7 +183,7 @@ class GrpcPolledFdWindows final : public GrpcPolledFd {
     buffer.buf = (char*)GRPC_SLICE_START_PTR(read_buf_);
     buffer.len = GRPC_SLICE_LENGTH(read_buf_);
     memset(&winsocket_->read_info.overlapped, 0, sizeof(OVERLAPPED));
-    recv_from_source_addr_len_ = 0;
+    recv_from_source_addr_len_ = sizeof(recv_from_source_addr_);
     DWORD flags = 0;
     if (WSARecvFrom(grpc_winsocket_wrapped_socket(winsocket_), &buffer, 1,
                     nullptr, &flags, (sockaddr*)recv_from_source_addr_,
@@ -307,7 +307,6 @@ class GrpcPolledFdWindows final : public GrpcPolledFd {
     // c-ares overloads this recv_from virtual socket function to receive
     // data on both UDP and TCP sockets, and from is nullptr for TCP.
     if (from != nullptr) {
-      CHECK(recv_from_source_addr_len_ != 0);
       CHECK(*from_len >= recv_from_source_addr_len_);
       memcpy(from, &recv_from_source_addr_, recv_from_source_addr_len_);
       *from_len = recv_from_source_addr_len_;

--- a/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -69,7 +69,7 @@ namespace {
 // instantiated at the top of the virtual socket function callstack.
 class WSAErrorContext final {
  public:
-  explicit WSAErrorContext(){};
+  explicit WSAErrorContext() {};
 
   ~WSAErrorContext() {
     if (error_ != 0) {

--- a/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -69,7 +69,7 @@ namespace {
 // instantiated at the top of the virtual socket function callstack.
 class WSAErrorContext final {
  public:
-  explicit WSAErrorContext() {};
+  explicit WSAErrorContext(){};
 
   ~WSAErrorContext() {
     if (error_ != 0) {
@@ -307,7 +307,7 @@ class GrpcPolledFdWindows final : public GrpcPolledFd {
     // c-ares overloads this recv_from virtual socket function to receive
     // data on both UDP and TCP sockets, and from is nullptr for TCP.
     if (from != nullptr) {
-      CHECK(*from_len <= recv_from_source_addr_len_);
+      CHECK(*from_len >= recv_from_source_addr_len_);
       memcpy(from, &recv_from_source_addr_, recv_from_source_addr_len_);
       *from_len = recv_from_source_addr_len_;
     }

--- a/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -183,7 +183,7 @@ class GrpcPolledFdWindows final : public GrpcPolledFd {
     buffer.buf = (char*)GRPC_SLICE_START_PTR(read_buf_);
     buffer.len = GRPC_SLICE_LENGTH(read_buf_);
     memset(&winsocket_->read_info.overlapped, 0, sizeof(OVERLAPPED));
-    recv_from_source_addr_len_ = sizeof(recv_from_source_addr_);
+    recv_from_source_addr_len_ = 0;
     DWORD flags = 0;
     if (WSARecvFrom(grpc_winsocket_wrapped_socket(winsocket_), &buffer, 1,
                     nullptr, &flags, (sockaddr*)recv_from_source_addr_,
@@ -307,6 +307,7 @@ class GrpcPolledFdWindows final : public GrpcPolledFd {
     // c-ares overloads this recv_from virtual socket function to receive
     // data on both UDP and TCP sockets, and from is nullptr for TCP.
     if (from != nullptr) {
+      CHECK(recv_from_source_addr_len_ != 0);
       CHECK(*from_len >= recv_from_source_addr_len_);
       memcpy(from, &recv_from_source_addr_, recv_from_source_addr_len_);
       *from_len = recv_from_source_addr_len_;


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/37969.

There is an inverted length check in GrpcPolledFdWindows before memcpying from gRPC's `recv_from_source_addr_` into c-ares' socket address structure. In newer c-ares version, it changed to use `struct sockaddr_storage` for the socket address which is 128 bytes and hit this issue.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

