### PR TITLE
Build grpc using system installed openssl on Power.

### DIFF
--- a/third_party/openssl/BUILD
+++ b/third_party/openssl/BUILD
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "openssl",
+    includes = ["."],
+    linkopts = ["-L/usr/lib", "-lssl", "-lcrypto"],
+    )
+cc_library(
+    name = "crypto",
+    includes = ["."],
+    linkopts = [
+        "-L/usr/lib",
+        "-lcrypto",  
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ssl",
+    includes = ["."],
+    linkopts = [
+        "-L/usr/lib",
+        "-lssl",  
+    ],
+        deps = [":crypto"],  
+    visibility = ["//visibility:public"],
+)

--- a/third_party/openssl/WORKSPACE
+++ b/third_party/openssl/WORKSPACE
@@ -1,0 +1,6 @@
+workspace(name = "openssl")
+
+new_local_repository(
+    name = "openssl",
+    path = "third_party/openssl",
+)


### PR DESCRIPTION
Hello Team,
We are working on building grpc on Power using system installed openssl instead of boringssl, as boringssl does not support Power. We have created a third_party directory called openssl which acts as a new repository, and this directory has a BUILD file and WORKSPACE file.
BUILD file has compiler/linker options so that compiler can use system paths for includes/libraries of openssl. We are able to build grpc with openssl using the command as below, `bazel build :all  --override_repository=boringssl=third_party/openssl.`
We will be working on refining changes to create new repository for openssl in bazel cache at runtime and fetch openssl's BUILD from there. We are also trying to find a way to use conditional statement to set `--override_repository` for power. Debugging for test failures faced on Power is also in progress.

Please let us know your thoughts about this.

