### PR TITLE
[CoreE2ETest] Cancel calls on server before expecting the shutdown notification

### DIFF
--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -468,6 +468,7 @@ class CoreEnd2endTest : public ::testing::Test {
   void ShutdownAndDestroyServer() {
     if (server_ == nullptr) return;
     ShutdownServerAndNotify(-1);
+    CancelAllCallsOnServer();
     Expect(-1, AnyStatus{});
     Step();
     DestroyServer();


### PR DESCRIPTION
Possible fix to flakes of the kind https://btx.cloud.google.com/invocations/fa6511c3-a195-4a49-8542-000d6c14dde1/targets/%2F%2Ftest%2Fcore%2Fend2end:cancel_after_invoke_test@poller%3Dpoll;config=73d114f34497fe815dc9359619f4998ad393f9a101551e59d2a81873570c0afd/log

```
[ RUN      ] CoreEnd2endTest.CancelAfterInvoke6/Chttp2FullstackLocalIpv6
I1111 23:40:09.828083      17 lb_policy_registry.cc:45] registering LB policy factory for "priority_experimental"
I1111 23:40:09.828392      17 lb_policy_registry.cc:45] registering LB policy factory for "outlier_detection_experimental"
I1111 23:40:09.828812      17 lb_policy_registry.cc:45] registering LB policy factory for "weighted_target_experimental"
I1111 23:40:09.829263      17 lb_policy_registry.cc:45] registering LB policy factory for "pick_first"
I1111 23:40:09.829713      17 lb_policy_registry.cc:45] registering LB policy factory for "round_robin"
I1111 23:40:09.830120      17 lb_policy_registry.cc:45] registering LB policy factory for "weighted_round_robin"
I1111 23:40:09.831267      17 lb_policy_registry.cc:45] registering LB policy factory for "grpclb"
I1111 23:40:09.832262      17 dns_resolver_plugin.cc:41] Using EventEngine dns resolver
I1111 23:40:09.832678      17 lb_policy_registry.cc:45] registering LB policy factory for "rls_experimental"
E1111 23:40:09.843624      17 cq_verifier.cc:365] Verify tag(1)-✅ for 10000ms
E1111 23:40:09.853657      17 cq_verifier.cc:365] Verify tag(-1)-🤷 for 10000ms
E1111 23:40:49.885623      17 cq_verifier.cc:316] No event received
checked @ ./test/core/end2end/end2end_tests.h:472
expected:
  ./test/core/end2end/end2end_tests.h:471: tag(-1) any success value
```

The theory is that server shutdown was timing out possibly due to the server not getting the connection closed notification. (Unable to verify the claim since I haven't been able to reproduce the flake.)