### PR TITLE
Add C# to server-reflection docs

### DIFF
--- a/doc/server-reflection.md
+++ b/doc/server-reflection.md
@@ -168,6 +168,7 @@ Enabling server reflection differs language-to-language. Here are links to docs 
 each language:
 
 - [Java](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md#enable-server-reflection)
+- [C#](https://learn.microsoft.com/en-us/aspnet/core/grpc/test-tools?view=aspnetcore-9.0&preserve-view=true#set-up-grpc-reflection)
 - [Go](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection)
 - [C++](https://grpc.io/grpc/cpp/md_doc_server_reflection_tutorial.html)
 - [Python](https://github.com/grpc/grpc/blob/master/doc/python/server_reflection.md)


### PR DESCRIPTION
This mini PR adds the a link to the the C# language docs about setting up gRPC server reflection.