### PR TITLE
re-enabling tooling-tests

### DIFF
--- a/tools/internal_ci/linux/grpc_toolingtests_python.sh
+++ b/tools/internal_ci/linux/grpc_toolingtests_python.sh
@@ -23,6 +23,4 @@ export DOCKERFILE_DIR=tools/dockerfile/distribtest/python_dev_ubuntu2204_x64
 export DOCKER_RUN_SCRIPT=tools/distrib/install_python_modules_and_run_tests.sh
 export GRPC_TEST_REPORT_BASE_DIR=reports
 
-# TODO: Reenable once the underlying test passes.
-true
-# exec tools/run_tests/dockerize/build_and_run_docker.sh
+exec tools/run_tests/dockerize/build_and_run_docker.sh


### PR DESCRIPTION
- We had multiple tooling tests earlier which were timing out in CI
- Have reduced number of tooling tests to one
- This enables tests in CI again

