### PR TITLE
interop-testing: update the Interop-test-descriptions doc to reflect the soak concurrency

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1045,9 +1045,6 @@ regexes:
   - `thread_id: \d+ soak iteration: \d+ elapsed_ms: \d+ peer: \S+ server_uri: 
   \S+ failed`
 
-- Thread-specific logs will include the thread_id, helping to track performance
-  across threads.
-
 This test must be configurable via a few different command line flags:
 
 * `soak_iterations`: Controls the number of RPCs to perform. This should

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1005,16 +1005,12 @@ Client asserts:
 ### rpc_soak
 
 The client performs many large_unary RPCs in sequence over the same channel.
-The test can run in either a concurrent or non-concurrent mode, depending on 
-the number of threads specified (`soak_num_threads`):
+The total number of RPCs to execute is controlled by the `soak_iterations` 
+parameter, which defaults to 10. The test runs in concurrent mode, where 
+multiple threads are used to execute the RPCs, with the number of threads 
+controlled by soak_num_threads. By default, `soak_num_threads` is set to 1. 
 
-* Non-Concurrent Mode: When `soak_num_threads = 1`, all RPCs are performed 
-  sequentially on a single thread.
-* Concurrent Mode: When `soak_num_threads > 1`, the client uses multiple threads
-  to distribute the workload. Each thread performs a portion of the total 
- `soak_iterations`, executing its own set of RPCs concurrently.
-
-In either case, the client records the latency and status of each RPC in 
+The client records the latency and status of each RPC in 
 thread-specific data structure, which are later aggregated to form the overall 
 results. If the test ever consumes `soak_overall_timeout_seconds` seconds 
 and still hasn't completed `soak_iterations` RPCs, then the test should 
@@ -1233,13 +1229,13 @@ languages. Therefore they are not part of our interop matrix.
 The client performs a number of large_unary RPCs over a single long-lived
 channel with a fixed but configurable interval between each RPC.
 
-[//]: # (#### concurrent_large_unary)
+#### concurrent_large_unary
 
-[//]: # ()
-[//]: # (Status: TODO)
 
-[//]: # ()
-[//]: # (Client performs 1000 large_unary tests in parallel on the same channel.)
+Status: TODO
+
+
+Client performs 1000 large_unary tests in parallel on the same channel.
 
 #### Flow control. Pushback at client for large messages (TODO: fix name)
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1044,7 +1044,7 @@ regexes:
   \S+ failed`
 
 - Thread-specific logs will include the thread_id, helping to track performance
-  across threads, especially when each thread is managing its own channel lifecycle.
+  across threads.
 
 This test must be configurable via a few different command line flags:
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1006,9 +1006,8 @@ Client asserts:
 
 The client performs many large_unary RPCs in sequence over the same channel.
 The total number of RPCs to execute is controlled by the `soak_iterations` 
-parameter, which defaults to 10. The test runs in concurrent mode, where 
-multiple threads are used to execute the RPCs, with the number of threads 
-controlled by soak_num_threads. By default, `soak_num_threads` is set to 1. 
+parameter, which defaults to 10. The number of threads used to execute RPCs 
+is controlled by `soak_num_threads`. By default, `soak_num_threads` is set to 1. 
 
 The client records the latency and status of each RPC in 
 thread-specific data structure, which are later aggregated to form the overall 
@@ -1068,8 +1067,10 @@ This test must be configurable via a few different command line flags:
   consecutive RPCs. Useful for limiting QPS.
 
 * `soak_num_threads`: Specifies the number of threads to use for concurrently 
-  executing the soak test. Each thread performs a portion of the total 
-  soak_iterations. This value defaults to 1 (i.e., no concurrency) but can be 
+  executing the soak test. Each thread performs `soak_iterations / soak_num_threads`
+  RPCs.
+
+This value defaults to 1 (i.e., no concurrency) but can be 
   increased for concurrent execution. The total soak_iterations must be 
   divisible by soak_num_threads.
 
@@ -1093,10 +1094,6 @@ latency measurement, but the teardown of that channel should **not** be
 included in that latency measurement (channel teardown semantics differ widely
 between languages). This latency measurement should also be the value that is
 logged and recorded in the latency histogram.
-
-Note on Concurrent Execution and Channel Creation: In a concurrent execution setting (i.e., when `soak_num_threads > 1`), each 
-thread performs a portion of the total soak_iterations and creates and destroys 
-its own channel for each RPC iteration.
 
 * `createNewChannel` Function: In channel_soak, the `createNewChannel` function 
 is used by each thread to create a new channel before every RPC. This function 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1004,10 +1004,12 @@ Client asserts:
 
 ### rpc_soak
 
-The client performs many large_unary RPCs in sequence over the same channel.
+The client performs many large_unary RPCs over the same channel.
 The total number of RPCs to execute is controlled by the `soak_iterations` 
 parameter, which defaults to 10. The number of threads used to execute RPCs 
 is controlled by `soak_num_threads`. By default, `soak_num_threads` is set to 1. 
+Each thread processes RPCs sequentially. If multiple threads are used, RPCs can 
+be executed concurrently, with each thread handling its own set of RPCs.
 
 The client records the latency and status of each RPC in 
 thread-specific data structure, which are later aggregated to form the overall 
@@ -1071,11 +1073,9 @@ This test must be configurable via a few different command line flags:
 
 * `soak_num_threads`: Specifies the number of threads to use for concurrently 
   executing the soak test. Each thread performs `soak_iterations / soak_num_threads`
-  RPCs.
-
-This value defaults to 1 (i.e., no concurrency) but can be 
+  RPCs. This value defaults to 1 (i.e., no concurrency) but can be 
   increased for concurrent execution. The total soak_iterations must be 
-  divisible by soak_num_threads.
+  divisible by soak_num_threads; otherwise, the client should fail.
 
 The following is optional but encouraged to improve debuggability:
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1221,9 +1221,7 @@ channel with a fixed but configurable interval between each RPC.
 
 #### concurrent_large_unary
 
-
 Status: TODO
-
 
 Client performs 1000 large_unary tests in parallel on the same channel.
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -1043,6 +1043,9 @@ regexes:
   - `thread_id: \d+ soak iteration: \d+ elapsed_ms: \d+ peer: \S+ server_uri: 
   \S+ failed`
 
+- Thread-specific logs will include the thread_id, helping to track performance
+  across threads, especially when each thread is managing its own channel lifecycle.
+
 This test must be configurable via a few different command line flags:
 
 * `soak_iterations`: Controls the number of RPCs to perform. This should
@@ -1094,16 +1097,6 @@ latency measurement, but the teardown of that channel should **not** be
 included in that latency measurement (channel teardown semantics differ widely
 between languages). This latency measurement should also be the value that is
 logged and recorded in the latency histogram.
-
-* `createNewChannel` Function: In channel_soak, the `createNewChannel` function 
-is used by each thread to create a new channel before every RPC. This function 
-ensures that each RPC has a separate channel, preventing race conditions by 
-isolating channels between threads. It shuts down the previous channel (if any)
-and creates a new one for each iteration, ensuring accurate latency measurement
-per RPC.
-* Thread-specific logs will include the thread_id, helping to track performance 
-across threads, especially when each thread is managing its own channel lifecycle.
-
 
 ### orca_per_rpc
 [orca_per_rpc]: #orca_per_rpc


### PR DESCRIPTION
-  Update the Interop-test-descriptions doc to reflect the concurrency improvement in the rpc_soak and channel_soak tests.

- PTAL @apolcyn
- Eric @ejona86
