### PR TITLE
[OnCall] Minor change to Python binary metadata documentation

### DIFF
--- a/examples/python/metadata/metadata_client.py
+++ b/examples/python/metadata/metadata_client.py
@@ -34,7 +34,7 @@ def run():
                 ("initial-metadata-1", "The value should be str"),
                 (
                     "binary-metadata-bin",
-                    b"With -bin surffix, the value can be bytes",
+                    b"With -bin surffix, the value should be bytes",
                 ),
                 ("accesstoken", "gRPC Python is great"),
             ),

--- a/examples/python/metadata/metadata_client.py
+++ b/examples/python/metadata/metadata_client.py
@@ -31,10 +31,10 @@ def run():
         response, call = stub.SayHello.with_call(
             helloworld_pb2.HelloRequest(name="you"),
             metadata=(
-                ("initial-metadata-1", "The value should be str"),
+                ("initial-metadata-1", "The value must be str"),
                 (
                     "binary-metadata-bin",
-                    b"With -bin surffix, the value should be bytes",
+                    b"With -bin surffix, the value must be bytes",
                 ),
                 ("accesstoken", "gRPC Python is great"),
             ),


### PR DESCRIPTION
The word "can" in this example makes it sound like it is optional. Changing it to should.

https://github.com/grpc/grpc/blob/e352e896cb854759a2991b9f86389d7b01cf52a1/src/python/grpcio/grpc/_cython/_cygrpc/metadata.pyx.pxi#L45

Making this change in response to a user query.
