### PR TITLE
[CI] v1.61.x: Update SHA for the test bazel build image

### DIFF
--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -87,7 +87,7 @@ DOCKERIMAGE_CURRENT_VERSIONS = {
     "tools/dockerfile/interoptest/grpc_interop_ruby.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_ruby@sha256:7b044d6848f82234dba81b38d8eca220b608f830f93b42932df59ed6fe20b24d",
     "tools/dockerfile/interoptest/lb_interop_fake_servers.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/lb_interop_fake_servers@sha256:b89a51dd9147e1293f50ee64dd719fce5929ca7894d3770a3d80dbdecb99fd52",
     "tools/dockerfile/test/android_ndk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/android_ndk@sha256:64ffc5d1e117172ca4dda89720087616830996181192de25fe10e03a88f0b3e5",
-    "tools/dockerfile/test/bazel.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf",
+    "tools/dockerfile/test/bazel.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel@sha256:3a6ac46d74b4c337f2cad2e5e6733c4fe47c9f74246fddd38e7612c375b6d98c",
     "tools/dockerfile/test/bazel_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/bazel_arm64@sha256:3b087387c44dee405c1b80d6ff50994e6d8e90a4ef67cc94b4291f1a29c0ef41",
     "tools/dockerfile/test/binder_transport_apk.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/binder_transport_apk@sha256:bf60a187cd2ce1abe8b4f32ae6479040a72ca6aa789cd5ab509f60ceb37a41f9",
     "tools/dockerfile/test/csharp_debian11_arm64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_debian11_arm64@sha256:4d4bc5f15e03f3d3d8fd889670ecde2c66a2e4d2dd9db80733c05c1d90c8a248",

--- a/tools/dockerfile/test/bazel.current_version
+++ b/tools/dockerfile/test/bazel.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:cacad91746cd598d8756de89b912be291de1f019@sha256:32bde2dcb2087f2a32afab59e4dfedf7e8c76a52c69881f63a239d311f0e5ecf
+us-docker.pkg.dev/grpc-testing/testing-images-public/bazel:cacad91746cd598d8756de89b912be291de1f019@sha256:3a6ac46d74b4c337f2cad2e5e6733c4fe47c9f74246fddd38e7612c375b6d98c


### PR DESCRIPTION
Updating deleted Bazel image hash with existing image hash.

Similar to #37991 for v1.61.x branch.

Passing Interop Test Runs:
- [x]  [grpc/core/v1.61.x/branch/linux/grpc_xds_v3](https://source.cloud.google.com/results/invocations/5e4a38a7-bad5-4bb5-a2e2-51ead00ef064)
- [x]  [grpc/core/v1.61.x/branch/linux/grpc_xds_v3_python](https://source.cloud.google.com/results/invocations/8f2206ec-d13c-46d4-8c31-719e1127477b)