### PR TITLE
[client-channel] log formatting cleanup

### DIFF
--- a/src/core/client_channel/client_channel.cc
+++ b/src/core/client_channel/client_channel.cc
@@ -260,7 +260,7 @@ class ClientChannel::SubchannelWrapper::WatcherWrapper
         << subchannel_wrapper_.get() << " subchannel "
         << subchannel_wrapper_->subchannel_.get()
         << " watcher=" << watcher_.get()
-        << "state=" << ConnectivityStateName(state) << " status=" << status;
+        << " state=" << ConnectivityStateName(state) << " status=" << status;
     absl::optional<absl::Cord> keepalive_throttling =
         status.GetPayload(kKeepaliveThrottlingKey);
     if (keepalive_throttling.has_value()) {


### PR DESCRIPTION
avoid these two variables being printed without intervening whitespace