### PR TITLE
[chaotic-good] ensure client transport advertises shutdown

### DIFF
--- a/src/core/ext/transport/chaotic_good/client_transport.cc
+++ b/src/core/ext/transport/chaotic_good/client_transport.cc
@@ -52,7 +52,6 @@ namespace grpc_core {
 namespace chaotic_good {
 
 void ChaoticGoodClientTransport::Orphan() {
-  GRPC_TRACE_LOG(chaotic_good, INFO) << "Client transport orphan " << this;
   AbortWithError();
   RefCountedPtr<Party> party;
   {

--- a/src/core/ext/transport/chaotic_good/client_transport.cc
+++ b/src/core/ext/transport/chaotic_good/client_transport.cc
@@ -195,8 +195,7 @@ ChaoticGoodClientTransport::ChaoticGoodClientTransport(
     PromiseEndpoint control_endpoint, PromiseEndpoint data_endpoint,
     const ChannelArgs& args,
     std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine)
-    : ClientTransport("ChaoticGoodClientTransport"),
-      allocator_(args.GetObject<ResourceQuota>()
+    : allocator_(args.GetObject<ResourceQuota>()
                      ->memory_quota()
                      ->CreateMemoryAllocator("chaotic-good")),
       outgoing_frames_(4) {

--- a/src/core/ext/transport/chaotic_good_legacy/client_transport.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/client_transport.cc
@@ -237,6 +237,9 @@ void ChaoticGoodClientTransport::AbortWithError() {
   ReleasableMutexLock lock(&mu_);
   StreamMap stream_map = std::move(stream_map_);
   stream_map_.clear();
+  state_tracker_.SetState(GRPC_CHANNEL_SHUTDOWN,
+                          absl::UnavailableError("transport closed"),
+                          "transport closed");
   lock.Release();
   for (const auto& pair : stream_map) {
     auto call_handler = pair.second;


### PR DESCRIPTION
Not doing so can lead to leaked channels