### PR TITLE
[CI] Keep ninja test only for Windows.

### DIFF
--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -1430,15 +1430,6 @@ tests = _exclude_unwanted_cc_tests(_extract_cc_tests(bazel_rules))
 # only very little "extra metadata" would be needed and/or it would be trivial
 # to generate it automatically.
 all_extra_metadata = {}
-# TODO(veblush): Remove this workaround once protobuf is upgraded to 26.x
-if "@com_google_protobuf//third_party/utf8_range:utf8_range" not in bazel_rules:
-    md = _BUILD_EXTRA_METADATA[
-        "@com_google_protobuf//third_party/utf8_range:utf8_range"
-    ]
-    del _BUILD_EXTRA_METADATA[
-        "@com_google_protobuf//third_party/utf8_range:utf8_range"
-    ]
-    _BUILD_EXTRA_METADATA["@utf8_range//:utf8_range"] = md
 all_extra_metadata.update(
     _generate_build_extra_metadata_for_tests(tests, bazel_rules)
 )

--- a/tools/internal_ci/windows/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/windows/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows c++ -j 4 --inner_jobs 8 --build_only"
+  value: "-f portability windows c++ -j 2 --inner_jobs 16 --build_only"
 }

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -392,17 +392,17 @@ def _create_portability_test_jobs(
 
     # portability C and C++ on Windows with the "Visual Studio 2022" cmake
     # generator, i.e. not using Ninja (to verify that we can still build with msbuild)
-    test_jobs += _generate_jobs(
-        languages=["c", "c++"],
-        configs=["dbg"],
-        platforms=["windows"],
-        arch="x64",
-        compiler="cmake_vs2022",
-        labels=["portability", "corelang"],
-        extra_args=extra_args,
-        inner_jobs=inner_jobs,
-        timeout_seconds=_CPP_RUNTESTS_TIMEOUT,
-    )
+    # test_jobs += _generate_jobs(
+    #     languages=["c", "c++"],
+    #     configs=["dbg"],
+    #     platforms=["windows"],
+    #     arch="x64",
+    #     compiler="cmake_vs2022",
+    #     labels=["portability", "corelang"],
+    #     extra_args=extra_args,
+    #     inner_jobs=inner_jobs,
+    #     timeout_seconds=_CPP_RUNTESTS_TIMEOUT,
+    # )
 
     # C and C++ with no-exceptions on Linux
     test_jobs += _generate_jobs(


### PR DESCRIPTION
This PR addresses the frequent timeouts encountered by the Windows portability build-only test suite. Currently, the suite includes two tests: one using MSBuild and another using Ninja, both with MSVC 2022. To mitigate the timeout issue, this PR disables the MSBuild test while retaining the Ninja test. 








