### PR TITLE
[C++ API] Fix alarm reuse on cancellation bug

### DIFF
--- a/src/cpp/common/alarm.cc
+++ b/src/cpp/common/alarm.cc
@@ -102,7 +102,7 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
     // until it has completed.
     // TODO(C++20): atomic wait?
     while (queued_.load() != executed_.load()) {
-      absl::SleepFor(absl::Milliseconds(100));
+      absl::SleepFor(absl::Milliseconds(10));
     }
   }
   void Destroy() {

--- a/src/cpp/common/alarm.cc
+++ b/src/cpp/common/alarm.cc
@@ -57,13 +57,10 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
   bool FinalizeResult(void** tag, bool* /*status*/) override {
     *tag = tag_;
     executed_++;
-    LOG(INFO) << "[DO NOT SUBMIT] Finalized";
     Unref();
     return true;
   }
   void Set(grpc::CompletionQueue* cq, gpr_timespec deadline, void* tag) {
-    LOG(INFO) << "\n"
-              << "[DO NOT SUBMIT] Setting";
     grpc_core::ExecCtx exec_ctx;
     GRPC_CQ_INTERNAL_REF(cq->cq(), "alarm");
     cq_ = cq->cq();
@@ -91,48 +88,22 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
         [this] { OnCallbackAlarm(true); });
   }
   void Cancel() {
-    LOG(INFO) << "[DO NOT SUBMIT] Cancelling";
     grpc_core::ExecCtx exec_ctx;
     if (callback_armed_.load() &&
         event_engine_->Cancel(callback_timer_handle_)) {
       event_engine_->Run([this] { OnCallbackAlarm(/*is_ok=*/false); });
     }
     if (cq_armed_.load()) {
-      // if (event_engine_->Cancel(cq_timer_handle_)) {
-      //   LOG(INFO) << "[DO NOT SUBMIT] cancelling inline";
-      //   OnCQAlarm(absl::CancelledError("cancelled"));
-      //   LOG(INFO) << "[DO NOT SUBMIT] cancelled inline";
-      // } else {
-      //   LOG(INFO) << "[DO NOT SUBMIT] could not cancel. Waiting for OnCQAlarm
-      //   to finish";
-      //   // Slow path on cancellation. If the timer can't be cancelled, wait
-      //   // until it has completed.
-      //   // TODO(C++20): atomic wait?
-      //   while (queued_.load() != executed_.load()) {
-      //     absl::SleepFor(absl::Milliseconds(100));
-      //   }
-      //   LOG(INFO) << "[DO NOT SUBMIT] OnCQAlarm finished";
-      // }
       if (event_engine_->Cancel(cq_timer_handle_)) {
-        LOG(INFO) << "[DO NOT SUBMIT] cancelling inline";
         OnCQAlarm(absl::CancelledError("cancelled"));
-        LOG(INFO) << "[DO NOT SUBMIT] cancelled inline";
-      } else {
-        LOG(INFO)
-            << "[DO NOT SUBMIT] OnCQAlarm timer cannot be cancelled. Waiting";
       }
     }
-    LOG(INFO) << "[DO NOT SUBMIT] Waiting for FinalizeResult to finish";
     // Slow path on cancellation. If the timer can't be cancelled, wait
     // until it has completed.
     // TODO(C++20): atomic wait?
     while (queued_.load() != executed_.load()) {
-      LOG(INFO) << "[DO NOT SUBMIT] looping in wait";
       absl::SleepFor(absl::Milliseconds(100));
     }
-    LOG(INFO) << "[DO NOT SUBMIT] Done waiting for queued == executed ("
-              << queued_.load() << ")";
-    LOG(INFO) << "[DO NOT SUBMIT] Cancel complete";
   }
   void Destroy() {
     Cancel();
@@ -141,7 +112,6 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
 
  private:
   void OnCQAlarm(grpc_error_handle error) {
-    LOG(INFO) << "[DO NOT SUBMIT] OnCQAlarm running";
     cq_armed_.store(false);
     grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
     grpc_core::ExecCtx exec_ctx;
@@ -150,7 +120,6 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
     grpc_completion_queue* cq = cq_;
     cq_ = nullptr;
     grpc_cq_completion* completion = new grpc_cq_completion();
-    LOG(INFO) << "[DO NOT SUBMIT] end op pushed";
     grpc_cq_end_op(
         cq, this, error,
         [](void* /*arg*/, grpc_cq_completion* completion) {
@@ -158,7 +127,6 @@ class AlarmImpl : public grpc::internal::CompletionQueueTag {
         },
         nullptr, completion);
     GRPC_CQ_INTERNAL_UNREF(cq, "alarm");
-    LOG(INFO) << "[DO NOT SUBMIT] OnCQAlarm Finished";
   }
 
   void OnCallbackAlarm(bool is_ok) {

--- a/test/cpp/common/alarm_test.cc
+++ b/test/cpp/common/alarm_test.cc
@@ -438,6 +438,24 @@ TEST(AlarmTest, UnsetDestruction) {
   Alarm alarm;
 }
 
+TEST(AlarmTest, CQAlarmReuse) {
+  constexpr int kIterations = 5000;
+  Alarm alarm;
+  CompletionQueue cq;
+  std::thread polling_thread([&]() {
+    void* tag;
+    bool ok = false;
+    for (int i = 0; i < kIterations; ++i) {
+      ASSERT_TRUE(cq.Next(&tag, &ok));
+    }
+  });
+  for (int i = 0; i < kIterations; ++i) {
+    alarm.Set(&cq, gpr_timespec{0, 0, GPR_TIMESPAN}, /*tag=*/nullptr);
+    alarm.Cancel();
+  }
+  polling_thread.join();
+}
+
 }  // namespace
 }  // namespace grpc
 

--- a/test/cpp/microbenchmarks/bm_alarm.cc
+++ b/test/cpp/microbenchmarks/bm_alarm.cc
@@ -42,7 +42,7 @@ static void BM_Alarm_Tag_Immediate(benchmark::State& state) {
     cq.Next(&output_tag, &ok);
   }
 }
-BENCHMARK(BM_Alarm_Tag_Immediate);
+BENCHMARK(BM_Alarm_Tag_Immediate)->MeasureProcessCPUTime()->UseRealTime();
 
 }  // namespace testing
 }  // namespace grpc


### PR DESCRIPTION
`bazel --bazelrc=tools/remote_build/linux.bazelrc test --config=opt //test/cpp/microbenchmarks:bm_alarm --test_arg='--benchmark_min_time=2s'  --test_arg='--benchmark_repetitions=10' --test_output=all`

* [Results](https://source.cloud.google.com/results/invocations/be18d9a7-d0b8-406e-bce2-239e6ead73ff) @ Head: 112698 iterations in 23925ns
* [Results](https://source.cloud.google.com/results/invocations/a8e56b0f-297b-447e-84d3-d3885e985745) with this fix: 125745 iterations in 23006 ns