### PR TITLE
increased timeout for windows grpc basictests python

### DIFF
--- a/tools/internal_ci/windows/grpc_basictests_python.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 180
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/pull_request/grpc_basictests_python.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_basictests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 90
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Increase timeout for Python basic tests on Windows

The tests are timing out on kokoro windows

We have added support for 3.13 python version but have not dropped support for any older version. hence overall number of tests have increased.