### PR TITLE
[resource_quota] Add global control knob for container memory usage

### DIFF
--- a/src/core/lib/resource_quota/memory_quota.h
+++ b/src/core/lib/resource_quota/memory_quota.h
@@ -588,6 +588,10 @@ inline MemoryQuotaRefPtr MakeMemoryQuota(std::string name) {
 
 std::vector<std::shared_ptr<BasicMemoryQuota>> AllMemoryQuotas();
 
+void SetContainerMemoryPressure(double pressure);
+
+double ContainerMemoryPressure();
+
 }  // namespace grpc_core
 
 #endif  // GRPC_SRC_CORE_LIB_RESOURCE_QUOTA_MEMORY_QUOTA_H

--- a/test/core/resource_quota/memory_quota_test.cc
+++ b/test/core/resource_quota/memory_quota_test.cc
@@ -187,6 +187,22 @@ TEST(MemoryQuotaTest, AllMemoryQuotas) {
   EXPECT_EQ(gather(), std::set<std::string>({"m2"}));
 }
 
+TEST(MemoryQuotaTest, ContainerMemoryAccountedFor) {
+  MemoryQuota memory_quota("foo");
+  memory_quota.SetSize(1000000);
+  EXPECT_EQ(ContainerMemoryPressure(), 0.0);
+  auto owner = memory_quota.CreateMemoryOwner();
+  const double original_memory_pressure =
+      owner.GetPressureInfo().instantaneous_pressure;
+  EXPECT_LT(original_memory_pressure, 0.01);
+  SetContainerMemoryPressure(1.0);
+  EXPECT_EQ(owner.GetPressureInfo().instantaneous_pressure, 1.0);
+  SetContainerMemoryPressure(0.0);
+  EXPECT_EQ(owner.GetPressureInfo().instantaneous_pressure,
+            original_memory_pressure);
+  SetContainerMemoryPressure(0.0);
+}
+
 }  // namespace testing
 
 namespace memory_quota_detail {


### PR DESCRIPTION
If not called this should not impact anything.

If `SetContainerMemoryPressure` is called, then the greater of its value and the measured memory pressure is used for instantaneous memory pressure whenever that value is calculated.

Later we'll wire this up to container memory measurements and use it to provide back pressure automatically.