### PR TITLE
[chttp2] Allow clients to reject on too many streams

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -562,6 +562,10 @@ static void read_channel_args(grpc_chttp2_transport* t,
   t->max_concurrent_streams_overload_protection =
       channel_args.GetBool(GRPC_ARG_MAX_CONCURRENT_STREAMS_OVERLOAD_PROTECTION)
           .value_or(true);
+
+  t->max_concurrent_streams_reject_on_client =
+      channel_args.GetBool(GRPC_ARG_MAX_CONCURRENT_STREAMS_REJECT_ON_CLIENT)
+          .value_or(false);
 }
 
 static void init_keepalive_pings_if_enabled_locked(
@@ -1427,8 +1431,29 @@ static void send_initial_metadata_locked(
     if (t->is_client) {
       if (t->closed_with_error.ok()) {
         CHECK_EQ(s->id, 0u);
-        grpc_chttp2_list_add_waiting_for_concurrency(t, s);
-        maybe_start_some_streams(t);
+        LOG(INFO) << "NEW STREAM "
+                  << GRPC_DUMP_ARGS(
+                         t->max_concurrent_streams_reject_on_client,
+                         t->stream_map.size(),
+                         t->settings.peer().max_concurrent_streams());
+        if (t->max_concurrent_streams_reject_on_client &&
+            t->stream_map.size() >=
+                t->settings.peer().max_concurrent_streams()) {
+          s->trailing_metadata_buffer.Set(
+              grpc_core::GrpcStreamNetworkState(),
+              grpc_core::GrpcStreamNetworkState::kNotSentOnWire);
+          grpc_chttp2_cancel_stream(
+              t, s,
+              grpc_error_set_int(
+                  GRPC_ERROR_CREATE_REFERENCING("Too many streams",
+                                                &t->closed_with_error, 1),
+                  grpc_core::StatusIntProperty::kRpcStatus,
+                  GRPC_STATUS_RESOURCE_EXHAUSTED),
+              false);
+        } else {
+          grpc_chttp2_list_add_waiting_for_concurrency(t, s);
+          maybe_start_some_streams(t);
+        }
       } else {
         s->trailing_metadata_buffer.Set(
             grpc_core::GrpcStreamNetworkState(),

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1431,11 +1431,6 @@ static void send_initial_metadata_locked(
     if (t->is_client) {
       if (t->closed_with_error.ok()) {
         CHECK_EQ(s->id, 0u);
-        LOG(INFO) << "NEW STREAM "
-                  << GRPC_DUMP_ARGS(
-                         t->max_concurrent_streams_reject_on_client,
-                         t->stream_map.size(),
-                         t->settings.peer().max_concurrent_streams());
         if (t->max_concurrent_streams_reject_on_client &&
             t->stream_map.size() >=
                 t->settings.peer().max_concurrent_streams()) {

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -548,6 +548,7 @@ struct grpc_chttp2_transport final : public grpc_core::FilterStackTransport,
   /// True if we count stream allocation (instead of HTTP2 concurrency) for
   /// MAX_CONCURRENT_STREAMS
   bool max_concurrent_streams_overload_protection = false;
+  bool max_concurrent_streams_reject_on_client = false;
 
   // What percentage of rst_stream frames on the server should cause a ping
   // frame to be generated.
@@ -697,6 +698,11 @@ struct grpc_chttp2_stream {
 // against MAX_CONCURRENT_STREAMS
 #define GRPC_ARG_MAX_CONCURRENT_STREAMS_OVERLOAD_PROTECTION \
   "grpc.http.overload_protection"
+
+// EXPERIMENTAL: Fail requests at the client if the client is over max
+// concurrent streams, so they may be retried elsewhere.
+#define GRPC_ARG_MAX_CONCURRENT_STREAMS_REJECT_ON_CLIENT \
+  "grpc.http.max_concurrent_streams_reject_on_client"
 
 /// Transport writing call flow:
 /// grpc_chttp2_initiate_write() is called anywhere that we know bytes need to

--- a/test/core/end2end/tests/max_concurrent_streams.cc
+++ b/test/core/end2end/tests/max_concurrent_streams.cc
@@ -247,6 +247,53 @@ CORE_END2END_TEST(Http2SingleHopTest, MaxConcurrentStreamsTimeoutOnSecond) {
   Expect(302, true);
   Expect(102, true);
   Step();
+  EXPECT_EQ(server_status2.status(), GRPC_STATUS_DEADLINE_EXCEEDED);
+}
+
+CORE_END2END_TEST(Http2SingleHopTest, MaxConcurrentStreamsRejectOnClient) {
+  SKIP_IF_MINSTACK();
+  InitServer(
+      ChannelArgs()
+          .Set(GRPC_ARG_MAX_CONCURRENT_STREAMS, 1)
+          .Set(GRPC_ARG_MAX_CONCURRENT_STREAMS_OVERLOAD_PROTECTION, false));
+  InitClient(ChannelArgs()
+                 .Set(GRPC_ARG_MAX_CONCURRENT_STREAMS_REJECT_ON_CLIENT, true)
+                 .Set(GRPC_ARG_ENABLE_RETRIES, false));
+  // perform a ping-pong to ensure that settings have had a chance to round
+  // trip
+  SimpleRequestBody(*this);
+  auto c1 = NewClientCall("/alpha").Timeout(Duration::Seconds(1000)).Create();
+  auto c2 = NewClientCall("/beta").Timeout(Duration::Seconds(3)).Create();
+  auto s1 = RequestCall(101);
+  c1.NewBatch(301).SendInitialMetadata({}).SendCloseFromClient();
+  IncomingMetadata server_initial_metadata1;
+  IncomingStatusOnClient server_status1;
+  c1.NewBatch(302)
+      .RecvStatusOnClient(server_status1)
+      .RecvInitialMetadata(server_initial_metadata1);
+  Expect(101, true);
+  Expect(301, true);
+  Step();
+  c2.NewBatch(401).SendInitialMetadata({}).SendCloseFromClient();
+  IncomingMetadata server_initial_metadata2;
+  IncomingStatusOnClient server_status2;
+  c2.NewBatch(402)
+      .RecvStatusOnClient(server_status2)
+      .RecvInitialMetadata(server_initial_metadata2);
+  // the second request fails
+  Expect(401, false);
+  Expect(402, true);
+  Step();
+  // now reply the first call
+  IncomingCloseOnServer client_close1;
+  s1.NewBatch(102)
+      .SendInitialMetadata({})
+      .RecvCloseOnServer(client_close1)
+      .SendStatusFromServer(GRPC_STATUS_UNIMPLEMENTED, "xyz", {});
+  Expect(302, true);
+  Expect(102, true);
+  Step();
+  EXPECT_EQ(server_status2.status(), GRPC_STATUS_RESOURCE_EXHAUSTED);
 }
 
 }  // namespace


### PR DESCRIPTION
Experimental feature to change max_concurrent_streams exceeded behavior from being a client side queuing to a client side early reject.