### PR TITLE
[CI] Added a gRPC_BUILD_TESTS guard to third_party protos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,10 @@ protobuf_generate_grpc_cpp_with_import_path_correction(
 protobuf_generate_grpc_cpp_with_import_path_correction(
   test/core/tsi/alts/fake_handshaker/transport_security_common.proto test/core/tsi/alts/fake_handshaker/transport_security_common.proto
 )
+
+# This enables CMake to build the project without requiring submodules
+# in the third_party directory as long as test builds are disabled.
+if (gRPC_BUILD_TESTS)
 protobuf_generate_grpc_cpp_with_import_path_correction(
   third_party/envoy-api/envoy/admin/v3/certs.proto envoy/admin/v3/certs.proto
 )
@@ -1235,6 +1239,7 @@ protobuf_generate_grpc_cpp_with_import_path_correction(
 protobuf_generate_grpc_cpp_with_import_path_correction(
   third_party/xds/xds/type/v3/typed_struct.proto xds/type/v3/typed_struct.proto
 )
+endif()
 
 if(gRPC_BUILD_TESTS)
   add_custom_target(buildtests_c)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -713,10 +713,24 @@
     DEPENDS tools_c tools_cxx)
 
   % for src in sorted(protobuf_gen_files):
+  % if not src.startswith('third_party/'):
   protobuf_generate_grpc_cpp_with_import_path_correction(
     ${src} ${third_party_proto_import_path(src)}
   )
+  % endif
   % endfor
+
+  # This enables CMake to build the project without requiring submodules
+  # in the third_party directory as long as test builds are disabled.
+  if (gRPC_BUILD_TESTS)
+  % for src in sorted(protobuf_gen_files):
+  % if src.startswith('third_party/'):
+  protobuf_generate_grpc_cpp_with_import_path_correction(
+    ${src} ${third_party_proto_import_path(src)}
+  )
+  % endif
+  % endfor
+  endif()
 
   if(gRPC_BUILD_TESTS)
     add_custom_target(buildtests_c)


### PR DESCRIPTION
When not having submodules under the `third_party` directory, CMake throws an error in building gRPC because it couldn't find proto files in those directories even though those files are only used for tests.

```
CMake Error at CMakeLists.txt:611 (file):
  file COPY cannot find
  "/root/grpc/third_party/googleapis/google/api/annotations.proto": No such
  file or directory.
Call Stack (most recent call first):
  CMakeLists.txt:1184 (protobuf_generate_grpc_cpp_with_import_path_correction)
```

There's a interesting quirk in the CMake build process:

- Empty `third_party/googleapis` directory: Build fails.
- No `third_party/googleapis` directory: Build succeeds.

This inconsistency went undetected by our distrib-test because it completely removes the third_party/googleapis directory. However, Cloud C++ encountered this issue because it downloads a tarball that creates an empty third_party/googleapis directory.

This fix hides those proto targets when `gRPC_BUILD_TESTS` is not turned on to not run ino this problem.