### PR TITLE
[xDS RBAC] Support string_match in HeaderMatcher

### DIFF
--- a/src/core/ext/filters/rbac/rbac_service_config_parser.cc
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.cc
@@ -353,6 +353,13 @@ void RbacConfig::RbacPolicy::Rules::Policy::HeaderMatch::JsonPostLoad(
                                              range_match->end, invert_match));
     return;
   }
+  auto string_match = LoadJsonObjectField<StringMatch>(
+      json.object(), args, "stringMatch", errors, /*required=*/false);
+  if (string_match.has_value()) {
+    matcher = HeaderMatcher::CreateFromStringMatcher(
+        name, std::move(string_match->matcher), invert_match);
+    return;
+  }
   if (errors->size() == original_error_size) {
     errors->AddError("no valid matcher found");
   }
@@ -390,7 +397,8 @@ void RbacConfig::RbacPolicy::Rules::Policy::StringMatch::JsonPostLoad(
                                                   field_name, errors,
                                                   /*required=*/false);
     if (match.has_value()) {
-      set_string_matcher(StringMatcher::Create(type, *match, ignore_case));
+      set_string_matcher(
+          StringMatcher::Create(type, *match, /*case_sensitive=*/!ignore_case));
       return true;
     }
     return false;
@@ -406,7 +414,7 @@ void RbacConfig::RbacPolicy::Rules::Policy::StringMatch::JsonPostLoad(
                                                          /*required=*/false);
   if (regex_match.has_value()) {
     set_string_matcher(StringMatcher::Create(StringMatcher::Type::kSafeRegex,
-                                             regex_match->regex, ignore_case));
+                                             regex_match->regex));
     return;
   }
   if (errors->size() == original_error_size) {

--- a/src/core/util/matchers.cc
+++ b/src/core/util/matchers.cc
@@ -183,8 +183,8 @@ absl::StatusOr<HeaderMatcher> HeaderMatcher::Create(
 HeaderMatcher HeaderMatcher::CreateFromStringMatcher(absl::string_view name,
                                                      StringMatcher matcher,
                                                      bool invert_match) {
-  return HeaderMatcher(name, static_cast<HeaderMatcher::Type>(matcher.type()),
-                       std::move(matcher), invert_match);
+  HeaderMatcher::Type type = static_cast<HeaderMatcher::Type>(matcher.type());
+  return HeaderMatcher(name, type, std::move(matcher), invert_match);
 }
 
 HeaderMatcher::HeaderMatcher(absl::string_view name, Type type,

--- a/src/core/util/matchers.cc
+++ b/src/core/util/matchers.cc
@@ -180,6 +180,13 @@ absl::StatusOr<HeaderMatcher> HeaderMatcher::Create(
   }
 }
 
+HeaderMatcher HeaderMatcher::CreateFromStringMatcher(absl::string_view name,
+                                                     StringMatcher matcher,
+                                                     bool invert_match) {
+  return HeaderMatcher(name, static_cast<HeaderMatcher::Type>(matcher.type()),
+                       std::move(matcher), invert_match);
+}
+
 HeaderMatcher::HeaderMatcher(absl::string_view name, Type type,
                              StringMatcher string_matcher, bool invert_match)
     : name_(name),

--- a/src/core/util/matchers.h
+++ b/src/core/util/matchers.h
@@ -115,6 +115,11 @@ class HeaderMatcher {
                                               bool invert_match = false,
                                               bool case_sensitive = true);
 
+  // Creates a HeaderMatcher from an existing StringMatcher instance.
+  static HeaderMatcher CreateFromStringMatcher(absl::string_view name,
+                                               StringMatcher matcher,
+                                               bool invert_match);
+
   HeaderMatcher() = default;
   HeaderMatcher(const HeaderMatcher& other);
   HeaderMatcher& operator=(const HeaderMatcher& other);

--- a/src/core/xds/grpc/xds_http_rbac_filter.cc
+++ b/src/core/xds/grpc/xds_http_rbac_filter.cc
@@ -81,6 +81,39 @@ Json ParseInt64RangeToJson(const envoy_type_v3_Int64Range* range) {
        {"end", Json::FromNumber(envoy_type_v3_Int64Range_end(range))}});
 }
 
+Json ParseStringMatcherToJson(
+    const envoy_type_matcher_v3_StringMatcher* matcher,
+    ValidationErrors* errors) {
+  Json::Object json;
+  if (envoy_type_matcher_v3_StringMatcher_has_exact(matcher)) {
+    json.emplace("exact",
+                 Json::FromString(UpbStringToStdString(
+                     envoy_type_matcher_v3_StringMatcher_exact(matcher))));
+  } else if (envoy_type_matcher_v3_StringMatcher_has_prefix(matcher)) {
+    json.emplace("prefix",
+                 Json::FromString(UpbStringToStdString(
+                     envoy_type_matcher_v3_StringMatcher_prefix(matcher))));
+  } else if (envoy_type_matcher_v3_StringMatcher_has_suffix(matcher)) {
+    json.emplace("suffix",
+                 Json::FromString(UpbStringToStdString(
+                     envoy_type_matcher_v3_StringMatcher_suffix(matcher))));
+  } else if (envoy_type_matcher_v3_StringMatcher_has_safe_regex(matcher)) {
+    json.emplace("safeRegex",
+                 ParseRegexMatcherToJson(
+                     envoy_type_matcher_v3_StringMatcher_safe_regex(matcher)));
+  } else if (envoy_type_matcher_v3_StringMatcher_has_contains(matcher)) {
+    json.emplace("contains",
+                 Json::FromString(UpbStringToStdString(
+                     envoy_type_matcher_v3_StringMatcher_contains(matcher))));
+  } else {
+    errors->AddError("invalid match pattern");
+  }
+  json.emplace(
+      "ignoreCase",
+      Json::FromBool(envoy_type_matcher_v3_StringMatcher_ignore_case(matcher)));
+  return Json::FromObject(std::move(json));
+}
+
 Json ParseHeaderMatcherToJson(const envoy_config_route_v3_HeaderMatcher* header,
                               ValidationErrors* errors) {
   Json::Object header_json;
@@ -130,6 +163,11 @@ Json ParseHeaderMatcherToJson(const envoy_config_route_v3_HeaderMatcher* header,
         "containsMatch",
         Json::FromString(UpbStringToStdString(
             envoy_config_route_v3_HeaderMatcher_contains_match(header))));
+  } else if (envoy_config_route_v3_HeaderMatcher_has_string_match(header)) {
+    header_json.emplace(
+        "stringMatch",
+        ParseStringMatcherToJson(
+            envoy_config_route_v3_HeaderMatcher_string_match(header), errors));
   } else {
     errors->AddError("invalid route header matcher specified");
   }
@@ -137,39 +175,6 @@ Json ParseHeaderMatcherToJson(const envoy_config_route_v3_HeaderMatcher* header,
       "invertMatch",
       Json::FromBool(envoy_config_route_v3_HeaderMatcher_invert_match(header)));
   return Json::FromObject(std::move(header_json));
-}
-
-Json ParseStringMatcherToJson(
-    const envoy_type_matcher_v3_StringMatcher* matcher,
-    ValidationErrors* errors) {
-  Json::Object json;
-  if (envoy_type_matcher_v3_StringMatcher_has_exact(matcher)) {
-    json.emplace("exact",
-                 Json::FromString(UpbStringToStdString(
-                     envoy_type_matcher_v3_StringMatcher_exact(matcher))));
-  } else if (envoy_type_matcher_v3_StringMatcher_has_prefix(matcher)) {
-    json.emplace("prefix",
-                 Json::FromString(UpbStringToStdString(
-                     envoy_type_matcher_v3_StringMatcher_prefix(matcher))));
-  } else if (envoy_type_matcher_v3_StringMatcher_has_suffix(matcher)) {
-    json.emplace("suffix",
-                 Json::FromString(UpbStringToStdString(
-                     envoy_type_matcher_v3_StringMatcher_suffix(matcher))));
-  } else if (envoy_type_matcher_v3_StringMatcher_has_safe_regex(matcher)) {
-    json.emplace("safeRegex",
-                 ParseRegexMatcherToJson(
-                     envoy_type_matcher_v3_StringMatcher_safe_regex(matcher)));
-  } else if (envoy_type_matcher_v3_StringMatcher_has_contains(matcher)) {
-    json.emplace("contains",
-                 Json::FromString(UpbStringToStdString(
-                     envoy_type_matcher_v3_StringMatcher_contains(matcher))));
-  } else {
-    errors->AddError("invalid match pattern");
-  }
-  json.emplace(
-      "ignoreCase",
-      Json::FromBool(envoy_type_matcher_v3_StringMatcher_ignore_case(matcher)));
-  return Json::FromObject(std::move(json));
 }
 
 Json ParsePathMatcherToJson(const envoy_type_matcher_v3_PathMatcher* matcher,


### PR DESCRIPTION
Left-over from https://github.com/grpc/grpc/pull/32993 which implemented https://github.com/grpc/proposal/blob/master/A63-xds-string-matcher-in-header-matching.md in gRPC Core.

Changes - 
* Propagate `string_match` in `header_matcher`'s JSON from xDS RBAC filter to RBAC service config parser. 
* Fix a bug where `StringMatcher` was incorrectly handling `ignoreCase`.