### PR TITLE
[benchmark] Reenable OSS benchmarks for dotnet.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -134,7 +134,6 @@ declare -A useLanguage=(
 # Disable specific languages.
 declare -a disabledLanguages=(
   # Add a language here to disable it.
-  dotnet
 )
 for language in "${disabledLanguages[@]}"; do
   unset "useLanguage[${language}]"

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -129,7 +129,6 @@ declare -A useLanguage=(
 # Disable specific languages.
 declare -a disabledLanguages=(
   # Add a language here to disable it.
-  dotnet
 )
 for language in "${disabledLanguages[@]}"; do
   unset "useLanguage[${language}]"


### PR DESCRIPTION
Fixed by https://github.com/grpc/test-infra/pull/400.

