### PR TITLE
[StatsPlugingTest] Fix flakiness by increasing sleep duration in test

### DIFF
--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -704,7 +704,7 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeAnnotations) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
+  absl::SleepFor(absl::Milliseconds(1000 * grpc_test_slowdown_factor()));
   TestUtils::Flush();
   ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
   traces_recorder_->StopRecording();


### PR DESCRIPTION
Fixes flakiness: https://btx.cloud.google.com/invocations/593adc43-f0fc-4c3a-8a1b-3be4e47f439d/targets/%2F%2Ftest%2Fcpp%2Fext%2Ffilters%2Fcensus:grpc_opencensus_plugin_test@poller%3Depoll1;config=73d114f34497fe815dc9359619f4998ad393f9a101551e59d2a81873570c0afd/log