### PR TITLE
[BmPicker] Reduce benchmark iterations for tsan builds to avoid timeouts

### DIFF
--- a/test/core/load_balancing/bm_picker.cc
+++ b/test/core/load_balancing/bm_picker.cc
@@ -32,7 +32,9 @@
 namespace grpc_core {
 namespace {
 
-bool IsSlowBuild() { return BuiltUnderMsan() || BuiltUnderUbsan(); }
+bool IsSlowBuild() {
+  return BuiltUnderMsan() || BuiltUnderUbsan() || BuiltUnderTsan();
+}
 
 class BenchmarkHelper : public std::enable_shared_from_this<BenchmarkHelper> {
  public:


### PR DESCRIPTION

Should fix timeouts such as: https://btx.cloud.google.com/invocations/41332a4c-4669-4e92-94d0-e4b420da004f/targets/%2F%2Ftest%2Fcore%2Fload_balancing:bm_picker;config=53c2f63e6667a07a5c22812db1ee3a914286ff734d9b52abc9d6afd7ccd980db/tests

