### PR TITLE
[CSM] Use xds-enabled server and xds credentials in examples (#38192)

### DIFF
--- a/examples/cpp/csm/observability/csm_greeter_server.cc
+++ b/examples/cpp/csm/observability/csm_greeter_server.cc
@@ -67,6 +67,6 @@ int main(int argc, char** argv) {
               << observability.status().ToString() << std::endl;
     return static_cast<int>(observability.status().code());
   }
-  RunServer(absl::GetFlag(FLAGS_port));
+  RunXdsEnabledServer(absl::GetFlag(FLAGS_port));
   return 0;
 }

--- a/examples/cpp/otel/BUILD
+++ b/examples/cpp/otel/BUILD
@@ -27,7 +27,6 @@ cc_library(
         "//:grpc++",
         "//:grpc++_reflection",
         "//:grpc++_xds_server",
-        "//:grpcpp_admin",
         "//examples/protos:helloworld_cc_grpc",
         "@io_opentelemetry_cpp//sdk/src/metrics",
     ],

--- a/examples/cpp/otel/BUILD
+++ b/examples/cpp/otel/BUILD
@@ -26,6 +26,8 @@ cc_library(
     deps = [
         "//:grpc++",
         "//:grpc++_reflection",
+        "//:grpc++_xds_server",
+        "//:grpcpp_admin",
         "//examples/protos:helloworld_cc_grpc",
         "@io_opentelemetry_cpp//sdk/src/metrics",
     ],

--- a/examples/cpp/otel/util.cc
+++ b/examples/cpp/otel/util.cc
@@ -23,9 +23,11 @@
 #define HAVE_ABSEIL
 #endif
 
+#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/xds_server_builder.h>
 
 #include <condition_variable>
 #include <mutex>
@@ -164,13 +166,38 @@ void RunServer(uint16_t port) {
   server->Wait();
 }
 
+void RunXdsEnabledServer(uint16_t port) {
+  std::string server_address = absl::StrFormat("0.0.0.0:%d", port);
+  GreeterServiceImpl service;
+
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  grpc::XdsServerBuilder builder;
+  // Listen on the given address without any authentication mechanism.
+  builder.AddListeningPort(
+      server_address,
+      grpc::XdsServerCredentials(grpc::InsecureServerCredentials()));
+  // Register "service" as the instance through which we'll communicate with
+  // clients. In this case it corresponds to an *synchronous* service.
+  builder.RegisterService(&service);
+  grpc::AddAdminServices(&builder);
+  // Finally assemble the server.
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  // Wait for the server to shutdown. Note that some other thread must be
+  // responsible for shutting down the server for this call to ever return.
+  server->Wait();
+}
+
 void RunClient(const std::string& target_str) {
   // Instantiate the client. It requires a channel, out of which the actual RPCs
   // are created. This channel models a connection to an endpoint specified by
   // the argument "--target=" which is the only expected argument.
   grpc::ChannelArguments args;
   GreeterClient greeter(grpc::CreateCustomChannel(
-      target_str, grpc::InsecureChannelCredentials(), args));
+      target_str, grpc::XdsCredentials(grpc::InsecureChannelCredentials()),
+      args));
   // Continuously send RPCs every second.
   while (true) {
     std::string user("world");

--- a/examples/cpp/otel/util.cc
+++ b/examples/cpp/otel/util.cc
@@ -23,7 +23,6 @@
 #define HAVE_ABSEIL
 #endif
 
-#include <grpcpp/ext/admin_services.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -180,7 +179,6 @@ void RunXdsEnabledServer(uint16_t port) {
   // Register "service" as the instance through which we'll communicate with
   // clients. In this case it corresponds to an *synchronous* service.
   builder.RegisterService(&service);
-  grpc::AddAdminServices(&builder);
   // Finally assemble the server.
   std::unique_ptr<Server> server(builder.BuildAndStart());
   std::cout << "Server listening on " << server_address << std::endl;

--- a/examples/cpp/otel/util.h
+++ b/examples/cpp/otel/util.h
@@ -29,5 +29,6 @@ void AddLatencyView(opentelemetry::sdk::metrics::MeterProvider* provider,
                     const std::string& name, const std::string& unit);
 
 void RunServer(uint16_t port);
+void RunXdsEnabledServer(uint16_t port);
 void RunClient(const std::string& target_str);
 #endif  // GRPCPP_EXAMPLES_CPP_OTEL_UTIL_H


### PR DESCRIPTION
Backport #38192 and #38196 to v1.68.x