### PR TITLE
[CSM Observability] Add option to use Xds server (v1.68.x backport)

### DIFF
--- a/examples/python/observability/csm/csm_greeter_server.py
+++ b/examples/python/observability/csm/csm_greeter_server.py
@@ -69,7 +69,8 @@ def _run(
     csm_plugin = _prepare_csm_observability_plugin(prometheus_endpoint)
     csm_plugin.register_global()
     server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=_THREAD_POOL_SIZE)
+        futures.ThreadPoolExecutor(max_workers=_THREAD_POOL_SIZE),
+        xds=secure_mode,
     )
     _configure_test_server(server, port, secure_mode, server_id)
     server.start()


### PR DESCRIPTION
Backport of #38194 to v1.68.x.
---
We already have the option to use Xds credentials based on `secure_mode` flag, this PR add the ability to create Xds server based on the same flag.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

