### PR TITLE
do not start threads while shutting down

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc
@@ -397,8 +397,8 @@ void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Lifeguard::
     if (pool_->IsShutdown()) {
       if (pool_->IsQuiesced()) break;
     } else {
-      lifeguard_should_shut_down_->WaitForNotificationWithTimeout(
-          absl::Milliseconds(backoff_.NextAttemptDelay().millis()));
+      if(lifeguard_should_shut_down_->WaitForNotificationWithTimeout(
+          absl::Milliseconds(backoff_.NextAttemptDelay().millis()))) break;
     }
     MaybeStartNewThread();
   }


### PR DESCRIPTION
prohibit workstealing thread pool lifeguard starting of threads while shutting down




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

