### PR TITLE
Fix the issue that the example cpp route_guide fails to parse command-line arguments.

### DIFF
--- a/examples/cpp/route_guide/helper.cc
+++ b/examples/cpp/route_guide/helper.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
 #include "absl/log/log.h"
 
 #ifdef BAZEL_BUILD
@@ -43,6 +44,7 @@ ABSL_FLAG(std::string, db_path, "route_guide_db.json", "Path to db file");
 namespace routeguide {
 
 std::string GetDbFileContent(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
   std::string db_path = absl::GetFlag(FLAGS_db_path);
   std::ifstream db_file(db_path);
   if (!db_file.is_open()) {


### PR DESCRIPTION
I compiled route_guide outside of `examples/cpp/route_guide/` (in examples/cpp/route_guide/build) and got `route_guide_server`. I was unable to set `route_guide_db.json` by specifying `--db_path`, and I found that `route_guide_server` did not parse the command. This problem can be solved by adding `absl::ParseCommandLine(argc, argv);`.

![image](https://github.com/user-attachments/assets/5c5cfbb3-cbb2-4844-a36b-c3a76b516464)



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

