### PR TITLE
[promises] Allow void returns

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -3505,6 +3505,24 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "retry_interceptor",
+    srcs = [
+        "client_channel/retry_interceptor.cc",
+    ],
+    hdrs = [
+        "client_channel/retry_interceptor.h",
+    ],
+    deps = [
+        "cancel_callback",
+        "for_each",
+        "interception_chain",
+        "map",
+        "request_buffer",
+        "sleep",
+    ],
+)
+
+grpc_cc_library(
     name = "retry_service_config",
     srcs = [
         "client_channel/retry_service_config.cc",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -3505,24 +3505,6 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
-    name = "retry_interceptor",
-    srcs = [
-        "client_channel/retry_interceptor.cc",
-    ],
-    hdrs = [
-        "client_channel/retry_interceptor.h",
-    ],
-    deps = [
-        "cancel_callback",
-        "for_each",
-        "interception_chain",
-        "map",
-        "request_buffer",
-        "sleep",
-    ],
-)
-
-grpc_cc_library(
     name = "retry_service_config",
     srcs = [
         "client_channel/retry_service_config.cc",

--- a/src/core/client_channel/direct_channel.cc
+++ b/src/core/client_channel/direct_channel.cc
@@ -59,7 +59,7 @@ void DirectChannel::StartCall(UnstartedCallHandler unstarted_handler) {
       "start",
       [interception_chain = interception_chain_, unstarted_handler]() mutable {
         interception_chain->StartCall(std::move(unstarted_handler));
-        return []() { return Empty{}; };
+        return []() {};
       });
 }
 

--- a/src/core/ext/transport/chaotic_good/client_transport.cc
+++ b/src/core/ext/transport/chaotic_good/client_transport.cc
@@ -238,7 +238,6 @@ void ChaoticGoodClientTransport::AbortWithError() {
     call_handler.SpawnInfallible("cancel", [call_handler]() mutable {
       call_handler.PushServerTrailingMetadata(ServerMetadataFromStatus(
           absl::UnavailableError("Transport closed.")));
-      return Empty{};
     });
   }
 }

--- a/src/core/ext/transport/chaotic_good/control_endpoint.h
+++ b/src/core/ext/transport/chaotic_good/control_endpoint.h
@@ -57,7 +57,6 @@ class ControlEndpoint {
             << " bytes on " << this;
         waker = std::move(flush_waker_);
         queued_output_.Append(buffer);
-        return Empty{};
       };
     }
 

--- a/src/core/ext/transport/chaotic_good/control_endpoint.h
+++ b/src/core/ext/transport/chaotic_good/control_endpoint.h
@@ -57,6 +57,7 @@ class ControlEndpoint {
             << " bytes on " << this;
         waker = std::move(flush_waker_);
         queued_output_.Append(buffer);
+        return Empty{};
       };
     }
 

--- a/src/core/ext/transport/chaotic_good/data_endpoints.cc
+++ b/src/core/ext/transport/chaotic_good/data_endpoints.cc
@@ -219,7 +219,6 @@ DataEndpoints::DataEndpoints(
                              input_queues](absl::StatusOr<SliceBuffer> buffer) {
                               input_queues->CompleteRead(ticket,
                                                          std::move(buffer));
-                              return Empty{};
                             });
                       });
                 },

--- a/src/core/ext/transport/chaotic_good/server_transport.cc
+++ b/src/core/ext/transport/chaotic_good/server_transport.cc
@@ -178,6 +178,7 @@ auto ChaoticGoodServerTransport::CallOutboundLoop(
                 GRPC_TRACE_VLOG(chaotic_good, 2)
                     << "CHAOTIC_GOOD: CallOutboundLoop: stream_id=" << stream_id
                     << " main_body_result=" << main_body_result;
+                return Empty{};
               }),
           call_initiator.PullServerTrailingMetadata(),
           // Capture the call_initiator to ensure the underlying call_spine

--- a/src/core/ext/transport/chaotic_good_legacy/client_transport.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/client_transport.cc
@@ -246,7 +246,6 @@ void ChaoticGoodClientTransport::AbortWithError() {
     call_handler.SpawnInfallible("cancel", [call_handler]() mutable {
       call_handler.PushServerTrailingMetadata(ServerMetadataFromStatus(
           absl::UnavailableError("Transport closed.")));
-      return Empty{};
     });
   }
 }

--- a/src/core/ext/transport/chaotic_good_legacy/server_transport.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/server_transport.cc
@@ -224,7 +224,6 @@ auto ChaoticGoodServerTransport::CallOutboundLoop(
                 GRPC_TRACE_VLOG(chaotic_good, 2)
                     << "CHAOTIC_GOOD: CallOutboundLoop: stream_id=" << stream_id
                     << " main_body_result=" << main_body_result;
-                return Empty{};
               }),
           call_initiator.PullServerTrailingMetadata(),
           // Capture the call_initator to ensure the underlying call_spine
@@ -422,10 +421,8 @@ void ChaoticGoodServerTransport::AbortWithError() {
   lock.Release();
   for (const auto& pair : stream_map) {
     auto call_initiator = pair.second;
-    call_initiator.SpawnInfallible("cancel", [call_initiator]() mutable {
-      call_initiator.Cancel();
-      return Empty{};
-    });
+    call_initiator.SpawnInfallible(
+        "cancel", [call_initiator]() mutable { call_initiator.Cancel(); });
   }
 }
 
@@ -474,10 +471,7 @@ absl::Status ChaoticGoodServerTransport::NewStream(
             self->ExtractStream(stream_id);
         if (call_initiator.has_value()) {
           auto c = std::move(*call_initiator);
-          c.SpawnInfallible("cancel", [c]() mutable {
-            c.Cancel();
-            return Empty{};
-          });
+          c.SpawnInfallible("cancel", [c]() mutable { c.Cancel(); });
         }
       });
   if (!on_done_added) {

--- a/src/core/lib/promise/map.h
+++ b/src/core/lib/promise/map.h
@@ -31,8 +31,20 @@ namespace promise_detail {
 // Implementation of mapping combinator - use this via the free function below!
 // Promise is the type of promise to poll on, Fn is a function that takes the
 // result of Promise and maps it to some new type.
+template <typename Promise, typename Fn, typename SfinaeVoid = void>
+class Map;
+
 template <typename Promise, typename Fn>
-class Map {
+class Map<Promise, Fn,
+          absl::enable_if_t<!std::is_void<
+#if (defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+              std::invoke_result_t<Fn, typename PromiseLike<Promise>::Result>
+#else
+              typename std::result_of<Fn(
+                  typename PromiseLike<Promise>::Result)>::type
+#endif
+              >::value>> {
  public:
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION Map(Promise promise, Fn fn)
       : promise_(std::move(promise)), fn_(std::move(fn)) {}
@@ -52,6 +64,45 @@ class Map {
     Poll<PromiseResult> r = promise_();
     if (auto* p = r.value_if_ready()) {
       return fn_(std::move(*p));
+    }
+    return Pending();
+  }
+
+ private:
+  PromiseLike<Promise> promise_;
+  Fn fn_;
+};
+
+template <typename Promise, typename Fn>
+class Map<Promise, Fn,
+          absl::enable_if_t<std::is_void<
+#if (defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+              std::invoke_result_t<Fn, typename PromiseLike<Promise>::Result>
+#else
+              typename std::result_of<Fn(
+                  typename PromiseLike<Promise>::Result)>::type
+#endif
+              >::value>> {
+ public:
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION Map(Promise promise, Fn fn)
+      : promise_(std::move(promise)), fn_(std::move(fn)) {}
+
+  Map(const Map&) = delete;
+  Map& operator=(const Map&) = delete;
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor): clang6 bug
+  Map(Map&& other) = default;
+  // NOLINTNEXTLINE(performance-noexcept-move-constructor): clang6 bug
+  Map& operator=(Map&& other) = default;
+
+  using PromiseResult = typename PromiseLike<Promise>::Result;
+  using Result = Empty;
+
+  GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION Poll<Result> operator()() {
+    Poll<PromiseResult> r = promise_();
+    if (auto* p = r.value_if_ready()) {
+      fn_(std::move(*p));
+      return Empty{};
     }
     return Pending();
   }

--- a/src/core/lib/surface/client_call.cc
+++ b/src/core/lib/surface/client_call.cc
@@ -162,7 +162,6 @@ void ClientCall::CancelWithError(grpc_error_handle error) {
             "CancelWithError", [self = WeakRefAsSubclass<ClientCall>(),
                                 error = std::move(error)]() mutable {
               self->started_call_initiator_.Cancel(std::move(error));
-              return Empty{};
             });
         return;
       default:

--- a/src/core/lib/surface/server_call.h
+++ b/src/core/lib/surface/server_call.h
@@ -80,7 +80,6 @@ class ServerCall final : public Call, public DualRefCounted<ServerCall> {
         [self = WeakRefAsSubclass<ServerCall>(), error = std::move(error)] {
           self->call_handler_.PushServerTrailingMetadata(
               CancelledServerMetadataFromStatus(error));
-          return Empty{};
         });
   }
   bool is_trailers_only() const override {

--- a/src/core/lib/transport/call_spine.cc
+++ b/src/core/lib/transport/call_spine.cc
@@ -45,10 +45,8 @@ void ForwardCall(CallHandler call_handler, CallInitiator call_initiator,
                 call_initiator.SpawnInfallible("finish-downstream-ok",
                                                [call_initiator]() mutable {
                                                  call_initiator.FinishSends();
-                                                 return Empty{};
                                                });
               }
-              return Empty{};
             });
       });
   call_handler.SpawnInfallible(
@@ -111,9 +109,7 @@ void ForwardCall(CallHandler call_handler, CallInitiator call_initiator,
                   "recv_trailing",
                   [call_handler, md = std::move(md)]() mutable {
                     call_handler.PushServerTrailingMetadata(std::move(md));
-                    return Empty{};
                   });
-              return Empty{};
             });
       });
 }

--- a/test/core/call/bm_client_call.cc
+++ b/test/core/call/bm_client_call.cc
@@ -160,7 +160,6 @@ void BM_Unary(benchmark::State& state) {
                 Arena::MakePooledForOverwrite<ServerMetadata>();
             trailing_metadata->Set(GrpcStatusMetadata(), GRPC_STATUS_OK);
             handler.PushServerTrailingMetadata(std::move(trailing_metadata));
-            return Empty{};
           });
     });
     auto ev = grpc_completion_queue_next(

--- a/test/core/call/yodel/yodel_test.h
+++ b/test/core/call/yodel/yodel_test.h
@@ -132,7 +132,6 @@ class SequenceSpawner {
           (*spawner)(name_and_location.name(),
                      WrapPromiseAndNext(std::move(action_state),
                                         std::move(promise), std::move(next)));
-          return Empty{};
         });
   }
 

--- a/test/core/call/yodel/yodel_test.h
+++ b/test/core/call/yodel/yodel_test.h
@@ -132,6 +132,7 @@ class SequenceSpawner {
           (*spawner)(name_and_location.name(),
                      WrapPromiseAndNext(std::move(action_state),
                                         std::move(promise), std::move(next)));
+          return Empty{};
         });
   }
 

--- a/test/core/client_channel/client_channel_test.cc
+++ b/test/core/client_channel/client_channel_test.cc
@@ -274,11 +274,9 @@ CLIENT_CHANNEL_TEST(StartCall) {
   QueueNameResolutionResult(
       MakeSuccessfulResolutionResult("ipv4:127.0.0.1:1234"));
   auto call_handler = TickUntilCallStarted();
-  SpawnTestSeq(call.initiator, "cancel",
-               [call_initiator = call.initiator]() mutable {
-                 call_initiator.Cancel();
-                 return Empty{};
-               });
+  SpawnTestSeq(
+      call.initiator, "cancel",
+      [call_initiator = call.initiator]() mutable { call_initiator.Cancel(); });
   WaitForAllPendingWork();
 }
 
@@ -361,13 +359,10 @@ CLIENT_CHANNEL_TEST(ConfigSelectorWithDynamicFilters) {
           EXPECT_TRUE(value.has_value());
           if (value.has_value()) EXPECT_EQ(*value, "bar");
         }
-        return Empty{};
       });
-  SpawnTestSeq(call.initiator, "cancel",
-               [call_initiator = call.initiator]() mutable {
-                 call_initiator.Cancel();
-                 return Empty{};
-               });
+  SpawnTestSeq(
+      call.initiator, "cancel",
+      [call_initiator = call.initiator]() mutable { call_initiator.Cancel(); });
   WaitForAllPendingWork();
 }
 

--- a/test/core/client_channel/connected_subchannel_test.cc
+++ b/test/core/client_channel/connected_subchannel_test.cc
@@ -165,7 +165,6 @@ CONNECTED_SUBCHANNEL_CHANNEL_TEST(StartCall) {
   SpawnTestSeq(
       call.handler, "start-call", [channel, handler = call.handler]() mutable {
         channel->unstarted_call_destination()->StartCall(std::move(handler));
-        return Empty{};
       });
   auto handler = TickUntilCallStarted();
   WaitForAllPendingWork();

--- a/test/core/client_channel/load_balanced_call_destination_test.cc
+++ b/test/core/client_channel/load_balanced_call_destination_test.cc
@@ -166,12 +166,8 @@ LOAD_BALANCED_CALL_DESTINATION_TEST(CreateCall) {
       call.initiator, "initiator",
       [this, handler = std::move(call.handler)]() {
         destination_under_test().StartCall(handler);
-        return Empty{};
       },
-      [call_initiator = call.initiator]() mutable {
-        call_initiator.Cancel();
-        return Empty{};
-      });
+      [call_initiator = call.initiator]() mutable { call_initiator.Cancel(); });
   WaitForAllPendingWork();
 }
 
@@ -180,7 +176,6 @@ LOAD_BALANCED_CALL_DESTINATION_TEST(StartCall) {
   SpawnTestSeq(call.initiator, "initiator",
                [this, handler = std::move(call.handler)]() {
                  destination_under_test().StartCall(handler);
-                 return Empty{};
                });
   auto mock_picker = MakeRefCounted<StrictMock<MockPicker>>();
   EXPECT_CALL(*mock_picker, Pick)
@@ -189,11 +184,9 @@ LOAD_BALANCED_CALL_DESTINATION_TEST(StartCall) {
       });
   picker().Set(mock_picker);
   auto handler = TickUntilCallStarted();
-  SpawnTestSeq(call.initiator, "cancel",
-               [call_initiator = call.initiator]() mutable {
-                 call_initiator.Cancel();
-                 return Empty{};
-               });
+  SpawnTestSeq(
+      call.initiator, "cancel",
+      [call_initiator = call.initiator]() mutable { call_initiator.Cancel(); });
   WaitForAllPendingWork();
 }
 
@@ -212,7 +205,6 @@ LOAD_BALANCED_CALL_DESTINATION_TEST(StartCallOnDestroyedChannel) {
       [](ServerMetadataHandle md) {
         EXPECT_EQ(md->get(GrpcStatusMetadata()).value_or(GRPC_STATUS_UNKNOWN),
                   GRPC_STATUS_UNAVAILABLE);
-        return Empty{};
       });
   // Set a picker and wait for at least one pick attempt to prove the call has
   // made it to the picker.

--- a/test/core/promise/party_test.cc
+++ b/test/core/promise/party_test.cc
@@ -99,13 +99,7 @@ TEST_F(PartyTest, CanSpawnWaitableAndRun) {
       },
       [&n](Empty) { n.Notify(); });
   ASSERT_FALSE(n.HasBeenNotified());
-  party1->Spawn(
-      "party1_notify_latch",
-      [&done]() {
-        done.Set();
-        return Empty{};
-      },
-      [](Empty) {});
+  party1->Spawn("party1_notify_latch", [&done]() { done.Set(); }, [](Empty) {});
   n.WaitForNotification();
 }
 
@@ -255,10 +249,8 @@ TEST_F(PartyTest, CanBulkSpawn) {
   Notification n2;
   {
     Party::WakeupHold hold(party.get());
-    party->Spawn(
-        "spawn1", []() { return Empty{}; }, [&n1](Empty) { n1.Notify(); });
-    party->Spawn(
-        "spawn2", []() { return Empty{}; }, [&n2](Empty) { n2.Notify(); });
+    party->Spawn("spawn1", []() {}, [&n1](Empty) { n1.Notify(); });
+    party->Spawn("spawn2", []() {}, [&n2](Empty) { n2.Notify(); });
     for (int i = 0; i < 5000; i++) {
       EXPECT_FALSE(n1.HasBeenNotified());
       EXPECT_FALSE(n2.HasBeenNotified());
@@ -275,10 +267,8 @@ TEST_F(PartyTest, CanNestWakeupHold) {
   {
     Party::WakeupHold hold1(party.get());
     Party::WakeupHold hold2(party.get());
-    party->Spawn(
-        "spawn1", []() { return Empty{}; }, [&n1](Empty) { n1.Notify(); });
-    party->Spawn(
-        "spawn2", []() { return Empty{}; }, [&n2](Empty) { n2.Notify(); });
+    party->Spawn("spawn1", []() {}, [&n1](Empty) { n1.Notify(); });
+    party->Spawn("spawn2", []() {}, [&n2](Empty) { n2.Notify(); });
     for (int i = 0; i < 5000; i++) {
       EXPECT_FALSE(n1.HasBeenNotified());
       EXPECT_FALSE(n2.HasBeenNotified());
@@ -559,7 +549,6 @@ TEST_F(PartyTest, NestedWakeup) {
               started3.WaitForNotification();
               EXPECT_EQ(whats_going_on, 3);
               whats_going_on = 4;
-              return Empty{};
             },
             [&](Empty) {
               EXPECT_EQ(whats_going_on, 4);
@@ -574,7 +563,6 @@ TEST_F(PartyTest, NestedWakeup) {
               done2.WaitForNotification();
               EXPECT_EQ(whats_going_on, 5);
               whats_going_on = 6;
-              return Empty{};
             },
             [&](Empty) {
               EXPECT_EQ(whats_going_on, 6);
@@ -583,7 +571,6 @@ TEST_F(PartyTest, NestedWakeup) {
             });
         EXPECT_EQ(whats_going_on, 1);
         whats_going_on = 2;
-        return Empty{};
       },
       [&](Empty) {
         EXPECT_EQ(whats_going_on, 2);

--- a/test/core/promise/promise_mutex_test.cc
+++ b/test/core/promise/promise_mutex_test.cc
@@ -33,24 +33,20 @@ TEST(PromiseMutexTest, Basic) {
   bool done = false;
   MakeActivity(
       [&]() {
-        return Seq(Join(Seq(mutex.Acquire(),
-                            [](PromiseMutex<int>::Lock l) {
-                              EXPECT_EQ(*l, 1);
-                              *l = 2;
-                              return Empty{};
-                            }),
-                        Seq(mutex.Acquire(),
-                            [](PromiseMutex<int>::Lock l) {
-                              EXPECT_EQ(*l, 2);
-                              *l = 3;
-                              return Empty{};
-                            }),
-                        Seq(mutex.Acquire(),
-                            [](PromiseMutex<int>::Lock l) {
-                              EXPECT_EQ(*l, 3);
-                              return Empty{};
-                            })),
-                   []() { return absl::OkStatus(); });
+        return Seq(
+            Join(Seq(mutex.Acquire(),
+                     [](PromiseMutex<int>::Lock l) {
+                       EXPECT_EQ(*l, 1);
+                       *l = 2;
+                     }),
+                 Seq(mutex.Acquire(),
+                     [](PromiseMutex<int>::Lock l) {
+                       EXPECT_EQ(*l, 2);
+                       *l = 3;
+                     }),
+                 Seq(mutex.Acquire(),
+                     [](PromiseMutex<int>::Lock l) { EXPECT_EQ(*l, 3); })),
+            []() { return absl::OkStatus(); });
       },
       InlineWakeupScheduler(),
       [&done](absl::Status status) {

--- a/test/core/promise/try_seq_test.cc
+++ b/test/core/promise/try_seq_test.cc
@@ -195,7 +195,6 @@ TEST(TrySeqContainer, Ok) {
                            [&expect](const std::unique_ptr<int>& i, Empty) {
                              EXPECT_EQ(*i, expect);
                              ++expect;
-                             return Empty{};
                            });
   EXPECT_THAT(p(), IsReady());
   EXPECT_EQ(expect, 4);

--- a/test/core/transport/bm_call_spine.cc
+++ b/test/core/transport/bm_call_spine.cc
@@ -73,14 +73,11 @@ class ForwardCallFixture {
           [p1_handler, &p2](ValueOrFailure<ClientMetadataHandle> md) mutable {
             CHECK(md.ok());
             ForwardCall(std::move(p1_handler), std::move(p2.initiator));
-            return Empty{};
           });
     });
     absl::optional<CallHandler> p2_handler;
-    p2.handler.SpawnInfallible("start", [&]() {
-      p2_handler = p2.handler.StartCall();
-      return Empty{};
-    });
+    p2.handler.SpawnInfallible("start",
+                               [&]() { p2_handler = p2.handler.StartCall(); });
     return {std::move(p1.initiator), std::move(*p2_handler)};
   }
 

--- a/test/core/transport/call_spine_test.cc
+++ b/test/core/transport/call_spine_test.cc
@@ -105,7 +105,6 @@ void CallSpineTest::UnaryRequest(CallInitiator initiator, CallHandler handler) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   SpawnTestSeq(
       handler, "handler",
@@ -139,7 +138,6 @@ void CallSpineTest::UnaryRequest(CallInitiator initiator, CallHandler handler) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
 }
 
@@ -161,7 +159,6 @@ CALL_SPINE_TEST(UnaryRequestThroughForwardCall) {
         auto call2 = MakeCall(std::move(md.value()));
         ForwardCall(handler, call2.initiator);
         UnaryRequest(initiator, call2.handler.StartCall());
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -180,7 +177,6 @@ CALL_SPINE_TEST(UnaryRequestThroughForwardCallWithServerTrailingMetadataHook) {
         ForwardCall(handler, call2.initiator,
                     [&got_md](ServerMetadata&) { got_md = true; });
         UnaryRequest(initiator, call2.handler.StartCall());
-        return Empty{};
       });
   WaitForAllPendingWork();
   EXPECT_TRUE(got_md);

--- a/test/core/transport/chaotic_good/client_transport_error_test.cc
+++ b/test/core/transport/chaotic_good/client_transport_error_test.cc
@@ -202,14 +202,12 @@ TEST_F(ClientTransportTest, AddOneStreamWithWriteFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -248,14 +246,12 @@ TEST_F(ClientTransportTest, AddOneStreamWithReadFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -310,14 +306,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithWriteFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done1](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done1.Call();
-              return Empty{};
             });
       });
   call2.initiator.SpawnInfallible(
@@ -326,14 +320,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithWriteFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done2](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done2.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -380,14 +372,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithReadFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done1](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done1.Call();
-              return Empty{};
             });
       });
   call2.initiator.SpawnInfallible(
@@ -396,14 +386,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithReadFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done2](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done2.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.

--- a/test/core/transport/chaotic_good/client_transport_test.cc
+++ b/test/core/transport/chaotic_good/client_transport_test.cc
@@ -151,20 +151,17 @@ TEST_F(TransportTest, AddOneStream) {
                             ->get_pointer(GrpcMessageMetadata())
                             ->as_string_view(),
                         "hello");
-              return Empty{};
             },
             [initiator]() mutable { return initiator.PullMessage(); },
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_TRUE(msg.has_value());
               EXPECT_EQ(msg.value().payload()->JoinIntoString(), many_as);
-              return Empty{};
             },
             [initiator]() mutable { return initiator.PullMessage(); },
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_FALSE(msg.has_value());
-              return Empty{};
             },
             [initiator]() mutable {
               return initiator.PullServerTrailingMetadata();
@@ -172,7 +169,6 @@ TEST_F(TransportTest, AddOneStream) {
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(), GRPC_STATUS_OK);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -239,33 +235,28 @@ TEST_F(TransportTest, AddOneStreamMultipleMessages) {
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
               EXPECT_TRUE(md.value().has_value());
-              return Empty{};
             },
             initiator.PullMessage(),
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_TRUE(msg.has_value());
               EXPECT_EQ(msg.value().payload()->JoinIntoString(), "12345678");
-              return Empty{};
             },
             initiator.PullMessage(),
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_TRUE(msg.has_value());
               EXPECT_EQ(msg.value().payload()->JoinIntoString(), "87654321");
-              return Empty{};
             },
             initiator.PullMessage(),
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_FALSE(msg.has_value());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(), GRPC_STATUS_OK);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.

--- a/test/core/transport/chaotic_good/data_endpoints_test.cc
+++ b/test/core/transport/chaotic_good/data_endpoints_test.cc
@@ -55,10 +55,7 @@ DATA_ENDPOINTS_TEST(CanWrite) {
   SpawnTestSeqWithoutContext(
       "write",
       data_endpoints.Write(SliceBuffer(Slice::FromCopiedString("hello"))),
-      [](uint32_t id) {
-        EXPECT_EQ(id, 0);
-        return Empty{};
-      });
+      [](uint32_t id) { EXPECT_EQ(id, 0); });
   WaitForAllPendingWork();
 }
 
@@ -79,15 +76,9 @@ DATA_ENDPOINTS_TEST(CanMultiWrite) {
   SpawnTestSeqWithoutContext(
       "write",
       data_endpoints.Write(SliceBuffer(Slice::FromCopiedString("hello"))),
-      [&write1_ep](uint32_t id) {
-        write1_ep = id;
-        return Empty{};
-      },
+      [&write1_ep](uint32_t id) { write1_ep = id; },
       data_endpoints.Write(SliceBuffer(Slice::FromCopiedString("world"))),
-      [&write2_ep](uint32_t id) {
-        write2_ep = id;
-        return Empty{};
-      });
+      [&write2_ep](uint32_t id) { write2_ep = id; });
   WaitForAllPendingWork();
   EXPECT_THAT(write1_ep, ::testing::AnyOf(0, 1));
   EXPECT_THAT(write2_ep, ::testing::AnyOf(0, 1));
@@ -111,7 +102,6 @@ DATA_ENDPOINTS_TEST(CanRead) {
                              [](absl::StatusOr<SliceBuffer> result) {
                                EXPECT_TRUE(result.ok());
                                EXPECT_EQ(result->JoinIntoString(), "hello");
-                               return Empty{};
                              });
   WaitForAllPendingWork();
 }

--- a/test/core/transport/chaotic_good/server_transport_test.cc
+++ b/test/core/transport/chaotic_good/server_transport_test.cc
@@ -136,20 +136,17 @@ TEST_F(TransportTest, ReadAndWriteOneMessage) {
                               ->get_pointer(HttpPathMetadata())
                               ->as_string_view(),
                           "/demo.Service/Step");
-                return Empty{};
               },
               [handler]() mutable { return handler.PullMessage(); },
               [](ClientToServerNextMessage msg) {
                 EXPECT_TRUE(msg.ok());
                 EXPECT_TRUE(msg.has_value());
                 EXPECT_EQ(msg.value().payload()->JoinIntoString(), "12345678");
-                return Empty{};
               },
               [handler]() mutable { return handler.PullMessage(); },
               [](ClientToServerNextMessage msg) {
                 EXPECT_TRUE(msg.ok());
                 EXPECT_FALSE(msg.has_value());
-                return Empty{};
               },
               [handler]() mutable {
                 return handler.PushServerInitialMetadata(TestInitialMetadata());
@@ -161,7 +158,6 @@ TEST_F(TransportTest, ReadAndWriteOneMessage) {
               [handler, &on_done]() mutable {
                 handler.PushServerTrailingMetadata(TestTrailingMetadata());
                 on_done.Call();
-                return Empty{};
               });
         });
       }));

--- a/test/core/transport/chaotic_good_legacy/client_transport_error_test.cc
+++ b/test/core/transport/chaotic_good_legacy/client_transport_error_test.cc
@@ -202,14 +202,12 @@ TEST_F(ClientTransportTest, AddOneStreamWithWriteFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -246,14 +244,12 @@ TEST_F(ClientTransportTest, AddOneStreamWithReadFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -306,14 +302,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithWriteFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done1](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done1.Call();
-              return Empty{};
             });
       });
   call2.initiator.SpawnInfallible(
@@ -322,14 +316,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithWriteFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done2](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done2.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -374,14 +366,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithReadFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done1](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done1.Call();
-              return Empty{};
             });
       });
   call2.initiator.SpawnInfallible(
@@ -390,14 +380,12 @@ TEST_F(ClientTransportTest, AddMultipleStreamWithReadFailed) {
             initiator.PullServerInitialMetadata(),
             [](ValueOrFailure<absl::optional<ServerMetadataHandle>> md) {
               EXPECT_TRUE(md.ok());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done2](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(),
                         GRPC_STATUS_UNAVAILABLE);
               on_done2.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.

--- a/test/core/transport/chaotic_good_legacy/client_transport_test.cc
+++ b/test/core/transport/chaotic_good_legacy/client_transport_test.cc
@@ -151,20 +151,17 @@ TEST_F(TransportTest, AddOneStream) {
                             ->get_pointer(HttpPathMetadata())
                             ->as_string_view(),
                         "/demo.Service/Step");
-              return Empty{};
             },
             [initiator]() mutable { return initiator.PullMessage(); },
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_TRUE(msg.has_value());
               EXPECT_EQ(msg.value().payload()->JoinIntoString(), "12345678");
-              return Empty{};
             },
             [initiator]() mutable { return initiator.PullMessage(); },
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_FALSE(msg.has_value());
-              return Empty{};
             },
             [initiator]() mutable {
               return initiator.PullServerTrailingMetadata();
@@ -172,7 +169,6 @@ TEST_F(TransportTest, AddOneStream) {
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(), GRPC_STATUS_OK);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.
@@ -241,33 +237,28 @@ TEST_F(TransportTest, AddOneStreamMultipleMessages) {
                             ->get_pointer(HttpPathMetadata())
                             ->as_string_view(),
                         "/demo.Service/Step");
-              return Empty{};
             },
             initiator.PullMessage(),
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_TRUE(msg.has_value());
               EXPECT_EQ(msg.value().payload()->JoinIntoString(), "12345678");
-              return Empty{};
             },
             initiator.PullMessage(),
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_TRUE(msg.has_value());
               EXPECT_EQ(msg.value().payload()->JoinIntoString(), "87654321");
-              return Empty{};
             },
             initiator.PullMessage(),
             [](ServerToClientNextMessage msg) {
               EXPECT_TRUE(msg.ok());
               EXPECT_FALSE(msg.has_value());
-              return Empty{};
             },
             initiator.PullServerTrailingMetadata(),
             [&on_done](ServerMetadataHandle md) {
               EXPECT_EQ(md->get(GrpcStatusMetadata()).value(), GRPC_STATUS_OK);
               on_done.Call();
-              return Empty{};
             });
       });
   // Wait until ClientTransport's internal activities to finish.

--- a/test/core/transport/chaotic_good_legacy/server_transport_test.cc
+++ b/test/core/transport/chaotic_good_legacy/server_transport_test.cc
@@ -134,20 +134,17 @@ TEST_F(TransportTest, ReadAndWriteOneMessage) {
                               ->get_pointer(HttpPathMetadata())
                               ->as_string_view(),
                           "/demo.Service/Step");
-                return Empty{};
               },
               [handler]() mutable { return handler.PullMessage(); },
               [](ClientToServerNextMessage msg) {
                 EXPECT_TRUE(msg.ok());
                 EXPECT_TRUE(msg.has_value());
                 EXPECT_EQ(msg.value().payload()->JoinIntoString(), "12345678");
-                return Empty{};
               },
               [handler]() mutable { return handler.PullMessage(); },
               [](ClientToServerNextMessage msg) {
                 EXPECT_TRUE(msg.ok());
                 EXPECT_FALSE(msg.has_value());
-                return Empty{};
               },
               [handler]() mutable {
                 return handler.PushServerInitialMetadata(TestInitialMetadata());
@@ -159,7 +156,6 @@ TEST_F(TransportTest, ReadAndWriteOneMessage) {
               [handler, &on_done]() mutable {
                 handler.PushServerTrailingMetadata(TestTrailingMetadata());
                 on_done.Call();
-                return Empty{};
               });
         });
       }));

--- a/test/core/transport/interception_chain_test.cc
+++ b/test/core/transport/interception_chain_test.cc
@@ -219,7 +219,6 @@ class TestHijackingInterceptor final : public Interceptor {
                        ForwardCall(
                            hijacked_call.value().original_call_handler(),
                            hijacked_call.value().MakeCall());
-                       return Empty{};
                      });
         });
   }
@@ -262,7 +261,6 @@ class InterceptionChainTest : public ::testing::Test {
           return Map(call.initiator.PullServerTrailingMetadata(),
                      [&trailing_md](ServerMetadataHandle md) {
                        trailing_md = std::move(md);
-                       return Empty{};
                      });
         });
     EXPECT_THAT(trailing_md, IsReady());

--- a/test/core/transport/test_suite/call_content.cc
+++ b/test/core/transport/test_suite/call_content.cc
@@ -103,7 +103,6 @@ TRANSPORT_TEST(UnaryWithSomeContent) {
         EXPECT_TRUE(md.ok());
         EXPECT_THAT(LowerMetadata(**md),
                     UnorderedElementsAreArray(server_trailing_metadata));
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -137,7 +136,6 @@ TRANSPORT_TEST(UnaryWithSomeContent) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         FillMetadata(server_trailing_metadata, *md);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }

--- a/test/core/transport/test_suite/call_shapes.cc
+++ b/test/core/transport/test_suite/call_shapes.cc
@@ -38,7 +38,6 @@ TRANSPORT_TEST(MetadataOnlyRequest) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -61,7 +60,6 @@ TRANSPORT_TEST(MetadataOnlyRequest) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -93,7 +91,6 @@ TRANSPORT_TEST(MetadataOnlyRequestServerAbortsAfterInitialMetadata) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -114,7 +111,6 @@ TRANSPORT_TEST(MetadataOnlyRequestServerAbortsAfterInitialMetadata) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -144,7 +140,6 @@ TRANSPORT_TEST(MetadataOnlyRequestServerAbortsImmediately) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -159,7 +154,6 @@ TRANSPORT_TEST(MetadataOnlyRequestServerAbortsImmediately) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -170,10 +164,7 @@ TRANSPORT_TEST(CanCreateCallThenAbandonIt) {
   md->Set(HttpPathMetadata(), Slice::FromExternalString("/foo/bar"));
   auto initiator = CreateCall(std::move(md));
   auto handler = TickUntilServerCall();
-  SpawnTestSeq(initiator, "end-call", [&]() {
-    initiator.Cancel();
-    return Empty{};
-  });
+  SpawnTestSeq(initiator, "end-call", [&]() { initiator.Cancel(); });
   WaitForAllPendingWork();
 }
 
@@ -216,7 +207,6 @@ TRANSPORT_TEST(UnaryRequest) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -250,7 +240,6 @@ TRANSPORT_TEST(UnaryRequest) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -289,7 +278,6 @@ TRANSPORT_TEST(UnaryRequestOmitCheckEndOfStream) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -318,7 +306,6 @@ TRANSPORT_TEST(UnaryRequestOmitCheckEndOfStream) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -360,7 +347,6 @@ TRANSPORT_TEST(UnaryRequestWaitForServerInitialMetadataBeforeSendingPayload) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -395,7 +381,6 @@ TRANSPORT_TEST(UnaryRequestWaitForServerInitialMetadataBeforeSendingPayload) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -450,7 +435,6 @@ TRANSPORT_TEST(ClientStreamingRequest) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -504,7 +488,6 @@ TRANSPORT_TEST(ClientStreamingRequest) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }
@@ -576,7 +559,6 @@ TRANSPORT_TEST(ServerStreamingRequest) {
         EXPECT_TRUE(md.ok());
         EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                   GRPC_STATUS_UNIMPLEMENTED);
-        return Empty{};
       });
   auto handler = TickUntilServerCall();
   SpawnTestSeq(
@@ -630,7 +612,6 @@ TRANSPORT_TEST(ServerStreamingRequest) {
         auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
         md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
         handler.PushServerTrailingMetadata(std::move(md));
-        return Empty{};
       });
   WaitForAllPendingWork();
 }

--- a/test/core/transport/test_suite/stress.cc
+++ b/test/core/transport/test_suite/stress.cc
@@ -70,7 +70,6 @@ TRANSPORT_TEST(ManyUnaryRequests) {
           EXPECT_TRUE(md.ok());
           EXPECT_EQ(*md.value()->get_pointer(GrpcStatusMetadata()),
                     GRPC_STATUS_UNIMPLEMENTED);
-          return Empty{};
         });
   }
   for (int i = 0; i < kNumRequests; i++) {
@@ -115,7 +114,6 @@ TRANSPORT_TEST(ManyUnaryRequests) {
           auto md = Arena::MakePooledForOverwrite<ServerMetadata>();
           md->Set(GrpcStatusMetadata(), GRPC_STATUS_UNIMPLEMENTED);
           handler.PushServerTrailingMetadata(std::move(md));
-          return Empty{};
         });
   }
   WaitForAllPendingWork();

--- a/test/core/transport/test_suite/transport_test.cc
+++ b/test/core/transport/test_suite/transport_test.cc
@@ -35,7 +35,6 @@ CallInitiator TransportTest::CreateCall(
       "start-call", [this, handler = call.handler]() mutable {
         transport_pair_.client->client_transport()->StartCall(
             handler.StartCall());
-        return Empty{};
       });
   return std::move(call.initiator);
 }


### PR DESCRIPTION
In my very initial prototypes of promises I couldn't figure out how to sensibly handle the special case of a void return value, and so I invented `Empty{}` as a placeholder and force folks to use that.

This created a sharp edge whereby reasonable looking code was rejected (with an impossible to decipher error message) when a void return on an instantaneously returning promise-like lambda occurred.

Remove this sharp edge by explicitly returning a `Poll<Empty>` that only ever contains `Empty{}` in these cases.