### PR TITLE
[chaotic-good] Disable e2e tests on Windows

### DIFF
--- a/test/core/end2end/end2end_test_suites.cc
+++ b/test/core/end2end/end2end_test_suites.cc
@@ -1000,6 +1000,7 @@ std::vector<CoreTestConfiguration> DefaultConfigs() {
             return std::make_unique<InsecureFixtureWithPipeForWakeupFd>();
           }},
 #endif
+#ifndef GPR_WINDOWS
       CoreTestConfiguration{"ChaoticGoodFullStack",
                             FEATURE_MASK_SUPPORTS_CLIENT_CHANNEL |
                                 FEATURE_MASK_DOES_NOT_SUPPORT_RETRY |
@@ -1009,7 +1010,9 @@ std::vector<CoreTestConfiguration> DefaultConfigs() {
                             [](const ChannelArgs& /*client_args*/,
                                const ChannelArgs& /*server_args*/) {
                               return std::make_unique<ChaoticGoodFixture>();
-                            }}};
+                            }},
+#endif
+  };
 }
 
 std::vector<CoreTestConfiguration> AllConfigs() {


### PR DESCRIPTION
These look like they've been failing for some weeks. They're not necessary at the moment, so disabling until I get a chance to look into them properly.