### PR TITLE
[C++] Make string_ref compatible with C++14 std::string_view

### DIFF
--- a/include/grpcpp/support/string_ref.h
+++ b/include/grpcpp/support/string_ref.h
@@ -101,10 +101,12 @@ class string_ref {
     return 0;
   }
 
+  [[deprecated("Use grpc::StartsWith() instead.")]]
   bool starts_with(string_ref x) const {
     return length_ >= x.length_ && (memcmp(data_, x.data_, x.length_) == 0);
   }
 
+  [[deprecated("Use grpc::EndsWith() instead.")]]
   bool ends_with(string_ref x) const {
     return length_ >= x.length_ &&
            (memcmp(data_ + (length_ - x.length_), x.data_, x.length_) == 0);
@@ -141,6 +143,17 @@ inline bool operator>=(string_ref x, string_ref y) { return x.compare(y) >= 0; }
 
 inline std::ostream& operator<<(std::ostream& out, const string_ref& string) {
   return out << std::string(string.begin(), string.end());
+}
+
+inline bool StartsWith(string_ref text, string_ref prefix) noexcept {
+  return text.length() >= prefix.length() &&
+         (memcmp(text.data(), prefix.data(), prefix.length()) == 0);
+}
+
+inline bool EndsWith(string_ref text, string_ref suffix) noexcept {
+  return text.length() >= suffix.length() &&
+         (memcmp(text.data() + (text.length() - suffix.length()), suffix.data(),
+                 suffix.length()) == 0);
 }
 
 }  // namespace grpc

--- a/src/objective-c/tests/CppCronetTests/CppCronetEnd2EndTests.mm
+++ b/src/objective-c/tests/CppCronetTests/CppCronetEnd2EndTests.mm
@@ -153,7 +153,7 @@ using std::chrono::system_clock;
   XCTAssertTrue(s.ok());
   const auto& trailing_metadata = context.GetServerTrailingMetadata();
   auto iter = trailing_metadata.find("user-agent");
-  XCTAssert(iter->second.starts_with("custom_prefix grpc-c++"));
+  grpc::StartsWith(XCTAssert(iter->second, "custom_prefix grpc-c++"));
 }
 
 - (void)testMultipleRPCs {

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -127,8 +127,8 @@ class HijackingInterceptor : public experimental::Interceptor {
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = pair.first.starts_with("testkey") &&
-                pair.second.starts_with("testvalue");
+        found = grpc::StartsWith(pair.first, "testkey") &&
+                grpc::StartsWith(pair.second, "testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);
@@ -248,8 +248,8 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = pair.first.starts_with("testkey") &&
-                pair.second.starts_with("testvalue");
+        found = grpc::StartsWith(pair.first, "testkey") &&
+                grpc::StartsWith(pair.second, "testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);
@@ -472,8 +472,8 @@ class ServerStreamingRpcHijackingInterceptor
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = pair.first.starts_with("testkey") &&
-                pair.second.starts_with("testvalue");
+        found = grpc::StartsWith(pair.first, "testkey") &&
+                grpc::StartsWith(pair.second, "testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);
@@ -620,8 +620,8 @@ class LoggingInterceptor : public experimental::Interceptor {
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = pair.first.starts_with("testkey") &&
-                pair.second.starts_with("testvalue");
+        found = grpc::StartsWith(pair.first, "testkey") &&
+                grpc::StartsWith(pair.second, "testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -829,7 +829,7 @@ TEST_P(End2endTest, SimpleRpcWithCustomUserAgentPrefix) {
   auto iter = trailing_metadata.find("user-agent");
   EXPECT_TRUE(iter != trailing_metadata.end());
   std::string expected_prefix = user_agent_prefix_ + " grpc-c++/";
-  EXPECT_TRUE(iter->second.starts_with(expected_prefix)) << iter->second;
+  EXPECT_TRUE(grpc::StartsWith(iter->second, expected_prefix)) << iter->second;
 }
 
 TEST_P(End2endTest, MultipleRpcsWithVariedBinaryMetadataValue) {

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -125,7 +125,8 @@ class BackendServiceImpl : public BackendService {
     // using GRPC_ARG_GRPCLB_CHANNEL_ARGS.
     auto it = context->client_metadata().find("user-agent");
     if (it != context->client_metadata().end()) {
-      EXPECT_FALSE(it->second.starts_with(kGrpclbSpecificUserAgentString));
+      EXPECT_FALSE(
+          grpc::StartsWith(it->second, kGrpclbSpecificUserAgentString));
     }
     // Backend should receive the call credentials metadata.
     auto call_credentials_entry =

--- a/test/cpp/end2end/interceptors_util.cc
+++ b/test/cpp/end2end/interceptors_util.cc
@@ -184,7 +184,7 @@ void MakeCallbackCall(const std::shared_ptr<Channel>& channel) {
 bool CheckMetadata(const std::multimap<grpc::string_ref, grpc::string_ref>& map,
                    const string& key, const string& value) {
   for (const auto& pair : map) {
-    if (pair.first.starts_with(key) && pair.second.starts_with(value)) {
+    if (StartsWith(pair.first, key) && StartsWith(pair.second, value)) {
       return true;
     }
   }

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -95,8 +95,8 @@ class LoggingInterceptor : public experimental::Interceptor {
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = absl::StartsWith(pair.first, "testkey") &&
-                absl::StartsWith(pair.second, "testvalue");
+        found = grpc::StartsWith(pair.first, "testkey") &&
+                grpc::StartsWith(pair.second, "testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);
@@ -109,8 +109,8 @@ class LoggingInterceptor : public experimental::Interceptor {
       bool found = false;
       // Check that we received the metadata as an echo
       for (const auto& pair : *map) {
-        found = pair.first.starts_with("testkey") &&
-                pair.second.starts_with("testvalue");
+        found = grpc::StartsWith(pair.first, "testkey") &&
+                grpc::StartsWith(pair.second, "testvalue");
         if (found) break;
       }
       EXPECT_EQ(found, true);

--- a/test/cpp/interop/istio_echo_server_lib.cc
+++ b/test/cpp/interop/istio_echo_server_lib.cc
@@ -86,7 +86,7 @@ Status EchoTestServiceImpl::Echo(ServerContext* context,
       context->client_metadata();
   for (const auto& kv : metadata) {
     // Skip all binary headers.
-    if (kv.first.ends_with("-bin")) {
+    if (grpc::EndsWith(kv.first, "-bin")) {
       continue;
     }
     absl::StrAppend(&s, kRequestHeader, "=", StringRefToStringView(kv.first),

--- a/test/cpp/util/string_ref_test.cc
+++ b/test/cpp/util/string_ref_test.cc
@@ -131,22 +131,22 @@ TEST_F(StringRefTest, StartsWith) {
   string_ref s1(kTestString);
   string_ref s2(kTestUnrelatedString);
   string_ref s3(kTestStringWithEmbeddedNull, kTestStringWithEmbeddedNullLength);
-  EXPECT_TRUE(s1.starts_with(s1));
-  EXPECT_FALSE(s1.starts_with(s2));
-  EXPECT_FALSE(s2.starts_with(s1));
-  EXPECT_FALSE(s1.starts_with(s3));
-  EXPECT_TRUE(s3.starts_with(s1));
+  EXPECT_TRUE(StartsWith(s1, s1));
+  EXPECT_FALSE(StartsWith(s1, s2));
+  EXPECT_FALSE(StartsWith(s2, s1));
+  EXPECT_FALSE(StartsWith(s1, s3));
+  EXPECT_TRUE(StartsWith(s3, s1));
 }
 
 TEST_F(StringRefTest, Endswith) {
   string_ref s1(kTestString);
   string_ref s2(kTestUnrelatedString);
   string_ref s3(kTestStringWithEmbeddedNull, kTestStringWithEmbeddedNullLength);
-  EXPECT_TRUE(s1.ends_with(s1));
-  EXPECT_FALSE(s1.ends_with(s2));
-  EXPECT_FALSE(s2.ends_with(s1));
-  EXPECT_FALSE(s2.ends_with(s3));
-  EXPECT_TRUE(s3.ends_with(s2));
+  EXPECT_TRUE(EndsWith(s1, s1));
+  EXPECT_FALSE(EndsWith(s1, s2));
+  EXPECT_FALSE(EndsWith(s2, s1));
+  EXPECT_FALSE(EndsWith(s2, s3));
+  EXPECT_TRUE(EndsWith(s3, s2));
 }
 
 TEST_F(StringRefTest, Find) {


### PR DESCRIPTION
To prepare for an eventual switch from `grpc::string_ref` to `std::string_view`, we need to ensure compatibility between the two. Main difference is lack of `starts_with` and `ends_with` of `std::string_view` in C++14/17. To bridge the cap, code is updated to use utility functions, `StartsWith` and `EndsWith` instead. This is how `absl::string_view` handles this issue.

Note that C++20 introduced `starts_with` and `ends_with` method to `std::string_view` ([ref](https://en.cppreference.com/w/cpp/string/basic_string_view/starts_with)) but gRPC won't be able to switch over c++20 yet.