### PR TITLE
[Test] Fix error_details_test

### DIFF
--- a/test/cpp/util/error_details_test.cc
+++ b/test/cpp/util/error_details_test.cc
@@ -98,7 +98,7 @@ TEST(SetTest, OutOfScopeErrorCode) {
 }
 
 TEST(SetTest, ValidScopeErrorCode) {
-  for (int c = StatusCode::OK; c <= StatusCode::UNAUTHENTICATED; c++) {
+  for (int c = StatusCode::CANCELLED; c <= StatusCode::UNAUTHENTICATED; c++) {
     google::rpc::Status expected;
     expected.set_code(c);
     expected.set_message("I am an error message");


### PR DESCRIPTION
This test incorrectly assumes that a gRPC status of OK can include Status-Details.  However, according to https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md, Status-Details are not permitted when the Status is OK. To align this test with the specification, we should remove the test case that checks for Status-Details with an OK status.   