### PR TITLE
Create nonblocking function pair for use with an external event loop

### DIFF
--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -251,6 +251,16 @@ class Server : public ServerInterface, private internal::GrpcLibrary {
   void ShutdownInternal(gpr_timespec deadline)
       ABSL_LOCKS_EXCLUDED(mu_) override;
 
+  virtual void* BeginShutdownInternal(CompletionQueue* cq)
+      ABSL_LOCKS_EXCLUDED(mu_) override;
+
+  virtual void* BeginShutdownInternalNoLock(CompletionQueue* cq);
+
+  virtual void CompleteShutdownInternal(CompletionQueue* cq)
+      ABSL_LOCKS_EXCLUDED(mu_) override;
+
+  virtual void CompleteShutdownInternalNoLock(CompletionQueue* cq);
+
   int max_receive_message_size() const override {
     return max_receive_message_size_;
   }
@@ -352,6 +362,9 @@ class Server : public ServerInterface, private internal::GrpcLibrary {
 
   // Interface to read or update server-wide metrics. Optional.
   experimental::ServerMetricRecorder* server_metric_recorder_ = nullptr;
+
+  // tag for non-blocking shutdown
+  std::unique_ptr<internal::CompletionQueueTag> shutdown_tag_;
 };
 
 }  // namespace grpc


### PR DESCRIPTION
When running with a EventEngine that relies on an external event loop for notifications, `grpc::Server::Shutdown()` can block indefinitely.

```c++
  void* tag;
  bool ok;
  grpc::CompletionQueue::NextStatus status =
      shutdown_cq.AsyncNext(&tag, &ok, deadline);
  // If this timed out, it means we are done with the grace period for a clean
  // shutdown. We should force a shutdown now by cancelling all inflight calls
  if (status == grpc::CompletionQueue::NextStatus::TIMEOUT) {
    grpc_server_cancel_all_calls(server_);
    status =
        shutdown_cq.AsyncNext(&tag, &ok, gpr_inf_future(GPR_CLOCK_MONOTONIC));
  }
```

If the first call returns `TIMEOUT`, AsyncNext with an infinite timeout is called, which eventually calls `epoll_wait`. Since the file descriptors are not registered with this particular epoll fd, nothing happens and the server gets frozen during shutdown.

This patch creates a pair of functions `BeginShutdown` and `CompleteShutdown` so that a server running with an external event loop can have a chance to fall back to the external loop for notifications and allowing them to complete the operation later.



