### PR TITLE
[call-v3] Put retries under an experiment

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -39,6 +39,7 @@ EXPERIMENT_ENABLES = {
     "promise_based_http2_client_transport": "promise_based_http2_client_transport",
     "promise_based_http2_server_transport": "promise_based_http2_server_transport",
     "promise_based_inproc_transport": "promise_based_inproc_transport",
+    "retry_in_callv3": "retry_in_callv3",
     "rq_fast_reject": "rq_fast_reject",
     "schedule_cancellation_over_write": "schedule_cancellation_over_write",
     "server_privacy": "server_privacy",
@@ -66,6 +67,7 @@ EXPERIMENTS = {
                 "chaotic_good_legacy_protocol",
                 "event_engine_dns_non_client_channel",
                 "local_connector_secure",
+                "retry_in_callv3",
             ],
             "endpoint_test": [
                 "tcp_frame_size_tuning",
@@ -123,6 +125,7 @@ EXPERIMENTS = {
                 "chaotic_good_legacy_protocol",
                 "event_engine_dns_non_client_channel",
                 "local_connector_secure",
+                "retry_in_callv3",
             ],
             "endpoint_test": [
                 "tcp_frame_size_tuning",
@@ -166,6 +169,7 @@ EXPERIMENTS = {
                 "chaotic_good_legacy_protocol",
                 "event_engine_dns_non_client_channel",
                 "local_connector_secure",
+                "retry_in_callv3",
             ],
             "endpoint_test": [
                 "tcp_frame_size_tuning",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -108,6 +108,8 @@ const char* const additional_constraints_promise_based_http2_server_transport =
 const char* const description_promise_based_inproc_transport =
     "Use promises for the in-process transport.";
 const char* const additional_constraints_promise_based_inproc_transport = "{}";
+const char* const description_retry_in_callv3 = "Support retries with call-v3";
+const char* const additional_constraints_retry_in_callv3 = "{}";
 const char* const description_rq_fast_reject =
     "Resource quota rejects requests immediately (before allocating the "
     "request structure) under very high memory pressure.";
@@ -208,6 +210,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_promise_based_inproc_transport,
      additional_constraints_promise_based_inproc_transport, nullptr, 0, false,
      false},
+    {"retry_in_callv3", description_retry_in_callv3,
+     additional_constraints_retry_in_callv3, nullptr, 0, false, true},
     {"rq_fast_reject", description_rq_fast_reject,
      additional_constraints_rq_fast_reject, nullptr, 0, false, true},
     {"schedule_cancellation_over_write",
@@ -321,6 +325,8 @@ const char* const additional_constraints_promise_based_http2_server_transport =
 const char* const description_promise_based_inproc_transport =
     "Use promises for the in-process transport.";
 const char* const additional_constraints_promise_based_inproc_transport = "{}";
+const char* const description_retry_in_callv3 = "Support retries with call-v3";
+const char* const additional_constraints_retry_in_callv3 = "{}";
 const char* const description_rq_fast_reject =
     "Resource quota rejects requests immediately (before allocating the "
     "request structure) under very high memory pressure.";
@@ -421,6 +427,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_promise_based_inproc_transport,
      additional_constraints_promise_based_inproc_transport, nullptr, 0, false,
      false},
+    {"retry_in_callv3", description_retry_in_callv3,
+     additional_constraints_retry_in_callv3, nullptr, 0, false, true},
     {"rq_fast_reject", description_rq_fast_reject,
      additional_constraints_rq_fast_reject, nullptr, 0, false, true},
     {"schedule_cancellation_over_write",
@@ -534,6 +542,8 @@ const char* const additional_constraints_promise_based_http2_server_transport =
 const char* const description_promise_based_inproc_transport =
     "Use promises for the in-process transport.";
 const char* const additional_constraints_promise_based_inproc_transport = "{}";
+const char* const description_retry_in_callv3 = "Support retries with call-v3";
+const char* const additional_constraints_retry_in_callv3 = "{}";
 const char* const description_rq_fast_reject =
     "Resource quota rejects requests immediately (before allocating the "
     "request structure) under very high memory pressure.";
@@ -634,6 +644,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_promise_based_inproc_transport,
      additional_constraints_promise_based_inproc_transport, nullptr, 0, false,
      false},
+    {"retry_in_callv3", description_retry_in_callv3,
+     additional_constraints_retry_in_callv3, nullptr, 0, false, true},
     {"rq_fast_reject", description_rq_fast_reject,
      additional_constraints_rq_fast_reject, nullptr, 0, false, true},
     {"schedule_cancellation_over_write",

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -85,6 +85,7 @@ inline bool IsPrioritizeFinishedRequestsEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ServerTransportEnabled() { return false; }
 inline bool IsPromiseBasedInprocTransportEnabled() { return false; }
+inline bool IsRetryInCallv3Enabled() { return false; }
 inline bool IsRqFastRejectEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }
@@ -130,6 +131,7 @@ inline bool IsPrioritizeFinishedRequestsEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ServerTransportEnabled() { return false; }
 inline bool IsPromiseBasedInprocTransportEnabled() { return false; }
+inline bool IsRetryInCallv3Enabled() { return false; }
 inline bool IsRqFastRejectEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }
@@ -175,6 +177,7 @@ inline bool IsPrioritizeFinishedRequestsEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ServerTransportEnabled() { return false; }
 inline bool IsPromiseBasedInprocTransportEnabled() { return false; }
+inline bool IsRetryInCallv3Enabled() { return false; }
 inline bool IsRqFastRejectEnabled() { return false; }
 inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsServerPrivacyEnabled() { return false; }
@@ -213,6 +216,7 @@ enum ExperimentIds {
   kExperimentIdPromiseBasedHttp2ClientTransport,
   kExperimentIdPromiseBasedHttp2ServerTransport,
   kExperimentIdPromiseBasedInprocTransport,
+  kExperimentIdRetryInCallv3,
   kExperimentIdRqFastReject,
   kExperimentIdScheduleCancellationOverWrite,
   kExperimentIdServerPrivacy,
@@ -312,6 +316,10 @@ inline bool IsPromiseBasedHttp2ServerTransportEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_PROMISE_BASED_INPROC_TRANSPORT
 inline bool IsPromiseBasedInprocTransportEnabled() {
   return IsExperimentEnabled<kExperimentIdPromiseBasedInprocTransport>();
+}
+#define GRPC_EXPERIMENT_IS_INCLUDED_RETRY_IN_CALLV3
+inline bool IsRetryInCallv3Enabled() {
+  return IsExperimentEnabled<kExperimentIdRetryInCallv3>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_RQ_FAST_REJECT
 inline bool IsRqFastRejectEnabled() {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -177,6 +177,11 @@
   owner: ctiller@google.com
   test_tags: []
   allow_in_fuzzing_config: false # experiment currently crashes if enabled
+- name: retry_in_callv3
+  description: Support retries with call-v3
+  expiry: 2025/06/06
+  owner: ctiller@google.com
+  test_tags: [core_end2end_test]
 - name: rq_fast_reject
   description:
     Resource quota rejects requests immediately (before allocating the request

--- a/test/core/end2end/end2end_test_suites.cc
+++ b/test/core/end2end/end2end_test_suites.cc
@@ -536,6 +536,7 @@ class ChaoticGoodFixture : public CoreTestFixture {
         args.Set(GRPC_ARG_CHAOTIC_GOOD_DATA_CONNECTIONS, data_connections_)
             .Set(GRPC_ARG_CHAOTIC_GOOD_MAX_RECV_CHUNK_SIZE, chunk_size_)
             .Set(GRPC_ARG_CHAOTIC_GOOD_MAX_SEND_CHUNK_SIZE, chunk_size_)
+            .Set(GRPC_ARG_ENABLE_RETRIES, IsRetryInCallv3Enabled())
             .ToC()
             .get(),
         nullptr);

--- a/test/core/end2end/tests/retry.cc
+++ b/test/core/end2end/tests/retry.cc
@@ -34,6 +34,7 @@ namespace grpc_core {
 // - first attempt returns ABORTED
 // - second attempt returns OK
 CORE_END2END_TEST(RetryTest, Retry) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_cancel_after_first_attempt_starts.cc
+++ b/test/core/end2end/tests/retry_cancel_after_first_attempt_starts.cc
@@ -30,6 +30,7 @@ namespace {
 // Tests that we can unref a call after the first attempt starts but
 // before any ops complete.  This should not cause a memory leak.
 CORE_END2END_TEST(RetryTest, RetryCancelAfterFirstAttemptStarts) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   // This is a workaround for the flakiness that if the server ever enters
   // GracefulShutdown for whatever reason while the client has already been
   // shutdown, the test would not timeout and fail.

--- a/test/core/end2end/tests/retry_cancellation.cc
+++ b/test/core/end2end/tests/retry_cancellation.cc
@@ -94,10 +94,12 @@ void TestRetryCancellation(CoreEnd2endTest& test,
 }
 
 CORE_END2END_TEST(RetryTest, RetryCancellation) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   TestRetryCancellation(*this, std::make_unique<CancelCancellationMode>());
 }
 
 CORE_END2END_TEST(RetryTest, RetryDeadline) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   TestRetryCancellation(*this, std::make_unique<DeadlineCancellationMode>());
 }
 

--- a/test/core/end2end/tests/retry_non_retriable_status.cc
+++ b/test/core/end2end/tests/retry_non_retriable_status.cc
@@ -34,6 +34,7 @@ namespace {
 // - 1 retry allowed for ABORTED status
 // - first attempt gets INVALID_ARGUMENT, so no retry is done
 CORE_END2END_TEST(RetryTest, RetryNonRetriableStatus) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_non_retriable_status_before_trailers.cc
+++ b/test/core/end2end/tests/retry_non_retriable_status_before_trailers.cc
@@ -36,6 +36,7 @@ namespace {
 // - first attempt gets INVALID_ARGUMENT, so no retry is done
 CORE_END2END_TEST(RetryTest,
                   RetryNonRetriableStatusBeforeRecvTrailingMetadataStarted) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_recv_initial_metadata.cc
+++ b/test/core/end2end/tests/retry_recv_initial_metadata.cc
@@ -35,6 +35,7 @@ namespace {
 // - first attempt receives initial metadata before trailing metadata,
 //   so no retry is done even though status was ABORTED
 CORE_END2END_TEST(RetryTest, RetryRecvInitialMetadata) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_recv_message.cc
+++ b/test/core/end2end/tests/retry_recv_message.cc
@@ -35,6 +35,7 @@ namespace {
 // - first attempt receives a message and therefore does not retry even
 //   though the final status is ABORTED
 CORE_END2END_TEST(RetryTest, RetryRecvMessage) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_send_initial_metadata_refs.cc
+++ b/test/core/end2end/tests/retry_send_initial_metadata_refs.cc
@@ -37,6 +37,7 @@ namespace {
 // - first attempt returns ABORTED
 // - second attempt returns OK
 CORE_END2END_TEST(RetryTest, RetrySendInitialMetadataRefs) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_server_pushback_delay.cc
+++ b/test/core/end2end/tests/retry_server_pushback_delay.cc
@@ -35,6 +35,7 @@ namespace {
 // - first attempt gets ABORTED with a long delay
 // - second attempt succeeds
 CORE_END2END_TEST(RetryTest, RetryServerPushbackDelay) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_server_pushback_disabled.cc
+++ b/test/core/end2end/tests/retry_server_pushback_disabled.cc
@@ -35,6 +35,7 @@ namespace {
 // - first attempt gets ABORTED
 // - second attempt gets ABORTED but server push back disables retrying
 CORE_END2END_TEST(RetryTest, RetryServerPushbackDisabled) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_throttled.cc
+++ b/test/core/end2end/tests/retry_throttled.cc
@@ -34,6 +34,7 @@ namespace {
 // - 1 retry allowed for ABORTED status
 // - first attempt gets ABORTED but is over limit, so no retry is done
 CORE_END2END_TEST(RetryTest, RetryThrottled) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,
       "{\n"

--- a/test/core/end2end/tests/retry_too_many_attempts.cc
+++ b/test/core/end2end/tests/retry_too_many_attempts.cc
@@ -34,6 +34,7 @@ namespace {
 // - first attempt gets ABORTED
 // - second attempt gets ABORTED but does not retry
 CORE_END2END_TEST(RetryTest, RetryTooManyAttempts) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_unref_before_finish.cc
+++ b/test/core/end2end/tests/retry_unref_before_finish.cc
@@ -29,6 +29,7 @@ namespace {
 // Tests that we can unref a call whose status is cached but not yet
 // requested by the application.  This should not cause a memory leak.
 CORE_END2END_TEST(RetryTest, RetryUnrefBeforeFinish) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,

--- a/test/core/end2end/tests/retry_unref_before_recv.cc
+++ b/test/core/end2end/tests/retry_unref_before_recv.cc
@@ -32,6 +32,7 @@ namespace {
 // they complete.  This ensures that we don't drop callbacks or cause a
 // memory leak.
 CORE_END2END_TEST(RetryTest, UnrefBeforeRecv) {
+  if (!IsRetryInCallv3Enabled()) SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,


### PR DESCRIPTION
I've observed a few test flakes with the new retry code... put it under an experiment for now so that those flakes don't block submission of unrelated code.
