### PR TITLE
[Ruby] increase ruby test timeout

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -36,6 +36,9 @@ _CPP_RUNTESTS_TIMEOUT = 6 * 60 * 60
 # Set timeout high for ObjC for Cocoapods to install pods
 _OBJC_RUNTESTS_TIMEOUT = 4 * 60 * 60
 
+# Set timeout high for Ruby for MacOS for slow xcodebuild
+_RUBY_RUNTESTS_TIMEOUT = 2 * 60 * 60
+
 # Number of jobs assigned to each run_tests.py instance
 _DEFAULT_INNER_JOBS = 2
 
@@ -308,6 +311,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         labels=["basictests", "multilang"],
         extra_args=extra_args + ["--report_multi_target"],
         inner_jobs=inner_jobs,
+        timeout_seconds=_RUBY_RUNTESTS_TIMEOUT,
     )
 
     # ARM64 Linux Ruby and PHP tests


### PR DESCRIPTION
Increase ruby timeout to 2 hours.

It timeout quite often, e.g.: https://btx.cloud.google.com/invocations/e0b8b0a1-dc56-4af1-b149-968c6108711d/targets/grpc%2Fcore%2Fpull_request%2Fmacos%2Fgrpc_basictests_ruby;config=default/log

When it ran successful, it took close to 1h (current timeout): https://btx.cloud.google.com/invocations/39e1debb-09a3-462e-922d-6b2c00ee3779/log