### PR TITLE
[chaotic-good] Cleanup

### DIFF
--- a/src/core/ext/transport/chaotic_good/chaotic_good_transport.h
+++ b/src/core/ext/transport/chaotic_good/chaotic_good_transport.h
@@ -160,7 +160,8 @@ class ChaoticGoodTransport : public RefCounted<ChaoticGoodTransport> {
           outgoing_frames.Next(),
           // Serialize and write it out.
           [self = self.get()](Frame client_frame) {
-            return self->WriteFrame(GetFrameInterface(client_frame));
+            return self->WriteFrame(
+                absl::ConvertVariantTo<FrameInterface&>(client_frame));
           },
           []() -> LoopCtl<absl::Status> {
             // The write failures will be caught in TrySeq and exit loop.

--- a/src/core/ext/transport/chaotic_good/frame.h
+++ b/src/core/ext/transport/chaotic_good/frame.h
@@ -186,33 +186,6 @@ using ServerFrame =
     absl::variant<ServerInitialMetadataFrame, MessageFrame, BeginMessageFrame,
                   MessageChunkFrame, ServerTrailingMetadataFrame>;
 
-inline FrameInterface& GetFrameInterface(ClientFrame& frame) {
-  return MatchMutable(
-      &frame,
-      [](ClientInitialMetadataFrame* frame) -> FrameInterface& {
-        return *frame;
-      },
-      [](MessageFrame* frame) -> FrameInterface& { return *frame; },
-      [](BeginMessageFrame* frame) -> FrameInterface& { return *frame; },
-      [](MessageChunkFrame* frame) -> FrameInterface& { return *frame; },
-      [](ClientEndOfStream* frame) -> FrameInterface& { return *frame; },
-      [](CancelFrame* frame) -> FrameInterface& { return *frame; });
-}
-
-inline FrameInterface& GetFrameInterface(ServerFrame& frame) {
-  return MatchMutable(
-      &frame,
-      [](ServerInitialMetadataFrame* frame) -> FrameInterface& {
-        return *frame;
-      },
-      [](MessageFrame* frame) -> FrameInterface& { return *frame; },
-      [](BeginMessageFrame* frame) -> FrameInterface& { return *frame; },
-      [](MessageChunkFrame* frame) -> FrameInterface& { return *frame; },
-      [](ServerTrailingMetadataFrame* frame) -> FrameInterface& {
-        return *frame;
-      });
-}
-
 }  // namespace chaotic_good
 }  // namespace grpc_core
 


### PR DESCRIPTION
Instead of open coding the interface conversion from variant, use the absl function that does this automatically instead.
