### PR TITLE
[xDS-enabled server] fix status code when RDS resource doesn't exist

### DIFF
--- a/src/core/server/xds_server_config_fetcher.cc
+++ b/src/core/server/xds_server_config_fetcher.cc
@@ -899,7 +899,7 @@ void XdsServerConfigFetcher::ListenerWatcher::FilterChainMatchManager::
       }
     }
     state.rds_update =
-        absl::NotFoundError("Requested route config does not exist");
+        absl::UnavailableError("Requested route config does not exist");
   }
   // Promote the filter chain match manager object if all the referenced
   // resources are fetched.
@@ -1342,7 +1342,7 @@ void XdsServerConfigFetcher::ListenerWatcher::FilterChainMatchManager::
 void XdsServerConfigFetcher::ListenerWatcher::FilterChainMatchManager::
     DynamicXdsServerConfigSelectorProvider::OnResourceDoesNotExist() {
   MutexLock lock(&mu_);
-  resource_ = absl::NotFoundError("Requested route config does not exist");
+  resource_ = absl::UnavailableError("Requested route config does not exist");
   if (watcher_ == nullptr) {
     return;
   }

--- a/test/cpp/end2end/xds/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test.cc
@@ -2125,7 +2125,7 @@ TEST_P(XdsServerRdsTest, NonInlineRouteConfigurationNotAvailable) {
   ASSERT_TRUE(backends_[0]->notifier()->WaitOnServingStatusChange(
       grpc_core::LocalIpAndPort(backends_[0]->port()), grpc::StatusCode::OK));
   SendRpc([this]() { return CreateInsecureChannel(); }, RpcOptions(), {}, {},
-          true /* test_expects_failure */, grpc::StatusCode::NOT_FOUND,
+          true /* test_expects_failure */, grpc::StatusCode::UNAVAILABLE,
           "Requested route config does not exist");
 }
 


### PR DESCRIPTION
When the RDS resource is not found, the xDS-enabled gRPC server was returning status NOT_FOUND for data plane RPCs.  That code should never be generated by gRPC itself, as per https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.  This PR changes it to return UNAVAILABLE in this case instead.