### PR TITLE
Use Label() instead of specifying the repo name

### DIFF
--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -102,7 +102,7 @@ def cc_grpc_library(
         generate_cc(
             name = codegen_grpc_target,
             srcs = proto_targets,
-            plugin = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
+            plugin = Label("//src/compiler:grpc_cpp_plugin"),
             well_known_protos = well_known_protos,
             generate_mocks = generate_mocks,
             **kwargs
@@ -114,6 +114,6 @@ def cc_grpc_library(
             hdrs = [":" + codegen_grpc_target],
             deps = deps +
                    extra_deps +
-                   ["@com_github_grpc_grpc//:grpc++_codegen_proto"],
+                   [Label("//:grpc++_codegen_proto")],
             **kwargs
         )

--- a/bazel/generate_objc.bzl
+++ b/bazel/generate_objc.bzl
@@ -163,7 +163,7 @@ generate_objc = rule(
             providers = [ProtoInfo],
         ),
         "plugin": attr.label(
-            default = "@com_github_grpc_grpc//src/compiler:grpc_objective_c_plugin",
+            default = Label("//src/compiler:grpc_objective_c_plugin"),
             executable = True,
             providers = ["files_to_run"],
             cfg = "exec",
@@ -177,7 +177,7 @@ generate_objc = rule(
             default = False,
         ),
         "well_known_protos": attr.label(
-            default = "@com_google_protobuf//:well_known_type_protos",
+            default = Label("@com_google_protobuf//:well_known_type_protos"),
         ),
         "_protoc": attr.label(
             default = Label("@com_google_protobuf//:protoc"),

--- a/bazel/objc_grpc_library.bzl
+++ b/bazel/objc_grpc_library.bzl
@@ -77,8 +77,8 @@ def objc_grpc_library(name, deps, srcs = [], use_well_known_protos = False, **kw
             "src/objective-c",
         ],
         deps = [
-            "@com_github_grpc_grpc//src/objective-c:proto_objc_rpc",
-            "@com_google_protobuf//:protobuf_objc",
+            Label("//src/objective-c:proto_objc_rpc"),
+            Label("@com_google_protobuf//:protobuf_objc"),
         ],
         **kwargs
     )


### PR DESCRIPTION
This allows dependents to use another repo name
and allows to avoid specifying transitive dependencies with Bzlmod.