### PR TITLE
[EventEngine] Add an example story for wrapping the default EventEngine

### DIFF
--- a/examples/cpp/event_engine/.gitignore
+++ b/examples/cpp/event_engine/.gitignore
@@ -1,0 +1,8 @@
+*.o
+*.pb.cc
+*.pb.h
+greeter_client
+greeter_server
+greeter_async_client
+greeter_async_client2
+greeter_async_server

--- a/examples/cpp/event_engine/BUILD
+++ b/examples/cpp/event_engine/BUILD
@@ -1,0 +1,41 @@
+# Copyright 2020 the gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])
+
+cc_binary(
+    name = "greeter_callback_client",
+    srcs = ["greeter_callback_client.cc"],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "//:grpc++",
+        "//examples/protos:helloworld_cc_grpc",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+    ],
+)
+
+cc_binary(
+    name = "greeter_callback_server",
+    srcs = ["greeter_callback_server.cc"],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "//:grpc++",
+        "//:grpc++_reflection",
+        "//examples/protos:helloworld_cc_grpc",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/examples/cpp/event_engine/README.md
+++ b/examples/cpp/event_engine/README.md
@@ -1,0 +1,6 @@
+# gRPC C++ Hello World Example
+
+You can find a complete set of instructions for building gRPC and running the
+Hello World app in the [C++ Quick Start][].
+
+[C++ Quick Start]: https://grpc.io/docs/languages/cpp/quickstart

--- a/examples/cpp/event_engine/greeter_callback_client.cc
+++ b/examples/cpp/event_engine/greeter_callback_client.cc
@@ -1,0 +1,131 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpcpp/grpcpp.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/log/log.h"
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/helloworld.grpc.pb.h"
+#else
+#include "helloworld.grpc.pb.h"
+#endif
+
+ABSL_FLAG(std::string, target, "localhost:50051", "Server address");
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+using namespace std::literals;
+
+class GreeterClient {
+ public:
+  GreeterClient(std::shared_ptr<Channel> channel)
+      : stub_(Greeter::NewStub(channel)) {}
+
+  std::string SayHello(const std::string& user) {
+    HelloRequest request;
+    request.set_name(user);
+    HelloReply reply;
+    ClientContext context;
+    std::mutex mu;
+    std::condition_variable cv;
+    bool done = false;
+    Status status;
+    stub_->async()->SayHello(&context, &request, &reply,
+                             [&mu, &cv, &done, &status](Status s) {
+                               status = std::move(s);
+                               std::lock_guard<std::mutex> lock(mu);
+                               done = true;
+                               cv.notify_one();
+                             });
+    std::unique_lock<std::mutex> lock(mu);
+    while (!done) {
+      cv.wait(lock);
+    }
+    // Act upon its status.
+    if (status.ok()) {
+      return reply.message();
+    } else {
+      std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+      return "RPC failed";
+    }
+  }
+
+ private:
+  std::unique_ptr<Greeter::Stub> stub_;
+};
+
+// Returns when the only shared EventEngine instance is owned by this function.
+//
+// usage: WaitForSingleOwner(std::move(engine));
+//
+// Note that all channels, stubs, and other gRPC application objects must be
+// destroyed. They each hold EventEngine references.
+template <typename T>
+void WaitForSingleOwner(std::shared_ptr<T>&& sp) {
+  std::cout << "Waiting for gRPC to be done using the EventEngine" << std::endl;
+  while (true) {
+    absl::SleepFor(absl::Milliseconds(500));
+    if (sp.use_count() == 1) {
+      break;
+    }
+    std::cout << "Current EventEngine use count: " << sp.use_count()
+              << std::endl;
+  }
+}
+
+int main(int argc, char** argv) {
+  // Have the application own an instance of the built-in EventEngine.
+  std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine =
+      grpc_event_engine::experimental::CreateEventEngine();
+  // Set a custom factory so that all requests for a new EventEngine will return
+  // this application-owned engine instance.
+  grpc_event_engine::experimental::SetEventEngineFactory([&engine] {
+    std::cout << "Calling the custom EventEngine factory" << std::endl;
+    return engine;
+  });
+  // Here is some arbitrary, application-specific use of the EventEngine API.
+  engine->RunAfter(
+      2s, [engine] { std::cout << "Application timer fired!" << std::endl; });
+  absl::ParseCommandLine(argc, argv);
+  {
+    std::string target_str = absl::GetFlag(FLAGS_target);
+    GreeterClient greeter(
+        grpc::CreateChannel(target_str, grpc::InsecureChannelCredentials()));
+    std::string user("EventEngine");
+    std::string reply = greeter.SayHello(user);
+    std::cout << "Greeter received: " << reply << std::endl;
+  }
+  WaitForSingleOwner(std::move(engine));
+  return 0;
+}

--- a/examples/cpp/event_engine/greeter_callback_server.cc
+++ b/examples/cpp/event_engine/greeter_callback_server.cc
@@ -1,0 +1,87 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/strings/str_format.h"
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/helloworld.grpc.pb.h"
+#else
+#include "helloworld.grpc.pb.h"
+#endif
+
+ABSL_FLAG(uint16_t, port, 50051, "Server port for the service");
+
+using grpc::CallbackServerContext;
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerUnaryReactor;
+using grpc::Status;
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+// Logic and data behind the server's behavior.
+class GreeterServiceImpl final : public Greeter::CallbackService {
+  ServerUnaryReactor* SayHello(CallbackServerContext* context,
+                               const HelloRequest* request,
+                               HelloReply* reply) override {
+    std::string prefix("Hello ");
+    reply->set_message(prefix + request->name());
+
+    ServerUnaryReactor* reactor = context->DefaultReactor();
+    reactor->Finish(Status::OK);
+    return reactor;
+  }
+};
+
+void RunServer(uint16_t port) {
+  std::string server_address = absl::StrFormat("0.0.0.0:%d", port);
+  GreeterServiceImpl service;
+
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  ServerBuilder builder;
+  // Listen on the given address without any authentication mechanism.
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  // Register "service" as the instance through which we'll communicate with
+  // clients. In this case it corresponds to an *synchronous* service.
+  builder.RegisterService(&service);
+  // Finally assemble the server.
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  // Wait for the server to shutdown. Note that some other thread must be
+  // responsible for shutting down the server for this call to ever return.
+  server->Wait();
+}
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  RunServer(absl::GetFlag(FLAGS_port));
+  return 0;
+}

--- a/include/grpc/event_engine/event_engine.h
+++ b/include/grpc/event_engine/event_engine.h
@@ -481,7 +481,7 @@ class EventEngine : public std::enable_shared_from_this<EventEngine>,
 /// created, applications must set a custom EventEngine factory method *before*
 /// grpc is initialized.
 void SetEventEngineFactory(
-    absl::AnyInvocable<std::unique_ptr<EventEngine>()> factory);
+    absl::AnyInvocable<std::shared_ptr<EventEngine>()> factory);
 
 /// Reset gRPC's EventEngine factory to the built-in default.
 ///
@@ -491,7 +491,7 @@ void SetEventEngineFactory(
 /// using the previous factories.
 void EventEngineFactoryReset();
 /// Create an EventEngine using the default factory.
-std::unique_ptr<EventEngine> CreateEventEngine();
+std::shared_ptr<EventEngine> CreateEventEngine();
 
 bool operator==(const EventEngine::TaskHandle& lhs,
                 const EventEngine::TaskHandle& rhs);

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -132,10 +132,7 @@ class PosixEnginePollerManager
 
 // An iomgr-based Posix EventEngine implementation.
 // All methods require an ExecCtx to already exist on the thread's stack.
-// TODO(ctiller): KeepsGrpcInitialized is an interim measure to ensure that
-// EventEngine is shut down before we shut down iomgr.
-class PosixEventEngine final : public PosixEventEngineWithFdSupport,
-                               public grpc_core::KeepsGrpcInitialized {
+class PosixEventEngine final : public PosixEventEngineWithFdSupport {
  public:
   class PosixDNSResolver : public EventEngine::DNSResolver {
    public:


### PR DESCRIPTION
Built upon https://github.com/grpc/grpc/pull/38281

This changes the EventEngine API to have `CreateEventEngine` provide a `std::shared_ptr<EventEngine>` instead of a unique_ptr. This provides applications with an easier way to guarantee that a single EventEngine instance can be shared. There are alternative solutions to that problem - like returning a unique_ptr to a ref-counted PIMPL wrapper of some application-owned engine - but this solution is fairly clean.

For usage, see greeter_callback_client.cc. That's the only application-visible difference from the helloworld example.