### PR TITLE
[ruby] pin bundler to 2.5 minor version in artifact build

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_ruby_artifact_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_ruby_artifact_rc
@@ -41,7 +41,9 @@ set -ex
 ruby --version
 
 # Bundler is required for grpc ruby artifact build.
-gem install bundler -v 2.5
+# TODO(apolcyn): unpin, bundler 2.6 seems to have broken us,
+# pinning as a workaround.
+gem install bundler -v 2.5.23
 
 # log gem versions for easier debugging if things go wrong
 gem list || true


### PR DESCRIPTION
Distribtests *seem* to be broken by bundler 2.6 release today