### PR TITLE
[call-v3] Send path optimization

### DIFF
--- a/src/core/ext/transport/chaotic_good/message_reassembly.h
+++ b/src/core/ext/transport/chaotic_good/message_reassembly.h
@@ -94,8 +94,9 @@ class MessageReassembly {
     return If(
         done,
         [&]() {
-          auto message = Arena::MakePooled<Message>(
-              std::move(chunk_receiver_->incoming), 0);
+          auto message =
+              Arena::MakePooled<Message>(std::move(chunk_receiver_->incoming),
+                                         GRPC_WRITE_INTERNAL_IMMEDIATE_PUSH);
           chunk_receiver_.reset();
           return sink.PushMessage(std::move(message));
         },

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -292,6 +292,7 @@ void Party::RunPartyAndUnref(uint64_t prev_state) {
     while (wakeup_mask_ != 0) {
       auto wakeup_mask = std::exchange(wakeup_mask_, 0);
       while (wakeup_mask != 0) {
+        GRPC_LATENT_SEE_INNER_SCOPE("run_one_promise");
         const uint64_t t = LowestOneBit(wakeup_mask);
         const int i = absl::countr_zero(t);
         wakeup_mask ^= t;

--- a/src/core/lib/surface/client_call.cc
+++ b/src/core/lib/surface/client_call.cc
@@ -296,7 +296,7 @@ void ClientCall::CommitBatch(const grpc_op* ops, size_t nops, void* notify_tag,
             send.c_slice_buffer());
         auto msg = arena()->MakePooled<Message>(
             std::move(send),
-            op.flags | (is_last ? GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE : 0));
+            op.flags | (is_last ? GRPC_WRITE_INTERNAL_IMMEDIATE_PUSH : 0));
         return [this, msg = std::move(msg)]() mutable {
           return started_call_initiator_.PushMessage(std::move(msg));
         };

--- a/src/core/lib/transport/call_state.h
+++ b/src/core/lib/transport/call_state.h
@@ -47,9 +47,10 @@ class CallState {
 
   // Begin a message push.
   void BeginPushClientToServerMessage();
-
-  // Poll for the push to be completed (up to FinishPullClientToServerMessage).
-  Poll<StatusFlag> PollPushClientToServerMessage();
+  // Poll for a push to be ready to start:
+  // - either the first push, or the last push has completed past
+  // FinishPullClientToServerMessage.
+  Poll<StatusFlag> PollReadyForPushClientToServerMessage();
 
   // Note that the client has half-closed the stream.
   void ClientToServerHalfClose();
@@ -81,7 +82,7 @@ class CallState {
   // Begin a message push.
   void BeginPushServerToClientMessage();
   // Poll for the push to be completed (up to FinishPullServerToClientMessage).
-  Poll<StatusFlag> PollPushServerToClientMessage();
+  Poll<StatusFlag> PollReadyForPushServerToClientMessage();
   // Push server trailing metadata.
   // This is idempotent: only the first call will have any effect.
   // Returns true if this is the first call.
@@ -380,9 +381,9 @@ CallState::BeginPushClientToServerMessage() {
 }
 
 GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION inline Poll<StatusFlag>
-CallState::PollPushClientToServerMessage() {
+CallState::PollReadyForPushClientToServerMessage() {
   GRPC_TRACE_LOG(call_state, INFO)
-      << "[call_state] PollPushClientToServerMessage: "
+      << "[call_state] PollReadyForPushClientToServerMessage: "
       << GRPC_DUMP_ARGS(this, client_to_server_push_state_);
   switch (client_to_server_push_state_) {
     case ClientToServerPushState::kIdle:
@@ -615,20 +616,20 @@ CallState::BeginPushServerToClientMessage() {
 }
 
 GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION inline Poll<StatusFlag>
-CallState::PollPushServerToClientMessage() {
+CallState::PollReadyForPushServerToClientMessage() {
   GRPC_TRACE_LOG(call_state, INFO)
-      << "[call_state] PollPushServerToClientMessage: "
+      << "[call_state] PollReadyForPushServerToClientMessage: "
       << GRPC_DUMP_ARGS(this, server_to_client_push_state_);
   switch (server_to_client_push_state_) {
     case ServerToClientPushState::kStart:
-    case ServerToClientPushState::kPushedServerInitialMetadata:
-      LOG(FATAL) << "PollPushServerToClientMessage called before "
+      LOG(FATAL) << "PollReadyForPushServerToClientMessage called before "
                  << "PushServerInitialMetadata";
     case ServerToClientPushState::kTrailersOnly:
       return false;
     case ServerToClientPushState::kPushedMessage:
     case ServerToClientPushState::kPushedServerInitialMetadataAndPushedMessage:
       return server_to_client_push_waiter_.pending();
+    case ServerToClientPushState::kPushedServerInitialMetadata:
     case ServerToClientPushState::kIdle:
       return Success{};
     case ServerToClientPushState::kFinished:

--- a/src/core/lib/transport/message.h
+++ b/src/core/lib/transport/message.h
@@ -27,9 +27,14 @@
 /// to be decompressed by the message_decompress filter. (Does not apply for
 /// stream compression.)
 #define GRPC_WRITE_INTERNAL_TEST_ONLY_WAS_COMPRESSED (0x40000000u)
+/// Internal bit flag for when we know a particular message is the last one to
+/// be sent: this allows various flow control optimizations.
+#define GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE (0x20000000u)
 /// Mask of all valid internal flags.
-#define GRPC_WRITE_INTERNAL_USED_MASK \
-  (GRPC_WRITE_INTERNAL_COMPRESS | GRPC_WRITE_INTERNAL_TEST_ONLY_WAS_COMPRESSED)
+#define GRPC_WRITE_INTERNAL_USED_MASK             \
+  (GRPC_WRITE_INTERNAL_COMPRESS |                 \
+   GRPC_WRITE_INTERNAL_TEST_ONLY_WAS_COMPRESSED | \
+   GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE)
 
 namespace grpc_core {
 

--- a/src/core/lib/transport/message.h
+++ b/src/core/lib/transport/message.h
@@ -27,14 +27,18 @@
 /// to be decompressed by the message_decompress filter. (Does not apply for
 /// stream compression.)
 #define GRPC_WRITE_INTERNAL_TEST_ONLY_WAS_COMPRESSED (0x40000000u)
-/// Internal bit flag for when we know a particular message is the last one to
-/// be sent: this allows various flow control optimizations.
-#define GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE (0x20000000u)
+/// Usually when we `Push` to a `CallInitiator` or `CallHandler` they block
+/// until the message has been pulled. This flag signals that instead the push
+/// should finish once the data is available to be pulled (this may still block
+/// if a previous message is not yet claimed).
+/// Setting this is appropriate for messages sent from the API that are known
+/// to be the last message to be sent, OR for messages from the transport.
+#define GRPC_WRITE_INTERNAL_IMMEDIATE_PUSH (0x20000000u)
 /// Mask of all valid internal flags.
 #define GRPC_WRITE_INTERNAL_USED_MASK             \
   (GRPC_WRITE_INTERNAL_COMPRESS |                 \
    GRPC_WRITE_INTERNAL_TEST_ONLY_WAS_COMPRESSED | \
-   GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE)
+   GRPC_WRITE_INTERNAL_IMMEDIATE_PUSH)
 
 namespace grpc_core {
 

--- a/test/core/transport/bm_call_spine.cc
+++ b/test/core/transport/bm_call_spine.cc
@@ -36,7 +36,9 @@ class CallSpineFixture {
     return Arena::MakePooledForOverwrite<ServerMetadata>();
   }
 
-  MessageHandle MakePayload() { return Arena::MakePooled<Message>(); }
+  MessageHandle MakePayload(uint32_t flags) {
+    return Arena::MakePooled<Message>(SliceBuffer(), flags);
+  }
 
   ServerMetadataHandle MakeServerTrailingMetadata() {
     return Arena::MakePooledForOverwrite<ServerMetadata>();
@@ -85,7 +87,9 @@ class ForwardCallFixture {
     return Arena::MakePooledForOverwrite<ServerMetadata>();
   }
 
-  MessageHandle MakePayload() { return Arena::MakePooled<Message>(); }
+  MessageHandle MakePayload(uint32_t flags) {
+    return Arena::MakePooled<Message>(SliceBuffer(), flags);
+  }
 
   ServerMetadataHandle MakeServerTrailingMetadata() {
     return Arena::MakePooledForOverwrite<ServerMetadata>();

--- a/test/core/transport/call_spine_benchmarks.h
+++ b/test/core/transport/call_spine_benchmarks.h
@@ -56,7 +56,8 @@ void BM_UnaryWithSpawnPerEnd(benchmark::State& state) {
                     }),
                 Map(handler.PullMessage(),
                     [](ClientToServerNextMessage msg) { return msg.status(); }),
-                handler.PushMessage(fixture.MakePayload())),
+                handler.PushMessage(fixture.MakePayload(
+                    GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE))),
             [&handler_done, &fixture, handler](StatusFlag status) mutable {
               CHECK(status.ok());
               handler.PushServerTrailingMetadata(
@@ -69,7 +70,8 @@ void BM_UnaryWithSpawnPerEnd(benchmark::State& state) {
                                                    &initiator_done]() mutable {
         return Map(
             AllOk<StatusFlag>(
-                Map(initiator.PushMessage(fixture.MakePayload()),
+                Map(initiator.PushMessage(fixture.MakePayload(
+                        GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE)),
                     [](StatusFlag) { return Success{}; }),
                 Map(initiator.PullServerInitialMetadata(),
                     [](absl::optional<ServerMetadataHandle> md) {
@@ -125,7 +127,7 @@ void BM_ClientToServerStreaming(benchmark::State& state) {
                  });
     });
     call.initiator.SpawnInfallible("initiator", [&]() {
-      return Map(call.initiator.PushMessage(fixture.MakePayload()),
+      return Map(call.initiator.PushMessage(fixture.MakePayload(0)),
                  [&](StatusFlag result) {
                    CHECK(result.ok());
                    initiator_done.Notify();

--- a/test/core/transport/call_spine_benchmarks.h
+++ b/test/core/transport/call_spine_benchmarks.h
@@ -56,8 +56,8 @@ void BM_UnaryWithSpawnPerEnd(benchmark::State& state) {
                     }),
                 Map(handler.PullMessage(),
                     [](ClientToServerNextMessage msg) { return msg.status(); }),
-                handler.PushMessage(fixture.MakePayload(
-                    GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE))),
+                handler.PushMessage(
+                    fixture.MakePayload(GRPC_WRITE_INTERNAL_IMMEDIATE_PUSH))),
             [&handler_done, &fixture, handler](StatusFlag status) mutable {
               CHECK(status.ok());
               handler.PushServerTrailingMetadata(
@@ -71,7 +71,7 @@ void BM_UnaryWithSpawnPerEnd(benchmark::State& state) {
         return Map(
             AllOk<StatusFlag>(
                 Map(initiator.PushMessage(fixture.MakePayload(
-                        GRPC_WRITE_INTERNAL_KNOWN_LAST_MESSAGE)),
+                        GRPC_WRITE_INTERNAL_IMMEDIATE_PUSH)),
                     [](StatusFlag) { return Success{}; }),
                 Map(initiator.PullServerInitialMetadata(),
                     [](absl::optional<ServerMetadataHandle> md) {


### PR DESCRIPTION
There are some places in the send path that we're being overly cautious about ensuring a message has been consumed by the next layer before completing the send - these center around messages from the transport (flow control is sufficient to cover these), and the last message from the application (we don't need to wait for the message to be claimed prior to pushing either end of stream or trailing metadata).

This change introduces a new message flag that can be transported through the stack to flag these cases, and adjusts call spine behavior to short circuit work when the flag is set.