### PR TITLE
[bazel] Remove deprecated config_setting usage

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -176,27 +176,12 @@ config_setting(
 
 config_setting(
     name = "windows",
-    values = {"cpu": "x64_windows"},
-)
-
-config_setting(
-    name = "windows_msvc",
-    values = {"cpu": "x64_windows_msvc"},
+    constraint_values = ["@platforms//os:windows"],
 )
 
 config_setting(
     name = "mac",
-    values = {"cpu": "darwin"},
-)
-
-config_setting(
-    name = "mac_x86_64",
-    values = {"cpu": "darwin_x86_64"},
-)
-
-config_setting(
-    name = "mac_arm64",
-    values = {"cpu": "darwin_arm64"},
+    constraint_values = ["@platforms//os:macos"],
 )
 
 config_setting(

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -45,7 +45,6 @@ EVENT_ENGINES = {"default": {"tags": []}}
 def if_not_windows(a):
     return select({
         "//:windows": [],
-        "//:windows_msvc": [],
         "//:windows_clang": [],
         "//conditions:default": a,
     })
@@ -53,7 +52,6 @@ def if_not_windows(a):
 def if_windows(a):
     return select({
         "//:windows": a,
-        "//:windows_msvc": a,
         "//:windows_clang": a,
         "//conditions:default": [],
     })

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2822,19 +2822,7 @@ grpc_cc_library(
     select_deps = [
         {
             "//:windows": ["windows_event_engine"],
-            "//:windows_os": ["windows_event_engine"],
-            "//:windows_msvc": ["windows_event_engine"],
-            "//:windows_clang": ["windows_event_engine"],
-            "//:windows_other": ["windows_event_engine"],
             "//:mac": [
-                "posix_event_engine",
-                "cf_event_engine",
-            ],
-            "//:mac_x86_64": [
-                "posix_event_engine",
-                "cf_event_engine",
-            ],
-            "//:mac_arm64": [
                 "posix_event_engine",
                 "cf_event_engine",
             ],


### PR DESCRIPTION
In a future version of bazel using `cpu` in `config_setting` is
deprecated, for these cases we can instead use platform constraints,
which actually simplifies this use case as well. Fixes:

```
WARNING: /.../external/grpc+/BUILD:192:15: in config_setting rule @@grpc+//:mac_arm64: select() on cpu is deprecated. Use platform constraints instead: https://bazel.build/docs/configurable-attributes#platforms.
```
