### PR TITLE
[interop] Add v1.67.3, v1.68.2, v1.69.2 releases of grpc-go to intero…

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -307,8 +307,9 @@ LANG_RELEASE_MATRIX = {
             ("v1.64.1", ReleaseInfo()),
             ("v1.65.1", ReleaseInfo()),
             ("v1.66.3", ReleaseInfo()),
-            ("v1.67.1", ReleaseInfo()),
-            ("v1.68.0", ReleaseInfo()),
+            ("v1.67.3", ReleaseInfo()),
+            ("v1.68.2", ReleaseInfo()),
+            ("v1.69.2", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```
$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_"$GO_VERSION" | grep "v1.69.2"
b5d579790c4b  infrastructure-public-image-v1.69.2,v1.69.2                                                                    2024-12-20T06:42:12  CRITICAL=5,HIGH=168,LOW=332,MEDIUM=390

$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_"$GO_VERSION" | grep "v1.67.3"
ba5bd4bbf416  infrastructure-public-image-v1.67.3,v1.67.3                                                                    2024-12-20T06:47:38  CRITICAL=5,HIGH=168,LOW=332,MEDIUM=390

$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_"$GO_VERSION" | grep "v1.68.2"
f34b66db3857  infrastructure-public-image-v1.68.2,v1.68.2                                                                    2024-12-20T06:44:02  CRITICAL=5,HIGH=168,LOW=332,MEDIUM=390
```