### PR TITLE
[benchmark] Skip broken benchmark on 8 cores.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -211,7 +211,7 @@ fi
 
 # Disable broken tests by regex.
 # The test disabled here hangs on 8 cores. The result of this test is not
-# displayed in the public dashboard. The test runs and passes on the 30-core
+# displayed on the public dashboard. The test runs and passes on the 30-core
 # ("32core") node pool. This can be considered a permanent fix, selectively
 # removing an unnecessary test and allowing the test run to become green.
 declare -a disabledTests8core=(

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -210,6 +210,10 @@ if [[ -v "useLanguage[ruby]" ]]; then
 fi
 
 # Disable broken tests by regex.
+# The test disabled here hangs on 8 cores. The result of this test is not
+# displayed in the public dashboard. The test runs and passes on the 30-core
+# ("32core") node pool. This can be considered a permanent fix, selectively
+# removing an unnecessary test and allowing the test run to become green.
 declare -a disabledTests8core=(
   cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure
 )

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -120,6 +120,25 @@ buildConfigs() {
     -o "loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
+# Regex to disable specific tests.
+# https://stackoverflow.com/questions/406230
+disableTestsRegex() {
+  if (($# == 0)); then
+    echo '.*'
+    return
+  fi
+  local s='^((?!'
+  s+="$1"
+  shift
+  while (($# > 0)); do
+    s+='|'
+    s+="$1"
+    shift
+  done
+  s+=').)*$'
+  echo "${s}"
+}
+
 # List all languages.
 declare -A useLanguage=(
   [c++]=1
@@ -190,8 +209,18 @@ if [[ -v "useLanguage[ruby]" ]]; then
   runnerLangArgs+=(-l "ruby:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
 fi
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${configLangArgs8core[@]}"
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}"
+# Disable broken tests by regex.
+declare -a disabledTests8core=(
+  cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure
+)
+declare -a disabledTests32core=()
+
+# Arguments to disable tests.
+regexArgs8core=(-r "$(disabledTestsRegex "${disabledTests8core[@]}")")
+regexArgs32core=(-r "$(disabledTestsRegex "${disabledTests32core[@]}")")
+
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${configLangArgs8core[@]}" "${regexArgs8core[@]}"
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}" "${regexArgs32core[@]}"
 
 # Delete prebuilt images on exit.
 deleteImages() {

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -206,7 +206,7 @@ fi
 
 # Disable broken tests by regex.
 # The test disabled here hangs on 8 cores. The result of this test is not
-# displayed in the public dashboard. The test runs and passes on the 30-core
+# displayed on the public dashboard. The test runs and passes on the 30-core
 # ("32core") node pool. This can be considered a permanent fix, selectively
 # removing an unnecessary test and allowing the test run to become green.
 declare -a disabledTests8core=(

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -205,6 +205,10 @@ if [[ -v "useLanguage[ruby]" ]]; then
 fi
 
 # Disable broken tests by regex.
+# The test disabled here hangs on 8 cores. The result of this test is not
+# displayed in the public dashboard. The test runs and passes on the 30-core
+# ("32core") node pool. This can be considered a permanent fix, selectively
+# removing an unnecessary test and allowing the test run to become green.
 declare -a disabledTests8core=(
   cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure
 )

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -115,6 +115,25 @@ buildConfigs() {
     -o "loadtest_with_prebuilt_workers_${pool}.yaml"
 }
 
+# Regex to disable specific tests.
+# https://stackoverflow.com/questions/406230
+disableTestsRegex() {
+  if (($# == 0)); then
+    echo '.*'
+    return
+  fi
+  local s='^((?!'
+  s+="$1"
+  shift
+  while (($# > 0)); do
+    s+='|'
+    s+="$1"
+    shift
+  done
+  s+=').)*$'
+  echo "${s}"
+}
+
 # List all languages.
 declare -A useLanguage=(
   [c++]=1
@@ -185,8 +204,18 @@ if [[ -v "useLanguage[ruby]" ]]; then
   runnerLangArgs+=(-l "ruby:${GRPC_CORE_REPO}:${GRPC_CORE_COMMIT}")
 fi
 
-buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${configLangArgs8core[@]}"
-buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}"
+# Disable broken tests by regex.
+declare -a disabledTests8core=(
+  cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure
+)
+declare -a disabledTests32core=()
+
+# Arguments to disable tests.
+regexArgs8core=(-r "$(disabledTestsRegex "${disabledTests8core[@]}")")
+regexArgs32core=(-r "$(disabledTestsRegex "${disabledTests32core[@]}")")
+
+buildConfigs "${WORKER_POOL_8CORE}" "${BIGQUERY_TABLE_8CORE}" "${configLangArgs8core[@]}" "${regexArgs8core[@]}"
+buildConfigs "${WORKER_POOL_32CORE}" "${BIGQUERY_TABLE_32CORE}" "${configLangArgs32core[@]}" "${regexArgs32core[@]}"
 
 # Delete prebuilt images on exit.
 deleteImages() {


### PR DESCRIPTION
This change skips one specific benchmark on 8 cores that only passes on 30 cores. The benchmark hangs and does not complete when run on the 8-core node pool. The 30-core node pool has `c2-standard-30` nodes, compared to `e2-standard-8` for the 8-core node pool.

The skipped benchmark is the following:

- `cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure`

With this change, all benchmarks on both node pools should be passing.
