### PR TITLE
[XdsClient] move ADS encoding and decoding directly into XdsClient

### DIFF
--- a/src/core/xds/xds_client/xds_api.cc
+++ b/src/core/xds/xds_client/xds_api.cc
@@ -16,61 +16,15 @@
 
 #include "src/core/xds/xds_client/xds_api.h"
 
-#include <grpc/status.h>
-#include <grpc/support/port_platform.h>
-#include <grpc/support/time.h>
-#include <stdint.h>
-#include <stdlib.h>
-
-#include <set>
-#include <string>
-#include <vector>
-
-#include "absl/log/log.h"
-#include "absl/strings/str_cat.h"
-#include "absl/strings/strip.h"
-#include "envoy/config/core/v3/base.upb.h"
-#include "envoy/config/endpoint/v3/load_report.upb.h"
-#include "envoy/service/discovery/v3/discovery.upb.h"
-#include "envoy/service/discovery/v3/discovery.upbdefs.h"
-#include "envoy/service/load_stats/v3/lrs.upb.h"
-#include "envoy/service/load_stats/v3/lrs.upbdefs.h"
-#include "envoy/service/status/v3/csds.upb.h"
-#include "google/protobuf/any.upb.h"
-#include "google/protobuf/duration.upb.h"
 #include "google/protobuf/struct.upb.h"
-#include "google/protobuf/timestamp.upb.h"
-#include "google/rpc/status.upb.h"
 #include "src/core/util/json/json.h"
 #include "src/core/util/upb_utils.h"
-#include "src/core/xds/xds_client/xds_client.h"
 #include "upb/base/string_view.h"
 #include "upb/mem/arena.hpp"
-#include "upb/reflection/def.h"
-#include "upb/text/encode.h"
-
-// IWYU pragma: no_include "upb/msg_internal.h"
 
 namespace grpc_core {
 
-XdsApi::XdsApi(XdsClient* client, TraceFlag* tracer,
-               const XdsBootstrap::Node* node, upb::DefPool* def_pool,
-               std::string user_agent_name, std::string user_agent_version)
-    : client_(client),
-      tracer_(tracer),
-      node_(node),
-      def_pool_(def_pool),
-      user_agent_name_(std::move(user_agent_name)),
-      user_agent_version_(std::move(user_agent_version)) {}
-
 namespace {
-
-struct XdsApiContext {
-  XdsClient* client;
-  TraceFlag* tracer;
-  upb_DefPool* def_pool;
-  upb_Arena* arena;
-};
 
 void PopulateMetadataValue(google_protobuf_Value* value_pb, const Json& value,
                            upb_Arena* arena);
@@ -171,94 +125,6 @@ void PopulateXdsNode(const XdsBootstrap::Node* node,
       node_msg,
       upb_StringView_FromString("envoy.lb.does_not_support_overprovisioning"),
       arena);
-}
-
-namespace {
-
-void MaybeLogDiscoveryResponse(
-    const XdsApiContext& context,
-    const envoy_service_discovery_v3_DiscoveryResponse* response) {
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
-    const upb_MessageDef* msg_type =
-        envoy_service_discovery_v3_DiscoveryResponse_getmsgdef(
-            context.def_pool);
-    char buf[10240];
-    upb_TextEncode(reinterpret_cast<const upb_Message*>(response), msg_type,
-                   nullptr, 0, buf, sizeof(buf));
-    VLOG(2) << "[xds_client " << context.client
-            << "] received response: " << buf;
-  }
-}
-
-}  // namespace
-
-absl::Status XdsApi::ParseAdsResponse(absl::string_view encoded_response,
-                                      AdsResponseParserInterface* parser) {
-  upb::Arena arena;
-  const XdsApiContext context = {client_, tracer_, def_pool_->ptr(),
-                                 arena.ptr()};
-  // Decode the response.
-  const envoy_service_discovery_v3_DiscoveryResponse* response =
-      envoy_service_discovery_v3_DiscoveryResponse_parse(
-          encoded_response.data(), encoded_response.size(), arena.ptr());
-  // If decoding fails, report a fatal error and return.
-  if (response == nullptr) {
-    return absl::InvalidArgumentError("Can't decode DiscoveryResponse.");
-  }
-  MaybeLogDiscoveryResponse(context, response);
-  // Report the type_url, version, nonce, and number of resources to the parser.
-  AdsResponseParserInterface::AdsResponseFields fields;
-  fields.type_url = std::string(absl::StripPrefix(
-      UpbStringToAbsl(
-          envoy_service_discovery_v3_DiscoveryResponse_type_url(response)),
-      "type.googleapis.com/"));
-  fields.version = UpbStringToStdString(
-      envoy_service_discovery_v3_DiscoveryResponse_version_info(response));
-  fields.nonce = UpbStringToStdString(
-      envoy_service_discovery_v3_DiscoveryResponse_nonce(response));
-  size_t num_resources;
-  const google_protobuf_Any* const* resources =
-      envoy_service_discovery_v3_DiscoveryResponse_resources(response,
-                                                             &num_resources);
-  fields.num_resources = num_resources;
-  absl::Status status = parser->ProcessAdsResponseFields(std::move(fields));
-  if (!status.ok()) return status;
-  // Process each resource.
-  for (size_t i = 0; i < num_resources; ++i) {
-    absl::string_view type_url = absl::StripPrefix(
-        UpbStringToAbsl(google_protobuf_Any_type_url(resources[i])),
-        "type.googleapis.com/");
-    absl::string_view serialized_resource =
-        UpbStringToAbsl(google_protobuf_Any_value(resources[i]));
-    // Unwrap Resource messages, if so wrapped.
-    absl::string_view resource_name;
-    if (type_url == "envoy.service.discovery.v3.Resource") {
-      const auto* resource_wrapper = envoy_service_discovery_v3_Resource_parse(
-          serialized_resource.data(), serialized_resource.size(), arena.ptr());
-      if (resource_wrapper == nullptr) {
-        parser->ResourceWrapperParsingFailed(
-            i, "Can't decode Resource proto wrapper");
-        continue;
-      }
-      const auto* resource =
-          envoy_service_discovery_v3_Resource_resource(resource_wrapper);
-      if (resource == nullptr) {
-        parser->ResourceWrapperParsingFailed(
-            i, "No resource present in Resource proto wrapper");
-        continue;
-      }
-      type_url = absl::StripPrefix(
-          UpbStringToAbsl(google_protobuf_Any_type_url(resource)),
-          "type.googleapis.com/");
-      serialized_resource =
-          UpbStringToAbsl(google_protobuf_Any_value(resource));
-      resource_name = UpbStringToAbsl(
-          envoy_service_discovery_v3_Resource_name(resource_wrapper));
-    }
-    parser->ParseResource(context.arena, i, type_url, resource_name,
-                          serialized_resource);
-  }
-  return absl::OkStatus();
 }
 
 }  // namespace grpc_core

--- a/src/core/xds/xds_client/xds_api.h
+++ b/src/core/xds/xds_client/xds_api.h
@@ -17,83 +17,12 @@
 #ifndef GRPC_SRC_CORE_XDS_XDS_CLIENT_XDS_API_H
 #define GRPC_SRC_CORE_XDS_XDS_CLIENT_XDS_API_H
 
-#include <grpc/support/port_platform.h>
-#include <stddef.h>
-
-#include <map>
-#include <set>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include "absl/status/status.h"
 #include "absl/strings/string_view.h"
-#include "envoy/admin/v3/config_dump_shared.upb.h"
-#include "envoy/service/status/v3/csds.upb.h"
-#include "src/core/lib/debug/trace.h"
-#include "src/core/util/ref_counted_ptr.h"
-#include "src/core/util/time.h"
+#include "envoy/config/core/v3/base.upb.h"
 #include "src/core/xds/xds_client/xds_bootstrap.h"
-#include "src/core/xds/xds_client/xds_locality.h"
 #include "upb/mem/arena.h"
-#include "upb/reflection/def.hpp"
 
 namespace grpc_core {
-
-class XdsClient;
-
-// TODO(roth): When we have time, remove this class and move its
-// functionality directly inside of XdsClient.
-class XdsApi final {
- public:
-  // Interface defined by caller and passed to ParseAdsResponse().
-  class AdsResponseParserInterface {
-   public:
-    struct AdsResponseFields {
-      std::string type_url;
-      std::string version;
-      std::string nonce;
-      size_t num_resources;
-    };
-
-    virtual ~AdsResponseParserInterface() = default;
-
-    // Called when the top-level ADS fields are parsed.
-    // If this returns non-OK, parsing will stop, and the individual
-    // resources will not be processed.
-    virtual absl::Status ProcessAdsResponseFields(AdsResponseFields fields) = 0;
-
-    // Called to parse each individual resource in the ADS response.
-    // Note that resource_name is non-empty only when the resource was
-    // wrapped in a Resource wrapper proto.
-    virtual void ParseResource(upb_Arena* arena, size_t idx,
-                               absl::string_view type_url,
-                               absl::string_view resource_name,
-                               absl::string_view serialized_resource) = 0;
-
-    // Called when a resource is wrapped in a Resource wrapper proto but
-    // we fail to parse the Resource wrapper.
-    virtual void ResourceWrapperParsingFailed(size_t idx,
-                                              absl::string_view message) = 0;
-  };
-
-  XdsApi(XdsClient* client, TraceFlag* tracer, const XdsBootstrap::Node* node,
-         upb::DefPool* def_pool, std::string user_agent_name,
-         std::string user_agent_version);
-
-  // Returns non-OK when failing to deserialize response message.
-  // Otherwise, all events are reported to the parser.
-  absl::Status ParseAdsResponse(absl::string_view encoded_response,
-                                AdsResponseParserInterface* parser);
-
- private:
-  XdsClient* client_;
-  TraceFlag* tracer_;
-  const XdsBootstrap::Node* node_;  // Do not own.
-  upb::DefPool* def_pool_;          // Do not own.
-  const std::string user_agent_name_;
-  const std::string user_agent_version_;
-};
 
 void PopulateXdsNode(const XdsBootstrap::Node* node,
                      absl::string_view user_agent_name,

--- a/src/core/xds/xds_client/xds_api.h
+++ b/src/core/xds/xds_client/xds_api.h
@@ -77,58 +77,6 @@ class XdsApi final {
                                               absl::string_view message) = 0;
   };
 
-  // The metadata of the xDS resource; used by the xDS config dump.
-  struct ResourceMetadata {
-    // Resource status from the view of a xDS client, which tells the
-    // synchronization status between the xDS client and the xDS server.
-    enum ClientResourceStatus {
-      // Client requested this resource but hasn't received any update from
-      // management server. The client will not fail requests, but will queue
-      // them
-      // until update arrives or the client times out waiting for the resource.
-      REQUESTED = 1,
-      // This resource has been requested by the client but has either not been
-      // delivered by the server or was previously delivered by the server and
-      // then subsequently removed from resources provided by the server.
-      DOES_NOT_EXIST,
-      // Client received this resource and replied with ACK.
-      ACKED,
-      // Client received this resource and replied with NACK.
-      NACKED
-    };
-
-    // The client status of this resource.
-    ClientResourceStatus client_status = REQUESTED;
-    // The serialized bytes of the last successfully updated raw xDS resource.
-    std::string serialized_proto;
-    // The timestamp when the resource was last successfully updated.
-    Timestamp update_time;
-    // The last successfully updated version of the resource.
-    std::string version;
-    // The rejected version string of the last failed update attempt.
-    std::string failed_version;
-    // Details about the last failed update attempt.
-    std::string failed_details;
-    // Timestamp of the last failed update attempt.
-    Timestamp failed_update_time;
-  };
-  static_assert(static_cast<ResourceMetadata::ClientResourceStatus>(
-                    envoy_admin_v3_REQUESTED) ==
-                    ResourceMetadata::ClientResourceStatus::REQUESTED,
-                "");
-  static_assert(static_cast<ResourceMetadata::ClientResourceStatus>(
-                    envoy_admin_v3_DOES_NOT_EXIST) ==
-                    ResourceMetadata::ClientResourceStatus::DOES_NOT_EXIST,
-                "");
-  static_assert(static_cast<ResourceMetadata::ClientResourceStatus>(
-                    envoy_admin_v3_ACKED) ==
-                    ResourceMetadata::ClientResourceStatus::ACKED,
-                "");
-  static_assert(static_cast<ResourceMetadata::ClientResourceStatus>(
-                    envoy_admin_v3_NACKED) ==
-                    ResourceMetadata::ClientResourceStatus::NACKED,
-                "");
-
   XdsApi(XdsClient* client, TraceFlag* tracer, const XdsBootstrap::Node* node,
          upb::DefPool* def_pool, std::string user_agent_name,
          std::string user_agent_version);

--- a/src/core/xds/xds_client/xds_api.h
+++ b/src/core/xds/xds_client/xds_api.h
@@ -81,19 +81,10 @@ class XdsApi final {
          upb::DefPool* def_pool, std::string user_agent_name,
          std::string user_agent_version);
 
-  // Creates an ADS request.
-  std::string CreateAdsRequest(absl::string_view type_url,
-                               absl::string_view version,
-                               absl::string_view nonce,
-                               const std::vector<std::string>& resource_names,
-                               absl::Status status, bool populate_node);
-
   // Returns non-OK when failing to deserialize response message.
   // Otherwise, all events are reported to the parser.
   absl::Status ParseAdsResponse(absl::string_view encoded_response,
                                 AdsResponseParserInterface* parser);
-
-  void PopulateNode(envoy_config_core_v3_Node* node_msg, upb_Arena* arena);
 
  private:
   XdsClient* client_;

--- a/src/core/xds/xds_client/xds_client.cc
+++ b/src/core/xds/xds_client/xds_client.cc
@@ -289,10 +289,12 @@ class XdsClient::XdsChannel::AdsCall final
         subscribed_resources;
   };
 
-  std::string CreateAdsRequest(
-      absl::string_view type_url, absl::string_view version,
-      absl::string_view nonce, const std::vector<std::string>& resource_names,
-      absl::Status status) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(&XdsClient::mu_);
+  std::string CreateAdsRequest(absl::string_view type_url,
+                               absl::string_view version,
+                               absl::string_view nonce,
+                               const std::vector<std::string>& resource_names,
+                               absl::Status status) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(&XdsClient::mu_);
 
   void SendMessageLocked(const XdsResourceType* type)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&XdsClient::mu_);
@@ -552,8 +554,8 @@ void XdsClient::XdsChannel::SetChannelStatusLocked(absl::Status status) {
         MaybeFallbackLocked(a.first, a.second)) {
       continue;
     }
-    for (const auto& t : a.second.resource_map) {  // type
-      for (const auto& r : t.second) {             // resource id
+    for (const auto& t : a.second.resource_map) {    // type
+      for (const auto& r : t.second) {               // resource id
         for (const auto& w : r.second.watchers()) {  // watchers
           watchers.insert(w.second);
         }
@@ -779,8 +781,7 @@ void MaybeLogDiscoveryRequest(
     char buf[10240];
     upb_TextEncode(reinterpret_cast<const upb_Message*>(request), msg_type,
                    nullptr, 0, buf, sizeof(buf));
-    VLOG(2) << "[xds_client " << client
-            << "] constructed ADS request: " << buf;
+    VLOG(2) << "[xds_client " << client << "] constructed ADS request: " << buf;
   }
 }
 
@@ -838,9 +839,9 @@ std::string XdsClient::XdsChannel::AdsCall::CreateAdsRequest(
     envoy_config_core_v3_Node* node_msg =
         envoy_service_discovery_v3_DiscoveryRequest_mutable_node(request,
                                                                  arena.ptr());
-    PopulateXdsNode(
-        xds_client()->bootstrap_->node(), xds_client()->user_agent_name_,
-        xds_client()->user_agent_version_, node_msg, arena.ptr());
+    PopulateXdsNode(xds_client()->bootstrap_->node(),
+                    xds_client()->user_agent_name_,
+                    xds_client()->user_agent_version_, node_msg, arena.ptr());
     envoy_config_core_v3_Node_add_client_features(
         node_msg, upb_StringView_FromString("xds.config.resource-in-sotw"),
         arena.ptr());
@@ -1025,7 +1026,7 @@ void XdsClient::XdsChannel::AdsCall::ParseResource(
   // If it didn't change, ignore it.
   if (resource_state.HasResource() &&
       context->type->ResourcesEqual(resource_state.resource().get(),
-                                   decode_result.resource->get())) {
+                                    decode_result.resource->get())) {
     GRPC_TRACE_LOG(xds_client, INFO)
         << "[xds_client " << xds_client() << "] " << context->type_url
         << " resource " << resource_name << " identical to current, ignoring.";
@@ -1059,8 +1060,7 @@ void MaybeLogDiscoveryResponse(
     char buf[10240];
     upb_TextEncode(reinterpret_cast<const upb_Message*>(response), msg_type,
                    nullptr, 0, buf, sizeof(buf));
-    VLOG(2) << "[xds_client " << client
-            << "] received response: " << buf;
+    VLOG(2) << "[xds_client " << client << "] received response: " << buf;
   }
 }
 
@@ -1126,9 +1126,9 @@ absl::Status XdsClient::XdsChannel::AdsCall::DecodeAdsResponse(
       const auto* resource =
           envoy_service_discovery_v3_Resource_resource(resource_wrapper);
       if (resource == nullptr) {
-        context->errors.emplace_back(absl::StrCat(
-            "resource index ", i,
-            ": No resource present in Resource proto wrappe"));
+        context->errors.emplace_back(
+            absl::StrCat("resource index ", i,
+                         ": No resource present in Resource proto wrappe"));
         ++context->num_invalid_resources;
         continue;
       }
@@ -1379,8 +1379,8 @@ void XdsClient::ResourceState::FillGenericXdsConfig(
         envoy_service_status_v3_ClientConfig_GenericXdsConfig_mutable_xds_config(
             entry, arena);
     google_protobuf_Any_set_type_url(any_field, type_url);
-    google_protobuf_Any_set_value(
-        any_field, StdStringToUpbString(serialized_proto_));
+    google_protobuf_Any_set_value(any_field,
+                                  StdStringToUpbString(serialized_proto_));
   }
   if (client_status_ == ClientResourceStatus::NACKED) {
     auto* update_failure_state = envoy_admin_v3_UpdateFailureState_new(arena);
@@ -1389,8 +1389,7 @@ void XdsClient::ResourceState::FillGenericXdsConfig(
     envoy_admin_v3_UpdateFailureState_set_version_info(
         update_failure_state, StdStringToUpbString(failed_version_));
     envoy_admin_v3_UpdateFailureState_set_last_update_attempt(
-        update_failure_state,
-        EncodeTimestamp(failed_update_time_, arena));
+        update_failure_state, EncodeTimestamp(failed_update_time_, arena));
     envoy_service_status_v3_ClientConfig_GenericXdsConfig_set_error_state(
         entry, update_failure_state);
   }

--- a/src/core/xds/xds_client/xds_client.cc
+++ b/src/core/xds/xds_client/xds_client.cc
@@ -41,7 +41,6 @@
 #include "envoy/config/core/v3/base.upb.h"
 #include "envoy/service/discovery/v3/discovery.upb.h"
 #include "envoy/service/discovery/v3/discovery.upbdefs.h"
-#include "envoy/service/status/v3/csds.upb.h"
 #include "google/protobuf/any.upb.h"
 #include "google/protobuf/timestamp.upb.h"
 #include "google/rpc/status.upb.h"
@@ -1418,7 +1417,6 @@ XdsClient::XdsClient(
       transport_factory_(std::move(transport_factory)),
       request_timeout_(resource_request_timeout),
       xds_federation_enabled_(XdsFederationEnabled()),
-      api_(this, &xds_client_trace, bootstrap_->node(), &def_pool_, "", ""),
       work_serializer_(engine),
       engine_(std::move(engine)),
       metrics_reporter_(std::move(metrics_reporter)) {

--- a/src/core/xds/xds_client/xds_client.h
+++ b/src/core/xds/xds_client/xds_client.h
@@ -31,6 +31,8 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "envoy/admin/v3/config_dump_shared.upb.h"
+#include "envoy/service/status/v3/csds.upb.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/util/dual_ref_counted.h"
 #include "src/core/util/orphanable.h"
@@ -391,7 +393,6 @@ class XdsClient : public DualRefCounted<XdsClient> {
   RefCountedPtr<XdsTransportFactory> transport_factory_;
   const Duration request_timeout_;
   const bool xds_federation_enabled_;
-  XdsApi api_;
   WorkSerializer work_serializer_;
   std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine_;
   std::unique_ptr<XdsMetricsReporter> metrics_reporter_;

--- a/src/core/xds/xds_client/xds_client.h
+++ b/src/core/xds/xds_client/xds_client.h
@@ -274,22 +274,19 @@ class XdsClient : public DualRefCounted<XdsClient> {
       // Client received this resource and replied with NACK.
       NACKED,
     };
-    static_assert(
-        static_cast<ClientResourceStatus>(envoy_admin_v3_REQUESTED) ==
-             ClientResourceStatus::REQUESTED,
-        "");
+    static_assert(static_cast<ClientResourceStatus>(envoy_admin_v3_REQUESTED) ==
+                      ClientResourceStatus::REQUESTED,
+                  "");
     static_assert(
         static_cast<ClientResourceStatus>(envoy_admin_v3_DOES_NOT_EXIST) ==
             ClientResourceStatus::DOES_NOT_EXIST,
         "");
-    static_assert(
-        static_cast<ClientResourceStatus>(envoy_admin_v3_ACKED) ==
-            ClientResourceStatus::ACKED,
-        "");
-    static_assert(
-        static_cast<ClientResourceStatus>(envoy_admin_v3_NACKED) ==
-            ClientResourceStatus::NACKED,
-        "");
+    static_assert(static_cast<ClientResourceStatus>(envoy_admin_v3_ACKED) ==
+                      ClientResourceStatus::ACKED,
+                  "");
+    static_assert(static_cast<ClientResourceStatus>(envoy_admin_v3_NACKED) ==
+                      ClientResourceStatus::NACKED,
+                  "");
 
     void AddWatcher(RefCountedPtr<ResourceWatcherInterface> watcher) {
       auto* watcher_ptr = watcher.get();
@@ -300,7 +297,8 @@ class XdsClient : public DualRefCounted<XdsClient> {
     }
     bool HasWatchers() const { return !watchers_.empty(); }
     const std::map<ResourceWatcherInterface*,
-                   RefCountedPtr<ResourceWatcherInterface>>& watchers() const {
+                   RefCountedPtr<ResourceWatcherInterface>>&
+    watchers() const {
       return watchers_;
     }
 

--- a/src/core/xds/xds_client/xds_client.h
+++ b/src/core/xds/xds_client/xds_client.h
@@ -386,6 +386,8 @@ class XdsClient : public DualRefCounted<XdsClient> {
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
   std::shared_ptr<XdsBootstrap> bootstrap_;
+  const std::string user_agent_name_;
+  const std::string user_agent_version_;
   RefCountedPtr<XdsTransportFactory> transport_factory_;
   const Duration request_timeout_;
   const bool xds_federation_enabled_;


### PR DESCRIPTION
There are no functional changes here; this is solely a code cleanup.