### PR TITLE
[ObjC] Raise Socket closed error when cfstream endpoint receive 0 byte data

### DIFF
--- a/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
+++ b/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
@@ -299,7 +299,8 @@ void CFStreamEndpointImpl::DoRead(
   }
 
   buffer->RemoveLastNBytes(buffer->Length() - read_size);
-  on_read(absl::OkStatus());
+  on_read(read_size == 0 ? absl::InternalError("Socket closed")
+                         : absl::OkStatus());
 }
 
 bool CFStreamEndpointImpl::Write(

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -131,6 +131,7 @@ EVENT_ENGINE_TEST_TARGETS=(
   //src/objective-c/tests:MacTests
   //src/objective-c/tests:UnitTests
   //src/objective-c/tests:EventEngineUnitTests
+  //src/objective-c/tests:CFStreamTests
   //src/objective-c/tests:tvtests_build_test
 )
 
@@ -143,7 +144,7 @@ objc_event_engine_bazel_tests/bazel_wrapper \
   "${BAZEL_REMOTE_CACHE_ARGS[@]}" \
   $BAZEL_FLAGS \
   --test_env=GRPC_EXPERIMENTS=event_engine_client \
-  --test_env=GRPC_VERBOSITY=debug --test_env=GRPC_TRACE=event_engine,api \
+  --test_env=GRPC_VERBOSITY=debug --test_env=GRPC_TRACE=event_engine*,api \
   "${OBJC_TEST_ENV_ARGS[@]}" \
   -- \
   "${EXAMPLE_TARGETS[@]}" \


### PR DESCRIPTION
While investigating https://github.com/firebase/firebase-ios-sdk/issues/14018, I noticed a different behavior of cfstream endpoint, where it returns ok when reading 0 bytes data while [posix_endpoint](https://github.com/grpc/grpc/blob/v1.69.0/src/core/lib/event_engine/posix_engine/posix_endpoint.cc#L355-L356) raises socket closed error.

This PR aligns the cfstream endpoint behavior with posix endpoint