### PR TITLE
[ruby] docs: Correct suggested Ruby version for local dev

### DIFF
--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -7,7 +7,7 @@ A Ruby implementation of gRPC.
 PREREQUISITES
 -------------
 
-- Ruby 2.x. The gRPC API uses keyword args.
+- Ruby 3.x. The gRPC API uses keyword args.
 
 INSTALLATION
 ---------------
@@ -33,7 +33,7 @@ BUILD FROM SOURCE
 git submodule update --init
 ```
 
-- Install Ruby 2.x. Consider doing this with [RVM](http://rvm.io), it's a nice way of controlling
+- Install Ruby 3.x. Consider doing this with [RVM](http://rvm.io), it's a nice way of controlling
   the exact ruby version that's used.
 ```sh
 $ command curl -sSL https://rvm.io/mpapis.asc | gpg --import -


### PR DESCRIPTION
The project has been built on Ruby 3.x for some time now. Just making new-contributor life slightly easier. :-)