### PR TITLE
Adding openssl support for bazel build.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,41 @@
 workspace(name = "com_github_grpc_grpc")
 
+# Define a local repository for OpenSSL
+new_local_repository(
+    name = "openssl",
+    path = "/usr/lib/ssl",  # Adjust this to your OpenSSL installation path
+    build_file_content = """
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "openssl",
+    includes = ["."],
+    linkopts = ["-L/usr/lib", "-lssl", "-lcrypto"],
+    )
+cc_library(
+name = "crypto",
+includes = ["."],
+linkopts = [
+        "-L/usr/lib",
+        "-lcrypto",  # Link against the Crypto library
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ssl",
+    includes = ["."],
+    linkopts = [
+        "-L/usr/lib",
+        "-lssl",  # Link against the SSL library
+    ],
+        deps = [":crypto"],  # SSL depends on Crypto
+    visibility = ["//visibility:public"],
+)
+    """,
+    
+)
+
 load("//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
 
 grpc_deps()

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -332,6 +332,18 @@ def grpc_deps():
             ],
         )
 
+    if "google_cloud_cpp_openssl" not in native.existing_rules():
+        http_archive(
+            name = "google_cloud_cpp_openssl",
+            sha256 = "e53ba3799c052d97acac9a6a6b27af24ce822dbde7bfde973bac9e5da714e6b2",
+            strip_prefix = "google-cloud-cpp-2.33.0",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.33.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.33.0.tar.gz",
+            ],
+            patches = ["@com_github_grpc_grpc//third_party:google_cloud_cpp_openssl.patch" ],
+        )
+
     if "google_cloud_cpp" not in native.existing_rules():
         http_archive(
             name = "google_cloud_cpp",

--- a/doc/using_openssl_with_bazel.md
+++ b/doc/using_openssl_with_bazel.md
@@ -1,0 +1,8 @@
+To use system installation of openssl with bazel, Please follow the below steps:
+
+ 1. You need to have the header files installed (in /usr/include/openssl) and during runtime, the shared library must be installed.
+ 2. export CC=gcc
+ 3. export BAZEL_CACHE=$(bazel info output_base)/external
+ 4. bazel build :all --override_repository=boringssl=$BAZEL_CACHE/openssl
+ 5. While testing please add this flag while using openssl with bazel,--override_repository=google_cloud_cpp=$BAZEL_CACHE/google_cloud_cpp_openssl along with bazel build :all --override_repository=boringssl=$BAZEL_CACHE/openssl
+ 6. The above command will pick openssl from bazel cache.

--- a/third_party/google_cloud_cpp_openssl.patch
+++ b/third_party/google_cloud_cpp_openssl.patch
@@ -1,0 +1,63 @@
+#This patch is only required for testing grpc with openssl and bazel.
+diff --git bazel/curl.BUILD bazel/curl.BUILD
+index f100543..22d1e5f 100644
+--- bazel/curl.BUILD
++++ bazel/curl.BUILD
+@@ -166,6 +166,22 @@ cc_library(
+     name = "curl",
+     srcs = [
+         "include/curl_config.h",
++        "include/curl/options.h",
++        "lib/dynbuf.h",
++        "lib/dynbuf.c",
++        "lib/mqtt.h",
++        "lib/mqtt.c",
++        "lib/c-hyper.h",
++        "lib/vtls/rustls.h",
++        "lib/vtls/keylog.h",
++        "lib/vtls/keylog.c",
++        "lib/version_win32.h",
++        "lib/bufref.h",
++        "lib/bufref.c",
++        "lib/hsts.h",
++        "lib/hsts.c",
++        "lib/http_aws_sigv4.h",
++        "lib/http_aws_sigv4.c",
+         "lib/altsvc.c",
+         "lib/altsvc.h",
+         "lib/amigaos.h",
+@@ -212,7 +228,6 @@ cc_library(
+         "lib/curl_rtmp.h",
+         "lib/curl_sasl.c",
+         "lib/curl_sasl.h",
+-        "lib/curl_sec.h",
+         "lib/curl_setup.h",
+         "lib/curl_setup_once.h",
+         "lib/curl_sha256.h",
+@@ -306,7 +321,6 @@ cc_library(
+         "lib/rename.h",
+         "lib/rtsp.c",
+         "lib/rtsp.h",
+-        "lib/security.c",
+         "lib/select.c",
+         "lib/select.h",
+         "lib/sendf.c",
+diff --git bazel/workspace0.bzl bazel/workspace0.bzl
+index e48854d..38eecb8 100644
+--- bazel/workspace0.bzl
++++ bazel/workspace0.bzl
+@@ -195,10 +195,10 @@ def gl_cpp_workspace0(name = None):
+         http_archive,
+         name = "com_github_curl_curl",
+         urls = [
+-            "https://curl.haxx.se/download/curl-7.69.1.tar.gz",
++            "https://curl.haxx.se/download/curl-7.81.0.tar.gz",
+         ],
+-        sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",
+-        strip_prefix = "curl-7.69.1",
++        sha256 = "ac8e1087711084548d788ef18b9b732c8de887457b81f616fc681d1044b32f98",
++        strip_prefix = "curl-7.81.0",
+         build_file = Label("//bazel:curl.BUILD"),
+     )
+
+


### PR DESCRIPTION
Hello Team ,
 We are working on building GRPC using openssl with Bazel. We have added new_repository in WORKSPACE for openssl and were able to build grpc using ```bazel build :all --override_repository=boringssl=$BAZEL_CACHE/openssl```. This PR also includes patch for google_cloud_cpp which will be applied only while testing.
Please let us know your thoughts about this.
 



