### PR TITLE
fix memory_owner was reset while there is  read callback in flight

### DIFF
--- a/src/core/handshaker/security/secure_endpoint.cc
+++ b/src/core/handshaker/security/secure_endpoint.cc
@@ -512,7 +512,6 @@ static void endpoint_destroy(grpc_endpoint* secure_ep) {
   secure_endpoint* ep = reinterpret_cast<secure_endpoint*>(secure_ep);
   ep->read_mu.Lock();
   ep->wrapped_ep.reset();
-  ep->memory_owner.Reset();
   ep->read_mu.Unlock();
   SECURE_ENDPOINT_UNREF(ep, "destroy");
 }


### PR DESCRIPTION
fixes https://github.com/firebase/firebase-ios-sdk/issues/14018

What happened was that when secure_endpoint was being destroyed, there was still an on-going read, however with the change in https://github.com/grpc/grpc/pull/37358, memory_owner was immediately deleted even its ref count was > 1.
Explicitly reset of memory_owner is not needed since it'll be [shutdown](https://github.com/grpc/grpc/blob/v1.69.0/include/grpc/event_engine/memory_allocator.h#L44) when the secure_endpoint was destructed.
If the memory leak recurred, we should looking for placeses where the secure_endpoint was not unref-ed.


Following logs show the sequence when the crash happens, I was able to verify it was the cause by adding sleep in cfstream endpoint right before calling the on_read callback and reproduced it, crash log was the same as the reports in the firestore issue and memory_owner holds a null allocator.

log:
```
E0000 00:00:1735779908.157067 4196699 cfstream_endpoint.cc:167] (event_engine endpoint) CFStreamEndpointImpl::ReadCallback, type: 2, this: 0x123223fc0
I0000 00:00:1735779908.218108 4195843 secure_endpoint.cc:521] xxxxx endpoint_destroy, this: 0x122881a00, ref: 3
E0000 00:00:1735779908.218236 4195843 cfstream_endpoint.cc:243] (event_engine endpoint) CFStreamEndpointImpl::Shutdown: this: 0x123223fc0
E0000 00:00:1735779913.162068 4195850 cfstream_endpoint.cc:309] (event_engine endpoint) CFStreamEndpointImpl::DoRead, call on_read, this: 0x123223fc0
I0000 00:00:1735779913.162452 4195850 secure_endpoint.cc:257] xxxxx on_read, this: 0x122881a00, ref: 1
```

allocator in memroy_owner was null, ref was 1:

<img width="594" alt="Screenshot 2025-01-02 at 9 01 27 AM" src="https://github.com/user-attachments/assets/3c9d382f-e194-4fb1-b5b6-e9c3da83e20d" />


stack:
```
#0	0x000000010b74812c in grpc_event_engine::experimental::MemoryAllocator::MakeSlice at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/include/grpc/event_engine/memory_allocator.h:137
#1	0x000000010bd9278c in flush_read_staging_buffer at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/handshaker/security/secure_endpoint.cc:231
#2	0x000000010bd9224c in on_read at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/handshaker/security/secure_endpoint.cc:314
#3	0x000000010b995598 in exec_ctx_run at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/iomgr/exec_ctx.cc:45
#4	0x000000010b99539c in grpc_core::ExecCtx::Flush at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/iomgr/exec_ctx.cc:84
#5	0x000000010b64e530 in grpc_core::ExecCtx::~ExecCtx at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/iomgr/exec_ctx.h:132
#6	0x000000010b64cffc in grpc_core::ExecCtx::~ExecCtx at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/iomgr/exec_ctx.h:130
#7	0x000000010b957afc in grpc_event_engine::experimental::(anonymous namespace)::EventEngineEndpointWrapper::FinishPendingRead at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/iomgr/event_engine_shims/endpoint.cc:142
#8	0x000000010b9588a4 in grpc_event_engine::experimental::(anonymous namespace)::EventEngineEndpointWrapper::Read(grpc_closure*, grpc_slice_buffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::'lambda'(absl::lts_20240116::Status)::operator()(absl::lts_20240116::Status) const at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/iomgr/event_engine_shims/endpoint.cc:113
#9	0x000000010b958830 in absl::lts_20240116::base_internal::Callable::Invoke<grpc_event_engine::experimental::(anonymous namespace)::EventEngineEndpointWrapper::Read(grpc_closure*, grpc_slice_buffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::'lambda'(absl::lts_20240116::Status)&, absl::lts_20240116::Status> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/base/internal/invoke.h:185
#10	0x000000010b9587ec in absl::lts_20240116::base_internal::invoke<grpc_event_engine::experimental::(anonymous namespace)::EventEngineEndpointWrapper::Read(grpc_closure*, grpc_slice_buffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::'lambda'(absl::lts_20240116::Status)&, absl::lts_20240116::Status> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/base/internal/invoke.h:212
#11	0x000000010b9587c0 in absl::lts_20240116::internal_any_invocable::InvokeR<void, grpc_event_engine::experimental::(anonymous namespace)::EventEngineEndpointWrapper::Read(grpc_closure*, grpc_slice_buffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::'lambda'(absl::lts_20240116::Status)&, absl::lts_20240116::Status, void> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/functional/internal/any_invocable.h:132
#12	0x000000010b958760 in absl::lts_20240116::internal_any_invocable::LocalInvoker<false, void, grpc_event_engine::experimental::(anonymous namespace)::EventEngineEndpointWrapper::Read(grpc_closure*, grpc_slice_buffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::'lambda'(absl::lts_20240116::Status)&, absl::lts_20240116::Status> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/functional/internal/any_invocable.h:310
#13	0x000000010b746674 in absl::lts_20240116::internal_any_invocable::Impl<void (absl::lts_20240116::Status)>::operator() at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/functional/internal/any_invocable.h:868
#14	0x000000010b74807c in grpc_event_engine::experimental::CFStreamEndpointImpl::DoRead at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc:312
#15	0x000000010b74ab1c in grpc_event_engine::experimental::CFStreamEndpointImpl::Read(absl::lts_20240116::AnyInvocable<void (absl::lts_20240116::Status)>, grpc_event_engine::experimental::SliceBuffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::$_0::operator()(absl::lts_20240116::Status) at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc:269
#16	0x000000010b74aa78 in absl::lts_20240116::base_internal::Callable::Invoke<grpc_event_engine::experimental::CFStreamEndpointImpl::Read(absl::lts_20240116::AnyInvocable<void (absl::lts_20240116::Status)>, grpc_event_engine::experimental::SliceBuffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::$_0&, absl::lts_20240116::Status> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/base/internal/invoke.h:185
#17	0x000000010b74aa34 in absl::lts_20240116::base_internal::invoke<grpc_event_engine::experimental::CFStreamEndpointImpl::Read(absl::lts_20240116::AnyInvocable<void (absl::lts_20240116::Status)>, grpc_event_engine::experimental::SliceBuffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::$_0&, absl::lts_20240116::Status> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/base/internal/invoke.h:212
#18	0x000000010b74aa08 in absl::lts_20240116::internal_any_invocable::InvokeR<void, grpc_event_engine::experimental::CFStreamEndpointImpl::Read(absl::lts_20240116::AnyInvocable<void (absl::lts_20240116::Status)>, grpc_event_engine::experimental::SliceBuffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::$_0&, absl::lts_20240116::Status, void> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/functional/internal/any_invocable.h:132
#19	0x000000010b74a880 in absl::lts_20240116::internal_any_invocable::RemoteInvoker<false, void, grpc_event_engine::experimental::CFStreamEndpointImpl::Read(absl::lts_20240116::AnyInvocable<void (absl::lts_20240116::Status)>, grpc_event_engine::experimental::SliceBuffer*, grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs const*)::$_0&, absl::lts_20240116::Status> at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/functional/internal/any_invocable.h:368
#20	0x000000010b746674 in absl::lts_20240116::internal_any_invocable::Impl<void (absl::lts_20240116::Status)>::operator() at /Users/hannahshi/Library/Developer/Xcode/DerivedData/FirestoreExample-eyfajojalcrgngcrwxuibwlodtjc/Build/Products/Debug-iphoneos/abseil/absl.framework/Headers/functional/internal/any_invocable.h:868
#21	0x000000010b748dec in grpc_event_engine::experimental::PosixEngineClosure::Run at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/posix_engine/posix_engine_closure.h:49
#22	0x000000010bf32c98 in grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc:580
#23	0x000000010bf32514 in grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::ThreadBody at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc:494
#24	0x000000010bf34ab0 in grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::$_0::operator()(void*) const at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc:261
#25	0x000000010bf34a80 in grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::StartThread()::$_0::__invoke(void*) at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.cc:259
#26	0x000000010beb03d4 in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::operator()(void*) const at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/gprpp/posix/thd.cc:148
#27	0x000000010beb02c8 in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*, grpc_core::Thread::Options const&)::'lambda'(void*)::__invoke(void*) at /Users/hannahshi/work/firebase-quickstart-ios/firestore/Pods/gRPC-Core/src/core/lib/gprpp/posix/thd.cc:118
#28	0x0000000213f740ec in _pthread_start ()
```