### PR TITLE
[ObjC] fix protoc link in !ProtoCompiler.podspec

### DIFF
--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -97,9 +97,9 @@ Pod::Spec.new do |s|
   s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
   repo = 'google/protobuf'
-  file = "protoc-#{v}-osx-x86_64.zip"
+  file = "protoc-#{v.delete_prefix("3.")}-osx-universal_binary.zip"
   s.source = {
-    :http => "https://github.com/#{repo}/releases/download/v#{v}/#{file}",
+    :http => "https://github.com/#{repo}/releases/download/v#{v.delete_prefix("3.")}/#{file}",
     # TODO(jcanizales): Add sha1 or sha256
     # :sha1 => '??',
   }

--- a/templates/src/objective-c/!ProtoCompiler.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler.podspec.template
@@ -99,9 +99,9 @@
     s.authors  = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
 
     repo = 'google/protobuf'
-    file = "protoc-#{v}-osx-x86_64.zip"
+    file = "protoc-#{v.delete_prefix("3.")}-osx-universal_binary.zip"
     s.source = {
-      :http => "https://github.com/#{repo}/releases/download/v#{v}/#{file}",
+      :http => "https://github.com/#{repo}/releases/download/v#{v.delete_prefix("3.")}/#{file}",
       # TODO(jcanizales): Add sha1 or sha256
       # :sha1 => '??',
     }


### PR DESCRIPTION
Protobuf release url doesn't contain the `3.` prefix in the versions anymore.
Also change to use universal binary.

dependency for https://github.com/grpc/grpc/issues/36801