### PR TITLE
[ObjC] build universal binary for grpc_proto_plugin on mac

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -27,6 +27,7 @@
 Contains macros used throughout the repo.
 """
 
+load("@build_bazel_apple_support//rules:universal_binary.bzl", "universal_binary")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@com_google_protobuf//bazel:upb_proto_library.bzl", "upb_proto_library", "upb_proto_reflection_library")
@@ -237,9 +238,23 @@ def grpc_cc_library(
 
 def grpc_proto_plugin(name, srcs = [], deps = []):
     native.cc_binary(
-        name = name,
+        name = name + "_native",
         srcs = srcs,
         deps = deps,
+    )
+    universal_binary(
+        name = name + "_universal",
+        binary = name + "_native",
+    )
+    native.genrule(
+        name = name,
+        srcs = select({
+            "@platforms//os:macos": [name + "_universal"],
+            "//conditions:default": [name + "_native"],
+        }),
+        outs = [name],
+        cmd = "cp $< $@",
+        executable = True,
     )
 
 def grpc_internal_proto_library(

--- a/tools/buildgen/extract_metadata_from_bazel_xml.py
+++ b/tools/buildgen/extract_metadata_from_bazel_xml.py
@@ -193,6 +193,7 @@ def _extract_rules_from_bazel_xml(xml_tree):
                 "upb_proto_reflection_library",
                 "alias",
                 "bind",
+                "genrule",
             ]:
                 if rule_name in result:
                     raise Exception("Rule %s already present" % rule_name)


### PR DESCRIPTION
https://github.com/grpc/grpc/issues/36801

```
file bazel-bin/src/compiler/grpc_objective_c_plugin
bazel-bin/src/compiler/grpc_objective_c_plugin: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
bazel-bin/src/compiler/grpc_objective_c_plugin (for architecture x86_64):	Mach-O 64-bit executable x86_64
bazel-bin/src/compiler/grpc_objective_c_plugin (for architecture arm64):	Mach-O 64-bit executable arm64
```