### PR TITLE
[party] Provide a legal but different allocation strategy in thready-tsan builds

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -647,6 +647,7 @@ grpc_cc_library(
         "absl/log:log",
         "absl/strings",
         "absl/strings:str_format",
+        "absl/random",
     ],
     language = "c++",
     deps = [

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -359,6 +359,40 @@ void Party::RunPartyAndUnref(uint64_t prev_state) {
   }
 }
 
+// Given a bitmask indicating allocation status of promises, return the index of
+// the next slot to allocate.
+// By default we use a deterministic and fast algorithm (fit-first), but we
+// don't want to guarantee that this is the order of spawning -- if a promise is
+// locked by another thread (for instance) a sequence of spawns may be reordered
+// for initial execution.
+// So for thready-tsan we provide an alternative implementation that
+// additionally reorders promises.
+#ifndef GRPC_MAXIMIZE_THREADYNESS
+uint64_t Party::NextAllocationMask(uint64_t current_allocation_mask) {
+  return LowestOneBit(~current_allocation_mask);
+}
+#else
+uint64_t Party::NextAllocationMask(uint64_t current_allocation_mask) {
+  CHECK_EQ(current_allocation_mask & ~kWakeupMask, 0);
+  if (current_allocation_mask == kWakeupMask) return kWakeupMask + 1;
+  // Count number of unset bits in the wakeup mask
+  size_t unset_bits = 0;
+  for (size_t i = 0; i < kMaxParticipants; i++) {
+    if (current_allocation_mask & (1ull << i)) continue;
+    ++unset_bits;
+  }
+  CHECK_GT(unset_bits, 0);
+  absl::BitGen bitgen;
+  size_t selected = absl::Uniform(bitgen, unset_bits);
+  for (size_t i = 0; i < kMaxParticipants; i++) {
+    if (current_allocation_mask & (1ull << i)) continue;
+    if (selected == 0) return 1ull << i;
+    --selected;
+  }
+  LOG(FATAL) << "unreachable";
+}
+#endif
+
 void Party::AddParticipant(Participant* participant) {
   GRPC_LATENT_SEE_INNER_SCOPE("Party::AddParticipant");
   uint64_t state = state_.load(std::memory_order_acquire);
@@ -372,7 +406,7 @@ void Party::AddParticipant(Participant* participant) {
   uint64_t new_state;
   do {
     allocated = (state & kAllocatedMask) >> kAllocatedShift;
-    wakeup_mask = LowestOneBit(~allocated);
+    wakeup_mask = NextAllocationMask(allocated);
     if (GPR_UNLIKELY((wakeup_mask & kWakeupMask) == 0)) {
       DelayAddParticipant(participant);
       return;

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -30,6 +30,7 @@
 #include "src/core/util/sync.h"
 
 #ifdef GRPC_MAXIMIZE_THREADYNESS
+#include "absl/random/random.h"           // IWYU pragma: keep
 #include "src/core/lib/iomgr/exec_ctx.h"  // IWYU pragma: keep
 #include "src/core/util/thd.h"            // IWYU pragma: keep
 #endif
@@ -377,14 +378,14 @@ uint64_t Party::NextAllocationMask(uint64_t current_allocation_mask) {
   if (current_allocation_mask == kWakeupMask) return kWakeupMask + 1;
   // Count number of unset bits in the wakeup mask
   size_t unset_bits = 0;
-  for (size_t i = 0; i < kMaxParticipants; i++) {
+  for (size_t i = 0; i < party_detail::kMaxParticipants; i++) {
     if (current_allocation_mask & (1ull << i)) continue;
     ++unset_bits;
   }
   CHECK_GT(unset_bits, 0);
   absl::BitGen bitgen;
-  size_t selected = absl::Uniform(bitgen, unset_bits);
-  for (size_t i = 0; i < kMaxParticipants; i++) {
+  size_t selected = absl::Uniform<size_t>(bitgen, 0, unset_bits);
+  for (size_t i = 0; i < party_detail::kMaxParticipants; i++) {
     if (current_allocation_mask & (1ull << i)) continue;
     if (selected == 0) return 1ull << i;
     --selected;

--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -424,6 +424,8 @@ class Party : public Activity, private Wakeable {
   void AddParticipant(Participant* participant);
   void DelayAddParticipant(Participant* participant);
 
+  static uint64_t NextAllocationMask(uint64_t current_allocation_mask);
+
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void LogStateChange(
       const char* op, uint64_t prev_state, uint64_t new_state,
       DebugLocation loc = {}) {


### PR DESCRIPTION
We currently have a fast and deterministic allocation strategy in party for newly spawned promises - but I'd prefer not to bake in assumptions that this will *always* be the strategy of choice - code that relies on this will cause long term brittleness.

So here I'm providing a different strategy on thready_tsan builds to shake out any inadvertent assumptions that are in place.