### PR TITLE
[benchmark] Match case of excluded scenario.

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke.sh
@@ -214,8 +214,9 @@ fi
 # displayed on the public dashboard. The test runs and passes on the 30-core
 # ("32core") node pool. This can be considered a permanent fix, selectively
 # removing an unnecessary test and allowing the test run to become green.
+# IMPORTANT: Scenario names are case-sensitive.
 declare -a disabledTests8core=(
-  cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure
+  cpp_protobuf_async_client_unary_1channel_64wide_128Breq_8MBresp_insecure
 )
 declare -a disabledTests32core=()
 

--- a/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_gke_experiment.sh
@@ -209,8 +209,9 @@ fi
 # displayed on the public dashboard. The test runs and passes on the 30-core
 # ("32core") node pool. This can be considered a permanent fix, selectively
 # removing an unnecessary test and allowing the test run to become green.
+# IMPORTANT: Scenario names are case-sensitive.
 declare -a disabledTests8core=(
-  cpp_protobuf_async_client_unary_1channel_64wide_128breq_8mbresp_insecure
+  cpp_protobuf_async_client_unary_1channel_64wide_128Breq_8MBresp_insecure
 )
 declare -a disabledTests32core=()
 


### PR DESCRIPTION
This change updates the case of the scenario excluded from OSS benchmarks to match the case generated by `scenario_config.py`. This is required because the mechanism used to exclude the scenario is case sensitive.


