### PR TITLE
[C++] Fix python build script to handle C and C++ std options properly for MSVC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,19 +263,20 @@ EXTRA_ENV_LINK_ARGS = os.environ.get("GRPC_PYTHON_LDFLAGS", None)
 if EXTRA_ENV_COMPILE_ARGS is None:
     EXTRA_ENV_COMPILE_ARGS = ""
     if "win32" in sys.platform:
-        # MSVC by defaults uses C++14 so C11 needs to be specified.
+        # MSVC by defaults uses C++14 and C89 so both needs to be configured.
+        EXTRA_ENV_COMPILE_ARGS += " /std:c++17"
         EXTRA_ENV_COMPILE_ARGS += " /std:c11"
         # We need to statically link the C++ Runtime, only the C runtime is
         # available dynamically
         EXTRA_ENV_COMPILE_ARGS += " /MT"
     elif "linux" in sys.platform:
-        # GCC by defaults uses C17 so only C++14 needs to be specified.
+        # GCC by defaults uses C17 so only C++17 needs to be specified.
         EXTRA_ENV_COMPILE_ARGS += " -std=c++17"
         EXTRA_ENV_COMPILE_ARGS += (
             " -fvisibility=hidden -fno-wrapv -fno-exceptions"
         )
     elif "darwin" in sys.platform:
-        # AppleClang by defaults uses C17 so only C++14 needs to be specified.
+        # AppleClang by defaults uses C17 so only C++17 needs to be specified.
         EXTRA_ENV_COMPILE_ARGS += " -std=c++17"
         EXTRA_ENV_COMPILE_ARGS += (
             " -stdlib=libc++ -fvisibility=hidden -fno-wrapv -fno-exceptions"

--- a/src/python/grpcio/_spawn_patch.py
+++ b/src/python/grpcio/_spawn_patch.py
@@ -31,6 +31,14 @@ _classic_spawn = ccompiler.CCompiler.spawn
 
 
 def _commandfile_spawn(self, command, **kwargs):
+    if os.name == "nt":
+        if any(arg.startswith("/Tc") for arg in command):
+            # Remove /std:c++17 option if this is a MSVC C complation
+            command = [arg for arg in command if arg != "/std:c++17"]
+        elif any(arg.startswith("/Tp") for arg in command):
+            # Remove /std:c11 option if this is a MSVC C++ complation
+            command = [arg for arg in command if arg != "/std:c11"]
+
     command_length = sum([len(arg) for arg in command])
     if os.name == "nt" and command_length > MAX_COMMAND_LENGTH:
         # Even if this command doesn't support the @command_file, it will

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -248,53 +248,22 @@ class BuildExt(build_ext.build_ext):
         return filename
 
     def build_extensions(self):
-        def compiler_ok_with_extra_std():
-            """Test if default compiler is okay with specifying c++ version
-            when invoked in C mode. GCC is okay with this, while clang is not.
-            """
-            try:
-                # TODO(lidiz) Remove the generated a.out for success tests.
-                cc = os.environ.get("CC", "cc")
-                cc_test = subprocess.Popen(
-                    [cc, "-x", "c", "-std=c++17", "-"],
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-                _, cc_err = cc_test.communicate(input=b"int main(){return 0;}")
-                return not "invalid argument" in str(cc_err)
-            except:
-                sys.stderr.write(
-                    "Non-fatal exception:" + traceback.format_exc() + "\n"
-                )
-                return False
+        # This is to let UnixCompiler get either C or C++ compiler options depending on the source.
+        # Note that this doesn't work for MSVCCompiler and will be handled by _spawn_patch.py.
+        old_compile = self.compiler._compile
 
-        # This special conditioning is here due to difference of compiler
-        #   behavior in gcc and clang. The clang doesn't take --stdc++11
-        #   flags but gcc does. Since the setuptools of Python only support
-        #   all C or all C++ compilation, the mix of C and C++ will crash.
-        #   *By default*, macOS and FreeBSD use clang and Linux use gcc
-        #
-        #   If we are not using a permissive compiler that's OK with being
-        #   passed wrong std flags, swap out compile function by adding a filter
-        #   for it.
-        if not compiler_ok_with_extra_std():
-            old_compile = self.compiler._compile
+        def new_compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
+            if src.endswith(".c"):
+                extra_postargs = [
+                    arg for arg in extra_postargs if arg != "-std=c++17"
+                ]
+            elif src.endswith((".cc", ".cpp")):
+                extra_postargs = [
+                    arg for arg in extra_postargs if arg != "-std=c11"
+                ]
+            return old_compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
-            def new_compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
-                if src.endswith(".c"):
-                    extra_postargs = [
-                        arg for arg in extra_postargs if "-std=c++" not in arg
-                    ]
-                elif src.endswith(".cc") or src.endswith(".cpp"):
-                    extra_postargs = [
-                        arg for arg in extra_postargs if "-std=gnu99" not in arg
-                    ]
-                return old_compile(
-                    obj, src, ext, cc_args, extra_postargs, pp_opts
-                )
-
-            self.compiler._compile = new_compile
+        self.compiler._compile = new_compile
 
         compiler = self.compiler.compiler_type
         if compiler in BuildExt.C_OPTIONS:

--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -118,7 +118,7 @@ def modifyCompileCommand(target, args):
         options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
         options += " -Wno-unused-function"
         if not target["file"].startswith("external/"):
-            # *.h file is treated as C header by default while our headers files are all C++14.
+            # *.h file is treated as C header by default while our headers files are all C++17.
             options = "-x c++ -std=c++17 -fexceptions " + options
 
     target["command"] = " ".join([cc, options])

--- a/tools/distrib/python/grpcio_tools/_spawn_patch.py
+++ b/tools/distrib/python/grpcio_tools/_spawn_patch.py
@@ -31,6 +31,14 @@ _classic_spawn = ccompiler.CCompiler.spawn
 
 
 def _commandfile_spawn(self, command, **kwargs):
+    if os.name == "nt":
+        if any(arg.startswith("/Tc") for arg in command):
+            # Remove /std:c++17 option if this is a MSVC C complation
+            command = [arg for arg in command if arg != "/std:c++17"]
+        elif any(arg.startswith("/Tp") for arg in command):
+            # Remove /std:c11 option if this is a MSVC C++ complation
+            command = [arg for arg in command if arg != "/std:c11"]
+
     command_length = sum([len(arg) for arg in command])
     if os.name == "nt" and command_length > MAX_COMMAND_LENGTH:
         # Even if this command doesn't support the @command_file, it will

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -130,25 +130,18 @@ class BuildExt(build_ext.build_ext):
         return filename
 
     def build_extensions(self):
-        # This special conditioning is here due to difference of compiler
-        #   behavior in gcc and clang. The clang doesn't take --stdc++11
-        #   flags but gcc does. Since the setuptools of Python only support
-        #   all C or all C++ compilation, the mix of C and C++ will crash.
-        #   *By default*, macOS and FreeBSD use clang and Linux use gcc
-        #
-        #   If we are not using a permissive compiler that's OK with being
-        #   passed wrong std flags, swap out compile function by adding a filter
-        #   for it.
+        # This is to let UnixCompiler get either C or C++ compiler options depending on the source.
+        # Note that this doesn't work for MSVCCompiler and will be handled by _spawn_patch.py.
         old_compile = self.compiler._compile
 
         def new_compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
             if src.endswith(".c"):
                 extra_postargs = [
-                    arg for arg in extra_postargs if "-std=c++" not in arg
+                    arg for arg in extra_postargs if arg != "-std=c++17"
                 ]
-            elif src.endswith(".cc") or src.endswith(".cpp"):
+            elif src.endswith((".cc", ".cpp")):
                 extra_postargs = [
-                    arg for arg in extra_postargs if "-std=c11" not in arg
+                    arg for arg in extra_postargs if arg != "-std=c11"
                 ]
             return old_compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
@@ -184,20 +177,21 @@ EXTRA_ENV_LINK_ARGS = os.environ.get("GRPC_PYTHON_LDFLAGS", None)
 if EXTRA_ENV_COMPILE_ARGS is None:
     EXTRA_ENV_COMPILE_ARGS = ""
     if "win32" in sys.platform:
-        # MSVC by defaults uses C++14 so C11 needs to be specified.
+        # MSVC by defaults uses C++14 and C89 so both needs to be configured.
+        EXTRA_ENV_COMPILE_ARGS += " /std:c++17"
         EXTRA_ENV_COMPILE_ARGS += " /std:c11"
         # We need to statically link the C++ Runtime, only the C runtime is
         # available dynamically
         EXTRA_ENV_COMPILE_ARGS += " /MT"
     elif "linux" in sys.platform:
-        # GCC by defaults uses C17 so only C++14 needs to be specified.
+        # GCC by defaults uses C17 so only C++17 needs to be specified.
         EXTRA_ENV_COMPILE_ARGS += " -std=c++17"
         EXTRA_ENV_COMPILE_ARGS += " -fno-wrapv -frtti"
         # Reduce the optimization level from O3 (in many cases) to O1 to
         # workaround gcc misalignment bug with MOVAPS (internal b/329134877)
         EXTRA_ENV_COMPILE_ARGS += " -O1"
     elif "darwin" in sys.platform:
-        # AppleClang by defaults uses C17 so only C++14 needs to be specified.
+        # AppleClang by defaults uses C17 so only C++17 needs to be specified.
         EXTRA_ENV_COMPILE_ARGS += " -std=c++17"
         EXTRA_ENV_COMPILE_ARGS += " -fno-wrapv -frtti"
         EXTRA_ENV_COMPILE_ARGS += " -stdlib=libc++ -DHAVE_UNISTD_H"


### PR DESCRIPTION
This PR makes necessary changes to Python build scripts for C++17 support, which were missed in #37919

- Fixed handling of C and C++ standard options for MSVC. 
  - Previously, a workaround relied on a specific method, `_compiler` found in the compiler class. [unixcompiler](https://github.com/pypa/distutils/blob/ff11eed0c36b35bd68615a8ebf36763b7c8a6f28/distutils/unixccompiler.py#L191) has it but [msvccompiler](https://github.com/pypa/distutils/blob/ff11eed0c36b35bd68615a8ebf36763b7c8a6f28/distutils/_msvccompiler.py#L367) doesn't. Therefore this won't work for MSVC even though it's supposed to work across all compilers.
  - To resolve this, a new workaround has been implemented. This involves adding logic directly into the `_commandfile_spawn` function, which is considered the most suitable location for this fix. Although not ideal, this ensures that C and C++ standard options are managed correctly for MSVC.
- Removed `compiler_ok_with_extra_std function` as isolating C and C++ standard options is always recommended.
- Updated comments to correctly refer to C++17.
