### PR TITLE
[xds] include all ambient errors in resolution_notes for LOGICAL_DNS clusters

### DIFF
--- a/src/core/resolver/xds/xds_dependency_manager.h
+++ b/src/core/resolver/xds/xds_dependency_manager.h
@@ -152,6 +152,10 @@ class XdsDependencyManager final : public RefCounted<XdsDependencyManager>,
   void PopulateDnsUpdate(const std::string& dns_name, Resolver::Result result,
                          DnsState* dns_state);
 
+  std::string GenerateResolutionNoteForCluster(
+      absl::string_view cluster_resolution_note,
+      absl::string_view endpoint_resolution_note) const;
+
   // Starts CDS and EDS/DNS watches for the specified cluster if needed.
   // Adds an entry to cluster_config_map, which will contain the cluster
   // data if the data is available.


### PR DESCRIPTION
I missed this in #38341.