### PR TITLE
[CI] Fix linux/grpc_portability error

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -597,13 +597,17 @@ class CLanguage(object):
             return (
                 "clang_7",
                 self._clang_cmake_configure_extra_args()
-                + "-DCMAKE_CXX_STANDARD=17",
+                + [
+                    "-DCMAKE_CXX_STANDARD=17",
+                ],
             )
         elif compiler == "clang19":
             return (
                 "clang_19",
                 self._clang_cmake_configure_extra_args()
-                + "-DCMAKE_CXX_STANDARD=17",
+                + [
+                    "-DCMAKE_CXX_STANDARD=17",
+                ],
             )
         else:
             raise Exception("Compiler %s not supported." % compiler)


### PR DESCRIPTION
Fix the following error

```
  File "tools/run_tests/run_tests.py", line 1846, in <module>
    l.configure(run_config, args)
  File "tools/run_tests/run_tests.py", line 333, in configure
    ) = self._compiler_options(
  File "tools/run_tests/run_tests.py", line 605, in _compiler_options
    self._clang_cmake_configure_extra_args()
TypeError: can only concatenate list (not "str") to list
```