### PR TITLE
[client channel] use absl map types for connectivity watchers

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -6635,6 +6635,7 @@ grpc_cc_library(
         "lib/transport/connectivity_state.h",
     ],
     external_deps = [
+        "absl/container:flat_hash_set",
         "absl/log:log",
         "absl/status",
     ],

--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -456,7 +456,7 @@ void Subchannel::ConnectivityStateWatcherList::NotifyLocked(
     grpc_connectivity_state state, const absl::Status& status) {
   for (const auto& watcher : watchers_) {
     subchannel_->work_serializer_.Schedule(
-        [watcher, state, status]() mutable {
+        [watcher = watcher->Ref(), state, status]() mutable {
           auto* watcher_ptr = watcher.get();
           watcher_ptr->OnConnectivityStateChange(std::move(watcher), state,
                                                  status);

--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -444,7 +444,7 @@ class Subchannel::ConnectedSubchannelStateWatcher final
 
 void Subchannel::ConnectivityStateWatcherList::AddWatcherLocked(
     RefCountedPtr<ConnectivityStateWatcherInterface> watcher) {
-  watchers_.insert(std::make_pair(watcher.get(), std::move(watcher)));
+  watchers_.insert(std::move(watcher));
 }
 
 void Subchannel::ConnectivityStateWatcherList::RemoveWatcherLocked(
@@ -454,9 +454,9 @@ void Subchannel::ConnectivityStateWatcherList::RemoveWatcherLocked(
 
 void Subchannel::ConnectivityStateWatcherList::NotifyLocked(
     grpc_connectivity_state state, const absl::Status& status) {
-  for (const auto& p : watchers_) {
+  for (const auto& watcher : watchers_) {
     subchannel_->work_serializer_.Schedule(
-        [watcher = p.second->Ref(), state, status]() mutable {
+        [watcher, state, status]() mutable {
           auto* watcher_ptr = watcher.get();
           watcher_ptr->OnConnectivityStateChange(std::move(watcher), state,
                                                  status);

--- a/src/core/client_channel/subchannel.h
+++ b/src/core/client_channel/subchannel.h
@@ -27,6 +27,7 @@
 #include <memory>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "src/core/client_channel/connector.h"
 #include "src/core/client_channel/subchannel_pool_interface.h"
@@ -307,10 +308,9 @@ class Subchannel final : public DualRefCounted<Subchannel> {
 
    private:
     Subchannel* subchannel_;
-    // TODO(roth): Once we can use C++-14 heterogeneous lookups, this can
-    // be a set instead of a map.
-    std::map<ConnectivityStateWatcherInterface*,
-             RefCountedPtr<ConnectivityStateWatcherInterface>>
+    absl::flat_hash_set<RefCountedPtr<ConnectivityStateWatcherInterface>,
+                        RefCountedPtrHash<ConnectivityStateWatcherInterface>,
+                        RefCountedPtrEq<ConnectivityStateWatcherInterface>>
         watchers_;
   };
 

--- a/src/core/lib/transport/connectivity_state.h
+++ b/src/core/lib/transport/connectivity_state.h
@@ -27,8 +27,8 @@
 #include <memory>
 #include <utility>
 
-#include "absl/status/status.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/util/orphanable.h"
 #include "src/core/util/work_serializer.h"

--- a/src/core/lib/transport/connectivity_state.h
+++ b/src/core/lib/transport/connectivity_state.h
@@ -28,6 +28,7 @@
 #include <utility>
 
 #include "absl/status/status.h"
+#include "absl/container/flat_hash_set.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/util/orphanable.h"
 #include "src/core/util/work_serializer.h"
@@ -132,10 +133,7 @@ class ConnectivityStateTracker {
   const char* name_;
   std::atomic<grpc_connectivity_state> state_{grpc_connectivity_state()};
   absl::Status status_;
-  // TODO(roth): Once we can use C++-14 heterogeneous lookups, this can
-  // be a set instead of a map.
-  std::map<ConnectivityStateWatcherInterface*,
-           OrphanablePtr<ConnectivityStateWatcherInterface>>
+  absl::flat_hash_set<OrphanablePtr<ConnectivityStateWatcherInterface>>
       watchers_;
 };
 


### PR DESCRIPTION
While looking at using C++17 features, I noticed some TODOs that actually should have been taken care of when we moved to C++14. :)