### PR TITLE
[Bazel] Added repo_mapping for absl's @googletest

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -150,6 +150,9 @@ def grpc_deps():
                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/20240722.0.tar.gz",
                 "https://github.com/abseil/abseil-cpp/archive/20240722.0.tar.gz",
             ],
+            repo_mapping = {
+                "@googletest": "@com_google_googletest",
+            },
         )
 
     if "bazel_toolchains" not in native.existing_rules():


### PR DESCRIPTION
To accommodate Abseil's renaming of `googletest` in their Bazel build ([commit](https://github.com/abseil/abseil-cpp/commit/90a7ba66e88bf1b6fe98b196208448704766dac0)), we've got to rename `googletest` back to  its original name (`com_google_googletest`).