### PR TITLE
[XdsClient] remove unnecessary dependency injection of tracer object

### DIFF
--- a/src/core/lib/debug/trace_flags.cc
+++ b/src/core/lib/debug/trace_flags.cc
@@ -125,7 +125,6 @@ TraceFlag xds_cluster_manager_lb_trace(false, "xds_cluster_manager_lb");
 TraceFlag xds_override_host_lb_trace(false, "xds_override_host_lb");
 TraceFlag xds_resolver_trace(false, "xds_resolver");
 TraceFlag xds_server_config_fetcher_trace(false, "xds_server_config_fetcher");
-TraceFlag xds_unittest_trace(true, "xds_unittest");
 TraceFlag xds_wrr_locality_lb_trace(false, "xds_wrr_locality_lb");
 
 const absl::flat_hash_map<std::string, TraceFlag*>& GetAllTraceFlags() {
@@ -210,7 +209,6 @@ const absl::flat_hash_map<std::string, TraceFlag*>& GetAllTraceFlags() {
           {"xds_override_host_lb", &xds_override_host_lb_trace},
           {"xds_resolver", &xds_resolver_trace},
           {"xds_server_config_fetcher", &xds_server_config_fetcher_trace},
-          {"xds_unittest", &xds_unittest_trace},
           {"xds_wrr_locality_lb", &xds_wrr_locality_lb_trace},
 #ifndef NDEBUG
           {"auth_context_refcount", &auth_context_refcount_trace},

--- a/src/core/lib/debug/trace_flags.h
+++ b/src/core/lib/debug/trace_flags.h
@@ -124,7 +124,6 @@ extern TraceFlag xds_cluster_manager_lb_trace;
 extern TraceFlag xds_override_host_lb_trace;
 extern TraceFlag xds_resolver_trace;
 extern TraceFlag xds_server_config_fetcher_trace;
-extern TraceFlag xds_unittest_trace;
 extern TraceFlag xds_wrr_locality_lb_trace;
 
 }  // namespace grpc_core

--- a/src/core/lib/debug/trace_flags.yaml
+++ b/src/core/lib/debug/trace_flags.yaml
@@ -349,10 +349,6 @@ xds_resolver:
 xds_server_config_fetcher:
   default: false
   description: XDS Server config fetcher.
-xds_unittest:
-  default: true
-  description: xDS unit tests.
-  internal: true
 xds_wrr_locality_lb:
   default: false
   description: XDS WRR locality LB policy.

--- a/src/core/xds/grpc/xds_cluster_parser.cc
+++ b/src/core/xds/grpc/xds_cluster_parser.cc
@@ -724,7 +724,7 @@ absl::StatusOr<std::shared_ptr<const XdsClusterResource>> CdsResourceParse(
 
 void MaybeLogCluster(const XdsResourceType::DecodeContext& context,
                      const envoy_config_cluster_v3_Cluster* cluster) {
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_config_cluster_v3_Cluster_getmsgdef(context.symtab);
     char buf[10240];
@@ -754,13 +754,13 @@ XdsResourceType::DecodeResult XdsClusterResourceType::Decode(
       UpbStringToStdString(envoy_config_cluster_v3_Cluster_name(resource));
   auto cds_resource = CdsResourceParse(context, resource);
   if (!cds_resource.ok()) {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(ERROR) << "[xds_client " << context.client << "] invalid Cluster "
                  << *result.name << ": " << cds_resource.status();
     }
     result.resource = cds_resource.status();
   } else {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(INFO) << "[xds_client " << context.client << "] parsed Cluster "
                 << *result.name << ": " << (*cds_resource)->ToString();
     }

--- a/src/core/xds/grpc/xds_endpoint_parser.cc
+++ b/src/core/xds/grpc/xds_endpoint_parser.cc
@@ -88,7 +88,7 @@ bool XdsEndpointHashKeyBackwardCompatEnabled() {
 void MaybeLogClusterLoadAssignment(
     const XdsResourceType::DecodeContext& context,
     const envoy_config_endpoint_v3_ClusterLoadAssignment* cla) {
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_config_endpoint_v3_ClusterLoadAssignment_getmsgdef(
             context.symtab);
@@ -455,14 +455,14 @@ XdsResourceType::DecodeResult XdsEndpointResourceType::Decode(
       envoy_config_endpoint_v3_ClusterLoadAssignment_cluster_name(resource));
   auto eds_resource = EdsResourceParse(context, resource);
   if (!eds_resource.ok()) {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(ERROR) << "[xds_client " << context.client
                  << "] invalid ClusterLoadAssignment " << *result.name << ": "
                  << eds_resource.status();
     }
     result.resource = eds_resource.status();
   } else {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(INFO) << "[xds_client " << context.client
                 << "] parsed ClusterLoadAssignment " << *result.name << ": "
                 << (*eds_resource)->ToString();

--- a/src/core/xds/grpc/xds_listener_parser.cc
+++ b/src/core/xds/grpc/xds_listener_parser.cc
@@ -135,7 +135,7 @@ void MaybeLogHttpConnectionManager(
     const XdsResourceType::DecodeContext& context,
     const envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager*
         http_connection_manager_config) {
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_extensions_filters_network_http_connection_manager_v3_HttpConnectionManager_getmsgdef(
             context.symtab);
@@ -952,7 +952,7 @@ absl::StatusOr<std::shared_ptr<const XdsListenerResource>> LdsResourceParse(
 
 void MaybeLogListener(const XdsResourceType::DecodeContext& context,
                       const envoy_config_listener_v3_Listener* listener) {
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_config_listener_v3_Listener_getmsgdef(context.symtab);
     char buf[10240];
@@ -982,13 +982,13 @@ XdsResourceType::DecodeResult XdsListenerResourceType::Decode(
       UpbStringToStdString(envoy_config_listener_v3_Listener_name(resource));
   auto listener = LdsResourceParse(context, resource);
   if (!listener.ok()) {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(ERROR) << "[xds_client " << context.client << "] invalid Listener "
                  << *result.name << ": " << listener.status();
     }
     result.resource = listener.status();
   } else {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(INFO) << "[xds_client " << context.client << "] parsed Listener "
                 << *result.name << ": " << (*listener)->ToString();
     }

--- a/src/core/xds/grpc/xds_metadata_parser.cc
+++ b/src/core/xds/grpc/xds_metadata_parser.cc
@@ -64,7 +64,7 @@ std::unique_ptr<XdsMetadataValue> ParseGcpAuthnAudience(
     errors->AddError("could not parse audience metadata");
     return nullptr;
   }
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_extensions_filters_http_gcp_authn_v3_Audience_getmsgdef(
             context.symtab);
@@ -99,7 +99,7 @@ std::unique_ptr<XdsMetadataValue> ParseAddress(
     errors->AddError("could not parse address metadata");
     return nullptr;
   }
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_config_core_v3_Address_getmsgdef(context.symtab);
     char buf[10240];

--- a/src/core/xds/grpc/xds_route_config_parser.cc
+++ b/src/core/xds/grpc/xds_route_config_parser.cc
@@ -448,7 +448,6 @@ XdsRouteConfigResource::TypedPerFilterConfig ParseTypedPerFilterConfig(
 }
 
 XdsRouteConfigResource::RetryPolicy RetryPolicyParse(
-    const XdsResourceType::DecodeContext& context,
     const envoy_config_route_v3_RetryPolicy* retry_policy_proto,
     ValidationErrors* errors) {
   XdsRouteConfigResource::RetryPolicy retry_policy;
@@ -624,7 +623,7 @@ absl::optional<XdsRouteConfigResource::Route::RouteAction> RouteActionParse(
       envoy_config_route_v3_RouteAction_retry_policy(route_action_proto);
   if (retry_policy != nullptr) {
     ValidationErrors::ScopedField field(errors, ".retry_policy");
-    route_action.retry_policy = RetryPolicyParse(context, retry_policy, errors);
+    route_action.retry_policy = RetryPolicyParse(retry_policy, errors);
   }
   // Host rewrite field.
   if (XdsAuthorityRewriteEnabled() &&
@@ -874,8 +873,7 @@ std::shared_ptr<const XdsRouteConfigResource> XdsRouteConfigResourceParse(
         envoy_config_route_v3_VirtualHost_retry_policy(virtual_hosts[i]);
     if (retry_policy != nullptr) {
       ValidationErrors::ScopedField field(errors, ".retry_policy");
-      virtual_host_retry_policy =
-          RetryPolicyParse(context, retry_policy, errors);
+      virtual_host_retry_policy = RetryPolicyParse(retry_policy, errors);
     }
     // Parse routes.
     ValidationErrors::ScopedField field2(errors, ".routes");

--- a/src/core/xds/grpc/xds_route_config_parser.cc
+++ b/src/core/xds/grpc/xds_route_config_parser.cc
@@ -467,7 +467,7 @@ XdsRouteConfigResource::RetryPolicy RetryPolicyParse(
     } else if (code == "unavailable") {
       retry_policy.retry_on.Add(GRPC_STATUS_UNAVAILABLE);
     } else {
-      if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+      if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
         LOG(INFO) << "Unsupported retry_on policy " << code;
       }
     }
@@ -907,7 +907,7 @@ namespace {
 void MaybeLogRouteConfiguration(
     const XdsResourceType::DecodeContext& context,
     const envoy_config_route_v3_RouteConfiguration* route_config) {
-  if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer) && ABSL_VLOG_IS_ON(2)) {
+  if (GRPC_TRACE_FLAG_ENABLED(xds_client) && ABSL_VLOG_IS_ON(2)) {
     const upb_MessageDef* msg_type =
         envoy_config_route_v3_RouteConfiguration_getmsgdef(context.symtab);
     char buf[10240];
@@ -942,14 +942,14 @@ XdsResourceType::DecodeResult XdsRouteConfigResourceType::Decode(
     absl::Status status =
         errors.status(absl::StatusCode::kInvalidArgument,
                       "errors validating RouteConfiguration resource");
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(ERROR) << "[xds_client " << context.client
                  << "] invalid RouteConfiguration " << *result.name << ": "
                  << status;
     }
     result.resource = std::move(status);
   } else {
-    if (GRPC_TRACE_FLAG_ENABLED_OBJ(*context.tracer)) {
+    if (GRPC_TRACE_FLAG_ENABLED(xds_client)) {
       LOG(INFO) << "[xds_client " << context.client
                 << "] parsed RouteConfiguration " << *result.name << ": "
                 << rds_update->ToString();

--- a/src/core/xds/xds_client/xds_client.cc
+++ b/src/core/xds/xds_client/xds_client.cc
@@ -925,8 +925,8 @@ void XdsClient::XdsChannel::AdsCall::ParseResource(
   }
   // Parse the resource.
   XdsResourceType::DecodeContext resource_type_context = {
-      xds_client(), xds_channel()->server_, &xds_client_trace,
-      xds_client()->def_pool_.ptr(), context->arena.ptr()};
+      xds_client(), xds_channel()->server_, xds_client()->def_pool_.ptr(),
+      context->arena.ptr()};
   XdsResourceType::DecodeResult decode_result =
       context->type->Decode(resource_type_context, serialized_resource);
   // If we didn't already have the resource name from the Resource

--- a/src/core/xds/xds_client/xds_resource_type.h
+++ b/src/core/xds/xds_client/xds_resource_type.h
@@ -41,7 +41,6 @@ class XdsResourceType {
   struct DecodeContext {
     XdsClient* client;
     const XdsBootstrap::XdsServer& server;
-    TraceFlag* tracer;
     upb_DefPool* symtab;
     upb_Arena* arena;
   };

--- a/test/core/xds/xds_audit_logger_registry_test.cc
+++ b/test/core/xds/xds_audit_logger_registry_test.cc
@@ -62,7 +62,7 @@ absl::StatusOr<std::string> ConvertAuditLoggerConfig(
   std::string serialized_config = config.SerializeAsString();
   upb::Arena arena;
   upb::DefPool def_pool;
-  XdsResourceType::DecodeContext context = {nullptr, GrpcXdsServer(), nullptr,
+  XdsResourceType::DecodeContext context = {nullptr, GrpcXdsServer(),
                                             def_pool.ptr(), arena.ptr()};
   auto* upb_config =
       envoy_config_rbac_v3_RBAC_AuditLoggingOptions_AuditLoggerConfig_parse(

--- a/test/core/xds/xds_cluster_resource_type_test.cc
+++ b/test/core/xds/xds_cluster_resource_type_test.cc
@@ -87,9 +87,9 @@ class XdsClusterTest : public ::testing::Test {
  protected:
   XdsClusterTest()
       : xds_client_(MakeXdsClient()),
-        decode_context_{
-            xds_client_.get(), *xds_client_->bootstrap().servers().front(),
-            &xds_unittest_trace, upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(),
+                        *xds_client_->bootstrap().servers().front(),
+                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
     grpc_error_handle error;

--- a/test/core/xds/xds_common_types_test.cc
+++ b/test/core/xds/xds_common_types_test.cc
@@ -70,9 +70,9 @@ class XdsCommonTypesTest : public ::testing::Test {
  protected:
   XdsCommonTypesTest()
       : xds_client_(MakeXdsClient()),
-        decode_context_{
-            xds_client_.get(), *xds_client_->bootstrap().servers().front(),
-            &xds_unittest_trace, upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(),
+                        *xds_client_->bootstrap().servers().front(),
+                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
     auto bootstrap = GrpcXdsBootstrap::Create(

--- a/test/core/xds/xds_endpoint_resource_type_test.cc
+++ b/test/core/xds/xds_endpoint_resource_type_test.cc
@@ -66,9 +66,9 @@ class XdsEndpointTest : public ::testing::Test {
  protected:
   XdsEndpointTest()
       : xds_client_(MakeXdsClient()),
-        decode_context_{
-            xds_client_.get(), *xds_client_->bootstrap().servers().front(),
-            &xds_unittest_trace, upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(),
+                        *xds_client_->bootstrap().servers().front(),
+                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
     grpc_error_handle error;

--- a/test/core/xds/xds_http_filters_test.cc
+++ b/test/core/xds/xds_http_filters_test.cc
@@ -97,8 +97,8 @@ class XdsHttpFilterTest : public ::testing::Test {
  protected:
   XdsHttpFilterTest()
       : xds_client_(MakeXdsClient()),
-        decode_context_{xds_client_.get(), xds_server_, nullptr,
-                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(), xds_server_, upb_def_pool_.ptr(),
+                        upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
     grpc_error_handle error;

--- a/test/core/xds/xds_lb_policy_registry_test.cc
+++ b/test/core/xds/xds_lb_policy_registry_test.cc
@@ -73,7 +73,7 @@ absl::StatusOr<std::string> ConvertXdsPolicy(
   std::string serialized_policy = policy.SerializeAsString();
   upb::Arena arena;
   upb::DefPool def_pool;
-  XdsResourceType::DecodeContext context = {nullptr, GrpcXdsServer(), nullptr,
+  XdsResourceType::DecodeContext context = {nullptr, GrpcXdsServer(),
                                             def_pool.ptr(), arena.ptr()};
   auto* upb_policy = envoy_config_cluster_v3_LoadBalancingPolicy_parse(
       serialized_policy.data(), serialized_policy.size(), arena.ptr());

--- a/test/core/xds/xds_listener_resource_type_test.cc
+++ b/test/core/xds/xds_listener_resource_type_test.cc
@@ -82,9 +82,9 @@ class XdsListenerTest : public ::testing::Test {
  protected:
   XdsListenerTest()
       : xds_client_(MakeXdsClient()),
-        decode_context_{
-            xds_client_.get(), *xds_client_->bootstrap().servers().front(),
-            &xds_unittest_trace, upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(),
+                        *xds_client_->bootstrap().servers().front(),
+                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
     grpc_error_handle error;

--- a/test/core/xds/xds_metadata_test.cc
+++ b/test/core/xds/xds_metadata_test.cc
@@ -53,9 +53,9 @@ class XdsMetadataTest : public ::testing::Test {
  protected:
   XdsMetadataTest()
       : xds_client_(MakeXdsClient()),
-        decode_context_{
-            xds_client_.get(), *xds_client_->bootstrap().servers().front(),
-            &xds_unittest_trace, upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(),
+                        *xds_client_->bootstrap().servers().front(),
+                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient() {
     auto bootstrap = GrpcXdsBootstrap::Create(

--- a/test/core/xds/xds_route_config_resource_type_test.cc
+++ b/test/core/xds/xds_route_config_resource_type_test.cc
@@ -78,9 +78,9 @@ class XdsRouteConfigTest : public ::testing::Test {
  protected:
   explicit XdsRouteConfigTest(bool trusted_xds_server = false)
       : xds_client_(MakeXdsClient(trusted_xds_server)),
-        decode_context_{
-            xds_client_.get(), *xds_client_->bootstrap().servers().front(),
-            &xds_unittest_trace, upb_def_pool_.ptr(), upb_arena_.ptr()} {}
+        decode_context_{xds_client_.get(),
+                        *xds_client_->bootstrap().servers().front(),
+                        upb_def_pool_.ptr(), upb_arena_.ptr()} {}
 
   static RefCountedPtr<XdsClient> MakeXdsClient(bool trusted_xds_server) {
     auto bootstrap = GrpcXdsBootstrap::Create(


### PR DESCRIPTION
This was originally done to avoid circuilar dependencies, but that problem went away when the trace flags were centralized in #36576.