### PR TITLE
[fork] Remove event handle lists for fork

### DIFF
--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -178,40 +178,7 @@ int EpollCreateAndCloexec() {
 // Only used when GRPC_ENABLE_FORK_SUPPORT=1
 std::list<Epoll1Poller*> fork_poller_list;
 
-// Only used when GRPC_ENABLE_FORK_SUPPORT=1
-Epoll1EventHandle* fork_fd_list_head = nullptr;
 gpr_mu fork_fd_list_mu;
-
-void ForkFdListAddHandle(Epoll1EventHandle* handle) {
-  if (grpc_core::Fork::Enabled()) {
-    gpr_mu_lock(&fork_fd_list_mu);
-    handle->ForkFdListPos().next = fork_fd_list_head;
-    handle->ForkFdListPos().prev = nullptr;
-    if (fork_fd_list_head != nullptr) {
-      fork_fd_list_head->ForkFdListPos().prev = handle;
-    }
-    fork_fd_list_head = handle;
-    gpr_mu_unlock(&fork_fd_list_mu);
-  }
-}
-
-void ForkFdListRemoveHandle(Epoll1EventHandle* handle) {
-  if (grpc_core::Fork::Enabled()) {
-    gpr_mu_lock(&fork_fd_list_mu);
-    if (fork_fd_list_head == handle) {
-      fork_fd_list_head = handle->ForkFdListPos().next;
-    }
-    if (handle->ForkFdListPos().prev != nullptr) {
-      handle->ForkFdListPos().prev->ForkFdListPos().next =
-          handle->ForkFdListPos().next;
-    }
-    if (handle->ForkFdListPos().next != nullptr) {
-      handle->ForkFdListPos().next->ForkFdListPos().prev =
-          handle->ForkFdListPos().prev;
-    }
-    gpr_mu_unlock(&fork_fd_list_mu);
-  }
-}
 
 void ForkPollerListAddPoller(Epoll1Poller* poller) {
   if (grpc_core::Fork::Enabled()) {
@@ -236,14 +203,7 @@ bool InitEpoll1PollerLinux();
 // the child process without interfering with connections or RPCs ongoing in the
 // parent.
 void ResetEventManagerOnFork() {
-  // Delete all pending Epoll1EventHandles.
   gpr_mu_lock(&fork_fd_list_mu);
-  while (fork_fd_list_head != nullptr) {
-    close(fork_fd_list_head->WrappedFd());
-    Epoll1EventHandle* next = fork_fd_list_head->ForkFdListPos().next;
-    delete fork_fd_list_head;
-    fork_fd_list_head = next;
-  }
   // Delete all registered pollers. This also closes all open epoll_sets
   while (!fork_poller_list.empty()) {
     Epoll1Poller* poller = fork_poller_list.front();
@@ -304,7 +264,6 @@ void Epoll1EventHandle::OrphanHandle(PosixEngineClosure* on_done,
     close(fd_);
   }
 
-  ForkFdListRemoveHandle(this);
   {
     // See Epoll1Poller::ShutdownHandle for explanation on why a mutex is
     // required here.
@@ -401,7 +360,6 @@ EventHandle* Epoll1Poller::CreateHandle(int fd, absl::string_view /*name*/,
       new_handle->ReInit(fd);
     }
   }
-  ForkFdListAddHandle(new_handle);
   struct epoll_event ev;
   ev.events = static_cast<uint32_t>(EPOLLIN | EPOLLOUT | EPOLLET);
   // Use the least significant bit of ev.data.ptr to store track_err. We expect

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -222,40 +222,7 @@ namespace {
 // Only used when GRPC_ENABLE_FORK_SUPPORT=1
 std::list<PollPoller*> fork_poller_list;
 
-// Only used when GRPC_ENABLE_FORK_SUPPORT=1
-PollEventHandle* fork_fd_list_head = nullptr;
 gpr_mu fork_fd_list_mu;
-
-void ForkFdListAddHandle(PollEventHandle* handle) {
-  if (grpc_core::Fork::Enabled()) {
-    gpr_mu_lock(&fork_fd_list_mu);
-    handle->ForkFdListPos().next = fork_fd_list_head;
-    handle->ForkFdListPos().prev = nullptr;
-    if (fork_fd_list_head != nullptr) {
-      fork_fd_list_head->ForkFdListPos().prev = handle;
-    }
-    fork_fd_list_head = handle;
-    gpr_mu_unlock(&fork_fd_list_mu);
-  }
-}
-
-void ForkFdListRemoveHandle(PollEventHandle* handle) {
-  if (grpc_core::Fork::Enabled()) {
-    gpr_mu_lock(&fork_fd_list_mu);
-    if (fork_fd_list_head == handle) {
-      fork_fd_list_head = handle->ForkFdListPos().next;
-    }
-    if (handle->ForkFdListPos().prev != nullptr) {
-      handle->ForkFdListPos().prev->ForkFdListPos().next =
-          handle->ForkFdListPos().next;
-    }
-    if (handle->ForkFdListPos().next != nullptr) {
-      handle->ForkFdListPos().next->ForkFdListPos().prev =
-          handle->ForkFdListPos().prev;
-    }
-    gpr_mu_unlock(&fork_fd_list_mu);
-  }
-}
 
 void ForkPollerListAddPoller(PollPoller* poller) {
   if (grpc_core::Fork::Enabled()) {
@@ -295,15 +262,7 @@ bool InitPollPollerPosix();
 // in the child process without interfering with connections or RPCs ongoing
 // in the parent.
 void ResetEventManagerOnFork() {
-  // Delete all pending Epoll1EventHandles.
   gpr_mu_lock(&fork_fd_list_mu);
-  while (fork_fd_list_head != nullptr) {
-    close(fork_fd_list_head->WrappedFd());
-    PollEventHandle* next = fork_fd_list_head->ForkFdListPos().next;
-    fork_fd_list_head->ForceRemoveHandleFromPoller();
-    delete fork_fd_list_head;
-    fork_fd_list_head = next;
-  }
   // Delete all registered pollers.
   while (!fork_poller_list.empty()) {
     PollPoller* poller = fork_poller_list.front();
@@ -337,7 +296,6 @@ EventHandle* PollPoller::CreateHandle(int fd, absl::string_view /*name*/,
   (void)track_err;
   DCHECK(track_err == false);
   PollEventHandle* handle = new PollEventHandle(fd, shared_from_this());
-  ForkFdListAddHandle(handle);
   // We need to send a kick to the thread executing Work(..) so that it can
   // add this new Fd into the list of Fds to poll.
   KickExternal(false);
@@ -346,7 +304,6 @@ EventHandle* PollPoller::CreateHandle(int fd, absl::string_view /*name*/,
 
 void PollEventHandle::OrphanHandle(PosixEngineClosure* on_done, int* release_fd,
                                    absl::string_view /*reason*/) {
-  ForkFdListRemoveHandle(this);
   ForceRemoveHandleFromPoller();
   {
     grpc_core::ReleasableMutexLock lock(&mu_);


### PR DESCRIPTION
This is remains of the "old" fork support that are not needed and looks like it never worked.