### PR TITLE
[memory-diff] Improve algorithm

### DIFF
--- a/tools/profiling/memory/memory_diff.py
+++ b/tools/profiling/memory/memory_diff.py
@@ -169,7 +169,7 @@ else:
     call_increase = 0
     channel_decrease = 0
     channel_increase = 0
-    call_significant = 64
+    call_significant = 100
     channel_significant = 1000
     for scenario in _SCENARIOS.keys():
         for key, value in sorted(_INTERESTING.items()):

--- a/tools/profiling/memory/memory_diff.py
+++ b/tools/profiling/memory/memory_diff.py
@@ -199,17 +199,17 @@ else:
     # -- this biases reporting towards increases, which is what we want to act on
     #    most regularly
     if call_increase > 0:
-        check_on_pr.label_significance_on_pr("per-call-memory", 1)
+        check_on_pr.label_increase_decrease_on_pr("per-call-memory", 1)
     elif call_decrease > 0:
-        check_on_pr.label_significance_on_pr("per-call-memory", -1)
+        check_on_pr.label_increase_decrease_on_pr("per-call-memory", -1)
     else:
-        check_on_pr.label_significance_on_pr("per-call-memory", 0)
+        check_on_pr.label_increase_decrease_on_pr("per-call-memory", 0)
     if channel_increase > 0:
-        check_on_pr.label_significance_on_pr("per-channel-memory", 1)
+        check_on_pr.label_increase_decrease_on_pr("per-channel-memory", 1)
     elif channel_decrease > 0:
-        check_on_pr.label_significance_on_pr("per-channel-memory", -1)
+        check_on_pr.label_increase_decrease_on_pr("per-channel-memory", -1)
     else:
-        check_on_pr.label_significance_on_pr("per-channel-memory", 0)
+        check_on_pr.label_increase_decrease_on_pr("per-channel-memory", 0)
 
 print(text)
 check_on_pr.check_on_pr("Memory Difference", "```\n%s\n```" % text)

--- a/tools/profiling/memory/memory_diff.py
+++ b/tools/profiling/memory/memory_diff.py
@@ -165,8 +165,12 @@ if old is None:
         text += "{}: {}\n".format(key, value)
 else:
     print(cur, old)
-    call_diff_size = 0
-    channel_diff_size = 0
+    call_decrease = 0
+    call_increase = 0
+    channel_decrease = 0
+    channel_increase = 0
+    call_significant = 64
+    channel_significant = 1000
     for scenario in _SCENARIOS.keys():
         for key, value in sorted(_INTERESTING.items()):
             key = scenario + ": " + key
@@ -175,20 +179,37 @@ else:
                     text += "{}: {}\n".format(key, cur[key])
                 else:
                     text += "{}: {} -> {}\n".format(key, old[key], cur[key])
+                    diff = cur[key] - old[key]
                     if "call" in key:
-                        call_diff_size += cur[key] - old[key]
+                        if diff < -call_significant:
+                            call_decrease += 1
+                        elif diff > call_significant:
+                            call_increase += 1
                     else:
-                        channel_diff_size += cur[key] - old[key]
+                        if diff < -channel_significant:
+                            channel_decrease += 1
+                        elif diff > channel_significant:
+                            channel_increase += 1
 
-    print("CALL_DIFF_SIZE: %f" % call_diff_size)
-    print("CHANNEL_DIFF_SIZE: %f" % channel_diff_size)
-    check_on_pr.label_increase_decrease_on_pr(
-        "per-call-memory", call_diff_size, 64
-    )
-    check_on_pr.label_increase_decrease_on_pr(
-        "per-channel-memory", channel_diff_size, 1000
-    )
-    # TODO(chennancy)Change significant value when minstack also runs for channel
+    print("CALL: %d increases, %d decreases" % (call_increase, call_decrease))
+    print("CHANNEL: %d increases, %d decreases" % (channel_increase, channel_decrease))
+    # if anything increased ==> label it an increase
+    # otherwise if anything decreased (and nothing increased) ==> label it a decrease
+    # otherwise label it neutral
+    # -- this biases reporting towards increases, which is what we want to act on
+    #    most regularly
+    if call_increase > 0:
+        check_on_pr.label_significance_on_pr("per-call-memory", 1)
+    elif call_decrease > 0:
+        check_on_pr.label_significance_on_pr("per-call-memory", -1)
+    else:
+        check_on_pr.label_significance_on_pr("per-call-memory", 0)
+    if channel_increase > 0:
+        check_on_pr.label_significance_on_pr("per-channel-memory", 1)
+    elif channel_decrease > 0:
+        check_on_pr.label_significance_on_pr("per-channel-memory", -1)
+    else:
+        check_on_pr.label_significance_on_pr("per-channel-memory", 0)
 
 print(text)
 check_on_pr.check_on_pr("Memory Difference", "```\n%s\n```" % text)

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -213,12 +213,3 @@ def label_significance_on_pr(name, change, labels=_CHANGE_LABELS):
         json=new,
     )
     print("Result of setting labels on PR:", resp.text)
-
-
-def label_increase_decrease_on_pr(name, change, significant):
-    if change <= -significant:
-        label_significance_on_pr(name, -1, _INCREASE_DECREASE)
-    elif change >= significant:
-        label_significance_on_pr(name, 1, _INCREASE_DECREASE)
-    else:
-        label_significance_on_pr(name, 0, _INCREASE_DECREASE)

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -213,3 +213,6 @@ def label_significance_on_pr(name, change, labels=_CHANGE_LABELS):
         json=new,
     )
     print("Result of setting labels on PR:", resp.text)
+
+def label_increase_decrease_on_pr(name, change):
+    label_significance_on_pr(name, change, labels)

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -215,4 +215,4 @@ def label_significance_on_pr(name, change, labels=_CHANGE_LABELS):
     print("Result of setting labels on PR:", resp.text)
 
 def label_increase_decrease_on_pr(name, change):
-    label_significance_on_pr(name, change, labels)
+    label_significance_on_pr(name, change, _INCREASE_DECREASE)


### PR DESCRIPTION
We used to use a thresholded sum of differences to determine significance of benchmark results. This is significantly flawed, especially when adding new checks - the significance threshold must also be updated, but it's unclear exactly how.

This new approach relies on counting the number of significant increases/decreases across the benchmarks, and then reporting based on how we should react: increases are biased towards (let's not increase memory blindly!), then decreases (huzzah, go collect your bonus!), then neutral changes.