### PR TITLE
[call-v3] Fix recent flakiness in retry filter under thready-tsan

### DIFF
--- a/src/core/lib/surface/server_call.cc
+++ b/src/core/lib/surface/server_call.cc
@@ -139,19 +139,14 @@ void ServerCall::CommitBatch(const grpc_op* ops, size_t nops, void* notify_tag,
                          return Success{};
                        });
           });
-      call_handler_.SpawnInfallible(
-          "final-batch",
-          GRPC_LATENT_SEE_PROMISE(
-              "ServerCallBatch",
-              InfallibleBatch(std::move(primary_ops),
-                              std::move(recv_trailing_metadata),
-                              is_notify_tag_closure, notify_tag, cq_)));
+      server_op_serializer_->Spawn(InfallibleBatch(
+          std::move(primary_ops), std::move(recv_trailing_metadata),
+          is_notify_tag_closure, notify_tag, cq_));
     } else {
-      call_handler_.SpawnInfallible(
-          "batch", GRPC_LATENT_SEE_PROMISE(
-                       "ServerCallBatch",
-                       FallibleBatch(std::move(primary_ops),
-                                     is_notify_tag_closure, notify_tag, cq_)));
+      server_op_serializer_->Spawn(GRPC_LATENT_SEE_PROMISE(
+          "ServerCallBatch",
+          FallibleBatch(std::move(primary_ops), is_notify_tag_closure,
+                        notify_tag, cq_)));
     }
   };
 

--- a/src/core/lib/surface/server_call.h
+++ b/src/core/lib/surface/server_call.h
@@ -150,6 +150,8 @@ class ServerCall final : public Call, public DualRefCounted<ServerCall> {
   std::string DebugTag() { return absl::StrFormat("SERVER_CALL[%p]: ", this); }
 
   CallHandler call_handler_;
+  Party::SpawnSerializer* const server_op_serializer_ =
+      call_handler_.party()->MakeSpawnSerializer();
   MessageReceiver message_receiver_;
   ClientMetadataHandle client_initial_metadata_stored_;
   grpc_completion_queue* const cq_;


### PR DESCRIPTION
We found another place where there was a spawn order assumption in the code written. Leverage #38436.
