### PR TITLE
[release] add 1.69.0 to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -137,6 +137,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.65.0", ReleaseInfo()),
             ("v1.66.0", ReleaseInfo()),
             ("v1.67.0", ReleaseInfo()),
+            ("v1.69.0", ReleaseInfo()),
         ]
     ),
     "go": OrderedDict(
@@ -828,6 +829,12 @@ LANG_RELEASE_MATRIX = {
                     runtimes=["python"], testcases_file="python__master"
                 ),
             ),
+            (
+                "v1.69.0",
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
+            ),
         ]
     ),
     "node": OrderedDict(
@@ -929,6 +936,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.65.0", ReleaseInfo()),
             ("v1.66.0", ReleaseInfo()),
             ("v1.67.0", ReleaseInfo()),
+            ("v1.69.0", ReleaseInfo()),
         ]
     ),
     "php": OrderedDict(
@@ -994,6 +1002,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.65.0", ReleaseInfo()),
             ("v1.66.0", ReleaseInfo()),
             ("v1.67.0", ReleaseInfo()),
+            ("v1.69.0", ReleaseInfo()),
         ]
     ),
     "csharp": OrderedDict(

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -1002,7 +1002,6 @@ LANG_RELEASE_MATRIX = {
             ("v1.65.0", ReleaseInfo()),
             ("v1.66.0", ReleaseInfo()),
             ("v1.67.0", ReleaseInfo()),
-            ("v1.69.0", ReleaseInfo()),
         ]
     ),
     "csharp": OrderedDict(


### PR DESCRIPTION
Not adding PHP, which will probably require #38463 to be merged and back-ported.