### PR TITLE
reset ep->wrapped_ep on endpoint destroy

### DIFF
--- a/src/core/handshaker/security/secure_endpoint.cc
+++ b/src/core/handshaker/security/secure_endpoint.cc
@@ -517,6 +517,7 @@ static void endpoint_destroy(grpc_endpoint* secure_ep) {
   secure_endpoint* ep = reinterpret_cast<secure_endpoint*>(secure_ep);
   ep->read_mu.Lock();
   grpc_endpoint_destroy(ep->wrapped_ep);
+  ep->wrapped_ep = nullptr;
   ep->memory_owner.Reset();
   ep->read_mu.Unlock();
   SECURE_ENDPOINT_UNREF(ep, "destroy");


### PR DESCRIPTION
Fix recommended by @markdroth  in https://github.com/grpc/grpc/pull/38375#discussion_r1917376427
This issue only exists in 1.65.5, no fixes needed in other releases or trunk.