### PR TITLE
[CI] Disable codegen test using sh on Windows

### DIFF
--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -100,5 +100,9 @@ grpc_sh_test(
         ":compiler_test_mock_golden",
         ":golden_file_test",
     ],
+    tags = [
+        # Windows doesn't have Bash.
+        "no_windows",
+    ],
     uses_polling = False,
 )


### PR DESCRIPTION
The codegen test which uses sh needs to be disabled on Windows due to the lack of sh.

Partial commit of #38254
