### PR TITLE
[CI] Updated bazel-db to the latest for clang-tidy

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -180,11 +180,11 @@ def grpc_deps():
     if "bazel_compdb" not in native.existing_rules():
         http_archive(
             name = "bazel_compdb",
-            sha256 = "bcecfd622c4ef272fd4ba42726a52e140b961c4eac23025f18b346c968a8cfb4",
-            strip_prefix = "bazel-compilation-database-0.4.5",
+            sha256 = "79502264d1a3a4b6309d4dae8c822e7349bcfe33e84f3c6d1affb2a40d11a31d",
+            strip_prefix = "bazel-compilation-database-d198303a4319092ab31895c4b98d64174ebe8872",
             urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz",
-                "https://github.com/grailbio/bazel-compilation-database/archive/0.4.5.tar.gz",
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/grailbio/bazel-compilation-database/archive/d198303a4319092ab31895c4b98d64174ebe8872.tar.gz",
+                "https://github.com/grailbio/bazel-compilation-database/archive/d198303a4319092ab31895c4b98d64174ebe8872.tar.gz",
             ],
         )
 

--- a/tools/distrib/gen_compilation_database.py
+++ b/tools/distrib/gen_compilation_database.py
@@ -61,9 +61,7 @@ def generateCompilationDatabase(args):
     for compdb_file in Path(execroot).glob("**/*.compile_commands.json"):
         compdb.extend(
             json.loads(
-                "["
-                + compdb_file.read_text().replace("__EXEC_ROOT__", execroot)
-                + "]"
+                compdb_file.read_text().replace("__EXEC_ROOT__", execroot)
             )
         )
 


### PR DESCRIPTION
Updated bazel-db to the latest for upcoming Bazel 8 upgrade.

Partial commit of https://github.com/grpc/grpc/pull/38254