### PR TITLE
[CI] Disabled bazel distribtest_python

### DIFF
--- a/tools/bazelify_tests/test/bazel_distribtests.bzl
+++ b/tools/bazelify_tests/test/bazel_distribtests.bzl
@@ -35,8 +35,8 @@ def generate_bazel_distribtests(name):
 
     for bazel_version in SUPPORTED_BAZEL_VERSIONS:
         for shard_name in _TEST_SHARDS:
-            # TODO(https://github.com/grpc/grpc/issues/35391): Fix bazel 7 + distribtest_python test
-            if bazel_version.startswith("7") and shard_name == "distribtest_python":
+            # TODO(https://github.com/grpc/grpc/issues/35391): Fix bazel 7 or later + distribtest_python test
+            if shard_name == "distribtest_python":
                 continue
             test_name = "bazel_distribtest_%s_%s" % (bazel_version, shard_name)
             grpc_run_bazel_distribtest_test(


### PR DESCRIPTION
This change doesn't change anything for now but it's necessary to keep distribtest_python disabled on Bazel 8+ while we wait for a fix to #35391.

Partial commit of https://github.com/grpc/grpc/pull/38254