### PR TITLE
[CI] Excluded non C++ example tests from strict Bazel test

### DIFF
--- a/tools/bazelify_tests/test/strict_tests.bzl
+++ b/tools/bazelify_tests/test/strict_tests.bzl
@@ -31,7 +31,7 @@ def generate_strict_tests(name = ""):
     strict_warning_jobs = []
 
     for source in [
-        ":all //src/core/... //src/compiler/... //examples/...",
+        ":all //src/core/... //src/compiler/... //examples/cpp/...",
         "//test/... -//test/core/... -//test/cpp/...",
         "//test/core/end2end/...",
         "//test/core/... -//test/core/end2end/...",


### PR DESCRIPTION
Example tests in languages other than C++ (e.g., Python) can be skipped during C++ warning checks.

Partial commit of #38254