### PR TITLE
[CI] Used rlocation to find binaries such as protoc

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -399,6 +399,7 @@ grpc_sh_test(
     srcs = ["PluginTest/plugin_test.sh"],
     data = [
         "//src/compiler:grpc_objective_c_plugin",
+        "@bazel_tools//tools/bash/runfiles",
         "@com_google_protobuf//:protoc",
     ] + glob(["PluginTest/*.proto"]),
     uses_polling = False,
@@ -409,6 +410,7 @@ grpc_sh_test(
     srcs = ["PluginTest/plugin_option_test.sh"],
     data = [
         "//src/compiler:grpc_objective_c_plugin",
+        "@bazel_tools//tools/bash/runfiles",
         "@com_google_protobuf//:protoc",
         "@com_google_protobuf//:well_known_type_protos",
     ] + glob(["RemoteTestClient/*.proto"]),

--- a/src/objective-c/tests/PluginTest/plugin_option_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_option_test.sh
@@ -16,12 +16,25 @@
 # Run this script via bazel test
 # It expects that protoc and grpc_objective_c_plugin have already been built.
 
+# shellcheck disable=SC1090
+
 set -ev
 
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
 # protoc and grpc_objective_c_plugin binaries are supplied as "data" in bazel
-PROTOC=./external/com_google_protobuf/protoc
-PLUGIN=./src/compiler/grpc_objective_c_plugin
-WELL_KNOWN_PROTOS_PATH=external/com_google_protobuf/src
+PROTOC=$(rlocation com_google_protobuf/protoc)
+PLUGIN=$(rlocation com_github_grpc_grpc/src/compiler/grpc_objective_c_plugin)
+WELL_KNOWN_PROTOS_PATH=$(rlocation com_google_protobuf/src)
 RUNTIME_IMPORT_PREFIX=prefix/dir/
 
 PROTO_OUT=./proto_out
@@ -29,7 +42,7 @@ rm -rf ${PROTO_OUT}
 mkdir -p ${PROTO_OUT}
 
 $PROTOC \
-    --plugin=protoc-gen-grpc=$PLUGIN \
+    --plugin=protoc-gen-grpc="$PLUGIN" \
     --objc_out=${PROTO_OUT} \
     --grpc_out=grpc_local_import_prefix=$RUNTIME_IMPORT_PREFIX,runtime_import_prefix=$RUNTIME_IMPORT_PREFIX:${PROTO_OUT} \
     -I . \

--- a/src/objective-c/tests/PluginTest/plugin_test.sh
+++ b/src/objective-c/tests/PluginTest/plugin_test.sh
@@ -16,18 +16,31 @@
 # Run this script via bazel test
 # It expects that protoc and grpc_objective_c_plugin have already been built.
 
+# shellcheck disable=SC1090
+
 set -ev
 
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
 # protoc and grpc_objective_c_plugin binaries are supplied as "data" in bazel
-PROTOC=./external/com_google_protobuf/protoc
-PLUGIN=./src/compiler/grpc_objective_c_plugin
+PROTOC=$(rlocation com_google_protobuf/protoc)
+PLUGIN=$(rlocation com_github_grpc_grpc/src/compiler/grpc_objective_c_plugin)
 
 PROTO_OUT=./proto_out
 rm -rf ${PROTO_OUT}
 mkdir -p ${PROTO_OUT}
 
 $PROTOC \
-    --plugin=protoc-gen-grpc=$PLUGIN \
+    --plugin=protoc-gen-grpc="$PLUGIN" \
     --objc_out=${PROTO_OUT} \
     --grpc_out=${PROTO_OUT} \
     -I src/objective-c/tests/PluginTest \

--- a/test/csharp/codegen/BUILD
+++ b/test/csharp/codegen/BUILD
@@ -24,6 +24,7 @@ grpc_sh_test(
         "simple/expected/HelloworldGrpc.cs",
         "simple/proto/helloworld.proto",
         "//src/compiler:grpc_csharp_plugin",
+        "@bazel_tools//tools/bash/runfiles",
         "@com_google_protobuf//:protoc",
     ],
     tags = [
@@ -45,6 +46,7 @@ grpc_sh_test(
         "deprecated/proto/depnothing.proto",
         "deprecated/proto/depservice.proto",
         "//src/compiler:grpc_csharp_plugin",
+        "@bazel_tools//tools/bash/runfiles",
         "@com_google_protobuf//:protoc",
     ],
     tags = [
@@ -64,6 +66,7 @@ grpc_sh_test(
     data = [
         "basenamespace/proto/namespacetest.proto",
         "//src/compiler:grpc_csharp_plugin",
+        "@bazel_tools//tools/bash/runfiles",
         "@com_google_protobuf//:protoc",
     ],
     tags = [

--- a/test/csharp/codegen/csharp_codegen_base_namespace_test.sh
+++ b/test/csharp/codegen/csharp_codegen_base_namespace_test.sh
@@ -18,13 +18,26 @@
 
 # Simple test - compare generated output to expected files
 
+# shellcheck disable=SC1090
+
 set -x
 
 TESTNAME=basenamespace
 
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
 # protoc and grpc_csharp_plugin binaries are supplied as "data" in bazel
-PROTOC=./external/com_google_protobuf/protoc
-PLUGIN=./src/compiler/grpc_csharp_plugin
+PROTOC=$(rlocation com_google_protobuf/protoc)
+PLUGIN=$(rlocation com_github_grpc_grpc/src/compiler/grpc_csharp_plugin)
 
 # where to find the test data
 DATA_DIR=./test/csharp/codegen/${TESTNAME}
@@ -36,7 +49,7 @@ mkdir -p ${PROTO_OUT}
 
 # run protoc and the plugin specifying the base_namespace options
 $PROTOC \
-    --plugin=protoc-gen-grpc-csharp=$PLUGIN \
+    --plugin=protoc-gen-grpc-csharp="$PLUGIN" \
     --csharp_out=${PROTO_OUT} \
     --grpc-csharp_out=${PROTO_OUT} \
     --csharp_opt=base_namespace=Example \
@@ -73,7 +86,7 @@ rm -rf ${PROTO_OUT}
 mkdir -p ${PROTO_OUT}
 
 $PROTOC \
-    --plugin=protoc-gen-grpc-csharp=$PLUGIN \
+    --plugin=protoc-gen-grpc-csharp="$PLUGIN" \
     --csharp_out=${PROTO_OUT} \
     --grpc-csharp_out=${PROTO_OUT} \
     --csharp_opt=base_namespace= \
@@ -109,7 +122,7 @@ rm -rf ${PROTO_OUT}
 mkdir -p ${PROTO_OUT}
 
 $PROTOC \
-    --plugin=protoc-gen-grpc-csharp=$PLUGIN \
+    --plugin=protoc-gen-grpc-csharp="$PLUGIN" \
     --csharp_out=${PROTO_OUT} \
     --grpc-csharp_out=${PROTO_OUT} \
     -I ${DATA_DIR}/proto \

--- a/test/csharp/codegen/csharp_codegen_simple_test.sh
+++ b/test/csharp/codegen/csharp_codegen_simple_test.sh
@@ -18,13 +18,26 @@
 
 # Simple test - compare generated output to expected files
 
+# shellcheck disable=SC1090
+
 set -x
 
 TESTNAME=simple
 
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
 # protoc and grpc_csharp_plugin binaries are supplied as "data" in bazel
-PROTOC=./external/com_google_protobuf/protoc
-PLUGIN=./src/compiler/grpc_csharp_plugin
+PROTOC=$(rlocation com_google_protobuf/protoc)
+PLUGIN=$(rlocation com_github_grpc_grpc/src/compiler/grpc_csharp_plugin)
 
 # where to find the test data
 DATA_DIR=./test/csharp/codegen/${TESTNAME}
@@ -36,7 +49,7 @@ mkdir -p ${PROTO_OUT}
 
 # run protoc and the plugin
 $PROTOC \
-    --plugin=protoc-gen-grpc=$PLUGIN \
+    --plugin=protoc-gen-grpc="$PLUGIN" \
     --csharp_out=${PROTO_OUT} \
     --grpc_out=${PROTO_OUT} \
     -I ${DATA_DIR}/proto \


### PR DESCRIPTION
Our test script broke with Bazel 8 because it changed where it puts executables. The Bazel team suggested using `rlocation` to fix this (like https://github.com/bazelbuild/bazel/commit/b09335b86e03732d6da2fe40a7ac07af48480771). This should fix our C# and Objective-C codegen tests.

Partial commit of #38254