### PR TITLE
[Bazel] Disable use_fast_cpp_protos=true

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -30,7 +30,6 @@ build --client_env=CC=clang
 build --copt=-DGRPC_BAZEL_BUILD
 build --host_copt=-DGRPC_BAZEL_BUILD
 build --action_env=GRPC_BAZEL_RUNTIME=1
-build --define=use_fast_cpp_protos=true
 
 build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384


### PR DESCRIPTION
Bazel build option `use_fast_cpp_protos=true` was added by https://github.com/grpc/grpc/pull/21480 to presumably make the python test run faster. This option is not working with Bazel 8 anymore and the Protobuf team is deprecating this (Using C++ implementation) in favor of upb one (which is not ready for Bazel yet) so let's not use this option.

Partial commit of https://github.com/grpc/grpc/pull/38254