### PR TITLE
[CI] Added BAZEL_SH to rbe_windows2019/Dockerfile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,8 @@ load("//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
+# RBE
+
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 
 custom_exec_properties(

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -237,6 +237,17 @@ def grpc_deps():
             ],
         )
 
+    if "rules_shell" not in native.existing_rules():
+        http_archive(
+            name = "rules_shell",
+            sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+            strip_prefix = "rules_shell-0.3.0",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+                "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+            ],
+        )
+
     if "io_bazel_rules_go" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_go",

--- a/bazel/grpc_extra_deps.bzl
+++ b/bazel/grpc_extra_deps.bzl
@@ -25,6 +25,7 @@ load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_dep
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@rules_python//python:repositories.bzl", "py_repositories")
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
 
 def grpc_extra_deps(ignore_version_differences = False):
     """Loads the extra dependencies.
@@ -49,6 +50,9 @@ def grpc_extra_deps(ignore_version_differences = False):
       ignore_version_differences: Plumbed directly to the invocation of
         apple_rules_dependencies.
     """
+    rules_shell_dependencies()
+    rules_shell_toolchains()
+
     protobuf_deps()
 
     rules_proto_dependencies()

--- a/third_party/toolchains/dockerfile/rbe_windows2019/Dockerfile
+++ b/third_party/toolchains/dockerfile/rbe_windows2019/Dockerfile
@@ -31,7 +31,6 @@ RUN New-Item -Path "C:/" -Name "TEMP" -ItemType "directory"; \
         -OutFile C:/TEMP/vc_redist.x64.exe -UseBasicParsing; \
     Start-Process -filepath C:/TEMP/vc_redist.x64.exe -ArgumentList '/install', '/passive', '/norestart' -Wait; \
     Remove-Item C:/TEMP/vc_redist.x64.exe
-
 # Install Visual Studio 2022 Build Tools.
 RUN Invoke-WebRequest "https://aka.ms/vs/17/release/vs_buildtools.exe" \
         -OutFile C:/TEMP/vs_buildtools.exe -UseBasicParsing; \
@@ -53,7 +52,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     msys 'pacman --noconfirm -Syy zstd'; \
     msys 'pacman --noconfirm -Syy git curl zip unzip'; \
     $old_path = [Environment]::GetEnvironmentVariable(\"PATH\", \"Machine\"); \
-    [Environment]::SetEnvironmentVariable(\"PATH\", $old_path + \";C:\msys64;C:\msys64\usr\bin\", \"Machine\");
+    [Environment]::SetEnvironmentVariable(\"PATH\", $old_path + \";C:\msys64;C:\msys64\usr\bin\", \"Machine\"); \
+    [Environment]::SetEnvironmentVariable(\"BAZEL_SH\", \"C:\msys64\usr\bin\bash.exe\", \"Machine\")
 # Install Python 3.
 RUN Invoke-WebRequest "https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe" \
                 -OutFile C:/TEMP/python_install.exe -UseBasicParsing; \

--- a/third_party/toolchains/generate_windows_rbe_configs.sh
+++ b/third_party/toolchains/generate_windows_rbe_configs.sh
@@ -28,7 +28,7 @@ wget https://github.com/bazelbuild/bazel-toolchains/releases/download/v5.1.2/rbe
 RBE_CONFIGS_GEN_TOOL_PATH="./rbe_configs_gen_windows_amd64.exe"
 
 # Actions on RBE will run under a dedicated docker image.
-WINDOWS_RBE_DOCKER_IMAGE=us-docker.pkg.dev/grpc-testing/testing-images-public/rbe_windows2019@sha256:5a97eb384a3089ac9180e6086ca89b1fdafa57735057624245b3d4a96b4744fe
+WINDOWS_RBE_DOCKER_IMAGE=us-docker.pkg.dev/grpc-testing/testing-images-public/rbe_windows2019@sha256:cfef0ae3681d4070f6a93a88afea44d616f5cbdfae36559b9394274e74873bc6
 
 # Bazel version used for configuring
 # Needs to be one of the versions from bazel/supported_versions.txt chosen so that the result is compatible

--- a/third_party/toolchains/rbe_windows_vs2022_bazel7/config/BUILD
+++ b/third_party/toolchains/rbe_windows_vs2022_bazel7/config/BUILD
@@ -40,7 +40,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rbe_windows2019@sha256:5a97eb384a3089ac9180e6086ca89b1fdafa57735057624245b3d4a96b4744fe",
+        "container-image": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rbe_windows2019@sha256:cfef0ae3681d4070f6a93a88afea44d616f5cbdfae36559b9394274e74873bc6",
         "OSFamily": "Windows",
     },
 )

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -81,6 +81,7 @@ _GRPC_DEP_NAMES = [
     "com_google_libprotobuf_mutator",
     "com_github_cncf_xds",
     "google_cloud_cpp",
+    "rules_shell",
 ]
 
 _GRPC_BAZEL_ONLY_DEPS = [
@@ -109,6 +110,7 @@ _GRPC_BAZEL_ONLY_DEPS = [
     "com_google_googleapis",
     "com_google_libprotobuf_mutator",
     "google_cloud_cpp",
+    "rules_shell",
 ]
 
 


### PR DESCRIPTION
Bazel 8 now requires gRPC to explicitly call `rules_shell_toolchains` when using shell. This was previously handled implicitly by Bazel. Without this explicit step, Bash-based targets will fail on Windows.

Partial commit of #38254