### PR TITLE
[ruby] add back logic to avoid rb_abi_version if RUBY_PATCHLEVEL >= 0

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -148,6 +148,13 @@ $CFLAGS << ' -g'
 
 def have_ruby_abi_version()
   return true if RUBY_ENGINE == 'truffleruby'
+  if RUBY_PATCHLEVEL >= 0
+    # ruby_abi_version is only available in development versions: https://github.com/ruby/ruby/pull/6231
+    # Note: this will also cause gems cross-compiled in rake-compiler-dock builds to NOT
+    # include rb_abi_version (assuming the "host" ruby version in those builds is not a dev version).
+    puts "RUBY_PATCHLEVEL: #{RUBY_PATCHLEVEL} is >= 0, assuming ruby_abi_version is NOT present"
+    return false
+  end
 
   m = /(\d+)\.(\d+)/.match(RUBY_VERSION)
   if m.nil?


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/38338 removed this check but I think it is better to keep in, out of caution, for a couple reasons:

- it's possible this might effect gems being built from source, which are not extremely well covered in our tests

- During binary release builds with rake-compiler-dock, this is actually coming from the "host" ruby version rather than the `RUBY_CC_VERSION` that we're building for i.e. the "target" ruby version. Currently it looks like rake-compiler-dock is using a "target" ruby version of 3.1. If that were to change say to 3.2, then without this check our logic in `extconf.rb` would change in evaluating `have_ruby_abi_version` from `false` to `true`. Adding this check back in prevents that (although in a slightly more brittle way than I'd like).

cc @chadlwilson FYI

