### PR TITLE
[retry] Fix call-v3 flakiness in retry_test

### DIFF
--- a/src/core/lib/surface/call_utils.h
+++ b/src/core/lib/surface/call_utils.h
@@ -197,8 +197,12 @@ class OpHandlerImpl {
   Poll<StatusFlag> operator()() {
     switch (state_) {
       case State::kDismissed:
+        GRPC_TRACE_LOG(call, INFO)
+            << Activity::current()->DebugTag() << "Dismissed " << OpName();
         return Success{};
       case State::kPromiseFactory: {
+        GRPC_TRACE_LOG(call, INFO)
+            << Activity::current()->DebugTag() << "Construct " << OpName();
         auto promise = promise_factory_.Make();
         Destruct(&promise_factory_);
         Construct(&promise_, std::move(promise));

--- a/src/core/lib/surface/server_call.h
+++ b/src/core/lib/surface/server_call.h
@@ -150,7 +150,7 @@ class ServerCall final : public Call, public DualRefCounted<ServerCall> {
   std::string DebugTag() { return absl::StrFormat("SERVER_CALL[%p]: ", this); }
 
   CallHandler call_handler_;
-  std::atomic<bool> sent_server_initial_metadata_batch_;
+  std::atomic<bool> sent_server_initial_metadata_batch_{false};
   Latch<void> server_initial_metadata_scheduled_;
   MessageReceiver message_receiver_;
   ClientMetadataHandle client_initial_metadata_stored_;

--- a/src/core/lib/surface/server_call.h
+++ b/src/core/lib/surface/server_call.h
@@ -150,6 +150,8 @@ class ServerCall final : public Call, public DualRefCounted<ServerCall> {
   std::string DebugTag() { return absl::StrFormat("SERVER_CALL[%p]: ", this); }
 
   CallHandler call_handler_;
+  std::atomic<bool> sent_server_initial_metadata_batch_;
+  Latch<void> server_initial_metadata_scheduled_;
   MessageReceiver message_receiver_;
   ClientMetadataHandle client_initial_metadata_stored_;
   grpc_completion_queue* const cq_;


### PR DESCRIPTION
Same idea as #38460 - serialize the send trailing metadata/send initial metadata ops, but scoped to *just those ops* -- the approach in the former PR was too aggressive and serialized sends behind receives - which broke way less than it should have, but was still terribly wrong.