### PR TITLE
[CI] Added rules_java dep to Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,16 +10,6 @@ load("//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
-# rules_java
-
-load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
-
-rules_java_dependencies()
-
-load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
-
-rules_java_toolchains()
-
 # RBE
 
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,6 +10,16 @@ load("//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
+# rules_java
+
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_toolchains")
+
+rules_java_toolchains()
+
 # RBE
 
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -248,6 +248,16 @@ def grpc_deps():
             ],
         )
 
+    if "rules_java" not in native.existing_rules():
+        http_archive(
+            name = "rules_java",
+            sha256 = "5449ed36d61269579dd9f4b0e532cd131840f285b389b3795ae8b4d717387dd8",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz",
+                "https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz",
+            ],
+        )
+
     if "io_bazel_rules_go" not in native.existing_rules():
         http_archive(
             name = "io_bazel_rules_go",

--- a/bazel/grpc_extra_deps.bzl
+++ b/bazel/grpc_extra_deps.bzl
@@ -23,6 +23,7 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@envoy_api//bazel:repositories.bzl", "api_dependencies")
 load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 load("@rules_python//python:repositories.bzl", "py_repositories")
 load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
@@ -52,6 +53,8 @@ def grpc_extra_deps(ignore_version_differences = False):
     """
     rules_shell_dependencies()
     rules_shell_toolchains()
+
+    rules_java_dependencies()
 
     protobuf_deps()
 

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -82,6 +82,7 @@ _GRPC_DEP_NAMES = [
     "com_github_cncf_xds",
     "google_cloud_cpp",
     "rules_shell",
+    "rules_java",
 ]
 
 _GRPC_BAZEL_ONLY_DEPS = [
@@ -111,6 +112,7 @@ _GRPC_BAZEL_ONLY_DEPS = [
     "com_google_libprotobuf_mutator",
     "google_cloud_cpp",
     "rules_shell",
+    "rules_java",
 ]
 
 


### PR DESCRIPTION
Bazel 8 and the upcoming Protobuf v30 will need `rules_java` version 8.x. While gRPC itself doesn't directly use `rules_java`, its dependency, Envoy API, needs it and uses `rules_java` 7.x. This creates a conflict because rules_java 7.x is incompatible with both Bazel 8 and Protobuf v30.  To resolve this, `rules_java` 8.x must be included in the build before Envoy API, fixing the build issue.

Note that gRPC doesn't call `rules_java_toolchains`, typically found in rules_java workspace configurations ([ref](https://github.com/bazelbuild/rules_java/releases/tag/8.7.0)). This is because it can't be included in `grpc_extra_deps` where `rules_java_dependencies` is called. This is acceptable since gRPC's primary concern is Bazel build setup, not Java functionality.

Partial commit of https://github.com/grpc/grpc/pull/38254