### PR TITLE
[Chttp2ServerListener] Fix flakiness

### DIFF
--- a/test/core/transport/chttp2/chttp2_server_listener_test.cc
+++ b/test/core/transport/chttp2/chttp2_server_listener_test.cc
@@ -193,6 +193,11 @@ class Chttp2ServerListenerTest : public ::testing::Test {
   void TearDown() override {
     CqVerifier cqv(cq_);
     grpc_server_shutdown_and_notify(server_->c_ptr(), cq_, CqVerifier::tag(-1));
+    // In some cases, the server has a lingering connection with an established
+    // transport. In such cases, server shutdown results in the start of
+    // graceful GOAWAYs which can take a long time for a non-responsive client.
+    // grpc_server_cancel_all_calls results in immediate disconnection.
+    grpc_server_cancel_all_calls(server_->c_ptr());
     cqv.Expect(CqVerifier::tag(-1), true);
     cqv.Verify();
     server_.reset();


### PR DESCRIPTION
Fix flakes like https://btx.cloud.google.com/invocations/eda04e4a-ce53-434b-b2c3-d809cf2c73e9/targets/%2F%2Ftest%2Fcore%2Ftransport%2Fchttp2:chttp2_server_listener_test;config=e40fe9f7387f05fce6736f0df14428beefd8f9b646fb6313baca14591546774a/log