### PR TITLE
[Chttp2Server] Set HTTP2 error to NO_ERROR to do graceful GOAWAYs

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -1207,8 +1207,10 @@ void NewChttp2ServerListener::ActiveConnection::SendGoAwayImplLocked() {
           // Send a GOAWAY if the transport exists
           if (transport != nullptr) {
             grpc_transport_op* op = grpc_make_transport_op(nullptr);
-            op->goaway_error =
-                GRPC_ERROR_CREATE("Server is stopping to serve requests.");
+            // Set an HTTP2 error of NO_ERROR to do graceful GOAWAYs.
+            op->goaway_error = grpc_error_set_int(
+                GRPC_ERROR_CREATE("Server is stopping to serve requests."),
+                StatusIntProperty::kHttp2Error, GRPC_HTTP2_NO_ERROR);
             transport->PerformOp(op);
           }
         });


### PR DESCRIPTION
Same as #37939 for NewChttp2ServerListener. 

Fixes flakes like https://btx.cloud.google.com/invocations/f13563e3-f5a1-4ebf-ae09-2acc093f7dc1/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_security_end2end_test@experiment%3Dserver_listener;config=f8ddc3bebf5e6cc62f388a7fd7ea6691e7afaf3538ca2c553c67e20cbad53251/tests