### PR TITLE
[tls] Provide more detailed error messages when validating credentials.

### DIFF
--- a/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
+++ b/src/core/lib/security/credentials/tls/grpc_tls_certificate_provider.cc
@@ -50,7 +50,10 @@ absl::Status ValidateRootCertificates(absl::string_view root_certificates) {
   absl::StatusOr<std::vector<X509*>> parsed_roots =
       ParsePemCertificateChain(root_certificates);
   if (!parsed_roots.ok()) {
-    return parsed_roots.status();
+    return absl::Status(
+        parsed_roots.status().code(),
+        absl::StrCat("Failed to parse root certificates as PEM: ",
+                     parsed_roots.status().message()));
   }
   for (X509* x509 : *parsed_roots) {
     X509_free(x509);
@@ -65,7 +68,10 @@ absl::Status ValidatePemKeyCertPair(absl::string_view cert_chain,
   absl::StatusOr<std::vector<X509*>> parsed_certs =
       ParsePemCertificateChain(cert_chain);
   if (!parsed_certs.ok()) {
-    return parsed_certs.status();
+    return absl::Status(
+        parsed_certs.status().code(),
+        absl::StrCat("Failed to parse certificate chain as PEM: ",
+                     parsed_certs.status().message()));
   }
   for (X509* x509 : *parsed_certs) {
     X509_free(x509);
@@ -74,7 +80,9 @@ absl::Status ValidatePemKeyCertPair(absl::string_view cert_chain,
   absl::StatusOr<EVP_PKEY*> parsed_private_key =
       ParsePemPrivateKey(private_key);
   if (!parsed_private_key.ok()) {
-    return parsed_private_key.status();
+    return absl::Status(parsed_private_key.status().code(),
+                        absl::StrCat("Failed to parse private key as PEM: ",
+                                     parsed_private_key.status().message()));
   }
   EVP_PKEY_free(*parsed_private_key);
   return absl::OkStatus();

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -248,7 +248,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
       malformed_cert_,
       MakeCertKeyPairs(private_key_.c_str(), cert_chain_.c_str()));
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::FailedPreconditionError("Invalid PEM."));
+            absl::FailedPreconditionError(
+                "Failed to parse root certificates as PEM: Invalid PEM."));
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
@@ -257,7 +258,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
       root_cert_,
       MakeCertKeyPairs(private_key_.c_str(), malformed_cert_.c_str()));
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::FailedPreconditionError("Invalid PEM."));
+            absl::FailedPreconditionError(
+                "Failed to parse certificate chain as PEM: Invalid PEM."));
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
@@ -266,7 +268,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
       root_cert_,
       MakeCertKeyPairs(malformed_key_.c_str(), cert_chain_.c_str()));
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::NotFoundError("No private key found."));
+            absl::NotFoundError(
+                "Failed to parse private key as PEM: No private key found."));
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
@@ -309,7 +312,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
   FileWatcherCertificateProvider provider(SERVER_KEY_PATH_2, SERVER_CERT_PATH_2,
                                           MALFORMED_CERT_PATH, 1);
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::FailedPreconditionError("Invalid PEM."));
+            absl::FailedPreconditionError(
+                "Failed to parse root certificates as PEM: Invalid PEM."));
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
@@ -317,7 +321,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
   FileWatcherCertificateProvider provider(
       SERVER_KEY_PATH_2, MALFORMED_CERT_PATH, CA_CERT_PATH_2, 1);
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::FailedPreconditionError("Invalid PEM."));
+            absl::FailedPreconditionError(
+                "Failed to parse certificate chain as PEM: Invalid PEM."));
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,
@@ -325,7 +330,8 @@ TEST_F(GrpcTlsCertificateProviderTest,
   FileWatcherCertificateProvider provider(
       MALFORMED_KEY_PATH, SERVER_CERT_PATH_2, CA_CERT_PATH_2, 1);
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::NotFoundError("No private key found."));
+            absl::NotFoundError(
+                "Failed to parse private key as PEM: No private key found."));
 }
 
 TEST_F(GrpcTlsCertificateProviderTest,

--- a/test/cpp/server/credentials_test.cc
+++ b/test/cpp/server/credentials_test.cc
@@ -134,7 +134,8 @@ TEST(CredentialsTest, StaticDataCertificateProviderWithMalformedRoot) {
   key_cert_pair.certificate_chain = GetFileContents(SERVER_CERT_PATH);
   StaticDataCertificateProvider provider(root_certificates, {key_cert_pair});
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::FailedPreconditionError("Invalid PEM."));
+            absl::FailedPreconditionError(
+                "Failed to parse root certificates as PEM: Invalid PEM."));
 }
 
 TEST(CredentialsTest,
@@ -148,7 +149,8 @@ TEST(CredentialsTest, FileWatcherCertificateProviderWithMalformedRoot) {
   FileWatcherCertificateProvider provider(SERVER_KEY_PATH, SERVER_CERT_PATH,
                                           MALFORMED_CERT_PATH, 1);
   EXPECT_EQ(provider.ValidateCredentials(),
-            absl::FailedPreconditionError("Invalid PEM."));
+            absl::FailedPreconditionError(
+                "Failed to parse root certificates as PEM: Invalid PEM."));
 }
 
 TEST(CredentialsTest, TlsServerCredentialsWithCrlChecking) {


### PR DESCRIPTION
Users of the TLS certificate provider were given the option to have validate their credentials at startup time in #37565, so that they can fail-fast. This is a small follow-up PR that provides finer-grained error messages in the event of a failure.
