### PR TITLE
[call-v3] Enable some tests for max_message_length

### DIFF
--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -149,7 +149,7 @@ ServerMetadataHandle CheckPayload(const Message& msg,
       << (is_send ? "send" : "recv") << " len:" << msg.payload()->Length()
       << " max:" << *max_length;
   if (msg.payload()->Length() <= *max_length) return nullptr;
-  return ServerMetadataFromStatus(
+  return CancelledServerMetadataFromStatus(
       GRPC_STATUS_RESOURCE_EXHAUSTED,
       absl::StrFormat("%s: %s message larger than max (%u vs. %d)",
                       is_client ? "CLIENT" : "SERVER",

--- a/test/core/end2end/tests/max_message_length.cc
+++ b/test/core/end2end/tests/max_message_length.cc
@@ -135,7 +135,6 @@ void TestMaxMessageLengthOnServerOnResponse(CoreEnd2endTest& test) {
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnClientOnRequestViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, 5));
   TestMaxMessageLengthOnClientOnRequest(*this);
@@ -182,7 +181,6 @@ CORE_END2END_TEST(
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnServerOnRequestViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));
   InitClient(ChannelArgs());
   TestMaxMessageLengthOnServerOnRequest(*this);
@@ -191,7 +189,6 @@ CORE_END2END_TEST(CoreEnd2endTest,
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnClientOnResponseViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));
   TestMaxMessageLengthOnClientOnResponse(*this);
@@ -238,7 +235,6 @@ CORE_END2END_TEST(
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnServerOnResponseViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs().Set(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, 5));
   InitClient(ChannelArgs());
   TestMaxMessageLengthOnServerOnResponse(*this);
@@ -246,7 +242,6 @@ CORE_END2END_TEST(CoreEnd2endTest,
 
 CORE_END2END_TEST(Http2Test, MaxMessageLengthOnServerOnRequestWithCompression) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   // Set limit via channel args.
   InitServer(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));
   InitClient(ChannelArgs());
@@ -283,7 +278,6 @@ CORE_END2END_TEST(Http2Test, MaxMessageLengthOnServerOnRequestWithCompression) {
 CORE_END2END_TEST(Http2Test,
                   MaxMessageLengthOnClientOnResponseWithCompression) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   // Set limit via channel args.
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));


### PR DESCRIPTION
Service config doesn't seem to be working with promise based inproc yet... need to take a look separately.