### PR TITLE
[interop] Add v1.69.4, v1.70.0 releases of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -310,7 +310,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.66.3", ReleaseInfo()),
             ("v1.67.3", ReleaseInfo()),
             ("v1.68.2", ReleaseInfo()),
-            ("v1.69.2", ReleaseInfo()),
+            ("v1.69.4", ReleaseInfo()),
             ("v1.70.0", ReleaseInfo()),
         ]
     ),

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -311,6 +311,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.67.3", ReleaseInfo()),
             ("v1.68.2", ReleaseInfo()),
             ("v1.69.2", ReleaseInfo()),
+            ("v1.70.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

Passing ad-hoc test run: https://source.cloud.google.com/results/invocations/c846a2fb-2f41-4579-babc-72145f6767b0
