### PR TITLE
[call-v3] Enable service config tests for max message length

### DIFF
--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -149,7 +149,7 @@ ServerMetadataHandle CheckPayload(const Message& msg,
       << (is_send ? "send" : "recv") << " len:" << msg.payload()->Length()
       << " max:" << *max_length;
   if (msg.payload()->Length() <= *max_length) return nullptr;
-  return ServerMetadataFromStatus(
+  return CancelledServerMetadataFromStatus(
       GRPC_STATUS_RESOURCE_EXHAUSTED,
       absl::StrFormat("%s: %s message larger than max (%u vs. %d)",
                       is_client ? "CLIENT" : "SERVER",

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -158,8 +158,9 @@ ServerMetadataHandle CheckPayload(const Message& msg,
 }
 }  // namespace
 
-ClientMessageSizeFilter::Call::Call(ClientMessageSizeFilter* filter)
-    : limits_(filter->parsed_config_) {
+void ClientMessageSizeFilter::Call::OnClientInitialMetadata(
+    ClientMetadata&, ClientMessageSizeFilter* filter) {
+  limits_ = filter->parsed_config_;
   // Get max sizes from channel data, then merge in per-method config values.
   // Note: Per-method config is only available on the client, so we
   // apply the max request size to the send limit and the max response

--- a/src/core/ext/filters/message_size/message_size_filter.h
+++ b/src/core/ext/filters/message_size/message_size_filter.h
@@ -127,9 +127,8 @@ class ClientMessageSizeFilter final
 
   class Call {
    public:
-    explicit Call(ClientMessageSizeFilter* filter);
-
-    static inline const NoInterceptor OnClientInitialMetadata;
+    void OnClientInitialMetadata(ClientMetadata&,
+                                 ClientMessageSizeFilter* filter);
     static inline const NoInterceptor OnServerInitialMetadata;
     static inline const NoInterceptor OnServerTrailingMetadata;
     static inline const NoInterceptor OnFinalize;

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -47,7 +47,7 @@
   test_tags: []
 - name: call_tracer_in_transport
   description: Transport directly passes byte counts to CallTracer.
-  expiry: 2025/02/01
+  expiry: 2025/06/01
   owner: roth@google.com
   test_tags: []
 - name: callv3_client_auth_filter

--- a/test/core/end2end/tests/max_message_length.cc
+++ b/test/core/end2end/tests/max_message_length.cc
@@ -135,7 +135,6 @@ void TestMaxMessageLengthOnServerOnResponse(CoreEnd2endTest& test) {
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnClientOnRequestViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, 5));
   TestMaxMessageLengthOnClientOnRequest(*this);
@@ -182,7 +181,6 @@ CORE_END2END_TEST(
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnServerOnRequestViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));
   InitClient(ChannelArgs());
   TestMaxMessageLengthOnServerOnRequest(*this);
@@ -191,7 +189,6 @@ CORE_END2END_TEST(CoreEnd2endTest,
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnClientOnResponseViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));
   TestMaxMessageLengthOnClientOnResponse(*this);
@@ -238,7 +235,6 @@ CORE_END2END_TEST(
 CORE_END2END_TEST(CoreEnd2endTest,
                   MaxMessageLengthOnServerOnResponseViaChannelArg) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs().Set(GRPC_ARG_MAX_SEND_MESSAGE_LENGTH, 5));
   InitClient(ChannelArgs());
   TestMaxMessageLengthOnServerOnResponse(*this);
@@ -246,7 +242,6 @@ CORE_END2END_TEST(CoreEnd2endTest,
 
 CORE_END2END_TEST(Http2Test, MaxMessageLengthOnServerOnRequestWithCompression) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   // Set limit via channel args.
   InitServer(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));
   InitClient(ChannelArgs());
@@ -283,7 +278,6 @@ CORE_END2END_TEST(Http2Test, MaxMessageLengthOnServerOnRequestWithCompression) {
 CORE_END2END_TEST(Http2Test,
                   MaxMessageLengthOnClientOnResponseWithCompression) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   // Set limit via channel args.
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, 5));

--- a/test/core/end2end/tests/max_message_length.cc
+++ b/test/core/end2end/tests/max_message_length.cc
@@ -144,7 +144,6 @@ CORE_END2END_TEST(
     CoreEnd2endTest,
     MaxMessageLengthOnClientOnRequestViaServiceConfigWithStringJsonValue) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,
@@ -163,7 +162,6 @@ CORE_END2END_TEST(
     CoreEnd2endTest,
     MaxMessageLengthOnClientOnRequestViaServiceConfigWithIntegerJsonValue) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,
@@ -198,7 +196,6 @@ CORE_END2END_TEST(
     CoreEnd2endTest,
     MaxMessageLengthOnClientOnResponseViaServiceConfigWithStringJsonValue) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,
@@ -217,7 +214,6 @@ CORE_END2END_TEST(
     CoreEnd2endTest,
     MaxMessageLengthOnClientOnResponseViaServiceConfigWithIntegerJsonValue) {
   SKIP_IF_MINSTACK();
-  SKIP_IF_V3();
   InitServer(ChannelArgs());
   InitClient(ChannelArgs().Set(
       GRPC_ARG_SERVICE_CONFIG,


### PR DESCRIPTION
In contrast to our emulation layer, call-v3 call objects are constructed prior to client initial metadata being processed.

Since service config context depends on context it needs to be set after client initial metadata, so we can't rely on it being there prior to client initial metadata as we were.