### PR TITLE
[Backport-v1.70.x] Minimal bzlmod support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,6 @@ iwyu_build/
 # fuzzer logs
 fuzz-*.log
 
-# bazel module files (MODULE.bazel will need to be removed here)
-MODULE.bazel
+# bazel module files
+third_party/**/MODULE.bazel
 MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@
 
 module(
     name = "grpc",
-    version = "1.71.0-dev",
+    version = "1.70.0",
     compatibility_level = 1,
     repo_name = "com_github_grpc_grpc",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,91 @@
+# Copyright 2025 the gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "grpc",
+    version = "1.71.0-dev",
+    compatibility_level = 1,
+    repo_name = "com_github_grpc_grpc",
+)
+
+bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+bazel_dep(name = "apple_support", version = "1.17.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
+bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
+bazel_dep(name = "envoy_api", version = "0.0.0-20241214-918efc9")  # mistmatched 20250106
+bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark")
+bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
+bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name = "io_opencensus_cpp")
+bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")  # mistmached 1.18.0
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "protoc-gen-validate", version = "1.0.4.bcr.2", repo_name = "com_envoyproxy_protoc_gen_validate")
+bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
+bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_java", version = "8.7.0")
+bazel_dep(name = "rules_proto", version = "7.0.2")
+bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
+bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+
+grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
+use_repo(
+    grpc_repo_deps_ext,
+    "google_cloud_cpp",
+)
+
+switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
+switched_rules.use_languages(
+    cc = True,
+    grpc = True,
+    python = True,
+)
+
+bazel_dep(name = "rules_python", version = "0.37.1")
+
+PYTHON_VERSIONS = [
+    "3.8",
+    "3.9",
+    "3.10",
+    "3.11",
+    "3.12",
+    "3.13",
+]
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+[
+    python.toolchain(
+        is_default = python_version == PYTHON_VERSIONS[-1],
+        python_version = python_version,
+    )
+    for python_version in PYTHON_VERSIONS
+]
+
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+[
+    pip.parse(
+        hub_name = "grpc_python_dependencies",
+        python_version = python_version,
+        requirements_lock = "//:requirements.bazel.txt",
+    )
+    for python_version in PYTHON_VERSIONS
+]
+
+use_repo(pip, "grpc_python_dependencies")
+
+bazel_dep(name = "cython", version = "3.0.11-1")

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -332,16 +332,7 @@ def grpc_deps():
             ],
         )
 
-    if "google_cloud_cpp" not in native.existing_rules():
-        http_archive(
-            name = "google_cloud_cpp",
-            sha256 = "e53ba3799c052d97acac9a6a6b27af24ce822dbde7bfde973bac9e5da714e6b2",
-            strip_prefix = "google-cloud-cpp-2.33.0",
-            urls = [
-                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.33.0.tar.gz",
-                "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.33.0.tar.gz",
-            ],
-        )
+    grpc_module_deps()
 
     grpc_python_deps()
 
@@ -424,3 +415,17 @@ def grpc_test_only_deps():
             strip_prefix = "libprotobuf-mutator-1f95f8083066f5b38fd2db172e7e7f9aa7c49d2d",
             build_file = "@com_github_grpc_grpc//third_party:libprotobuf_mutator.BUILD",
         )
+
+def grpc_module_deps():
+    if "google_cloud_cpp" not in native.existing_rules():
+        http_archive(
+            name = "google_cloud_cpp",
+            sha256 = "e53ba3799c052d97acac9a6a6b27af24ce822dbde7bfde973bac9e5da714e6b2",
+            strip_prefix = "google-cloud-cpp-2.33.0",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.33.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.33.0.tar.gz",
+            ],
+        )
+
+grpc_repo_deps_ext = module_extension(implementation = lambda ctx: grpc_module_deps())

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -1,0 +1,93 @@
+%YAML 1.2
+--- |
+    # Copyright 2025 the gRPC authors.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    module(
+        name = "grpc",
+        version = "${settings.cpp_version}",
+        compatibility_level = 1,
+        repo_name = "com_github_grpc_grpc",
+    )
+
+    bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
+    bazel_dep(name = "apple_support", version = "1.17.1", repo_name = "build_bazel_apple_support")
+    bazel_dep(name = "bazel_skylib", version = "1.7.1")
+    bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
+    bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
+    bazel_dep(name = "envoy_api", version = "0.0.0-20241214-918efc9")  # mistmatched 20250106
+    bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark")
+    bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
+    bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+    bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name = "io_opencensus_cpp")
+    bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")  # mistmached 1.18.0
+    bazel_dep(name = "platforms", version = "0.0.10")
+    bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+    bazel_dep(name = "protoc-gen-validate", version = "1.0.4.bcr.2", repo_name = "com_envoyproxy_protoc_gen_validate")
+    bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
+    bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
+    bazel_dep(name = "rules_cc", version = "0.0.17")
+    bazel_dep(name = "rules_java", version = "8.7.0")
+    bazel_dep(name = "rules_proto", version = "7.0.2")
+    bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
+    bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+
+    grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
+    use_repo(
+        grpc_repo_deps_ext,
+        "google_cloud_cpp",
+    )
+
+    switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
+    switched_rules.use_languages(
+        cc = True,
+        grpc = True,
+        python = True,
+    )
+
+    bazel_dep(name = "rules_python", version = "0.37.1")
+
+    PYTHON_VERSIONS = [
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+    ]
+
+    python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+
+    [
+        python.toolchain(
+            is_default = python_version == PYTHON_VERSIONS[-1],
+            python_version = python_version,
+        )
+        for python_version in PYTHON_VERSIONS
+    ]
+
+    pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+
+    [
+        pip.parse(
+            hub_name = "grpc_python_dependencies",
+            python_version = python_version,
+            requirements_lock = "//:requirements.bazel.txt",
+        )
+        for python_version in PYTHON_VERSIONS
+    ]
+
+    use_repo(pip, "grpc_python_dependencies")
+
+    bazel_dep(name = "cython", version = "3.0.11-1")

--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -217,6 +217,13 @@ test_suite(
 generate_strict_tests()
 
 grpc_run_simple_command_test(
+    name = "bazel_build_with_bzlmod_linux",
+    size = "enormous",
+    args = ["tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh"],
+    docker_image_version = "tools/dockerfile/test/bazel.current_version",
+)
+
+grpc_run_simple_command_test(
     name = "bazel_build_with_grpc_no_xds_linux",
     size = "enormous",
     args = ["tools/bazelify_tests/test/bazel_build_with_grpc_no_xds_linux.sh"],
@@ -233,6 +240,7 @@ grpc_run_simple_command_test(
 test_suite(
     name = "bazel_build_tests_linux",
     tests = [
+        ":bazel_build_with_bzlmod_linux",
         ":bazel_build_with_grpc_no_xds_linux",
         ":bazel_build_with_grpc_no_xds_negative_test_linux",
         ":bazel_build_with_strict_warnings_linux",

--- a/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2025 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+tools/bazel build :grpc++ --enable_bzlmod=true --enable_workspace=false

--- a/tools/distrib/buildifier_format_code.sh
+++ b/tools/distrib/buildifier_format_code.sh
@@ -65,6 +65,6 @@ fi
 dir=$(dirname "${0}")
 cd "${dir}/../.."
 
-bazel_files=$(find . \( -iname 'BUILD' -o -iname '*.bzl' -o -iname '*.bazel' -o -iname 'WORKSPACE' \) -type f -not -path "./third_party/*")
+bazel_files=$(find . \( -iname 'BUILD' -o -iname '*.bzl' -o -iname '*.bazel' -o -iname 'WORKSPACE' \) -type f -not -path "./third_party/*" -not -path './MODULE.bazel')
 # shellcheck disable=SC2086,SC2068
 ${buildifier_bin} ${EXTRA_BUILDIFIER_FLAGS[@]} -v ${bazel_files}

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -160,6 +160,11 @@ with open(os.path.join("bazel", "grpc_deps.bzl"), "r") as f:
     eval_state = BazelEvalState(names_and_urls)
     bazel_file = f.read()
 
+# Remove bzlmod specific functions
+bazel_file = re.sub(
+    r"^grpc_repo_deps_ext.*$", "", bazel_file, flags=re.MULTILINE
+)
+
 # grpc_deps.bzl only defines 'grpc_deps' and 'grpc_test_only_deps', add these
 # lines to call them.
 bazel_file += "\ngrpc_deps()\n"


### PR DESCRIPTION
Backport of #38456

We need to exclude `MODULE.bazel` from `buildifier_format_code.sh` in this backport. The 1.70.x branch still uses build tool version 4.2.2, which incorrectly flags a warning in `MODULE.bazel`. This is resolved in the master branch, which uses version 8.0.0.