### PR TITLE
[MetricsTest] Reduce test logging

### DIFF
--- a/test/core/telemetry/metrics_test.cc
+++ b/test/core/telemetry/metrics_test.cc
@@ -706,6 +706,8 @@ TEST_F(MetricsDeathTest, RegisterTheSameMetricNameWouldCrash) {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
+  grpc_core::GlobalInstrumentsRegistryTestPeer::
+      ResetGlobalInstrumentsRegistry();
   int ret = RUN_ALL_TESTS();
   return ret;
 }

--- a/test/core/test_util/fake_stats_plugin.h
+++ b/test/core/test_util/fake_stats_plugin.h
@@ -224,8 +224,6 @@ class FakeStatsPlugin : public StatsPlugin {
                 descriptor) {
           if (!use_disabled_by_default_metrics &&
               !descriptor.enable_by_default) {
-            VLOG(2) << "FakeStatsPlugin[" << this
-                    << "]: skipping disabled metric: " << descriptor.name;
             return;
           }
           switch (descriptor.instrument_type) {


### PR DESCRIPTION
This is timing out on our windows portability tests on of the tests that registers 10000 stats plugins. This log line ends up getting executed probably around ~20k times causing timeout.