### PR TITLE
[ruby] bump ruby artifact build timeout

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -275,7 +275,7 @@ class RubyArtifact:
                 self.gem_platform,
             ],
             use_workspace=True,
-            timeout_seconds=120 * 60,
+            timeout_seconds=180 * 60,
             environ=environ,
         )
 
@@ -471,10 +471,10 @@ def targets():
             PythonArtifact("windows", "x64", "Python312"),
             PythonArtifact("windows", "x64", "Python313", presubmit=True),
             RubyArtifact("linux", "x86-mingw32", presubmit=True),
-            RubyArtifact("linux", "x64-mingw32", presubmit=True),
+            RubyArtifact("linux", "x64-mingw32"),
             RubyArtifact("linux", "x64-mingw-ucrt", presubmit=True),
             RubyArtifact("linux", "x86_64-linux", presubmit=True),
-            RubyArtifact("linux", "x86-linux", presubmit=True),
+            RubyArtifact("linux", "x86-linux"),
             RubyArtifact("linux", "aarch64-linux", presubmit=True),
             RubyArtifact("linux", "x86_64-darwin", presubmit=True),
             RubyArtifact("linux", "arm64-darwin", presubmit=True),


### PR DESCRIPTION
To roll forward https://github.com/grpc/grpc/pull/38515

As described https://github.com/grpc/grpc/pull/38515#issuecomment-2609034151, the addition of ruby-3.4 to our cross-compilation matrix caused ruby artifact build times to exceed the 2 hour timeout *on release builds*.

For some context around where this was failing, note there are three kokoro jobs that build ruby artifacts:

- pull_request `grpc_distribtests_ruby`: runs on 32-core VMs (for presubmit tests)
- master branch `grpc_distribtests_ruby`: runs on 32-core VMs (for continuous master branch coverage)
- release `grpc_distribtests_ruby`: runs on 16-core VMs (for release builds)

Even though all three jobs currently build the *same* set of ruby gems (that is slightly changing with this PR), the release build takes much longer presumably because of the smaller machine type.

So even though https://github.com/grpc/grpc/pull/38515 was passing during presubmit runs and even on master branch CI, release builds ran into timeouts. So lengthen the timeout for the release builds, which are the slowest.

Note our build matrix will shrink again around April when we drop ruby 3.0 (the ruby build matrix is largest between January and April b/c we are adding a new ruby minor version target, but waiting until ~April to delete the new oldest one).
