### PR TITLE
increased timeout of python_windows_opt_native test to 90 minutes

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -207,6 +207,9 @@ def _generate_jobs(
                             timeout_seconds=timeout_seconds,
                         )
                     else:
+                        if platform == "windows" and language == "python":
+                            timeout_seconds = _DEFAULT_RUNTESTS_TIMEOUT * 2
+
                         job = _workspace_jobspec(
                             name=name,
                             runtests_args=runtests_args,

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -36,6 +36,9 @@ _CPP_RUNTESTS_TIMEOUT = 6 * 60 * 60
 # Set timeout high for ObjC for Cocoapods to install pods
 _OBJC_RUNTESTS_TIMEOUT = 4 * 60 * 60
 
+# Set higher timeout for python_windows_opt_native test
+_PYTHON_WINDOWS_RUNTESTS_TIMEOUT = 1.5 * 60 * 60
+
 # Set timeout high for Ruby for MacOS for slow xcodebuild
 _RUBY_RUNTESTS_TIMEOUT = 2 * 60 * 60
 
@@ -208,7 +211,7 @@ def _generate_jobs(
                         )
                     else:
                         if platform == "windows" and language == "python":
-                            timeout_seconds = _DEFAULT_RUNTESTS_TIMEOUT * 2
+                            timeout_seconds = _PYTHON_WINDOWS_RUNTESTS_TIMEOUT
 
                         job = _workspace_jobspec(
                             name=name,


### PR DESCRIPTION
Multiple python_windows_opt_native_test runs are failing with Timeouts with intermittent passes. 
When checking the passing runs, the test run times are close to 59-60 minutes.
Hence increasing the timeout should resolve the Timeout failures