### PR TITLE
Remove internal from the ALPN channel arg

### DIFF
--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -74,7 +74,7 @@
  NOTE: This is an experimental feature. It is not fully implemented and is not
  currently functional.
  TODO(gtcooke94) - update with specific details when implementing. */
-#define GRPC_ARG_TRANSPORT_PROTOCOLS "grpc.internal.transport_protocols"
+#define GRPC_ARG_TRANSPORT_PROTOCOLS "grpc.transport_protocols"
 
 namespace grpc_core {
 


### PR DESCRIPTION
Remove internal from https://github.com/grpc/grpc/pull/38579

This is causing the channel arg to get dropped before it reaches code where it is needed.

