### PR TITLE
Fix MSVC static runtime build with CMake  >= 3.15

### DIFF
--- a/cmake/msvc_static_runtime.cmake
+++ b/cmake/msvc_static_runtime.cmake
@@ -16,15 +16,7 @@ option(gRPC_MSVC_STATIC_RUNTIME "Link with static msvc runtime libraries" OFF)
 
 if(gRPC_MSVC_STATIC_RUNTIME)
   # switch from dynamic to static linking of msvcrt
-  foreach(flag_var
-    CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-    CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
-    CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-    CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-
-    if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-    endif()
-  endforeach()
+  set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>)
+else()
+  set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreaded$<$<CONFIG:Debug>:Debug>DLL)
 endif()
-


### PR DESCRIPTION
Since Cmake 3.15 there is no /MD flag in CMAKE_<LANG>_FLAGS(_<BUILD_TYPE>) variable like `CMAKE_CXX_FLAGS_DEBUG`. So we can't replace in with /MT.
Use new cmake functionality with `CMAKE_MSVC_RUNTIME_LIBRARY`.
The change is similar to similar to protobuf https://github.com/protocolbuffers/protobuf/blob/2d4414f384dc499af113b5991ce3eaa9df6dd931/CMakeLists.txt#L213
But grpc requires minimum cmake version 3.16 so we may simply replace old code with the new one

