### PR TITLE
[CI] Clean-up bzlmod deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,18 +25,13 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
 bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
 bazel_dep(name = "envoy_api", version = "0.0.0-20250128-4de3c74")
-bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark")
 bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
-bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
-bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name = "io_opencensus_cpp")
 bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")  # mistmached 1.18.0
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
-bazel_dep(name = "protoc-gen-validate", version = "1.0.4.bcr.2", repo_name = "com_envoyproxy_protoc_gen_validate")
 bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
 bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_cc", version = "0.0.17")
-bazel_dep(name = "rules_java", version = "8.7.0")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -27,18 +27,13 @@
     bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
     bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
     bazel_dep(name = "envoy_api", version = "0.0.0-20250128-4de3c74")
-    bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark")
     bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
-    bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
-    bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name = "io_opencensus_cpp")
     bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")  # mistmached 1.18.0
     bazel_dep(name = "platforms", version = "0.0.10")
     bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
-    bazel_dep(name = "protoc-gen-validate", version = "1.0.4.bcr.2", repo_name = "com_envoyproxy_protoc_gen_validate")
     bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
     bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
     bazel_dep(name = "rules_cc", version = "0.0.17")
-    bazel_dep(name = "rules_java", version = "8.7.0")
     bazel_dep(name = "rules_proto", version = "7.0.2")
     bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
     bazel_dep(name = "zlib", version = "1.3.1.bcr.3")

--- a/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
@@ -15,4 +15,11 @@
 
 set -ex
 
-tools/bazel build :grpc++ --enable_bzlmod=true --enable_workspace=false
+tools/bazel \
+    build \
+    --enable_bzlmod=true \
+    --enable_workspace=false \
+    :grpc \
+    :grpc_unsecure \
+    :grpc++ \
+    :grpc++_unsecure


### PR DESCRIPTION
Removed the following deps from `MODULE.bazel` because they public gRPC targets don't need them.
- `google_benchmark`
- `googletest`
- `opencensus-cpp`
- `protoc-gen-validate`
- `rules_java`