### PR TITLE
[XdsInteropClient] Remove incorrect behavior around keep-open (#38613)

### DIFF
--- a/test/cpp/interop/xds_interop_client.cc
+++ b/test/cpp/interop/xds_interop_client.cc
@@ -163,11 +163,6 @@ class TestClient {
     }
     for (const auto& data : config.metadata) {
       call->context.AddMetadata(data.first, data.second);
-      // TODO(@donnadionne): move deadline to separate proto.
-      if (data.first == "rpc-behavior" && data.second == "keep-open") {
-        deadline =
-            std::chrono::system_clock::now() + std::chrono::seconds(INT_MAX);
-      }
     }
     SimpleRequest request;
     request.set_response_size(config.response_payload_size);
@@ -205,11 +200,6 @@ class TestClient {
     }
     for (const auto& data : config.metadata) {
       call->context.AddMetadata(data.first, data.second);
-      // TODO(@donnadionne): move deadline to separate proto.
-      if (data.first == "rpc-behavior" && data.second == "keep-open") {
-        deadline =
-            std::chrono::system_clock::now() + std::chrono::seconds(INT_MAX);
-      }
     }
     call->context.set_deadline(deadline);
     call->result.saved_request_id = saved_request_id;


### PR DESCRIPTION
Backport #381613 to v1.70.x

Based on the [spec](https://github.com/grpc/grpc/blob/master/doc/xds-test-descriptions.md#server) and the [reference Java implementation](https://github.com/grpc/grpc-java/blob/master/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java), it's the server that needs to honor the "keep-open" behavior and not the client.

(I'm not changing the server's behavior in this PR, since we are not using C++ servers and instead using Java servers for the concerned tests.)

