### PR TITLE
[fuzzer] Fix UB in status parsing

### DIFF
--- a/include/grpc/status.h
+++ b/include/grpc/status.h
@@ -146,7 +146,7 @@ typedef enum {
   GRPC_STATUS_DATA_LOSS = 15,
 
   /** Force users to include a default branch: */
-  GRPC_STATUS__DO_NOT_USE = 0xffffffffu,
+  GRPC_STATUS__DO_NOT_USE = 0x7fffffffu,
 } grpc_status_code;
 
 #ifdef __cplusplus

--- a/include/grpc/status.h
+++ b/include/grpc/status.h
@@ -146,7 +146,7 @@ typedef enum {
   GRPC_STATUS_DATA_LOSS = 15,
 
   /** Force users to include a default branch: */
-  GRPC_STATUS__DO_NOT_USE = -1
+  GRPC_STATUS__DO_NOT_USE = 0xffffffffu,
 } grpc_status_code;
 
 #ifdef __cplusplus

--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -370,6 +370,51 @@ struct SimpleIntBasedMetadata : public SimpleIntBasedMetadataBase<Int> {
 
 // grpc-status metadata trait.
 struct GrpcStatusMetadata {
+  using ValueType = grpc_status_code;
+  using MementoType = grpc_status_code;
+  static ValueType MementoToValue(MementoType value) { return value; }
+  static Slice Encode(ValueType x) { return Slice::FromInt64(x); }
+  static std::string DisplayValue(ValueType x) {
+    switch (x) {
+      case GRPC_STATUS_OK:
+        return "OK";
+      case GRPC_STATUS_CANCELLED:
+        return "CANCELLED";
+      case GRPC_STATUS_UNKNOWN:
+        return "UNKNOWN";
+      case GRPC_STATUS_INVALID_ARGUMENT:
+        return "INVALID_ARGUMENT";
+      case GRPC_STATUS_DEADLINE_EXCEEDED:
+        return "DEADLINE_EXCEEDED";
+      case GRPC_STATUS_NOT_FOUND:
+        return "NOT_FOUND";
+      case GRPC_STATUS_ALREADY_EXISTS:
+        return "ALREADY_EXISTS";
+      case GRPC_STATUS_PERMISSION_DENIED:
+        return "PERMISSION_DENIED";
+      case GRPC_STATUS_RESOURCE_EXHAUSTED:
+        return "RESOURCE_EXHAUSTED";
+      case GRPC_STATUS_FAILED_PRECONDITION:
+        return "FAILED_PRECONDITION";
+      case GRPC_STATUS_ABORTED:
+        return "ABORTED";
+      case GRPC_STATUS_OUT_OF_RANGE:
+        return "OUT_OF_RANGE";
+      case GRPC_STATUS_UNIMPLEMENTED:
+        return "UNIMPLEMENTED";
+      case GRPC_STATUS_INTERNAL:
+        return "INTERNAL";
+      case GRPC_STATUS_UNAVAILABLE:
+        return "UNAVAILABLE";
+      case GRPC_STATUS_DATA_LOSS:
+        return "DATA_LOSS";
+      case GRPC_STATUS_UNAUTHENTICATED:
+        return "UNAUTHENTICATED";
+      default:
+        return absl::StrCat("UNKNOWN(", static_cast<int>(x), ")");
+    }
+  }
+  static auto DisplayMemento(MementoType x) { return DisplayValue(x); }
   static constexpr bool kRepeatable = false;
   static constexpr bool kTransferOnTrailersOnly = false;
   using CompressionTraits = SmallIntegralValuesCompressor<16>;

--- a/test/core/transport/chttp2/hpack_sync_fuzzer.cc
+++ b/test/core/transport/chttp2/hpack_sync_fuzzer.cc
@@ -225,5 +225,25 @@ void FuzzOneInput(const hpack_sync_fuzzer::Msg& msg) {
 }
 FUZZ_TEST(HpackSyncFuzzer, FuzzOneInput);
 
+auto ParseTestProto(const std::string& proto) {
+  hpack_sync_fuzzer::Msg msg;
+  CHECK(proto2::TextFormat::ParseFromString(proto, &msg));
+  return msg;
+}
+
+TEST(HpackSyncFuzzer, FuzzOneInputRegression1) {
+  FuzzOneInput(ParseTestProto(
+      R"pb(
+        headers { literal_not_idx { key: "grpc-status" value: "72" } }
+      )pb"));
+}
+
+TEST(HpackSyncFuzzer, FuzzOneInputRegression2) {
+  FuzzOneInput(ParseTestProto(
+      R"pb(
+        headers { literal_not_idx { key: "grpc-status" value: "-1" } }
+      )pb"));
+}
+
 }  // namespace
 }  // namespace grpc_core

--- a/test/core/transport/chttp2/hpack_sync_fuzzer.cc
+++ b/test/core/transport/chttp2/hpack_sync_fuzzer.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <google/protobuf/text_format.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -227,7 +228,7 @@ FUZZ_TEST(HpackSyncFuzzer, FuzzOneInput);
 
 auto ParseTestProto(const std::string& proto) {
   hpack_sync_fuzzer::Msg msg;
-  CHECK(proto2::TextFormat::ParseFromString(proto, &msg));
+  CHECK(google::protobuf::TextFormat::ParseFromString(proto, &msg));
   return msg;
 }
 


### PR DESCRIPTION
We're supposed to support putting integers outside the status code range into the `grpc_status_code` enum, as a future proofing against ever adding a new status code, however unlikely that may be.

Unfortunately, whilst we parse a uint32_t, we didn't take steps to guarantee that the enum was sufficiently wide to store the value.

Compilers we care about have been getting this right in opt builds regardless, but for safety we should get this right going forward.