### PR TITLE
[inproc] Fix fuzzer found crash

### DIFF
--- a/src/core/ext/transport/inproc/legacy_inproc_transport.cc
+++ b/src/core/ext/transport/inproc/legacy_inproc_transport.cc
@@ -185,13 +185,13 @@ struct inproc_stream {
 
     if (!server_data) {
       t->ref();
+      other_side = nullptr;  // will get filled in soon
       inproc_transport* st = t->other_side;
       if (st->accept_stream_cb == nullptr) {
         cancel_stream_locked(this,
                              absl::UnavailableError("inproc server closed"));
       } else {
         st->ref();
-        other_side = nullptr;  // will get filled in soon
         // Pass the client-side stream address to the server-side for a ref
         ref("inproc_init_stream:clt");  // ref it now on behalf of server
                                         // side to avoid destruction

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -16,6 +16,7 @@
 //
 //
 
+#include <google/protobuf/text_format.h>
 #include <grpc/credentials.h>
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
@@ -43,6 +44,7 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "fuzztest/fuzztest.h"
+#include "gtest/gtest.h"
 #include "src/core/ext/transport/inproc/inproc_transport.h"
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/channel/channel_args.h"
@@ -69,12 +71,6 @@
 #include "test/core/test_util/test_config.h"
 
 // IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
-
-////////////////////////////////////////////////////////////////////////////////
-// logging
-
-bool squelch = true;
-bool leak_check = true;
 
 ////////////////////////////////////////////////////////////////////////////////
 // dns resolution
@@ -514,14 +510,31 @@ void ApiFuzzer::DestroyChannel() {
 }
 
 void RunApiFuzzer(const api_fuzzer::Msg& msg) {
-  if (squelch && !GetEnv("GRPC_TRACE_FUZZER").has_value()) {
-    grpc_disable_all_absl_logs();
-  }
   ApplyFuzzConfigVars(msg.config_vars());
   TestOnlyReloadExperimentsFromConfigVariables();
   ApiFuzzer(msg.event_engine_actions()).Run(msg.actions());
 }
 FUZZ_TEST(MyTestSuite, RunApiFuzzer);
+
+auto ParseTestProto(const std::string& proto) {
+  api_fuzzer::Msg msg;
+  CHECK(google::protobuf::TextFormat::ParseFromString(proto, &msg));
+  return msg;
+}
+
+TEST(MyTestSuite, RunApiFuzzerRegression1) {
+  RunApiFuzzer(ParseTestProto(
+      R"pb(actions { create_server {} }
+           actions { shutdown_server {} }
+           actions { create_channel { inproc: true } }
+           actions {
+             create_call {
+               method { value: "\364\217\277\277" }
+               host { value: ")" }
+             }
+           }
+      )pb"));
+}
 
 }  // namespace testing
 }  // namespace grpc_core


### PR DESCRIPTION
If we shutdown an inproc server before we create a call, we go boom.
