### PR TITLE
[work-serializer] API modernization

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2858,6 +2858,7 @@ grpc_cc_library(
         "absl/container:inlined_vector",
         "absl/log",
         "absl/log:check",
+        "absl/functional:any_invocable",
     ],
     visibility = ["@grpc:client_channel"],
     deps = [

--- a/src/core/client_channel/client_channel.cc
+++ b/src/core/client_channel/client_channel.cc
@@ -243,8 +243,7 @@ class ClientChannel::SubchannelWrapper::WatcherWrapper
             *subchannel_wrapper_->client_channel_->work_serializer_) {
           ApplyUpdateInControlPlaneWorkSerializer(state, status);
           Unref();
-        },
-        DEBUG_LOCATION);
+        });
   }
 
   grpc_pollset_set* interested_parties() override { return nullptr; }
@@ -367,8 +366,7 @@ void ClientChannel::SubchannelWrapper::Orphaned() {
             }
           }
         }
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 void ClientChannel::SubchannelWrapper::WatchConnectivityState(
@@ -660,8 +658,7 @@ void ClientChannel::Orphaned() {
   work_serializer_->Run(
       [self]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*self->work_serializer_) {
         self->DestroyResolverAndLbPolicyLocked();
-      },
-      DEBUG_LOCATION);
+      });
   // IncreaseCallCount() introduces a phony call and prevents the idle
   // timer from being reset by other threads.
   idle_state_.IncreaseCallCount();
@@ -681,8 +678,7 @@ grpc_connectivity_state ClientChannel::CheckConnectivityState(
     work_serializer_->Run(
         [self]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*self->work_serializer_) {
           self->TryToConnectLocked();
-        },
-        DEBUG_LOCATION);
+        });
   }
   return state;
 }
@@ -787,8 +783,7 @@ void ClientChannel::AddConnectivityWatcher(
   //       watcher = std::move(watcher)]()
   //            ABSL_EXCLUSIVE_LOCKS_REQUIRED(*work_serializer_) {
   //        self->state_tracker_.AddWatcher(initial_state, std::move(watcher));
-  //      },
-  //      DEBUG_LOCATION);
+  //      });
 }
 
 void ClientChannel::RemoveConnectivityWatcher(
@@ -797,8 +792,7 @@ void ClientChannel::RemoveConnectivityWatcher(
   work_serializer_->Run(
       [self, watcher]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*self->work_serializer_) {
         self->state_tracker_.RemoveWatcher(watcher);
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 void ClientChannel::GetInfo(const grpc_channel_info* info) {
@@ -816,8 +810,7 @@ void ClientChannel::ResetConnectionBackoff() {
   work_serializer_->Run(
       [self]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*self->work_serializer_) {
         if (self->lb_policy_ != nullptr) self->lb_policy_->ResetBackoffLocked();
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 namespace {
@@ -1367,8 +1360,7 @@ void ClientChannel::StartIdleTimer() {
                 // might need to check for any calls that are
                 // queued waiting for a resolver result or an LB
                 // pick.
-              },
-              DEBUG_LOCATION);
+              });
         }
       },
       std::move(arena)));

--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -547,8 +547,7 @@ class ClientChannelFilter::SubchannelWrapper final
             }
           }
           WeakUnref(DEBUG_LOCATION, "subchannel map cleanup");
-        },
-        DEBUG_LOCATION);
+        });
   }
 
   void WatchConnectivityState(
@@ -639,8 +638,7 @@ class ClientChannelFilter::SubchannelWrapper final
               *parent_->chand_->work_serializer_) {
             ApplyUpdateInControlPlaneWorkSerializer(state, status);
             Unref();
-          },
-          DEBUG_LOCATION);
+          });
     }
 
     grpc_pollset_set* interested_parties() override {
@@ -759,8 +757,7 @@ ClientChannelFilter::ExternalConnectivityWatcher::ExternalConnectivityWatcher(
       [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
         // The ref is passed to AddWatcherLocked().
         AddWatcherLocked();
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 ClientChannelFilter::ExternalConnectivityWatcher::
@@ -813,8 +810,7 @@ void ClientChannelFilter::ExternalConnectivityWatcher::Notify(
         [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
           RemoveWatcherLocked();
           Unref(DEBUG_LOCATION, "RemoveWatcherLocked()");
-        },
-        DEBUG_LOCATION);
+        });
   }
 }
 
@@ -833,8 +829,7 @@ void ClientChannelFilter::ExternalConnectivityWatcher::Cancel() {
       [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
         RemoveWatcherLocked();
         Unref(DEBUG_LOCATION, "RemoveWatcherLocked()");
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 void ClientChannelFilter::ExternalConnectivityWatcher::AddWatcherLocked() {
@@ -864,8 +859,7 @@ class ClientChannelFilter::ConnectivityWatcherAdder final {
     chand_->work_serializer_->Run(
         [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
           AddWatcherLocked();
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -894,8 +888,7 @@ class ClientChannelFilter::ConnectivityWatcherRemover final {
     chand_->work_serializer_->Run(
         [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
           RemoveWatcherLocked();
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -1740,8 +1733,7 @@ void ClientChannelFilter::StartTransportOp(grpc_channel_element* elem,
   chand->work_serializer_->Run(
       [chand, op]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand->work_serializer_) {
         chand->StartTransportOpLocked(op);
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 void ClientChannelFilter::GetChannelInfo(grpc_channel_element* elem,
@@ -1778,8 +1770,7 @@ grpc_connectivity_state ClientChannelFilter::CheckConnectivityState(
   if (out == GRPC_CHANNEL_IDLE && try_to_connect) {
     GRPC_CHANNEL_STACK_REF(owning_stack_, "TryToConnect");
     work_serializer_->Run([this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(
-                              *work_serializer_) { TryToConnectLocked(); },
-                          DEBUG_LOCATION);
+                              *work_serializer_) { TryToConnectLocked(); });
   }
   return out;
 }
@@ -2061,8 +2052,7 @@ void ClientChannelFilter::FilterBasedCallData::StartTransportStreamOpBatch(
           [chand]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand->work_serializer_) {
             chand->CheckConnectivityState(/*try_to_connect=*/true);
             GRPC_CHANNEL_STACK_UNREF(chand->owning_stack_, "ExitIdle");
-          },
-          DEBUG_LOCATION);
+          });
     }
     calld->TryCheckResolution(/*was_queued=*/false);
   } else {

--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -529,25 +529,24 @@ class ClientChannelFilter::SubchannelWrapper final
     // WorkSerializer.
     // Ref held by callback.
     WeakRef(DEBUG_LOCATION, "subchannel map cleanup").release();
-    chand_->work_serializer_->Run(
-        [this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(*chand_->work_serializer_) {
-          chand_->subchannel_wrappers_.erase(this);
-          if (chand_->channelz_node_ != nullptr) {
-            auto* subchannel_node = subchannel_->channelz_node();
-            if (subchannel_node != nullptr) {
-              auto it =
-                  chand_->subchannel_refcount_map_.find(subchannel_.get());
-              CHECK(it != chand_->subchannel_refcount_map_.end());
-              --it->second;
-              if (it->second == 0) {
-                chand_->channelz_node_->RemoveChildSubchannel(
-                    subchannel_node->uuid());
-                chand_->subchannel_refcount_map_.erase(it);
-              }
-            }
+    chand_->work_serializer_->Run([this]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(
+                                      *chand_->work_serializer_) {
+      chand_->subchannel_wrappers_.erase(this);
+      if (chand_->channelz_node_ != nullptr) {
+        auto* subchannel_node = subchannel_->channelz_node();
+        if (subchannel_node != nullptr) {
+          auto it = chand_->subchannel_refcount_map_.find(subchannel_.get());
+          CHECK(it != chand_->subchannel_refcount_map_.end());
+          --it->second;
+          if (it->second == 0) {
+            chand_->channelz_node_->RemoveChildSubchannel(
+                subchannel_node->uuid());
+            chand_->subchannel_refcount_map_.erase(it);
           }
-          WeakUnref(DEBUG_LOCATION, "subchannel map cleanup");
-        });
+        }
+      }
+      WeakUnref(DEBUG_LOCATION, "subchannel map cleanup");
+    });
   }
 
   void WatchConnectivityState(

--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -453,12 +453,11 @@ void Subchannel::ConnectivityStateWatcherList::RemoveWatcherLocked(
 void Subchannel::ConnectivityStateWatcherList::NotifyLocked(
     grpc_connectivity_state state, const absl::Status& status) {
   for (const auto& watcher : watchers_) {
-    subchannel_->work_serializer_.Run(
-        [watcher = watcher->Ref(), state, status]() mutable {
-          auto* watcher_ptr = watcher.get();
-          watcher_ptr->OnConnectivityStateChange(std::move(watcher), state,
-                                                 status);
-        });
+    subchannel_->work_serializer_.Run([watcher = watcher->Ref(), state,
+                                       status]() mutable {
+      auto* watcher_ptr = watcher.get();
+      watcher_ptr->OnConnectivityStateChange(std::move(watcher), state, status);
+    });
   }
 }
 

--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -458,8 +458,7 @@ void Subchannel::ConnectivityStateWatcherList::NotifyLocked(
           auto* watcher_ptr = watcher.get();
           watcher_ptr->OnConnectivityStateChange(std::move(watcher), state,
                                                  status);
-        },
-        DEBUG_LOCATION);
+        });
   }
 }
 

--- a/src/core/lib/transport/connectivity_state.cc
+++ b/src/core/lib/transport/connectivity_state.cc
@@ -59,8 +59,7 @@ class AsyncConnectivityStateWatcherInterface::Notifier {
       : watcher_(std::move(watcher)), state_(state), status_(status) {
     if (work_serializer != nullptr) {
       work_serializer->Run(
-          [this]() { SendNotification(this, absl::OkStatus()); },
-          DEBUG_LOCATION);
+          [this]() { SendNotification(this, absl::OkStatus()); });
     } else {
       GRPC_CLOSURE_INIT(&closure_, SendNotification, this,
                         grpc_schedule_on_exec_ctx);

--- a/src/core/load_balancing/grpclb/grpclb.cc
+++ b/src/core/load_balancing/grpclb/grpclb.cc
@@ -329,8 +329,7 @@ class GrpcLb final : public LoadBalancingPolicy {
               self->lb_policy_->CacheDeletedSubchannelLocked(
                   self->wrapped_subchannel());
             }
-          },
-          DEBUG_LOCATION);
+          });
     }
 
     RefCountedPtr<GrpcLb> lb_policy_;
@@ -1018,7 +1017,7 @@ void GrpcLb::BalancerCallState::ScheduleNextClientLoadReportLocked() {
             ApplicationCallbackExecCtx callback_exec_ctx;
             ExecCtx exec_ctx;
             grpclb_policy()->work_serializer()->Run(
-                [this] { MaybeSendClientLoadReportLocked(); }, DEBUG_LOCATION);
+                [this] { MaybeSendClientLoadReportLocked(); });
           });
 }
 
@@ -1091,8 +1090,7 @@ void GrpcLb::BalancerCallState::ClientLoadReportDone(void* arg,
                                                      grpc_error_handle error) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   lb_calld->grpclb_policy()->work_serializer()->Run(
-      [lb_calld, error]() { lb_calld->ClientLoadReportDoneLocked(error); },
-      DEBUG_LOCATION);
+      [lb_calld, error]() { lb_calld->ClientLoadReportDoneLocked(error); });
 }
 
 void GrpcLb::BalancerCallState::ClientLoadReportDoneLocked(
@@ -1110,7 +1108,7 @@ void GrpcLb::BalancerCallState::OnInitialRequestSent(
     void* arg, grpc_error_handle /*error*/) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   lb_calld->grpclb_policy()->work_serializer()->Run(
-      [lb_calld]() { lb_calld->OnInitialRequestSentLocked(); }, DEBUG_LOCATION);
+      [lb_calld]() { lb_calld->OnInitialRequestSentLocked(); });
 }
 
 void GrpcLb::BalancerCallState::OnInitialRequestSentLocked() {
@@ -1129,8 +1127,7 @@ void GrpcLb::BalancerCallState::OnBalancerMessageReceived(
     void* arg, grpc_error_handle /*error*/) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   lb_calld->grpclb_policy()->work_serializer()->Run(
-      [lb_calld]() { lb_calld->OnBalancerMessageReceivedLocked(); },
-      DEBUG_LOCATION);
+      [lb_calld]() { lb_calld->OnBalancerMessageReceivedLocked(); });
 }
 
 void GrpcLb::BalancerCallState::OnBalancerMessageReceivedLocked() {
@@ -1287,8 +1284,7 @@ void GrpcLb::BalancerCallState::OnBalancerStatusReceived(
     void* arg, grpc_error_handle error) {
   BalancerCallState* lb_calld = static_cast<BalancerCallState*>(arg);
   lb_calld->grpclb_policy()->work_serializer()->Run(
-      [lb_calld, error]() { lb_calld->OnBalancerStatusReceivedLocked(error); },
-      DEBUG_LOCATION);
+      [lb_calld, error]() { lb_calld->OnBalancerStatusReceivedLocked(error); });
 }
 
 void GrpcLb::BalancerCallState::OnBalancerStatusReceivedLocked(
@@ -1557,9 +1553,9 @@ absl::Status GrpcLb::UpdateLocked(UpdateArgs args) {
               ApplicationCallbackExecCtx callback_exec_ctx;
               ExecCtx exec_ctx;
               auto self_ptr = self.get();
-              self_ptr->work_serializer()->Run(
-                  [self = std::move(self)]() { self->OnFallbackTimerLocked(); },
-                  DEBUG_LOCATION);
+              self_ptr->work_serializer()->Run([self = std::move(self)]() {
+                self->OnFallbackTimerLocked();
+              });
             });
     // Start watching the channel's connectivity state.  If the channel
     // goes into state TRANSIENT_FAILURE before the timer fires, we go into
@@ -1666,11 +1662,9 @@ void GrpcLb::StartBalancerCallRetryTimerLocked() {
             ApplicationCallbackExecCtx callback_exec_ctx;
             ExecCtx exec_ctx;
             auto self_ptr = self.get();
-            self_ptr->work_serializer()->Run(
-                [self = std::move(self)]() {
-                  self->OnBalancerCallRetryTimerLocked();
-                },
-                DEBUG_LOCATION);
+            self_ptr->work_serializer()->Run([self = std::move(self)]() {
+              self->OnBalancerCallRetryTimerLocked();
+            });
           });
 }
 
@@ -1831,8 +1825,7 @@ void GrpcLb::StartSubchannelCacheTimerLocked() {
             self_ptr->work_serializer()->Run(
                 [self = std::move(self)]() mutable {
                   self->OnSubchannelCacheTimerLocked();
-                },
-                DEBUG_LOCATION);
+                });
           });
 }
 

--- a/src/core/load_balancing/lb_policy.cc
+++ b/src/core/load_balancing/lb_policy.cc
@@ -79,12 +79,10 @@ LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
                  GRPC_CLOSURE_CREATE(
                      [](void* arg, grpc_error_handle /*error*/) {
                        auto* parent = static_cast<LoadBalancingPolicy*>(arg);
-                       parent->work_serializer()->Run(
-                           [parent]() {
-                             parent->ExitIdleLocked();
-                             parent->Unref();
-                           },
-                           DEBUG_LOCATION);
+                       parent->work_serializer()->Run([parent]() {
+                         parent->ExitIdleLocked();
+                         parent->Unref();
+                       });
                      },
                      parent, nullptr),
                  absl::OkStatus());

--- a/src/core/load_balancing/outlier_detection/outlier_detection.cc
+++ b/src/core/load_balancing/outlier_detection/outlier_detection.cc
@@ -215,13 +215,11 @@ class OutlierDetectionLb final : public LoadBalancingPolicy {
     };
 
     void Orphaned() override {
-      work_serializer_->Run(
-          [self = WeakRefAsSubclass<SubchannelWrapper>()]() {
-            if (self->subchannel_state_ != nullptr) {
-              self->subchannel_state_->RemoveSubchannel(self.get());
-            }
-          },
-          DEBUG_LOCATION);
+      work_serializer_->Run([self = WeakRefAsSubclass<SubchannelWrapper>()]() {
+        if (self->subchannel_state_ != nullptr) {
+          self->subchannel_state_->RemoveSubchannel(self.get());
+        }
+      });
     }
 
     std::shared_ptr<WorkSerializer> work_serializer_;
@@ -838,8 +836,7 @@ OutlierDetectionLb::EjectionTimer::EjectionTimer(
         ExecCtx exec_ctx;
         auto self_ptr = self.get();
         self_ptr->parent_->work_serializer()->Run(
-            [self = std::move(self)]() { self->OnTimerLocked(); },
-            DEBUG_LOCATION);
+            [self = std::move(self)]() { self->OnTimerLocked(); });
       });
 }
 

--- a/src/core/load_balancing/pick_first/pick_first.cc
+++ b/src/core/load_balancing/pick_first/pick_first.cc
@@ -973,8 +973,7 @@ void PickFirst::SubchannelList::SubchannelData::RequestConnectionWithTimer() {
                     if (subchannel_list->policy_->selected_ != nullptr) return;
                     ++subchannel_list->attempting_index_;
                     subchannel_list->StartConnectingNextSubchannel();
-                  },
-                  DEBUG_LOCATION);
+                  });
             });
   }
 }
@@ -1854,8 +1853,7 @@ void OldPickFirst::SubchannelList::SubchannelData::
                     if (subchannel_list->policy_->selected_ != nullptr) return;
                     ++subchannel_list->attempting_index_;
                     subchannel_list->StartConnectingNextSubchannel();
-                  },
-                  DEBUG_LOCATION);
+                  });
             });
   }
 }

--- a/src/core/load_balancing/priority/priority.cc
+++ b/src/core/load_balancing/priority/priority.cc
@@ -507,8 +507,7 @@ PriorityLb::ChildPriority::DeactivationTimer::DeactivationTimer(
             ExecCtx exec_ctx;
             auto self_ptr = self.get();
             self_ptr->child_priority_->priority_policy_->work_serializer()->Run(
-                [self = std::move(self)]() { self->OnTimerLocked(); },
-                DEBUG_LOCATION);
+                [self = std::move(self)]() { self->OnTimerLocked(); });
           });
 }
 
@@ -560,8 +559,8 @@ PriorityLb::ChildPriority::FailoverTimer::FailoverTimer(
                 ExecCtx exec_ctx;
                 auto self_ptr = self.get();
                 self_ptr->child_priority_->priority_policy_->work_serializer()
-                    ->Run([self = std::move(self)]() { self->OnTimerLocked(); },
-                          DEBUG_LOCATION);
+                    ->Run(
+                        [self = std::move(self)]() { self->OnTimerLocked(); });
               });
 }
 

--- a/src/core/load_balancing/ring_hash/ring_hash.cc
+++ b/src/core/load_balancing/ring_hash/ring_hash.cc
@@ -276,14 +276,12 @@ class RingHash final : public LoadBalancingPolicy {
      private:
       static void RunInExecCtx(void* arg, grpc_error_handle /*error*/) {
         auto* self = static_cast<EndpointConnectionAttempter*>(arg);
-        self->ring_hash_->work_serializer()->Run(
-            [self]() {
-              if (!self->ring_hash_->shutdown_) {
-                self->endpoint_->RequestConnectionLocked();
-              }
-              delete self;
-            },
-            DEBUG_LOCATION);
+        self->ring_hash_->work_serializer()->Run([self]() {
+          if (!self->ring_hash_->shutdown_) {
+            self->endpoint_->RequestConnectionLocked();
+          }
+          delete self;
+        });
       }
 
       RefCountedPtr<RingHash> ring_hash_;

--- a/src/core/load_balancing/rls/rls.cc
+++ b/src/core/load_balancing/rls/rls.cc
@@ -1057,8 +1057,7 @@ RlsLb::Cache::Entry::BackoffTimer::BackoffTimer(RefCountedPtr<Entry> entry,
             ExecCtx exec_ctx;
             auto self_ptr = self.get();
             self_ptr->entry_->lb_policy_->work_serializer()->Run(
-                [self = std::move(self)]() { self->OnBackoffTimerLocked(); },
-                DEBUG_LOCATION);
+                [self = std::move(self)]() { self->OnBackoffTimerLocked(); });
           });
 }
 
@@ -1392,8 +1391,7 @@ void RlsLb::Cache::StartCleanupTimer() {
                 [this, lb_policy = std::move(lb_policy)]() {
                   // The lb_policy ref is held until the callback completes
                   OnCleanupTimer();
-                },
-                DEBUG_LOCATION);
+                });
           });
 }
 
@@ -1661,12 +1659,10 @@ void RlsLb::RlsRequest::Orphan() {
 
 void RlsLb::RlsRequest::StartCall(void* arg, grpc_error_handle /*error*/) {
   auto* request = static_cast<RlsRequest*>(arg);
-  request->lb_policy_->work_serializer()->Run(
-      [request]() {
-        request->StartCallLocked();
-        request->Unref(DEBUG_LOCATION, "StartCall");
-      },
-      DEBUG_LOCATION);
+  request->lb_policy_->work_serializer()->Run([request]() {
+    request->StartCallLocked();
+    request->Unref(DEBUG_LOCATION, "StartCall");
+  });
 }
 
 void RlsLb::RlsRequest::StartCallLocked() {
@@ -1714,12 +1710,10 @@ void RlsLb::RlsRequest::StartCallLocked() {
 
 void RlsLb::RlsRequest::OnRlsCallComplete(void* arg, grpc_error_handle error) {
   auto* request = static_cast<RlsRequest*>(arg);
-  request->lb_policy_->work_serializer()->Run(
-      [request, error]() {
-        request->OnRlsCallCompleteLocked(error);
-        request->Unref(DEBUG_LOCATION, "OnRlsCallComplete");
-      },
-      DEBUG_LOCATION);
+  request->lb_policy_->work_serializer()->Run([request, error]() {
+    request->OnRlsCallCompleteLocked(error);
+    request->Unref(DEBUG_LOCATION, "OnRlsCallComplete");
+  });
 }
 
 void RlsLb::RlsRequest::OnRlsCallCompleteLocked(grpc_error_handle error) {
@@ -2078,13 +2072,11 @@ void RlsLb::UpdatePickerAsync() {
 
 void RlsLb::UpdatePickerCallback(void* arg, grpc_error_handle /*error*/) {
   auto* rls_lb = static_cast<RlsLb*>(arg);
-  rls_lb->work_serializer()->Run(
-      [rls_lb]() {
-        RefCountedPtr<RlsLb> lb_policy(rls_lb);
-        lb_policy->UpdatePickerLocked();
-        lb_policy.reset(DEBUG_LOCATION, "UpdatePickerCallback");
-      },
-      DEBUG_LOCATION);
+  rls_lb->work_serializer()->Run([rls_lb]() {
+    RefCountedPtr<RlsLb> lb_policy(rls_lb);
+    lb_policy->UpdatePickerLocked();
+    lb_policy.reset(DEBUG_LOCATION, "UpdatePickerCallback");
+  });
 }
 
 void RlsLb::UpdatePickerLocked() {

--- a/src/core/load_balancing/weighted_target/weighted_target.cc
+++ b/src/core/load_balancing/weighted_target/weighted_target.cc
@@ -470,8 +470,7 @@ WeightedTargetLb::WeightedChild::DelayedRemovalTimer::DelayedRemovalTimer(
             auto* self_ptr = self.get();  // Avoid use-after-move problem.
             self_ptr->weighted_child_->weighted_target_policy_
                 ->work_serializer()
-                ->Run([self = std::move(self)] { self->OnTimerLocked(); },
-                      DEBUG_LOCATION);
+                ->Run([self = std::move(self)] { self->OnTimerLocked(); });
           });
 }
 

--- a/src/core/load_balancing/xds/xds_cluster_manager.cc
+++ b/src/core/load_balancing/xds/xds_cluster_manager.cc
@@ -504,8 +504,7 @@ void XdsClusterManagerLb::ClusterChild::DeactivateLocked() {
                 self_ptr->xds_cluster_manager_policy_->work_serializer()->Run(
                     [self = std::move(self)]() {
                       self->OnDelayedRemovalTimerLocked();
-                    },
-                    DEBUG_LOCATION);
+                    });
               });
 }
 

--- a/src/core/load_balancing/xds/xds_override_host.cc
+++ b/src/core/load_balancing/xds/xds_override_host.cc
@@ -333,12 +333,10 @@ class XdsOverrideHostLb final : public LoadBalancingPolicy {
      private:
       static void RunInExecCtx(void* arg, grpc_error_handle /*error*/) {
         auto* self = static_cast<SubchannelConnectionRequester*>(arg);
-        self->subchannel_->policy()->work_serializer()->Run(
-            [self]() {
-              self->subchannel_->RequestConnection();
-              delete self;
-            },
-            DEBUG_LOCATION);
+        self->subchannel_->policy()->work_serializer()->Run([self]() {
+          self->subchannel_->RequestConnection();
+          delete self;
+        });
       }
 
       RefCountedPtr<SubchannelWrapper> subchannel_;
@@ -515,8 +513,7 @@ XdsOverrideHostLb::Picker::PickOverriddenHost(
         [policy = policy_,
          address = std::string(address_with_no_subchannel)]() {
           policy->CreateSubchannelForAddress(address);
-        },
-        DEBUG_LOCATION);
+        });
     return PickResult::Queue();
   }
   // No entry found that was not in TRANSIENT_FAILURE.
@@ -575,8 +572,7 @@ XdsOverrideHostLb::IdleTimer::IdleTimer(RefCountedPtr<XdsOverrideHostLb> policy,
         ExecCtx exec_ctx;
         auto self_ptr = self.get();
         self_ptr->policy_->work_serializer()->Run(
-            [self = std::move(self)]() { self->OnTimerLocked(); },
-            DEBUG_LOCATION);
+            [self = std::move(self)]() { self->OnTimerLocked(); });
       });
 }
 
@@ -1038,8 +1034,7 @@ void XdsOverrideHostLb::SubchannelWrapper::Orphaned() {
           self->subchannel_entry_->OnSubchannelWrapperOrphan(
               self.get(), self->policy()->connection_idle_timeout_);
         }
-      },
-      DEBUG_LOCATION);
+      });
 }
 
 void XdsOverrideHostLb::SubchannelWrapper::UpdateConnectivityState(

--- a/src/core/resolver/fake/fake_resolver.cc
+++ b/src/core/resolver/fake/fake_resolver.cc
@@ -159,16 +159,15 @@ void FakeResolverResponseGenerator::SendResultToResolver(
     RefCountedPtr<FakeResolver> resolver, Resolver::Result result,
     Notification* notify_when_set) {
   auto* resolver_ptr = resolver.get();
-  resolver_ptr->work_serializer_->Run(
-      [resolver = std::move(resolver), result = std::move(result),
-       notify_when_set]() mutable {
-        if (!resolver->shutdown_) {
-          resolver->next_result_ = std::move(result);
-          resolver->MaybeSendResultLocked();
-        }
-        if (notify_when_set != nullptr) notify_when_set->Notify();
-      },
-      DEBUG_LOCATION);
+  resolver_ptr->work_serializer_->Run([resolver = std::move(resolver),
+                                       result = std::move(result),
+                                       notify_when_set]() mutable {
+    if (!resolver->shutdown_) {
+      resolver->next_result_ = std::move(result);
+      resolver->MaybeSendResultLocked();
+    }
+    if (notify_when_set != nullptr) notify_when_set->Notify();
+  });
 }
 
 bool FakeResolverResponseGenerator::WaitForResolverSet(absl::Duration timeout) {

--- a/src/core/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/resolver/google_c2p/google_c2p_resolver.cc
@@ -160,8 +160,7 @@ void GoogleCloud2ProdResolver::StartLocked() {
             [resolver, result = std::move(result)]() mutable {
               resolver->ZoneQueryDone(result.ok() ? std::move(result).value()
                                                   : "");
-            },
-            DEBUG_LOCATION);
+            });
       },
       Duration::Seconds(10));
   ipv6_query_ = MakeOrphanable<GcpMetadataQuery>(
@@ -177,8 +176,7 @@ void GoogleCloud2ProdResolver::StartLocked() {
               // servers in the wild, which can in some cases return 200
               // plus an empty result when they should have returned 404.
               resolver->IPv6QueryDone(result.ok() && !result->empty());
-            },
-            DEBUG_LOCATION);
+            });
       },
       Duration::Seconds(10));
 }

--- a/src/core/resolver/google_c2p/google_c2p_resolver.cc
+++ b/src/core/resolver/google_c2p/google_c2p_resolver.cc
@@ -156,11 +156,10 @@ void GoogleCloud2ProdResolver::StartLocked() {
       [resolver = RefAsSubclass<GoogleCloud2ProdResolver>()](
           std::string /* attribute */,
           absl::StatusOr<std::string> result) mutable {
-        resolver->work_serializer_->Run(
-            [resolver, result = std::move(result)]() mutable {
-              resolver->ZoneQueryDone(result.ok() ? std::move(result).value()
-                                                  : "");
-            });
+        resolver->work_serializer_->Run([resolver,
+                                         result = std::move(result)]() mutable {
+          resolver->ZoneQueryDone(result.ok() ? std::move(result).value() : "");
+        });
       },
       Duration::Seconds(10));
   ipv6_query_ = MakeOrphanable<GcpMetadataQuery>(

--- a/src/core/resolver/polling_resolver.cc
+++ b/src/core/resolver/polling_resolver.cc
@@ -110,8 +110,7 @@ void PollingResolver::ScheduleNextResolutionTimer(Duration delay) {
             ExecCtx exec_ctx;
             auto* self_ptr = self.get();
             self_ptr->work_serializer_->Run(
-                [self = std::move(self)]() { self->OnNextResolutionLocked(); },
-                DEBUG_LOCATION);
+                [self = std::move(self)]() { self->OnNextResolutionLocked(); });
           });
 }
 
@@ -142,8 +141,7 @@ void PollingResolver::MaybeCancelNextResolutionTimer() {
 void PollingResolver::OnRequestComplete(Result result) {
   Ref(DEBUG_LOCATION, "OnRequestComplete").release();
   work_serializer_->Run(
-      [this, result]() mutable { OnRequestCompleteLocked(std::move(result)); },
-      DEBUG_LOCATION);
+      [this, result]() mutable { OnRequestCompleteLocked(std::move(result)); });
 }
 
 void PollingResolver::OnRequestCompleteLocked(Result result) {

--- a/src/core/resolver/xds/xds_dependency_manager.cc
+++ b/src/core/resolver/xds/xds_dependency_manager.cc
@@ -68,8 +68,7 @@ class XdsDependencyManager::ListenerWatcher final
         [dependency_mgr = dependency_mgr_, status = std::move(status),
          read_delay_handle = std::move(read_delay_handle)]() mutable {
           dependency_mgr->OnListenerAmbientError(std::move(status));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -97,8 +96,7 @@ class XdsDependencyManager::RouteConfigWatcher final
          read_delay_handle = std::move(read_delay_handle)]() mutable {
           self->dependency_mgr_->OnRouteConfigUpdate(self->name_,
                                                      std::move(route_config));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
   void OnAmbientError(
@@ -109,8 +107,7 @@ class XdsDependencyManager::RouteConfigWatcher final
          read_delay_handle = std::move(read_delay_handle)]() mutable {
           self->dependency_mgr_->OnRouteConfigAmbientError(self->name_,
                                                            std::move(status));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -137,8 +134,7 @@ class XdsDependencyManager::ClusterWatcher final
          read_delay_handle = std::move(read_delay_handle)]() mutable {
           self->dependency_mgr_->OnClusterUpdate(self->name_,
                                                  std::move(cluster));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
   void OnAmbientError(
@@ -149,8 +145,7 @@ class XdsDependencyManager::ClusterWatcher final
          read_delay_handle = std::move(read_delay_handle)]() mutable {
           self->dependency_mgr_->OnClusterAmbientError(self->name_,
                                                        std::move(status));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -190,8 +185,7 @@ class XdsDependencyManager::EndpointWatcher final
          read_delay_handle = std::move(read_delay_handle)]() mutable {
           self->dependency_mgr_->OnEndpointAmbientError(self->name_,
                                                         std::move(status));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -215,8 +209,7 @@ class XdsDependencyManager::DnsResultHandler final
         [dependency_mgr = dependency_mgr_, name = name_,
          result = std::move(result)]() mutable {
           dependency_mgr->OnDnsResult(name, std::move(result));
-        },
-        DEBUG_LOCATION);
+        });
   }
 
  private:
@@ -229,12 +222,10 @@ class XdsDependencyManager::DnsResultHandler final
 //
 
 void XdsDependencyManager::ClusterSubscription::Orphaned() {
-  dependency_mgr_->work_serializer_->Run(
-      [self = WeakRef()]() {
-        self->dependency_mgr_->OnClusterSubscriptionUnref(self->cluster_name_,
-                                                          self.get());
-      },
-      DEBUG_LOCATION);
+  dependency_mgr_->work_serializer_->Run([self = WeakRef()]() {
+    self->dependency_mgr_->OnClusterSubscriptionUnref(self->cluster_name_,
+                                                      self.get());
+  });
 }
 
 //

--- a/src/core/resolver/xds/xds_resolver.cc
+++ b/src/core/resolver/xds/xds_resolver.cc
@@ -164,11 +164,9 @@ class XdsResolver final : public Resolver {
 
     void Orphaned() override {
       XdsResolver* resolver_ptr = resolver_.get();
-      resolver_ptr->work_serializer_->Run(
-          [resolver = std::move(resolver_)]() {
-            resolver->MaybeRemoveUnusedClusters();
-          },
-          DEBUG_LOCATION);
+      resolver_ptr->work_serializer_->Run([resolver = std::move(resolver_)]() {
+        resolver->MaybeRemoveUnusedClusters();
+      });
       cluster_subscription_.reset();
     }
 
@@ -633,11 +631,9 @@ XdsResolver::XdsConfigSelector::~XdsConfigSelector() {
       << "[xds_resolver " << resolver_.get()
       << "] destroying XdsConfigSelector " << this;
   route_config_data_.reset();
-  resolver_->work_serializer_->Run(
-      [resolver = std::move(resolver_)]() {
-        resolver->MaybeRemoveUnusedClusters();
-      },
-      DEBUG_LOCATION);
+  resolver_->work_serializer_->Run([resolver = std::move(resolver_)]() {
+    resolver->MaybeRemoveUnusedClusters();
+  });
 }
 
 std::optional<uint64_t> HeaderHashHelper(

--- a/src/core/util/work_serializer.cc
+++ b/src/core/util/work_serializer.cc
@@ -61,7 +61,7 @@ class WorkSerializer::WorkSerializerImpl
       std::shared_ptr<grpc_event_engine::experimental::EventEngine>
           event_engine)
       : event_engine_(std::move(event_engine)) {}
-  void Run(std::function<void()> callback, const DebugLocation& location);
+  void Run(absl::AnyInvocable<void()> callback, DebugLocation location);
   void Run() override;
   void Orphan() override;
 
@@ -73,9 +73,10 @@ class WorkSerializer::WorkSerializerImpl
  private:
   // Wrapper to capture DebugLocation for the callback.
   struct CallbackWrapper {
-    CallbackWrapper(std::function<void()> cb, const DebugLocation& loc)
-        : callback(std::move(cb)), location(loc) {}
-    std::function<void()> callback;
+    CallbackWrapper(absl::AnyInvocable<void()>&& cb, const DebugLocation& loc)
+        : callback(std::forward<absl::AnyInvocable<void()>>(cb)),
+          location(loc) {}
+    absl::AnyInvocable<void()> callback;
     // GPR_NO_UNIQUE_ADDRESS means this is 0 sized in release builds.
     GPR_NO_UNIQUE_ADDRESS DebugLocation location;
   };
@@ -160,8 +161,8 @@ void WorkSerializer::WorkSerializerImpl::Orphan() {
 }
 
 // Implementation of WorkSerializerImpl::Run
-void WorkSerializer::WorkSerializerImpl::Run(std::function<void()> callback,
-                                             const DebugLocation& location) {
+void WorkSerializer::WorkSerializerImpl::Run(
+    absl::AnyInvocable<void()> callback, DebugLocation location) {
   GRPC_TRACE_LOG(work_serializer, INFO)
       << "WorkSerializer[" << this << "] Scheduling callback ["
       << location.file() << ":" << location.line() << "]";
@@ -284,8 +285,8 @@ WorkSerializer::WorkSerializer(
 
 WorkSerializer::~WorkSerializer() = default;
 
-void WorkSerializer::Run(std::function<void()> callback,
-                         const DebugLocation& location) {
+void WorkSerializer::Run(absl::AnyInvocable<void()> callback,
+                         DebugLocation location) {
   impl_->Run(std::move(callback), location);
 }
 

--- a/src/core/util/work_serializer.h
+++ b/src/core/util/work_serializer.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/functional/any_invocable.h"
 #include "src/core/util/debug_location.h"
 #include "src/core/util/orphanable.h"
 
@@ -62,7 +63,7 @@ class ABSL_LOCKABLE WorkSerializer {
   //         }, DEBUG_LOCATION);
   //   }
   //   void callback() ABSL_EXCLUSIVE_LOCKS_REQUIRED(work_serializer) { ... }
-  void Run(std::function<void()> callback, const DebugLocation& location);
+  void Run(absl::AnyInvocable<void()> callback, DebugLocation location = {});
 
 #ifndef NDEBUG
   // Returns true if the current thread is running in the WorkSerializer.

--- a/test/core/client_channel/bm_client_channel.cc
+++ b/test/core/client_channel/bm_client_channel.cc
@@ -121,12 +121,10 @@ class TestResolver final : public Resolver {
         work_serializer_(std::move(work_serializer)) {}
 
   void StartLocked() override {
-    work_serializer_->Run(
-        [self = RefAsSubclass<TestResolver>()] {
-          self->result_handler_->ReportResult(
-              self->MakeSuccessfulResolutionResult("ipv4:127.0.0.1:1234"));
-        },
-        DEBUG_LOCATION);
+    work_serializer_->Run([self = RefAsSubclass<TestResolver>()] {
+      self->result_handler_->ReportResult(
+          self->MakeSuccessfulResolutionResult("ipv4:127.0.0.1:1234"));
+    });
   }
   void ShutdownLocked() override {}
 

--- a/test/core/client_channel/client_channel_test.cc
+++ b/test/core/client_channel/client_channel_test.cc
@@ -190,12 +190,10 @@ class ClientChannelTest : public YodelTest {
 
     void QueueNameResolutionResult(Resolver::Result result) {
       result.args = result.args.UnionWith(args_);
-      work_serializer_->Run(
-          [self = RefAsSubclass<TestResolver>(),
-           result = std::move(result)]() mutable {
-            self->result_handler_->ReportResult(std::move(result));
-          },
-          DEBUG_LOCATION);
+      work_serializer_->Run([self = RefAsSubclass<TestResolver>(),
+                             result = std::move(result)]() mutable {
+        self->result_handler_->ReportResult(std::move(result));
+      });
     }
 
    private:

--- a/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
+++ b/test/core/ext/filters/event_engine_client_channel_resolver/resolver_fuzzer.cc
@@ -266,10 +266,10 @@ void Fuzz(const event_engine_client_channel_resolver::Msg& msg) {
             .Set(GRPC_INTERNAL_ARG_EVENT_ENGINE, engine),
         &done_resolving, work_serializer);
     auto resolver = resolver_factory.CreateResolver(std::move(resolver_args));
-    work_serializer->Run(
-        [resolver_ptr = resolver.get()]() ABSL_EXCLUSIVE_LOCKS_REQUIRED(
-            *work_serializer) { resolver_ptr->StartLocked(); },
-        DEBUG_LOCATION);
+    work_serializer->Run([resolver_ptr = resolver.get()]()
+                             ABSL_EXCLUSIVE_LOCKS_REQUIRED(*work_serializer) {
+                               resolver_ptr->StartLocked();
+                             });
     // wait for result (no need to check validity)
     while (!done_resolving) {
       engine->Tick();

--- a/test/core/load_balancing/bm_picker.cc
+++ b/test/core/load_balancing/bm_picker.cc
@@ -80,8 +80,7 @@ class BenchmarkHelper : public std::enable_shared_from_this<BenchmarkHelper> {
                 std::make_shared<EndpointAddressesListIterator>(
                     std::move(addresses)),
                 config_, "", ChannelArgs()}));
-          },
-          DEBUG_LOCATION);
+          });
     }
   }
 
@@ -130,12 +129,10 @@ class BenchmarkHelper : public std::enable_shared_from_this<BenchmarkHelper> {
         std::shared_ptr<ConnectivityStateWatcherInterface> watcher) {
       {
         MutexLock lock(&helper_->mu_);
-        helper_->work_serializer_->Run(
-            [watcher]() {
-              watcher->OnConnectivityStateChange(GRPC_CHANNEL_READY,
-                                                 absl::OkStatus());
-            },
-            DEBUG_LOCATION);
+        helper_->work_serializer_->Run([watcher]() {
+          watcher->OnConnectivityStateChange(GRPC_CHANNEL_READY,
+                                             absl::OkStatus());
+        });
         helper_->connectivity_watchers_.insert(std::move(watcher));
       }
     }

--- a/test/core/load_balancing/bm_picker.cc
+++ b/test/core/load_balancing/bm_picker.cc
@@ -62,25 +62,23 @@ class BenchmarkHelper : public std::enable_shared_from_this<BenchmarkHelper> {
     {
       MutexLock lock(&mu_);
       picker_ = nullptr;
-      work_serializer_->Run(
-          [this, num_endpoints]() {
-            EndpointAddressesList addresses;
-            for (size_t i = 0; i < num_endpoints; i++) {
-              grpc_resolved_address addr;
-              int port = i % 65536;
-              int ip = i / 65536;
-              CHECK_LT(ip, 256);
-              CHECK(grpc_parse_uri(
-                  URI::Parse(absl::StrCat("ipv4:127.0.0.", ip, ":", port))
-                      .value(),
-                  &addr));
-              addresses.emplace_back(addr, ChannelArgs());
-            }
-            CHECK_OK(lb_policy_->UpdateLocked(LoadBalancingPolicy::UpdateArgs{
-                std::make_shared<EndpointAddressesListIterator>(
-                    std::move(addresses)),
-                config_, "", ChannelArgs()}));
-          });
+      work_serializer_->Run([this, num_endpoints]() {
+        EndpointAddressesList addresses;
+        for (size_t i = 0; i < num_endpoints; i++) {
+          grpc_resolved_address addr;
+          int port = i % 65536;
+          int ip = i / 65536;
+          CHECK_LT(ip, 256);
+          CHECK(grpc_parse_uri(
+              URI::Parse(absl::StrCat("ipv4:127.0.0.", ip, ":", port)).value(),
+              &addr));
+          addresses.emplace_back(addr, ChannelArgs());
+        }
+        CHECK_OK(lb_policy_->UpdateLocked(LoadBalancingPolicy::UpdateArgs{
+            std::make_shared<EndpointAddressesListIterator>(
+                std::move(addresses)),
+            config_, "", ChannelArgs()}));
+      });
     }
   }
 

--- a/test/core/load_balancing/pick_first_test.cc
+++ b/test/core/load_balancing/pick_first_test.cc
@@ -466,22 +466,18 @@ TEST_F(PickFirstTest, ResolverUpdateBeforeLeavingIdle) {
         // exit idle, so that the second update gets run before the initial
         // subchannel connectivity state notifications from the first update
         // are delivered.
-        work_serializer_->Run(
-            [&]() {
-              // Second update.
-              absl::Status status = lb_policy()->UpdateLocked(
-                  BuildUpdate(kNewAddresses, MakePickFirstConfig(false)));
-              EXPECT_TRUE(status.ok()) << status;
-              // Trigger notification once all connectivity state
-              // notifications have been delivered.
-              work_serializer_->Run([&]() { notification.Notify(); },
-                                    DEBUG_LOCATION);
-            },
-            DEBUG_LOCATION);
+        work_serializer_->Run([&]() {
+          // Second update.
+          absl::Status status = lb_policy()->UpdateLocked(
+              BuildUpdate(kNewAddresses, MakePickFirstConfig(false)));
+          EXPECT_TRUE(status.ok()) << status;
+          // Trigger notification once all connectivity state
+          // notifications have been delivered.
+          work_serializer_->Run([&]() { notification.Notify(); });
+        });
         // Exit idle.
         lb_policy()->ExitIdleLocked();
-      },
-      DEBUG_LOCATION);
+      });
   while (!notification.HasBeenNotified()) {
     fuzzing_ee_->Tick();
   }

--- a/test/core/resolver/dns_resolver_cooldown_test.cc
+++ b/test/core/resolver/dns_resolver_cooldown_test.cc
@@ -398,9 +398,9 @@ static void test_cooldown() {
   OnResolutionCallbackArg* res_cb_arg = new OnResolutionCallbackArg();
   res_cb_arg->uri_str = "dns:127.0.0.1";
 
-  (*g_work_serializer)
-      ->Run([res_cb_arg]() { start_test_under_work_serializer(res_cb_arg); },
-            DEBUG_LOCATION);
+  (*g_work_serializer)->Run([res_cb_arg]() {
+    start_test_under_work_serializer(res_cb_arg);
+  });
   grpc_core::ExecCtx::Get()->Flush();
   poll_pollset_until_request_done(&g_iomgr_args);
   iomgr_args_finish(&g_iomgr_args);

--- a/test/core/resolver/fake_resolver_test.cc
+++ b/test/core/resolver/fake_resolver_test.cc
@@ -130,12 +130,10 @@ class FakeResolverTest : public ::testing::Test {
 
   void RunSynchronously(std::function<void()> callback) {
     Notification notification;
-    work_serializer_->Run(
-        [callback = std::move(callback), &notification]() {
-          callback();
-          notification.Notify();
-        },
-        DEBUG_LOCATION);
+    work_serializer_->Run([callback = std::move(callback), &notification]() {
+      callback();
+      notification.Notify();
+    });
     notification.WaitForNotification();
   }
 

--- a/test/core/util/work_serializer_test.cc
+++ b/test/core/util/work_serializer_test.cc
@@ -59,8 +59,7 @@ TEST(WorkSerializerTest, ExecuteOneRun) {
   auto lock = std::make_unique<WorkSerializer>(GetDefaultEventEngine());
   gpr_event done;
   gpr_event_init(&done);
-  lock->Run([&done]() { gpr_event_set(&done, reinterpret_cast<void*>(1)); },
-            DEBUG_LOCATION);
+  lock->Run([&done]() { gpr_event_set(&done, reinterpret_cast<void*>(1)); });
   EXPECT_TRUE(gpr_event_wait(&done, grpc_timeout_seconds_to_deadline(5)) !=
               nullptr);
   lock.reset();
@@ -225,7 +224,7 @@ TEST(WorkSerializerTest, ExecuteManyMixedRunScheduleAndDrain) {
 // Tests that work serializers allow destruction from the last callback
 TEST(WorkSerializerTest, CallbackDestroysWorkSerializer) {
   auto lock = std::make_shared<WorkSerializer>(GetDefaultEventEngine());
-  lock->Run([&]() { lock.reset(); }, DEBUG_LOCATION);
+  lock->Run([&]() { lock.reset(); });
   WaitForSingleOwner(GetDefaultEventEngine());
 }
 
@@ -239,7 +238,7 @@ TEST(WorkSerializerTest, WorkSerializerDestructionRace) {
       notification.WaitForNotification();
       lock.reset();
     });
-    lock->Run([&]() { notification.Notify(); }, DEBUG_LOCATION);
+    lock->Run([&]() { notification.Notify(); });
     t1.join();
   }
   WaitForSingleOwner(GetDefaultEventEngine());
@@ -255,7 +254,7 @@ TEST(WorkSerializerTest, WorkSerializerDestructionRaceMultipleThreads) {
   for (int i = 0; i < 10; ++i) {
     threads.emplace_back([lock, &barrier]() mutable {
       barrier.Block();
-      lock->Run([lock]() mutable { lock.reset(); }, DEBUG_LOCATION);
+      lock->Run([lock]() mutable { lock.reset(); });
     });
   }
   barrier.Block();
@@ -407,8 +406,8 @@ TEST(WorkSerializerTest, RunningInWorkSerializer) {
   EXPECT_FALSE(work_serializer2->RunningInWorkSerializer());
   Notification done1;
   Notification done2;
-  work_serializer1->Run([&done1]() { done1.Notify(); }, DEBUG_LOCATION);
-  work_serializer2->Run([&done2]() { done2.Notify(); }, DEBUG_LOCATION);
+  work_serializer1->Run([&done1]() { done1.Notify(); });
+  work_serializer2->Run([&done2]() { done2.Notify(); });
   done1.WaitForNotification();
   done2.WaitForNotification();
   work_serializer1.reset();

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -116,7 +116,7 @@ void DoNothing(void* /*arg*/, grpc_error_handle /*error*/) {}
 
 void ArgsFinish(ArgsStruct* args) {
   grpc_core::Notification notification;
-  args->lock->Run([&notification]() { notification.Notify(); }, DEBUG_LOCATION);
+  args->lock->Run([&notification]() { notification.Notify(); });
   args->lock.reset();
   notification.WaitForNotification();
   grpc_pollset_set_del_pollset(args->pollset_set, args->pollset);

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -505,8 +505,7 @@ void RunResolvesRelevantRecordsTest(
           whole_uri.c_str(), resolver_args, args.pollset_set, args.lock,
           CreateResultHandler(&args));
   auto* resolver_ptr = resolver.get();
-  args.lock->Run([resolver_ptr]() { StartResolvingLocked(resolver_ptr); },
-                 DEBUG_LOCATION);
+  args.lock->Run([resolver_ptr]() { StartResolvingLocked(resolver_ptr); });
   grpc_core::ExecCtx::Get()->Flush();
   PollPollsetUntilRequestDone(&args);
   ArgsFinish(&args);


### PR DESCRIPTION
Move callback from `std::function` --> `absl::AnyInvocable` to enable move-only callbacks, and remove the requirement to pass a `DebugLocation` - since we can synthesize this with a default argument - which cleans up a lot of visual noise across the codebase.