### PR TITLE
[Build] Updated bzlmod again

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,6 +26,8 @@ bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
 bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
 bazel_dep(name = "envoy_api", version = "0.0.0-20250128-4de3c74")
 bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
+bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name = "io_opencensus_cpp")
 bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")  # mistmached 1.18.0
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
@@ -35,12 +37,6 @@ bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
 bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
-
-grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
-use_repo(
-    grpc_repo_deps_ext,
-    "google_cloud_cpp",
-)
 
 switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
 switched_rules.use_languages(

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -28,6 +28,8 @@
     bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
     bazel_dep(name = "envoy_api", version = "0.0.0-20250128-4de3c74")
     bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
+    bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+    bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name = "io_opencensus_cpp")
     bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")  # mistmached 1.18.0
     bazel_dep(name = "platforms", version = "0.0.10")
     bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
@@ -37,12 +39,6 @@
     bazel_dep(name = "rules_proto", version = "7.0.2")
     bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
     bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
-
-    grpc_repo_deps_ext = use_extension("//bazel:grpc_deps.bzl", "grpc_repo_deps_ext")
-    use_repo(
-        grpc_repo_deps_ext,
-        "google_cloud_cpp",
-    )
 
     switched_rules = use_extension("@com_google_googleapis//:extensions.bzl", "switched_rules")
     switched_rules.use_languages(

--- a/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
@@ -32,4 +32,4 @@ tools/bazel \
     :grpcpp_csds \
     :grpcpp_orca_service \
     :grpcpp_gcp_observability
-    :grpcpp_csm_observability  # Needed google_cloud_cpp to be added to BCR
+    # :grpcpp_csm_observability  # Needed google_cloud_cpp to be added to BCR

--- a/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
@@ -21,5 +21,15 @@ tools/bazel \
     --enable_workspace=false \
     :grpc \
     :grpc_unsecure \
+    :grpc_opencensus_plugin \
+    :grpc_security_base \
     :grpc++ \
-    :grpc++_unsecure
+    :grpc++_unsecure \
+    :grpc++_reflection \
+    :grpc++_test \
+    :grpcpp_admin \
+    :grpcpp_channelz \
+    :grpcpp_csds \
+    :grpcpp_orca_service \
+    :grpcpp_gcp_observability
+    :grpcpp_csm_observability  # Needed google_cloud_cpp to be added to BCR


### PR DESCRIPTION
A few changes to address comments from https://github.com/bazelbuild/bazel-central-registry/pull/3671

- Reintroduced a few more dependencies in the gRPC Bazel modules since those turned out to be required for some public gRPC targets (e.g. `googletest` is needed for `grpc++_test`)
- Removed `google_cloud_cpp` from the dependency as it's not yet registered to BCR and using it sometimes causes strange problems.
- Added a few public Bazel targets to `bazel_build_with_bzlmod_linux.sh` to make sure those are actually buildable.

Following-up of https://github.com/grpc/grpc/pull/38626