### PR TITLE
Update return value of server_unary_response

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -247,6 +247,7 @@ module GRPC
 
       @call.run_batch(ops)
       set_output_stream_done
+      req
     end
 
     # remote_read reads a response from the remote endpoint.


### PR DESCRIPTION
Proposing an ergonomic change of returning the response in the return value of `server_unary_response`. This is useful when making a server interceptor that you want to log the response. Currently the yield block in this example always return nil, while after this change it will return the response object. Verified locally that this works.

```
  class ServerInterceptor < GRPC::ServerInterceptor
    extend T::Sig
    sig do
      params(
        request: T.untyped,
        call: GRPC::ActiveCall::SingleReqView,
        method: T.untyped
      ).returns(T.untyped)
    end
    def request_response(request:, call:, method:)
      begin
        response = yield
        # response is always nil
        ...
```

For context here's the upstream of how this method is called:
https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/generic/rpc_desc.rb#L77


