### PR TITLE
[Build] Some improvement to bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,9 @@ module(
     repo_name = "com_github_grpc_grpc",
 )
 
+# Regular dependencies
+# ====================
+
 bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
 bazel_dep(name = "apple_support", version = "1.17.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -44,6 +47,16 @@ switched_rules.use_languages(
     grpc = True,
     python = True,
 )
+
+# Development dependencies
+# ========================
+
+bazel_dep(name = "fuzztest", version = "20241028.0", repo_name = "com_google_fuzztest", dev_dependency=True)  # mistmached 2023-05-16
+bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark", dev_dependency=True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency=True)
+
+# Python dependencies
+# ===================
 
 bazel_dep(name = "rules_python", version = "0.37.1")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,9 +51,9 @@ switched_rules.use_languages(
 # Development dependencies
 # ========================
 
-bazel_dep(name = "fuzztest", version = "20241028.0", repo_name = "com_google_fuzztest", dev_dependency=True)  # mistmached 2023-05-16
-bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark", dev_dependency=True)
-bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency=True)
+bazel_dep(name = "fuzztest", version = "20241028.0", dev_dependency = True, repo_name = "com_google_fuzztest")  # mistmached 2023-05-16
+bazel_dep(name = "google_benchmark", version = "1.9.0", dev_dependency = True, repo_name = "com_github_google_benchmark")
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 
 # Python dependencies
 # ===================

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -53,9 +53,9 @@
     # Development dependencies
     # ========================
 
-    bazel_dep(name = "fuzztest", version = "20241028.0", repo_name = "com_google_fuzztest", dev_dependency=True)  # mistmached 2023-05-16
-    bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark", dev_dependency=True)
-    bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency=True)
+    bazel_dep(name = "fuzztest", version = "20241028.0", dev_dependency = True, repo_name = "com_google_fuzztest")  # mistmached 2023-05-16
+    bazel_dep(name = "google_benchmark", version = "1.9.0", dev_dependency = True, repo_name = "com_github_google_benchmark")
+    bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 
     # Python dependencies
     # ===================

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -21,6 +21,9 @@
         repo_name = "com_github_grpc_grpc",
     )
 
+    # Regular dependencies
+    # ====================
+
     bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_absl")
     bazel_dep(name = "apple_support", version = "1.17.1", repo_name = "build_bazel_apple_support")
     bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -46,6 +49,16 @@
         grpc = True,
         python = True,
     )
+
+    # Development dependencies
+    # ========================
+
+    bazel_dep(name = "fuzztest", version = "20241028.0", repo_name = "com_google_fuzztest", dev_dependency=True)  # mistmached 2023-05-16
+    bazel_dep(name = "google_benchmark", version = "1.9.0", repo_name = "com_github_google_benchmark", dev_dependency=True)
+    bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency=True)
+
+    # Python dependencies
+    # ===================
 
     bazel_dep(name = "rules_python", version = "0.37.1")
 

--- a/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
@@ -15,21 +15,33 @@
 
 set -ex
 
+# Test if public targets are buildable without dev dependencies.
 tools/bazel \
     build \
     --enable_bzlmod=true \
     --enable_workspace=false \
-    :grpc \
-    :grpc_unsecure \
-    :grpc_opencensus_plugin \
-    :grpc_security_base \
-    :grpc++ \
-    :grpc++_unsecure \
-    :grpc++_reflection \
-    :grpc++_test \
-    :grpcpp_admin \
-    :grpcpp_channelz \
-    :grpcpp_csds \
-    :grpcpp_orca_service \
-    :grpcpp_gcp_observability
-    # :grpcpp_csm_observability  # Needed google_cloud_cpp to be added to BCR
+    --ignore_dev_dependency \
+    -- \
+    :all \
+    -:grpcpp_csm_observability  # Needs google_cloud_cpp to be added to BCR
+
+# Test if examples are buildable without dev dependencies.
+tools/bazel \
+    build \
+    --enable_bzlmod=true \
+    --enable_workspace=false \
+    --ignore_dev_dependency \
+    -- \
+    //examples/cpp/... \
+    -//examples/cpp/csm/...  # Needs grpcpp_csm_observability
+
+# Test if a few basic tests can pass.
+# This is a temporary sanity check covering essential features,
+# to be replaced by a comprehensive test suite once the bzlmod migration is finished.
+tools/bazel \
+    test \
+    --enable_bzlmod=true \
+    --enable_workspace=false \
+    -- \
+    //test/core/config:all \
+    //test/cpp/common:all


### PR DESCRIPTION
A few changes to improve bzlmod

- Added development dependencies (see [bazel_dep](https://bazel.build/rules/lib/globals/module#bazel_dep)) which are used only when developing gRPC.
- Added more tests to `bazel_build_with_bzlmod_linux.sh`
  - Added all root target except `grpcpp_csm_observability` which is not possible at this point.
  - Added building `examples/cpp` test.
  - Added a few basic test run test.