### PR TITLE
[Dep] Updated c-ares to 1.19.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "abseil-cpp", version = "20240722.0", repo_name = "com_google_a
 bazel_dep(name = "apple_support", version = "1.17.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
-bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
+bazel_dep(name = "c-ares", version = "1.19.1", repo_name = "com_github_cares_cares")
 bazel_dep(name = "envoy_api", version = "0.0.0-20250128-4de3c74")
 bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
 bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -25,7 +25,7 @@
     bazel_dep(name = "apple_support", version = "1.17.1", repo_name = "build_bazel_apple_support")
     bazel_dep(name = "bazel_skylib", version = "1.7.1")
     bazel_dep(name = "boringssl", version = "0.20241024.0")  # mistmatched 20241211
-    bazel_dep(name = "c-ares", version = "1.15.0", repo_name = "com_github_cares_cares")  # mistmatched 1.19.1
+    bazel_dep(name = "c-ares", version = "1.19.1", repo_name = "com_github_cares_cares")
     bazel_dep(name = "envoy_api", version = "0.0.0-20250128-4de3c74")
     bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name = "com_google_googleapis")
     bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")


### PR DESCRIPTION
Updated c-ares of bzlmod to 1.19.1 to have the same version as workspace.