### PR TITLE
[Build] Added this missing line from copybara commit

### DIFF
--- a/test/cpp/naming/utils/BUILD
+++ b/test/cpp/naming/utils/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 load("//bazel:grpc_build_system.bzl", "grpc_py_binary")
 
 package(


### PR DESCRIPTION
NOT MEANT FOR MERGE AS https://github.com/grpc/grpc/pull/38705 IS BEING MERGED. THIS IS JUST FOR REFERENCE.

Copybara appears to have missed this line when merging https://github.com/grpc/grpc/pull/38692 by this [commit](https://github.com/grpc/grpc/commit/68b5dc5125dc65bfe2b6e6f888f7fc3aaed16d60). This missing line is causing Bazel build failures.  Since the line isn't required internally, I'm adding it directly to resolve the build issues.