### PR TITLE
[build] Allow absl/status:status_matchers test only library

### DIFF
--- a/src/abseil-cpp/preprocessed_builds.yaml
+++ b/src/abseil-cpp/preprocessed_builds.yaml
@@ -1821,6 +1821,19 @@
   - third_party/abseil-cpp/absl/status/internal/status_internal.cc
   - third_party/abseil-cpp/absl/status/status.cc
   - third_party/abseil-cpp/absl/status/status_payload_printer.cc
+- cmake_target: absl::status_matchers
+  deps:
+  - '@com_google_googletest//:gtest'
+  - absl/base:config
+  - absl/status:status
+  - absl/status:statusor
+  - absl/strings:string_view
+  headers:
+  - third_party/abseil-cpp/absl/status/internal/status_matchers.h
+  - third_party/abseil-cpp/absl/status/status_matchers.h
+  name: absl/status:status_matchers
+  src:
+  - third_party/abseil-cpp/absl/status/internal/status_matchers.cc
 - cmake_target: absl::statusor
   deps:
   - absl/base:base

--- a/src/abseil-cpp/preprocessed_builds.yaml
+++ b/src/abseil-cpp/preprocessed_builds.yaml
@@ -1531,7 +1531,7 @@
   - third_party/abseil-cpp/absl/random/internal/mock_helpers.h
   name: absl/random/internal:mock_helpers
   src: []
-- cmake_target: ''
+- cmake_target: absl::random_internal_mock_validators
   deps:
   - absl/base:config
   - absl/base:raw_logging_internal

--- a/src/abseil-cpp/preprocessed_builds.yaml.gen.py
+++ b/src/abseil-cpp/preprocessed_builds.yaml.gen.py
@@ -183,18 +183,22 @@ def resolve_srcs(files):
 def resolve_deps(targets):
     return [(t[2:] if t.startswith("//") else t) for t in targets]
 
+def absl_testonly(rule):
+    return rule.testonly and not rule.name in [
+        "status_matchers", "absl::status_matchers"
+    ]
 
 def generate_builds(root_path):
     """Generates builds from all BUILD files under absl directory."""
     bazel_rules = list(
         filter(
-            lambda r: r.type == "cc_library" and not r.testonly,
+            lambda r: r.type == "cc_library" and not absl_testonly(r),
             collect_bazel_rules(root_path),
         )
     )
     cmake_rules = list(
         filter(
-            lambda r: r.type == "absl_cc_library" and not r.testonly,
+            lambda r: r.type == "absl_cc_library" and not absl_testonly(r),
             collect_cmake_rules(root_path),
         )
     )

--- a/src/abseil-cpp/preprocessed_builds.yaml.gen.py
+++ b/src/abseil-cpp/preprocessed_builds.yaml.gen.py
@@ -184,24 +184,21 @@ def resolve_deps(targets):
     return [(t[2:] if t.startswith("//") else t) for t in targets]
 
 
-def absl_testonly(rule):
-    return rule.testonly and not rule.name in [
-        "status_matchers",
-        "absl::status_matchers",
-    ]
+def absl_internal_testonly(rule):
+    return rule.testonly and rule.name != "status_matchers"
 
 
 def generate_builds(root_path):
     """Generates builds from all BUILD files under absl directory."""
     bazel_rules = list(
         filter(
-            lambda r: r.type == "cc_library" and not absl_testonly(r),
+            lambda r: r.type == "cc_library" and not absl_internal_testonly(r),
             collect_bazel_rules(root_path),
         )
     )
     cmake_rules = list(
         filter(
-            lambda r: r.type == "absl_cc_library" and not absl_testonly(r),
+            lambda r: r.type == "absl_cc_library",
             collect_cmake_rules(root_path),
         )
     )

--- a/src/abseil-cpp/preprocessed_builds.yaml.gen.py
+++ b/src/abseil-cpp/preprocessed_builds.yaml.gen.py
@@ -183,10 +183,13 @@ def resolve_srcs(files):
 def resolve_deps(targets):
     return [(t[2:] if t.startswith("//") else t) for t in targets]
 
+
 def absl_testonly(rule):
     return rule.testonly and not rule.name in [
-        "status_matchers", "absl::status_matchers"
+        "status_matchers",
+        "absl::status_matchers",
     ]
+
 
 def generate_builds(root_path):
     """Generates builds from all BUILD files under absl directory."""


### PR DESCRIPTION
This library would be a huge improvement for gRPC tests that deal with absl::Status and absl::StatusOr objects.

