### PR TITLE
[pick_first] fix bug that caused us to stop triggering connection attempts

### DIFF
--- a/test/core/load_balancing/pick_first_test.cc
+++ b/test/core/load_balancing/pick_first_test.cc
@@ -1172,7 +1172,7 @@ TEST_F(PickFirstTest, AddressUpdateRetainsSelectedAddress) {
 // This exercizes a bug seen in the wild that caused a crash.  For
 // details, see https://github.com/grpc/grpc/pull/38144.
 TEST_F(PickFirstTest, SubchannelNotificationAfterShutdown) {
-  // Send an update containing one address.
+  // Send an update containing two addresses.
   constexpr std::array<absl::string_view, 2> kAddresses = {
       "ipv4:127.0.0.1:443", "ipv4:127.0.0.1:444"};
   absl::Status status = ApplyUpdate(
@@ -1224,6 +1224,66 @@ TEST_F(PickFirstTest, SubchannelNotificationAfterShutdown) {
   // Now the subchannel reports IDLE.  Before the bug fix, this
   // triggered a crash.
   subchannel->SetConnectivityState(GRPC_CHANNEL_IDLE);
+}
+
+// This exercizes a bug seen in the wild that caused us to silently stop
+// triggering connection attempts at the end of the Happy Eyeballs pass.
+TEST_F(PickFirstTest,
+       SubchannelInitiallyReportsTransientFailureButIsIdleForHappyEyeballs) {
+  constexpr std::array<absl::string_view, 2> kAddresses = {
+      "ipv4:127.0.0.1:443", "ipv4:127.0.0.1:444"};
+  // Pre-initialize the second subchannel to report TRANSIENT_FAILURE as
+  // its initial state.
+  auto* subchannel2 = CreateSubchannel(kAddresses[1]);
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_TRANSIENT_FAILURE,
+                                    absl::UnavailableError("failed to connect"),
+                                    /*validate_state_transition=*/false);
+  // Send an update containing two addresses.
+  absl::Status status = ApplyUpdate(
+      BuildUpdate(kAddresses, MakePickFirstConfig(false)), lb_policy());
+  EXPECT_TRUE(status.ok()) << status;
+  // LB policy should have created a subchannel for the first address.
+  auto* subchannel = FindSubchannel(kAddresses[0]);
+  ASSERT_NE(subchannel, nullptr);
+  // When the LB policy receives the first subchannel's initial connectivity
+  // state notification (IDLE), it will request a connection.
+  EXPECT_TRUE(subchannel->ConnectionRequested());
+  // This causes the subchannel to start to connect, so it reports CONNECTING.
+  subchannel->SetConnectivityState(GRPC_CHANNEL_CONNECTING);
+  // LB policy should have reported CONNECTING state.
+  ExpectConnectingUpdate();
+  // Second subchannel finishes backoff.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_IDLE);
+  // No connection attempt triggered on the second subchannel yet.
+  EXPECT_FALSE(subchannel2->ConnectionRequested());
+  // Now the Happy Eyeballs timer fires.
+  IncrementTimeBy(Duration::Milliseconds(250));
+  // This triggers a connection attempt on the second subchannel.
+  EXPECT_TRUE(subchannel2->ConnectionRequested());
+  // This causes the subchannel to start to connect, so it reports CONNECTING.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_CONNECTING);
+  // LB policy should have reported CONNECTING state.
+  ExpectConnectingUpdate();
+  // Second subchannel fails immediately.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_TRANSIENT_FAILURE,
+                                    absl::UnavailableError("ugh"));
+  // Second subchannel finishes backoff.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_IDLE);
+  // Now the first subchannel fails.
+  subchannel->SetConnectivityState(GRPC_CHANNEL_TRANSIENT_FAILURE,
+                                   absl::UnavailableError("ugh2"));
+  // This should trigger an immediate re-attempt on the second subchannel.
+  EXPECT_TRUE(subchannel2->ConnectionRequested());
+  // Subchannel should report CONNECTING.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_CONNECTING);
+  // The LB policy should request re-resolution.
+  ExpectReresolutionRequest();
+  // The LB policy will report TRANSIENT_FAILURE.
+  WaitForConnectionFailed([&](const absl::Status& status) {
+    EXPECT_EQ(status,
+              absl::UnavailableError("failed to connect to all addresses; "
+                                     "last error: UNAVAILABLE: ugh2"));
+  });
 }
 
 TEST_F(PickFirstTest, WithShuffle) {


### PR DESCRIPTION
The bug was triggered in a fairly rare sequence of events: the subchannel needed to report TRANSIENT_FAILURE as its initial state but then be in IDLE state by the time that Happy Eyeballs got to it.  Because we had recorded that the subchannel already saw TRANSIENT_FAILURE state before Happy Eyeballs got to it, it was not considered a new failure, which broke the logic we use to trigger exiting from the initial Happy Eyeballs pass and continue connecting.  The fix is to not record that the subchannel saw TRANSIENT_FAILURE state until we get to it in the Happy Eyeballs pass.

b/394267714