### PR TITLE
[Clean-up] Changed php_generator.h to names.h

### DIFF
--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -16,7 +16,7 @@
  *
  */
 
-#include <google/protobuf/compiler/php/php_generator.h>
+#include <google/protobuf/compiler/php/names.h>
 
 #include <map>
 


### PR DESCRIPTION
It turned out that gRPC doesn't need to include `google/protobuf/compiler/php/php_generator.h`. Rather including `google/protobuf/compiler/php/names.h` (which is a smaller one) should be sufficient.