### PR TITLE
[XdsClient] fix ubsan failure

### DIFF
--- a/src/core/xds/xds_client/xds_client.cc
+++ b/src/core/xds/xds_client/xds_client.cc
@@ -532,6 +532,13 @@ void XdsClient::XdsChannel::SetHealthyLocked() {
           << "[xds_client " << xds_client_.get() << "] authority " << authority
           << ": Falling forward to " << server_.server_uri();
       // Lower priority channels are no longer needed, connection is back!
+      // Note that we move the lower priority channels out of the vector
+      // before we unref them, or else
+      // MaybeRemoveUnsubscribedCacheEntriesForTypeLocked() will try to
+      // access the vector while we are modifying it.
+      std::vector<RefCountedPtr<XdsChannel>> channels_to_unref(
+          std::make_move_iterator(channel_it + 1),
+          std::make_move_iterator(channels.end()));
       channels.erase(channel_it + 1, channels.end());
     }
   }


### PR DESCRIPTION
This fixes a ubsan failure introduced in #38698.  In xDS fallback, when a higher-priority server comes back online, we [remove the lower-priority channels from the authority state](https://github.com/grpc/grpc/blob/686fc9dbebb2ba2c68a73fb973f1c8e8e6d89b45/src/core/xds/xds_client/xds_client.cc#L535), but unreffing the channels triggers a call to `MaybeRemoveUnsubscribedCacheEntriesForTypeLocked()`, which [attempts to access the list of channels](https://github.com/grpc/grpc/blob/686fc9dbebb2ba2c68a73fb973f1c8e8e6d89b45/src/core/xds/xds_client/xds_client.cc#L1788) while we're in the process of modifying it.

Example failure:

https://btx.cloud.google.com/invocations/69469281-f334-4a1f-91b4-3eb8905b63f4/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_fallback_end2end_test@experiment%3Dno_server_listener;config=79d74d08dc8cd749c211bbf112a92eee46adbf3f6203bc27099b142ea4e7aac9/log