### PR TITLE
[fuzzing] Fix fuzzer found bug

### DIFF
--- a/src/core/lib/promise/inter_activity_latch.h
+++ b/src/core/lib/promise/inter_activity_latch.h
@@ -71,9 +71,10 @@ class InterActivityLatch {
 
  private:
   std::string DebugTag() {
-    return absl::StrCat(GetContext<Activity>()->DebugTag(),
-                        " INTER_ACTIVITY_LATCH[0x",
-                        reinterpret_cast<uintptr_t>(this), "]: ");
+    return absl::StrCat(
+        HasContext<Activity>() ? GetContext<Activity>()->DebugTag()
+                               : "NO_ACTIVITY:",
+        " INTER_ACTIVITY_LATCH[0x", reinterpret_cast<uintptr_t>(this), "]: ");
   }
 
   std::string StateString() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {

--- a/test/core/end2end/tests/simple_metadata.cc
+++ b/test/core/end2end/tests/simple_metadata.cc
@@ -73,9 +73,8 @@ CORE_END2END_TEST(CoreEnd2endTests, SimpleMetadata) {
 
 TEST(Fuzzers, CoreEnd2endTestsSimpleMetadataRegression1) {
   CoreEnd2endTests_SimpleMetadata(
-    CoreTestConfigurationNamed("ChaoticGoodOneByteChunk"),
-    ParseTestProto(R"pb(config_vars { trace: "promise_primitives" })pb")
-  );
+      CoreTestConfigurationNamed("ChaoticGoodOneByteChunk"),
+      ParseTestProto(R"pb(config_vars { trace: "promise_primitives" })pb"));
 }
 
 }  // namespace

--- a/test/core/end2end/tests/simple_metadata.cc
+++ b/test/core/end2end/tests/simple_metadata.cc
@@ -71,7 +71,7 @@ CORE_END2END_TEST(CoreEnd2endTests, SimpleMetadata) {
   EXPECT_EQ(server_status.GetTrailingMetadata("key6"), "val6");
 }
 
-TEST(Fuzzers, CoreEnd2endTests_SimpleMetadataRegression) {
+TEST(Fuzzers, CoreEnd2endTestsSimpleMetadataRegression1) {
   CoreEnd2endTests_SimpleMetadata(
     CoreTestConfigurationNamed("ChaoticGoodOneByteChunk"),
     ParseTestProto(R"pb(config_vars { trace: "promise_primitives" })pb")

--- a/test/core/end2end/tests/simple_metadata.cc
+++ b/test/core/end2end/tests/simple_metadata.cc
@@ -71,5 +71,12 @@ CORE_END2END_TEST(CoreEnd2endTests, SimpleMetadata) {
   EXPECT_EQ(server_status.GetTrailingMetadata("key6"), "val6");
 }
 
+TEST(Fuzzers, CoreEnd2endTests_SimpleMetadataRegression) {
+  CoreEnd2endTests_SimpleMetadata(
+    CoreTestConfigurationNamed("ChaoticGoodOneByteChunk"),
+    ParseTestProto(R"pb(config_vars { trace: "promise_primitives" })pb")
+  );
+}
+
 }  // namespace
 }  // namespace grpc_core


### PR DESCRIPTION
If we enable the tracer `promise_primitives` during this test we end up dereferencing a nullptr.