### PR TITLE
[XdsClient] fix edge case found by fuzzer

### DIFF
--- a/src/core/xds/xds_client/xds_client.cc
+++ b/src/core/xds/xds_client/xds_client.cc
@@ -476,6 +476,12 @@ void XdsClient::XdsChannel::UnsubscribeLocked(const XdsResourceType* type,
       if (!call->HasSubscribedResources()) {
         ads_call_.reset();
       }
+    } else {
+      // If there is currently no ADS call because we're in retry backoff,
+      // then we immediately trigger deletion of unsubscribed cache entries.
+      // This may orphan the XdsChannel, which would stop the retry
+      // timer, since we would no longer need to restart the ADS call.
+      xds_client_->MaybeRemoveUnsubscribedCacheEntriesForTypeLocked(this, type);
     }
   }
 }

--- a/test/core/xds/xds_client_fuzzer.cc
+++ b/test/core/xds/xds_client_fuzzer.cc
@@ -606,4 +606,56 @@ TEST(XdsClientFuzzer, IgnoresConnectionFailuresWithOkStatus) {
   )pb"));
 }
 
+TEST(XdsClientFuzzer, UnsubscribeWhileAdsCallInBackoff) {
+  Fuzz(ParseTestProto(R"pb(
+    bootstrap: "{\"xds_servers\": [{\"server_uri\":\"xds.example.com:443\", \"channel_creds\":[{\"type\": \"fake\"}]}]}"
+    actions {
+      start_watch {
+        resource_type { listener {} }
+        resource_name: "server.example.com"
+      }
+    }
+    actions { send_status_to_client { stream_id { ads {} } } }
+    actions {
+      stop_watch {
+        resource_type { listener {} }
+        resource_name: "server.example.com"
+      }
+    }
+    actions {
+      send_message_to_client {
+        stream_id { ads {} }
+        response {
+          version_info: "1"
+          nonce: "A"
+          type_url: "type.googleapis.com/envoy.config.listener.v3.Listener"
+          resources {
+            [type.googleapis.com/envoy.config.listener.v3.Listener] {
+              name: "server.example.com"
+              api_listener {
+                api_listener {
+                  [type.googleapis.com/envoy.extensions.filters.network
+                       .http_connection_manager.v3.HttpConnectionManager] {
+                    http_filters {
+                      name: "router"
+                      typed_config {
+                        [type.googleapis.com/
+                         envoy.extensions.filters.http.router.v3.Router] {}
+                      }
+                    }
+                    rds {
+                      route_config_name: "route_config"
+                      config_source { self {} }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  )pb"));
+}
+
 }  // namespace grpc_core


### PR DESCRIPTION
The fuzzer found an edge case introduced in https://github.com/grpc/grpc/pull/38698.

If the last watch for a given xDS channel is stopped while the ADS stream is in retry backoff, then we didn't wind up unreffing the xDS channel, so we incorrectly started a new ADS stream once the backoff timer fired.  In that new ADS stream, if we receive a message (which admittedly shouldn't happen in practice, since we haven't yet sent any subscription requests on the stream, but it's not impossible if there's a misbehaving xDS server), then we will [call `SendMessageLocked()` to send an ACK or NACK](https://github.com/grpc/grpc/blob/822f9b15191840228d17dc0d305887374150150e/src/core/xds/xds_client/xds_client.cc#L1366).  `SendMessageLocked()` would then finally [do a pass to remove unsubscribed cached resources](https://github.com/grpc/grpc/blob/822f9b15191840228d17dc0d305887374150150e/src/core/xds/xds_client/xds_client.cc#L894), which would unref the xDS channel and the ADS stream.  That would cause [the underlying stream to be orphaned](https://github.com/grpc/grpc/blob/822f9b15191840228d17dc0d305887374150150e/src/core/xds/xds_client/xds_client.cc#L760), but then [`SendMessageLocked()` would try accessing it](https://github.com/grpc/grpc/blob/822f9b15191840228d17dc0d305887374150150e/src/core/xds/xds_client/xds_client.cc#L908) after that, leading to a use-after-free crash.

The fix is that if we unsubscribe to a resource while we are in backoff, we immediately do the pass to remove unsubscribed cached resources, which will immediately unref the xDS channel and stop the backoff timer if it was the last resource subscribed to on that stream.

b/396323510
b/396313839