### PR TITLE
[api-fuzzer] Fix a bug in the fuzzer

### DIFF
--- a/src/core/call/filter_fusion.h
+++ b/src/core/call/filter_fusion.h
@@ -219,4 +219,4 @@ using FusedFilter = filters_detail::FusedFilter<Filters...>;
 
 }  // namespace grpc_core
 
-#endif
+#endif  // GRPC_SRC_CORE_CALL_FILTER_FUSION_H

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -534,5 +534,35 @@ TEST(MyTestSuite, RunApiFuzzerRegression1) {
       )pb"));
 }
 
+TEST(MyTestSuite, RunApiFuzzerRegression2) {
+  RunApiFuzzer(ParseTestProto(
+      R"pb(actions { create_server { http2_ports { server_creds {} } } }
+           actions { request_call {} }
+           actions {
+             create_channel {
+               channel_args {}
+               inproc: true
+             }
+           }
+           actions {
+             create_call {
+               method { value: "\364\217\277\277\355\237\277" }
+               timeout: -1482173017
+             }
+           }
+           actions { poll_cq {} }
+           actions {
+             queue_batch {
+               operations {
+                 send_status_from_server {
+                   status_code: 4294967295
+                   status_details { value: "_" }
+                 }
+               }
+             }
+           }
+      )pb"));
+}
+
 }  // namespace testing
 }  // namespace grpc_core

--- a/test/core/end2end/fuzzers/fuzzing_common.cc
+++ b/test/core/end2end/fuzzers/fuzzing_common.cc
@@ -27,6 +27,7 @@
 #include <grpc/support/time.h>
 #include <string.h>
 
+#include <limits>
 #include <memory>
 #include <new>
 #include <optional>
@@ -43,6 +44,7 @@
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/channel.h"
 #include "src/core/util/crash.h"
+#include "src/core/util/useful.h"
 #include "test/core/end2end/fuzzers/api_fuzzer.pb.h"
 
 namespace grpc_core {
@@ -193,7 +195,9 @@ class Call : public std::enable_shared_from_this<Call> {
         op.data.send_status_from_server.trailing_metadata_count = ary.count;
         op.data.send_status_from_server.trailing_metadata = ary.metadata;
         op.data.send_status_from_server.status = static_cast<grpc_status_code>(
-            batch_op.send_status_from_server().status_code());
+            Clamp<int64_t>(batch_op.send_status_from_server().status_code(),
+                           std::numeric_limits<int>::min(),
+                           std::numeric_limits<int>::max()));
         op.data.send_status_from_server.status_details =
             batch_op.send_status_from_server().has_status_details()
                 ? NewCopy(ReadSlice(


### PR DESCRIPTION
We can't put a uint32 into a C-style enum, so clamp the input from the fuzzer to an acceptable range.

