### PR TITLE
Change WithResult to AssertResultType for better readability.

### DIFF
--- a/src/core/lib/promise/promise.h
+++ b/src/core/lib/promise/promise.h
@@ -83,12 +83,12 @@ struct ImmediateOkStatus {
 };
 
 // Typecheck that a promise returns the expected return type.
-// usage: auto promise = WithResult<int>([]() { return 3; });
+// usage: auto promise = AssertResultType<int>([]() { return 3; });
 // NOTE: there are tests in promise_test.cc that are commented out because they
 // should fail to compile. When modifying this code these should be uncommented
 // and their miscompilation verified.
 template <typename T, typename F>
-GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION inline auto WithResult(F f) ->
+GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION inline auto AssertResultType(F f) ->
     typename std::enable_if<std::is_same<decltype(f()), Poll<T>>::value,
                             F>::type {
   return f;

--- a/src/core/lib/security/transport/auth_filters.h
+++ b/src/core/lib/security/transport/auth_filters.h
@@ -96,7 +96,7 @@ class ClientAuthFilter final : public ImplementChannelFilter<ClientAuthFilter> {
                                  ClientAuthFilter* filter) {
       filter->InstallContext();
       auto* host = md->get_pointer(HttpAuthorityMetadata());
-      return WithResult<absl::StatusOr<ClientMetadataHandle>>(If(
+      return AssertResultType<absl::StatusOr<ClientMetadataHandle>>(If(
           host == nullptr,
           [&md]() mutable -> absl::StatusOr<ClientMetadataHandle> {
             return std::move(md);

--- a/test/core/promise/promise_test.cc
+++ b/test/core/promise/promise_test.cc
@@ -28,10 +28,10 @@ TEST(PromiseTest, Works) {
 
 TEST(PromiseTest, Immediate) { EXPECT_EQ(Immediate(42)(), Poll<int>(42)); }
 
-TEST(PromiseTest, WithResult) {
-  EXPECT_EQ(WithResult<int>(Immediate(42))(), Poll<int>(42));
-  // Fails to compile: WithResult<int>(Immediate(std::string("hello")));
-  // Fails to compile: WithResult<int>(Immediate(42.9));
+TEST(PromiseTest, AssertResultType) {
+  EXPECT_EQ(AssertResultType<int>(Immediate(42))(), Poll<int>(42));
+  // Fails to compile: AssertResultType<int>(Immediate(std::string("hello")));
+  // Fails to compile: AssertResultType<int>(Immediate(42.9));
 }
 
 TEST(PromiseTest, NowOrNever) {


### PR DESCRIPTION
WithResult acts as a type checker to assert that the promise passed to the function returns the expected type (i.e. Poll\<T\>). The name WithResult does not imply that the function is an assertion. 