### PR TITLE
[EventEngine] Use EE DNSResolver in dualstack_socket_test

### DIFF
--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -555,10 +555,10 @@ grpc_cc_test(
         "//:gpr",
         "//:grpc",
         "//:grpc_public_hdrs",
-        "//:sockaddr_utils",
         "//src/core:error",
+        "//src/core:event_engine_common",
+        "//src/core:event_engine_tcp_socket_utils",
         "//src/core:iomgr_port",
-        "//src/core:resolved_address",
         "//test/core/test_util:grpc_test_util",
     ],
 )

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -1,5 +1,3 @@
-//
-//
 // Copyright 2015 gRPC authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-//
 
 #include <grpc/impl/propagation_bits.h>
 #include <grpc/slice.h>
@@ -29,7 +25,6 @@
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "src/core/lib/iomgr/port.h"
-#include "src/core/lib/iomgr/resolved_address.h"
 
 // This test won't work except with posix sockets enabled
 #ifdef GRPC_POSIX_SOCKET_EV
@@ -46,17 +41,19 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
-#include "src/core/lib/address_utils/sockaddr_utils.h"
-#include "src/core/lib/iomgr/error.h"
-#include "src/core/lib/iomgr/resolve_address.h"
+#include "src/core/lib/event_engine/tcp_socket_utils.h"
+#include "src/core/lib/event_engine/utils.h"
 #include "src/core/lib/iomgr/socket_utils_posix.h"
-#include "src/core/lib/transport/error_utils.h"
 #include "src/core/util/host_port.h"
 #include "test/core/end2end/cq_verifier.h"
 #include "test/core/test_util/port.h"
 #include "test/core/test_util/test_config.h"
 
 // This test exercises IPv4, IPv6, and dualstack sockets in various ways.
+
+using grpc_event_engine::experimental::EventEngine;
+
+static absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver;
 
 static void drain_cq(grpc_completion_queue* cq) {
   grpc_event ev;
@@ -67,15 +64,21 @@ static void drain_cq(grpc_completion_queue* cq) {
 }
 
 static void log_resolved_addrs(const char* label, const char* hostname) {
-  absl::StatusOr<std::vector<grpc_resolved_address>> addresses_or =
-      grpc_core::GetDNSResolver()->LookupHostnameBlocking(hostname, "80");
-  if (!addresses_or.ok()) {
-    GRPC_LOG_IF_ERROR(hostname,
-                      absl_status_to_grpc_error(addresses_or.status()));
+  if (!ee_resolver.ok()) {
     return;
   }
-  for (const auto& addr : *addresses_or) {
-    LOG(INFO) << label << ": " << grpc_sockaddr_to_uri(&addr)->c_str();
+  absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> addresses =
+      grpc_event_engine::experimental::LookupHostnameBlocking(
+          ee_resolver->get(), hostname, "80");
+  if (!addresses.ok()) {
+    LOG(ERROR) << "Failed to lookup hostname: " << hostname
+               << ", status: " << addresses.status();
+    return;
+  }
+  for (const auto& addr : *addresses) {
+    LOG(INFO)
+        << label << ": "
+        << grpc_event_engine::experimental::ResolvedAddressToURI(addr)->c_str();
   }
 }
 
@@ -284,19 +287,23 @@ void test_connect(const char* server_host, const char* client_host, int port,
 }
 
 int external_dns_works(const char* host) {
-  auto addresses_or =
-      grpc_core::GetDNSResolver()->LookupHostnameBlocking(host, "80");
-  if (!addresses_or.ok()) {
+  if (!ee_resolver.ok()) {
+    return 0;
+  }
+  absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> addresses =
+      grpc_event_engine::experimental::LookupHostnameBlocking(
+          ee_resolver->get(), host, "80");
+  if (!addresses.ok()) {
     return 0;
   }
   int result = 1;
-  for (const auto& addr : *addresses_or) {
+  for (const auto& addr : *addresses) {
     // Kokoro on Macservice uses Google DNS64 servers by default
     // (https://en.wikipedia.org/wiki/Google_Public_DNS) and that breaks
     // "dualstack_socket_test" due to loopback4.unittest.grpc.io resolving to
     // [64:ff9b::7f00:1]. (Working as expected for DNS64, but it prevents the
     // dualstack_socket_test from functioning correctly). See b/201064791.
-    if (grpc_sockaddr_to_uri(&addr).value() ==
+    if (grpc_event_engine::experimental::ResolvedAddressToURI(addr).value() ==
         "ipv6:%5B64:ff9b::7f00:1%5D:80") {
       LOG(INFO) << "Detected DNS64 server response. Tests that depend on "
                    "*.unittest.grpc.io. will be skipped as they won't work "
@@ -317,6 +324,15 @@ int main(int argc, char** argv) {
   if (!grpc_ipv6_loopback_available()) {
     LOG(INFO) << "Can't bind to ::1.  Skipping IPv6 tests.";
     do_ipv6 = 0;
+  }
+
+  ee_resolver =
+      grpc_event_engine::experimental::GetDefaultEventEngine()->GetDNSResolver(
+          grpc_event_engine::experimental::EventEngine::DNSResolver::
+              ResolverOptions());
+  if (!ee_resolver.ok()) {
+    LOG(ERROR) << "Failed to get EventEngine DNSResolver: "
+               << ee_resolver.status();
   }
 
   // For coverage, test with and without dualstack sockets.


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

