### PR TITLE
[promise] Add an inter-activity promise based mutex

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -1233,6 +1233,18 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "inter_activity_mutex",
+    hdrs = [
+        "lib/promise/inter_activity_mutex.h",
+    ],
+    external_deps = ["absl/log:check", "absl/log"],
+    deps = [
+        "activity",
+        "poll",
+    ],
+)
+
+grpc_cc_library(
     name = "inter_activity_pipe",
     hdrs = [
         "lib/promise/inter_activity_pipe.h",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -1237,7 +1237,10 @@ grpc_cc_library(
     hdrs = [
         "lib/promise/inter_activity_mutex.h",
     ],
-    external_deps = ["absl/log:check", "absl/log"],
+    external_deps = [
+        "absl/log:check",
+        "absl/log",
+    ],
     deps = [
         "activity",
         "poll",

--- a/src/core/lib/promise/inter_activity_mutex.h
+++ b/src/core/lib/promise/inter_activity_mutex.h
@@ -123,6 +123,7 @@ class InterActivityMutex {
             if (state_.compare_exchange_weak(prev_state, State::kAcquired,
                                              std::memory_order_release,
                                              std::memory_order_relaxed)) {
+              waker_.Wakeup();
               return;
             }
             break;

--- a/src/core/lib/promise/inter_activity_mutex.h
+++ b/src/core/lib/promise/inter_activity_mutex.h
@@ -1,0 +1,425 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_SRC_CORE_LIB_PROMISE_INTER_ACTIVITY_MUTEX_H
+#define GRPC_SRC_CORE_LIB_PROMISE_INTER_ACTIVITY_MUTEX_H
+
+#include <atomic>
+#include <utility>
+
+#include "absl/log/log.h"
+#include "src/core/lib/debug/trace.h"
+#include "src/core/lib/promise/activity.h"
+#include "src/core/lib/promise/poll.h"
+#include "src/core/util/dump_args.h"
+
+namespace grpc_core {
+
+template <typename T>
+class InterActivityMutex {
+ public:
+  class Lock {
+   public:
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+    Lock(Lock&& other) noexcept
+        : mutex_(std::exchange(other.mutex_, nullptr)) {}
+    Lock& operator=(Lock&& other) noexcept {
+      if (mutex_ != nullptr) mutex_->Unlock();
+      mutex_ = std::exchange(other.mutex_, nullptr);
+      return *this;
+    }
+    ~Lock() {
+      if (mutex_ != nullptr) mutex_->Unlock();
+    }
+
+    T& operator*() { return mutex_->value_; }
+    T* operator->() { return &mutex_->value_; }
+    const T& operator*() const { return mutex_->value_; }
+    const T* operator->() const { return &mutex_->value_; }
+
+   private:
+    friend class InterActivityMutex;
+    explicit Lock(InterActivityMutex* mutex) : mutex_(mutex) {
+      GRPC_TRACE_LOG(promise_primitives, INFO)
+          << "[mutex " << mutex_ << "] Lock acquired";
+    }
+    InterActivityMutex* mutex_;
+  };
+
+  InterActivityMutex() = default;
+  explicit InterActivityMutex(T value) : value_(std::move(value)) {}
+
+ private:
+  class Unlocker;
+
+  class Waiter {
+   public:
+    explicit Waiter(InterActivityMutex* mutex, Waiter* next = nullptr)
+        : mutex_(mutex), next_(next) {}
+
+    bool WasAcquisitionCancelled() {
+      return state_.load(std::memory_order_relaxed) ==
+             State::kAcquisitionCancelled;
+    }
+    virtual bool CanAcquire() = 0;
+
+    void FailedAddToQueue() {
+      DCHECK_EQ(state_, State::kWaiting);
+      delete this;
+    }
+
+    void RemovedFromQueue() {
+      DCHECK_EQ(state_, State::kAcquisitionCancelled);
+      delete this;
+    }
+
+    void AcquisitionCancelled() {
+      State prev_state = State::kWaiting;
+      while (true) {
+        switch (prev_state) {
+          case State::kWaiting:
+            if (state_.compare_exchange_weak(
+                    prev_state, State::kAcquisitionCancelled,
+                    std::memory_order_relaxed, std::memory_order_relaxed)) {
+              return;
+            }
+            break;
+          case State::kAcquisitionCancelled:
+            LOG(DFATAL) << "unreachable";
+            return;
+          case State::kAcquired:
+            mutex_->Unlock();
+            delete this;
+            return;
+        }
+      }
+    }
+    bool CheckAcquired() {
+      bool acquired =
+          state_.load(std::memory_order_acquire) == State::kAcquired;
+      if (acquired) delete this;
+      return acquired;
+    }
+    void BecomeAcquired() {
+      State prev_state = State::kWaiting;
+      while (true) {
+        switch (prev_state) {
+          case State::kWaiting:
+            if (state_.compare_exchange_weak(prev_state, State::kAcquired,
+                                             std::memory_order_release,
+                                             std::memory_order_relaxed)) {
+              return;
+            }
+            break;
+          case State::kAcquisitionCancelled:
+            mutex_->Unlock();
+            delete this;
+            return;
+          case State::kAcquired:
+            LOG(DFATAL) << "unreachable";
+            return;
+        }
+      }
+    }
+
+    Waiter* Reverse() {
+      std::vector<Waiter*> waiters;
+      for (Waiter* waiter = this; waiter != nullptr; waiter = waiter->next_) {
+        waiters.push_back(waiter);
+      }
+      waiters[0]->next_ = nullptr;
+      for (size_t i = 1; i < waiters.size(); ++i) {
+        waiters[i]->next_ = waiters[i - 1];
+      }
+      return waiters[waiters.size() - 1];
+    }
+
+   protected:
+    const T& value() const { return mutex_->value_; }
+
+    virtual ~Waiter() = default;
+
+   private:
+    friend class Unlocker;
+
+    enum State {
+      kWaiting,
+      kAcquisitionCancelled,
+      kAcquired,
+    };
+
+    std::atomic<State> state_{State::kWaiting};
+    InterActivityMutex* const mutex_;
+    Waiter* next_;
+    Waker waker_ = GetContext<Activity>()->MakeNonOwningWaker();
+  };
+
+  template <class F>
+  class WaiterImpl : public Waiter {
+   public:
+    WaiterImpl(InterActivityMutex* mutex, Waiter* next, F f)
+        : Waiter(mutex, next), f_(std::move(f)) {}
+    bool CanAcquire() override { return f_(this->value()); }
+
+   private:
+    GPR_NO_UNIQUE_ADDRESS F f_;
+  };
+
+  template <class F>
+  class Acquirer {
+   public:
+    explicit Acquirer(InterActivityMutex* mutex, F f)
+        : mutex_(mutex), f_(std::move(f)) {}
+    ~Acquirer() {
+      switch (state_) {
+        case State::kStart:
+          break;
+        case State::kFastLocked:
+          mutex_->Unlock();
+          break;
+        case State::kMovedFrom:
+          break;
+        case State::kWaiting:
+          waiter_->AcquisitionCancelled();
+          break;
+      }
+    }
+
+    Poll<Lock> operator()() {
+      GRPC_TRACE_LOG(promise_primitives, INFO)
+          << "[mutex " << mutex_ << " aquirerer " << this
+          << "] Poll: " << GRPC_DUMP_ARGS(state_);
+      switch (state_) {
+        case State::kStart:
+          return PollStart();
+        case State::kFastLocked:
+          return PollFastLocked();
+        case State::kWaiting:
+          return PollWaiting();
+        case State::kMovedFrom:
+          LOG(FATAL) << "Mutex acquirer already moved from";
+      }
+    }
+
+   private:
+    enum class State : uint8_t { kStart, kFastLocked, kWaiting, kMovedFrom };
+
+    template <typename Sink>
+    friend void AbslStringify(Sink& sink, State state) {
+      switch (state) {
+        case State::kStart:
+          sink.Append("Start");
+          break;
+        case State::kFastLocked:
+          sink.Append("FastLocked");
+          break;
+        case State::kWaiting:
+          sink.Append("Waiting");
+          break;
+        case State::kMovedFrom:
+          sink.Append("MovedFrom");
+          break;
+      }
+    }
+
+    Poll<Lock> PollStart() {
+      while (true) {
+        GRPC_TRACE_LOG(promise_primitives, INFO)
+            << "[mutex " << mutex_ << " aquirerer " << this
+            << "] PollStart: " << GRPC_DUMP_ARGS(prev_state_);
+        if (prev_state_ == kUnlocked) {
+          if (mutex_->state_.compare_exchange_weak(prev_state_, kLocked,
+                                                   std::memory_order_acquire,
+                                                   std::memory_order_relaxed)) {
+            return PollFastLocked();
+          }
+        } else if (prev_state_ == kLocked) {
+          waiter_ = new WaiterImpl<F>(mutex_, nullptr, std::move(f_));
+          state_ = State::kWaiting;
+          if (mutex_->state_.compare_exchange_weak(
+                  prev_state_, reinterpret_cast<uintptr_t>(waiter_),
+                  std::memory_order_release, std::memory_order_relaxed)) {
+            return Pending{};
+          }
+          state_ = State::kStart;
+          waiter_->FailedAddToQueue();
+        } else {
+          waiter_ = new WaiterImpl<F>(
+              mutex_, reinterpret_cast<Waiter*>(prev_state_), std::move(f_));
+          state_ = State::kWaiting;
+          if (mutex_->state_.compare_exchange_weak(
+                  prev_state_, reinterpret_cast<uintptr_t>(waiter_),
+                  std::memory_order_release, std::memory_order_relaxed)) {
+            return Pending{};
+          }
+          state_ = State::kStart;
+          waiter_->FailedAddToQueue();
+        }
+      }
+    }
+
+    Poll<Lock> PollFastLocked() {
+      // We've acquired the lock via the fast lock path, but have not
+      // yet checked if we can actually acquire the lock.
+      if (f_(mutex_->value_)) {
+        state_ = State::kMovedFrom;
+        return Lock(mutex_);
+      }
+      waiter_ = new WaiterImpl<F>(mutex_, mutex_->waiters_, std::move(f_));
+      mutex_->waiters_ = waiter_;
+      state_ = State::kWaiting;
+      if (mutex_->state_.compare_exchange_strong(prev_state_, kUnlocked,
+                                                 std::memory_order_release,
+                                                 std::memory_order_release)) {
+        return Pending{};
+      }
+      DCHECK_NE(prev_state_, kUnlocked);
+      // some other waiter was added to the queue while we were waiting
+      // go through the slow unlock path
+      mutex_->Unlock();
+      // we should not be able to acquire the lock still!
+      DCHECK_NE(waiter_->CheckAcquired(), true);
+      return Pending{};
+    }
+
+    Poll<Lock> PollWaiting() {
+      if (waiter_->CheckAcquired()) {
+        state_ = State::kMovedFrom;
+        return Lock(mutex_);
+      }
+      return Pending{};
+    }
+
+    InterActivityMutex* mutex_;
+    uintptr_t prev_state_ = kUnlocked;
+    State state_ = mutex_->state_.compare_exchange_weak(prev_state_, kLocked)
+                       ? State::kFastLocked
+                       : State::kStart;
+    GPR_NO_UNIQUE_ADDRESS F f_;
+    Waiter* waiter_;
+  };
+
+ public:
+  auto Acquire() {
+    return AcquireWhen([](const T&) { return true; });
+  }
+  template <typename F>
+  auto AcquireWhen(F f) {
+    return Acquirer<F>(this, std::move(f));
+  }
+
+ private:
+  static constexpr uintptr_t kUnlocked = 0;
+  static constexpr uintptr_t kLocked = 1;
+
+  class Unlocker {
+   public:
+    explicit Unlocker(InterActivityMutex* mutex) : mutex_(mutex) {}
+
+    void Run() {
+      while (DrainSeenWaiters() && MaybeRefillWaiters()) {
+      }
+    }
+
+   private:
+    bool DrainSeenWaiters() {
+      // First, check if any waiter can acquire the mutex.
+      while (waiter_ != nullptr) {
+        GRPC_TRACE_LOG(promise_primitives, INFO)
+            << "[mutex " << mutex_
+            << "] DrainSeenWaiters: " << GRPC_DUMP_ARGS(prev_waiter_, waiter_);
+        if (waiter_->WasAcquisitionCancelled()) {
+          GRPC_TRACE_LOG(promise_primitives, INFO)
+              << "[mutex " << mutex_
+              << "] DrainSeenWaiters acquisition cancelled: "
+              << GRPC_DUMP_ARGS(prev_waiter_, waiter_);
+          prev_waiter_->next_ = waiter_->next_;
+          waiter_->RemovedFromQueue();
+          waiter_ = prev_waiter_->next_;
+          continue;
+        }
+        if (waiter_->CanAcquire()) {
+          GRPC_TRACE_LOG(promise_primitives, INFO)
+              << "[mutex " << mutex_
+              << "] DrainSeenWaiters acquisition successful: "
+              << GRPC_DUMP_ARGS(prev_waiter_, waiter_);
+          if (prev_waiter_ == nullptr) {
+            mutex_->waiters_ = waiter_->next_;
+          } else {
+            prev_waiter_->next_ = waiter_->next_;
+          }
+          waiter_->BecomeAcquired();
+          return false;
+        }
+        prev_waiter_ = waiter_;
+        waiter_ = waiter_->next_;
+      }
+      return true;
+    }
+
+    bool MaybeRefillWaiters() {
+      // Next, consider any waiters that were queued up.
+      // These will be in reverse order of addition to the queue, so we need to
+      // reverse them before processing.
+      auto prev_state = mutex_->state_.load(std::memory_order_relaxed);
+      while (true) {
+        GRPC_TRACE_LOG(promise_primitives, INFO)
+            << "[mutex " << mutex_
+            << "] MaybeRefillWaiters: " << GRPC_DUMP_ARGS(prev_state);
+        DCHECK_NE(prev_state, kUnlocked);
+        if (prev_state == kLocked) {
+          if (mutex_->state_.compare_exchange_weak(prev_state, kUnlocked,
+                                                   std::memory_order_release,
+                                                   std::memory_order_relaxed)) {
+            return false;
+          }
+        } else {
+          if (mutex_->state_.compare_exchange_weak(prev_state, kLocked,
+                                                   std::memory_order_acquire,
+                                                   std::memory_order_release)) {
+            Waiter* next = reinterpret_cast<Waiter*>(prev_state);
+            if (prev_waiter_ == nullptr) {
+              mutex_->waiters_ = next->Reverse();
+              waiter_ = mutex_->waiters_;
+            } else {
+              DCHECK_EQ(prev_waiter_->next_, nullptr);
+              prev_waiter_->next_ = next->Reverse();
+              waiter_ = prev_waiter_->next_;
+            }
+            return true;
+          }
+        }
+      }
+    }
+
+    InterActivityMutex* const mutex_;
+    Waiter* prev_waiter_ = nullptr;
+    Waiter* waiter_ = mutex_->waiters_;
+  };
+
+  void Unlock() {
+    GRPC_TRACE_LOG(promise_primitives, INFO)
+        << "[mutex " << this << "] Unlocking";
+    Unlocker(this).Run();
+  }
+
+  std::atomic<uintptr_t> state_{kUnlocked};
+  Waiter* waiters_ = nullptr;
+  T value_;
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_LIB_PROMISE_INTER_ACTIVITY_MUTEX_H

--- a/src/core/lib/promise/inter_activity_mutex.h
+++ b/src/core/lib/promise/inter_activity_mutex.h
@@ -372,9 +372,14 @@ class InterActivityMutex {
               << "[mutex " << mutex_
               << "] DrainSeenWaiters acquisition cancelled: "
               << GRPC_DUMP_ARGS(prev_waiter_, waiter_);
-          prev_waiter_->next_ = waiter_->next_;
+          Waiter* next = waiter_->next_;
+          if (prev_waiter_ == nullptr) {
+            mutex_->waiters_ = next;
+          } else {
+            prev_waiter_->next_ = next;
+          }
           waiter_->RemovedFromQueue();
-          waiter_ = prev_waiter_->next_;
+          waiter_ = next;
           continue;
         }
         if (waiter_->CanAcquire()) {

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -739,9 +739,17 @@ grpc_cc_proto_library(
 grpc_fuzz_test(
     name = "inter_activity_mutex_test",
     srcs = ["inter_activity_mutex_test.cc"],
-    external_deps = ["gtest", "fuzztest", "fuzztest_main"],
+    external_deps = [
+        "gtest",
+        "fuzztest",
+        "fuzztest_main",
+    ],
     tags = ["promise_test"],
-    deps = ["//src/core:inter_activity_mutex", "poll_matcher", "inter_activity_mutex_test_cc_proto"],
+    deps = [
+        "inter_activity_mutex_test_cc_proto",
+        "poll_matcher",
+        "//src/core:inter_activity_mutex",
+    ],
 )
 
 grpc_cc_benchmark(

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -726,12 +726,22 @@ grpc_cc_test(
     ],
 )
 
+grpc_internal_proto_library(
+    name = "inter_activity_mutex_test_proto",
+    srcs = ["inter_activity_mutex_test.proto"],
+)
+
+grpc_cc_proto_library(
+    name = "inter_activity_mutex_test_cc_proto",
+    deps = ["inter_activity_mutex_test_proto"],
+)
+
 grpc_fuzz_test(
     name = "inter_activity_mutex_test",
     srcs = ["inter_activity_mutex_test.cc"],
     external_deps = ["gtest", "fuzztest", "fuzztest_main"],
     tags = ["promise_test"],
-    deps = ["//src/core:inter_activity_mutex", "poll_matcher"],
+    deps = ["//src/core:inter_activity_mutex", "poll_matcher", "inter_activity_mutex_test_cc_proto"],
 )
 
 grpc_cc_benchmark(

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -726,6 +726,16 @@ grpc_cc_test(
     ],
 )
 
+grpc_cc_test(
+    name = "inter_activity_mutex_test",
+    srcs = ["inter_activity_mutex_test.cc"],
+    external_deps = ["gtest"],
+    tags = ["promise_test"],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = ["//src/core:inter_activity_mutex", "poll_matcher"],
+)
+
 grpc_cc_benchmark(
     name = "bm_party",
     srcs = ["bm_party.cc"],

--- a/test/core/promise/BUILD
+++ b/test/core/promise/BUILD
@@ -726,13 +726,11 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_fuzz_test(
     name = "inter_activity_mutex_test",
     srcs = ["inter_activity_mutex_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = ["gtest", "fuzztest", "fuzztest_main"],
     tags = ["promise_test"],
-    uses_event_engine = False,
-    uses_polling = False,
     deps = ["//src/core:inter_activity_mutex", "poll_matcher"],
 )
 

--- a/test/core/promise/inter_activity_mutex_test.cc
+++ b/test/core/promise/inter_activity_mutex_test.cc
@@ -1,0 +1,98 @@
+// Copyright 2023 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/lib/promise/inter_activity_mutex.h"
+
+#include <grpc/grpc.h>
+
+#include "gtest/gtest.h"
+#include "test/core/promise/poll_matcher.h"
+
+using ::testing::StrictMock;
+
+namespace grpc_core {
+namespace {
+// A mock activity that can be activated and deactivated.
+class MockActivity : public Activity, public Wakeable {
+ public:
+  MOCK_METHOD(void, WakeupRequested, ());
+
+  void ForceImmediateRepoll(WakeupMask /*mask*/) override { WakeupRequested(); }
+  void Orphan() override {}
+  Waker MakeOwningWaker() override { return Waker(this, 0); }
+  Waker MakeNonOwningWaker() override { return Waker(this, 0); }
+  void Wakeup(WakeupMask /*mask*/) override { WakeupRequested(); }
+  void WakeupAsync(WakeupMask /*mask*/) override { WakeupRequested(); }
+  void Drop(WakeupMask /*mask*/) override {}
+  std::string DebugTag() const override { return "MockActivity"; }
+  std::string ActivityDebugTag(WakeupMask /*mask*/) const override {
+    return DebugTag();
+  }
+
+  void Activate() {
+    if (scoped_activity_ == nullptr) {
+      scoped_activity_ = std::make_unique<ScopedActivity>(this);
+    }
+  }
+
+  void Deactivate() { scoped_activity_.reset(); }
+
+ private:
+  std::unique_ptr<ScopedActivity> scoped_activity_;
+};
+
+#define EXPECT_WAKEUP(activity, statement)                                 \
+  EXPECT_CALL((activity), WakeupRequested()).Times(::testing::AtLeast(1)); \
+  statement;                                                               \
+  Mock::VerifyAndClearExpectations(&(activity));
+
+template <typename Lock>
+void Drop(Lock lock) {}
+
+TEST(InterActivityMutexTest, Basic) {
+  InterActivityMutex<int> mutex(42);
+  auto acq = mutex.Acquire();
+  auto lock = acq();
+  EXPECT_THAT(lock, IsReady());
+  EXPECT_EQ(*lock.value(), 42);
+}
+
+TEST(InterActivityMutexTest, TwoAcquires) {
+  StrictMock<MockActivity> activity;
+  activity.Activate();
+  InterActivityMutex<int> mutex(42);
+  auto acq1 = mutex.Acquire();
+  auto acq2 = mutex.Acquire();
+  auto lock1 = acq1();
+  auto lock2 = acq2();
+  EXPECT_THAT(lock1, IsReady());
+  EXPECT_EQ(*lock1.value(), 42);
+  *lock1.value() = 43;
+  EXPECT_THAT(lock2, IsPending());
+  lock2 = acq2();
+  EXPECT_THAT(lock2, IsPending());
+  Drop(std::move(lock1.value()));
+  lock2 = acq2();
+  EXPECT_THAT(lock2, IsReady());
+  EXPECT_EQ(*lock2.value(), 43);
+}
+
+}  // namespace
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc_tracer_init();
+  return RUN_ALL_TESTS();
+}

--- a/test/core/promise/inter_activity_mutex_test.cc
+++ b/test/core/promise/inter_activity_mutex_test.cc
@@ -182,17 +182,7 @@ class AlwaysFairFuzzer {
     switch (op.type_case()) {
       case Op::kPoll: {
         if (op.poll().id() >= kNumSlots) return;
-        auto& slot = slots_[op.poll().id()];
-        auto poll = slot.poll();
-        // If a lock is returned, we should not have a lock already.
-        if (poll.ready()) {
-          CHECK(!lock_.has_value());
-          CHECK_EQ(op.poll().id(), ExpectedVictor());
-          lock_.emplace(std::move(poll.value()));
-          slot.poll = []() { return Pending{}; };
-          slot.trigger = None{};
-        }
-        // TODO: check fairness
+        Poll(op.poll().id());
       } break;
       case Op::kDrop: {
         if (op.drop().id() >= kNumSlots) return;
@@ -202,19 +192,11 @@ class AlwaysFairFuzzer {
       } break;
       case Op::kAcquire: {
         if (op.acquire().id() >= kNumSlots) return;
-        auto& slot = slots_[op.acquire().id()];
-        slot.poll = mutex_.Acquire();
-        slot.trigger = Always{};
-        slot.acquire_order = next_acquire_order_++;
+        Acquire(op.acquire().id());
       } break;
       case Op::kAcquireWhen: {
         if (op.acquire_when().id() >= kNumSlots) return;
-        auto& slot = slots_[op.acquire_when().id()];
-        slot.poll =
-            mutex_.AcquireWhen([trigger = op.acquire_when().when()](
-                                   uint32_t x) { return trigger == x; });
-        slot.trigger = op.acquire_when().when();
-        slot.acquire_order = next_acquire_order_++;
+        AcquireWhen(op.acquire_when().id(), op.acquire_when().when());
       } break;
       case Op::kDropLock: {
         lock_.reset();
@@ -241,15 +223,44 @@ class AlwaysFairFuzzer {
     absl::AnyInvocable<Poll<Lock>()> poll = []() { return Pending{}; };
   };
 
+  void Poll(uint32_t id) {
+    auto& slot = slots_[id];
+    auto poll = slot.poll();
+    // If a lock is returned, we should not have a lock already.
+    if (poll.ready()) {
+      CHECK(!lock_.has_value());
+      CHECK_EQ(id, ExpectedVictor()) << ExpectedQueue();
+      lock_.emplace(std::move(poll.value()));
+      slot.poll = []() { return Pending{}; };
+      slot.trigger = None{};
+    }
+  }
+
+  void Acquire(uint32_t id) {
+    auto& slot = slots_[id];
+    slot.poll = mutex_.Acquire();
+    slot.trigger = Always{};
+    slot.acquire_order = next_acquire_order_++;
+    Poll(id);
+  }
+
+  void AcquireWhen(uint32_t id, uint32_t when) {
+    auto& slot = slots_[id];
+    slot.poll = mutex_.AcquireWhen([when](uint32_t x) { return x == when; });
+    slot.trigger = when;
+    slot.acquire_order = next_acquire_order_++;
+    Poll(id);
+  }
+
   uint32_t ExpectedVictor() const {
     const Slot* ordered_slots[kNumSlots];
     for (size_t i = 0; i < kNumSlots; ++i) {
       ordered_slots[i] = &slots_[i];
     }
-    std::sort(ordered_slots, ordered_slots + kNumSlots,
-              [](const Slot* a, const Slot* b) {
-                return a->acquire_order < b->acquire_order;
-              });
+    std::stable_sort(ordered_slots, ordered_slots + kNumSlots,
+                     [](const Slot* a, const Slot* b) {
+                       return a->acquire_order < b->acquire_order;
+                     });
     for (size_t i = 0; i < kNumSlots; ++i) {
       const Slot& slot = *ordered_slots[i];
       size_t index = ordered_slots[i] - slots_;
@@ -260,9 +271,36 @@ class AlwaysFairFuzzer {
     return std::numeric_limits<uint32_t>::max();
   }
 
-  Slot slots_[kNumSlots];
+  std::string ExpectedQueue() const {
+    std::vector<std::string> wtf;
+    wtf.push_back(absl::StrCat("lock_value=", lock_value_));
+    const Slot* ordered_slots[kNumSlots];
+    for (size_t i = 0; i < kNumSlots; ++i) {
+      ordered_slots[i] = &slots_[i];
+    }
+    std::stable_sort(ordered_slots, ordered_slots + kNumSlots,
+                     [](const Slot* a, const Slot* b) {
+                       return a->acquire_order < b->acquire_order;
+                     });
+    for (size_t i = 0; i < kNumSlots; ++i) {
+      const Slot& slot = *ordered_slots[i];
+      size_t index = ordered_slots[i] - slots_;
+      if (std::holds_alternative<None>(slot.trigger)) continue;
+      if (std::holds_alternative<Always>(slot.trigger)) {
+        wtf.push_back(
+            absl::StrCat("[", index, "]: Always order=", slot.acquire_order));
+        continue;
+      }
+      wtf.push_back(absl::StrCat(
+          "[", index, "]: trigger=", std::get<uint32_t>(slot.trigger),
+          ", order=", slot.acquire_order));
+    }
+    return absl::StrJoin(wtf, "\n");
+  }
+
   uint32_t lock_value_ = 0;
   Mutex mutex_{lock_value_};
+  Slot slots_[kNumSlots];
   std::optional<Lock> lock_;
   uint64_t next_acquire_order_ = 1;
 };
@@ -295,10 +333,12 @@ TEST(InterActivityMutexTest, AlwaysFairRegression2) {
   AlwaysFair({ParseTestProto(R"pb(acquire_when {})pb"),
               ParseTestProto(R"pb(acquire { id: 1 })pb"),
               ParseTestProto(R"pb(acquire {})pb"),
-              ParseTestProto(R"pb(poll {})pb"),
-              ParseTestProto(R"pb(acquire_when { when: 4294967292 })pb"),
-              ParseTestProto(R"pb(poll {})pb"),
-              ParseTestProto(R"pb(drop_lock {})pb")});
+              ParseTestProto(R"pb(poll {})pb")});
+}
+
+TEST(InterActivityMutexTest, AlwaysFairRegression3) {
+  AlwaysFair({ParseTestProto(R"pb(acquire_when { when: 4294967295 })pb"),
+              ParseTestProto(R"pb(acquire_when { when: 1 })pb")});
 }
 
 }  // namespace

--- a/test/core/promise/inter_activity_mutex_test.cc
+++ b/test/core/promise/inter_activity_mutex_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2023 gRPC authors.
+// Copyright 2025 gRPC authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,9 +14,15 @@
 
 #include "src/core/lib/promise/inter_activity_mutex.h"
 
+#include <google/protobuf/text_format.h>
 #include <grpc/grpc.h>
 
+#include <limits>
+#include <optional>
+
+#include "fuzztest/fuzztest.h"
 #include "gtest/gtest.h"
+#include "test/core/promise/inter_activity_mutex_test.pb.h"
 #include "test/core/promise/poll_matcher.h"
 
 using ::testing::Mock;
@@ -136,6 +142,163 @@ TEST(InterActivityMutexTest, ThreeAcquiresWithCancelledAcquisition) {
   lock3 = acq3();
   EXPECT_THAT(lock3, IsReady());
   EXPECT_EQ(*lock3.value(), 42);
+}
+
+TEST(InterActivityMutexTest, ThreeAcquireWhens) {
+  StrictMock<MockActivity> activity;
+  activity.Activate();
+  InterActivityMutex<int> mutex(42);
+  auto acq1 = mutex.AcquireWhen([](int x) { return x == 100; });
+  auto acq2 = mutex.AcquireWhen([](int x) { return x == 200; });
+  auto acq3 = mutex.AcquireWhen([](int x) { return x == 42; });
+  auto lock1 = acq1();
+  auto lock2 = acq2();
+  auto lock3 = acq3();
+  EXPECT_THAT(lock1, IsPending());
+  EXPECT_THAT(lock2, IsPending());
+  EXPECT_THAT(lock3, IsReady());
+  EXPECT_EQ(*lock3.value(), 42);
+  *lock3.value() = 100;
+  EXPECT_WAKEUP(activity, Drop(std::move(lock3)));
+  lock1 = acq1();
+  lock2 = acq2();
+  EXPECT_THAT(lock1, IsReady());
+  EXPECT_THAT(lock2, IsPending());
+  EXPECT_EQ(*lock1.value(), 100);
+  *lock1.value() = 200;
+  EXPECT_WAKEUP(activity, Drop(std::move(lock1)));
+  lock2 = acq2();
+  EXPECT_THAT(lock2, IsReady());
+  EXPECT_EQ(*lock2.value(), 200);
+}
+
+class AlwaysFairFuzzer {
+ public:
+  using Op = inter_activity_mutex_test::Op;
+  using Mutex = InterActivityMutex<uint32_t>;
+  using Lock = typename Mutex::Lock;
+
+  void Run(Op op) {
+    switch (op.type_case()) {
+      case Op::kPoll: {
+        if (op.poll().id() >= kNumSlots) return;
+        auto& slot = slots_[op.poll().id()];
+        auto poll = slot.poll();
+        // If a lock is returned, we should not have a lock already.
+        if (poll.ready()) {
+          CHECK(!lock_.has_value());
+          CHECK_EQ(op.poll().id(), ExpectedVictor());
+          lock_.emplace(std::move(poll.value()));
+          slot.poll = []() { return Pending{}; };
+          slot.trigger = None{};
+        }
+        // TODO: check fairness
+      } break;
+      case Op::kDrop: {
+        if (op.drop().id() >= kNumSlots) return;
+        auto& slot = slots_[op.drop().id()];
+        slot.poll = []() { return Pending{}; };
+        slot.trigger = None{};
+      } break;
+      case Op::kAcquire: {
+        if (op.acquire().id() >= kNumSlots) return;
+        auto& slot = slots_[op.acquire().id()];
+        slot.poll = mutex_.Acquire();
+        slot.trigger = Always{};
+        slot.acquire_order = next_acquire_order_++;
+      } break;
+      case Op::kAcquireWhen: {
+        if (op.acquire_when().id() >= kNumSlots) return;
+        auto& slot = slots_[op.acquire_when().id()];
+        slot.poll =
+            mutex_.AcquireWhen([trigger = op.acquire_when().when()](
+                                   uint32_t x) { return trigger == x; });
+        slot.trigger = op.acquire_when().when();
+        slot.acquire_order = next_acquire_order_++;
+      } break;
+      case Op::kDropLock: {
+        lock_.reset();
+      } break;
+      case Op::kSetLock: {
+        if (!lock_.has_value()) return;
+        lock_value_ = op.set_lock().value();
+        **lock_ = lock_value_;
+      } break;
+      case Op::TYPE_NOT_SET:
+        break;
+    }
+  }
+
+ private:
+  static constexpr const size_t kNumSlots = 1024;
+
+  struct None {};
+  struct Always {};
+
+  struct Slot {
+    uint64_t acquire_order = 0;
+    std::variant<None, Always, uint32_t> trigger = None{};
+    absl::AnyInvocable<Poll<Lock>()> poll = []() { return Pending{}; };
+  };
+
+  uint32_t ExpectedVictor() const {
+    const Slot* ordered_slots[kNumSlots];
+    for (size_t i = 0; i < kNumSlots; ++i) {
+      ordered_slots[i] = &slots_[i];
+    }
+    std::sort(ordered_slots, ordered_slots + kNumSlots,
+              [](const Slot* a, const Slot* b) {
+                return a->acquire_order < b->acquire_order;
+              });
+    for (size_t i = 0; i < kNumSlots; ++i) {
+      const Slot& slot = *ordered_slots[i];
+      size_t index = ordered_slots[i] - slots_;
+      if (std::holds_alternative<None>(slot.trigger)) continue;
+      if (std::holds_alternative<Always>(slot.trigger)) return index;
+      if (std::get<uint32_t>(slot.trigger) == lock_value_) return index;
+    }
+    return std::numeric_limits<uint32_t>::max();
+  }
+
+  Slot slots_[kNumSlots];
+  uint32_t lock_value_ = 0;
+  Mutex mutex_{lock_value_};
+  std::optional<Lock> lock_;
+  uint64_t next_acquire_order_ = 1;
+};
+
+void AlwaysFair(std::vector<inter_activity_mutex_test::Op> ops) {
+  MockActivity activity;
+  activity.Activate();
+  EXPECT_CALL(activity, WakeupRequested()).Times(::testing::AnyNumber());
+  AlwaysFairFuzzer fuzzer;
+  for (const auto& op : ops) {
+    fuzzer.Run(op);
+  }
+}
+FUZZ_TEST(InterActivityMutexTest, AlwaysFair);
+
+auto ParseTestProto(const std::string& proto) {
+  inter_activity_mutex_test::Op msg;
+  CHECK(google::protobuf::TextFormat::ParseFromString(proto, &msg));
+  return msg;
+}
+
+TEST(InterActivityMutexTest, AlwaysFairRegression1) {
+  AlwaysFair({ParseTestProto(R"pb(acquire_when { when: 1 })pb"),
+              ParseTestProto(R"pb(poll {})pb"),
+              ParseTestProto(R"pb(drop {})pb"),
+              ParseTestProto(R"pb(acquire {})pb")});
+}
+
+TEST(InterActivityMutexTest, AlwaysFairRegression2) {
+  AlwaysFair({ParseTestProto(R"pb(acquire_when {})pb"),
+              ParseTestProto(R"pb(acquire { id: 1 })pb"),
+              ParseTestProto(R"pb(acquire {})pb"),
+              ParseTestProto(R"pb(poll {})pb"),
+              ParseTestProto(R"pb(acquire_when { when: 4294967292 })pb"),
+              ParseTestProto(R"pb(poll {})pb"),
+              ParseTestProto(R"pb(drop_lock {})pb")});
 }
 
 }  // namespace

--- a/test/core/promise/inter_activity_mutex_test.proto
+++ b/test/core/promise/inter_activity_mutex_test.proto
@@ -1,0 +1,51 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package inter_activity_mutex_test;
+
+message Op {
+  message Poll {
+    uint32 id = 1;
+  }
+
+  message Drop {
+    uint32 id = 1;
+  }
+
+  message Acquire {
+    uint32 id = 1;
+  }
+
+  message AcquireWhen {
+    uint32 id = 1;
+    uint32 when = 2;
+  }
+
+  message DropLock {}
+
+  message SetLock {
+    uint32 value = 1;
+  }
+
+  oneof type {
+    Poll poll = 1;
+    Drop drop = 2;
+    Acquire acquire = 3;
+    AcquireWhen acquire_when = 4;
+    DropLock drop_lock = 5;
+    SetLock set_lock = 6;
+  }
+}


### PR DESCRIPTION
This is going to be key to getting flow control going - we have several async steps that need to be completed as a group by disparate pieces of logic, and so this allows us to protect state between those pieces - regardless of the party they're running on.