### PR TITLE
[flaky test] Fix flaky xds security end2end test

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -596,6 +596,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
         // Prefixes added for context
         "(Failed to connect to remote host: )?"
         "(Timeout occurred: )?"
+        "(Endpoint closing)?"
         // Syscall
         "((connect|sendmsg|recvmsg|getsockopt\\(SO\\_ERROR\\)): ?)?"
         // strerror() output or other message

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -596,14 +596,14 @@ class ClientLbEnd2endTest : public ::testing::Test {
         // Prefixes added for context
         "(Failed to connect to remote host: )?"
         "(Timeout occurred: )?"
-        "(Endpoint closing)?"
         // Syscall
         "((connect|sendmsg|recvmsg|getsockopt\\(SO\\_ERROR\\)): ?)?"
         // strerror() output or other message
         "(Connection refused"
         "|Connection reset by peer"
         "|Socket closed"
-        "|FD shutdown)"
+        "|FD shutdown"
+        "|Endpoint closing)"
         // errno value
         "( \\([0-9]+\\))?");
   }

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -857,7 +857,6 @@ std::string XdsEnd2endTest::MakeConnectionFailureRegex(
       // Prefixes added for context
       "(Failed to connect to remote host: )?"
       "(Timeout occurred: )?"
-      "(Endpoint closing)?"
       // Syscall
       "((connect|sendmsg|recvmsg|getsockopt\\(SO\\_ERROR\\)): ?)?"
       // strerror() output or other message
@@ -865,7 +864,8 @@ std::string XdsEnd2endTest::MakeConnectionFailureRegex(
       "|Connection reset by peer"
       "|Socket closed"
       "|Broken pipe"
-      "|FD shutdown)"
+      "|FD shutdown"
+      "|Endpoint closing)"
       // errno value
       "( \\([0-9]+\\))?",
       // xDS node ID

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -857,6 +857,7 @@ std::string XdsEnd2endTest::MakeConnectionFailureRegex(
       // Prefixes added for context
       "(Failed to connect to remote host: )?"
       "(Timeout occurred: )?"
+      "(Endpoint closing)?"
       // Syscall
       "((connect|sendmsg|recvmsg|getsockopt\\(SO\\_ERROR\\)): ?)?"
       // strerror() output or other message


### PR DESCRIPTION

Should fix failures such as: [link](https://btx.cloud.google.com/invocations/3221fe8b-95ac-44c6-9d71-b3795827d193/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_security_end2end_test@poller%3Depoll1;config=fb129a3f88b42a340a418d9403c2dc7c362b97326ca2b0a1a4fc33561b3b5fa2/tests)

