### PR TITLE
[interop] Change time query from PRECISE to MONOTONIC

### DIFF
--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -182,7 +182,7 @@ class TestServiceImpl : public TestService::Service {
   Status CacheableUnaryCall(ServerContext* context,
                             const SimpleRequest* /*request*/,
                             SimpleResponse* response) override {
-    gpr_timespec ts = gpr_now(GPR_CLOCK_PRECISE);
+    gpr_timespec ts = gpr_now(GPR_CLOCK_MONOTONIC);
     std::string timestamp = std::to_string(ts.tv_nsec);
     response->mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
     context->AddInitialMetadata("cache-control", "max-age=60, public");


### PR DESCRIPTION
This almost certainly doesn't need the PRECISE clock type, and is the only call site to use it right now.
Once this is gone we can remove GPR_CLOCK_PRECISE, and then an entire timer subsystem that backs it.