### PR TITLE
[CallAttemptTracer] Fix call attempt tracer lifetimes for retries (#38729)

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -19,6 +19,7 @@
 EXPERIMENT_ENABLES = {
     "backoff_cap_initial_at_max": "backoff_cap_initial_at_max",
     "call_tracer_in_transport": "call_tracer_in_transport",
+    "call_tracer_transport_fix": "call_tracer_transport_fix",
     "callv3_client_auth_filter": "callv3_client_auth_filter",
     "event_engine_client": "event_engine_client",
     "event_engine_dns": "event_engine_dns",

--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -20,7 +20,6 @@ EXPERIMENT_ENABLES = {
     "backoff_cap_initial_at_max": "backoff_cap_initial_at_max",
     "call_tracer_in_transport": "call_tracer_in_transport",
     "callv3_client_auth_filter": "callv3_client_auth_filter",
-    "disable_buffer_hint_on_high_memory_pressure": "disable_buffer_hint_on_high_memory_pressure",
     "event_engine_client": "event_engine_client",
     "event_engine_dns": "event_engine_dns",
     "event_engine_dns_non_client_channel": "event_engine_dns_non_client_channel",
@@ -34,7 +33,6 @@ EXPERIMENT_ENABLES = {
     "multiping": "multiping",
     "pick_first_new": "pick_first_new",
     "posix_ee_skip_grpc_init": "posix_ee_skip_grpc_init",
-    "prioritize_finished_requests": "prioritize_finished_requests",
     "promise_based_http2_client_transport": "promise_based_http2_client_transport",
     "promise_based_http2_server_transport": "promise_based_http2_server_transport",
     "promise_based_inproc_transport": "promise_based_inproc_transport",
@@ -44,7 +42,6 @@ EXPERIMENT_ENABLES = {
     "server_listener": "server_listener",
     "tcp_frame_size_tuning": "tcp_frame_size_tuning",
     "tcp_rcv_lowat": "tcp_rcv_lowat",
-    "trace_record_callops": "trace_record_callops",
     "unconstrained_max_quota_buffer_size": "unconstrained_max_quota_buffer_size",
 }
 

--- a/src/core/client_channel/client_channel_filter.h
+++ b/src/core/client_channel/client_channel_filter.h
@@ -374,8 +374,7 @@ class ClientChannelFilter::LoadBalancedCall
  protected:
   ClientChannelFilter* chand() const { return chand_; }
   ClientCallTracer::CallAttemptTracer* call_attempt_tracer() const {
-    return DownCast<ClientCallTracer::CallAttemptTracer*>(
-        arena_->GetContext<CallTracerInterface>());
+    return call_attempt_tracer_;
   }
   ConnectedSubchannel* connected_subchannel() const {
     return connected_subchannel_.get();
@@ -431,6 +430,11 @@ class ClientChannelFilter::LoadBalancedCall
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannelFilter::lb_mu_) = 0;
 
   ClientChannelFilter* chand_;
+  // When we start a new attempt for a call, we might not have cleaned up the
+  // previous attempt yet leading to a situation where we have two active call
+  // attempt tracers, and so we cannot rely on the arena to give us the right
+  // tracer when performing cleanup.
+  ClientCallTracer::CallAttemptTracer* call_attempt_tracer_;
 
   absl::AnyInvocable<void()> on_commit_;
 

--- a/src/core/ext/filters/http/message_compress/compression_filter.cc
+++ b/src/core/ext/filters/http/message_compress/compression_filter.cc
@@ -101,11 +101,11 @@ ChannelCompression::ChannelCompression(const ChannelArgs& args)
 }
 
 MessageHandle ChannelCompression::CompressMessage(
-    MessageHandle message, grpc_compression_algorithm algorithm) const {
+    MessageHandle message, grpc_compression_algorithm algorithm,
+    CallTracerInterface* call_tracer) const {
   GRPC_TRACE_LOG(compression, INFO)
       << "CompressMessage: len=" << message->payload()->Length()
       << " alg=" << algorithm << " flags=" << message->flags();
-  auto* call_tracer = MaybeGetContext<CallTracerInterface>();
   if (call_tracer != nullptr) {
     call_tracer->RecordSendMessage(*message);
   }
@@ -155,12 +155,12 @@ MessageHandle ChannelCompression::CompressMessage(
 }
 
 absl::StatusOr<MessageHandle> ChannelCompression::DecompressMessage(
-    bool is_client, MessageHandle message, DecompressArgs args) const {
+    bool is_client, MessageHandle message, DecompressArgs args,
+    CallTracerInterface* call_tracer) const {
   GRPC_TRACE_LOG(compression, INFO)
       << "DecompressMessage: len=" << message->payload()->Length()
       << " max=" << args.max_recv_message_length.value_or(-1)
       << " alg=" << args.algorithm;
-  auto* call_tracer = MaybeGetContext<CallTracerInterface>();
   if (call_tracer != nullptr) {
     call_tracer->RecordReceivedMessage(*message);
   }
@@ -233,14 +233,15 @@ void ClientCompressionFilter::Call::OnClientInitialMetadata(
       "ClientCompressionFilter::Call::OnClientInitialMetadata");
   compression_algorithm_ =
       filter->compression_engine_.HandleOutgoingMetadata(md);
+  call_tracer_ = MaybeGetContext<CallTracerInterface>();
 }
 
 MessageHandle ClientCompressionFilter::Call::OnClientToServerMessage(
     MessageHandle message, ClientCompressionFilter* filter) {
   GRPC_LATENT_SEE_INNER_SCOPE(
       "ClientCompressionFilter::Call::OnClientToServerMessage");
-  return filter->compression_engine_.CompressMessage(std::move(message),
-                                                     compression_algorithm_);
+  return filter->compression_engine_.CompressMessage(
+      std::move(message), compression_algorithm_, call_tracer_);
 }
 
 void ClientCompressionFilter::Call::OnServerInitialMetadata(
@@ -256,7 +257,7 @@ ClientCompressionFilter::Call::OnServerToClientMessage(
   GRPC_LATENT_SEE_INNER_SCOPE(
       "ClientCompressionFilter::Call::OnServerToClientMessage");
   return filter->compression_engine_.DecompressMessage(
-      /*is_client=*/true, std::move(message), decompress_args_);
+      /*is_client=*/true, std::move(message), decompress_args_, call_tracer_);
 }
 
 void ServerCompressionFilter::Call::OnClientInitialMetadata(
@@ -272,7 +273,8 @@ ServerCompressionFilter::Call::OnClientToServerMessage(
   GRPC_LATENT_SEE_INNER_SCOPE(
       "ServerCompressionFilter::Call::OnClientToServerMessage");
   return filter->compression_engine_.DecompressMessage(
-      /*is_client=*/false, std::move(message), decompress_args_);
+      /*is_client=*/false, std::move(message), decompress_args_,
+      MaybeGetContext<CallTracerInterface>());
 }
 
 void ServerCompressionFilter::Call::OnServerInitialMetadata(
@@ -287,8 +289,9 @@ MessageHandle ServerCompressionFilter::Call::OnServerToClientMessage(
     MessageHandle message, ServerCompressionFilter* filter) {
   GRPC_LATENT_SEE_INNER_SCOPE(
       "ServerCompressionFilter::Call::OnServerToClientMessage");
-  return filter->compression_engine_.CompressMessage(std::move(message),
-                                                     compression_algorithm_);
+  return filter->compression_engine_.CompressMessage(
+      std::move(message), compression_algorithm_,
+      MaybeGetContext<CallTracerInterface>());
 }
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/http/message_compress/compression_filter.h
+++ b/src/core/ext/filters/http/message_compress/compression_filter.h
@@ -84,11 +84,12 @@ class ChannelCompression {
 
   // Compress one message synchronously.
   MessageHandle CompressMessage(MessageHandle message,
-                                grpc_compression_algorithm algorithm) const;
+                                grpc_compression_algorithm algorithm,
+                                CallTracerInterface* call_tracer) const;
   // Decompress one message synchronously.
-  absl::StatusOr<MessageHandle> DecompressMessage(bool is_client,
-                                                  MessageHandle message,
-                                                  DecompressArgs args) const;
+  absl::StatusOr<MessageHandle> DecompressMessage(
+      bool is_client, MessageHandle message, DecompressArgs args,
+      CallTracerInterface* call_tracer) const;
 
  private:
   // Max receive message length, if set.
@@ -137,6 +138,9 @@ class ClientCompressionFilter final
    private:
     grpc_compression_algorithm compression_algorithm_;
     ChannelCompression::DecompressArgs decompress_args_;
+    // TODO(yashykt): Remove call_tracer_ after migration to call v3 stack. (See
+    // https://github.com/grpc/grpc/pull/38729 for more information.)
+    CallTracerInterface* call_tracer_ = nullptr;
   };
 
  private:

--- a/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.cc
+++ b/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.cc
@@ -30,7 +30,7 @@ void Chttp2CallTracerWrapper::RecordIncomingBytes(
   stream_->stats.incoming.header_bytes += transport_byte_size.header_bytes;
   // Update new API.
   if (!IsCallTracerInTransportEnabled()) return;
-  auto* call_tracer = stream_->arena->GetContext<CallTracerInterface>();
+  auto* call_tracer = stream_->CallTracer();
   if (call_tracer != nullptr) {
     call_tracer->RecordIncomingBytes(transport_byte_size);
   }
@@ -44,7 +44,7 @@ void Chttp2CallTracerWrapper::RecordOutgoingBytes(
   stream_->stats.outgoing.header_bytes +=
       transport_byte_size.header_bytes;  // Update new API.
   if (!IsCallTracerInTransportEnabled()) return;
-  auto* call_tracer = stream_->arena->GetContext<CallTracerInterface>();
+  auto* call_tracer = stream_->CallTracer();
   if (call_tracer != nullptr) {
     call_tracer->RecordOutgoingBytes(transport_byte_size);
   }

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -229,9 +229,6 @@ using TaskHandle = ::grpc_event_engine::experimental::EventEngine::TaskHandle;
 
 grpc_core::CallTracerAnnotationInterface* CallTracerIfSampled(
     grpc_chttp2_stream* s) {
-  if (!grpc_core::IsTraceRecordCallopsEnabled()) {
-    return nullptr;
-  }
   auto* call_tracer =
       s->arena->GetContext<grpc_core::CallTracerAnnotationInterface>();
   if (call_tracer == nullptr || !call_tracer->IsSampled()) {
@@ -242,9 +239,6 @@ grpc_core::CallTracerAnnotationInterface* CallTracerIfSampled(
 
 std::shared_ptr<grpc_core::TcpTracerInterface> TcpTracerIfSampled(
     grpc_chttp2_stream* s) {
-  if (!grpc_core::IsTraceRecordCallopsEnabled()) {
-    return nullptr;
-  }
   auto* call_attempt_tracer =
       s->arena->GetContext<grpc_core::CallTracerInterface>();
   if (call_attempt_tracer == nullptr || !call_attempt_tracer->IsSampled()) {
@@ -1395,7 +1389,7 @@ static void trace_annotations(grpc_chttp2_stream* s) {
               .Add(s->t->flow_control.stats())
               .Add(s->flow_control.stats()));
     }
-  } else if (grpc_core::IsTraceRecordCallopsEnabled()) {
+  } else {
     auto* call_tracer = s->arena->GetContext<grpc_core::CallTracerInterface>();
     if (call_tracer != nullptr && call_tracer->IsSampled()) {
       call_tracer->RecordAnnotation(
@@ -1504,18 +1498,6 @@ static void send_message_locked(
                                       absl::OkStatus(),
                                       "fetching_send_message_finished");
   } else {
-    // Buffer hint is used to buffer the message in the transport until the
-    // write buffer size (specified through GRPC_ARG_HTTP2_WRITE_BUFFER_SIZE) is
-    // reached. This is to batch writes sent down to tcp. However, if the memory
-    // pressure is high, disable the buffer hint to flush data down to tcp as
-    // soon as possible to avoid OOM.
-    if (grpc_core::IsDisableBufferHintOnHighMemoryPressureEnabled() &&
-        t->memory_owner.GetPressureInfo().pressure_control_value >= 0.8) {
-      // Disable write buffer hint if memory pressure is high. The value of 0.8
-      // is chosen to match the threshold used by the tcp endpoint (in
-      // allocating memory for socket reads).
-      op_payload->send_message.flags &= ~GRPC_WRITE_BUFFER_HINT;
-    }
     flags = op_payload->send_message.flags;
     uint8_t* frame_hdr = grpc_slice_buffer_tiny_add(&s->flow_controlled_buffer,
                                                     GRPC_HEADER_SIZE_IN_BYTES);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -227,14 +227,14 @@ namespace {
 using EventEngine = ::grpc_event_engine::experimental::EventEngine;
 using TaskHandle = ::grpc_event_engine::experimental::EventEngine::TaskHandle;
 
-grpc_core::CallTracerAnnotationInterface* CallTracerIfSampled(
+grpc_core::CallTracerAnnotationInterface* ParentCallTracerIfSampled(
     grpc_chttp2_stream* s) {
-  auto* call_tracer =
+  auto* parent_call_tracer =
       s->arena->GetContext<grpc_core::CallTracerAnnotationInterface>();
-  if (call_tracer == nullptr || !call_tracer->IsSampled()) {
+  if (parent_call_tracer == nullptr || !parent_call_tracer->IsSampled()) {
     return nullptr;
   }
-  return call_tracer;
+  return parent_call_tracer;
 }
 
 std::shared_ptr<grpc_core::TcpTracerInterface> TcpTracerIfSampled(
@@ -1381,16 +1381,16 @@ static void log_metadata(const grpc_metadata_batch* md_batch, uint32_t id,
 }
 
 static void trace_annotations(grpc_chttp2_stream* s) {
-  if (!grpc_core::IsCallTracerInTransportEnabled()) {
-    if (s->call_tracer != nullptr) {
-      s->call_tracer->RecordAnnotation(
+  if (!grpc_core::IsCallTracerTransportFixEnabled()) {
+    if (s->parent_call_tracer != nullptr) {
+      s->parent_call_tracer->RecordAnnotation(
           grpc_core::HttpAnnotation(grpc_core::HttpAnnotation::Type::kStart,
                                     gpr_now(GPR_CLOCK_REALTIME))
               .Add(s->t->flow_control.stats())
               .Add(s->flow_control.stats()));
     }
   } else {
-    auto* call_tracer = s->arena->GetContext<grpc_core::CallTracerInterface>();
+    auto* call_tracer = s->CallTracer();
     if (call_tracer != nullptr && call_tracer->IsSampled()) {
       call_tracer->RecordAnnotation(
           grpc_core::HttpAnnotation(grpc_core::HttpAnnotation::Type::kStart,
@@ -1646,8 +1646,15 @@ static void perform_stream_op_locked(void* stream_op,
   grpc_chttp2_transport* t = s->t.get();
 
   s->traced = op->is_traced;
-  if (!grpc_core::IsCallTracerInTransportEnabled()) {
-    s->call_tracer = CallTracerIfSampled(s);
+  if (!grpc_core::IsCallTracerTransportFixEnabled()) {
+    s->parent_call_tracer = ParentCallTracerIfSampled(s);
+  }
+  // TODO(yashykt): Remove call_tracer field after transition to call v3. (See
+  // https://github.com/grpc/grpc/pull/38729 for more information.) On the
+  // client, the call attempt tracer will be available for use when the
+  // send_initial_metadata op arrives.
+  if (s->t->is_client && op->send_initial_metadata) {
+    s->call_tracer = s->arena->GetContext<grpc_core::CallTracerInterface>();
   }
   s->tcp_tracer = TcpTracerIfSampled(s);
   if (GRPC_TRACE_FLAG_ENABLED(http)) {

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1138,7 +1138,8 @@ grpc_error_handle HPackParser::ParseInput(
       HandleMetadataSoftSizeLimitExceeded(&input);
     }
     global_stats().IncrementHttp2MetadataSize(state_.frame_length);
-    if (call_tracer != nullptr && metadata_buffer_ != nullptr) {
+    if (call_tracer != nullptr && call_tracer->IsSampled() &&
+        metadata_buffer_ != nullptr) {
       MetadataSizesAnnotation metadata_sizes_annotation(
           metadata_buffer_, state_.metadata_early_detection.soft_limit(),
           state_.metadata_early_detection.hard_limit());

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -672,10 +672,10 @@ struct grpc_chttp2_stream {
 
   grpc_core::Chttp2CallTracerWrapper call_tracer_wrapper;
 
-  /// Only set when enabled.
-  // TODO(roth): Remove this when the call_tracer_in_transport
-  // experiment finishes rolling out.
-  grpc_core::CallTracerAnnotationInterface* call_tracer = nullptr;
+  // TODO(roth): Remove this when call v3 is supported.
+  grpc_core::CallTracerInterface* call_tracer = nullptr;
+  // TODO(yashykt): Remove this once call_tracer_transport_fix is rolled out
+  grpc_core::CallTracerAnnotationInterface* parent_call_tracer = nullptr;
 
   /// Only set when enabled.
   std::shared_ptr<grpc_core::TcpTracerInterface> tcp_tracer;
@@ -700,6 +700,14 @@ struct grpc_chttp2_stream {
   // The last time a stream window update was received.
   grpc_core::Timestamp last_window_update_time =
       grpc_core::Timestamp::InfPast();
+
+  // TODO(yashykt): Remove this when call v3 is supported.
+  grpc_core::CallTracerInterface* CallTracer() const {
+    if (t->is_client) {
+      return call_tracer;
+    }
+    return arena->GetContext<grpc_core::CallTracerInterface>();
+  }
 };
 
 #define GRPC_ARG_PING_TIMEOUT_MS "grpc.http2.ping_timeout_ms"

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -960,8 +960,8 @@ grpc_error_handle grpc_chttp2_header_parser_parse(void* hpack_parser,
     s->call_tracer_wrapper.RecordIncomingBytes(
         {0, 0, GRPC_SLICE_LENGTH(slice)});
     call_tracer =
-        grpc_core::IsCallTracerInTransportEnabled()
-            ? s->arena->GetContext<grpc_core::CallTracerInterface>()
+        grpc_core::IsCallTracerTransportFixEnabled()
+            ? s->CallTracer()
             : s->arena->GetContext<grpc_core::CallTracerAnnotationInterface>();
   }
   grpc_error_handle error = parser->Parse(

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -484,7 +484,7 @@ class StreamWriteContext {
                 .Add(s_->flow_control.stats())
                 .Add(write_stats));
       }
-    } else if (grpc_core::IsTraceRecordCallopsEnabled()) {
+    } else {
       auto* call_tracer =
           s_->arena->GetContext<grpc_core::CallTracerInterface>();
       if (call_tracer != nullptr && call_tracer->IsSampled()) {
@@ -646,7 +646,7 @@ class StreamWriteContext {
                 .Add(s_->t->flow_control.stats())
                 .Add(s_->flow_control.stats()));
       }
-    } else if (grpc_core::IsTraceRecordCallopsEnabled()) {
+    } else {
       auto* call_tracer =
           s_->arena->GetContext<grpc_core::CallTracerInterface>();
       if (call_tracer != nullptr && call_tracer->IsSampled()) {

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -29,6 +29,9 @@ const char* const additional_constraints_backoff_cap_initial_at_max = "{}";
 const char* const description_call_tracer_in_transport =
     "Transport directly passes byte counts to CallTracer.";
 const char* const additional_constraints_call_tracer_in_transport = "{}";
+const char* const description_call_tracer_transport_fix =
+    "Use the correct call tracer in transport";
+const char* const additional_constraints_call_tracer_transport_fix = "{}";
 const char* const description_callv3_client_auth_filter =
     "Use the CallV3 client auth filter.";
 const char* const additional_constraints_callv3_client_auth_filter = "{}";
@@ -131,6 +134,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_backoff_cap_initial_at_max, nullptr, 0, true, true},
     {"call_tracer_in_transport", description_call_tracer_in_transport,
      additional_constraints_call_tracer_in_transport, nullptr, 0, true, true},
+    {"call_tracer_transport_fix", description_call_tracer_transport_fix,
+     additional_constraints_call_tracer_transport_fix, nullptr, 0, true, true},
     {"callv3_client_auth_filter", description_callv3_client_auth_filter,
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
     {"event_engine_client", description_event_engine_client,
@@ -205,6 +210,9 @@ const char* const additional_constraints_backoff_cap_initial_at_max = "{}";
 const char* const description_call_tracer_in_transport =
     "Transport directly passes byte counts to CallTracer.";
 const char* const additional_constraints_call_tracer_in_transport = "{}";
+const char* const description_call_tracer_transport_fix =
+    "Use the correct call tracer in transport";
+const char* const additional_constraints_call_tracer_transport_fix = "{}";
 const char* const description_callv3_client_auth_filter =
     "Use the CallV3 client auth filter.";
 const char* const additional_constraints_callv3_client_auth_filter = "{}";
@@ -307,6 +315,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_backoff_cap_initial_at_max, nullptr, 0, true, true},
     {"call_tracer_in_transport", description_call_tracer_in_transport,
      additional_constraints_call_tracer_in_transport, nullptr, 0, true, true},
+    {"call_tracer_transport_fix", description_call_tracer_transport_fix,
+     additional_constraints_call_tracer_transport_fix, nullptr, 0, true, true},
     {"callv3_client_auth_filter", description_callv3_client_auth_filter,
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
     {"event_engine_client", description_event_engine_client,
@@ -381,6 +391,9 @@ const char* const additional_constraints_backoff_cap_initial_at_max = "{}";
 const char* const description_call_tracer_in_transport =
     "Transport directly passes byte counts to CallTracer.";
 const char* const additional_constraints_call_tracer_in_transport = "{}";
+const char* const description_call_tracer_transport_fix =
+    "Use the correct call tracer in transport";
+const char* const additional_constraints_call_tracer_transport_fix = "{}";
 const char* const description_callv3_client_auth_filter =
     "Use the CallV3 client auth filter.";
 const char* const additional_constraints_callv3_client_auth_filter = "{}";
@@ -483,6 +496,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_backoff_cap_initial_at_max, nullptr, 0, true, true},
     {"call_tracer_in_transport", description_call_tracer_in_transport,
      additional_constraints_call_tracer_in_transport, nullptr, 0, true, true},
+    {"call_tracer_transport_fix", description_call_tracer_transport_fix,
+     additional_constraints_call_tracer_transport_fix, nullptr, 0, true, true},
     {"callv3_client_auth_filter", description_callv3_client_auth_filter,
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
     {"event_engine_client", description_event_engine_client,

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -32,11 +32,6 @@ const char* const additional_constraints_call_tracer_in_transport = "{}";
 const char* const description_callv3_client_auth_filter =
     "Use the CallV3 client auth filter.";
 const char* const additional_constraints_callv3_client_auth_filter = "{}";
-const char* const description_disable_buffer_hint_on_high_memory_pressure =
-    "Disable buffer hint flag parsing in the transport under high memory "
-    "pressure.";
-const char* const
-    additional_constraints_disable_buffer_hint_on_high_memory_pressure = "{}";
 const char* const description_event_engine_client =
     "Use EventEngine clients instead of iomgr's grpc_tcp_client";
 const char* const additional_constraints_event_engine_client = "{}";
@@ -86,10 +81,6 @@ const char* const description_posix_ee_skip_grpc_init =
     "Prevent the PosixEventEngine from calling grpc_init & grpc_shutdown on "
     "creation and destruction.";
 const char* const additional_constraints_posix_ee_skip_grpc_init = "{}";
-const char* const description_prioritize_finished_requests =
-    "Prioritize flushing out finished requests over other in-flight requests "
-    "during transport writes.";
-const char* const additional_constraints_prioritize_finished_requests = "{}";
 const char* const description_promise_based_http2_client_transport =
     "Use promises for the http2 client transport. We have kept client and "
     "server transport experiments separate to help with smoother roll outs and "
@@ -127,9 +118,6 @@ const char* const additional_constraints_tcp_frame_size_tuning = "{}";
 const char* const description_tcp_rcv_lowat =
     "Use SO_RCVLOWAT to avoid wakeups on the read path.";
 const char* const additional_constraints_tcp_rcv_lowat = "{}";
-const char* const description_trace_record_callops =
-    "Enables tracing of call batch initiation and completion.";
-const char* const additional_constraints_trace_record_callops = "{}";
 const char* const description_unconstrained_max_quota_buffer_size =
     "Discard the cap on the max free pool size for one memory allocator";
 const char* const additional_constraints_unconstrained_max_quota_buffer_size =
@@ -145,10 +133,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_call_tracer_in_transport, nullptr, 0, true, true},
     {"callv3_client_auth_filter", description_callv3_client_auth_filter,
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
-    {"disable_buffer_hint_on_high_memory_pressure",
-     description_disable_buffer_hint_on_high_memory_pressure,
-     additional_constraints_disable_buffer_hint_on_high_memory_pressure,
-     nullptr, 0, false, true},
     {"event_engine_client", description_event_engine_client,
      additional_constraints_event_engine_client, nullptr, 0, false, false},
     {"event_engine_dns", description_event_engine_dns,
@@ -179,9 +163,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_pick_first_new, nullptr, 0, true, true},
     {"posix_ee_skip_grpc_init", description_posix_ee_skip_grpc_init,
      additional_constraints_posix_ee_skip_grpc_init, nullptr, 0, false, true},
-    {"prioritize_finished_requests", description_prioritize_finished_requests,
-     additional_constraints_prioritize_finished_requests, nullptr, 0, false,
-     true},
     {"promise_based_http2_client_transport",
      description_promise_based_http2_client_transport,
      additional_constraints_promise_based_http2_client_transport, nullptr, 0,
@@ -208,8 +189,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_tcp_frame_size_tuning, nullptr, 0, false, true},
     {"tcp_rcv_lowat", description_tcp_rcv_lowat,
      additional_constraints_tcp_rcv_lowat, nullptr, 0, false, true},
-    {"trace_record_callops", description_trace_record_callops,
-     additional_constraints_trace_record_callops, nullptr, 0, true, true},
     {"unconstrained_max_quota_buffer_size",
      description_unconstrained_max_quota_buffer_size,
      additional_constraints_unconstrained_max_quota_buffer_size, nullptr, 0,
@@ -229,11 +208,6 @@ const char* const additional_constraints_call_tracer_in_transport = "{}";
 const char* const description_callv3_client_auth_filter =
     "Use the CallV3 client auth filter.";
 const char* const additional_constraints_callv3_client_auth_filter = "{}";
-const char* const description_disable_buffer_hint_on_high_memory_pressure =
-    "Disable buffer hint flag parsing in the transport under high memory "
-    "pressure.";
-const char* const
-    additional_constraints_disable_buffer_hint_on_high_memory_pressure = "{}";
 const char* const description_event_engine_client =
     "Use EventEngine clients instead of iomgr's grpc_tcp_client";
 const char* const additional_constraints_event_engine_client = "{}";
@@ -283,10 +257,6 @@ const char* const description_posix_ee_skip_grpc_init =
     "Prevent the PosixEventEngine from calling grpc_init & grpc_shutdown on "
     "creation and destruction.";
 const char* const additional_constraints_posix_ee_skip_grpc_init = "{}";
-const char* const description_prioritize_finished_requests =
-    "Prioritize flushing out finished requests over other in-flight requests "
-    "during transport writes.";
-const char* const additional_constraints_prioritize_finished_requests = "{}";
 const char* const description_promise_based_http2_client_transport =
     "Use promises for the http2 client transport. We have kept client and "
     "server transport experiments separate to help with smoother roll outs and "
@@ -324,9 +294,6 @@ const char* const additional_constraints_tcp_frame_size_tuning = "{}";
 const char* const description_tcp_rcv_lowat =
     "Use SO_RCVLOWAT to avoid wakeups on the read path.";
 const char* const additional_constraints_tcp_rcv_lowat = "{}";
-const char* const description_trace_record_callops =
-    "Enables tracing of call batch initiation and completion.";
-const char* const additional_constraints_trace_record_callops = "{}";
 const char* const description_unconstrained_max_quota_buffer_size =
     "Discard the cap on the max free pool size for one memory allocator";
 const char* const additional_constraints_unconstrained_max_quota_buffer_size =
@@ -342,10 +309,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_call_tracer_in_transport, nullptr, 0, true, true},
     {"callv3_client_auth_filter", description_callv3_client_auth_filter,
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
-    {"disable_buffer_hint_on_high_memory_pressure",
-     description_disable_buffer_hint_on_high_memory_pressure,
-     additional_constraints_disable_buffer_hint_on_high_memory_pressure,
-     nullptr, 0, false, true},
     {"event_engine_client", description_event_engine_client,
      additional_constraints_event_engine_client, nullptr, 0, true, false},
     {"event_engine_dns", description_event_engine_dns,
@@ -376,9 +339,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_pick_first_new, nullptr, 0, true, true},
     {"posix_ee_skip_grpc_init", description_posix_ee_skip_grpc_init,
      additional_constraints_posix_ee_skip_grpc_init, nullptr, 0, false, true},
-    {"prioritize_finished_requests", description_prioritize_finished_requests,
-     additional_constraints_prioritize_finished_requests, nullptr, 0, false,
-     true},
     {"promise_based_http2_client_transport",
      description_promise_based_http2_client_transport,
      additional_constraints_promise_based_http2_client_transport, nullptr, 0,
@@ -405,8 +365,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_tcp_frame_size_tuning, nullptr, 0, false, true},
     {"tcp_rcv_lowat", description_tcp_rcv_lowat,
      additional_constraints_tcp_rcv_lowat, nullptr, 0, false, true},
-    {"trace_record_callops", description_trace_record_callops,
-     additional_constraints_trace_record_callops, nullptr, 0, true, true},
     {"unconstrained_max_quota_buffer_size",
      description_unconstrained_max_quota_buffer_size,
      additional_constraints_unconstrained_max_quota_buffer_size, nullptr, 0,
@@ -426,11 +384,6 @@ const char* const additional_constraints_call_tracer_in_transport = "{}";
 const char* const description_callv3_client_auth_filter =
     "Use the CallV3 client auth filter.";
 const char* const additional_constraints_callv3_client_auth_filter = "{}";
-const char* const description_disable_buffer_hint_on_high_memory_pressure =
-    "Disable buffer hint flag parsing in the transport under high memory "
-    "pressure.";
-const char* const
-    additional_constraints_disable_buffer_hint_on_high_memory_pressure = "{}";
 const char* const description_event_engine_client =
     "Use EventEngine clients instead of iomgr's grpc_tcp_client";
 const char* const additional_constraints_event_engine_client = "{}";
@@ -480,10 +433,6 @@ const char* const description_posix_ee_skip_grpc_init =
     "Prevent the PosixEventEngine from calling grpc_init & grpc_shutdown on "
     "creation and destruction.";
 const char* const additional_constraints_posix_ee_skip_grpc_init = "{}";
-const char* const description_prioritize_finished_requests =
-    "Prioritize flushing out finished requests over other in-flight requests "
-    "during transport writes.";
-const char* const additional_constraints_prioritize_finished_requests = "{}";
 const char* const description_promise_based_http2_client_transport =
     "Use promises for the http2 client transport. We have kept client and "
     "server transport experiments separate to help with smoother roll outs and "
@@ -521,9 +470,6 @@ const char* const additional_constraints_tcp_frame_size_tuning = "{}";
 const char* const description_tcp_rcv_lowat =
     "Use SO_RCVLOWAT to avoid wakeups on the read path.";
 const char* const additional_constraints_tcp_rcv_lowat = "{}";
-const char* const description_trace_record_callops =
-    "Enables tracing of call batch initiation and completion.";
-const char* const additional_constraints_trace_record_callops = "{}";
 const char* const description_unconstrained_max_quota_buffer_size =
     "Discard the cap on the max free pool size for one memory allocator";
 const char* const additional_constraints_unconstrained_max_quota_buffer_size =
@@ -539,10 +485,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_call_tracer_in_transport, nullptr, 0, true, true},
     {"callv3_client_auth_filter", description_callv3_client_auth_filter,
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
-    {"disable_buffer_hint_on_high_memory_pressure",
-     description_disable_buffer_hint_on_high_memory_pressure,
-     additional_constraints_disable_buffer_hint_on_high_memory_pressure,
-     nullptr, 0, false, true},
     {"event_engine_client", description_event_engine_client,
      additional_constraints_event_engine_client, nullptr, 0, true, false},
     {"event_engine_dns", description_event_engine_dns,
@@ -573,9 +515,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_pick_first_new, nullptr, 0, true, true},
     {"posix_ee_skip_grpc_init", description_posix_ee_skip_grpc_init,
      additional_constraints_posix_ee_skip_grpc_init, nullptr, 0, false, true},
-    {"prioritize_finished_requests", description_prioritize_finished_requests,
-     additional_constraints_prioritize_finished_requests, nullptr, 0, false,
-     true},
     {"promise_based_http2_client_transport",
      description_promise_based_http2_client_transport,
      additional_constraints_promise_based_http2_client_transport, nullptr, 0,
@@ -602,8 +541,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_tcp_frame_size_tuning, nullptr, 0, false, true},
     {"tcp_rcv_lowat", description_tcp_rcv_lowat,
      additional_constraints_tcp_rcv_lowat, nullptr, 0, false, true},
-    {"trace_record_callops", description_trace_record_callops,
-     additional_constraints_trace_record_callops, nullptr, 0, true, true},
     {"unconstrained_max_quota_buffer_size",
      description_unconstrained_max_quota_buffer_size,
      additional_constraints_unconstrained_max_quota_buffer_size, nullptr, 0,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -61,6 +61,8 @@ namespace grpc_core {
 inline bool IsBackoffCapInitialAtMaxEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_TRANSPORT_FIX
+inline bool IsCallTracerTransportFixEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 inline bool IsEventEngineClientEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
@@ -96,6 +98,8 @@ inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 inline bool IsBackoffCapInitialAtMaxEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_TRANSPORT_FIX
+inline bool IsCallTracerTransportFixEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
@@ -134,6 +138,8 @@ inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 inline bool IsBackoffCapInitialAtMaxEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() { return true; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_TRANSPORT_FIX
+inline bool IsCallTracerTransportFixEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
@@ -172,6 +178,7 @@ inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 enum ExperimentIds {
   kExperimentIdBackoffCapInitialAtMax,
   kExperimentIdCallTracerInTransport,
+  kExperimentIdCallTracerTransportFix,
   kExperimentIdCallv3ClientAuthFilter,
   kExperimentIdEventEngineClient,
   kExperimentIdEventEngineDns,
@@ -205,6 +212,10 @@ inline bool IsBackoffCapInitialAtMaxEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() {
   return IsExperimentEnabled<kExperimentIdCallTracerInTransport>();
+}
+#define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_TRANSPORT_FIX
+inline bool IsCallTracerTransportFixEnabled() {
+  return IsExperimentEnabled<kExperimentIdCallTracerTransportFix>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALLV3_CLIENT_AUTH_FILTER
 inline bool IsCallv3ClientAuthFilterEnabled() {

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -62,7 +62,6 @@ inline bool IsBackoffCapInitialAtMaxEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
-inline bool IsDisableBufferHintOnHighMemoryPressureEnabled() { return false; }
 inline bool IsEventEngineClientEnabled() { return false; }
 inline bool IsEventEngineDnsEnabled() { return false; }
 inline bool IsEventEngineDnsNonClientChannelEnabled() { return false; }
@@ -80,7 +79,6 @@ inline bool IsMultipingEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PICK_FIRST_NEW
 inline bool IsPickFirstNewEnabled() { return true; }
 inline bool IsPosixEeSkipGrpcInitEnabled() { return false; }
-inline bool IsPrioritizeFinishedRequestsEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ServerTransportEnabled() { return false; }
 inline bool IsPromiseBasedInprocTransportEnabled() { return false; }
@@ -91,8 +89,6 @@ inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsServerListenerEnabled() { return true; }
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
 inline bool IsTcpRcvLowatEnabled() { return false; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_TRACE_RECORD_CALLOPS
-inline bool IsTraceRecordCallopsEnabled() { return true; }
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 
 #elif defined(GPR_WINDOWS)
@@ -101,7 +97,6 @@ inline bool IsBackoffCapInitialAtMaxEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
-inline bool IsDisableBufferHintOnHighMemoryPressureEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
@@ -122,7 +117,6 @@ inline bool IsMultipingEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PICK_FIRST_NEW
 inline bool IsPickFirstNewEnabled() { return true; }
 inline bool IsPosixEeSkipGrpcInitEnabled() { return false; }
-inline bool IsPrioritizeFinishedRequestsEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ServerTransportEnabled() { return false; }
 inline bool IsPromiseBasedInprocTransportEnabled() { return false; }
@@ -133,8 +127,6 @@ inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsServerListenerEnabled() { return true; }
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
 inline bool IsTcpRcvLowatEnabled() { return false; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_TRACE_RECORD_CALLOPS
-inline bool IsTraceRecordCallopsEnabled() { return true; }
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 
 #else
@@ -143,7 +135,6 @@ inline bool IsBackoffCapInitialAtMaxEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALL_TRACER_IN_TRANSPORT
 inline bool IsCallTracerInTransportEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
-inline bool IsDisableBufferHintOnHighMemoryPressureEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
@@ -164,7 +155,6 @@ inline bool IsMultipingEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_PICK_FIRST_NEW
 inline bool IsPickFirstNewEnabled() { return true; }
 inline bool IsPosixEeSkipGrpcInitEnabled() { return false; }
-inline bool IsPrioritizeFinishedRequestsEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() { return false; }
 inline bool IsPromiseBasedHttp2ServerTransportEnabled() { return false; }
 inline bool IsPromiseBasedInprocTransportEnabled() { return false; }
@@ -175,8 +165,6 @@ inline bool IsScheduleCancellationOverWriteEnabled() { return false; }
 inline bool IsServerListenerEnabled() { return true; }
 inline bool IsTcpFrameSizeTuningEnabled() { return false; }
 inline bool IsTcpRcvLowatEnabled() { return false; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_TRACE_RECORD_CALLOPS
-inline bool IsTraceRecordCallopsEnabled() { return true; }
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 #endif
 
@@ -185,7 +173,6 @@ enum ExperimentIds {
   kExperimentIdBackoffCapInitialAtMax,
   kExperimentIdCallTracerInTransport,
   kExperimentIdCallv3ClientAuthFilter,
-  kExperimentIdDisableBufferHintOnHighMemoryPressure,
   kExperimentIdEventEngineClient,
   kExperimentIdEventEngineDns,
   kExperimentIdEventEngineDnsNonClientChannel,
@@ -199,7 +186,6 @@ enum ExperimentIds {
   kExperimentIdMultiping,
   kExperimentIdPickFirstNew,
   kExperimentIdPosixEeSkipGrpcInit,
-  kExperimentIdPrioritizeFinishedRequests,
   kExperimentIdPromiseBasedHttp2ClientTransport,
   kExperimentIdPromiseBasedHttp2ServerTransport,
   kExperimentIdPromiseBasedInprocTransport,
@@ -209,7 +195,6 @@ enum ExperimentIds {
   kExperimentIdServerListener,
   kExperimentIdTcpFrameSizeTuning,
   kExperimentIdTcpRcvLowat,
-  kExperimentIdTraceRecordCallops,
   kExperimentIdUnconstrainedMaxQuotaBufferSize,
   kNumExperiments
 };
@@ -224,11 +209,6 @@ inline bool IsCallTracerInTransportEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_CALLV3_CLIENT_AUTH_FILTER
 inline bool IsCallv3ClientAuthFilterEnabled() {
   return IsExperimentEnabled<kExperimentIdCallv3ClientAuthFilter>();
-}
-#define GRPC_EXPERIMENT_IS_INCLUDED_DISABLE_BUFFER_HINT_ON_HIGH_MEMORY_PRESSURE
-inline bool IsDisableBufferHintOnHighMemoryPressureEnabled() {
-  return IsExperimentEnabled<
-      kExperimentIdDisableBufferHintOnHighMemoryPressure>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() {
@@ -282,10 +262,6 @@ inline bool IsPickFirstNewEnabled() {
 inline bool IsPosixEeSkipGrpcInitEnabled() {
   return IsExperimentEnabled<kExperimentIdPosixEeSkipGrpcInit>();
 }
-#define GRPC_EXPERIMENT_IS_INCLUDED_PRIORITIZE_FINISHED_REQUESTS
-inline bool IsPrioritizeFinishedRequestsEnabled() {
-  return IsExperimentEnabled<kExperimentIdPrioritizeFinishedRequests>();
-}
 #define GRPC_EXPERIMENT_IS_INCLUDED_PROMISE_BASED_HTTP2_CLIENT_TRANSPORT
 inline bool IsPromiseBasedHttp2ClientTransportEnabled() {
   return IsExperimentEnabled<kExperimentIdPromiseBasedHttp2ClientTransport>();
@@ -321,10 +297,6 @@ inline bool IsTcpFrameSizeTuningEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_TCP_RCV_LOWAT
 inline bool IsTcpRcvLowatEnabled() {
   return IsExperimentEnabled<kExperimentIdTcpRcvLowat>();
-}
-#define GRPC_EXPERIMENT_IS_INCLUDED_TRACE_RECORD_CALLOPS
-inline bool IsTraceRecordCallopsEnabled() {
-  return IsExperimentEnabled<kExperimentIdTraceRecordCallops>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_UNCONSTRAINED_MAX_QUOTA_BUFFER_SIZE
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -55,11 +55,6 @@
   expiry: 2025/06/01
   owner: ctiller@google.com
   test_tags: [core_end2end_test]
-- name: disable_buffer_hint_on_high_memory_pressure
-  description: Disable buffer hint flag parsing in the transport under high memory pressure.
-  expiry: 2025/03/01
-  owner: vigneshbabu@google.com
-  test_tags: []
 - name: event_engine_callback_cq
   description: Use EventEngine instead of the CallbackAlternativeCQ.
   expiry: 2025/05/01
@@ -140,12 +135,6 @@
   expiry: 2025/03/02
   owner: hork@google.com
   test_tags: ["core_end2end_test", "cpp_end2end_test"]
-- name: prioritize_finished_requests
-  description: Prioritize flushing out finished requests over other in-flight
-    requests during transport writes.
-  expiry: 2025/03/01
-  owner: vigneshbabu@google.com
-  test_tags: []
 - name: promise_based_http2_client_transport
   description:
     Use promises for the http2 client transport. We have kept client and
@@ -206,11 +195,6 @@
   expiry: 2025/03/01
   owner: vigneshbabu@google.com
   test_tags: ["endpoint_test", "flow_control_test"]
-- name: trace_record_callops
-  description: Enables tracing of call batch initiation and completion.
-  expiry: 2025/01/30
-  owner: vigneshbabu@google.com
-  test_tags: []
 - name: unconstrained_max_quota_buffer_size
   description: Discard the cap on the max free pool size for one memory allocator
   expiry: 2025/09/03

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -50,6 +50,11 @@
   expiry: 2025/06/01
   owner: roth@google.com
   test_tags: []
+- name: call_tracer_transport_fix
+  description: Use the correct call tracer in transport
+  expiry: 2025/06/01
+  owner: yashkt@google.com
+  test_tags: []
 - name: callv3_client_auth_filter
   description: Use the CallV3 client auth filter.
   expiry: 2025/06/01

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -46,8 +46,6 @@
   default: true
 - name: call_v3
   default: false
-- name: disable_buffer_hint_on_high_memory_pressure
-  default: false
 - name: event_engine_callback_cq
   default: true
 - name: event_engine_client
@@ -82,8 +80,6 @@
   default: true
 - name: posix_ee_skip_grpc_init
   default: false
-- name: prioritize_finished_requests
-  default: false
 - name: promise_based_http2_client_transport
   default: false
 - name: promise_based_http2_server_transport
@@ -100,7 +96,5 @@
   default: false
 - name: tcp_rcv_lowat
   default: false
-- name: trace_record_callops
-  default: true
 - name: unconstrained_max_quota_buffer_size
   default: false

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -44,6 +44,8 @@
   default: true
 - name: call_tracer_in_transport
   default: true
+- name: call_tracer_transport_fix
+  default: true
 - name: call_v3
   default: false
 - name: event_engine_callback_cq

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -830,7 +830,7 @@ TEST_F(StatsPluginEnd2EndTest, TestMetadataSizeAnnotations) {
   auto sent_span_data = GetSpanByName(
       recorded_spans,
       absl::StrCat(
-          grpc_core::IsCallTracerInTransportEnabled() ? "Attempt." : "Sent.",
+          grpc_core::IsCallTracerTransportFixEnabled() ? "Attempt." : "Sent.",
           client_method_name_));
   ASSERT_NE(sent_span_data, recorded_spans.end());
   EXPECT_TRUE(IsAnnotationPresent(
@@ -876,7 +876,7 @@ TEST_F(StatsPluginEnd2EndTest, TestHttpAnnotations) {
   auto client_span_data = GetSpanByName(
       recorded_spans,
       absl::StrCat(
-          grpc_core::IsCallTracerInTransportEnabled() ? "Attempt." : "Sent.",
+          grpc_core::IsCallTracerTransportFixEnabled() ? "Attempt." : "Sent.",
           client_method_name_));
   ASSERT_NE(client_span_data, recorded_spans.end());
   EXPECT_TRUE(IsAnnotationPresent(client_span_data,

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -1110,7 +1110,6 @@ TEST(StatsPluginDeclarationTest, Declarations) {
 
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
-  grpc_core::ForceEnableExperiment("trace_record_callops", true);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Backport #38729 to v1.71.x. (also backporting [#38774](https://github.com/grpc/grpc/pull/38774) as a pre-requisite)