### PR TITLE
[PH2][Trivial][BUILD] Adding log

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -7472,6 +7472,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/functional:function_ref",
+        "absl/log",
         "absl/strings",
     ],
     deps = [
@@ -7490,6 +7491,10 @@ grpc_cc_library(
     hdrs = [
         "ext/transport/chttp2/transport/http2_client_transport.h",
     ],
+    external_deps = [
+        "absl/log",
+        "absl/log:check",
+    ],
     deps = [
         "grpc_promise_endpoint",
         "//:grpc_base",
@@ -7505,6 +7510,10 @@ grpc_cc_library(
     ],
     hdrs = [
         "ext/transport/chttp2/transport/http2_server_transport.h",
+    ],
+    external_deps = [
+        "absl/log",
+        "absl/log:check",
     ],
     deps = [
         "grpc_promise_endpoint",
@@ -8676,6 +8685,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/base:core_headers",
+        "absl/log",
         "absl/log:check",
         "absl/status",
         "absl/status:statusor",
@@ -8887,6 +8897,7 @@ grpc_cc_library(
     ],
     external_deps = [
         "absl/functional:any_invocable",
+        "absl/log",
         "absl/log:check",
     ],
     deps = [
@@ -8944,6 +8955,7 @@ grpc_cc_library(
         "absl/container:flat_hash_set",
         "absl/container:inlined_vector",
         "absl/functional:function_ref",
+        "absl/log",
         "absl/log:check",
         "absl/meta:type_traits",
         "absl/strings",

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -490,7 +490,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "http2_client_transport_test",
     srcs = ["http2_client_transport_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     uses_polling = False,
     deps = [
         "//:gpr",
@@ -506,7 +509,10 @@ grpc_cc_test(
 grpc_cc_test(
     name = "http2_server_transport_test",
     srcs = ["http2_server_transport_test.cc"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     uses_polling = False,
     deps = [
         "//:gpr",
@@ -575,6 +581,7 @@ grpc_cc_library(
     testonly = 1,
     hdrs = ["http2_frame_test_helper.h"],
     external_deps = [
+        "absl/log:log",
         "absl/strings",
         "absl/types:span",
     ],

--- a/test/core/transport/util/BUILD
+++ b/test/core/transport/util/BUILD
@@ -26,7 +26,10 @@ grpc_cc_library(
     testonly = 1,
     srcs = ["mock_promise_endpoint.cc"],
     hdrs = ["mock_promise_endpoint.h"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     deps = [
         "//:grpc",
         "//src/core:grpc_promise_endpoint",
@@ -37,7 +40,10 @@ grpc_cc_library(
     name = "transport_test",
     testonly = 1,
     hdrs = ["transport_test.h"],
-    external_deps = ["gtest"],
+    external_deps = [
+        "absl/log:log",
+        "gtest",
+    ],
     deps = [
         "//:iomgr_timer",
         "//src/core:memory_quota",


### PR DESCRIPTION
[PH2][Trivial][BUILD] Adding log 

Adding logs were I debug frequently. It is annoying to add it manually each time I need to debug in a new workspace. 

Eventually debugging and debuggability code will be added to all these critical files. Better to reduce time waste of adding log to dependencies each time I am just trying to see a LOG statement. 