### PR TITLE
[xds_cluster_type_e2e_test] fix expectation bug

### DIFF
--- a/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_type_end2end_test.cc
@@ -166,8 +166,8 @@ TEST_P(LogicalDNSClusterTest, FailedBackendConnectionCausesReresolution) {
     if (!result.status.ok()) {
       EXPECT_EQ(StatusCode::UNAVAILABLE, result.status.error_code());
       EXPECT_THAT(result.status.error_message(),
-                  MakeConnectionFailureRegex(
-                      "connections to all backends failing; last error: "));
+                  ::testing::MatchesRegex(MakeConnectionFailureRegex(
+                      "connections to all backends failing; last error: ")));
     }
   });
 }


### PR DESCRIPTION
I noticed this while working on something unrelated.  It hasn't actually caused any flakes as far as I know, so the test probably isn't actually hitting this condition, but the expectation would definitely fail if it did, since it's using literal string matching to match against a regexp.