### PR TITLE
[PH2][Test][Transport] New flags for new transport

### DIFF
--- a/doc/trace_flags.md
+++ b/doc/trace_flags.md
@@ -102,7 +102,7 @@ accomplished by invoking `bazel build --config=dbg <target>`
   - lb_policy_refcount - LB policy refcounting.
   - party_state - Coordination of activities related to a call.
   - pending_tags - Still-in-progress tags on completion queues. The `api` tracer must be enabled for this flag to have any effect.
-  - ph2 - Promise Based HTTP2 transport.
+  - http2_ph2_transport - Promise Based HTTP2 transport.
   - polling - The active polling engine.
   - polling_api - API calls to polling engine.
   - promise_primitives - Low-level primitives in the promise library.

--- a/src/core/lib/debug/trace_flags.cc
+++ b/src/core/lib/debug/trace_flags.cc
@@ -37,7 +37,7 @@ DebugOnlyTraceFlag fd_trace_trace(false, "fd_trace");
 DebugOnlyTraceFlag lb_policy_refcount_trace(false, "lb_policy_refcount");
 DebugOnlyTraceFlag party_state_trace(false, "party_state");
 DebugOnlyTraceFlag pending_tags_trace(false, "pending_tags");
-DebugOnlyTraceFlag ph2_trace(false, "ph2");
+DebugOnlyTraceFlag http2_ph2_transport_trace(false, "http2_ph2_transport");
 DebugOnlyTraceFlag polling_trace(false, "polling");
 DebugOnlyTraceFlag polling_api_trace(false, "polling_api");
 DebugOnlyTraceFlag promise_primitives_trace(false, "promise_primitives");
@@ -227,7 +227,7 @@ const absl::flat_hash_map<std::string, TraceFlag*>& GetAllTraceFlags() {
           {"lb_policy_refcount", &lb_policy_refcount_trace},
           {"party_state", &party_state_trace},
           {"pending_tags", &pending_tags_trace},
-          {"ph2", &ph2_trace},
+          {"http2_ph2_transport", &http2_ph2_transport_trace},
           {"polling", &polling_trace},
           {"polling_api", &polling_api_trace},
           {"promise_primitives", &promise_primitives_trace},

--- a/src/core/lib/debug/trace_flags.h
+++ b/src/core/lib/debug/trace_flags.h
@@ -37,7 +37,7 @@ extern DebugOnlyTraceFlag fd_trace_trace;
 extern DebugOnlyTraceFlag lb_policy_refcount_trace;
 extern DebugOnlyTraceFlag party_state_trace;
 extern DebugOnlyTraceFlag pending_tags_trace;
-extern DebugOnlyTraceFlag ph2_trace;
+extern DebugOnlyTraceFlag http2_ph2_transport_trace;
 extern DebugOnlyTraceFlag polling_trace;
 extern DebugOnlyTraceFlag polling_api_trace;
 extern DebugOnlyTraceFlag promise_primitives_trace;

--- a/src/core/lib/debug/trace_flags.yaml
+++ b/src/core/lib/debug/trace_flags.yaml
@@ -229,7 +229,7 @@ pending_tags:
   debug_only: true
   default: false
   description: Still-in-progress tags on completion queues. The `api` tracer must be enabled for this flag to have any effect.
-ph2:
+http2_ph2_transport:
   debug_only: true
   default: false
   description: Promise Based HTTP2 transport.


### PR DESCRIPTION
[PH2][Test][Transport] New flags for new transport

And we will make it such that passing "http2*" will still cause our new logs to printed in debug mode (our new trace is a debug only trace)