### PR TITLE
[Dep] Upgrade protoc-gen-validate to 1.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,14 +455,23 @@ if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opencensus-proto/src AND 
     opencensus-proto-0.3.0/src
   )
 endif()
-# Setup external proto library at third_party/protoc-gen-validate if it doesn't exist
+# Setup external proto library at third_party/protoc-gen-validate with 2 download URLs
 if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protoc-gen-validate AND gRPC_DOWNLOAD_ARCHIVES)
   # Download the archive via HTTP, validate the checksum, and extract to third_party/protoc-gen-validate.
   download_archive(
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protoc-gen-validate
-    https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.0.4.zip
-    9372f9ecde8fbadf83c8c7de3dbb49b11067aa26fb608c501106d0b4bf06c28f
-    protoc-gen-validate-1.0.4
+    https://storage.googleapis.com/grpc-bazel-mirror/github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip
+    ab51e978326b87e06be7a12fc6496f3ff6586339043557dbbd31f622332a5d45
+    protoc-gen-validate-1.2.1
+  )
+endif()
+if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protoc-gen-validate AND gRPC_DOWNLOAD_ARCHIVES)
+  # Download the archive via HTTP, validate the checksum, and extract to third_party/protoc-gen-validate.
+  download_archive(
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protoc-gen-validate
+    https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip
+    ab51e978326b87e06be7a12fc6496f3ff6586339043557dbbd31f622332a5d45
+    protoc-gen-validate-1.2.1
   )
 endif()
 # Setup external proto library at third_party/xds with 2 download URLs

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -34,6 +34,7 @@ bazel_dep(name = "opencensus-cpp", version = "0.0.0-20230502-50eb5de", repo_name
 bazel_dep(name = "opentelemetry-cpp", version = "1.19.0", repo_name = "io_opentelemetry_cpp")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+bazel_dep(name = "protoc-gen-validate", version = "1.2.1", repo_name = "com_envoyproxy_protoc_gen_validate")  # Not needed directly
 bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
 bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_cc", version = "0.0.17")

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -328,9 +328,12 @@ def grpc_deps():
     if "com_envoyproxy_protoc_gen_validate" not in native.existing_rules():
         http_archive(
             name = "com_envoyproxy_protoc_gen_validate",
-            sha256 = "9372f9ecde8fbadf83c8c7de3dbb49b11067aa26fb608c501106d0b4bf06c28f",
-            strip_prefix = "protoc-gen-validate-1.0.4",
-            urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.0.4.zip"],
+            sha256 = "ab51e978326b87e06be7a12fc6496f3ff6586339043557dbbd31f622332a5d45",
+            strip_prefix = "protoc-gen-validate-1.2.1",
+            urls = [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip",
+                "https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip"
+            ],
         )
 
     if "com_github_cncf_xds" not in native.existing_rules():

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -332,7 +332,7 @@ def grpc_deps():
             strip_prefix = "protoc-gen-validate-1.2.1",
             urls = [
                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip",
-                "https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip"
+                "https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip",
             ],
         )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -21365,11 +21365,12 @@ external_proto_libraries:
   - https://storage.googleapis.com/grpc-bazel-mirror/github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz
   - https://github.com/census-instrumentation/opencensus-proto/archive/v0.3.0.tar.gz
 - destination: third_party/protoc-gen-validate
-  hash: 9372f9ecde8fbadf83c8c7de3dbb49b11067aa26fb608c501106d0b4bf06c28f
+  hash: ab51e978326b87e06be7a12fc6496f3ff6586339043557dbbd31f622332a5d45
   proto_prefix: third_party/protoc-gen-validate/
-  strip_prefix: protoc-gen-validate-1.0.4
+  strip_prefix: protoc-gen-validate-1.2.1
   urls:
-  - https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.0.4.zip
+  - https://storage.googleapis.com/grpc-bazel-mirror/github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip
+  - https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.zip
 - destination: third_party/xds
   hash: dc305e20c9fa80822322271b50aa2ffa917bf4fd3973bcec52bfc28dc32c5927
   proto_prefix: third_party/xds/

--- a/templates/MODULE.bazel.template
+++ b/templates/MODULE.bazel.template
@@ -36,6 +36,7 @@
     bazel_dep(name = "opentelemetry-cpp", version = "1.19.0", repo_name = "io_opentelemetry_cpp")
     bazel_dep(name = "platforms", version = "0.0.10")
     bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
+    bazel_dep(name = "protoc-gen-validate", version = "1.2.1", repo_name = "com_envoyproxy_protoc_gen_validate")  # Not needed directly
     bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
     bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
     bazel_dep(name = "rules_cc", version = "0.0.17")


### PR DESCRIPTION
To fix a compatibility issue between protobuf v30 and an older `protoc-gen-validate` version (identified in gRPC PR #38725), we must update `protoc-gen-validate`, even though gRPC doesn't directly use it. This dependency is brought in via envoy-api.