### PR TITLE
[fuzzing] If no configuration is available, skip the test silently

### DIFF
--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -739,9 +739,7 @@ inline auto MaybeAddNullConfig(
   };                                                                           \
   void suite##_##name(const grpc_core::CoreTestConfiguration* config,          \
                       core_end2end_test_fuzzer::Msg msg) {                     \
-    if (config == nullptr) {                                                   \
-      GTEST_SKIP() << "config not available on this platform";                 \
-    }                                                                          \
+    if (config == nullptr) return;                                             \
     if (absl::StartsWith(#name, "DISABLED_")) GTEST_SKIP() << "disabled test"; \
     if (!IsEventEngineListenerEnabled() || !IsEventEngineClientEnabled() ||    \
         !IsEventEngineDnsEnabled()) {                                          \


### PR DESCRIPTION
This reduces a simply incredible amount of spam when running the end2end fuzzers right now.