### PR TITLE
[grpc_error] remove unnecessary debugging attributes

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -724,11 +724,7 @@ static void destroy_transport_locked(void* tp, grpc_error_handle /*error*/) {
   grpc_core::RefCountedPtr<grpc_chttp2_transport> t(
       static_cast<grpc_chttp2_transport*>(tp));
   t->destroying = 1;
-  close_transport_locked(
-      t.get(),
-      grpc_error_set_int(GRPC_ERROR_CREATE("Transport destroyed"),
-                         grpc_core::StatusIntProperty::kOccurredDuringWrite,
-                         t->write_state));
+  close_transport_locked(t.get(), GRPC_ERROR_CREATE("Transport destroyed"));
   t->memory_owner.Reset();
 }
 
@@ -2857,9 +2853,7 @@ static void read_action_locked(
   }
   grpc_error_handle err = error;
   if (!err.ok()) {
-    err = grpc_error_set_int(
-        GRPC_ERROR_CREATE_REFERENCING("Endpoint read failed", &err, 1),
-        grpc_core::StatusIntProperty::kOccurredDuringWrite, t->write_state);
+    err = GRPC_ERROR_CREATE_REFERENCING("Endpoint read failed", &err, 1);
   }
   std::swap(err, error);
   read_action_parse_loop_locked(std::move(t), std::move(err));

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -277,8 +277,6 @@ void PosixEndpointImpl::FinishEstimate() {
 }
 
 absl::Status PosixEndpointImpl::TcpAnnotateError(absl::Status src_error) const {
-  grpc_core::StatusSetInt(&src_error, grpc_core::StatusIntProperty::kFd,
-                          handle_->WrappedFd());
   grpc_core::StatusSetInt(&src_error, grpc_core::StatusIntProperty::kRpcStatus,
                           GRPC_STATUS_UNAVAILABLE);
   return src_error;

--- a/src/core/lib/event_engine/windows/windows_listener.cc
+++ b/src/core/lib/event_engine/windows/windows_listener.cc
@@ -257,8 +257,8 @@ WindowsEventEngineListener::SinglePortSocketListener::PrepareListenerSocket(
     SOCKET sock, const EventEngine::ResolvedAddress& addr) {
   auto fail = [&](absl::Status error) -> absl::Status {
     CHECK(!error.ok());
-    error = GRPC_ERROR_CREATE_REFERENCING(
-        "Failed to prepare server socket", &error, 1);
+    error = GRPC_ERROR_CREATE_REFERENCING("Failed to prepare server socket",
+                                          &error, 1);
     if (sock != INVALID_SOCKET) closesocket(sock);
     return error;
   };

--- a/src/core/lib/event_engine/windows/windows_listener.cc
+++ b/src/core/lib/event_engine/windows/windows_listener.cc
@@ -257,10 +257,8 @@ WindowsEventEngineListener::SinglePortSocketListener::PrepareListenerSocket(
     SOCKET sock, const EventEngine::ResolvedAddress& addr) {
   auto fail = [&](absl::Status error) -> absl::Status {
     CHECK(!error.ok());
-    error = grpc_error_set_int(
-        GRPC_ERROR_CREATE_REFERENCING("Failed to prepare server socket", &error,
-                                      1),
-        grpc_core::StatusIntProperty::kFd, static_cast<intptr_t>(sock));
+    error = GRPC_ERROR_CREATE_REFERENCING(
+        "Failed to prepare server socket", &error, 1);
     if (sock != INVALID_SOCKET) closesocket(sock);
     return error;
   };

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -738,7 +738,7 @@ static void finish_estimate(grpc_tcp* tcp) {
 static grpc_error_handle tcp_annotate_error(grpc_error_handle src_error,
                                             grpc_tcp* tcp) {
   return grpc_error_set_int(
-      grpc_error_set_int(src_error, grpc_core::StatusIntProperty::kFd, tcp->fd),
+      src_error,
       // All tcp errors are marked with UNAVAILABLE so that application may
       // choose to retry.
       grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -737,11 +737,11 @@ static void finish_estimate(grpc_tcp* tcp) {
 
 static grpc_error_handle tcp_annotate_error(grpc_error_handle src_error,
                                             grpc_tcp* tcp) {
-  return grpc_error_set_int(
-      src_error,
-      // All tcp errors are marked with UNAVAILABLE so that application may
-      // choose to retry.
-      grpc_core::StatusIntProperty::kRpcStatus, GRPC_STATUS_UNAVAILABLE);
+  return grpc_error_set_int(src_error,
+                            // All tcp errors are marked with UNAVAILABLE so
+                            // that application may choose to retry.
+                            grpc_core::StatusIntProperty::kRpcStatus,
+                            GRPC_STATUS_UNAVAILABLE);
 }
 
 static void tcp_handle_read(void* arg /* grpc_tcp */, grpc_error_handle error);

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -273,10 +273,7 @@ error:
   if (fd >= 0) {
     close(fd);
   }
-  grpc_error_handle ret = grpc_error_set_int(
-      GRPC_ERROR_CREATE_REFERENCING("Unable to configure socket", &err, 1),
-      grpc_core::StatusIntProperty::kFd, fd);
-  return ret;
+  return GRPC_ERROR_CREATE_REFERENCING("Unable to configure socket", &err, 1);
 }
 
 #endif  // GRPC_POSIX_SOCKET_TCP_SERVER_UTILS_COMMON

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -292,8 +292,8 @@ static grpc_error_handle prepare_socket(SOCKET sock,
 
 failure:
   CHECK(!error.ok());
-  error = GRPC_ERROR_CREATE_REFERENCING(
-      "Failed to prepare server socket", &error, 1);
+  error = GRPC_ERROR_CREATE_REFERENCING("Failed to prepare server socket",
+                                        &error, 1);
   if (sock != INVALID_SOCKET) closesocket(sock);
   return error;
 }

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -292,9 +292,8 @@ static grpc_error_handle prepare_socket(SOCKET sock,
 
 failure:
   CHECK(!error.ok());
-  error = grpc_error_set_int(GRPC_ERROR_CREATE_REFERENCING(
-                                 "Failed to prepare server socket", &error, 1),
-                             grpc_core::StatusIntProperty::kFd, (intptr_t)sock);
+  error = GRPC_ERROR_CREATE_REFERENCING(
+      "Failed to prepare server socket", &error, 1);
   if (sock != INVALID_SOCKET) closesocket(sock);
   return error;
 }

--- a/src/core/util/status_helper.cc
+++ b/src/core/util/status_helper.cc
@@ -57,8 +57,6 @@ const absl::string_view kChildrenPropertyUrl = TYPE_URL(TYPE_CHILDREN_TAG);
 
 const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
   switch (key) {
-    case StatusIntProperty::kFileLine:
-      return TYPE_URL(TYPE_INT_TAG "file_line");
     case StatusIntProperty::kStreamId:
       return TYPE_URL(TYPE_INT_TAG "stream_id");
     case StatusIntProperty::kRpcStatus:
@@ -77,8 +75,6 @@ const char* GetStatusStrPropertyUrl(StatusStrProperty key) {
   switch (key) {
     case StatusStrProperty::kDescription:
       return TYPE_URL(TYPE_STR_TAG "description");
-    case StatusStrProperty::kFile:
-      return TYPE_URL(TYPE_STR_TAG "file");
     case StatusStrProperty::kGrpcMessage:
       return TYPE_URL(TYPE_STR_TAG "grpc_message");
   }
@@ -132,12 +128,6 @@ absl::Status StatusCreate(absl::StatusCode code, absl::string_view msg,
                           const DebugLocation& location,
                           std::vector<absl::Status> children) {
   absl::Status s(code, msg);
-  if (location.file() != nullptr) {
-    StatusSetStr(&s, StatusStrProperty::kFile, location.file());
-  }
-  if (location.line() != -1) {
-    StatusSetInt(&s, StatusIntProperty::kFileLine, location.line());
-  }
   StatusSetTime(&s, StatusTimeProperty::kCreated, absl::Now());
   for (const absl::Status& child : children) {
     if (!child.ok()) {

--- a/src/core/util/status_helper.cc
+++ b/src/core/util/status_helper.cc
@@ -65,8 +65,6 @@ const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
       return TYPE_URL(TYPE_INT_TAG "grpc_status");
     case StatusIntProperty::kHttp2Error:
       return TYPE_URL(TYPE_INT_TAG "http2_error");
-    case StatusIntProperty::kFd:
-      return TYPE_URL(TYPE_INT_TAG "fd");
     case StatusIntProperty::ChannelConnectivityState:
       return TYPE_URL(TYPE_INT_TAG "channel_connectivity_state");
     case StatusIntProperty::kLbPolicyDrop:

--- a/src/core/util/status_helper.cc
+++ b/src/core/util/status_helper.cc
@@ -67,8 +67,6 @@ const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
       return TYPE_URL(TYPE_INT_TAG "http2_error");
     case StatusIntProperty::kFd:
       return TYPE_URL(TYPE_INT_TAG "fd");
-    case StatusIntProperty::kOccurredDuringWrite:
-      return TYPE_URL(TYPE_INT_TAG "occurred_during_write");
     case StatusIntProperty::ChannelConnectivityState:
       return TYPE_URL(TYPE_INT_TAG "channel_connectivity_state");
     case StatusIntProperty::kLbPolicyDrop:

--- a/src/core/util/status_helper.h
+++ b/src/core/util/status_helper.h
@@ -46,8 +46,6 @@ namespace grpc_core {
 
 /// This enum should have the same value of grpc_error_ints
 enum class StatusIntProperty {
-  /// __LINE__ from the call site creating the error
-  kFileLine,
   /// stream identifier: for errors that are associated with an individual
   /// wire stream
   kStreamId,
@@ -66,8 +64,6 @@ enum class StatusIntProperty {
 enum class StatusStrProperty {
   /// top-level textual description of this error
   kDescription,
-  /// source file in which this error occurred
-  kFile,
   /// peer that we were trying to communicate when this error occurred
   kGrpcMessage,
 };

--- a/src/core/util/status_helper.h
+++ b/src/core/util/status_helper.h
@@ -56,8 +56,6 @@ enum class StatusIntProperty {
   kRpcStatus,
   /// http2 error code associated with the error (see the HTTP2 RFC)
   kHttp2Error,
-  /// File descriptor associated with this error
-  kFd,
   /// channel connectivity state associated with the error
   ChannelConnectivityState,
   /// LB policy drop

--- a/src/core/util/status_helper.h
+++ b/src/core/util/status_helper.h
@@ -58,8 +58,6 @@ enum class StatusIntProperty {
   kHttp2Error,
   /// File descriptor associated with this error
   kFd,
-  /// chttp2: did the error occur while a write was in progress
-  kOccurredDuringWrite,
   /// channel connectivity state associated with the error
   ChannelConnectivityState,
   /// LB policy drop

--- a/src/core/util/status_helper.h
+++ b/src/core/util/status_helper.h
@@ -68,12 +68,6 @@ enum class StatusStrProperty {
   kGrpcMessage,
 };
 
-/// This enum should have the same value of grpc_error_times
-enum class StatusTimeProperty {
-  /// timestamp of error creation
-  kCreated,
-};
-
 /// Creates a status with given additional information
 absl::Status StatusCreate(absl::StatusCode code, absl::string_view msg,
                           const DebugLocation& location,
@@ -94,14 +88,6 @@ void StatusSetStr(absl::Status* status, StatusStrProperty key,
 /// Gets the str property from the status
 GRPC_MUST_USE_RESULT std::optional<std::string> StatusGetStr(
     const absl::Status& status, StatusStrProperty key);
-
-/// Sets the time property to the status
-void StatusSetTime(absl::Status* status, StatusTimeProperty key,
-                   absl::Time time);
-
-/// Gets the time property from the status
-GRPC_MUST_USE_RESULT std::optional<absl::Time> StatusGetTime(
-    const absl::Status& status, StatusTimeProperty key);
 
 /// Adds a child status to status
 void StatusAddChild(absl::Status* status, absl::Status child);

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -33,12 +33,6 @@ TEST(ErrorTest, SetGetInt) {
   grpc_error_handle error = GRPC_ERROR_CREATE("Test");
   EXPECT_NE(error, absl::OkStatus());
   intptr_t i = 0;
-#ifndef NDEBUG
-  // grpc_core::StatusIntProperty::kFileLine is for debug only
-  EXPECT_TRUE(
-      grpc_error_get_int(error, grpc_core::StatusIntProperty::kFileLine, &i));
-  EXPECT_TRUE(i);  // line set will never be 0
-#endif
   EXPECT_TRUE(
       !grpc_error_get_int(error, grpc_core::StatusIntProperty::kStreamId, &i));
   EXPECT_TRUE(!grpc_error_get_int(
@@ -56,15 +50,6 @@ TEST(ErrorTest, SetGetStr) {
   grpc_error_handle error = GRPC_ERROR_CREATE("Test");
 
   std::string str;
-#ifndef NDEBUG
-  // grpc_core::StatusStrProperty::kFile   is for debug only
-  EXPECT_TRUE(
-      grpc_error_get_str(error, grpc_core::StatusStrProperty::kFile, &str));
-  EXPECT_THAT(str, testing::HasSubstr("error_test.c"));
-  // __FILE__ expands differently on
-  // Windows. All should at least
-  // contain error_test.c
-#endif
   EXPECT_TRUE(grpc_error_get_str(
       error, grpc_core::StatusStrProperty::kDescription, &str));
   EXPECT_EQ(str, "Test");

--- a/test/core/util/status_helper_test.cc
+++ b/test/core/util/status_helper_test.cc
@@ -36,10 +36,6 @@ TEST(StatusUtilTest, CreateStatus) {
                    {absl::OkStatus(), absl::CancelledError()});
   EXPECT_EQ(absl::StatusCode::kUnknown, s.code());
   EXPECT_EQ("Test", s.message());
-#ifndef NDEBUG
-  EXPECT_EQ(true, StatusGetStr(s, StatusStrProperty::kFile).has_value());
-  EXPECT_EQ(true, StatusGetInt(s, StatusIntProperty::kFileLine).has_value());
-#endif
   EXPECT_EQ(true, StatusGetTime(s, StatusTimeProperty::kCreated).has_value());
   EXPECT_THAT(StatusGetChildren(s),
               ::testing::ElementsAre(absl::CancelledError()));
@@ -59,14 +55,14 @@ TEST(StatusUtilTest, GetIntNotExistent) {
 
 TEST(StatusUtilTest, SetAndGetStr) {
   absl::Status s = absl::CancelledError();
-  StatusSetStr(&s, StatusStrProperty::kFile, "value");
-  EXPECT_EQ("value", StatusGetStr(s, StatusStrProperty::kFile));
+  StatusSetStr(&s, StatusStrProperty::kDescription, "value");
+  EXPECT_EQ("value", StatusGetStr(s, StatusStrProperty::kDescription));
 }
 
 TEST(StatusUtilTest, GetStrNotExistent) {
   absl::Status s = absl::CancelledError();
   EXPECT_EQ(std::optional<std::string>(),
-            StatusGetStr(s, StatusStrProperty::kFile));
+            StatusGetStr(s, StatusStrProperty::kDescription));
 }
 
 TEST(StatusUtilTest, SetAndGetTime) {
@@ -97,7 +93,6 @@ TEST(StatusUtilTest, AddAndGetChildren) {
 TEST(StatusUtilTest, ToAndFromProto) {
   absl::Status s = absl::CancelledError("Message");
   StatusSetInt(&s, StatusIntProperty::kStreamId, 2021);
-  StatusSetStr(&s, StatusStrProperty::kFile, "value");
   upb::Arena arena;
   google_rpc_Status* msg = internal::StatusToProto(s, arena.ptr());
   size_t len;
@@ -110,7 +105,6 @@ TEST(StatusUtilTest, ToAndFromProto) {
 TEST(StatusUtilTest, ToAndFromProtoWithNonUTF8Characters) {
   absl::Status s = absl::CancelledError("_\xAB\xCD\xEF_");
   StatusSetInt(&s, StatusIntProperty::kStreamId, 2021);
-  StatusSetStr(&s, StatusStrProperty::kFile, "!\xFF\xCC\xAA!");
   upb::Arena arena;
   google_rpc_Status* msg = internal::StatusToProto(s, arena.ptr());
   size_t len;
@@ -162,12 +156,12 @@ TEST(StatusUtilTest, ComplexErrorWithChildrenToString) {
   absl::Status s1 = absl::AbortedError("Message1");
   StatusAddChild(&s, s1);
   absl::Status s2 = absl::AlreadyExistsError("Message2");
-  StatusSetStr(&s2, StatusStrProperty::kFile, "value");
+  StatusSetStr(&s2, StatusStrProperty::kDescription, "value");
   StatusAddChild(&s, s2);
   std::string t = StatusToString(s);
   EXPECT_EQ(
       "CANCELLED:Message {stream_id:2021, children:["
-      "ABORTED:Message1, ALREADY_EXISTS:Message2 {file:\"value\"}]}",
+      "ABORTED:Message1, ALREADY_EXISTS:Message2 {description:\"value\"}]}",
       t);
 }
 

--- a/test/core/util/status_helper_test.cc
+++ b/test/core/util/status_helper_test.cc
@@ -36,7 +36,6 @@ TEST(StatusUtilTest, CreateStatus) {
                    {absl::OkStatus(), absl::CancelledError()});
   EXPECT_EQ(absl::StatusCode::kUnknown, s.code());
   EXPECT_EQ("Test", s.message());
-  EXPECT_EQ(true, StatusGetTime(s, StatusTimeProperty::kCreated).has_value());
   EXPECT_THAT(StatusGetChildren(s),
               ::testing::ElementsAre(absl::CancelledError()));
 }
@@ -63,19 +62,6 @@ TEST(StatusUtilTest, GetStrNotExistent) {
   absl::Status s = absl::CancelledError();
   EXPECT_EQ(std::optional<std::string>(),
             StatusGetStr(s, StatusStrProperty::kDescription));
-}
-
-TEST(StatusUtilTest, SetAndGetTime) {
-  absl::Status s = absl::CancelledError();
-  absl::Time t = absl::Now();
-  StatusSetTime(&s, StatusTimeProperty::kCreated, t);
-  EXPECT_EQ(t, StatusGetTime(s, StatusTimeProperty::kCreated));
-}
-
-TEST(StatusUtilTest, GetTimeNotExistent) {
-  absl::Status s = absl::CancelledError();
-  EXPECT_EQ(std::optional<absl::Time>(),
-            StatusGetTime(s, StatusTimeProperty::kCreated));
 }
 
 TEST(StatusUtilTest, AddAndGetChildren) {
@@ -138,16 +124,6 @@ TEST(StatusUtilTest, ErrorWithStrPropertyToString) {
   StatusSetStr(&s, StatusStrProperty::kDescription, "Hey");
   std::string t = StatusToString(s);
   EXPECT_EQ("CANCELLED:Message {description:\"Hey\"}", t);
-}
-
-TEST(StatusUtilTest, ErrorWithTimePropertyToString) {
-  absl::Status s = absl::CancelledError("Message");
-  absl::Time t = absl::FromCivil(absl::CivilSecond(2021, 4, 29, 8, 56, 30),
-                                 absl::LocalTimeZone());
-  StatusSetTime(&s, StatusTimeProperty::kCreated, t);
-  EXPECT_EQ(StatusToString(s),
-            absl::StrCat("CANCELLED:Message {created_time:\"",
-                         absl::FormatTime(t), "\"}"));
 }
 
 TEST(StatusUtilTest, ComplexErrorWithChildrenToString) {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -1515,11 +1515,6 @@ TEST_P(End2endTest, ExpectErrorTest) {
     EXPECT_EQ(iter->error_message(), s.error_message());
     EXPECT_EQ(iter->binary_error_details(), s.error_details());
     EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "created"));
-#ifndef NDEBUG
-    // grpc_core::StatusIntProperty::kFileLine is for debug only
-    EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "file"));
-    EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "line"));
-#endif
     EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "status"));
     EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "13"));
   }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -1514,7 +1514,6 @@ TEST_P(End2endTest, ExpectErrorTest) {
     EXPECT_EQ(iter->code(), s.error_code());
     EXPECT_EQ(iter->error_message(), s.error_message());
     EXPECT_EQ(iter->binary_error_details(), s.error_details());
-    EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "created"));
     EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "status"));
     EXPECT_TRUE(absl::StrContains(context.debug_error_string(), "13"));
   }


### PR DESCRIPTION
This removes the following attributes, which we believe to not be useful:
- StatusIntProperty::kFileLine
- StatusIntProperty::kFd
- StatusIntProperty::kOccurredDuringWrite
- StatusStrProperty::kFile
- StatusTimeProperty::kCreated