### PR TITLE
[grpc_error] remove kDescription and kGrpcMessage attributes

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -118,7 +118,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
     grpc_error_handle error;
     if (reason != GRPC_HTTP2_NO_ERROR || s->trailing_metadata_buffer.empty()) {
       error = grpc_error_set_int(
-          absl::UnknownError(
+          GRPC_ERROR_CREATE(
               absl::StrCat("Received RST_STREAM with error code ", reason)),
           grpc_core::StatusIntProperty::kHttp2Error,
           static_cast<intptr_t>(reason));

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -118,9 +118,7 @@ grpc_error_handle grpc_chttp2_rst_stream_parser_parse(void* parser,
     grpc_error_handle error;
     if (reason != GRPC_HTTP2_NO_ERROR || s->trailing_metadata_buffer.empty()) {
       error = grpc_error_set_int(
-          grpc_error_set_str(
-              GRPC_ERROR_CREATE("RST_STREAM"),
-              grpc_core::StatusStrProperty::kGrpcMessage,
+          absl::UnknownError(
               absl::StrCat("Received RST_STREAM with error code ", reason)),
           grpc_core::StatusIntProperty::kHttp2Error,
           static_cast<intptr_t>(reason));

--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -153,54 +153,18 @@ grpc_error_handle grpc_error_set_str(grpc_error_handle src,
     StatusSetInt(&src, grpc_core::StatusIntProperty::kRpcStatus,
                  GRPC_STATUS_OK);
   }
-  if (which == grpc_core::StatusStrProperty::kDescription) {
-    // To change the message of absl::Status, a new instance should be created
-    // with a code and payload because it doesn't have a setter for it.
-    absl::Status s = absl::Status(src.code(), str);
-    src.ForEachPayload(
-        [&](absl::string_view type_url, const absl::Cord& payload) {
-          s.SetPayload(type_url, payload);
-        });
-    return s;
-  } else {
-    grpc_core::StatusSetStr(&src, which, str);
-  }
+  grpc_core::StatusSetStr(&src, which, str);
   return src;
 }
 
 bool grpc_error_get_str(grpc_error_handle error,
                         grpc_core::StatusStrProperty which, std::string* s) {
-  if (which == grpc_core::StatusStrProperty::kDescription) {
-    // absl::Status uses the message field for
-    // grpc_core::StatusStrProperty::kDescription instead of using payload.
-    absl::string_view msg = error.message();
-    if (msg.empty()) {
-      return false;
-    } else {
-      *s = std::string(msg);
-      return true;
-    }
+  std::optional<std::string> value = grpc_core::StatusGetStr(error, which);
+  if (value.has_value()) {
+    *s = std::move(*value);
+    return true;
   } else {
-    std::optional<std::string> value = grpc_core::StatusGetStr(error, which);
-    if (value.has_value()) {
-      *s = std::move(*value);
-      return true;
-    } else {
-      // TODO(veblush): Remove this once absl::Status migration is done
-      if (which == grpc_core::StatusStrProperty::kGrpcMessage) {
-        switch (error.code()) {
-          case absl::StatusCode::kOk:
-            *s = "";
-            return true;
-          case absl::StatusCode::kCancelled:
-            *s = "CANCELLED";
-            return true;
-          default:
-            break;
-        }
-      }
-      return false;
-    }
+    return false;
   }
 }
 

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -265,14 +265,9 @@ finish:
   done = (--ac->refs == 0);
   gpr_mu_unlock(&ac->mu);
   if (!error.ok()) {
-    std::string str;
-    bool ret = grpc_error_get_str(
-        error, grpc_core::StatusStrProperty::kDescription, &str);
-    CHECK(ret);
-    std::string description =
-        absl::StrCat("Failed to connect to remote host: ", str);
-    error = grpc_error_set_str(
-        error, grpc_core::StatusStrProperty::kDescription, description);
+    error = absl::Status(
+        static_cast<absl::StatusCode>(error.code()),
+        absl::StrCat("Failed to connect to remote host: ", error.message()));
   }
   if (done) {
     // This is safe even outside the lock, because "done", the sentinel, is

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -219,11 +219,9 @@ void Call::CancelWithStatus(grpc_status_code status, const char* description) {
   // guarantee that can be short-lived.
   // TODO(ctiller): change to
   // absl::Status(static_cast<absl::StatusCode>(status), description)
-  // (ie remove the set_int, set_str).
+  // (ie remove the set_int).
   CancelWithError(grpc_error_set_int(
-      grpc_error_set_str(
-          absl::Status(static_cast<absl::StatusCode>(status), description),
-          StatusStrProperty::kGrpcMessage, description),
+      absl::Status(static_cast<absl::StatusCode>(status), description),
       StatusIntProperty::kRpcStatus, status));
 }
 

--- a/src/core/lib/surface/filter_stack_call.cc
+++ b/src/core/lib/surface/filter_stack_call.cc
@@ -915,7 +915,7 @@ grpc_call_error FilterStackCall::StartBatch(const grpc_op* ops, size_t nops,
                       absl::Status(
                           static_cast<absl::StatusCode>(
                               op->data.send_status_from_server.status),
-                          message().empty()
+                          message.empty()
                               ? "Server returned error"
                               : message),
                       StatusIntProperty::kRpcStatus,

--- a/src/core/lib/surface/filter_stack_call.cc
+++ b/src/core/lib/surface/filter_stack_call.cc
@@ -915,9 +915,7 @@ grpc_call_error FilterStackCall::StartBatch(const grpc_op* ops, size_t nops,
                       absl::Status(
                           static_cast<absl::StatusCode>(
                               op->data.send_status_from_server.status),
-                          message.empty()
-                              ? "Server returned error"
-                              : message),
+                          message.empty() ? "Server returned error" : message),
                       StatusIntProperty::kRpcStatus,
                       static_cast<intptr_t>(
                           op->data.send_status_from_server.status));

--- a/src/core/lib/surface/filter_stack_call.cc
+++ b/src/core/lib/surface/filter_stack_call.cc
@@ -454,10 +454,9 @@ void FilterStackCall::RecvTrailingFilter(grpc_metadata_batch* b,
       grpc_error_handle error;
       auto grpc_message = b->Take(GrpcMessageMetadata());
       if (*grpc_status != GRPC_STATUS_OK) {
-        error = absl::Status(static_cast<absl::StatusCode>(*grpc_status),
-                             grpc_message.has_value()
-                                 ? grpc_message->as_string_view()
-                                 : "");
+        error = absl::Status(
+            static_cast<absl::StatusCode>(*grpc_status),
+            grpc_message.has_value() ? grpc_message->as_string_view() : "");
       }
       SetFinalStatus(error);
     } else if (!is_client()) {

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -106,13 +106,7 @@ void grpc_error_get_status(grpc_error_handle error,
     }
   }
 
-  // If the error has a status message, use it.  Otherwise, fall back to
-  // the error description.
-  if (message != nullptr) {
-    *message = found_error.message().empty()
-                   ? grpc_core::StatusToString(error)
-                   : std::string(found_error.message());
-  }
+  if (message != nullptr) *message = std::string(found_error.message());
 }
 
 absl::Status grpc_error_to_absl_status(grpc_error_handle error) {

--- a/src/core/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -330,15 +330,12 @@ AresClientChannelDNSResolver::AresRequestWrapper::OnResolvedLocked(
     GRPC_TRACE_VLOG(cares_resolver, 2)
         << "(c-ares resolver) resolver:" << this
         << " dns resolution failed: " << StatusToString(error);
-    std::string error_message;
-    grpc_error_get_str(error, StatusStrProperty::kDescription, &error_message);
     absl::Status status = absl::UnavailableError(
         absl::StrCat("DNS resolution failed for ", resolver_->name_to_resolve(),
-                     ": ", error_message));
+                     ": ", error.message()));
     result.addresses = status;
     result.service_config = status;
   }
-
   return std::move(result);
 }
 

--- a/src/core/util/status_helper.cc
+++ b/src/core/util/status_helper.cc
@@ -79,12 +79,8 @@ const char* GetStatusIntPropertyUrl(StatusIntProperty key) {
 
 const char* GetStatusStrPropertyUrl(StatusStrProperty key) {
   switch (key) {
-    case StatusStrProperty::kDescription:
-      return TYPE_URL(TYPE_STR_TAG "description");
     case StatusStrProperty::kFile:
       return TYPE_URL(TYPE_STR_TAG "file");
-    case StatusStrProperty::kGrpcMessage:
-      return TYPE_URL(TYPE_STR_TAG "grpc_message");
   }
   GPR_UNREACHABLE_CODE(return "unknown");
 }

--- a/src/core/util/status_helper.h
+++ b/src/core/util/status_helper.h
@@ -68,12 +68,8 @@ enum class StatusIntProperty {
 
 /// This enum should have the same value of grpc_error_strs
 enum class StatusStrProperty {
-  /// top-level textual description of this error
-  kDescription,
   /// source file in which this error occurred
   kFile,
-  /// peer that we were trying to communicate when this error occurred
-  kGrpcMessage,
 };
 
 /// This enum should have the same value of grpc_error_times

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -65,15 +65,11 @@ TEST(ErrorTest, SetGetStr) {
   // Windows. All should at least
   // contain error_test.c
 #endif
+  error = grpc_error_set_str(error, grpc_core::StatusStrProperty::kFile,
+                             "foo.cc");
   EXPECT_TRUE(grpc_error_get_str(
-      error, grpc_core::StatusStrProperty::kDescription, &str));
-  EXPECT_EQ(str, "Test");
-
-  error = grpc_error_set_str(error, grpc_core::StatusStrProperty::kGrpcMessage,
-                             "longer message");
-  EXPECT_TRUE(grpc_error_get_str(
-      error, grpc_core::StatusStrProperty::kGrpcMessage, &str));
-  EXPECT_EQ(str, "longer message");
+      error, grpc_core::StatusStrProperty::kFile, &str));
+  EXPECT_EQ(str, "foo.cc");
 }
 
 TEST(ErrorTest, CopyAndUnRef) {
@@ -99,31 +95,21 @@ TEST(ErrorTest, CopyAndUnRef) {
 }
 
 TEST(ErrorTest, CreateReferencing) {
-  grpc_error_handle child =
-      grpc_error_set_str(GRPC_ERROR_CREATE("Child"),
-                         grpc_core::StatusStrProperty::kGrpcMessage, "message");
+  grpc_error_handle child = GRPC_ERROR_CREATE("message");
   grpc_error_handle parent = GRPC_ERROR_CREATE_REFERENCING("Parent", &child, 1);
   EXPECT_NE(parent, absl::OkStatus());
 }
 
 TEST(ErrorTest, CreateReferencingMany) {
   grpc_error_handle children[3];
-  children[0] =
-      grpc_error_set_str(GRPC_ERROR_CREATE("Child1"),
-                         grpc_core::StatusStrProperty::kGrpcMessage, "message");
+  children[0] = GRPC_ERROR_CREATE("Child1");
   children[1] =
       grpc_error_set_int(GRPC_ERROR_CREATE("Child2"),
                          grpc_core::StatusIntProperty::kHttp2Error, 5);
-  children[2] = grpc_error_set_str(GRPC_ERROR_CREATE("Child3"),
-                                   grpc_core::StatusStrProperty::kGrpcMessage,
-                                   "message 3");
-
+  children[2] = GRPC_ERROR_CREATE("Child3");
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING("Parent", children, 3);
   EXPECT_NE(parent, absl::OkStatus());
-
-  for (size_t i = 0; i < 3; ++i) {
-  }
 }
 
 TEST(ErrorTest, PrintErrorString) {
@@ -132,29 +118,19 @@ TEST(ErrorTest, PrintErrorString) {
       GRPC_STATUS_UNIMPLEMENTED);
   error =
       grpc_error_set_int(error, grpc_core::StatusIntProperty::kHttp2Error, 666);
-  error = grpc_error_set_str(error, grpc_core::StatusStrProperty::kGrpcMessage,
-                             "message");
   //  VLOG(2) << grpc_core::StatusToString(error);
 }
 
 TEST(ErrorTest, PrintErrorStringReference) {
   grpc_error_handle children[2];
-  children[0] = grpc_error_set_str(
-      grpc_error_set_int(GRPC_ERROR_CREATE("1"),
-                         grpc_core::StatusIntProperty::kRpcStatus,
-                         GRPC_STATUS_UNIMPLEMENTED),
-      grpc_core::StatusStrProperty::kGrpcMessage, "message for child 1");
-  children[1] = grpc_error_set_str(
-      grpc_error_set_int(GRPC_ERROR_CREATE("2sd"),
-                         grpc_core::StatusIntProperty::kRpcStatus,
-                         GRPC_STATUS_INTERNAL),
-      grpc_core::StatusStrProperty::kGrpcMessage, "message for child 2");
-
+  children[0] = grpc_error_set_int(GRPC_ERROR_CREATE("1"),
+                                   grpc_core::StatusIntProperty::kRpcStatus,
+                                   GRPC_STATUS_UNIMPLEMENTED);
+  children[1] = grpc_error_set_int(GRPC_ERROR_CREATE("2sd"),
+                                   grpc_core::StatusIntProperty::kRpcStatus,
+                                   GRPC_STATUS_INTERNAL);
   grpc_error_handle parent =
       GRPC_ERROR_CREATE_REFERENCING("Parent", children, 2);
-
-  for (size_t i = 0; i < 2; ++i) {
-  }
 }
 
 TEST(ErrorTest, TestOsError) {

--- a/test/core/iomgr/error_test.cc
+++ b/test/core/iomgr/error_test.cc
@@ -65,10 +65,10 @@ TEST(ErrorTest, SetGetStr) {
   // Windows. All should at least
   // contain error_test.c
 #endif
-  error = grpc_error_set_str(error, grpc_core::StatusStrProperty::kFile,
-                             "foo.cc");
-  EXPECT_TRUE(grpc_error_get_str(
-      error, grpc_core::StatusStrProperty::kFile, &str));
+  error =
+      grpc_error_set_str(error, grpc_core::StatusStrProperty::kFile, "foo.cc");
+  EXPECT_TRUE(
+      grpc_error_get_str(error, grpc_core::StatusStrProperty::kFile, &str));
   EXPECT_EQ(str, "foo.cc");
 }
 

--- a/test/core/security/aws_request_signer_test.cc
+++ b/test/core/security/aws_request_signer_test.cc
@@ -246,10 +246,7 @@ TEST(GrpcAwsRequestSignerTest, InvalidUrl) {
   grpc_core::AwsRequestSigner signer("access_key_id", "secret_access_key",
                                      "token", "POST", "invalid_url",
                                      "us-east-1", "", {}, &error);
-  std::string actual_error_description;
-  CHECK(grpc_error_get_str(error, grpc_core::StatusStrProperty::kDescription,
-                           &actual_error_description));
-  EXPECT_EQ(actual_error_description, "Invalid Aws request url.");
+  EXPECT_EQ(error.message(), "Invalid Aws request url.");
 }
 
 TEST(GrpcAwsRequestSignerTest, DuplicateRequestDate) {
@@ -258,10 +255,7 @@ TEST(GrpcAwsRequestSignerTest, DuplicateRequestDate) {
       "access_key_id", "secret_access_key", "token", "POST", "invalid_url",
       "us-east-1", "", {{"date", kBotoTestDate}, {"x-amz-date", kAmzTestDate}},
       &error);
-  std::string actual_error_description;
-  CHECK(grpc_error_get_str(error, grpc_core::StatusStrProperty::kDescription,
-                           &actual_error_description));
-  EXPECT_EQ(actual_error_description,
+  EXPECT_EQ(error.message(),
             "Only one of {date, x-amz-date} can be specified, not both.");
 }
 

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -3008,10 +3008,8 @@ TEST_F(ExternalAccountCredentialsTest,
   auto json = JsonParse(options_string1);
   ASSERT_TRUE(json.ok()) << json.status();
   auto creds = ExternalAccountCredentials::Create(*json, {"scope1", "scope2"});
-  std::string actual_error;
-  grpc_error_get_str(creds.status(), StatusStrProperty::kDescription,
-                     &actual_error);
-  EXPECT_EQ("token_lifetime_seconds must be more than 600s", actual_error);
+  EXPECT_EQ("token_lifetime_seconds must be more than 600s",
+            creds.status().message());
 
   const char* options_string2 =
       "{\"type\":\"external_account\",\"audience\":\"audience\","
@@ -3030,9 +3028,8 @@ TEST_F(ExternalAccountCredentialsTest,
   json = JsonParse(options_string2);
   ASSERT_TRUE(json.ok()) << json.status();
   creds = ExternalAccountCredentials::Create(*json, {"scope1", "scope2"});
-  grpc_error_get_str(creds.status(), StatusStrProperty::kDescription,
-                     &actual_error);
-  EXPECT_EQ("token_lifetime_seconds must be less than 43200s", actual_error);
+  EXPECT_EQ("token_lifetime_seconds must be less than 43200s",
+            creds.status().message());
 }
 
 TEST_F(ExternalAccountCredentialsTest, FailureInvalidTokenUrl) {
@@ -3299,10 +3296,7 @@ TEST_F(ExternalAccountCredentialsTest,
   };
   auto creds = UrlExternalAccountCredentials::Create(options, {});
   ASSERT_FALSE(creds.ok());
-  std::string actual_error;
-  grpc_error_get_str(creds.status(), StatusStrProperty::kDescription,
-                     &actual_error);
-  EXPECT_THAT(actual_error,
+  EXPECT_THAT(creds.status().message(),
               ::testing::StartsWith("Invalid credential source url."));
 }
 
@@ -4113,10 +4107,7 @@ TEST_F(ExternalAccountCredentialsTest,
   auto creds =
       AwsExternalAccountCredentials::Create(options, {}, event_engine_);
   ASSERT_FALSE(creds.ok());
-  std::string actual_error;
-  grpc_error_get_str(creds.status(), StatusStrProperty::kDescription,
-                     &actual_error);
-  EXPECT_EQ("environment_id does not match.", actual_error);
+  EXPECT_EQ("environment_id does not match.", creds.status().message());
 }
 
 TEST_F(ExternalAccountCredentialsTest,

--- a/test/core/security/grpc_tls_certificate_distributor_test.cc
+++ b/test/core/security/grpc_tls_certificate_distributor_test.cc
@@ -134,15 +134,12 @@ class GrpcTlsCertificateDistributorTest : public ::testing::Test {
                  grpc_error_handle identity_cert_error) override {
       CHECK(!root_cert_error.ok() || !identity_cert_error.ok());
       std::string root_error_str;
-      std::string identity_error_str;
       if (!root_cert_error.ok()) {
-        CHECK(grpc_error_get_str(
-            root_cert_error, StatusStrProperty::kDescription, &root_error_str));
+        root_error_str = root_cert_error.message();
       }
+      std::string identity_error_str;
       if (!identity_cert_error.ok()) {
-        CHECK(grpc_error_get_str(identity_cert_error,
-                                 StatusStrProperty::kDescription,
-                                 &identity_error_str));
+        identity_error_str = identity_cert_error.message();
       }
       state_->error_queue.emplace_back(std::move(root_error_str),
                                        std::move(identity_error_str));

--- a/test/core/security/grpc_tls_certificate_provider_test.cc
+++ b/test/core/security/grpc_tls_certificate_provider_test.cc
@@ -138,15 +138,12 @@ class GrpcTlsCertificateProviderTest : public ::testing::Test {
       MutexLock lock(&state_->mu);
       CHECK(!root_cert_error.ok() || !identity_cert_error.ok());
       std::string root_error_str;
-      std::string identity_error_str;
       if (!root_cert_error.ok()) {
-        CHECK(grpc_error_get_str(
-            root_cert_error, StatusStrProperty::kDescription, &root_error_str));
+        root_error_str = root_cert_error.message();
       }
+      std::string identity_error_str;
       if (!identity_cert_error.ok()) {
-        CHECK(grpc_error_get_str(identity_cert_error,
-                                 StatusStrProperty::kDescription,
-                                 &identity_error_str));
+        identity_error_str = identity_cert_error.message();
       }
       state_->error_queue.emplace_back(std::move(root_error_str),
                                        std::move(identity_error_str));

--- a/test/core/security/tls_security_connector_test.cc
+++ b/test/core/security/tls_security_connector_test.cc
@@ -74,15 +74,8 @@ class TlsSecurityConnectorTest : public ::testing::Test {
     if (expected_error_msg == nullptr) {
       EXPECT_EQ(error, absl::OkStatus());
     } else {
-      EXPECT_EQ(GetErrorMsg(error), expected_error_msg);
+      EXPECT_EQ(error.message(), expected_error_msg);
     }
-  }
-
-  static std::string GetErrorMsg(grpc_error_handle error) {
-    std::string error_str;
-    CHECK(
-        grpc_error_get_str(error, StatusStrProperty::kDescription, &error_str));
-    return error_str;
   }
 
   std::string root_cert_1_;

--- a/test/core/transport/error_utils_test.cc
+++ b/test/core/transport/error_utils_test.cc
@@ -108,10 +108,7 @@ TEST(ErrorUtilsTest, AbslUnavailableToGrpcError) {
       error, grpc_core::StatusIntProperty::kRpcStatus, &code));
   ASSERT_EQ(static_cast<grpc_status_code>(code), GRPC_STATUS_UNAVAILABLE);
   // Status message checks
-  std::string message;
-  ASSERT_TRUE(grpc_error_get_str(
-      error, grpc_core::StatusStrProperty::kDescription, &message));
-  ASSERT_EQ(message, "Making tea");
+  ASSERT_EQ(error.message(), "Making tea");
 }
 
 TEST(ErrorUtilsTest, GrpcErrorUnavailableToAbslStatus) {

--- a/test/core/util/status_helper_test.cc
+++ b/test/core/util/status_helper_test.cc
@@ -141,9 +141,9 @@ TEST(StatusUtilTest, ErrorWithIntPropertyToString) {
 
 TEST(StatusUtilTest, ErrorWithStrPropertyToString) {
   absl::Status s = absl::CancelledError("Message");
-  StatusSetStr(&s, StatusStrProperty::kDescription, "Hey");
+  StatusSetStr(&s, StatusStrProperty::kFile, "foo.cc");
   std::string t = StatusToString(s);
-  EXPECT_EQ("CANCELLED:Message {description:\"Hey\"}", t);
+  EXPECT_EQ("CANCELLED:Message {file:\"foo.cc\"}", t);
 }
 
 TEST(StatusUtilTest, ErrorWithTimePropertyToString) {

--- a/test/core/util/status_helper_test.cc
+++ b/test/core/util/status_helper_test.cc
@@ -52,18 +52,6 @@ TEST(StatusUtilTest, GetIntNotExistent) {
             StatusGetInt(s, StatusIntProperty::kStreamId));
 }
 
-TEST(StatusUtilTest, SetAndGetStr) {
-  absl::Status s = absl::CancelledError();
-  StatusSetStr(&s, StatusStrProperty::kDescription, "value");
-  EXPECT_EQ("value", StatusGetStr(s, StatusStrProperty::kDescription));
-}
-
-TEST(StatusUtilTest, GetStrNotExistent) {
-  absl::Status s = absl::CancelledError();
-  EXPECT_EQ(std::optional<std::string>(),
-            StatusGetStr(s, StatusStrProperty::kDescription));
-}
-
 TEST(StatusUtilTest, AddAndGetChildren) {
   absl::Status s = absl::CancelledError();
   absl::Status child1 = absl::AbortedError("Message1");
@@ -119,25 +107,18 @@ TEST(StatusUtilTest, ErrorWithIntPropertyToString) {
   EXPECT_EQ("CANCELLED:Message {stream_id:2021}", t);
 }
 
-TEST(StatusUtilTest, ErrorWithStrPropertyToString) {
-  absl::Status s = absl::CancelledError("Message");
-  StatusSetStr(&s, StatusStrProperty::kFile, "foo.cc");
-  std::string t = StatusToString(s);
-  EXPECT_EQ("CANCELLED:Message {file:\"foo.cc\"}", t);
-}
-
 TEST(StatusUtilTest, ComplexErrorWithChildrenToString) {
   absl::Status s = absl::CancelledError("Message");
   StatusSetInt(&s, StatusIntProperty::kStreamId, 2021);
   absl::Status s1 = absl::AbortedError("Message1");
   StatusAddChild(&s, s1);
   absl::Status s2 = absl::AlreadyExistsError("Message2");
-  StatusSetStr(&s2, StatusStrProperty::kDescription, "value");
+  StatusSetInt(&s2, StatusIntProperty::kRpcStatus, 5);
   StatusAddChild(&s, s2);
   std::string t = StatusToString(s);
   EXPECT_EQ(
       "CANCELLED:Message {stream_id:2021, children:["
-      "ABORTED:Message1, ALREADY_EXISTS:Message2 {description:\"value\"}]}",
+      "ABORTED:Message1, ALREADY_EXISTS:Message2 {grpc_status:5}]}",
       t);
 }
 


### PR DESCRIPTION
The `kDescription` was simply an alias for the top-level `absl::Status::message()`, so this PR removes that attribute and changes callers to directly use the status message instead.

The `kGrpcMessage` attribute was an alternative string that would be used in preference to the top-level message when generating RPC failure statuses to return from C-core.  This PR changes the few callers that generated this attribute to instead set the status message, so this attribute is no longer necessary.