### PR TITLE
[logging] Allow http_proxy_fixture to log in the no_logging test

### DIFF
--- a/test/core/end2end/tests/no_logging.cc
+++ b/test/core/end2end/tests/no_logging.cc
@@ -103,7 +103,9 @@ class VerifyLogNoiseLogSink : public absl::LogSink {
           std::regex(
               "Only [0-9]+ addresses added out of total [0-9]+ resolved")},
          {"trace.cc", std::regex("Unknown tracer:.*")},
-         {"config.cc", std::regex("gRPC experiments enabled:.*")}});
+         {"config.cc", std::regex("gRPC experiments enabled:.*")},
+         // logs from fixtures are never a production issue
+         {"http_proxy_fixture.cc", ".*"}});
 
     if (IsVlogWithVerbosityMoreThan1(entry)) {
       return;


### PR DESCRIPTION
It looks like this fixture throws out some messages that might be interesting, but that needn't fail the no_logging test as they pose no danger to production systems.

https://btx.cloud.google.com/invocations/b4b31afc-ac9a-4899-b772-c22052e338c8/targets/%2F%2Ftest%2Fcore%2Fend2end:end2end_http2_no_logging_test@poller%3Depoll1;config=d1d796853829b38520a1cb7c8e7476c3b09606cb23d8d1c16b5e6044aa588efb/log