### PR TITLE
[Example] Fixed examples/cpp/health test

### DIFF
--- a/examples/cpp/health/health_client.cc
+++ b/examples/cpp/health/health_client.cc
@@ -105,7 +105,9 @@ class GreeterClient {
                 << ": " << status.error_message() << "\n";
       return;
     }
-    std::cout << message << ": " << response.DebugString();
+    std::cout << message << ": status: "
+              << HealthCheckResponse::ServingStatus_Name(response.status())
+              << "\n";
   }
 
  private:


### PR DESCRIPTION
Starting with Protobuf v30, the `DebugString` output has become "keep-changing" causing our example tests, which depend on its exact output string, to fail. To ensure consistent test output, I've replaced the use of `DebugString` with direct member access & manual formatting.
