### PR TITLE
[EventEngine] Remove CFStream exception from PosixEventEngine

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -67,9 +67,7 @@
 
 // IWYU pragma: no_include <ratio>
 
-// TODO(eryu): remove this GRPC_CFSTREAM condition when the CFEngine is ready.
-// The posix poller currently crashes iOS.
-#if defined(GRPC_POSIX_SOCKET_TCP) && !defined(GRPC_CFSTREAM) && \
+#if defined(GRPC_POSIX_SOCKET_TCP) && \
     !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
 #define GRPC_PLATFORM_SUPPORTS_POSIX_POLLING true
 #else

--- a/src/core/lib/event_engine/shim.cc
+++ b/src/core/lib/event_engine/shim.cc
@@ -22,9 +22,7 @@
 namespace grpc_event_engine::experimental {
 
 bool UseEventEngineClient() {
-// TODO(hork, eryu): Adjust the ifdefs accordingly when event engines become
-// available for other platforms.
-#if defined(GRPC_POSIX_SOCKET_TCP) && !defined(GRPC_CFSTREAM) && \
+#if defined(GRPC_POSIX_SOCKET_TCP) && \
     !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
   return grpc_core::IsEventEngineClientEnabled();
 #elif defined(GPR_WINDOWS) && !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
@@ -37,9 +35,7 @@ bool UseEventEngineClient() {
 }
 
 bool UseEventEngineListener() {
-// TODO(hork, eryu): Adjust the ifdefs accordingly when event engines become
-// available for other platforms.
-#if defined(GRPC_POSIX_SOCKET_TCP) && !defined(GRPC_CFSTREAM) && \
+#if defined(GRPC_POSIX_SOCKET_TCP) && \
     !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
   return grpc_core::IsEventEngineListenerEnabled();
 #else


### PR DESCRIPTION
I believe this is now unnecessary, given CFEngine has been used in production for some time.