### PR TITLE
[Dep] Small changes to how to pull in Protobuf

### DIFF
--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -50,6 +50,7 @@ ExternalProject_Add(utf8_range
         -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/utf8_range
         -DCMAKE_CXX_STANDARD:STRING=17
         -Dutf8_range_ENABLE_TESTS:BOOL=OFF
+        -Dprotobuf_VERSION:STRING=0.0.1
         -Dabsl_DIR:STRING=${CMAKE_CURRENT_BINARY_DIR}/absl/lib/cmake/absl
   DEPENDS absl
 )

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -35,4 +35,12 @@ bazel --version
 
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_rbe
 
-call bazel_rbe/bazel_wrapper.bat --bazelrc=tools/remote_build/windows.bazelrc --output_user_root=T:\_bazel_output test %BAZEL_FLAGS% -- //test/... || exit /b 1
+call bazel_rbe/bazel_wrapper.bat ^
+  --bazelrc=tools/remote_build/windows.bazelrc ^
+  --output_user_root=T:\_bazel_output ^
+  test ^
+  %BAZEL_FLAGS% ^
+  --define=protobuf_allow_msvc=true ^
+  -- ^
+  //test/... ^
+  || exit /b 1


### PR DESCRIPTION
Two changes are made to accept upcoming Protobuf v30
- Protobuf v30 will introduce a change that removes Bazel+MSVC support unless the `protobuf_allow_msvc option` is explicitly enabled. Therefore, to maintain compatibility, CI needs to define this option.
- CMake file for `protobuf/upb` now depends on the `protobuf_VERSION` variable, which is set in the main protobuf CMake file. A specific `cmake_externalproject` test includes `protobuf/upb` directly and therefore misses the opportunity to define this variable. To address this, the test now defines `protobuf_VERSION` directly.