### PR TITLE
[CI] Added .bcr for publish-to-bcr

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,14 @@
+{
+    "homepage": "https://github.com/grpc/grpc",
+    "maintainers": [
+        {
+            "email": "bcr-maintainers@bazel.build",
+            "name": "No Maintainer Specified"
+        }
+    ],
+    "repository": [
+        "github:grpc/grpc"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/patches/adopt_bzlmod.patch
+++ b/.bcr/patches/adopt_bzlmod.patch
@@ -1,0 +1,34 @@
+diff --git a/bazel/cython_library.bzl b/bazel/cython_library.bzl
+index dc2ef7a890..93e99962db 100644
+--- a/bazel/cython_library.bzl
++++ b/bazel/cython_library.bzl
+@@ -72,7 +72,10 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
+         native.cc_binary(
+             name = shared_object_name,
+             srcs = [stem + ".cpp"],
+-            deps = deps + ["@local_config_python//:python_headers"],
++            deps = deps + [
++                "@rules_python//python/cc:current_py_cc_headers",
++                "@rules_python//python/cc:current_py_cc_libs",
++            ],
+             defines = defines,
+             linkshared = 1,
+         )
++grpc_repo_deps_ext = module_extension(implementation = lambda ctx: grpc_deps(bzlmod = True))
+diff --git a/bazel/python_rules.bzl b/bazel/python_rules.bzl
+index f5fa1a0550..56b2a2d42c 100644
+--- a/bazel/python_rules.bzl
++++ b/bazel/python_rules.bzl
+@@ -191,11 +191,7 @@ def _generate_pb2_grpc_src_impl(context):
+     arguments = []
+     tools = [context.executable._protoc, context.executable._grpc_plugin]
+     out_dir = get_out_dir(protos, context)
+-    if out_dir.import_path:
+-        # is virtual imports
+-        out_path = out_dir.path
+-    else:
+-        out_path = context.genfiles_dir.path
++    out_path = out_dir.path
+     arguments += get_plugin_args(
+         context.executable._grpc_plugin,
+         plugin_flags,

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,47 @@
+matrix:
+  platform:
+    - debian11
+    - macos
+    - macos_arm64
+    - ubuntu2004
+    - ubuntu2204
+    - ubuntu2404
+  bazel:
+    - 7.x
+    - 8.x
+
+tasks:
+  verify_targets:
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@grpc//:grpc"
+      - "@grpc//:grpc_unsecure"
+      - "@grpc//:grpc_opencensus_plugin"
+      - "@grpc//:grpc_security_base"
+      - "@grpc//:grpc++"
+      - "@grpc//:grpc++_unsecure"
+      - "@grpc//:grpc++_reflection"
+      - "@grpc//:grpc++_test"
+      - "@grpc//:grpcpp_admin"
+      - "@grpc//:grpcpp_channelz"
+      - "@grpc//:grpcpp_csds"
+      - "@grpc//:grpcpp_orca_service"
+      - "@grpc//examples/protos/..."
+
+  verify_targets_on_windows:
+    platform: "windows"
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@grpc//:grpc"
+      - "@grpc//:grpc_unsecure"
+      - "@grpc//:grpc_opencensus_plugin"
+      - "@grpc//:grpc_security_base"
+      - "@grpc//:grpc++"
+      - "@grpc//:grpc++_unsecure"
+      - "@grpc//:grpc++_reflection"
+      - "@grpc//:grpc++_test"
+      - "@grpc//:grpcpp_admin"
+      - "@grpc//:grpcpp_channelz"
+      - "@grpc//:grpcpp_csds"
+      - "@grpc//:grpcpp_orca_service"

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz",
+    "patch_strip": 1,
+    "patches": {
+        "adopt_bzlmod.patch": "sha256-MJbyswKT9oNCKHkNt1RvOcHnHOU5WyJGk3EhE2vxszQ="
+    }
+}


### PR DESCRIPTION
To allow `publish-to-bcr` to publish gRPC packages to BCR automatically, I added .bcr files by following https://github.com/bazel-contrib/publish-to-bcr/tree/main/templates and all fields are based on [1.70.1](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/grpc/1.70.1).