### PR TITLE
[weighted_target] improve error message formatting

### DIFF
--- a/src/core/load_balancing/weighted_target/weighted_target.cc
+++ b/src/core/load_balancing/weighted_target/weighted_target.cc
@@ -350,7 +350,7 @@ absl::Status WeightedTargetLb::UpdateLocked(UpdateArgs args) {
   update_in_progress_ = false;
   if (config_->target_map().empty()) {
     absl::Status status = absl::UnavailableError(absl::StrCat(
-        "no children in weighted_target policy: ", args.resolution_note));
+        "no children in weighted_target policy (", args.resolution_note, ")"));
     channel_control_helper()->UpdateState(
         GRPC_CHANNEL_TRANSIENT_FAILURE, status,
         MakeRefCounted<TransientFailurePicker>(status));

--- a/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_cluster_end2end_test.cc
@@ -601,10 +601,10 @@ TEST_P(EdsTest, LocalityBecomesEmptyWithDeactivatedChildStateUpdate) {
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
   // Wait for RPCs to start failing.
   constexpr char kErrorMessage[] =
-      "no children in weighted_target policy: "
+      "no children in weighted_target policy \\("
       "EDS resource eds_service_name: contains empty localities: "
       "\\[\\{region=\"xds_default_locality_region\", "
-      "zone=\"xds_default_locality_zone\", sub_zone=\"locality0\"\\}\\]";
+      "zone=\"xds_default_locality_zone\", sub_zone=\"locality0\"\\}\\]\\)";
   SendRpcsUntilFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE, kErrorMessage);
   // Shut down backend.  This triggers a connectivity state update from the
   // deactivated child of the weighted_target policy.
@@ -637,8 +637,8 @@ TEST_P(EdsTest, NoLocalities) {
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
   // RPCs should fail.
   constexpr char kErrorMessage[] =
-      "no children in weighted_target policy: EDS resource eds_service_name: "
-      "contains no localities";
+      "no children in weighted_target policy "
+      "\\(EDS resource eds_service_name: contains no localities\\)";
   CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE, kErrorMessage);
   // Send EDS resource that has an endpoint.
   args = EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});
@@ -853,10 +853,10 @@ TEST_P(EdsTest, OneLocalityWithNoEndpoints) {
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
   // RPCs should fail.
   constexpr char kErrorMessage[] =
-      "no children in weighted_target policy: "
+      "no children in weighted_target policy \\("
       "EDS resource eds_service_name: contains empty localities: "
       "\\[\\{region=\"xds_default_locality_region\", "
-      "zone=\"xds_default_locality_zone\", sub_zone=\"locality0\"\\}\\]";
+      "zone=\"xds_default_locality_zone\", sub_zone=\"locality0\"\\}\\]\\)";
   CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE, kErrorMessage);
   // Send EDS resource that has an endpoint.
   args = EdsResourceArgs({{"locality0", CreateEndpointsForBackends()}});

--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -518,8 +518,8 @@ TEST_P(TimeoutTest, EdsServerIgnoresRequest) {
   balancer_->ads_service()->IgnoreResourceType(kEdsTypeUrl);
   CheckRpcSendFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "no children in weighted_target policy: EDS resource "
-      "eds_service_name: does not exist \\(node ID:xds_end2end_test\\)",
+      "no children in weighted_target policy \\(EDS resource "
+      "eds_service_name: does not exist \\(node ID:xds_end2end_test\\)\\)",
       RpcOptions().set_timeout_ms(4000));
 }
 
@@ -528,8 +528,8 @@ TEST_P(TimeoutTest, EdsResourceNotPresentInRequest) {
   // by default.
   CheckRpcSendFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "no children in weighted_target policy: EDS resource "
-      "eds_service_name: does not exist \\(node ID:xds_end2end_test\\)",
+      "no children in weighted_target policy \\(EDS resource "
+      "eds_service_name: does not exist \\(node ID:xds_end2end_test\\)\\)",
       RpcOptions().set_timeout_ms(4000));
 }
 
@@ -556,9 +556,9 @@ TEST_P(TimeoutTest, EdsSecondResourceNotPresentInRequest) {
   // May need to wait a bit for the RDS change to propagate to the client.
   SendRpcsUntilFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "no children in weighted_target policy: "
+      "no children in weighted_target policy \\("
       "EDS resource eds_service_name_does_not_exist: "
-      "does not exist \\(node ID:xds_end2end_test\\)",
+      "does not exist \\(node ID:xds_end2end_test\\)\\)",
       /*timeout_ms=*/30000,
       RpcOptions().set_rpc_method(METHOD_ECHO1).set_timeout_ms(4000));
 }
@@ -1011,10 +1011,10 @@ TEST_P(XdsFederationTest, EdsResourceNameAuthorityUnknown) {
   EXPECT_EQ(status.error_code(), StatusCode::UNAVAILABLE);
   EXPECT_EQ(
       status.error_message(),
-      "no children in weighted_target policy: EDS resource "
+      "no children in weighted_target policy (EDS resource "
       "xdstp://xds.unknown.com/envoy.config.endpoint.v3.ClusterLoadAssignment/"
       "edsservice_name: authority \"xds.unknown.com\" not "
-      "present in bootstrap config (node ID:xds_end2end_test)");
+      "present in bootstrap config (node ID:xds_end2end_test))");
   ASSERT_EQ(GRPC_CHANNEL_TRANSIENT_FAILURE, channel2->GetState(false));
 }
 

--- a/test/cpp/end2end/xds/xds_csds_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_csds_end2end_test.cc
@@ -772,8 +772,8 @@ TEST_P(CsdsShortAdsTimeoutTest, XdsConfigDumpEndpointDoesNotExist) {
   balancer_->ads_service()->UnsetResource(kEdsTypeUrl, kDefaultEdsServiceName);
   CheckRpcSendFailure(
       DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-      "no children in weighted_target policy: EDS resource eds_service_name: "
-      "does not exist \\(node ID:xds_end2end_test\\)",
+      "no children in weighted_target policy \\(EDS resource eds_service_name: "
+      "does not exist \\(node ID:xds_end2end_test\\)\\)",
       RpcOptions().set_timeout_ms(kTimeoutMillisecond));
   auto csds_response = FetchCsdsResponse();
   EXPECT_THAT(


### PR DESCRIPTION
This changes weighted_target to use the same error message format as the other policies that I changed in #38341.