### PR TITLE
[examples/cpp/route_guide] Fix callback client command line arg parsing

### DIFF
--- a/examples/cpp/route_guide/BUILD
+++ b/examples/cpp/route_guide/BUILD
@@ -69,6 +69,7 @@ cc_binary(
         ":route_guide_helper",
         "//:grpc++",
         "//examples/protos:route_guide",
+        "@com_google_absl//absl/flags:parse",
     ],
 )
 

--- a/examples/cpp/route_guide/route_guide_callback_client.cc
+++ b/examples/cpp/route_guide/route_guide_callback_client.cc
@@ -32,6 +32,7 @@
 #include <string>
 #include <thread>
 
+#include "absl/flags/parse.h"
 #include "helper.h"
 #ifdef BAZEL_BUILD
 #include "examples/protos/route_guide.grpc.pb.h"
@@ -344,6 +345,7 @@ class RouteGuideClient {
 };
 
 int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
   // Expect only arg: --db_path=path/to/route_guide_db.json.
   std::string db = routeguide::GetDbFileContent(argc, argv);
   RouteGuideClient guide(


### PR DESCRIPTION
route_guide_callback_client only works if started from the grpc/ directory. If started from other directories, it fails with the following error:
```
grpc/examples/cpp/route_guide
› ../../. /bazel-bin/examples/cpp/route_guide/route_guide_callback_client -db_path ./route_guide_db.json WARNING: All log messages before absl:: InitializeLog() is called are written to STDERR E0000 00:00:1740838254.946166 3533952 helper.cc:49] Failed to open examples/cpp/route_guide/route_guide_db.json
[1]    21202 abort ../../../bazel-bin/examples/cpp/route_guide/route_guide_callback_client
```

Add 'absl::ParseCommandLine(argc, argv)' to route_guide_callback_client so that the db_path argument is parsed.
