### PR TITLE
Build protobufs for tests only if gRPC_BUILD_TESTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -716,6 +716,10 @@ protobuf_generate_grpc_cpp_with_import_path_correction(
 protobuf_generate_grpc_cpp_with_import_path_correction(
   src/proto/grpc/reflection/v1alpha/reflection.proto src/proto/grpc/reflection/v1alpha/reflection.proto
 )
+
+# This enables CMake to build the project without requiring submodules
+# in the third_party directory as long as test builds are disabled.
+if (gRPC_BUILD_TESTS)
 protobuf_generate_grpc_cpp_with_import_path_correction(
   src/proto/grpc/testing/benchmark_service.proto src/proto/grpc/testing/benchmark_service.proto
 )
@@ -788,10 +792,6 @@ protobuf_generate_grpc_cpp_with_import_path_correction(
 protobuf_generate_grpc_cpp_with_import_path_correction(
   test/core/tsi/alts/fake_handshaker/transport_security_common.proto test/core/tsi/alts/fake_handshaker/transport_security_common.proto
 )
-
-# This enables CMake to build the project without requiring submodules
-# in the third_party directory as long as test builds are disabled.
-if (gRPC_BUILD_TESTS)
 protobuf_generate_grpc_cpp_with_import_path_correction(
   third_party/envoy-api/envoy/admin/v3/certs.proto envoy/admin/v3/certs.proto
 )

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -713,7 +713,7 @@
     DEPENDS tools_c tools_cxx)
 
   % for src in sorted(protobuf_gen_files):
-  % if not src.startswith('third_party/'):
+  % if not (src.startswith('third_party/') or src.startswith('test/') or src.startswith('src/proto/grpc/testing/')):
   protobuf_generate_grpc_cpp_with_import_path_correction(
     ${src} ${third_party_proto_import_path(src)}
   )
@@ -724,7 +724,7 @@
   # in the third_party directory as long as test builds are disabled.
   if (gRPC_BUILD_TESTS)
   % for src in sorted(protobuf_gen_files):
-  % if src.startswith('third_party/'):
+  % if (src.startswith('third_party/') or src.startswith('test/') or src.startswith('src/proto/grpc/testing/')):
   protobuf_generate_grpc_cpp_with_import_path_correction(
     ${src} ${third_party_proto_import_path(src)}
   )


### PR DESCRIPTION
Don't generate test protos if tests aren't being built.

See the calls here
https://github.com/grpc/grpc/blob/12fcd268d42237999c857ee5c14671cd1ec76eac/CMakeLists.txt#L719-L790

which all come before the
```CMake
# This enables CMake to build the project without requiring submodules
# in the third_party directory as long as test builds are disabled.
if (gRPC_BUILD_TESTS)
```
that currently gates only the protos from third_party submodules.