### PR TITLE
add enable_testing() so tests can be run by ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ option(gRPC_BUILD_TESTS "Build tests" OFF)
 option(gRPC_BUILD_CODEGEN "Build codegen" ON)
 option(gRPC_DOWNLOAD_ARCHIVES "Download archives for empty 3rd party directories" ON)
 
+if(gRPC_BUILD_TESTS)
+  enable_testing()
+endif()
+
 set(gRPC_INSTALL_default ON)
 if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Disable gRPC_INSTALL by default if building as a submodule

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -304,6 +304,10 @@
   option(gRPC_BUILD_CODEGEN "Build codegen" ON)
   option(gRPC_DOWNLOAD_ARCHIVES "Download archives for empty 3rd party directories" ON)
 
+  if(gRPC_BUILD_TESTS)
+    enable_testing()
+  endif()
+
   set(gRPC_INSTALL_default ON)
   if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     # Disable gRPC_INSTALL by default if building as a submodule


### PR DESCRIPTION
I don't know how grpc currently runs its test suite, but doing a CMake build à la:
```bash
mkdir build
cd build

cmake  -G Ninja .. # and other relevant configs

cmake --build .
ctest --progress --output-on-failure
cmake --install .
```
doesn't actually run anything currently, because ctest needs a call to `enable_testing()` for it to work. Add that call at least.

This ends up running something like the following. Not sure if that's complete, given how long the tests take to compile, and how little time they take to run.

<details>

```
+ ctest --progress --output-on-failure
Test project /home/conda/feedstock_root/build_artifacts/grpc-split_1740784437750/work/build-cpp
      Start  1: benchmark
 1/66 Test  #1: benchmark ..................................   Passed    3.39 sec
      Start  2: spec_arg
 2/66 Test  #2: spec_arg ...................................   Passed    0.00 sec
      Start  3: spec_arg_verbosity
 3/66 Test  #3: spec_arg_verbosity .........................   Passed    0.00 sec
      Start  4: benchmark_setup_teardown
 4/66 Test  #4: benchmark_setup_teardown ...................   Passed    0.01 sec
      Start  5: min_time_flag_time
 5/66 Test  #5: min_time_flag_time .........................   Passed    0.00 sec
      Start  6: min_time_flag_iters
 6/66 Test  #6: min_time_flag_iters ........................   Passed    0.00 sec
      Start  7: filter_simple
 7/66 Test  #7: filter_simple ..............................   Passed    0.00 sec
      Start  8: filter_simple_list_only
 8/66 Test  #8: filter_simple_list_only ....................   Passed    0.00 sec
      Start  9: filter_simple_negative
 9/66 Test  #9: filter_simple_negative .....................   Passed    0.00 sec
      Start 10: filter_simple_negative_list_only
10/66 Test #10: filter_simple_negative_list_only ...........   Passed    0.00 sec
      Start 11: filter_suffix
11/66 Test #11: filter_suffix ..............................   Passed    0.00 sec
      Start 12: filter_suffix_list_only
12/66 Test #12: filter_suffix_list_only ....................   Passed    0.00 sec
      Start 13: filter_suffix_negative
13/66 Test #13: filter_suffix_negative .....................   Passed    0.00 sec
      Start 14: filter_suffix_negative_list_only
14/66 Test #14: filter_suffix_negative_list_only ...........   Passed    0.00 sec
      Start 15: filter_regex_all
15/66 Test #15: filter_regex_all ...........................   Passed    0.00 sec
      Start 16: filter_regex_all_list_only
16/66 Test #16: filter_regex_all_list_only .................   Passed    0.00 sec
      Start 17: filter_regex_all_negative
17/66 Test #17: filter_regex_all_negative ..................   Passed    0.00 sec
      Start 18: filter_regex_all_negative_list_only
18/66 Test #18: filter_regex_all_negative_list_only ........   Passed    0.00 sec
      Start 19: filter_regex_blank
19/66 Test #19: filter_regex_blank .........................   Passed    0.00 sec
      Start 20: filter_regex_blank_list_only
20/66 Test #20: filter_regex_blank_list_only ...............   Passed    0.00 sec
      Start 21: filter_regex_blank_negative
21/66 Test #21: filter_regex_blank_negative ................   Passed    0.00 sec
      Start 22: filter_regex_blank_negative_list_only
22/66 Test #22: filter_regex_blank_negative_list_only ......   Passed    0.00 sec
      Start 23: filter_regex_none
23/66 Test #23: filter_regex_none ..........................   Passed    0.00 sec
      Start 24: filter_regex_none_list_only
24/66 Test #24: filter_regex_none_list_only ................   Passed    0.00 sec
      Start 25: filter_regex_none_negative
25/66 Test #25: filter_regex_none_negative .................   Passed    0.00 sec
      Start 26: filter_regex_none_negative_list_only
26/66 Test #26: filter_regex_none_negative_list_only .......   Passed    0.00 sec
      Start 27: filter_regex_wildcard
27/66 Test #27: filter_regex_wildcard ......................   Passed    0.00 sec
      Start 28: filter_regex_wildcard_list_only
28/66 Test #28: filter_regex_wildcard_list_only ............   Passed    0.00 sec
      Start 29: filter_regex_wildcard_negative
29/66 Test #29: filter_regex_wildcard_negative .............   Passed    0.00 sec
      Start 30: filter_regex_wildcard_negative_list_only
30/66 Test #30: filter_regex_wildcard_negative_list_only ...   Passed    0.00 sec
      Start 31: filter_regex_begin
31/66 Test #31: filter_regex_begin .........................   Passed    0.00 sec
      Start 32: filter_regex_begin_list_only
32/66 Test #32: filter_regex_begin_list_only ...............   Passed    0.00 sec
      Start 33: filter_regex_begin_negative
33/66 Test #33: filter_regex_begin_negative ................   Passed    0.00 sec
      Start 34: filter_regex_begin_negative_list_only
34/66 Test #34: filter_regex_begin_negative_list_only ......   Passed    0.00 sec
      Start 35: filter_regex_begin2
35/66 Test #35: filter_regex_begin2 ........................   Passed    0.00 sec
      Start 36: filter_regex_begin2_list_only
36/66 Test #36: filter_regex_begin2_list_only ..............   Passed    0.00 sec
      Start 37: filter_regex_begin2_negative
37/66 Test #37: filter_regex_begin2_negative ...............   Passed    0.00 sec
      Start 38: filter_regex_begin2_negative_list_only
38/66 Test #38: filter_regex_begin2_negative_list_only .....   Passed    0.00 sec
      Start 39: filter_regex_end
39/66 Test #39: filter_regex_end ...........................   Passed    0.00 sec
      Start 40: filter_regex_end_list_only
40/66 Test #40: filter_regex_end_list_only .................   Passed    0.00 sec
      Start 41: filter_regex_end_negative
41/66 Test #41: filter_regex_end_negative ..................   Passed    0.00 sec
      Start 42: filter_regex_end_negative_list_only
42/66 Test #42: filter_regex_end_negative_list_only ........   Passed    0.00 sec
      Start 43: options_benchmarks
43/66 Test #43: options_benchmarks .........................   Passed    2.22 sec
      Start 44: basic_benchmark
44/66 Test #44: basic_benchmark ............................   Passed    0.75 sec
      Start 45: repetitions_benchmark
45/66 Test #45: repetitions_benchmark ......................   Passed    0.02 sec
      Start 46: diagnostics_test
46/66 Test #46: diagnostics_test ...........................   Passed    0.04 sec
      Start 47: skip_with_error_test
47/66 Test #47: skip_with_error_test .......................   Passed    0.21 sec
      Start 48: donotoptimize_test
48/66 Test #48: donotoptimize_test .........................   Passed    0.00 sec
      Start 49: fixture_test
49/66 Test #49: fixture_test ...............................   Passed    0.00 sec
      Start 50: register_benchmark_test
50/66 Test #50: register_benchmark_test ....................   Passed    0.00 sec
      Start 51: map_test
51/66 Test #51: map_test ...................................   Passed    0.25 sec
      Start 52: multiple_ranges_test
52/66 Test #52: multiple_ranges_test .......................   Passed    0.35 sec
      Start 53: args_product_test
53/66 Test #53: args_product_test ..........................   Passed    0.25 sec
      Start 54: link_main_test
54/66 Test #54: link_main_test .............................   Passed    0.03 sec
      Start 55: reporter_output_test
55/66 Test #55: reporter_output_test .......................   Passed    0.19 sec
      Start 56: templated_fixture_test
56/66 Test #56: templated_fixture_test .....................   Passed    0.04 sec
      Start 57: user_counters_test
57/66 Test #57: user_counters_test .........................   Passed    0.24 sec
      Start 58: perf_counters_test
58/66 Test #58: perf_counters_test .........................   Passed    0.00 sec
      Start 59: internal_threading_test
59/66 Test #59: internal_threading_test ....................   Passed    1.83 sec
      Start 60: report_aggregates_only_test
60/66 Test #60: report_aggregates_only_test ................   Passed    0.01 sec
      Start 61: display_aggregates_only_test
61/66 Test #61: display_aggregates_only_test ...............   Passed    0.01 sec
      Start 62: user_counters_tabular_test
62/66 Test #62: user_counters_tabular_test .................   Passed    0.24 sec
      Start 63: user_counters_thousands_test
63/66 Test #63: user_counters_thousands_test ...............   Passed    0.01 sec
      Start 64: memory_manager_test
64/66 Test #64: memory_manager_test ........................   Passed    0.03 sec
      Start 65: cxx03
65/66 Test #65: cxx03 ......................................   Passed    0.20 sec
      Start 66: complexity_benchmark
66/66 Test #66: complexity_benchmark .......................   Passed    1.42 sec

100% tests passed, 0 tests failed out of 66

Total Test time (real) =  11.92 sec
```

</details>