### PR TITLE
[CI] Added apt-get update to grpc_flaky_network

### DIFF
--- a/tools/internal_ci/linux/grpc_flaky_network_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_flaky_network_in_docker.sh
@@ -18,7 +18,7 @@
 set -ex
 
 # iptables is used to drop traffic between client and server
-apt-get install -y iptables iproute2
+apt-get update && apt-get install -y iptables iproute2
 
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_flaky_network_test
 bazel_flaky_network_test/bazel_wrapper test --test_output=all --test_timeout=1200 //test/cpp/end2end:flaky_network_test --test_env=GRPC_TRACE=http --test_env=GRPC_VERBOSITY=DEBUG


### PR DESCRIPTION
To fix this error at `grpc_flaky_network` ([log](https://fusion2.corp.google.com/ci;ids=1930537984/kokoro/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_flaky_network/activity/c855f33a-7591-4b53-a663-ef27f6f27a59/log))

```
+ apt-get install -y iptables iproute2
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libatm1 libcap2 libcap2-bin libip4tc2 libip6tc2 libmnl0
  libnetfilter-conntrack3 libnfnetlink0 libnftnl11 libpam-cap libxtables12
Suggested packages:
  iproute2-doc firewalld kmod nftables
The following NEW packages will be installed:
  iproute2 iptables libatm1 libcap2 libcap2-bin libip4tc2 libip6tc2 libmnl0
  libnetfilter-conntrack3 libnfnetlink0 libnftnl11 libpam-cap libxtables12
0 upgraded, 13 newly installed, 0 to remove and 36 not upgraded.
Need to get 1513 kB of archives.
After this operation, 6581 kB of additional disk space will be used.
Ign:1 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcap2 amd64 1:2.32-1ubuntu0.1
Get:2 http://archive.ubuntu.com/ubuntu focal/main amd64 libmnl0 amd64 1.0.4-2 [12.3 kB]
Err:1 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libcap2 amd64 1:2.32-1ubuntu0.1
  404  Not Found [IP: 185.125.190.82 80]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libxtables12 amd64 1.8.4-3ubuntu2.1 [28.7 kB]
Ign:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcap2-bin amd64 1:2.32-1ubuntu0.1
Get:5 http://archive.ubuntu.com/ubuntu focal/main amd64 iproute2 amd64 5.5.0-1ubuntu1 [858 kB]
Err:4 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libcap2-bin amd64 1:2.32-1ubuntu0.1
  404  Not Found [IP: 185.125.190.82 80]
Get:6 http://archive.ubuntu.com/ubuntu focal/main amd64 libatm1 amd64 1:2.5.1-4 [21.8 kB]
Get:7 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libip4tc2 amd64 1.8.4-3ubuntu2.1 [19.1 kB]
Ign:8 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libpam-cap amd64 1:2.32-1ubuntu0.1
Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libip6tc2 amd64 1.8.4-3ubuntu2.1 [19.4 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/main amd64 libnfnetlink0 amd64 1.0.1-3build1 [13.8 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal/main amd64 libnetfilter-conntrack3 amd64 1.0.7-2 [41.4 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal/main amd64 libnftnl11 amd64 1.1.5-1 [57.8 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 iptables amd64 1.8.4-3ubuntu2.1 [390 kB]
Err:8 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libpam-cap amd64 1:2.32-1ubuntu0.1
  404  Not Found [IP: 185.125.190.82 80]
Fetched 1463 kB in 1s (1446 kB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libc/libcap2/libcap2_2.32-1ubuntu0.1_amd64.deb  404  Not Found [IP: 185.125.190.82 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libc/libcap2/libcap2-bin_2.32-1ubuntu0.1_amd64.deb  404  Not Found [IP: 185.125.190.82 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libc/libcap2/libpam-cap_2.32-1ubuntu0.1_amd64.deb  404  Not Found [IP: 185.125.190.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```