### PR TITLE
[testing] remove racey check in destroy_grpclb_channel_with_active_connect_stress_test

### DIFF
--- a/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
+++ b/test/cpp/client/destroy_grpclb_channel_with_active_connect_stress_test.cc
@@ -94,7 +94,6 @@ void TryConnectAndDestroy() {
   channel->GetState(true /* try_to_connect */);
   ASSERT_FALSE(
       channel->WaitForConnected(grpc_timeout_milliseconds_to_deadline(100)));
-  ASSERT_EQ("grpclb", channel->GetLoadBalancingPolicyName());
   channel.reset();
 };
 


### PR DESCRIPTION
Checking the service config in this way is broken b/c service config resolution happens asynchronously. If nothing else we need to [jump into the work serializer](https://github.com/grpc/grpc/blob/f409bf12e7ee735d911ee5d6b1d1f1bdfddd28d3/src/core/client_channel/client_channel.cc#L678).
