### PR TITLE
[CI] Enhancement on push_testing_images.sh

### DIFF
--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -27,7 +27,7 @@ cd $(dirname $0)/../..
 #  CHECK_MODE: if set, the script will check that all the .current_version files are up-to-date (used by sanity tests).
 #  SKIP_UPLOAD: if set, script won't push docker images it built to artifact registry.
 #  HOST_ARCH_ONLY: if set, script will build docker images with the same architecture as the machine running the script.
-#  ALWAYS_BUILD: if set, script will build docker images all the times.
+#  ALWAYS_BUILD: if set, script will build docker images all the time.
 
 # How to configure docker before running this script for the first time:
 # Configure docker:

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -66,6 +66,18 @@ ALL_DOCKERFILE_DIRS=(
   third_party/rake-compiler-dock/*
 )
 
+# a list of docker directories that are based on ARM64 base images
+ARM_DOCKERFILE_DIRS=(
+  tools/dockerfile/distribtest/python_alpine_aarch64
+  tools/dockerfile/distribtest/python_python39_buster_aarch64
+  tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64
+  tools/dockerfile/test/bazel_arm64
+  tools/dockerfile/test/csharp_debian11_arm64
+  tools/dockerfile/test/php8_debian12_arm64
+  tools/dockerfile/test/python_debian11_default_arm64
+  tools/dockerfile/test/ruby_debian11_arm64
+)
+
 CHECK_FAILED=""
 
 if [ "${CHECK_MODE}" != "" ]
@@ -104,9 +116,15 @@ do
   # if HOST_ARCH_ONLY is set, skip if the docker image's arthiecture doesn't match with the host architecture
   if [ "${HOST_ARCH_ONLY}" != "" ]; then
     [[ "$(uname -m)" == aarch64 ]] && is_host_arm=1 || is_host_arm=0
-    [[ "$DOCKER_IMAGE_NAME" == *arm* || "$DOCKER_IMAGE_NAME" == *aarch* ]] && is_docker_for_arm=1 || is_docker_for_arm=0
+    is_docker_for_arm=0
+    for ARM_DOCKERFILE_DIR in "${ARM_DOCKERFILE_DIRS[@]}"; do
+      if [ "$DOCKERFILE_DIR" == "$ARM_DOCKERFILE_DIR" ]; then
+        is_docker_for_arm=1
+        break
+      fi
+    done
     if [ "$is_host_arm" != "$is_docker_for_arm" ]; then
-      echo "Skipped due to the different architecture " ${DOCKER_IMAGE_NAME}
+      echo "Skipped due to the different architecture:" ${DOCKER_IMAGE_NAME}
       continue
     fi
   fi


### PR DESCRIPTION
The `TRANSFER_FROM_DOCKERHUB` option has been removed, as the associated migration is complete. 
Two new options have been introduced: `HOST_ARCH_ONLY` and `ALWAYS_BUILD`. 
- `HOST_ARCH_ONLY` allows building ARM-specific Docker images on ARM machines, addressing compatibility issues on x86 platforms. 
- `ALWAYS_BUILD` forces image rebuilds, ensuring updates to base images and package installations, even when Dockerfiles remain unchanged.
