### PR TITLE
[build] Support Bazel C++ proto_library import_prefix rules.

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -21,8 +21,11 @@ load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
     "//bazel:protobuf.bzl",
     "get_include_directory",
+    "get_out_dir",
     "get_plugin_args",
+    "get_proto_arguments",
     "get_proto_root",
+    "is_in_virtual_imports",
     "proto_path_to_generated_filename",
 )
 
@@ -43,11 +46,6 @@ def _strip_package_from_path(label_package, file):
     if not path.startswith(label_package + "/", prefix_len):
         fail("'{}' does not lie within '{}'.".format(path, label_package))
     return path[prefix_len + len(label_package + "/"):]
-
-def _get_srcs_file_path(file):
-    if not file.is_source and file.path.startswith(file.root.path):
-        return file.path[len(file.root.path) + 1:]
-    return file.path
 
 def _join_directories(directories):
     massaged_directories = [directory for directory in directories if len(directory) != 0]
@@ -112,31 +110,34 @@ def generate_cc_impl(ctx):
             for proto in protos
         ]
     out_files = [ctx.actions.declare_file(out) for out in outs]
-    dir_out = str(ctx.genfiles_dir.path + proto_root)
+    out_dir_info = get_out_dir(protos, ctx)
+    output_dir = out_dir_info.path
 
     arguments = []
     if ctx.executable.plugin:
         arguments += get_plugin_args(
             ctx.executable.plugin,
             ctx.attr.flags,
-            dir_out,
+            output_dir,
             ctx.attr.generate_mocks,
             ctx.attr.allow_deprecated,
         )
         tools = [ctx.executable.plugin]
     else:
-        arguments.append("--cpp_out=" + ",".join(ctx.attr.flags) + ":" + dir_out)
+        arguments.append("--cpp_out=" + ",".join(ctx.attr.flags) + ":" + output_dir)
         tools = []
 
-    arguments += [
-        "--proto_path={}".format(get_include_directory(i))
-        for i in includes
-    ]
+    proto_root = get_proto_root(ctx.label.workspace_root)
+    dir_out = str(ctx.genfiles_dir.path + proto_root)
+    proto_paths = [dir_out]
+    for inc in includes:
+        inc_dir = get_include_directory(inc)
+        if inc_dir not in proto_paths:
+            proto_paths.append(inc_dir)
+    arguments += ["--proto_path={}".format(path) for path in proto_paths]
 
-    # Include the output directory so that protoc puts the generated code in the
-    # right directory.
-    arguments.append("--proto_path={0}".format(dir_out))
-    arguments += [_get_srcs_file_path(proto) for proto in protos]
+    # Add proto files to compile.
+    arguments += get_proto_arguments(protos, ctx.genfiles_dir.path)
 
     # create a list of well known proto files if the argument is non-None
     well_known_proto_files = []
@@ -164,7 +165,23 @@ def generate_cc_impl(ctx):
         use_default_shell_env = True,
     )
 
-    return DefaultInfo(files = depset(out_files))
+    # Create symlinks from _virtual_imports to _virtual_includes for headers.
+    virtual_includes_files = []
+    for out_file in out_files:
+        if (is_in_virtual_imports(out_file) and
+            out_file.path.endswith(".grpc.pb.h")):
+            virtual_imports_str = "_virtual_imports"
+            path_idx = out_file.path.find(virtual_imports_str) + len(virtual_imports_str)
+            rel_path = out_file.path[path_idx:]
+            virtual_includes_path = "_virtual_includes" + rel_path
+            virtual_includes_file = ctx.actions.declare_file(virtual_includes_path)
+            ctx.actions.symlink(
+                output = virtual_includes_file,
+                target_file = out_file,
+            )
+            virtual_includes_files.append(virtual_includes_file)
+
+    return DefaultInfo(files = depset(out_files + virtual_includes_files))
 
 _generate_cc = rule(
     attrs = {


### PR DESCRIPTION
The cc_grpc_library Bazel build rule does not seem to respect the import_prefix/strip_import_prefix args defined on a proto_library.  It looks like there are two issues: GRPC header files are not being symlinked into _virtual_includes (cc_proto_library does this) and the paths to the proto files are not generated correctly when virtual imports are needed.

I created an example in examples/cpp/prefixes in the https://github.com/bstoll/grpc/tree/cpp-prefixes-example branch ([diff](https://github.com/grpc/grpc/commit/eecae265505b6b6587f95ced29470eb9f38020f3)) to demonstrate the problem - with this PR the examples build successfully.

When running `bazel build -s //:greeter_server` in /examples/cpp/prefixes/external, we now deduplicate the import path args (`--proto_path=bazel-out/k8-fastbuild/bin/external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto`) as well as use the correct paths to the .proto files respecting the import_prefix/strip_import_prefix flags.

Old:
```
  bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/protobuf+/protoc '--plugin=protoc-gen-PLUGIN=bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/grpc+/src/compiler/grpc_cpp_plugin' '--PLUGIN_out=bazel-out/k8-fastbuild/bin/external/grpc+' '--proto_path=bazel-out/k8-fastbuild/bin/external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto' '--proto_path=bazel-out/k8-fastbuild/bin/external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto' '--proto_path=bazel-out/k8-fastbuild/bin/external/protobuf+/src/google/protobuf/_virtual_imports/any_proto' '--proto_path=bazel-out/k8-fastbuild/bin/external/grpc+' external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto/custom/prefix/service.proto external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto/custom/prefix/service_extra.proto)
```

New:
```
  bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/protobuf+/protoc '--plugin=protoc-gen-PLUGIN=bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/grpc+/src/compiler/grpc_cpp_plugin' '--PLUGIN_out=bazel-out/k8-fastbuild/bin/external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto' '--proto_path=bazel-out/k8-fastbuild/bin/external/grpc+' '--proto_path=bazel-out/k8-fastbuild/bin/external/grpc+/examples/cpp/prefixes/_virtual_imports/service_proto' '--proto_path=bazel-out/k8-fastbuild/bin/external/protobuf+/src/google/protobuf/_virtual_imports/any_proto' custom/prefix/service.proto custom/prefix/service_extra.proto)
```

I am relatively new to Starlark so any remarks are welcome.

This should resolve #26796, #38287, #33377, and #20675.