### PR TITLE
[interop] Add grpc-java 1.71.0 to client_matrix.py

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -462,6 +462,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.68.3", ReleaseInfo()),
             ("v1.69.1", ReleaseInfo()),
             ("v1.70.0", ReleaseInfo()),
+            ("v1.71.0", ReleaseInfo()),
         ]
     ),
     "python": OrderedDict(


### PR DESCRIPTION
Ad-hoc test run: https://fusion2.corp.google.com/ci/kokoro/prod:grpc%2Fcore%2Fexperimental%2Flinux%2Fgrpc_interop_matrix_adhoc/activity/72739729-2934-4cdf-a845-b24e8e014493/tests