### PR TITLE
Fix race conditions during pre-fork hook leading to assertion error

### DIFF
--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -175,7 +175,6 @@ void Executor::SetThreading(bool threading) {
             << curr_num_threads << " joined";
       }
 
-      gpr_atm_rel_store(&num_threads_, 0);
       for (size_t i = 0; i < max_threads_; i++) {
         gpr_mu_destroy(&thd_state_[i].mu);
         gpr_cv_destroy(&thd_state_[i].cv);

--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -167,6 +167,7 @@ void Executor::SetThreading(bool threading) {
     // multiple times, we ensure that `num_threads_` is still equal to the expected
     // number we read at the beginning of the function and atomically set it to 0. That way,
     // only one of the multiple invocations will join the threads and perform the cleanup.
+    curr_num_threads = gpr_atm_no_barrier_load(&num_threads_);
     if (gpr_atm_no_barrier_cas(&num_threads_, curr_num_threads, 0)) {
       for (gpr_atm i = 0; i < curr_num_threads; i++) {
         thd_state_[i].thd.Join();


### PR DESCRIPTION
## Summary

This commit fixes a couple race conditions inside the Executor class which can lead to assertion errors (joining an uninitialized Thread or joining a Thread multiple times) or deadlocks.

The first race exists between the call to `SetThreading(false)` made during a `grpc_shutdown_internal_locked` call and the `Enqueue` method which may be called whenever a callback is registered. More details can be found under the following issue comment
https://github.com/grpc/grpc/issues/38251#issuecomment-2685537047. The TL;DR is that the thread state lock is not held continuously in the `Enqueue` method between the time to decide to spawn a new Thread and the time to actually instantiate it. This means that it can decide to spawn one (ie. `shutdown` is false), the `SetThreading(false)` then sets the `shutdown` attribute to false but the `Enqueue` method still creates the thread. This race can have two bad outcomes for the program: 1) the `SetThreading(false)` method may call `Join` on a thread that hasn't yet been initialized (`num_threads_` is not accessed with a lock held) or 2) the newly created Thread is never cleanly closed leading to a deadlock (setting `shutdown` to false is done prior to the race and is the only way to close a thread). This commit addresses both outcomes by preventing the `Enqueue` method from creating a thread when the `shutdown` attribute is false. It is done by re-acquiring this lock right before actually creating the thread.

The second race exists when `SetThreading(false)` is called concurrently. This can occur during pre-fork and a call to `grpc_shutdown` (eg. after a channel is closed). This method doesn't protect against running multiple times since the check for `num_threads_` to be 0 is not done while holding any lock. It's then possible that multiple threads run this function and walk the active thread list to join them. Since this is illegal (the Thread class cleaning up its `impl` attribute after join), it leads to assertion error from the Tread class.

## Testing

[x] Run `run_tests.py -l c++`
[x] Run `run_tests.py -l python`


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

