### PR TITLE
[EventEngine] Isolate CFStream client decision logic

### DIFF
--- a/src/core/lib/event_engine/shim.cc
+++ b/src/core/lib/event_engine/shim.cc
@@ -22,25 +22,17 @@
 namespace grpc_event_engine::experimental {
 
 bool UseEventEngineClient() {
-#if defined(GRPC_POSIX_SOCKET_TCP) && \
-    !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
-  return grpc_core::IsEventEngineClientEnabled();
-#elif defined(GPR_WINDOWS) && !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
-  return grpc_core::IsEventEngineClientEnabled();
-#elif GRPC_IOS_EVENT_ENGINE_CLIENT
-  return true;
-#else
+#if defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
   return false;
 #endif
+  return grpc_core::IsEventEngineClientEnabled();
 }
 
 bool UseEventEngineListener() {
-#if defined(GRPC_POSIX_SOCKET_TCP) && \
-    !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
-  return grpc_core::IsEventEngineListenerEnabled();
-#else
+#if defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
   return false;
 #endif
+  return grpc_core::IsEventEngineListenerEnabled();
 }
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/iomgr/tcp_client_cfstream.cc
+++ b/src/core/lib/iomgr/tcp_client_cfstream.cc
@@ -147,11 +147,10 @@ static int64_t CFStreamClientConnect(
     grpc_pollset_set* /*interested_parties*/,
     const grpc_event_engine::experimental::EndpointConfig& config,
     const grpc_resolved_address* resolved_addr, grpc_core::Timestamp deadline) {
-  if (grpc_event_engine::experimental::UseEventEngineClient()) {
-    return grpc_event_engine::experimental::event_engine_tcp_client_connect(
-        closure, ep, config, resolved_addr, deadline);
-  }
-
+#if GRPC_IOS_EVENT_ENGINE_CLIENT
+  return grpc_event_engine::experimental::event_engine_tcp_client_connect(
+      closure, ep, config, resolved_addr, deadline);
+#endif
   auto addr_uri = grpc_sockaddr_to_uri(resolved_addr);
   if (!addr_uri.ok()) {
     grpc_error_handle error = GRPC_ERROR_CREATE(addr_uri.status().ToString());
@@ -198,10 +197,10 @@ static int64_t CFStreamClientConnect(
 }
 
 static bool CFStreamClientCancelConnect(int64_t connection_handle) {
-  if (grpc_event_engine::experimental::UseEventEngineClient()) {
-    return grpc_event_engine::experimental::
-        event_engine_tcp_client_cancel_connect(connection_handle);
-  }
+#if GRPC_IOS_EVENT_ENGINE_CLIENT
+  return grpc_event_engine::experimental::
+      event_engine_tcp_client_cancel_connect(connection_handle);
+#endif
   return false;
 }
 


### PR DESCRIPTION
The iOS EventEngine does not rely on the C-core experiment system, but the EventEngine client switch logic was intertwined with every other engine. This PR separates the iOS logic, and cleans up the `UseEventEngine*` methods.

This is a no-op cleanup.