### PR TITLE
[http2] Fix rst_stream_fix

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2307,7 +2307,8 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                             &http_error, nullptr);
       grpc_core::MaybeTarpit(
           t, tarpit,
-          [s, http_error,
+          [id = s->id, sent_initial_metadata = s->sent_initial_metadata,
+           http_error,
            remove_stream_handle = grpc_chttp2_mark_stream_closed(
                t, s, 1, 1, due_to_error)](grpc_chttp2_transport* t) {
             // Do not send RST_STREAM from the client for a stream that hasn't
@@ -2315,11 +2316,11 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
             // marked the stream closed above, we won't be writing to it
             // anymore.
             if (grpc_core::IsRstStreamFixEnabled() && t->is_client &&
-                !s->sent_initial_metadata) {
+                !sent_initial_metadata) {
               return;
             }
             grpc_chttp2_add_rst_stream_to_next_write(
-                t, s->id, static_cast<uint32_t>(http_error), nullptr);
+                t, id, static_cast<uint32_t>(http_error), nullptr);
             grpc_chttp2_initiate_write(t,
                                        GRPC_CHTTP2_INITIATE_WRITE_RST_STREAM);
           });

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2307,6 +2307,8 @@ void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                             &http_error, nullptr);
       grpc_core::MaybeTarpit(
           t, tarpit,
+          // Capture the individual fields of the stream by value, since the
+          // stream state might have been deleted by the time we run the lambda.
           [id = s->id, sent_initial_metadata = s->sent_initial_metadata,
            http_error,
            remove_stream_handle = grpc_chttp2_mark_stream_closed(


### PR DESCRIPTION
Noticed an ASAN heap-use-after-free on server_fuzzer - 
```
=================================================================
==1223949==ERROR: AddressSanitizer: heap-use-after-free on address 0x7e3a11a8a128 at pc 0x557c8533cdb7 bp 0x7ffdd4d3e960 sp 0x7ffdd4d3e958
READ of size 4 at 0x7e3a11a8a128 thread T0
    #0 0x557c8533cdb6 in operator() [third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc:2319](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc?l=2319&cl=733979049):23
    #1 0x557c8533cdb6 in operator() [third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc:2282](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc?l=2282&cl=733979049):15
    #2 0x557c8533cdb6 in grpc_closure* grpc_core::NewClosure<void grpc_core::(anonymous namespace)::MaybeTarpit<grpc_chttp2_cancel_stream(grpc_chttp2_transport*, grpc_chttp2_stream*, absl::Status, bool)::$_0>(grpc_chttp2_transport*, bool, grpc_chttp2_cancel_stream(grpc_chttp2_transport*, grpc_chttp2_stream*, absl::Status, bool)::$_0)::'lambda'()::operator()()::'lambda'(absl::Status)>(grpc_chttp2_cancel_stream(grpc_chttp2_transport*, grpc_chttp2_stream*, absl::Status, bool)::$_0)::Closure::Run(void*, absl::Status) [third_party/grpc/src/core/lib/iomgr/closure.h:159](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/lib/iomgr/closure.h?l=159&cl=733979049):7
    #3 0x557c85cc2073 in grpc_combiner_continue_exec_ctx() [third_party/grpc/src/core/lib/iomgr/combiner.cc:216](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/lib/iomgr/combiner.cc?l=216&cl=733979049):5
    #4 0x557c85cc4334 in grpc_core::ExecCtx::Flush() [third_party/grpc/src/core/lib/iomgr/exec_ctx.cc:77](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/lib/iomgr/exec_ctx.cc?l=77&cl=733979049):17
    #5 0x557c8304adc1 in grpc_core::ExecCtx::~ExecCtx() [third_party/grpc/src/core/lib/iomgr/exec_ctx.h:137](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/lib/iomgr/exec_ctx.h?l=137&cl=733979049):5
    #6 0x557c8533cb09 in operator() [third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc:2285](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc?l=2285&cl=733979049):7
    #7 0x557c8533cb09 in __invoke<(lambda at [third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc:2275](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc?l=2275&cl=733979049):17) &> [third_party/crosstool/v18/stable/src/libcxx/include/__type_traits/invoke.h:179](https://cs.corp.google.com/piper///depot/google3/third_party/crosstool/v18/stable/src/libcxx/include/__type_traits/invoke.h?l=179&cl=733979049):25
    #8 0x557c8533cb09 in invoke<(lambda at [third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc:2275](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc?l=2275&cl=733979049):17) &> [third_party/crosstool/v18/stable/src/libcxx/include/__functional/invoke.h:29](https://cs.corp.google.com/piper///depot/google3/third_party/crosstool/v18/stable/src/libcxx/include/__functional/invoke.h?l=29&cl=733979049):10
    #9 0x557c8533cb09 in InvokeR<void, (lambda at [third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc:2275](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/src/core/ext/transport/chttp2/transport/chttp2_transport.cc?l=2275&cl=733979049):17) &> [third_party/absl/functional/internal/any_invocable.h:120](https://cs.corp.google.com/piper///depot/google3/third_party/absl/functional/internal/any_invocable.h?l=120&cl=733979049):5
    #10 0x557c8533cb09 in void absl::internal_any_invocable::RemoteInvoker<false, void, void grpc_core::(anonymous namespace)::MaybeTarpit<grpc_chttp2_cancel_stream(grpc_chttp2_transport*, grpc_chttp2_stream*, absl::Status, bool)::$_0>(grpc_chttp2_transport*, bool, grpc_chttp2_cancel_stream(grpc_chttp2_transport*, grpc_chttp2_stream*, absl::Status, bool)::$_0)::'lambda'()&>(absl::internal_any_invocable::TypeErasedState*) [third_party/absl/functional/internal/any_invocable.h:326](https://cs.corp.google.com/piper///depot/google3/third_party/absl/functional/internal/any_invocable.h?l=326&cl=733979049):10
    #11 0x557c832d0010 in operator() [third_party/absl/functional/internal/any_invocable.h:759](https://cs.corp.google.com/piper///depot/google3/third_party/absl/functional/internal/any_invocable.h?l=759&cl=733979049):1
    #12 0x557c832d0010 in grpc_event_engine::experimental::FuzzingEventEngine::Tick(std::__u::chrono::duration<long, std::__u::ratio<1l, 1000000000l>>) [third_party/grpc/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc:174](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc?l=174&cl=733979049):7
    #13 0x557c831ce7fb in grpc_core::testing::BasicFuzzer::Tick() [third_party/grpc/test/core/end2end/fuzzers/fuzzing_common.cc:384](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/test/core/end2end/fuzzers/fuzzing_common.cc?l=384&cl=733979049):12
    #14 0x557c831d22a7 in grpc_core::testing::BasicFuzzer::Run(absl::Span<api_fuzzer::Action const* const>) [third_party/grpc/test/core/end2end/fuzzers/fuzzing_common.cc:751](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/test/core/end2end/fuzzers/fuzzing_common.cc?l=751&cl=733979049):5
    #15 0x557c83047681 in grpc_core::testing::RunServerFuzzer(fuzzer_input::Msg const&, absl::FunctionRef<void (grpc_server*, int, grpc_core::ChannelArgs const&)>) [third_party/grpc/test/core/end2end/fuzzers/server_fuzzer.cc:103](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/test/core/end2end/fuzzers/server_fuzzer.cc?l=103&cl=733979049):44
    #16 0x557c8304a422 in grpc_core::testing::Chttp2(fuzzer_input::Msg) [third_party/grpc/test/core/end2end/fuzzers/server_fuzzer.cc:135](https://cs.corp.google.com/piper///depot/google3/third_party/grpc/test/core/end2end/fuzzers/server_fuzzer.cc?l=135&cl=733979049):3
```

There is a chance that the stream might have been deleted by the time we run the closure, so we need to capture the fields of the stream we need.