### PR TITLE
[ObjC] use c++17 in spm package and add a build test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2336,5 +2336,5 @@ let package = Package(
     ),
   ],
   cLanguageStandard: .gnu11,
-  cxxLanguageStandard: .cxx14
+  cxxLanguageStandard: .cxx17
 )

--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -36,13 +36,25 @@ rm -rf Pods
 rm -rf *.xcworkspace
 rm -f Podfile.lock
 
-time pod install
+if [ -f Podfile ]; then
+  time pod install
+fi
 
 set -o pipefail  # preserve xcodebuild exit code when piping output
 
 XCODEBUILD_FILTER_OUTPUT_SCRIPT="${TEST_PATH}/xcodebuild_filter_output.sh"
 
-if [ "$SCHEME" == "tvOS-sample" ]; then
+if [ "$SCHEME" == "gRPC-Package" ]; then
+  time xcodebuild \
+    build \
+    -scheme $SCHEME \
+    -destination generic/platform=iOS 
+    -derivedDataPath Build/Build \
+    CODE_SIGN_IDENTITY="" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    | "${XCODEBUILD_FILTER_OUTPUT_SCRIPT}"
+elif [ "$SCHEME" == "tvOS-sample" ]; then
   time xcodebuild \
     build \
     -workspace *.xcworkspace \

--- a/templates/Package.swift.template
+++ b/templates/Package.swift.template
@@ -123,5 +123,5 @@
         ),
       ],
       cLanguageStandard: .gnu11,
-      cxxLanguageStandard: .cxx14
+      cxxLanguageStandard: .cxx17
     )

--- a/tools/internal_ci/macos/grpc_basictests_objc_examples.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_objc_examples.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix_objc.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_objc_examples.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_objc_examples.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix_objc.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1184,7 +1184,7 @@ class ObjCLanguage(object):
         out.append(
             self.config.job_spec(
                 ["src/objective-c/tests/build_one_example.sh"],
-                timeout_seconds=60 * 60,
+                timeout_seconds=120 * 60,
                 shortname="ios-buildtest-example-switft-package",
                 cpu_cost=1e6,
                 environ={

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1181,6 +1181,18 @@ class ObjCLanguage(object):
                 },
             )
         )
+        out.append(
+            self.config.job_spec(
+                ["src/objective-c/tests/build_one_example.sh"],
+                timeout_seconds=60 * 60,
+                shortname="ios-buildtest-example-switft-package",
+                cpu_cost=1e6,
+                environ={
+                    "SCHEME": "gRPC-Package",
+                    "EXAMPLE_PATH": ".",
+                },
+            )
+        )
 
         # Disabled due to #20258
         # TODO (mxyan): Reenable this test when #20258 is resolved.


### PR DESCRIPTION
Build fails with errors like the following which requires c++17
```
/Users/hannahshi/work/grpc/spm-core-include/grpc/event_engine/endpoint_config.h:36:11: error: no template named 'optional' in namespace 'std'; did you mean 'absl::optional'?
   36 |   virtual std::optional<int> GetInt(absl::string_view key) const = 0;
      |           ^~~~~~~~~~~~~
      |           absl::optional
```
```
/Users/hannahshi/work/grpc/src/core/lib/promise/detail/promise_factory.h:169:31: error: no template named 'is_same_v' in namespace 'std'; did you mean 'is_same'?
  169 |                          std::is_same_v<ResultOf<F()>, void>,
      |                          ~~~~~^~~~~~~~~
      |                               is_same
```