### PR TITLE
Revert "[PH2][Trivial][Transport] Keeping the sizes of the classes in check (#38927)"

### DIFF
--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.h
@@ -20,7 +20,6 @@
 #define GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_HTTP2_CLIENT_TRANSPORT_H
 
 #include <cstdint>
-#include <type_traits>
 #include <utility>
 
 #include "src/core/ext/transport/chttp2/transport/frame.h"
@@ -147,8 +146,6 @@ class Http2ClientTransport final : public ClientTransport {
   uint32_t MakeStream(CallHandler call_handler);
   RefCountedPtr<Http2ClientTransport::Stream> LookupStream(uint32_t stream_id);
 };
-
-static_assert(sizeof(Http2ClientTransport) <= 240, "Transport too large");
 
 }  // namespace http2
 }  // namespace grpc_core

--- a/src/core/ext/transport/chttp2/transport/http2_server_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_server_transport.h
@@ -19,8 +19,6 @@
 #ifndef GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_HTTP2_SERVER_TRANSPORT_H
 #define GRPC_SRC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_HTTP2_SERVER_TRANSPORT_H
 
-#include <type_traits>
-
 #include "src/core/ext/transport/chttp2/transport/hpack_encoder.h"
 #include "src/core/ext/transport/chttp2/transport/hpack_parser.h"
 #include "src/core/lib/transport/promise_endpoint.h"
@@ -58,8 +56,6 @@ class Http2ServerTransport final : public ServerTransport {
   void Orphan() override;
   void AbortWithError();
 };
-
-static_assert(sizeof(Http2ServerTransport) <= 240, "Transport too large");
 
 }  // namespace http2
 }  // namespace grpc_core

--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -23,7 +23,6 @@
 #include <atomic>
 #include <limits>
 #include <string>
-#include <type_traits>
 #include <utility>
 
 #include "absl/base/attributes.h"
@@ -638,8 +637,6 @@ class Party : public Activity, private Wakeable {
   std::atomic<Participant*> participants_[party_detail::kMaxParticipants] = {};
   RefCountedPtr<Arena> arena_;
 };
-
-static_assert(sizeof(Party) <= 180, "Party too large");
 
 template <>
 struct ContextSubclass<Party> {


### PR DESCRIPTION
This reverts commit 648f151cdf5f2fb33df9479a3fac5f1f744a0187.

Breaks the MacOS build by making the transport too large. Please check the CI before merging changes.
The Bazel MacOS job on that PR showed the breakage. https://btx.cloud.google.com/invocations/26c4f857-715b-4f0c-830e-5f623c077d8d/targets
