### PR TITLE
[SubchannelStreamClient] fix use-after-free bug

### DIFF
--- a/src/core/client_channel/subchannel_stream_client.cc
+++ b/src/core/client_channel/subchannel_stream_client.cc
@@ -411,6 +411,10 @@ void SubchannelStreamClient::CallState::RecvTrailingMetadataReady(
   // Clean up.
   self->recv_trailing_metadata_.Clear();
   // Report call end.
+  // Note: We hold a ref to the SubchannelStreamClient here to ensure
+  // that it lives long enough for us to release the mutex, since the
+  // call to CallEndedLocked() may release the last ref.
+  auto subchannel_stream_client = self->subchannel_stream_client_->Ref();
   MutexLock lock(&self->subchannel_stream_client_->mu_);
   if (self->subchannel_stream_client_->event_handler_ != nullptr) {
     self->subchannel_stream_client_->event_handler_

--- a/src/core/client_channel/subchannel_stream_client.h
+++ b/src/core/client_channel/subchannel_stream_client.h
@@ -202,7 +202,7 @@ class SubchannelStreamClient final
   Mutex mu_;
   std::unique_ptr<CallEventHandler> event_handler_ ABSL_GUARDED_BY(mu_);
 
-  // The data associated with the current health check call.  It holds a ref
+  // The data associated with the current call.  It holds a ref
   // to this SubchannelStreamClient object.
   OrphanablePtr<CallState> call_state_ ABSL_GUARDED_BY(mu_);
 


### PR DESCRIPTION
Also remove some lingering references to health checking, which I missed when I originally refactored this code out of the health checking client code back in #29024.