### PR TITLE
[xDS] make InitUpbSymtab() method non-pure virtual

### DIFF
--- a/src/core/lib/promise/mpsc.h
+++ b/src/core/lib/promise/mpsc.h
@@ -268,7 +268,7 @@ class MpscReceiver {
         std::move(buffer_it_, buffer_.end(), std::back_inserter(tmp_buffer));
         buffer_.clear();
         buffer_it_ = buffer_.end();
-        return tmp_buffer;
+        return ValueOrFailure<std::vector<T>>(std::move(tmp_buffer));
       }
 
       auto p = center_->PollReceiveBatch(buffer_);
@@ -277,7 +277,7 @@ class MpscReceiver {
         auto tmp_buffer(std::move(buffer_));
         buffer_.clear();
         buffer_it_ = buffer_.end();
-        return tmp_buffer;
+        return ValueOrFailure<std::vector<T>>(std::move(tmp_buffer));
       }
       return Pending{};
     };

--- a/src/core/xds/xds_client/xds_resource_type.h
+++ b/src/core/xds/xds_client/xds_resource_type.h
@@ -88,7 +88,7 @@ class XdsResourceType {
   // Note: This won't actually work properly until upb adds support for
   // Any fields in textproto printing (internal b/178821188).
   virtual void InitUpbSymtab(XdsClient* xds_client,
-                             upb_DefPool* symtab) const = 0;
+                             upb_DefPool* symtab) const {}
 };
 
 }  // namespace grpc_core

--- a/src/core/xds/xds_client/xds_resource_type.h
+++ b/src/core/xds/xds_client/xds_resource_type.h
@@ -87,8 +87,7 @@ class XdsResourceType {
   // properly in logs.
   // Note: This won't actually work properly until upb adds support for
   // Any fields in textproto printing (internal b/178821188).
-  virtual void InitUpbSymtab(XdsClient* xds_client, upb_DefPool* symtab) const {
-  }
+  virtual void InitUpbSymtab(XdsClient*, upb_DefPool*) const {}
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
This will allow external users of our XdsClient code to avoid taking a direct dependency on upb if they want to use protobuf instead.