### PR TITLE
fix: resolve issue where pre-release versions of protobuf are installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # GRPC Python setup requirements
 coverage>=4.0
 cython>=3.0.0
-protobuf>=6.30.0,<7.0dev
+protobuf>=6.30.0,<7.0.0
 wheel>=0.29

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -65,7 +65,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_csds/setup.py
+++ b/src/python/grpcio_csds/setup.py
@@ -41,7 +41,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     f"xds-protos=={grpc_version.VERSION}",
     f"grpcio>={grpc_version.VERSION}",
 )

--- a/src/python/grpcio_csm_observability/setup.py
+++ b/src/python/grpcio_csm_observability/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = (
     "opentelemetry-sdk>=1.25.0",
     "opentelemetry-resourcedetector-gcp>=1.6.0a0",
     "grpcio=={version}".format(version=grpc_version.VERSION),
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
 )
 
 setuptools.setup(

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -63,7 +63,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -64,7 +64,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -63,7 +63,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
     "googleapis-common-protos>=1.5.5",
 )

--- a/src/python/grpcio_testing/setup.py
+++ b/src/python/grpcio_testing/setup.py
@@ -49,7 +49,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -46,7 +46,7 @@ INSTALL_REQUIRES = (
     "grpcio-observability>={version}".format(version=grpc_version.VERSION),
     "xds-protos>={version}".format(version=grpc_version.VERSION),
     "oauth2client>=1.4.7",
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "google-auth>=1.17.2",
     "requests>=2.14.2",
     "absl-py>=1.4.0",

--- a/tools/distrib/docgen/requirements.docs.lock
+++ b/tools/distrib/docgen/requirements.docs.lock
@@ -26,7 +26,7 @@ opentelemetry-sdk==1.25.0
 opentelemetry-semantic-conventions==0.46b0
 prometheus_client==0.20.0
 proto-plus==1.25.0
-protobuf>=5.27.1,<6.0dev
+protobuf>=5.27.1,<6.0.0
 pyasn1-modules==0.3.0
 pyasn1==0.5.0
 requests==2.25.1

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
     packages=setuptools.find_packages("."),
     python_requires=f">={python_version.MIN_PYTHON_VERSION}",
     install_requires=[
-        "protobuf>=6.30.0,<7.0dev",
+        "protobuf>=6.30.0,<7.0.0",
         "grpcio>={version}".format(version=grpc_version.VERSION),
         "setuptools",
     ],

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -40,7 +40,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "grpcio>=1.49.0",
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
 ]
 
 SETUP_REQUIRES = INSTALL_REQUIRES + ["grpcio-tools>=1.49.0"]

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -172,7 +172,7 @@ pip_install_dir_and_deps() {
 pip_install -U gevent
 
 pip_install --upgrade 'cython>=3.0.0'
-pip_install --upgrade six 'protobuf>=6.30.0,<7.0dev'
+pip_install --upgrade six 'protobuf>=6.30.0,<7.0.0'
 
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then


### PR DESCRIPTION
Remove `dev` from `setup.py` to avoid installing pre-release versions of dependency `protobuf`. See https://github.com/googleapis/google-cloud-python/issues/13585 for more information.

If possible, we should back port this fix to active release branches.

https://github.com/pypa/pip/blob/main/NEWS.rst#2501-2025-02-09

![image](https://github.com/user-attachments/assets/bd031558-6066-40f3-b0e6-ad5398ab5472)
