### PR TITLE
[backport][build] Use correct image for docs building (#38987)

### DIFF
--- a/tools/distrib/docgen/_generate_python_doc.sh
+++ b/tools/distrib/docgen/_generate_python_doc.sh
@@ -26,6 +26,6 @@ export HOME
 pip install -r tools/distrib/docgen/requirements.docs.lock
 tools/run_tests/run_tests.py -c opt -l python --compiler python3.9 --newline_on_success -j 8 --build_only
 # shellcheck disable=SC1091
-source py38/bin/activate
+source py39/bin/activate
 pip install --upgrade Sphinx
 python setup.py doc

--- a/tools/distrib/docgen/all_lang_docgen.sh
+++ b/tools/distrib/docgen/all_lang_docgen.sh
@@ -83,7 +83,7 @@ docker run --rm -it \
     -v "$(pwd)":/work \
     -w /work \
     --user "$(id -u):$(id -g)" \
-    python:3.8 tools/distrib/docgen/_generate_python_doc.sh
+    python:3.9 tools/distrib/docgen/_generate_python_doc.sh
 mv doc/build "${PAGES_PATH}/python"
 
 # At this point, document generation is finished.


### PR DESCRIPTION
Scripts now expect Python3.9.
