### PR TITLE
[C++ API] update doc for channel args SetLoadBalancingPolicyName() method

### DIFF
--- a/include/grpcpp/support/channel_arguments.h
+++ b/include/grpcpp/support/channel_arguments.h
@@ -84,8 +84,10 @@ class ChannelArguments {
   void SetMaxSendMessageSize(int size);
 
   /// Set LB policy name.
-  /// Note that if the name resolver returns only balancer addresses, the
-  /// grpclb LB policy will be used, regardless of what is specified here.
+  /// Note that this API implicitly provides an empty config for the
+  /// specified LB policy, so it cannot be used for any policy with
+  /// required configuration parameters.  For those cases, set the LB
+  /// policy via the service config instead.
   void SetLoadBalancingPolicyName(const std::string& lb_policy_name);
 
   /// Set service config in JSON form.


### PR DESCRIPTION
The existing comment has been incorrect since we implemented [gRFC A26](https://github.com/grpc/proposal/blob/master/A26-grpclb-selection.md), so I removed it.  And I added a new comment that describes restrictions that have been in place since [gRFC A24](https://github.com/grpc/proposal/blob/master/A24-lb-policy-config.md).