### PR TITLE
[ObjC] add GRPC_CFSTREAM_MAX_THREADPOOL_SIZE to limit cf event engine thread pool to size

### DIFF
--- a/src/core/lib/event_engine/cf_engine/cf_engine.cc
+++ b/src/core/lib/event_engine/cf_engine/cf_engine.cc
@@ -33,7 +33,7 @@
 #include "src/core/util/crash.h"
 
 #ifndef GRPC_CFSTREAM_MAX_THREADPOOL_SIZE
-#define GRPC_CFSTREAM_MAX_THREADPOOL_SIZE 2u
+#define GRPC_CFSTREAM_MAX_THREADPOOL_SIZE 16u
 #endif  // GRPC_CFSTREAM_MAX_THREADPOOL_SIZE
 
 namespace grpc_event_engine::experimental {

--- a/src/core/lib/event_engine/cf_engine/cf_engine.cc
+++ b/src/core/lib/event_engine/cf_engine/cf_engine.cc
@@ -53,9 +53,7 @@ struct CFEventEngine::Closure final : public EventEngine::Closure {
 };
 
 CFEventEngine::CFEventEngine()
-    : thread_pool_(
-          MakeThreadPool(grpc_core::Clamp(gpr_cpu_num_cores(), 2u, 16u))),
-      timer_manager_(thread_pool_) {}
+    : thread_pool_(MakeThreadPool(2)), timer_manager_(thread_pool_) {}
 
 CFEventEngine::~CFEventEngine() {
   {

--- a/src/core/lib/event_engine/cf_engine/cf_engine.cc
+++ b/src/core/lib/event_engine/cf_engine/cf_engine.cc
@@ -32,6 +32,10 @@
 #include "src/core/lib/event_engine/utils.h"
 #include "src/core/util/crash.h"
 
+#ifndef GRPC_CFSTREAM_MAX_THREADPOOL_SIZE
+#define GRPC_CFSTREAM_MAX_THREADPOOL_SIZE 2u
+#endif  // GRPC_CFSTREAM_MAX_THREADPOOL_SIZE
+
 namespace grpc_event_engine::experimental {
 
 struct CFEventEngine::Closure final : public EventEngine::Closure {
@@ -53,7 +57,9 @@ struct CFEventEngine::Closure final : public EventEngine::Closure {
 };
 
 CFEventEngine::CFEventEngine()
-    : thread_pool_(MakeThreadPool(2)), timer_manager_(thread_pool_) {}
+    : thread_pool_(MakeThreadPool(grpc_core::Clamp(
+          gpr_cpu_num_cores(), 2u, GRPC_CFSTREAM_MAX_THREADPOOL_SIZE))),
+      timer_manager_(thread_pool_) {}
 
 CFEventEngine::~CFEventEngine() {
   {


### PR DESCRIPTION
ThreadPool::Quiesce requires at least two threads (and work stealing?) otherwise will deadlock.
CF engine should not need too many threads as the network traffic and dns resolving are already runing in iOS dispatch queue.

This should help reduce the memory consumption by 2.94M-per-thread * (6 - 2) threads, on a typical iPhone with 6 cores,  before we have a better thread pool implementation on iOS.