### PR TITLE
[http2] Save call_tracer on server transport during initialization

### DIFF
--- a/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.cc
+++ b/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.cc
@@ -30,7 +30,7 @@ void Chttp2CallTracerWrapper::RecordIncomingBytes(
   stream_->stats.incoming.header_bytes += transport_byte_size.header_bytes;
   // Update new API.
   if (!IsCallTracerInTransportEnabled()) return;
-  auto* call_tracer = stream_->CallTracer();
+  auto* call_tracer = stream_->call_tracer;
   if (call_tracer != nullptr) {
     call_tracer->RecordIncomingBytes(transport_byte_size);
   }
@@ -44,7 +44,7 @@ void Chttp2CallTracerWrapper::RecordOutgoingBytes(
   stream_->stats.outgoing.header_bytes +=
       transport_byte_size.header_bytes;  // Update new API.
   if (!IsCallTracerInTransportEnabled()) return;
-  auto* call_tracer = stream_->CallTracer();
+  auto* call_tracer = stream_->call_tracer;
   if (call_tracer != nullptr) {
     call_tracer->RecordOutgoingBytes(transport_byte_size);
   }

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -672,7 +672,16 @@ struct grpc_chttp2_stream {
 
   grpc_core::Chttp2CallTracerWrapper call_tracer_wrapper;
 
-  // TODO(roth): Remove this when call v3 is supported.
+  // TODO(yashykt): Remove call_tracer field after transition to call v3. (See
+  // https://github.com/grpc/grpc/pull/38729 for more information.)
+  // In the transport, we use tracers for two things, recording byte stats and
+  // recording annotations. Recording byte stats is safe as long as call_tracer
+  // is non null. Recording annotations on the other hand is only safe after
+  // send_initial_metadata. On the client, this is not an issue since that is
+  // the first operation. On the server, we would ideally be able to record
+  // annotations as soon as we have parsed initial metadata, but in our legacy
+  // stack, we create the stream before parsing headers. In the new v3 stack,
+  // that won't be an issue.
   grpc_core::CallTracerInterface* call_tracer = nullptr;
   // TODO(yashykt): Remove this once call_tracer_transport_fix is rolled out
   grpc_core::CallTracerAnnotationInterface* parent_call_tracer = nullptr;

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -700,14 +700,6 @@ struct grpc_chttp2_stream {
   // The last time a stream window update was received.
   grpc_core::Timestamp last_window_update_time =
       grpc_core::Timestamp::InfPast();
-
-  // TODO(yashykt): Remove this when call v3 is supported.
-  grpc_core::CallTracerInterface* CallTracer() const {
-    if (t->is_client) {
-      return call_tracer;
-    }
-    return arena->GetContext<grpc_core::CallTracerInterface>();
-  }
 };
 
 #define GRPC_ARG_PING_TIMEOUT_MS "grpc.http2.ping_timeout_ms"

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -961,7 +961,7 @@ grpc_error_handle grpc_chttp2_header_parser_parse(void* hpack_parser,
         {0, 0, GRPC_SLICE_LENGTH(slice)});
     call_tracer =
         grpc_core::IsCallTracerTransportFixEnabled()
-            ? s->CallTracer()
+            ? s->call_tracer
             : s->arena->GetContext<grpc_core::CallTracerAnnotationInterface>();
   }
   grpc_error_handle error = parser->Parse(

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -485,11 +485,10 @@ class StreamWriteContext {
                 .Add(write_stats));
       }
     } else {
-      auto* call_tracer = s_->CallTracer();
-      if (call_tracer != nullptr && call_tracer->IsSampled()) {
+      if (s_->call_tracer != nullptr && s_->call_tracer->IsSampled()) {
         grpc_core::HttpAnnotation::WriteStats write_stats;
         write_stats.target_write_size = write_context_->target_write_size();
-        call_tracer->RecordAnnotation(
+        s_->call_tracer->RecordAnnotation(
             grpc_core::HttpAnnotation(
                 grpc_core::HttpAnnotation::Type::kHeadWritten,
                 gpr_now(GPR_CLOCK_REALTIME))
@@ -646,9 +645,8 @@ class StreamWriteContext {
                 .Add(s_->flow_control.stats()));
       }
     } else {
-      auto* call_tracer = s_->CallTracer();
-      if (call_tracer != nullptr && call_tracer->IsSampled()) {
-        call_tracer->RecordAnnotation(
+      if (s_->call_tracer != nullptr && s_->call_tracer->IsSampled()) {
+        s_->call_tracer->RecordAnnotation(
             grpc_core::HttpAnnotation(grpc_core::HttpAnnotation::Type::kEnd,
                                       gpr_now(GPR_CLOCK_REALTIME))
                 .Add(s_->t->flow_control.stats())


### PR DESCRIPTION
Save call_tracer on server transport during initialization unless `call_tracer_in_transport` is disabled, in which case, get it on send_initial_metadata on the server.

Additional details - 
Assuming that call_tracer_in_transport experiment is rolled out, the call tracer will always be available in the context on HTTP2 stream creation.

In  the HTTP2 transport, we use the tracer for two things currently - 
- Recording incoming/outgoing stats
- Recording annotations

On the client-side, both of those operations are safe since the filters/tracers have already set the call tracer on the context by the point, we reach the transport.

The server-side is trickier. If the `call_tracer_in_transport` experiment is disabled, we won't have the call tracer available in the context on stream creation, since there are filters that only set it on receiving headers. Irrespective of whether the experiment is enabled, the actual span for the tracer would not be created till the headers have been received. We can still record incoming/outgoing stats, but we won't be able to record annotations till we have created the span after parsing headers. This issue will go away once we move to call v3 where we only create the stream after parsing headers.