### PR TITLE
[fix] Avoid ruby compiler problem: CHECK_NE(unique_ptr, nullptr)

### DIFF
--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -679,7 +679,7 @@ static grpc_error_handle event_engine_create(grpc_closure* shutdown_complete,
       std::make_unique<MemoryQuotaBasedMemoryAllocatorFactory>(
           resource_quota->memory_quota()));
   GRPC_RETURN_IF_ERROR(listener.status());
-  CHECK_NE(*listener, nullptr);
+  CHECK_NE(listener->get(), nullptr);
   GRPC_TRACE_LOG(event_engine, INFO)
       << "EventEngine::" << engine << ": created Listener::" << listener->get();
   s->ee_listener = std::move(*listener);


### PR DESCRIPTION
See https://btx.cloud.google.com/invocations/34e7ab65-1505-4ff8-8317-a8e60d1495c5/details