### PR TITLE
[experiment] event_engine_dns config cleanup

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -164,6 +164,9 @@ EXPERIMENTS = {
             ],
         },
         "on": {
+            "cancel_ares_query_test": [
+                "event_engine_dns",
+            ],
             "core_end2end_test": [
                 "event_engine_for_all_other_endpoints",
                 "posix_ee_skip_grpc_init",
@@ -171,6 +174,9 @@ EXPERIMENTS = {
             ],
             "cpp_end2end_test": [
                 "posix_ee_skip_grpc_init",
+            ],
+            "resolver_component_tests_runner_invoker": [
+                "event_engine_dns",
             ],
             "xds_end2end_test": [
                 "server_listener",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -175,7 +175,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_client", description_event_engine_client,
      additional_constraints_event_engine_client, nullptr, 0, false, false},
     {"event_engine_dns", description_event_engine_dns,
-     additional_constraints_event_engine_dns, nullptr, 0, false, false},
+     additional_constraints_event_engine_dns, nullptr, 0, true, false},
     {"event_engine_dns_non_client_channel",
      description_event_engine_dns_non_client_channel,
      additional_constraints_event_engine_dns_non_client_channel, nullptr, 0,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -67,7 +67,8 @@ inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 inline bool IsChaoticGoodFramingLayerEnabled() { return false; }
 inline bool IsErrorFlattenEnabled() { return false; }
 inline bool IsEventEngineClientEnabled() { return false; }
-inline bool IsEventEngineDnsEnabled() { return false; }
+#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
+inline bool IsEventEngineDnsEnabled() { return true; }
 inline bool IsEventEngineDnsNonClientChannelEnabled() { return false; }
 inline bool IsEventEngineForkEnabled() { return false; }
 inline bool IsEventEngineListenerEnabled() { return false; }

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -59,11 +59,7 @@
     posix: true
     windows: true
 - name: event_engine_dns
-  default:
-    # not tested on iOS at all
-    ios: broken
-    posix: true
-    windows: true
+  default: true
 - name: event_engine_for_all_other_endpoints
   default: true
 - name: event_engine_fork


### PR DESCRIPTION
This is mostly a formality, all relevant platforms were already enabled. It does however change some test configuration.