### PR TITLE
grpcio-tools: add script

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -206,7 +206,6 @@ if sys.version_info >= (3, 5, 0):
         _maybe_install_proto_finders()
 
 
-
 def entrypoint() -> None:
     proto_include = _get_resource_file_name("grpc_tools", "_proto")
     sys.exit(main(sys.argv + ["-I{}".format(proto_include)]))

--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -205,6 +205,12 @@ if sys.version_info >= (3, 5, 0):
     if not os.getenv(_DISABLE_DYNAMIC_STUBS):
         _maybe_install_proto_finders()
 
-if __name__ == "__main__":
+
+
+def entrypoint() -> None:
     proto_include = _get_resource_file_name("grpc_tools", "_proto")
     sys.exit(main(sys.argv + ["-I{}".format(proto_include)]))
+
+
+if __name__ == "__main__":
+    entrypoint()

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -351,4 +351,9 @@ setuptools.setup(
     cmdclass={
         "build_ext": BuildExt,
     },
+    entry_points={
+        "console_scripts": [
+            "py-grpc-tools-protoc = grpc_tools.protoc:main",
+        ],
+    },
 )

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -353,7 +353,7 @@ setuptools.setup(
     },
     entry_points={
         "console_scripts": [
-            "python-grpc-tools-protoc = grpc_tools.protoc:main",
+            "python-grpc-tools-protoc = grpc_tools.protoc:entrypoint",
         ],
     },
 )

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -353,7 +353,7 @@ setuptools.setup(
     },
     entry_points={
         "console_scripts": [
-            "py-grpc-tools-protoc = grpc_tools.protoc:main",
+            "python-grpc-tools-protoc = grpc_tools.protoc:main",
         ],
     },
 )


### PR DESCRIPTION
This change adds a "python-grpcio-tools-protoc" script. This complements the current way of invoking this tool, `python -m grpcio-tools.protoc`, with a CLI tool.

The main motivation is to be able to run it through [pipx](https://github.com/pypa/pipx).

Currently,
```sh
$ pipx run --spec grpcio-tools
'grpcio-tools' executable script not found in package 'grpcio-tools'.
Available executable scripts:
```