### PR TITLE
[fix] Avoid ruby compiler problem (v2): CHECK_NE(unique_ptr, nullptr)

### DIFF
--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -107,12 +107,14 @@ grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(
         event_engine_supports_win_sockets->CreateEndpointFromWinSocket(
             sv[1], grpc_event_engine::experimental::ChannelArgsEndpointConfig(
                        new_args));
-    CHECK_NE(client_endpoint, nullptr) << "Failed to create client endpoint";
+    CHECK_NE(client_endpoint.get(), nullptr)
+        << "Failed to create client endpoint";
     auto server_endpoint =
         event_engine_supports_win_sockets->CreateEndpointFromWinSocket(
             sv[0], grpc_event_engine::experimental::ChannelArgsEndpointConfig(
                        new_args));
-    CHECK_NE(server_endpoint, nullptr) << "Failed to create server endpoint";
+    CHECK_NE(server_endpoint.get(), nullptr)
+        << "Failed to create server endpoint";
     p.client = grpc_event_engine_endpoint_create(std::move(client_endpoint));
     p.server = grpc_event_engine_endpoint_create(std::move(server_endpoint));
   } else {


### PR DESCRIPTION
See https://btx.cloud.google.com/invocations/7cb20c46-f12e-4479-bb69-d97e9e459ae6/targets/github%2Fgrpc%2Fbuild_artifacts;config=default/tests

This is another instance of the odd build error fixed in https://github.com/grpc/grpc/pull/39077. Ruby is using gcc 9.3 in a mingw environment with abseil 20240722. The root cause here is unknown, it looks like maybe an abseil bug from an 8-month old abseil version, so I'm working around it.