### PR TITLE
[EventEngine] Disable the grpc_core::DNSResolver when EE is enabled

### DIFF
--- a/src/core/lib/iomgr/resolve_address.cc
+++ b/src/core/lib/iomgr/resolve_address.cc
@@ -22,7 +22,7 @@
 #include <grpc/support/port_platform.h>
 
 #include "absl/strings/str_cat.h"
-#include "src/core/util/crash.h"
+#include "src/core/lib/experiments/experiments.h"
 #include "src/core/util/no_destruct.h"
 
 namespace grpc_core {
@@ -40,7 +40,14 @@ void ResetDNSResolver(std::shared_ptr<DNSResolver> resolver) {
   *g_dns_resolver = std::move(resolver);
 }
 
-std::shared_ptr<DNSResolver> GetDNSResolver() { return *g_dns_resolver; }
+std::shared_ptr<DNSResolver> GetDNSResolver() {
+  if (IsEventEngineDnsEnabled() && IsEventEngineDnsNonClientChannelEnabled()) {
+    LOG(ERROR) << "The legacy iomgr DNS resolver is disabled. Please use "
+                  "EventEngine's DNSResolver instead.";
+    return nullptr;
+  }
+  return *g_dns_resolver;
+}
 
 bool operator==(const DNSResolver::LookupTaskHandle& lhs,
                 const DNSResolver::LookupTaskHandle& rhs) {


### PR DESCRIPTION
Now that all internal `grpc_core::GetDNSResolver` uses are skipped when EventEngine DNS experiments are running, the resolver can be disabled when those experiments are on. This will dissuade any new uses, and catch any external users that are inappropriately reaching into gRPC internals for their own DNS resolution.

This depends on a few other PRs going in first, and will not be merged until all DNS call sites are handled.