### PR TITLE
[test] Use IPv4 only for Windows port server communications

### DIFF
--- a/test/core/test_util/port_server_client.h
+++ b/test/core/test_util/port_server_client.h
@@ -19,11 +19,19 @@
 #ifndef GRPC_TEST_CORE_TEST_UTIL_PORT_SERVER_CLIENT_H
 #define GRPC_TEST_CORE_TEST_UTIL_PORT_SERVER_CLIENT_H
 
-#include <memory>
+#include <grpc/support/port_platform.h>
+
 // C interface to port_server.py
 
 // must be synchronized with tools/run_tests/python_utils/start_port_server.py
+#ifdef GPR_WINDOWS
+// IPv6 is incredibly slow in the Windows CI stack, possibly more broadly.
+// Using IPv4-only brings the HTTP Get response time down from 2 seconds to
+// O(10ms).
+#define GRPC_PORT_SERVER_ADDRESS "127.0.0.1:32766"
+#else
 #define GRPC_PORT_SERVER_ADDRESS "localhost:32766"
+#endif
 
 int grpc_pick_port_using_server(void);
 void grpc_free_port_using_server(int port);


### PR DESCRIPTION
This fixes a timeout in the end2end test framework (and likely many other places). See https://btx.cloud.google.com/invocations/2df37f19-46a3-4ddb-86c4-ac433690b26b/targets/%2F%2Ftest%2Fcore%2Fend2end:end2end_http2_security_test@experiment%3Dcallv3_client_auth_filter;config=a1c741c989628574ce0fae60f9ee74e83e2083b0b087c03cc94eb91973e1d44d/log

In short, calling `HttpRequest::Get` with "localhost:32766" on Windows will take around 2 seconds. Making the same GET request to "127.0.0.1:32766" takes milliseconds. The proxy tests get two ports on fixture creation, one for the server, and one for the proxy. This adds 4 seconds to every test, and the test linked above has a 5 second timeout.

Someone should likely fix the test framework at some point, the call timeout begins before the proxy & server have even started, and the timer should likely start after the servers have been created.