### PR TITLE
[test] Use IP for local port server communications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3094,14 +3094,22 @@ if(gRPC_BUILD_TESTS)
 add_library(grpc_test_util
   test/core/event_engine/test_init.cc
   test/core/test_util/build.cc
+  test/core/test_util/cmdline.cc
+  test/core/test_util/grpc_profiler.cc
+  test/core/test_util/histogram.cc
+  test/core/test_util/mock_endpoint.cc
+  test/core/test_util/parse_hexstring.cc
   test/core/test_util/port.cc
   test/core/test_util/port_ci.cc
   test/core/test_util/port_server_client.cc
   test/core/test_util/reconnect_server.cc
+  test/core/test_util/resolve_localhost_ip46.cc
+  test/core/test_util/slice_splitter.cc
   test/core/test_util/stack_tracer.cc
   test/core/test_util/test_config.cc
   test/core/test_util/test_tcp_server.cc
   test/core/test_util/tls_utils.cc
+  test/core/test_util/tracer_util.cc
 )
 
 target_compile_features(grpc_test_util PUBLIC cxx_std_17)
@@ -3161,13 +3169,21 @@ if(gRPC_BUILD_TESTS)
 add_library(grpc_test_util_unsecure
   test/core/event_engine/test_init.cc
   test/core/test_util/build.cc
+  test/core/test_util/cmdline.cc
+  test/core/test_util/grpc_profiler.cc
+  test/core/test_util/histogram.cc
+  test/core/test_util/mock_endpoint.cc
+  test/core/test_util/parse_hexstring.cc
   test/core/test_util/port.cc
   test/core/test_util/port_ci.cc
   test/core/test_util/port_server_client.cc
   test/core/test_util/reconnect_server.cc
+  test/core/test_util/resolve_localhost_ip46.cc
+  test/core/test_util/slice_splitter.cc
   test/core/test_util/stack_tracer.cc
   test/core/test_util/test_config.cc
   test/core/test_util/test_tcp_server.cc
+  test/core/test_util/tracer_util.cc
 )
 
 target_compile_features(grpc_test_util_unsecure PUBLIC cxx_std_17)
@@ -4357,14 +4373,6 @@ add_library(benchmark_helpers ${_gRPC_STATIC_WIN32}
   ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.pb.h
   ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.h
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/cpp/microbenchmarks/helpers.cc
 )
 
@@ -5113,14 +5121,6 @@ add_library(grpc++_test_util
   test/core/end2end/data/server1_cert.cc
   test/core/end2end/data/server1_key.cc
   test/core/end2end/data/test_root_cert.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/cpp/util/byte_buffer_proto_helper.cc
   test/cpp/util/create_test_channel.cc
   test/cpp/util/string_ref_helper.cc
@@ -6127,14 +6127,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(fd_conservation_posix_test
     test/core/iomgr/fd_conservation_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -6349,14 +6341,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
   add_executable(address_sorting_test_unsecure
     src/core/util/subprocess_posix.cc
     src/core/util/subprocess_windows.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/cpp/naming/address_sorting_test.cc
     test/cpp/util/byte_buffer_proto_helper.cc
     test/cpp/util/string_ref_helper.cc
@@ -6970,14 +6954,6 @@ if(gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(alarm_test
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/cpp/common/alarm_test.cc
   )
   if(WIN32 AND MSVC)
@@ -7515,14 +7491,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(alts_security_connector_test
   test/core/credentials/transport/alts/alts_security_connector_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -7904,14 +7872,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(auth_context_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/auth_context_test.cc
 )
 if(WIN32 AND MSVC)
@@ -7998,14 +7958,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(authorization_matchers_test
   test/core/security/authorization_matchers_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -8137,14 +8089,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(aws_request_signer_test
   test/core/credentials/call/external/aws_request_signer_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -8335,14 +8279,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     src/core/util/subprocess_windows.cc
     test/core/bad_ssl/bad_ssl_test.cc
     test/core/end2end/cq_verifier.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -8390,14 +8326,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     src/core/util/subprocess_windows.cc
     test/core/bad_ssl/bad_ssl_test.cc
     test/core/end2end/cq_verifier.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -8790,14 +8718,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(buffer_list_test
   test/core/iomgr/buffer_list_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -8975,15 +8895,7 @@ add_executable(call_credentials_test
   test/core/credentials/call/call_credentials_test.cc
   test/core/event_engine/event_engine_test_utils.cc
   test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
   test/core/test_util/test_call_creds.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -9768,14 +9680,6 @@ add_executable(cel_authorization_engine_test
   src/core/ext/upb-gen/xds/type/v3/typed_struct.upb_minitable.c
   src/core/lib/security/authorization/cel_authorization_engine.cc
   test/core/security/cel_authorization_engine_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -10157,14 +10061,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(channel_creds_registry_test
   test/core/credentials/transport/channel_creds_registry_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -10622,14 +10518,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(check_gcp_environment_linux_test
   test/core/credentials/transport/alts/check_gcp_environment_linux_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -10672,14 +10560,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(check_gcp_environment_windows_test
   test/core/credentials/transport/alts/check_gcp_environment_windows_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -10722,14 +10602,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(chttp2_server_listener_test
   test/core/end2end/cq_verifier.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/chttp2_server_listener_test.cc
 )
 if(WIN32 AND MSVC)
@@ -11492,15 +11364,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(cmdline_test
-  test/core/test_util/cmdline.cc
   test/core/test_util/cmdline_test.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -11632,14 +11496,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(combiner_test
     test/core/iomgr/combiner_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -11894,14 +11750,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(connection_context_test
   test/core/surface/connection_context_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -12030,14 +11878,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(connectivity_state_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/connectivity_state_test.cc
 )
 if(WIN32 AND MSVC)
@@ -14501,14 +14341,6 @@ if(gRPC_BUILD_TESTS)
 add_executable(endpoint_pair_test
   test/core/iomgr/endpoint_pair_test.cc
   test/core/iomgr/endpoint_tests.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -14662,14 +14494,6 @@ if(gRPC_BUILD_TESTS)
 add_executable(error_test
   test/core/iomgr/endpoint_tests.cc
   test/core/iomgr/error_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -14711,14 +14535,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(error_utils_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/error_utils_test.cc
 )
 if(WIN32 AND MSVC)
@@ -14762,14 +14578,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(evaluate_args_test
   test/core/security/evaluate_args_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -15307,14 +15115,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(fd_posix_test
     test/core/iomgr/fd_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -16070,14 +15870,6 @@ add_executable(format_request_test
   test/core/end2end/data/server1_cert.cc
   test/core/end2end/data/server1_key.cc
   test/core/end2end/data/test_root_cert.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/util/http_client/format_request_test.cc
 )
 if(WIN32 AND MSVC)
@@ -16661,14 +16453,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_alts_credentials_options_test
   test/core/credentials/transport/alts/grpc_alts_credentials_options_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -16754,14 +16538,6 @@ if(gRPC_BUILD_TESTS)
 add_executable(grpc_authorization_engine_test
   test/core/security/grpc_authorization_engine_test.cc
   test/core/test_util/audit_logging_utils.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -16804,14 +16580,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_authorization_policy_provider_test
   test/core/security/grpc_authorization_policy_provider_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -17144,14 +16912,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_ipv6_loopback_available_test
   test/core/iomgr/grpc_ipv6_loopback_available_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -17432,14 +17192,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_tls_certificate_distributor_test
   test/core/credentials/transport/tls/grpc_tls_certificate_distributor_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -17482,14 +17234,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_tls_certificate_provider_test
   test/core/credentials/transport/tls/grpc_tls_certificate_provider_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -17532,14 +17276,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_tls_certificate_verifier_test
   test/core/credentials/transport/tls/grpc_tls_certificate_verifier_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -17582,14 +17318,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_tls_credentials_options_comparator_test
   test/core/credentials/transport/tls/grpc_tls_credentials_options_comparator_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -17632,14 +17360,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(grpc_tls_credentials_options_test
   test/core/credentials/transport/tls/grpc_tls_credentials_options_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -18443,15 +18163,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(histogram_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
   test/core/test_util/histogram_test.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -18535,14 +18247,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(hpack_encoder_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/hpack_encoder_test.cc
 )
 if(WIN32 AND MSVC)
@@ -18585,14 +18289,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(hpack_parser_table_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/hpack_parser_table_test.cc
 )
 if(WIN32 AND MSVC)
@@ -18635,14 +18331,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(hpack_parser_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/hpack_parser_test.cc
 )
 if(WIN32 AND MSVC)
@@ -18746,14 +18434,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     src/core/lib/promise/wait_set.cc
     src/core/lib/transport/promise_endpoint.cc
     test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/core/transport/chttp2/http2_client_transport_test.cc
     test/core/transport/util/mock_promise_endpoint.cc
   )
@@ -18808,14 +18488,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     src/core/lib/promise/wait_set.cc
     src/core/lib/transport/promise_endpoint.cc
     test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/core/transport/chttp2/http2_server_transport_test.cc
     test/core/transport/util/mock_promise_endpoint.cc
   )
@@ -19350,14 +19022,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(insecure_security_connector_test
   test/core/credentials/transport/insecure/insecure_security_connector_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -19994,14 +19658,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(json_token_test
   test/core/credentials/call/jwt/json_token_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -20044,14 +19700,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(jwt_verifier_test
   test/core/credentials/call/jwt/jwt_verifier_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -20408,14 +20056,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(local_security_connector_test
   test/core/credentials/transport/local/local_security_connector_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -20729,14 +20369,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(matchers_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/util/matchers_test.cc
 )
 if(WIN32 AND MSVC)
@@ -20942,14 +20574,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(message_compress_test
   test/core/compression/message_compress_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -21034,14 +20658,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(metadata_map_test
   test/core/call/metadata_map_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -22444,14 +22060,6 @@ add_executable(parser_test
   test/core/end2end/data/server1_cert.cc
   test/core/end2end/data/server1_key.cc
   test/core/end2end/data/test_root_cert.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/util/http_client/parser_test.cc
 )
 if(WIN32 AND MSVC)
@@ -22741,14 +22349,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(ping_abuse_policy_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/ping_abuse_policy_test.cc
 )
 if(WIN32 AND MSVC)
@@ -22833,14 +22433,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(ping_configuration_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/ping_configuration_test.cc
 )
 if(WIN32 AND MSVC)
@@ -22883,14 +22475,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(ping_rate_policy_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/ping_rate_policy_test.cc
 )
 if(WIN32 AND MSVC)
@@ -24763,14 +24347,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(rbac_translator_test
   test/core/security/rbac_translator_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -25042,14 +24618,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(resolve_address_using_ares_resolver_posix_test
     test/core/iomgr/resolve_address_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -25093,15 +24661,7 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(resolve_address_using_ares_resolver_test
   test/core/iomgr/resolve_address_test.cc
-  test/core/test_util/cmdline.cc
   test/core/test_util/fake_udp_and_tcp_server.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -25146,14 +24706,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(resolve_address_using_native_resolver_posix_test
     test/core/iomgr/resolve_address_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -25197,15 +24749,7 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(resolve_address_using_native_resolver_test
   test/core/iomgr/resolve_address_test.cc
-  test/core/test_util/cmdline.cc
   test/core/test_util/fake_udp_and_tcp_server.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -25798,14 +25342,6 @@ if(gRPC_BUILD_TESTS)
 add_executable(secure_endpoint_test
   test/core/handshake/secure_endpoint_test.cc
   test/core/iomgr/endpoint_tests.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -25848,14 +25384,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(security_connector_test
   test/core/credentials/transport/security_connector_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -26100,14 +25628,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.pb.h
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.h
     test/core/event_engine/event_engine_test_utils.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/cpp/server/server_builder_test.cc
   )
   if(WIN32 AND MSVC)
@@ -26186,14 +25706,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.cc
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.pb.h
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.h
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/cpp/server/server_builder_with_socket_mutator_test.cc
   )
   if(WIN32 AND MSVC)
@@ -26637,14 +26149,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.cc
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.pb.h
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.h
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/cpp/server/server_request_call_test.cc
   )
   if(WIN32 AND MSVC)
@@ -26899,14 +26403,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(settings_timeout_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/settings_timeout_test.cc
 )
 if(WIN32 AND MSVC)
@@ -27290,14 +26786,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(socket_utils_test
     test/core/iomgr/socket_utils_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -27675,14 +27163,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(status_conversion_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/status_conversion_test.cc
 )
 if(WIN32 AND MSVC)
@@ -27968,14 +27448,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(streams_not_seen_test
   test/core/end2end/cq_verifier.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/chttp2/streams_not_seen_test.cc
 )
 if(WIN32 AND MSVC)
@@ -28232,14 +27704,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(system_roots_test
   test/core/credentials/transport/tls/system_roots_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -28319,14 +27783,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(tcp_client_posix_test
     test/core/iomgr/tcp_client_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -28416,14 +27872,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_POSIX)
   add_executable(tcp_posix_test
     test/core/iomgr/endpoint_tests.cc
     test/core/iomgr/tcp_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -28468,14 +27916,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 
   add_executable(tcp_server_posix_test
     test/core/iomgr/tcp_server_posix_test.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
   )
   if(WIN32 AND MSVC)
     if(BUILD_SHARED_LIBS)
@@ -28600,14 +28040,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(test_core_credentials_transport_ssl_ssl_credentials_test
   test/core/credentials/transport/ssl/ssl_credentials_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -28793,14 +28225,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(test_core_iomgr_timer_heap_test
   test/core/iomgr/timer_heap_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -29690,14 +29114,6 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(timeout_encoding_test
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
   test/core/transport/timeout_encoding_test.cc
 )
 if(WIN32 AND MSVC)
@@ -29993,15 +29409,7 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(tls_security_connector_test
   test/core/credentials/transport/tls/tls_security_connector_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
   test/core/test_util/test_call_creds.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)
@@ -31207,14 +30615,6 @@ if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     ${_gRPC_PROTO_GENS_DIR}/xds/data/orca/v3/orca_load_report.grpc.pb.h
     test/core/event_engine/event_engine_test_utils.cc
     test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-    test/core/test_util/cmdline.cc
-    test/core/test_util/grpc_profiler.cc
-    test/core/test_util/histogram.cc
-    test/core/test_util/mock_endpoint.cc
-    test/core/test_util/parse_hexstring.cc
-    test/core/test_util/resolve_localhost_ip46.cc
-    test/core/test_util/slice_splitter.cc
-    test/core/test_util/tracer_util.cc
     test/cpp/performance/writes_per_rpc_test.cc
   )
   if(WIN32 AND MSVC)
@@ -34856,14 +34256,6 @@ if(gRPC_BUILD_TESTS)
 
 add_executable(xds_credentials_test
   test/core/credentials/transport/xds/xds_credentials_test.cc
-  test/core/test_util/cmdline.cc
-  test/core/test_util/grpc_profiler.cc
-  test/core/test_util/histogram.cc
-  test/core/test_util/mock_endpoint.cc
-  test/core/test_util/parse_hexstring.cc
-  test/core/test_util/resolve_localhost_ip46.cc
-  test/core/test_util/slice_splitter.cc
-  test/core/test_util/tracer_util.cc
 )
 if(WIN32 AND MSVC)
   if(BUILD_SHARED_LIBS)

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2114,24 +2114,41 @@ libs:
   headers:
   - test/core/event_engine/test_init.h
   - test/core/test_util/build.h
+  - test/core/test_util/cmdline.h
+  - test/core/test_util/evaluate_args_test_util.h
+  - test/core/test_util/grpc_profiler.h
+  - test/core/test_util/histogram.h
+  - test/core/test_util/mock_endpoint.h
+  - test/core/test_util/parse_hexstring.h
   - test/core/test_util/port.h
   - test/core/test_util/port_server_client.h
   - test/core/test_util/reconnect_server.h
+  - test/core/test_util/resolve_localhost_ip46.h
+  - test/core/test_util/slice_splitter.h
   - test/core/test_util/stack_tracer.h
   - test/core/test_util/test_config.h
   - test/core/test_util/test_tcp_server.h
   - test/core/test_util/tls_utils.h
+  - test/core/test_util/tracer_util.h
   src:
   - test/core/event_engine/test_init.cc
   - test/core/test_util/build.cc
+  - test/core/test_util/cmdline.cc
+  - test/core/test_util/grpc_profiler.cc
+  - test/core/test_util/histogram.cc
+  - test/core/test_util/mock_endpoint.cc
+  - test/core/test_util/parse_hexstring.cc
   - test/core/test_util/port.cc
   - test/core/test_util/port_ci.cc
   - test/core/test_util/port_server_client.cc
   - test/core/test_util/reconnect_server.cc
+  - test/core/test_util/resolve_localhost_ip46.cc
+  - test/core/test_util/slice_splitter.cc
   - test/core/test_util/stack_tracer.cc
   - test/core/test_util/test_config.cc
   - test/core/test_util/test_tcp_server.cc
   - test/core/test_util/tls_utils.cc
+  - test/core/test_util/tracer_util.cc
   deps:
   - absl/debugging:failure_signal_handler
   - absl/debugging:stacktrace
@@ -2145,22 +2162,39 @@ libs:
   headers:
   - test/core/event_engine/test_init.h
   - test/core/test_util/build.h
+  - test/core/test_util/cmdline.h
+  - test/core/test_util/evaluate_args_test_util.h
+  - test/core/test_util/grpc_profiler.h
+  - test/core/test_util/histogram.h
+  - test/core/test_util/mock_endpoint.h
+  - test/core/test_util/parse_hexstring.h
   - test/core/test_util/port.h
   - test/core/test_util/port_server_client.h
   - test/core/test_util/reconnect_server.h
+  - test/core/test_util/resolve_localhost_ip46.h
+  - test/core/test_util/slice_splitter.h
   - test/core/test_util/stack_tracer.h
   - test/core/test_util/test_config.h
   - test/core/test_util/test_tcp_server.h
+  - test/core/test_util/tracer_util.h
   src:
   - test/core/event_engine/test_init.cc
   - test/core/test_util/build.cc
+  - test/core/test_util/cmdline.cc
+  - test/core/test_util/grpc_profiler.cc
+  - test/core/test_util/histogram.cc
+  - test/core/test_util/mock_endpoint.cc
+  - test/core/test_util/parse_hexstring.cc
   - test/core/test_util/port.cc
   - test/core/test_util/port_ci.cc
   - test/core/test_util/port_server_client.cc
   - test/core/test_util/reconnect_server.cc
+  - test/core/test_util/resolve_localhost_ip46.cc
+  - test/core/test_util/slice_splitter.cc
   - test/core/test_util/stack_tracer.cc
   - test/core/test_util/test_config.cc
   - test/core/test_util/test_tcp_server.cc
+  - test/core/test_util/tracer_util.cc
   deps:
   - absl/debugging:failure_signal_handler
   - absl/debugging:stacktrace
@@ -3631,15 +3665,6 @@ libs:
   language: c++
   public_headers: []
   headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   - test/cpp/microbenchmarks/fullstack_context_mutators.h
   - test/cpp/microbenchmarks/fullstack_fixtures.h
   - test/cpp/microbenchmarks/helpers.h
@@ -3652,14 +3677,6 @@ libs:
   - third_party/googleapis/google/rpc/status.proto
   - third_party/protoc-gen-validate/validate/validate.proto
   - third_party/xds/xds/data/orca/v3/orca_load_report.proto
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/microbenchmarks/helpers.cc
   deps:
   - benchmark
@@ -4025,15 +4042,6 @@ libs:
   headers:
   - src/core/util/subprocess.h
   - test/core/end2end/data/ssl_test_data.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   - test/cpp/util/byte_buffer_proto_helper.h
   - test/cpp/util/create_test_channel.h
   - test/cpp/util/credentials.h
@@ -4047,14 +4055,6 @@ libs:
   - test/core/end2end/data/server1_cert.cc
   - test/core/end2end/data/server1_key.cc
   - test/core/end2end/data/test_root_cert.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/util/byte_buffer_proto_helper.cc
   - test/cpp/util/create_test_channel.cc
   - test/cpp/util/string_ref_helper.cc
@@ -5094,26 +5094,9 @@ targets:
 - name: fd_conservation_posix_test
   build: test
   language: c
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/fd_conservation_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - grpc_test_util
   platforms:
@@ -5216,15 +5199,6 @@ targets:
   language: c++
   headers:
   - src/core/util/subprocess.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   - test/cpp/util/byte_buffer_proto_helper.h
   - test/cpp/util/credentials.h
   - test/cpp/util/string_ref_helper.h
@@ -5232,14 +5206,6 @@ targets:
   src:
   - src/core/util/subprocess_posix.cc
   - src/core/util/subprocess_windows.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/naming/address_sorting_test.cc
   - test/cpp/util/byte_buffer_proto_helper.cc
   - test/cpp/util/string_ref_helper.cc
@@ -5401,25 +5367,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/common/alarm_test.cc
   deps:
   - gtest
@@ -5595,26 +5544,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/alts/alts_security_connector_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -5712,25 +5644,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/auth_context_test.cc
   deps:
   - gtest
@@ -5751,26 +5666,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/security/authorization_matchers_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -5809,26 +5707,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/call/external/aws_request_signer_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -5881,28 +5762,11 @@ targets:
   headers:
   - src/core/util/subprocess.h
   - test/core/end2end/cq_verifier.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - src/core/util/subprocess_posix.cc
   - src/core/util/subprocess_windows.cc
   - test/core/bad_ssl/bad_ssl_test.cc
   - test/core/end2end/cq_verifier.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -5917,28 +5781,11 @@ targets:
   headers:
   - src/core/util/subprocess.h
   - test/core/end2end/cq_verifier.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - src/core/util/subprocess_posix.cc
   - src/core/util/subprocess_windows.cc
   - test/core/bad_ssl/bad_ssl_test.cc
   - test/core/end2end/cq_verifier.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -6088,26 +5935,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/buffer_list_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -6155,30 +5985,13 @@ targets:
   headers:
   - test/core/event_engine/event_engine_test_utils.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
   - test/core/test_util/test_call_creds.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.proto
   - test/core/credentials/call/call_credentials_test.cc
   - test/core/event_engine/event_engine_test_utils.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
   - test/core/test_util/test_call_creds.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - protobuf
@@ -7296,15 +7109,6 @@ targets:
   - src/core/lib/security/authorization/mock_cel/cel_value.h
   - src/core/lib/security/authorization/mock_cel/evaluator_core.h
   - src/core/lib/security/authorization/mock_cel/flat_expr_builder.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - src/core/ext/upb-gen/envoy/annotations/deprecation.upb_minitable.c
   - src/core/ext/upb-gen/envoy/annotations/resource.upb_minitable.c
@@ -7398,14 +7202,6 @@ targets:
   - src/core/ext/upb-gen/xds/type/v3/typed_struct.upb_minitable.c
   - src/core/lib/security/authorization/cel_authorization_engine.cc
   - test/core/security/cel_authorization_engine_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -7516,26 +7312,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/channel_creds_registry_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -7711,26 +7490,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/alts/check_gcp_environment_linux_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -7738,26 +7500,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/alts/check_gcp_environment_windows_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -7767,25 +7512,8 @@ targets:
   language: c++
   headers:
   - test/core/end2end/cq_verifier.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/end2end/cq_verifier.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/chttp2_server_listener_test.cc
   deps:
   - gtest
@@ -8105,26 +7833,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
   - test/core/test_util/cmdline_test.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -8158,26 +7869,9 @@ targets:
   build: test
   run: false
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/combiner_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -8246,26 +7940,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/surface/connection_context_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -8300,25 +7977,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/connectivity_state_test.cc
   deps:
   - gtest
@@ -10199,26 +9859,9 @@ targets:
   language: c++
   headers:
   - test/core/iomgr/endpoint_tests.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/iomgr/endpoint_pair_test.cc
   - test/core/iomgr/endpoint_tests.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -10256,26 +9899,9 @@ targets:
   language: c++
   headers:
   - test/core/iomgr/endpoint_tests.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/iomgr/endpoint_tests.cc
   - test/core/iomgr/error_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -10284,25 +9910,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/error_utils_test.cc
   deps:
   - gtest
@@ -10311,26 +9920,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/security/evaluate_args_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -10556,26 +10148,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/fd_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -11477,28 +11052,11 @@ targets:
   language: c++
   headers:
   - test/core/end2end/data/ssl_test_data.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/end2end/data/client_certs.cc
   - test/core/end2end/data/server1_cert.cc
   - test/core/end2end/data/server1_key.cc
   - test/core/end2end/data/test_root_cert.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/util/http_client/format_request_test.cc
   deps:
   - gtest
@@ -11689,26 +11247,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/alts/grpc_alts_credentials_options_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -11728,26 +11269,9 @@ targets:
   language: c++
   headers:
   - test/core/test_util/audit_logging_utils.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/security/grpc_authorization_engine_test.cc
   - test/core/test_util/audit_logging_utils.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -11755,26 +11279,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/security/grpc_authorization_policy_provider_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_authorization_provider
@@ -11869,26 +11376,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/grpc_ipv6_loopback_available_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -11957,26 +11447,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/tls/grpc_tls_certificate_distributor_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -11984,26 +11457,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/tls/grpc_tls_certificate_provider_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -12011,26 +11467,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/tls/grpc_tls_certificate_verifier_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -12038,26 +11477,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/tls/grpc_tls_credentials_options_comparator_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -12065,26 +11487,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/tls/grpc_tls_credentials_options_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -12420,26 +11825,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
   - test/core/test_util/histogram_test.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -12459,25 +11847,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/hpack_encoder_test.cc
   deps:
   - gtest
@@ -12487,25 +11858,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/hpack_parser_table_test.cc
   deps:
   - gtest
@@ -12515,25 +11869,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/hpack_parser_test.cc
   deps:
   - gtest
@@ -12567,15 +11904,6 @@ targets:
   - src/core/lib/transport/promise_endpoint.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
   - test/core/promise/poll_matcher.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   - test/core/transport/chttp2/http2_frame_test_helper.h
   - test/core/transport/util/mock_promise_endpoint.h
   - test/core/transport/util/transport_test.h
@@ -12586,14 +11914,6 @@ targets:
   - src/core/lib/promise/wait_set.cc
   - src/core/lib/transport/promise_endpoint.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/http2_client_transport_test.cc
   - test/core/transport/util/mock_promise_endpoint.cc
   deps:
@@ -12617,15 +11937,6 @@ targets:
   - src/core/lib/promise/wait_set.h
   - src/core/lib/transport/promise_endpoint.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   - test/core/transport/chttp2/http2_frame_test_helper.h
   - test/core/transport/util/mock_promise_endpoint.h
   - test/core/transport/util/transport_test.h
@@ -12635,14 +11946,6 @@ targets:
   - src/core/lib/promise/wait_set.cc
   - src/core/lib/transport/promise_endpoint.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/http2_server_transport_test.cc
   - test/core/transport/util/mock_promise_endpoint.cc
   deps:
@@ -12815,26 +12118,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/insecure/insecure_security_connector_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -13160,26 +12446,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/call/jwt/json_token_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -13188,26 +12457,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/call/jwt/jwt_verifier_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -13342,26 +12594,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/local/local_security_connector_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -13576,25 +12811,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/util/matchers_test.cc
   deps:
   - gtest
@@ -13649,26 +12867,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/compression/message_compress_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -13687,26 +12888,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/call/metadata_map_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -14202,28 +13386,11 @@ targets:
   language: c++
   headers:
   - test/core/end2end/data/ssl_test_data.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/end2end/data/client_certs.cc
   - test/core/end2end/data/server1_cert.cc
   - test/core/end2end/data/server1_key.cc
   - test/core/end2end/data/test_root_cert.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/util/http_client/parser_test.cc
   deps:
   - gtest
@@ -14366,25 +13533,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/ping_abuse_policy_test.cc
   deps:
   - gtest
@@ -14406,25 +13556,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/ping_configuration_test.cc
   deps:
   - gtest
@@ -14434,25 +13567,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/ping_rate_policy_test.cc
   deps:
   - gtest
@@ -15133,26 +14249,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/security/rbac_translator_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_authorization_provider
@@ -15363,26 +14462,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/resolve_address_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -15397,27 +14479,10 @@ targets:
   build: test
   language: c++
   headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
   - test/core/test_util/fake_udp_and_tcp_server.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/iomgr/resolve_address_test.cc
-  - test/core/test_util/cmdline.cc
   - test/core/test_util/fake_udp_and_tcp_server.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -15426,26 +14491,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/resolve_address_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -15460,27 +14508,10 @@ targets:
   build: test
   language: c++
   headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
   - test/core/test_util/fake_udp_and_tcp_server.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/iomgr/resolve_address_test.cc
-  - test/core/test_util/cmdline.cc
   - test/core/test_util/fake_udp_and_tcp_server.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -15657,26 +14688,9 @@ targets:
   language: c++
   headers:
   - test/core/iomgr/endpoint_tests.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/handshake/secure_endpoint_test.cc
   - test/core/iomgr/endpoint_tests.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -15684,26 +14698,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/security_connector_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -15771,15 +14768,6 @@ targets:
   language: c++
   headers:
   - test/core/event_engine/event_engine_test_utils.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - src/proto/grpc/testing/echo.proto
   - src/proto/grpc/testing/echo_messages.proto
@@ -15790,14 +14778,6 @@ targets:
   - third_party/protoc-gen-validate/validate/validate.proto
   - third_party/xds/xds/data/orca/v3/orca_load_report.proto
   - test/core/event_engine/event_engine_test_utils.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/server/server_builder_test.cc
   deps:
   - gtest
@@ -15811,16 +14791,7 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - src/proto/grpc/testing/echo.proto
   - src/proto/grpc/testing/echo_messages.proto
@@ -15830,14 +14801,6 @@ targets:
   - third_party/googleapis/google/rpc/status.proto
   - third_party/protoc-gen-validate/validate/validate.proto
   - third_party/xds/xds/data/orca/v3/orca_load_report.proto
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/server/server_builder_with_socket_mutator_test.cc
   deps:
   - gtest
@@ -15947,16 +14910,7 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - src/proto/grpc/testing/echo.proto
   - src/proto/grpc/testing/echo_messages.proto
@@ -15966,14 +14920,6 @@ targets:
   - third_party/googleapis/google/rpc/status.proto
   - third_party/protoc-gen-validate/validate/validate.proto
   - third_party/xds/xds/data/orca/v3/orca_load_report.proto
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/server/server_request_call_test.cc
   deps:
   - gtest
@@ -16044,25 +14990,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/settings_timeout_test.cc
   deps:
   - gtest
@@ -16176,26 +15105,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/socket_utils_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -16313,25 +15225,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/status_conversion_test.cc
   deps:
   - gtest
@@ -16413,25 +15308,8 @@ targets:
   language: c++
   headers:
   - test/core/end2end/cq_verifier.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/end2end/cq_verifier.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/chttp2/streams_not_seen_test.cc
   deps:
   - gtest
@@ -16504,26 +15382,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/tls/system_roots_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -16548,26 +15409,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/tcp_client_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -16596,26 +15440,9 @@ targets:
   language: c++
   headers:
   - test/core/iomgr/endpoint_tests.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/iomgr/endpoint_tests.cc
   - test/core/iomgr/tcp_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -16626,26 +15453,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/tcp_server_posix_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -16688,26 +15498,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/ssl/ssl_credentials_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -16785,26 +15578,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/iomgr/timer_heap_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -17068,25 +15844,8 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/core/transport/timeout_encoding_test.cc
   deps:
   - gtest
@@ -17171,27 +15930,10 @@ targets:
   build: test
   language: c++
   headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
   - test/core/test_util/test_call_creds.h
-  - test/core/test_util/tracer_util.h
   src:
   - test/core/credentials/transport/tls/tls_security_connector_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
   - test/core/test_util/test_call_creds.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util
@@ -17621,15 +16363,6 @@ targets:
   headers:
   - test/core/event_engine/event_engine_test_utils.h
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
   src:
   - src/proto/grpc/testing/echo.proto
   - src/proto/grpc/testing/echo_messages.proto
@@ -17642,14 +16375,6 @@ targets:
   - third_party/xds/xds/data/orca/v3/orca_load_report.proto
   - test/core/event_engine/event_engine_test_utils.cc
   - test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   - test/cpp/performance/writes_per_rpc_test.cc
   deps:
   - gtest
@@ -18662,26 +17387,9 @@ targets:
   gtest: true
   build: test
   language: c++
-  headers:
-  - test/core/test_util/cmdline.h
-  - test/core/test_util/evaluate_args_test_util.h
-  - test/core/test_util/grpc_profiler.h
-  - test/core/test_util/histogram.h
-  - test/core/test_util/mock_endpoint.h
-  - test/core/test_util/parse_hexstring.h
-  - test/core/test_util/resolve_localhost_ip46.h
-  - test/core/test_util/slice_splitter.h
-  - test/core/test_util/tracer_util.h
+  headers: []
   src:
   - test/core/credentials/transport/xds/xds_credentials_test.cc
-  - test/core/test_util/cmdline.cc
-  - test/core/test_util/grpc_profiler.cc
-  - test/core/test_util/histogram.cc
-  - test/core/test_util/mock_endpoint.cc
-  - test/core/test_util/parse_hexstring.cc
-  - test/core/test_util/resolve_localhost_ip46.cc
-  - test/core/test_util/slice_splitter.cc
-  - test/core/test_util/tracer_util.cc
   deps:
   - gtest
   - grpc_test_util

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -126,6 +126,7 @@ grpc_cc_library(
     ],
     deps = [
         "build",
+        "grpc_test_util_base",
         "stack_tracer",
         "//:config",
         "//:exec_ctx",

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -174,6 +174,7 @@ grpc_cc_library(
     ],
     deps = [
         "build",
+        "grpc_test_util_base",
         "stack_tracer",
         "//:config",
         "//:exec_ctx",

--- a/test/core/test_util/port_server_client.h
+++ b/test/core/test_util/port_server_client.h
@@ -22,9 +22,6 @@
 #include <memory>
 // C interface to port_server.py
 
-// must be synchronized with tools/run_tests/python_utils/start_port_server.py
-#define GRPC_PORT_SERVER_ADDRESS "localhost:32766"
-
 int grpc_pick_port_using_server(void);
 void grpc_free_port_using_server(int port);
 


### PR DESCRIPTION
Alternative to https://github.com/grpc/grpc/pull/39108, which presumably works with IPv6 (I don't believe CI tests it). This resolves the localhost IP before requesting a port from the port server, which avoids the 2 second HTTP Get penalty on Windows. Full report below.

----

This fixes a timeout in the end2end test framework (and likely many other places). See https://btx.cloud.google.com/invocations/2df37f19-46a3-4ddb-86c4-ac433690b26b/targets/%2F%2Ftest%2Fcore%2Fend2end:end2end_http2_security_test@experiment%3Dcallv3_client_auth_filter;config=a1c741c989628574ce0fae60f9ee74e83e2083b0b087c03cc94eb91973e1d44d/log

In short, calling HttpRequest::Get with "localhost:32766" on Windows will take around 2 seconds. Making the same GET request to "127.0.0.1:32766" takes milliseconds. The proxy tests get two ports on fixture creation, one for the server, and one for the proxy. This adds 4 seconds to every test, and the test linked above has a 5 second timeout.

Someone should likely fix the test framework at some point, the call timeout begins before the proxy & server have even started, and the timer should likely start after the servers have been created.