### PR TITLE
Improve test for PHP extension `pcntl_fork()` compatibility

### DIFF
--- a/src/php/docker/fork-support/Dockerfile
+++ b/src/php/docker/fork-support/Dockerfile
@@ -16,12 +16,7 @@ FROM grpc-php/php-src
 
 WORKDIR /tmp
 
+COPY src/php/docker/fork-support/run_tests.sh .
 COPY src/php/docker/fork-support/fork.php .
 
-RUN echo '\
-extension=grpc.so\n\
-grpc.enable_fork_support=1\n\
-grpc.poll_strategy=epoll1\n\
-' >> /usr/local/lib/php.ini
-
-CMD ["php", "fork.php"]
+CMD ["/bin/sh", "run_tests.sh"]

--- a/src/php/docker/fork-support/run_tests.sh
+++ b/src/php/docker/fork-support/run_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+echo "=> TEST: extension not loaded"
+timeout 5 php fork.php
+echo "=> PASS"
+echo ""
+
+echo "=> TEST: extension loaded, default configuration"
+timeout 5 php -d extension=grpc.so fork.php
+echo "=> PASS"
+echo ""
+
+echo "=> TEST: extension loaded, fork support enabled"
+timeout 5 php -d extension=grpc.so -d grpc.enable_fork_support=1 fork.php
+echo "=> PASS"
+echo ""
+
+echo "=> TEST: extension loaded, fork support enabled, poll strategy set"
+timeout 5 php -d extension=grpc.so -d grpc.enable_fork_support=1 -d grpc.poll_strategy=epoll1 fork.php
+echo "=> PASS"
+echo ""


### PR DESCRIPTION
When this PHP extension is loaded with its default configuration, a PHP process using `pcntl_fork()` will hang. This has been reported numerous times and in most cases, the issue has been closed with instructions for how to configure the extension with INI settings or environment variables.

This pull request expands on the existing test for `pcntl_fork()` compatibility to demonstrate the bug. I haven't yet found how this test runs as part of the test suite. I don't see any details of this in https://github.com/grpc/grpc/pull/20411 where the test was introduced.