### PR TITLE
[test] Remove usage of the APIs deprecated in C++17

### DIFF
--- a/test/core/event_engine/factory_test.cc
+++ b/test/core/event_engine/factory_test.cc
@@ -85,12 +85,12 @@ TEST_F(EventEngineFactoryTest, SharedPtrGlobalEventEngineLifetimesAreValid) {
     ASSERT_EQ(ee2.use_count(), 2);
   }
   // Ensure the first shared_ptr did not delete the global
-  ASSERT_TRUE(ee2.unique());
+  ASSERT_EQ(ee2.use_count(), 1);
   // destroy the global engine via the last shared_ptr, and create a new one.
   ee2.reset();
   ee2 = GetDefaultEventEngine();
   ASSERT_EQ(2, create_count);
-  ASSERT_TRUE(ee2.unique());
+  ASSERT_EQ(ee2.use_count(), 1);
 }
 
 }  // namespace


### PR DESCRIPTION
This clears the following warnings:
```
test/core/event_engine/factory_test.cc:88:19: warning: 'unique' is deprecated [-Wdeprecated-declarations]
   88 |   ASSERT_TRUE(ee2.unique());
test/core/event_engine/factory_test.cc:93:19: warning: 'unique' is deprecated [-Wdeprecated-declarations]
   93 |   ASSERT_TRUE(ee2.unique());
2 warnings generated.
```