### PR TITLE
[core-e2e] Fix no-logging logic

### DIFF
--- a/test/core/end2end/tests/no_logging.cc
+++ b/test/core/end2end/tests/no_logging.cc
@@ -72,6 +72,10 @@ class VerifyLogNoiseLogSink : public absl::LogSink {
   VerifyLogNoiseLogSink(const VerifyLogNoiseLogSink& other) = delete;
   VerifyLogNoiseLogSink& operator=(const VerifyLogNoiseLogSink& other) = delete;
 
+  void AllowInfoLogs(bool allow) {
+    allow_info_logs_.store(allow, std::memory_order_relaxed);
+  }
+
  private:
   bool IsVlogWithVerbosityMoreThan1(const absl::LogEntry& entry) const {
     return entry.log_severity() == absl::LogSeverity::kInfo &&
@@ -109,6 +113,11 @@ class VerifyLogNoiseLogSink : public absl::LogSink {
          {"http_connect_handshaker.cc",
           std::regex("HTTP proxy handshake with .* failed:.*")}});
 
+    if (allow_info_logs_.load(std::memory_order_relaxed) &&
+        entry.log_severity() == absl::LogSeverity::kInfo) {
+      return;
+    }
+
     if (IsVlogWithVerbosityMoreThan1(entry)) {
       return;
     }
@@ -139,6 +148,7 @@ class VerifyLogNoiseLogSink : public absl::LogSink {
   int saved_absl_verbosity_;
   SavedTraceFlags saved_trace_flags_;
   bool log_noise_absent_;
+  std::atomic<bool> allow_info_logs_{false};
 };
 
 void SimpleRequest(CoreEnd2endTest& test) {
@@ -181,6 +191,9 @@ CORE_END2END_TEST(NoLoggingTests, NoLoggingTest) {
   }
 #endif
   VerifyLogNoiseLogSink nolog_verifier(absl::LogSeverityAtLeast::kInfo, 2);
+  nolog_verifier.AllowInfoLogs(true);
+  SimpleRequest(*this);
+  nolog_verifier.AllowInfoLogs(false);
   for (int i = 0; i < 10; i++) {
     SimpleRequest(*this);
   }


### PR DESCRIPTION
This test is intended to verify that there's no logs on the ordinary RPC path - but not necessarily on the channel creation paths.

Since there's no way to know the origination of the log, we allow the first RPC to emit some spam, so long as subsequent ones do not.

This carve out was removed in #37177 and since then we've had a slow but continuous stream of additions to the exemption list.

Returning to the original logic in the hopes that we no longer need to maintain said list. In a follow-up PR we should trim the exemptions we've added once more.