### PR TITLE
Fix gRPC Python issue #37518: Ensure context.abort() properly raises …

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -306,7 +306,7 @@ cdef class _SyncServicerContext:
             self._context.abort(code, details, trailing_metadata),
             self._loop)
         # Abort should raise an AbortError
-        future.exception()
+        future.result()
 
     def send_initial_metadata(self, object metadata):
         future = asyncio.run_coroutine_threadsafe(


### PR DESCRIPTION
Fix GRPC Python issue #37518: Ensure **context.abort()** properly raises exception

Previously, **_SyncServicerContext.abort()** retrieved exceptions using `future.exception()`, 
 but we were not throwing an exception so this prevented `_handle_exceptions` 
from catching it. This resulted in post-abort code execution.

**Root Cause:**
- **asyncio.run_coroutine_threadsafe()** schedules **_ServicerContext.abort()** in **self._loop**.
- Using `future.exception()` retrieves the exception early, preventing proper error propagation.
- `_handle_exceptions` was never triggered.

**Fix:**
- Replaced **future.exception()** with **future.result(),** ensuring proper exception propagation.

 **Impact:**
- Ensures context.abort() works as expected, preventing unintended code execution.
- Fixes issue for users transitioning from synchronous to asyncio-based GRPC servers.


