### PR TITLE
[ObjC] disable ios-buildtest-example-switft-package

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1181,18 +1181,20 @@ class ObjCLanguage(object):
                 },
             )
         )
-        out.append(
-            self.config.job_spec(
-                ["src/objective-c/tests/build_one_example.sh"],
-                timeout_seconds=120 * 60,
-                shortname="ios-buildtest-example-switft-package",
-                cpu_cost=1e6,
-                environ={
-                    "SCHEME": "gRPC-Package",
-                    "EXAMPLE_PATH": ".",
-                },
-            )
-        )
+
+        # TODO: re-enable after abseil fixes
+        # out.append(
+        #     self.config.job_spec(
+        #         ["src/objective-c/tests/build_one_example.sh"],
+        #         timeout_seconds=120 * 60,
+        #         shortname="ios-buildtest-example-switft-package",
+        #         cpu_cost=1e6,
+        #         environ={
+        #             "SCHEME": "gRPC-Package",
+        #             "EXAMPLE_PATH": ".",
+        #         },
+        #     )
+        # )
 
         # Disabled due to #20258
         # TODO (mxyan): Reenable this test when #20258 is resolved.


### PR DESCRIPTION
Fails with error: 
```
[/absl/numeric/int128.h:1182](https://cs.corp.google.com/piper///depot/google3/Users/kbuilder/Library/Developer/Xcode/DerivedData/workspace_objc_macos_opt_native-auypnimqokfdevhekumkyzytzaba/SourcePackages/checkouts/abseil-cpp-SwiftPM/absl/numeric/int128.h?l=1182&ws&snapshot=0):1: error: redundant #include of module 'abseil' appears within namespace 'absl::lts_20240722' [-Wmodules-import-nested-redundant]
#include "absl/numeric/int128_have_intrinsic.inc"  // IWYU pragma: export
^
/[Users/kbuilder/Library/Developer/Xcode/DerivedData/workspace_objc_macos_opt_native-auypnimqokfdevhekumkyzytzaba/SourcePackages/checkouts/abseil-cpp-SwiftPM/absl/numeric/int128.h:557](https://cs.corp.google.com/piper///depot/google3/Users/kbuilder/Library/Developer/Xcode/DerivedData/workspace_objc_macos_opt_native-auypnimqokfdevhekumkyzytzaba/SourcePackages/checkouts/abseil-cpp-SwiftPM/absl/numeric/int128.h?l=557&ws&snapshot=0):1: note: namespace 'absl::lts_20240722' begins here
ABSL_NAMESPACE_BEGIN
^
```

ref: https://github.com/abseil/abseil-cpp/pull/1861