### PR TITLE
[channelz] Add a facility to expand JSON output from arbitrary data sources

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1229,6 +1229,7 @@ grpc_cc_library(
         "absl/log:check",
         "absl/status:statusor",
         "absl/strings",
+        "absl/container:inlined_vector",
     ],
     deps = [
         "exec_ctx",

--- a/src/core/channelz/channelz.cc
+++ b/src/core/channelz/channelz.cc
@@ -62,6 +62,35 @@ std::string BaseNode::RenderJsonString() {
   return JsonDump(json);
 }
 
+void BaseNode::PopulateJsonFromDataSources(Json::Object& json) {
+  MutexLock lock(&data_sources_mu_);
+  for (DataSource* data_source : data_sources_) {
+    data_source->AddJson(json);
+  }
+}
+
+//
+// DataSource
+//
+
+DataSource::DataSource(RefCountedPtr<BaseNode> node) : node_(std::move(node)) {
+  MutexLock lock(&node_->data_sources_mu_);
+  node_->data_sources_.push_back(this);
+}
+
+DataSource::~DataSource() {
+  if (node_ != nullptr) ResetDataSource();
+}
+
+void DataSource::ResetDataSource() {
+  auto node = std::move(node_);
+  DCHECK(node != nullptr);
+  MutexLock lock(&node->data_sources_mu_);
+  node->data_sources_.erase(
+      std::remove(node->data_sources_.begin(), node->data_sources_.end(), this),
+      node->data_sources_.end());
+}
+
 //
 // CallCountingHelper
 //
@@ -210,6 +239,7 @@ Json ChannelNode::RenderJson() {
   // Template method. Child classes may override this to add their specific
   // functionality.
   PopulateChildRefs(&json);
+  PopulateJsonFromDataSources(json);
   return Json::FromObject(std::move(json));
 }
 
@@ -320,6 +350,7 @@ Json SubchannelNode::RenderJson() {
         }),
     });
   }
+  PopulateJsonFromDataSources(data);
   return Json::FromObject(object);
 }
 
@@ -410,6 +441,7 @@ Json ServerNode::RenderJson() {
       object["listenSocket"] = Json::FromArray(std::move(array));
     }
   }
+  PopulateJsonFromDataSources(object);
   return Json::FromObject(std::move(object));
 }
 
@@ -644,6 +676,7 @@ Json SocketNode::RenderJson() {
   }
   PopulateSocketAddressJson(&object, "remote", remote_.c_str());
   PopulateSocketAddressJson(&object, "local", local_.c_str());
+  PopulateJsonFromDataSources(data);
   return Json::FromObject(std::move(object));
 }
 
@@ -663,6 +696,7 @@ Json ListenSocketNode::RenderJson() {
               })},
   };
   PopulateSocketAddressJson(&object, "local", local_addr_.c_str());
+  PopulateJsonFromDataSources(object);
   return Json::FromObject(std::move(object));
 }
 

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -286,7 +286,7 @@ TEST_P(ChannelzChannelTest, BasicChannel) {
 class TestDataSource final : public DataSource {
  public:
   using DataSource::DataSource;
-  void AddJson(Json::Object& object) {
+  void AddJson(Json::Object& object) override {
     object["test"] = Json::FromString("yes");
   }
 };


### PR DESCRIPTION
We'd like to significantly expand the fidelity of data output from channelz.

Since this is often from disparate data sources, the current state of the art of placing all relevant information in the channelz nodes is going to cause severe duplication of state, leading to a memory blow-up.

Instead, allow data sources to be queried directly for information from the channelz node.

Note: If those sources go away, we lose the data they provide, so this is not a replacement for ALL state on the nodes, but there's certainly a class of state that we'll benefit from having here -- eg, retrieving the current kernel attributes from an open socket.