### PR TITLE
[doc] Add docs for connection backoff channel args

### DIFF
--- a/include/grpc/impl/channel_arg_names.h
+++ b/include/grpc/impl/channel_arg_names.h
@@ -168,13 +168,19 @@
 /** Secondary user agent: goes at the end of the user-agent metadata
     sent on each request. A string. */
 #define GRPC_ARG_SECONDARY_USER_AGENT_STRING "grpc.secondary_user_agent"
-/** The minimum time between subsequent connection attempts, in ms. Defaults to
- * 20 seconds. */
+/** The minimum time between subsequent connection attempts, in ms. Refer to
+ * MIN_CONNECT_TIMEOUT from
+ * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md. Defaults
+ * to 20 seconds. */
 #define GRPC_ARG_MIN_RECONNECT_BACKOFF_MS "grpc.min_reconnect_backoff_ms"
-/** The maximum time between subsequent connection attempts, in ms. Defaults to
- * 120 seconds. */
+/** The maximum time between subsequent connection attempts, in ms. Refer to
+ * MAX_BACKOFF from
+ * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md. Defaults
+ * to 120 seconds.  */
 #define GRPC_ARG_MAX_RECONNECT_BACKOFF_MS "grpc.max_reconnect_backoff_ms"
-/** The time between the first and second connection attempts, in ms. Defaults
+/** The time between the first and second connection attempts, in ms. Refer to
+ * INITIAL_BACKOFF from
+ * https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md. Defaults
  * to 1 second. */
 #define GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS \
   "grpc.initial_reconnect_backoff_ms"


### PR DESCRIPTION
This along with [#39135](https://github.com/grpc/grpc/pull/39135) closes https://github.com/grpc/grpc/issues/21417