### PR TITLE
Fix the code parsing docker container port mapping output

### DIFF
--- a/tools/run_tests/python_utils/dockerjob.py
+++ b/tools/run_tests/python_utils/dockerjob.py
@@ -55,7 +55,7 @@ def docker_mapped_port(cid, port, timeout_seconds=15):
             output = subprocess.check_output(
                 "docker port %s %s" % (cid, port), stderr=_DEVNULL, shell=True
             ).decode()
-            return int(output.split(":", 2)[1])
+            return int(output.split("\n")[0].split(":", 2)[1])
         except subprocess.CalledProcessError as e:
             pass
     raise Exception(


### PR DESCRIPTION
The output from docker port  is like
```
docker port 8f64a57ed2e0 80
0.0.0.0:80
[::]:80
```
so we need to split the command output by newline to get the first line first.