### PR TITLE
[test] FuzzingEventEngine::Tick nanos instead of millis

### DIFF
--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -196,7 +196,7 @@ void FuzzingEventEngine::Tick(Duration max_time) {
                 exponential_gate_time_increment_ / 1000;
           }
           incr = std::max(incr, std::chrono::duration_cast<Duration>(
-                                    std::chrono::milliseconds(1)));
+                                    std::chrono::nanoseconds(1)));
           now_ += incr;
           CHECK_GE(now_.time_since_epoch().count(), 0);
           ++current_tick_;


### PR DESCRIPTION
This circumvents an issue with the FuzzingEventEngine in contexts where tests want to assert a fixed amount of time has passed, such as the `XdsOverrideHostTest.IdleTimer` test.

When the following 3 experiments are enabled, the FuzzingEventEngine has used nanosecond increments on the global timer whenever the engine ticked forward: event_engine_client, event_engine_listener, and event_engine_dns.

If any of those were not enabled, the FuzzingEventEngine incremented the global time by milliseconds. Key difference in time viewed between EE experiments on and off:

On: `lb_policy_test_lib.h:1412] Incrementing time by 5000ms. It is now = @33ms vs fuzzing_ee_->Now() = 5033000000ns`

Off: `lb_policy_test_lib.h:1412] Incrementing time by 5000ms. It is now = @0ms vs fuzzing_ee_->Now() = 5000033000ns`

This PR ensures that time increments by nanoseconds instead of milliseconds for every engine tick.

@markdroth note that this still only delays the issues that will happen with the XDS test, since time is still incrementing on every tick, albeit 1000x slower. The test asserts that time is precisely as expected by the RunAfter timeout, with no lag, albeit with reduced precision (which is why it works today).