### PR TITLE
Fix grpc_proto_plugin() genrule warnings (#39060)

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -199,7 +199,7 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
         binary = name + "_native",
     )
     native.genrule(
-        name = name,
+        name = name + "_select",
         srcs = select({
             "@platforms//os:macos": [name + "_universal"],
             "//conditions:default": [name + "_native"],


### PR DESCRIPTION
We here address the following warnings:

    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:87:18: target 'grpc_cpp_plugin' is both a rule and a file; please choose another name for the rule
    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:93:18: target 'grpc_csharp_plugin' is both a rule and a file; please choose another name for the rule
    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:99:18: target 'grpc_node_plugin' is both a rule and a file; please choose another name for the rule
    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:105:18: target 'grpc_objective_c_plugin' is both a rule and a file; please choose another name for the rule
    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:111:18: target 'grpc_php_plugin' is both a rule and a file; please choose another name for the rule
    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:117:18: target 'grpc_python_plugin' is both a rule and a file; please choose another name for the rule
    WARNING: /Users/dws/src/grpc-dws/src/compiler/BUILD:123:18: target 'grpc_ruby_plugin' is both a rule and a file; please choose another name for the rule

that come from asking Bazel to build the following:

    @com_github_grpc_grpc//src/compiler:grpc_cpp_plugin
    @com_github_grpc_grpc//src/compiler:grpc_csharp_plugin
    @com_github_grpc_grpc//src/compiler:grpc_node_plugin
    @com_github_grpc_grpc//src/compiler:grpc_objective_c_plugin
    @com_github_grpc_grpc//src/compiler:grpc_php_plugin
    @com_github_grpc_grpc//src/compiler:grpc_python_plugin
    @com_github_grpc_grpc//src/compiler:grpc_ruby_plugin

The macro grpc_proto_plugin() in bazel/grpc_build_system.bzl has a genrule that uses the same name for both the rule and its output file.  This macro gets used in src/compiler/BUILD to define the above plugin targets.

We address this by giving the rule a different name than its output file.  This doesn't take away from the ability to ask Bazel to build the output file of the rule using the same label as before.

Closes #39060