### PR TITLE
[Fix] Bazel build warning: "target is both a rule and a file" 

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -251,7 +251,7 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
             "@platforms//os:macos": [name + "_universal"],
             "//conditions:default": [name + "_native"],
         }),
-        outs = [name],
+        outs = [name + "_binary"],
         cmd = "cp $< $@",
         executable = True,
     )


### PR DESCRIPTION

Fixes warning in #39060

