### PR TITLE
[combiner] Add combiner closure running to latent-see

### DIFF
--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -167,6 +167,8 @@ static void queue_offload(grpc_core::Combiner* lock) {
 }
 
 bool grpc_combiner_continue_exec_ctx() {
+  GRPC_LATENT_SEE_PARENT_SCOPE("grpc_combiner_continue_exec_ctx");
+
   grpc_core::Combiner* lock =
       grpc_core::ExecCtx::Get()->combiner_data()->active_combiner;
   if (lock == nullptr) {


### PR DESCRIPTION
This should make it more obvious where we're getting unwanted contention on the combiner lock in the traces.