### PR TITLE
adding e2e test cases for GRPC_COMPRESSION_CHANNEL_DEFAULT_LEVEL

### DIFF
--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -449,5 +449,32 @@ CORE_END2END_TEST(Http2SingleHopTests,
       .RequestWithPayload(0, {});
 }
 
+CORE_END2END_TEST(Http2SingleHopTests,
+                  RequestWithDefaultMediumLevelDecompressInCore) {
+  TestConfigurator(*this)
+      .ServerDefaultCompressionLevel(GRPC_COMPRESS_LEVEL_MED)
+      .DecompressInApp()
+      .ExpectedAlgorithmFromServer(GRPC_COMPRESS_DEFLATE)
+      .RequestWithPayload(0, {});
+}
+
+CORE_END2END_TEST(Http2SingleHopTests,
+                  RequestWithDefaultLowLevelDecompressInCore) {
+  TestConfigurator(*this)
+      .ServerDefaultCompressionLevel(GRPC_COMPRESS_LEVEL_LOW)
+      .DecompressInApp()
+      .ExpectedAlgorithmFromServer(GRPC_COMPRESS_GZIP)
+      .RequestWithPayload(0, {});
+}
+
+CORE_END2END_TEST(Http2SingleHopTests,
+                  RequestWithDefaultNoneLevelDecompressInCore) {
+  TestConfigurator(*this)
+      .ServerDefaultCompressionLevel(GRPC_COMPRESS_LEVEL_NONE)
+      .DecompressInApp()
+      .ExpectedAlgorithmFromServer(GRPC_COMPRESS_NONE)
+      .RequestWithPayload(0, {});
+}
+
 }  // namespace
 }  // namespace grpc_core

--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -440,9 +440,9 @@ CORE_END2END_TEST(
       .RequestWithPayload(0, {{"grpc-internal-encoding-request", "identity"}});
 }
 
-// Note: The compression level is currently tied to the specific algorithm being
-// used declared in the CompressionAlgorithmForLevel function in the compression
-// library.
+// Note: This test currently assumes that the compression level is tied to a
+// specific algorithm. When the semantics around compression level become more
+// clear, this would need to change.
 CORE_END2END_TEST(Http2SingleHopTests,
                   RequestWithDefaultHighLevelDecompressInCore) {
   TestConfigurator(*this)

--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -440,6 +440,8 @@ CORE_END2END_TEST(
       .RequestWithPayload(0, {{"grpc-internal-encoding-request", "identity"}});
 }
 
+// Note: The compression level is currently tied to the specific algorithm being used
+// declared in the CompressionAlgorithmForLevel function in the compression library.
 CORE_END2END_TEST(Http2SingleHopTests,
                   RequestWithDefaultHighLevelDecompressInCore) {
   TestConfigurator(*this)

--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -58,6 +58,13 @@ class TestConfigurator {
     return *this;
   }
 
+  TestConfigurator& ServerDefaultCompressionLevel(
+      grpc_compression_level level) {
+    server_args_ =
+        server_args_.Set(GRPC_COMPRESSION_CHANNEL_DEFAULT_LEVEL, level);
+    return *this;
+  }
+
   TestConfigurator& ServerDefaultAlgorithm(
       grpc_compression_algorithm algorithm) {
     server_args_ =
@@ -431,6 +438,15 @@ CORE_END2END_TEST(
       .ClientDefaultAlgorithm(GRPC_COMPRESS_DEFLATE)
       .DecompressInApp()
       .RequestWithPayload(0, {{"grpc-internal-encoding-request", "identity"}});
+}
+
+CORE_END2END_TEST(Http2SingleHopTests,
+                  RequestWithDefaultHighLevelDecompressInCore) {
+  TestConfigurator(*this)
+      .ServerDefaultCompressionLevel(GRPC_COMPRESS_LEVEL_HIGH)
+      .DecompressInApp()
+      .ExpectedAlgorithmFromServer(GRPC_COMPRESS_DEFLATE)
+      .RequestWithPayload(0, {});
 }
 
 }  // namespace

--- a/test/core/end2end/tests/compressed_payload.cc
+++ b/test/core/end2end/tests/compressed_payload.cc
@@ -440,8 +440,9 @@ CORE_END2END_TEST(
       .RequestWithPayload(0, {{"grpc-internal-encoding-request", "identity"}});
 }
 
-// Note: The compression level is currently tied to the specific algorithm being used
-// declared in the CompressionAlgorithmForLevel function in the compression library.
+// Note: The compression level is currently tied to the specific algorithm being
+// used declared in the CompressionAlgorithmForLevel function in the compression
+// library.
 CORE_END2END_TEST(Http2SingleHopTests,
                   RequestWithDefaultHighLevelDecompressInCore) {
   TestConfigurator(*this)


### PR DESCRIPTION
Fixes: [17935](https://github.com/grpc/grpc/issues/17935)

Since only server side supports compression level setting therefore added test case for the same.