### PR TITLE
Revert "add cleanup job for psm interop dualstack resources (#39184)"

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
+++ b/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
@@ -86,14 +86,6 @@ cleanup::job::cleanup_cluster_gamma() {
 }
 
 #######################################
-# The Dualstack cluster is used by the dualstack test suites.
-#######################################
-cleanup::job::cleanup_cluster_dualstack() {
-  cleanup::activate_cluster GKE_CLUSTER_DUALSTACK
-  cleanup::run_clean "$1" --mode=k8s
-}
-
-#######################################
 # Set common variables for the cleanup script.
 # Globals:
 #   TEST_DRIVER_FLAGFILE: Relative path to test driver flagfile
@@ -148,7 +140,6 @@ main() {
     "cleanup_cluster_security"
     "cleanup_cluster_url_map"
     "cleanup_cluster_gamma"
-    "cleanup_cluster_dualstack"
   )
   for job_name in "${cleanup_jobs[@]}"; do
     echo "-------------------- Starting job ${job_name} --------------------"


### PR DESCRIPTION
This reverts commit 34b206e29d7f34a9eeb271ef2d185cc0810eea8d / PR #39184.

The initial PR is missing several important flags that setup the framework to work with the dualstack environment, which will result inconsistently deleted and orphaned dualstack resources.

Related work: grpc/psm-interop#165.

