### PR TITLE
[CI] Added protobuf_allow_msvc=true for BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -38,6 +38,7 @@ tasks:
     build_flags:
     - '--cxxopt=/std:c++17'
     - '--host_cxxopt=/std:c++17'
+    - '--define=protobuf_allow_msvc=true'
     build_targets:
       - "@grpc//:grpc"
       - "@grpc//:grpc_unsecure"


### PR DESCRIPTION
To address the following issue found in https://github.com/bazelbuild/bazel-central-registry/pull/4269

```
bazel-out/x64_windows-opt-exec-ST-d57f47055a04/bin/external/protobuf~/src/google/protobuf/stubs/_virtual_includes/lite\google/protobuf/stubs/port.h(38): fatal error C1189: 
#error:      "Protobuf will be dropping support for MSVC + Bazel in 34.0.  To continue using it until then, use the flag --define=protobuf_allow_msvc=true.  For feedback or discussion, see github.com/protocolbuffers/protobuf/issues/20085."
```

This is a short-term fix to unblock the BCR release. Long-term solution is to change it to use clang on Windows.