### PR TITLE
[Cherry-pick to 1.72.x] Added protobuf_allow_msvc=true for BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -38,6 +38,7 @@ tasks:
     build_flags:
     - '--cxxopt=/std:c++17'
     - '--host_cxxopt=/std:c++17'
+    - '--define=protobuf_allow_msvc=true'
     build_targets:
       - "@grpc//:grpc"
       - "@grpc//:grpc_unsecure"


### PR DESCRIPTION
Cherry-pick of https://github.com/grpc/grpc/pull/39192
