### PR TITLE
[ruby] Expose method to control the thread that initializes gRPC

### DIFF
--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -354,6 +354,13 @@ void grpc_ruby_init() {
                     "prev g_grpc_ruby_init_count:", g_grpc_ruby_init_count++);
 }
 
+// Wrapper around grpc_ruby_init that can be exposed to Ruby
+// in order to force initialization on the current thread.
+static VALUE grpc_rb_init_threads(VALUE self) {
+  grpc_ruby_init();
+  return Qnil;
+}
+
 // fork APIs, useable on linux with env var: GRPC_ENABLE_FORK_SUPPORT=1
 //
 // Must be called once and only once before forking. Must be called on the
@@ -484,6 +491,7 @@ void Init_grpc_c() {
   Init_grpc_time_consts();
   Init_grpc_compression_options();
   // define fork APIs
+  rb_define_module_function(grpc_rb_mGRPC, "init_threads", grpc_rb_init_threads, 0);
   rb_define_module_function(grpc_rb_mGRPC, "prefork", grpc_rb_prefork, 0);
   rb_define_module_function(grpc_rb_mGRPC, "postfork_child",
                             grpc_rb_postfork_child, 0);


### PR DESCRIPTION
If gRPC is lazily initialized on a different thread than the one that
calls fork it will raise.

If an app server is managing the fork calls
it also needs to be able to force the initialization of the threads
so that it can be sure both are done on the same thread.

This PR simply exposes a method to Ruby to force this initialization
so that apps don't have to resort to hacks like calling `GRPC::Core::Channel.allocate`.

This is simple test to demonstrate:
```ruby
ENV["GRPC_ENABLE_FORK_SUPPORT"] = "1"
require "grpc"

def main(init_threads)
  GRPC.init_threads if init_threads

  Thread.new do
    GRPC::Core::Channel.allocate
  end.join

  # This will raise if the thread was the first thing to initialize the GRPC threads.
  GRPC.prefork
  fork do
    GRPC.postfork_child
    exit!
  end
  GRPC.postfork_parent
  puts "yay"
end

main(ENV["INIT_THREADS"])
```

```
root@36084f9f602e:/src# ruby -I src/ruby/lib test.rb
test.rb:12:in 'GRPC.prefork': GRPC.prefork and fork need to be called from the same thread that GRPC was initialized on (GRPC lazy-initializes when when the first GRPC object is created (RuntimeError)
        from test.rb:12:in 'Object#main'
        from test.rb:21:in '<main>'

root@36084f9f602e:/src# INIT_THREADS=1 ruby -I src/ruby/lib test.rb
yay
```

What do you think?
Is `grpc_ruby_init` the best function to be wrapping here?
Does this warrant a new test?
Is `GRPC.init_threads` a good name for this?