### PR TITLE
[CMake] remove forced CONFIG mode for find_package(Protobuf)

### DIFF
--- a/examples/cpp/cmake/common.cmake
+++ b/examples/cpp/cmake/common.cmake
@@ -100,7 +100,7 @@ else()
   # Find Protobuf installation
   # Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
   option(protobuf_MODULE_COMPATIBLE TRUE)
-  find_package(Protobuf CONFIG REQUIRED)
+  find_package(Protobuf REQUIRED)
   message(STATUS "Using protobuf ${Protobuf_VERSION}")
 
   set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)


### PR DESCRIPTION
I installed gRPC and protobuf on my system (Fedora 41) via the package manager and want to build the C++ example from the repo. The CMake invocation fails because it can't find protobuf. As it turned out, this is due protobuf being searched for in config mode only, so it ignores the `FindProtobuf.cmake` module available on my system. Removing the enforced config-mode-only search fixes the issue.