### PR TITLE
Fix #17891: Replace rand() with absl::Random in gRPC C-core

### DIFF
--- a/src/core/lib/transport/bdp_estimator.cc
+++ b/src/core/lib/transport/bdp_estimator.cc
@@ -62,8 +62,9 @@ Timestamp BdpEstimator::CompletePing() {
     stable_estimate_count_++;
     if (stable_estimate_count_ >= 2) {
       // if the ping estimate is steady, slowly ramp down the probe time
+      static thread_local absl::BitGen bitgen;
       inter_ping_delay_ += Duration::Milliseconds(
-          100 + static_cast<int>(rand() * 100.0 / RAND_MAX));
+          100 + absl::uniform((bitgen, 0, 100));
     }
   }
   if (start_inter_ping_delay != inter_ping_delay_) {

--- a/src/core/lib/transport/bdp_estimator.h
+++ b/src/core/lib/transport/bdp_estimator.h
@@ -27,6 +27,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/random/random.h"
 #include "absl/strings/string_view.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/util/time.h"

--- a/src/core/resolver/dns/event_engine/service_config_helper.cc
+++ b/src/core/resolver/dns/event_engine/service_config_helper.cc
@@ -81,7 +81,8 @@ absl::StatusOr<std::string> ChooseServiceConfig(
     }
     // Check percentage, if specified.
     if (choice.percentage != -1) {
-      int random_pct = rand() % 100;
+      static thread_local absl::BitGen bitgen;
+      int random_pct = absl::uniform(bitgen, 0, 100);
       if (random_pct > choice.percentage || choice.percentage == 0) {
         continue;
       }

--- a/src/core/resolver/dns/event_engine/service_config_helper.h
+++ b/src/core/resolver/dns/event_engine/service_config_helper.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "absl/random/random.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1287,7 +1287,9 @@ grpc_error_handle Server::SetupTransport(
     }
     if (cq_idx == cqs_.size()) {
       // Completion queue not found.  Pick a random one to publish new calls to.
-      cq_idx = static_cast<size_t>(rand()) % std::max<size_t>(1, cqs_.size());
+      static thread_local absl::BitGen bitgen;
+      cq_idx =
+          absl::uniform(bitgen, size_t{0}, std::max<size_t>(1, cqs_.size()));
     }
     intptr_t channelz_socket_uuid = 0;
     if (socket_node != nullptr) {

--- a/src/core/xds/grpc/xds_routing.cc
+++ b/src/core/xds/grpc/xds_routing.cc
@@ -150,7 +150,9 @@ bool HeadersMatch(const std::vector<HeaderMatcher>& header_matchers,
 
 bool UnderFraction(const uint32_t fraction_per_million) {
   // Generate a random number in [0, 1000000).
-  const uint32_t random_number = rand() % 1000000;
+  static thread_local absl::BitGen bitgen;
+  const uint32_t random_number =
+      absl::uniform(bitgen, uint32_t{0}, uint32_t{1000000});
   return random_number < fraction_per_million;
 }
 

--- a/src/core/xds/grpc/xds_routing.h
+++ b/src/core/xds/grpc/xds_routing.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/random/random.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "src/core/call/metadata_batch.h"


### PR DESCRIPTION


Raised PR for this issue https://github.com/grpc/grpc/issues/17891, replaced rand() function in code with absl::uniform based on absl::BitGen.
Followed the approach in [Updated backoff to use absl::Random #27193](https://github.com/grpc/grpc/pull/27193)] in this PR 

