### PR TITLE
[ztrace] Limit maximum trace time, concurrency of ztraces

### DIFF
--- a/src/core/channelz/channelz.cc
+++ b/src/core/channelz/channelz.cc
@@ -78,6 +78,7 @@ void BaseNode::RunZTrace(
     std::map<std::string, std::string> args,
     std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine,
     absl::AnyInvocable<void(Json)> callback) {
+  deadline = std::min(deadline, Timestamp::Now() + Duration::Minutes(10));
   auto fail = [&callback, event_engine](absl::Status status) {
     event_engine->Run(
         [callback = std::move(callback), status = std::move(status)]() mutable {

--- a/src/core/channelz/channelz.cc
+++ b/src/core/channelz/channelz.cc
@@ -78,6 +78,8 @@ void BaseNode::RunZTrace(
     std::map<std::string, std::string> args,
     std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine,
     absl::AnyInvocable<void(Json)> callback) {
+  // Limit deadline to help contain potential resource exhaustion due to
+  // tracing.
   deadline = std::min(deadline, Timestamp::Now() + Duration::Minutes(10));
   auto fail = [&callback, event_engine](absl::Status status) {
     event_engine->Run(

--- a/src/core/channelz/ztrace_collector.h
+++ b/src/core/channelz/ztrace_collector.h
@@ -144,6 +144,7 @@ class ZTraceCollector {
       RefCountedPtr<Instance> oldest_instance;
       MutexLock lock(&impl->mu);
       if (impl->instances.size() > 20) {
+        // Eject oldest running trace
         Timestamp oldest_time = Timestamp::InfFuture();
         for (auto& instance : impl->instances) {
           if (instance->start_time < oldest_time) {

--- a/src/core/channelz/ztrace_collector.h
+++ b/src/core/channelz/ztrace_collector.h
@@ -119,6 +119,7 @@ class ZTraceCollector {
       });
     }
     Config config;
+    const Timestamp start_time = Timestamp::Now();
     std::shared_ptr<grpc_event_engine::experimental::EventEngine> event_engine;
     grpc_event_engine::experimental::EventEngine::TaskHandle task_handle{
         grpc_event_engine::experimental::EventEngine::TaskHandle::kInvalid};
@@ -140,7 +141,21 @@ class ZTraceCollector {
       auto instance = MakeRefCounted<Instance>(std::move(args), event_engine,
                                                std::move(callback));
       auto impl = std::move(impl_);
+      RefCountedPtr<Instance> oldest_instance;
       MutexLock lock(&impl->mu);
+      if (impl->instances.size() > 20) {
+        Timestamp oldest_time = Timestamp::InfFuture();
+        for (auto& instance : impl->instances) {
+          if (instance->start_time < oldest_time) {
+            oldest_time = instance->start_time;
+            oldest_instance = instance;
+          }
+        }
+        CHECK(oldest_instance != nullptr);
+        impl->instances.erase(oldest_instance);
+        oldest_instance->Finish(
+            absl::ResourceExhaustedError("Too many concurrent ztrace queries"));
+      }
       instance->task_handle = event_engine->RunAfter(
           deadline - Timestamp::Now(), [instance, impl]() {
             bool finish;

--- a/test/core/channelz/ztrace_collector_test.cc
+++ b/test/core/channelz/ztrace_collector_test.cc
@@ -159,4 +159,40 @@ TEST(ZTraceCollectorTest, EarlyTerminationWorks) {
   grpc_shutdown();
 }
 
+struct ExhaustionResult {
+  Json result;
+  Notification n;
+};
+
+TEST(ZTraceCollectorTest, ExhaustionTest) {
+  grpc_init();
+  ZTraceCollector<TestConfig, TestData> collector;
+  std::vector<std::unique_ptr<ExhaustionResult>> results;
+  for (size_t i = 0; i < 10000; i++) {
+    results.emplace_back(std::make_unique<ExhaustionResult>());
+    auto* r = results.back().get();
+    collector.MakeZTrace()->Run(
+        Timestamp::Now() + Duration::Hours(100), {{"test_arg", "test_value"}},
+        grpc_event_engine::experimental::GetDefaultEventEngine(), [r](Json j) {
+          r->result = j;
+          r->n.Notify();
+        });
+  }
+  size_t num_completed_before_finish = 0;
+  for (auto& r : results) {
+    if (r->n.HasBeenNotified()) ++num_completed_before_finish;
+  }
+  ASSERT_GT(num_completed_before_finish, 9950);
+  ASSERT_LT(num_completed_before_finish, 10000);
+  collector.Append(TestData{42});
+  for (auto& r : results) {
+    r->n.WaitForNotification();
+    ASSERT_EQ(r->result.type(), Json::Type::kObject);
+    auto status_it = r->result.object().find("status");
+    ASSERT_NE(status_it, r->result.object().end());
+    ASSERT_EQ(status_it->second.type(), Json::Type::kString);
+  }
+  grpc_shutdown();
+}
+
 }  // namespace grpc_core::channelz

--- a/test/core/channelz/ztrace_collector_test.cc
+++ b/test/core/channelz/ztrace_collector_test.cc
@@ -178,11 +178,12 @@ TEST(ZTraceCollectorTest, ExhaustionTest) {
           r->n.Notify();
         });
   }
+  absl::SleepFor(absl::Seconds(1));
   size_t num_completed_before_finish = 0;
   for (auto& r : results) {
     if (r->n.HasBeenNotified()) ++num_completed_before_finish;
   }
-  ASSERT_GT(num_completed_before_finish, 9950);
+  ASSERT_GT(num_completed_before_finish, 9000);
   ASSERT_LT(num_completed_before_finish, 10000);
   collector.Append(TestData{42});
   for (auto& r : results) {


### PR DESCRIPTION
Ensure better bounds on how much work ztrace is willing to do.