### PR TITLE
[EventEngine] Reduce likelihood of busy loop in work stealing lifeguard shutdown due to quiesced flag

### DIFF
--- a/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
+++ b/src/core/lib/event_engine/thread_pool/work_stealing_thread_pool.h
@@ -136,6 +136,7 @@ class WorkStealingThreadPool final : public ThreadPool {
     bool IsShutdown();
     bool IsForking();
     bool IsQuiesced();
+    void WaitQuiesced();
     size_t reserve_threads() { return reserve_threads_; }
     BusyThreadCount* busy_thread_count() { return &busy_thread_count_; }
     LivingThreadCount* living_thread_count() { return &living_thread_count_; }
@@ -192,6 +193,8 @@ class WorkStealingThreadPool final : public ThreadPool {
     // Set of threads for verbose failure debugging
     grpc_core::Mutex thd_set_mu_;
     absl::flat_hash_set<gpr_thd_id> thds_ ABSL_GUARDED_BY(thd_set_mu_);
+    grpc_core::BackOff backoff_;
+    std::unique_ptr<grpc_core::Notification> lifeguard_is_quiesced_;
   };
 
   class ThreadState {


### PR DESCRIPTION
Reduce likelihood of busy loop in work stealing lifeguard shutdown due to "quiesced" flag.

## Rationale

A busy loop seems to exist when `pool_->IsShutdown()==true and pool_->IsQuiesced()==false`:

```
void WorkStealingThreadPool::WorkStealingThreadPoolImpl::Lifeguard::
    LifeguardMain() {
  while (true) {
    if (pool_->IsForking()) break;
    // If the pool is shut down, loop quickly until quiesced. Otherwise,
    // reduce the check rate if the pool is idle.
    if (pool_->IsShutdown()) {
      if (pool_->IsQuiesced()) break;
...
  }
```

^^^^The "else" branch leads to a **busy loop until the flag is triggered**. This can consume up to several minutes of CPU typically under valgrind.

This PR attempts to fix this busy loop by introducing a notification mechanism similar to the one previously introduced in https://github.com/grpc/grpc/pull/33386
