### PR TITLE
[event_engine] Introduce PosixEventEngine factory

### DIFF
--- a/src/core/lib/event_engine/default_event_engine_factory.cc
+++ b/src/core/lib/event_engine/default_event_engine_factory.cc
@@ -45,7 +45,7 @@ std::shared_ptr<EventEngine> DefaultEventEngineFactory() {
 namespace grpc_event_engine::experimental {
 
 std::shared_ptr<EventEngine> DefaultEventEngineFactory() {
-  return std::make_shared<PosixEventEngine>();
+  return PosixEventEngine::MakePosixEventEngine();
 }
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -358,9 +358,10 @@ std::shared_ptr<PosixEventEngine> PosixEventEngine::MakePosixEventEngine() {
 }
 
 #ifdef GRPC_POSIX_SOCKET_TCP
+
 // The posix EventEngine returned by this method would have a shared ownership
 // of the poller and would not be in-charge of driving the poller by calling
-// its Work(..) method. Instead its upto the test to drive the poller. The
+// its Work(..) method. Instead its up to the test to drive the poller. The
 // returned posix EventEngine will also not attempt to shutdown the poller
 // since it does not own it.
 std::shared_ptr<PosixEventEngine>

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -150,18 +150,7 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport,
     grpc_core::OrphanablePtr<RefCountedDNSResolverInterface> dns_resolver_;
   };
 
-#ifdef GRPC_POSIX_SOCKET_TCP
-  // Constructs an EventEngine which has a shared ownership of the poller. Do
-  // not call this constructor directly. Instead use the
-  // MakeTestOnlyPosixEventEngine static method. Its expected to be used only in
-  // tests.
-  explicit PosixEventEngine(
-      std::shared_ptr<grpc_event_engine::experimental::PosixEventPoller>
-          poller);
-  PosixEventEngine();
-#else   // GRPC_POSIX_SOCKET_TCP
-  PosixEventEngine();
-#endif  // GRPC_POSIX_SOCKET_TCP
+  static std::shared_ptr<PosixEventEngine> MakePosixEventEngine();
 
   ~PosixEventEngine() override;
 
@@ -216,13 +205,24 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport,
   // since it does not own it.
   static std::shared_ptr<PosixEventEngine> MakeTestOnlyPosixEventEngine(
       std::shared_ptr<grpc_event_engine::experimental::PosixEventPoller>
-          test_only_poller) {
-    return std::make_shared<PosixEventEngine>(std::move(test_only_poller));
-  }
+          test_only_poller);
 #endif  // GRPC_POSIX_SOCKET_TCP
 
  private:
   struct ClosureData;
+
+  PosixEventEngine();
+
+#ifdef GRPC_POSIX_SOCKET_TCP
+  // Constructs an EventEngine which has a shared ownership of the poller. Do
+  // not call this constructor directly. Instead use the
+  // MakeTestOnlyPosixEventEngine static method. Its expected to be used only in
+  // tests.
+  explicit PosixEventEngine(
+      std::shared_ptr<grpc_event_engine::experimental::PosixEventPoller>
+          poller);
+#endif  // GRPC_POSIX_SOCKET_TCP
+
   EventEngine::TaskHandle RunAfterInternal(Duration when,
                                            absl::AnyInvocable<void()> cb);
 

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -373,12 +373,9 @@ void WaitAndShutdown(server* sv, client* cl) {
 
 class EventPollerTest : public ::testing::Test {
   void SetUp() override {
-    engine_ = grpc_event_engine::experimental::PosixEventEngine::
-        MakePosixEventEngine();
+    engine_ = PosixEventEngine::MakePosixEventEngine();
     EXPECT_NE(engine_, nullptr);
-    scheduler_ =
-        std::make_unique<grpc_event_engine::experimental::TestScheduler>(
-            engine_.get());
+    scheduler_ = std::make_unique<TestScheduler>(engine_.get());
     EXPECT_NE(scheduler_, nullptr);
     g_event_poller = MakeDefaultPoller(scheduler_.get());
     engine_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(g_event_poller);
@@ -399,8 +396,8 @@ class EventPollerTest : public ::testing::Test {
   TestScheduler* Scheduler() { return scheduler_.get(); }
 
  private:
-  std::shared_ptr<grpc_event_engine::experimental::PosixEventEngine> engine_;
-  std::unique_ptr<grpc_event_engine::experimental::TestScheduler> scheduler_;
+  std::shared_ptr<PosixEventEngine> engine_;
+  std::unique_ptr<TestScheduler> scheduler_;
 };
 
 // Test grpc_fd. Start an upload server and client, upload a stream of bytes

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -373,8 +373,8 @@ void WaitAndShutdown(server* sv, client* cl) {
 
 class EventPollerTest : public ::testing::Test {
   void SetUp() override {
-    engine_ =
-        std::make_unique<grpc_event_engine::experimental::PosixEventEngine>();
+    engine_ = grpc_event_engine::experimental::PosixEventEngine::
+        MakePosixEventEngine();
     EXPECT_NE(engine_, nullptr);
     scheduler_ =
         std::make_unique<grpc_event_engine::experimental::TestScheduler>(

--- a/test/core/event_engine/posix/posix_event_engine_connect_test.cc
+++ b/test/core/event_engine/posix/posix_event_engine_connect_test.cc
@@ -146,7 +146,8 @@ TEST(PosixEventEngineTest, IndefiniteConnectTimeoutOrRstTest) {
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
   CHECK_OK(resolved_addr);
-  std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
+  std::shared_ptr<EventEngine> posix_ee =
+      PosixEventEngine::MakePosixEventEngine();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();
   auto sockets = CreateConnectedSockets(*resolved_addr);
@@ -175,7 +176,8 @@ TEST(PosixEventEngineTest, IndefiniteConnectCancellationTest) {
       "ipv6:[::1]:", std::to_string(grpc_pick_unused_port_or_die()));
   auto resolved_addr = URIToResolvedAddress(target_addr);
   CHECK_OK(resolved_addr);
-  std::shared_ptr<EventEngine> posix_ee = std::make_shared<PosixEventEngine>();
+  std::shared_ptr<EventEngine> posix_ee =
+      PosixEventEngine::MakePosixEventEngine();
   std::string resolved_addr_str =
       ResolvedAddressToNormalizedString(*resolved_addr).value();
   auto sockets = CreateConnectedSockets(*resolved_addr);

--- a/test/core/event_engine/test_suite/posix_event_engine_native_dns_test.cc
+++ b/test/core/event_engine/test_suite/posix_event_engine_native_dns_test.cc
@@ -30,8 +30,8 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   SetEventEngineFactories(
       []() {
-        return std::make_unique<
-            grpc_event_engine::experimental::PosixEventEngine>();
+        return grpc_event_engine::experimental::PosixEventEngine::
+            MakePosixEventEngine();
       },
       []() {
         return std::make_unique<

--- a/test/core/event_engine/test_suite/posix_event_engine_test.cc
+++ b/test/core/event_engine/test_suite/posix_event_engine_test.cc
@@ -29,8 +29,8 @@ int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   SetEventEngineFactories(
       []() {
-        return std::make_unique<
-            grpc_event_engine::experimental::PosixEventEngine>();
+        return grpc_event_engine::experimental::PosixEventEngine::
+            MakePosixEventEngine();
       },
       []() {
         return std::make_unique<

--- a/test/core/event_engine/test_suite/thready_posix_event_engine_test.cc
+++ b/test/core/event_engine/test_suite/thready_posix_event_engine_test.cc
@@ -32,8 +32,8 @@ int main(int argc, char** argv) {
       []() {
         return std::make_unique<
             grpc_event_engine::experimental::ThreadyEventEngine>(
-            std::make_unique<
-                grpc_event_engine::experimental::PosixEventEngine>());
+            grpc_event_engine::experimental::PosixEventEngine::
+                MakePosixEventEngine());
       },
       []() {
         return std::make_unique<

--- a/test/core/event_engine/test_suite/tools/echo_client.cc
+++ b/test/core/event_engine/test_suite/tools/echo_client.cc
@@ -56,7 +56,7 @@
 #include "src/core/util/notification.h"
 
 extern absl::AnyInvocable<
-    std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
+    std::shared_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory();
 
 ABSL_FLAG(std::string, target, "ipv4:127.0.0.1:50051", "Target string");

--- a/test/core/event_engine/test_suite/tools/posix_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/posix_event_engine_factory.cc
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include "absl/functional/any_invocable.h"
-#include "absl/log/check.h"
+#include "absl/log/check.h"  // IWYU pragma: keep
 #include "src/core/lib/iomgr/port.h"
 
 #ifdef GRPC_POSIX_SOCKET_TCP
@@ -26,11 +26,11 @@
 #include "src/core/lib/event_engine/posix_engine/posix_engine.h"
 
 absl::AnyInvocable<
-    std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
+    std::shared_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
   return []() {
-    return std::make_unique<
-        grpc_event_engine::experimental::PosixEventEngine>();
+    return grpc_event_engine::experimental::PosixEventEngine::
+        MakePosixEventEngine();
   };
 }
 

--- a/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
+++ b/test/core/event_engine/test_suite/tools/windows_event_engine_factory.cc
@@ -25,10 +25,10 @@
 #include "src/core/lib/event_engine/windows/windows_engine.h"
 
 absl::AnyInvocable<
-    std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
+    std::shared_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
   return []() {
-    return std::make_unique<
+    return std::make_shared<
         grpc_event_engine::experimental::WindowsEventEngine>();
   };
 }
@@ -36,7 +36,7 @@ CustomEventEngineFactory() {
 #else
 
 absl::AnyInvocable<
-    std::unique_ptr<grpc_event_engine::experimental::EventEngine>(void)>
+    std::shared_ptr<grpc_event_engine::experimental::EventEngine>(void)>
 CustomEventEngineFactory() {
   CHECK(false) << "This tool was not built for Windows.";
 }


### PR DESCRIPTION
Fork support will need to register each PEE instance with the fork handler. This will be done after the shared pointer was created so we need a factory method.