### PR TITLE
[bloat] Add a compile time option to remove ztraces from the build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -58,6 +58,11 @@ config_setting(
 )
 
 config_setting(
+    name = "grpc_no_ztrace_define",
+    values = {"define": "grpc_no_ztrace=true"},
+)
+
+config_setting(
     name = "grpc_experiments_are_final_define",
     values = {"define": "grpc_experiments_are_final=true"},
 )
@@ -121,6 +126,19 @@ selects.config_setting_group(
     match_any = [
         ":grpc_no_xds_define",
         # In addition to disabling XDS support when --define=grpc_no_xds=true is
+        # specified, we also disable it on mobile platforms where it is not
+        # likely to be needed and where reducing the binary size is more
+        # important.
+        ":android",
+        ":ios",
+    ],
+)
+
+selects.config_setting_group(
+    name = "grpc_no_ztrace",
+    match_any = [
+        ":grpc_no_ztrace_define",
+        # In addition to disabling ztrace support when --define=grpc_no_ztrace=true is
         # specified, we also disable it on mobile platforms where it is not
         # likely to be needed and where reducing the binary size is more
         # important.

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -9448,6 +9448,10 @@ grpc_cc_library(
     external_deps = [
         "absl/container:flat_hash_set",
     ],
+    defines = select({
+        "//:grpc_no_ztrace": ["GRPC_NO_ZTRACE"],
+        "//conditions:default": [],
+    }),
     deps = [
         "single_set_ptr",
         "sync",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -9445,13 +9445,13 @@ grpc_cc_library(
 grpc_cc_library(
     name = "ztrace_collector",
     hdrs = ["channelz/ztrace_collector.h"],
-    external_deps = [
-        "absl/container:flat_hash_set",
-    ],
     defines = select({
         "//:grpc_no_ztrace": ["GRPC_NO_ZTRACE"],
         "//conditions:default": [],
     }),
+    external_deps = [
+        "absl/container:flat_hash_set",
+    ],
     deps = [
         "single_set_ptr",
         "sync",

--- a/src/core/channelz/ztrace_collector.h
+++ b/src/core/channelz/ztrace_collector.h
@@ -28,10 +28,8 @@
 #include "src/core/util/sync.h"
 #include "src/core/util/time.h"
 
-namespace grpc_core::channelz {
-
 #ifdef GRPC_NO_ZTRACE
-
+namespace grpc_core::channelz {
 namespace ztrace_collector_detail {
 class ZTraceImpl final : public ZTrace {
  public:
@@ -60,12 +58,13 @@ class StubImpl {
 
 template <typename...>
 class ZTraceCollector : public ztrace_collector_detail::StubImpl {};
-
+}  // namespace grpc_core::channelz
 #else
+namespace grpc_core::channelz {
 namespace ztrace_collector_detail {
 
 template <typename T>
-using Collection = std::deque<std::pair<gpr_cycle_counter, T>>;
+using Collection = std::deque<std::pair<gpr_cycle_counter, T> >;
 
 template <typename T>
 void AppendResults(const Collection<T>& data, Json::Array& results) {
@@ -159,7 +158,7 @@ class ZTraceCollector {
     void Append(std::pair<gpr_cycle_counter, T> value) {
       memory_used_ += value.second.MemoryUsage();
       while (memory_used_ > memory_cap_) RemoveMostRecent();
-      std::get<Collection<T>>(data).push_back(std::move(value));
+      std::get<Collection<T> >(data).push_back(std::move(value));
     }
     void RemoveMostRecent() {
       RemoveMostRecentState state;
@@ -169,12 +168,12 @@ class ZTraceCollector {
     }
     template <typename T>
     void UpdateRemoveMostRecentState(RemoveMostRecentState* state) {
-      auto& collection = std::get<Collection<T>>(data);
+      auto& collection = std::get<Collection<T> >(data);
       if (collection.empty()) return;
       if (state->enact == nullptr ||
           collection.front().first > state->most_recent) {
         state->enact = +[](Instance* instance) {
-          auto& collection = std::get<Collection<T>>(instance->data);
+          auto& collection = std::get<Collection<T> >(instance->data);
           const size_t ent_usage = collection.front().second.MemoryUsage();
           CHECK_GE(instance->memory_used_, ent_usage);
           instance->memory_used_ -= ent_usage;
@@ -189,7 +188,7 @@ class ZTraceCollector {
                          memory_used = memory_used_]() mutable {
         Json::Array entries;
         (ztrace_collector_detail::AppendResults(
-             std::get<Collection<Data>>(data), entries),
+             std::get<Collection<Data> >(data), entries),
          ...);
         Json::Object result;
         result["entries"] = Json::FromArray(entries);
@@ -211,7 +210,7 @@ class ZTraceCollector {
   };
   struct Impl : public RefCounted<Impl> {
     Mutex mu;
-    absl::flat_hash_set<RefCountedPtr<Instance>> instances ABSL_GUARDED_BY(mu);
+    absl::flat_hash_set<RefCountedPtr<Instance> > instances ABSL_GUARDED_BY(mu);
   };
   class ZTraceImpl final : public ZTrace {
    public:
@@ -276,7 +275,7 @@ class ZTraceCollector {
           }
         } break;
         default: {
-          std::vector<RefCountedPtr<Instance>> finished;
+          std::vector<RefCountedPtr<Instance> > finished;
           for (auto& instance : impl->instances) {
             const bool finishes = instance->config.Finishes(value.second);
             instance->Append(value);
@@ -295,8 +294,7 @@ class ZTraceCollector {
 
   SingleSetRefCountedPtr<Impl> impl_;
 };
-#endif  // GRPC_NO_ZTRACE
-
 }  // namespace grpc_core::channelz
+#endif  // GRPC_NO_ZTRACE
 
 #endif  // GRPC_SRC_CORE_CHANNELZ_ZTRACE_COLLECTOR_H

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -110,7 +110,9 @@ subprocess.check_call(
     ["cmake", "-G", "Unix Makefiles", "../third_party/bloaty"],
     cwd="bloaty-build",
 )
-subprocess.check_call("make -j%d bloaty" % args.jobs, shell=True, cwd="bloaty-build")
+subprocess.check_call(
+    "make -j%d bloaty" % args.jobs, shell=True, cwd="bloaty-build"
+)
 
 text = ""
 diff_size = 0

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -110,7 +110,7 @@ subprocess.check_call(
     ["cmake", "-G", "Unix Makefiles", "../third_party/bloaty"],
     cwd="bloaty-build",
 )
-subprocess.check_call("make -j%d" % args.jobs, shell=True, cwd="bloaty-build")
+subprocess.check_call("make -j%d bloaty" % args.jobs, shell=True, cwd="bloaty-build")
 
 text = ""
 diff_size = 0


### PR DESCRIPTION
These can be reasonably heavy-weight right now, and we don't need them on mobile platforms.