### PR TITLE
[shared-bit-gen] Stop using inline static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2924,6 +2924,7 @@ add_library(grpc
   src/core/util/posix/directory_reader.cc
   src/core/util/random_early_detection.cc
   src/core/util/ref_counted_string.cc
+  src/core/util/shared_bit_gen.cc
   src/core/util/status_helper.cc
   src/core/util/time.cc
   src/core/util/time_averaged_stats.cc
@@ -3645,6 +3646,7 @@ add_library(grpc_unsecure
   src/core/util/per_cpu.cc
   src/core/util/random_early_detection.cc
   src/core/util/ref_counted_string.cc
+  src/core/util/shared_bit_gen.cc
   src/core/util/status_helper.cc
   src/core/util/time.cc
   src/core/util/time_averaged_stats.cc
@@ -5902,6 +5904,7 @@ add_library(grpc_authorization_provider
   src/core/util/matchers.cc
   src/core/util/per_cpu.cc
   src/core/util/ref_counted_string.cc
+  src/core/util/shared_bit_gen.cc
   src/core/util/status_helper.cc
   src/core/util/time.cc
   src/core/util/time_averaged_stats.cc
@@ -9548,6 +9551,7 @@ add_executable(call_utils_test
   src/core/util/load_file.cc
   src/core/util/per_cpu.cc
   src/core/util/ref_counted_string.cc
+  src/core/util/shared_bit_gen.cc
   src/core/util/status_helper.cc
   src/core/util/time.cc
   src/core/util/time_averaged_stats.cc
@@ -15634,6 +15638,7 @@ add_executable(filter_fusion_test
   src/core/util/load_file.cc
   src/core/util/per_cpu.cc
   src/core/util/ref_counted_string.cc
+  src/core/util/shared_bit_gen.cc
   src/core/util/status_helper.cc
   src/core/util/time.cc
   src/core/util/time_averaged_stats.cc
@@ -27050,6 +27055,7 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(shared_bit_gen_test
+  src/core/util/shared_bit_gen.cc
   test/core/util/shared_bit_gen_test.cc
 )
 target_compile_features(shared_bit_gen_test PUBLIC cxx_std_17)

--- a/Makefile
+++ b/Makefile
@@ -1474,6 +1474,7 @@ LIBGRPC_SRC = \
     src/core/util/posix/tmpfile.cc \
     src/core/util/random_early_detection.cc \
     src/core/util/ref_counted_string.cc \
+    src/core/util/shared_bit_gen.cc \
     src/core/util/status_helper.cc \
     src/core/util/strerror.cc \
     src/core/util/string.cc \

--- a/Package.swift
+++ b/Package.swift
@@ -1959,6 +1959,7 @@ let package = Package(
         "src/core/util/ref_counted_string.cc",
         "src/core/util/ref_counted_string.h",
         "src/core/util/ring_buffer.h",
+        "src/core/util/shared_bit_gen.cc",
         "src/core/util/shared_bit_gen.h",
         "src/core/util/single_set_ptr.h",
         "src/core/util/sorted_pack.h",

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2047,6 +2047,7 @@ libs:
   - src/core/util/posix/directory_reader.cc
   - src/core/util/random_early_detection.cc
   - src/core/util/ref_counted_string.cc
+  - src/core/util/shared_bit_gen.cc
   - src/core/util/status_helper.cc
   - src/core/util/time.cc
   - src/core/util/time_averaged_stats.cc
@@ -3161,6 +3162,7 @@ libs:
   - src/core/util/per_cpu.cc
   - src/core/util/random_early_detection.cc
   - src/core/util/ref_counted_string.cc
+  - src/core/util/shared_bit_gen.cc
   - src/core/util/status_helper.cc
   - src/core/util/time.cc
   - src/core/util/time_averaged_stats.cc
@@ -4952,6 +4954,7 @@ libs:
   - src/core/util/matchers.cc
   - src/core/util/per_cpu.cc
   - src/core/util/ref_counted_string.cc
+  - src/core/util/shared_bit_gen.cc
   - src/core/util/status_helper.cc
   - src/core/util/time.cc
   - src/core/util/time_averaged_stats.cc
@@ -6748,6 +6751,7 @@ targets:
   - src/core/util/load_file.cc
   - src/core/util/per_cpu.cc
   - src/core/util/ref_counted_string.cc
+  - src/core/util/shared_bit_gen.cc
   - src/core/util/status_helper.cc
   - src/core/util/time.cc
   - src/core/util/time_averaged_stats.cc
@@ -10812,6 +10816,7 @@ targets:
   - src/core/util/load_file.cc
   - src/core/util/per_cpu.cc
   - src/core/util/ref_counted_string.cc
+  - src/core/util/shared_bit_gen.cc
   - src/core/util/status_helper.cc
   - src/core/util/time.cc
   - src/core/util/time_averaged_stats.cc
@@ -15464,6 +15469,7 @@ targets:
   headers:
   - src/core/util/shared_bit_gen.h
   src:
+  - src/core/util/shared_bit_gen.cc
   - test/core/util/shared_bit_gen_test.cc
   deps:
   - gtest

--- a/config.m4
+++ b/config.m4
@@ -848,6 +848,7 @@ if test "$PHP_GRPC" != "no"; then
     src/core/util/posix/tmpfile.cc \
     src/core/util/random_early_detection.cc \
     src/core/util/ref_counted_string.cc \
+    src/core/util/shared_bit_gen.cc \
     src/core/util/status_helper.cc \
     src/core/util/strerror.cc \
     src/core/util/string.cc \

--- a/config.w32
+++ b/config.w32
@@ -813,6 +813,7 @@ if (PHP_GRPC != "no") {
     "src\\core\\util\\posix\\tmpfile.cc " +
     "src\\core\\util\\random_early_detection.cc " +
     "src\\core\\util\\ref_counted_string.cc " +
+    "src\\core\\util\\shared_bit_gen.cc " +
     "src\\core\\util\\status_helper.cc " +
     "src\\core\\util\\strerror.cc " +
     "src\\core\\util\\string.cc " +

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -2075,6 +2075,7 @@ Pod::Spec.new do |s|
                       'src/core/util/ref_counted_string.cc',
                       'src/core/util/ref_counted_string.h',
                       'src/core/util/ring_buffer.h',
+                      'src/core/util/shared_bit_gen.cc',
                       'src/core/util/shared_bit_gen.h',
                       'src/core/util/single_set_ptr.h',
                       'src/core/util/sorted_pack.h',

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -1961,6 +1961,7 @@ Gem::Specification.new do |s|
   s.files += %w( src/core/util/ref_counted_string.cc )
   s.files += %w( src/core/util/ref_counted_string.h )
   s.files += %w( src/core/util/ring_buffer.h )
+  s.files += %w( src/core/util/shared_bit_gen.cc )
   s.files += %w( src/core/util/shared_bit_gen.h )
   s.files += %w( src/core/util/single_set_ptr.h )
   s.files += %w( src/core/util/sorted_pack.h )

--- a/package.xml
+++ b/package.xml
@@ -1943,6 +1943,7 @@
     <file baseinstalldir="/" name="src/core/util/ref_counted_string.cc" role="src" />
     <file baseinstalldir="/" name="src/core/util/ref_counted_string.h" role="src" />
     <file baseinstalldir="/" name="src/core/util/ring_buffer.h" role="src" />
+    <file baseinstalldir="/" name="src/core/util/shared_bit_gen.cc" role="src" />
     <file baseinstalldir="/" name="src/core/util/shared_bit_gen.h" role="src" />
     <file baseinstalldir="/" name="src/core/util/single_set_ptr.h" role="src" />
     <file baseinstalldir="/" name="src/core/util/sorted_pack.h" role="src" />

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -6237,6 +6237,9 @@ grpc_cc_library(
 
 grpc_cc_library(
     name = "shared_bit_gen",
+    srcs = [
+        "util/shared_bit_gen.cc",
+    ],
     hdrs = [
         "util/shared_bit_gen.h",
     ],

--- a/src/core/util/shared_bit_gen.cc
+++ b/src/core/util/shared_bit_gen.cc
@@ -1,0 +1,21 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/util/shared_bit_gen.h"
+
+namespace grpc_core {
+
+thread_local absl::BitGen SharedBitGen::bit_gen_;
+
+}  // namespace grpc_core

--- a/src/core/util/shared_bit_gen.h
+++ b/src/core/util/shared_bit_gen.h
@@ -36,7 +36,7 @@ class SharedBitGen {
  private:
   // TODO(ctiller): Perhaps use per-cpu storage? Would add additional overhead
   // for the mutex acquisition.
-  static inline thread_local absl::BitGen bit_gen_;
+  static thread_local absl::BitGen bit_gen_;
 };
 
 }  // namespace grpc_core

--- a/src/python/grpcio/grpc_core_dependencies.py
+++ b/src/python/grpcio/grpc_core_dependencies.py
@@ -823,6 +823,7 @@ CORE_SOURCE_FILES = [
     'src/core/util/posix/tmpfile.cc',
     'src/core/util/random_early_detection.cc',
     'src/core/util/ref_counted_string.cc',
+    'src/core/util/shared_bit_gen.cc',
     'src/core/util/status_helper.cc',
     'src/core/util/strerror.cc',
     'src/core/util/string.cc',

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -2928,6 +2928,7 @@ src/core/util/ref_counted_ptr.h \
 src/core/util/ref_counted_string.cc \
 src/core/util/ref_counted_string.h \
 src/core/util/ring_buffer.h \
+src/core/util/shared_bit_gen.cc \
 src/core/util/shared_bit_gen.h \
 src/core/util/single_set_ptr.h \
 src/core/util/sorted_pack.h \

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -2742,6 +2742,7 @@ src/core/util/ref_counted_ptr.h \
 src/core/util/ref_counted_string.cc \
 src/core/util/ref_counted_string.h \
 src/core/util/ring_buffer.h \
+src/core/util/shared_bit_gen.cc \
 src/core/util/shared_bit_gen.h \
 src/core/util/single_set_ptr.h \
 src/core/util/sorted_pack.h \


### PR DESCRIPTION
Possibly avoid Ruby binding mis-compile




