### PR TITLE
[tracing] Make sampling bit non-virtual

### DIFF
--- a/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h
+++ b/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h
@@ -33,7 +33,7 @@ namespace grpc_core {
 class Chttp2CallTracerWrapper final : public CallTracerInterface {
  public:
   explicit Chttp2CallTracerWrapper(grpc_chttp2_stream* stream)
-      : stream_(stream) {}
+      : CallTracerInterface(false), stream_(stream) {}
 
   void RecordIncomingBytes(
       const TransportByteSize& transport_byte_size) override;
@@ -59,7 +59,6 @@ class Chttp2CallTracerWrapper final : public CallTracerInterface {
   void RecordAnnotation(const Annotation& /*annotation*/) override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 
  private:
   grpc_chttp2_stream* stream_;

--- a/src/core/telemetry/call_tracer.cc
+++ b/src/core/telemetry/call_tracer.cc
@@ -87,7 +87,7 @@ class DelegatingClientCallTracer : public ClientCallTracer {
     explicit DelegatingClientCallAttemptTracer(
         std::vector<CallAttemptTracer*> tracers)
         : ClientCallTracer::CallAttemptTracer(
-              std::all_of(tracers.begin(), tracers.end(),
+              std::any_of(tracers.begin(), tracers.end(),
                           [](ClientCallTracer::CallAttemptTracer* p) {
                             return p->IsSampled();
                           })),


### PR DESCRIPTION
We can do a bunch of optimization in not presenting data to call tracers if it's not needed, but we need to know that.

First steps: make the IsSampled() function inlinable, non-virtual.
