### PR TITLE
[metrics] Make IsSampled() inline-able

### DIFF
--- a/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h
+++ b/src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h
@@ -59,7 +59,6 @@ class Chttp2CallTracerWrapper final : public CallTracerInterface {
   void RecordAnnotation(const Annotation& /*annotation*/) override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 
  private:
   grpc_chttp2_stream* stream_;

--- a/src/core/telemetry/call_tracer.cc
+++ b/src/core/telemetry/call_tracer.cc
@@ -86,6 +86,11 @@ class DelegatingClientCallTracer : public ClientCallTracer {
     explicit DelegatingClientCallAttemptTracer(
         std::vector<CallAttemptTracer*> tracers)
         : tracers_(std::move(tracers)) {
+      if (std::any_of(
+              tracers_.begin(), tracers_.end(),
+              [](CallAttemptTracer* tracer) { return tracer->IsSampled(); })) {
+        set_sampled();
+      }
       DCHECK(!tracers_.empty());
     }
     ~DelegatingClientCallAttemptTracer() override {}
@@ -180,7 +185,6 @@ class DelegatingClientCallTracer : public ClientCallTracer {
     }
     std::string TraceId() override { return tracers_[0]->TraceId(); }
     std::string SpanId() override { return tracers_[0]->SpanId(); }
-    bool IsSampled() override { return tracers_[0]->IsSampled(); }
     bool IsDelegatingTracer() override { return true; }
 
    private:
@@ -191,7 +195,13 @@ class DelegatingClientCallTracer : public ClientCallTracer {
     std::vector<CallAttemptTracer*> tracers_;
   };
   explicit DelegatingClientCallTracer(ClientCallTracer* tracer)
-      : tracers_{tracer} {}
+      : tracers_{tracer} {
+    if (std::any_of(
+            tracers_.begin(), tracers_.end(),
+            [](ClientCallTracer* tracer) { return tracer->IsSampled(); })) {
+      set_sampled();
+    }
+  }
   ~DelegatingClientCallTracer() override {}
   CallAttemptTracer* StartNewAttempt(bool is_transparent_retry) override {
     std::vector<CallAttemptTracer*> attempt_tracers;
@@ -217,7 +227,6 @@ class DelegatingClientCallTracer : public ClientCallTracer {
   }
   std::string TraceId() override { return tracers_[0]->TraceId(); }
   std::string SpanId() override { return tracers_[0]->SpanId(); }
-  bool IsSampled() override { return tracers_[0]->IsSampled(); }
   bool IsDelegatingTracer() override { return true; }
 
   // There is no additional synchronization needed since filters/interceptors
@@ -233,7 +242,13 @@ class DelegatingClientCallTracer : public ClientCallTracer {
 class DelegatingServerCallTracer : public ServerCallTracer {
  public:
   explicit DelegatingServerCallTracer(ServerCallTracer* tracer)
-      : tracers_{tracer} {}
+      : tracers_{tracer} {
+    if (std::any_of(
+            tracers_.begin(), tracers_.end(),
+            [](ServerCallTracer* tracer) { return tracer->IsSampled(); })) {
+      set_sampled();
+    }
+  }
   ~DelegatingServerCallTracer() override {}
   void RecordSendInitialMetadata(
       grpc_metadata_batch* send_initial_metadata) override {
@@ -316,7 +331,6 @@ class DelegatingServerCallTracer : public ServerCallTracer {
   std::shared_ptr<TcpCallTracer> StartNewTcpTrace() override { return nullptr; }
   std::string TraceId() override { return tracers_[0]->TraceId(); }
   std::string SpanId() override { return tracers_[0]->SpanId(); }
-  bool IsSampled() override { return tracers_[0]->IsSampled(); }
   bool IsDelegatingTracer() override { return true; }
 
   void AddTracer(ServerCallTracer* tracer) { tracers_.push_back(tracer); }

--- a/src/core/telemetry/call_tracer.h
+++ b/src/core/telemetry/call_tracer.h
@@ -78,11 +78,18 @@ class CallTracerAnnotationInterface {
   virtual void RecordAnnotation(const Annotation& annotation) = 0;
   virtual std::string TraceId() = 0;
   virtual std::string SpanId() = 0;
-  virtual bool IsSampled() = 0;
   // Indicates whether this tracer is a delegating tracer or not.
   // `DelegatingClientCallTracer`, `DelegatingClientCallAttemptTracer` and
   // `DelegatingServerCallTracer` are the only delegating call tracers.
   virtual bool IsDelegatingTracer() { return false; }
+
+  bool IsSampled() { return is_sampled_; }
+
+ protected:
+  void set_sampled() { is_sampled_ = true; }
+
+ private:
+  bool is_sampled_ = false;
 };
 
 // The base class for CallAttemptTracer and ServerCallTracer.

--- a/src/cpp/ext/filters/census/client_filter.cc
+++ b/src/cpp/ext/filters/census/client_filter.cc
@@ -118,6 +118,7 @@ OpenCensusCallTracer::OpenCensusCallAttemptTracer::OpenCensusCallAttemptTracer(
       arena_allocated_(arena_allocated),
       context_(parent_->CreateCensusContextForCallAttempt()),
       start_time_(absl::Now()) {
+  if (context_.Span().IsSampled()) set_sampled();
   if (parent_->tracing_enabled_) {
     context_.AddSpanAttribute("previous-rpc-attempts", attempt_num);
     context_.AddSpanAttribute("transparent-retry", is_transparent_retry);
@@ -323,6 +324,7 @@ OpenCensusCallTracer::OpenCensusCallTracer(grpc_core::Slice path,
   GenerateClientContext(tracing_enabled_ ? absl::StrCat("Sent.", method_) : "",
                         &context_,
                         (parent_context == nullptr) ? nullptr : parent_context);
+  if (context_.Span().IsSampled()) set_sampled();
 }
 
 OpenCensusCallTracer::~OpenCensusCallTracer() {

--- a/src/cpp/ext/filters/census/open_census_call_tracer.h
+++ b/src/cpp/ext/filters/census/open_census_call_tracer.h
@@ -77,8 +77,6 @@ class OpenCensusCallTracer : public grpc_core::ClientCallTracer {
       return context_.Context().span_id().ToHex();
     }
 
-    bool IsSampled() override { return context_.Span().IsSampled(); }
-
     void RecordSendInitialMetadata(
         grpc_metadata_batch* send_initial_metadata) override;
     void RecordSendTrailingMetadata(
@@ -140,8 +138,6 @@ class OpenCensusCallTracer : public grpc_core::ClientCallTracer {
   }
 
   std::string SpanId() override { return context_.Context().span_id().ToHex(); }
-
-  bool IsSampled() override { return context_.Span().IsSampled(); }
 
   void GenerateContext();
   OpenCensusCallAttemptTracer* StartNewAttempt(

--- a/src/cpp/ext/filters/census/server_call_tracer.cc
+++ b/src/cpp/ext/filters/census/server_call_tracer.cc
@@ -108,8 +108,6 @@ class OpenCensusServerCallTracer : public grpc_core::ServerCallTracer {
 
   std::string SpanId() override { return context_.Context().span_id().ToHex(); }
 
-  bool IsSampled() override { return context_.Span().IsSampled(); }
-
   // Please refer to `grpc_transport_stream_op_batch_payload` for details on
   // arguments.
   void RecordSendInitialMetadata(
@@ -216,6 +214,7 @@ void OpenCensusServerCallTracer::RecordReceivedInitialMetadata(
   GenerateServerContext(
       tracing_enabled ? sml.tracing_slice.as_string_view() : "",
       absl::StrCat("Recv.", method_), &context_);
+  if (context_.Span().IsSampled()) set_sampled();
   if (tracing_enabled) {
     grpc_core::SetContext<census_context>(
         reinterpret_cast<census_context*>(&context_));

--- a/src/cpp/ext/otel/otel_client_call_tracer.h
+++ b/src/cpp/ext/otel/otel_client_call_tracer.h
@@ -65,11 +65,6 @@ class OpenTelemetryPluginImpl::ClientCallTracer
       return "";
     }
 
-    bool IsSampled() override {
-      // Not implemented
-      return false;
-    }
-
     void RecordSendInitialMetadata(
         grpc_metadata_batch* send_initial_metadata) override;
     void RecordSendTrailingMetadata(
@@ -137,11 +132,6 @@ class OpenTelemetryPluginImpl::ClientCallTracer
   std::string SpanId() override {
     // Not implemented
     return "";
-  }
-
-  bool IsSampled() override {
-    // Not implemented
-    return false;
   }
 
   CallAttemptTracer* StartNewAttempt(bool is_transparent_retry) override;

--- a/src/cpp/ext/otel/otel_server_call_tracer.h
+++ b/src/cpp/ext/otel/otel_server_call_tracer.h
@@ -53,11 +53,6 @@ class OpenTelemetryPluginImpl::ServerCallTracer
     return "";
   }
 
-  bool IsSampled() override {
-    // Not implemented
-    return false;
-  }
-
   // Please refer to `grpc_transport_stream_op_batch_payload` for details on
   // arguments.
   void RecordSendInitialMetadata(

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -55,6 +55,7 @@ PythonOpenCensusCallTracer::PythonOpenCensusCallTracer(
   GenerateClientContext(absl::StrCat("Sent.", method_),
                         absl::string_view(trace_id),
                         absl::string_view(parent_span_id), &context_);
+  if (context_.GetSpanContext().IsSampled()) set_sampled();
 }
 
 void PythonOpenCensusCallTracer::GenerateContext() {}

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.h
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.h
@@ -49,8 +49,6 @@ class PythonOpenCensusCallTracer : public grpc_core::ClientCallTracer {
           absl::string_view(context_.GetSpanContext().SpanId()));
     }
 
-    bool IsSampled() override { return context_.GetSpanContext().IsSampled(); }
-
     void RecordSendInitialMetadata(
         grpc_metadata_batch* send_initial_metadata) override;
     void RecordSendTrailingMetadata(
@@ -123,8 +121,6 @@ class PythonOpenCensusCallTracer : public grpc_core::ClientCallTracer {
     return absl::BytesToHexString(
         absl::string_view(context_.GetSpanContext().SpanId()));
   }
-
-  bool IsSampled() override { return context_.GetSpanContext().IsSampled(); }
 
   void GenerateContext();
   PythonOpenCensusCallAttemptTracer* StartNewAttempt(

--- a/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
@@ -277,10 +277,6 @@ std::string PythonOpenCensusServerCallTracer::SpanId() {
       absl::string_view(context_.GetSpanContext().SpanId()));
 }
 
-bool PythonOpenCensusServerCallTracer::IsSampled() {
-  return context_.GetSpanContext().IsSampled();
-}
-
 //
 // PythonOpenCensusServerCallTracerFactory
 //

--- a/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/server_call_tracer.cc
@@ -111,6 +111,7 @@ void PythonOpenCensusServerCallTracer::RecordReceivedInitialMetadata(
   GenerateServerContext(
       tracing_enabled ? som.tracing_slice.as_string_view() : "",
       absl::StrCat("Recv.", method_), &context_);
+  if (context_.GetSpanContext().IsSampled()) set_sampled();
   registered_method_ =
       recv_initial_metadata->get(grpc_core::GrpcRegisteredMethod())
           .value_or(nullptr) != nullptr;

--- a/src/python/grpcio_observability/grpc_observability/server_call_tracer.h
+++ b/src/python/grpcio_observability/grpc_observability/server_call_tracer.h
@@ -71,8 +71,6 @@ class PythonOpenCensusServerCallTracer : public grpc_core::ServerCallTracer {
 
   std::string SpanId() override;
 
-  bool IsSampled() override;
-
   // Please refer to `grpc_transport_stream_op_batch_payload` for details on
   // arguments.
   // It's not a requirement to have this metric thus left unimplemented.

--- a/test/core/end2end/tests/http2_stats.cc
+++ b/test/core/end2end/tests/http2_stats.cc
@@ -146,7 +146,6 @@ class FakeCallTracer : public ClientCallTracer {
     }
     std::string TraceId() override { return ""; }
     std::string SpanId() override { return ""; }
-    bool IsSampled() override { return false; }
     void RecordSendInitialMetadata(
         grpc_metadata_batch* /*send_initial_metadata*/) override {}
     void RecordSendTrailingMetadata(
@@ -210,7 +209,6 @@ class FakeCallTracer : public ClientCallTracer {
   ~FakeCallTracer() override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 
   FakeCallAttemptTracer* StartNewAttempt(
       bool /*is_transparent_retry*/) override {
@@ -275,7 +273,6 @@ class FakeServerCallTracer : public ServerCallTracer {
   void RecordAnnotation(const Annotation& /*annotation*/) override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 
  private:
   std::shared_ptr<TestState> test_state_;

--- a/test/core/test_util/fake_stats_plugin.h
+++ b/test/core/test_util/fake_stats_plugin.h
@@ -103,7 +103,6 @@ class FakeClientCallTracer : public ClientCallTracer {
     }
     std::string TraceId() override { return ""; }
     std::string SpanId() override { return ""; }
-    bool IsSampled() override { return false; }
 
     const std::map<OptionalLabelKey, RefCountedStringValue>& GetOptionalLabels()
         const {
@@ -131,7 +130,6 @@ class FakeClientCallTracer : public ClientCallTracer {
   void RecordAnnotation(const Annotation& /*annotation*/) override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 
   FakeClientCallAttemptTracer* GetLastCallAttemptTracer() const {
     return call_attempt_tracers_.back().get();
@@ -194,7 +192,6 @@ class FakeServerCallTracer : public ServerCallTracer {
   std::shared_ptr<TcpCallTracer> StartNewTcpTrace() override { return nullptr; }
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 
  private:
   std::vector<std::string>* annotation_logger_;

--- a/test/core/transport/chttp2/hpack_encoder_test.cc
+++ b/test/core/transport/chttp2/hpack_encoder_test.cc
@@ -174,7 +174,6 @@ class FakeCallTracer final : public CallTracerInterface {
   void RecordAnnotation(const Annotation& annotation) override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 };
 
 }  // namespace grpc_core

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -79,7 +79,6 @@ class FakeCallTracer final : public CallTracerInterface {
   void RecordAnnotation(const Annotation& annotation) override {}
   std::string TraceId() override { return ""; }
   std::string SpanId() override { return ""; }
-  bool IsSampled() override { return false; }
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
I'd like to dump a whole lot more state into sampled call tracers, but that requires the check be as cheap as we can make it.

This change makes it non-virtual at least.