### PR TITLE
[gRPC HTTP/2 spec] pseudo-headers must come first, as per RFC-9113

### DIFF
--- a/doc/PROTOCOL-HTTP2.md
+++ b/doc/PROTOCOL-HTTP2.md
@@ -21,7 +21,7 @@ The following is the general sequence of message atoms in a GRPC request & respo
 Request-Headers are delivered as HTTP2 headers in HEADERS + CONTINUATION frames.
 
 * **Request-Headers** → Call-Definition \*Custom-Metadata
-* **Call-Definition** → Method Scheme Path TE [Authority] [Timeout] Content-Type [Message-Type] [Message-Encoding] [Message-Accept-Encoding] [User-Agent]
+* **Call-Definition** → Method Scheme Path [Authority] TE [Timeout] Content-Type [Message-Type] [Message-Encoding] [Message-Accept-Encoding] [User-Agent]
 * **Method** →  ":method POST"
 * **Scheme** → ":scheme "  ("http" / "https")
 * **Path** → ":path" "/" Service-Name "/" {_method name_}  ; But see note below.


### PR DESCRIPTION
Fixes #39267.