### PR TITLE
[Draft] Disable GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER flag from Python builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -456,7 +456,7 @@ else:
 
 # Fix for multiprocessing support on Apple devices.
 # TODO(vigneshbabu): Remove this once the poll poller gets fork support.
-DEFINE_MACROS += (("GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER", 1),)
+# DEFINE_MACROS += (("GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER", 1),)
 
 # Fix for Cython build issue in aarch64.
 # It's required to define this macro before include <inttypes.h>.

--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -32,7 +32,7 @@ pyx_library(
         "cygrpc.pyx",
     ],
     data = [":copy_roots_pem"],
-    defines = ["GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER=1"],
+    # defines = ["GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER=1"],
     deps = [
         "//:grpc",
     ],


### PR DESCRIPTION
Enable EventEngine in Python by disabling the GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER flag from setup.py and Bazel builds