### PR TITLE
[CI] PHP build setup changes for MacOs Sonoma (v1.72.x backport)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -200,21 +200,37 @@ fi
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PHP}" == "true" ]
 then
   time brew install php@8.1 || true
-  export LDFLAGS="-L/usr/local/opt/php@8.1/lib ${LDFLAGS}"
-  export CPPFLAGS="-I/usr/local/opt/php@8.1/include ${CPPFLAGS}"
-  export PATH="/usr/local/opt/php@8.1/bin:/usr/local/opt/php@8.1/sbin:${PATH}"
+  if [ -e "/usr/local/opt/php@8.1/" ]; then
+    PHP_PATH="/usr/local/opt/php@8.1/"
+  elif [ -e "/opt/homebrew/opt/php@8.1" ]; then
+    PHP_PATH="/opt/homebrew/opt/php@8.1"
+  else
+    echo "Error: Unable to check php install path" >&2
+    exit 1
+  fi
+
+  export LDFLAGS="-L${PHP_PATH}/lib ${LDFLAGS}"
+  export CPPFLAGS="-I${PHP_PATH}include ${CPPFLAGS}"
+  export PATH="${PHP_PATH}/bin:${PHP_PATH}/sbin:${PATH}"
 
   # the exit code from "brew install php@8.1" is useless
   # so instead we check if PHP was indeed installed successfully.
   # Failing early is better than cryptic errors later in the build process.
-  /usr/local/opt/php@8.1/bin/php --version
+  php --version
 
-  # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081
-  mkdir -p /usr/local/lib/php/pecl
-
-  # Download the right version of phpunit to match PHP version
-  sudo curl -sSL https://phar.phpunit.de/phpunit-9.5.9.phar -o /usr/local/bin/phpunit
-  sudo chmod +x /usr/local/bin/phpunit
+  if $is_sonoma; then
+    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+    php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }"
+    php composer-setup.php --install-dir /tmp
+    php -r "unlink('composer-setup.php');"
+    php /tmp/composer.phar global require phpunit/phpunit:9.5.9
+  else
+    # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081
+    mkdir -p /usr/local/lib/php/pecl
+    # Download the right version of phpunit to match PHP version
+    sudo curl -sSL https://phar.phpunit.de/phpunit-9.5.9.phar -o /usr/local/bin/phpunit
+    sudo chmod +x /usr/local/bin/phpunit
+  fi
 fi
 
 # TODO(jtattermusch): better debugging of clock skew, remove once not needed


### PR DESCRIPTION
Backport of #39103 to v1.72.x.
---
null

Verified backport this can fix PHP job: https://source.cloud.google.com/results/invocations/cb9bc98d-91b6-4396-b419-2c3913718547