### PR TITLE
[CI] Reverting output path from RBE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ Podfile.lock
 bazel-*
 bazel_format_virtual_environment/
 tools/bazel-*
+.bazel_rbe
 
 # Bazel wrapper
 bazel_wrapper

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -73,6 +73,7 @@ TEST_TARGETS=(
 # TODO(jtattermusch): can we make ObjC test not depend on running a local interop_server?
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path build_interop_server
 build_interop_server/bazel_wrapper \
+  --output_base=.bazel_rbe \
   --bazelrc=tools/remote_build/mac.bazelrc \
   build \
   --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \

--- a/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
@@ -44,6 +44,7 @@ python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_
 
 # run all C/C++ tests
 bazel_c_cpp_tests/bazel_wrapper \
+  --output_base=.bazel_rbe \
   --bazelrc=tools/remote_build/mac.bazelrc \
   test \
   --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \

--- a/tools/remote_build/include/rbe_base_config.bazelrc
+++ b/tools/remote_build/include/rbe_base_config.bazelrc
@@ -18,7 +18,6 @@
 # Note that remote build and test execution is left unconfigured.
 
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
-startup --output_base=out_bin
 
 # the RBE instance to use
 build --remote_instance_name=projects/grpc-testing/instances/default_instance


### PR DESCRIPTION

Reverts the base path change added in https://github.com/grpc/grpc/pull/39300 as it was impacting other platforms.

Added base path only for CI run in command script

