### PR TITLE
[Python] Remove outdated python version note from grpcio-tools README

### DIFF
--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -3,14 +3,10 @@ gRPC Python Tools
 
 Package for gRPC Python tools.
 
-Supported Python Versions
--------------------------
-Python >= 3.9, <=3.13
-
 Installation
 ------------
 
-The gRPC Python tools package is available for Linux, Mac OS X, and Windows.
+The gRPC Python tools package is available for Linux, macOS, and Windows.
 
 Installing From PyPI
 ~~~~~~~~~~~~~~~~~~~~
@@ -37,7 +33,7 @@ when you installed Python (if not go back and install it!) then invoke:
 Windows users may need to invoke :code:`pip.exe` from a command line ran as
 administrator.
 
-n.b. On Windows and on Mac OS X one *must* have a recent release of :code:`pip`
+n.b. On Windows and on macOS one *must* have a recent release of :code:`pip`
 to retrieve the proper wheel from PyPI. Be sure to upgrade to the latest
 version!
 

--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -5,7 +5,7 @@ Package for gRPC Python tools.
 
 Supported Python Versions
 -------------------------
-Python >= 3.6
+Python >= 3.9, <=3.13
 
 Installation
 ------------


### PR DESCRIPTION
Change the gRPC Python Tools supported versions to match ones in

tools/distrib/python/grpcio_tools/python_version.py

