### PR TITLE
Removed no-gen2 flag to allow support for Python313 runtime

### DIFF
--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -45,7 +45,7 @@ trap cleanup SIGINT SIGTERM EXIT
 
 # Deploy
 
-DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated --no-gen2)
+DEPLOY_OUTPUT=$(gcloud functions deploy "${FUNCTION_NAME}" --entry-point test_publish --runtime "${RUNTIME}" --trigger-http --allow-unauthenticated)
 HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 
 # Send Requests


### PR DESCRIPTION
Python313 is a new Cloud Run functions runtime that was added yesterday as a preview feature: https://cloud.google.com/functions/docs/release-notes#April_21_2025

However, checking using `gcloud functions runtimes list` it is only supported for 2nd Gen
```
$ gcloud functions runtimes list
NAME       STAGE       ENVIRONMENTS
python38   DEPRECATED  1st gen, 2nd gen
python39   GA          1st gen, 2nd gen
python310  GA          1st gen, 2nd gen
python311  GA          1st gen, 2nd gen
python312  GA          1st gen, 2nd gen
python313  BETA        2nd gen
```
However, the script currently uses the flag --no-gen2 which is probably preventing it to not use 2nd gen and hence throwing the error:
```
ERROR: (gcloud.functions.deploy) argument `--runtime`: python313 is not a supported runtime on GCF 1st gen. Use `gcloud functions runtimes list` to get a list of available runtimes
```

This PR hence removes the `--no-gen2` flag. Also given all Python versions are supported in 2nd gen, it is probably safe to remove the `--no-gen2` flag to support Python313 as well as older runtimes. 

