### PR TITLE
Increase timeout for dualstack test to 240 minutes (v1.66.x backport)

### DIFF
--- a/tools/internal_ci/linux/psm-dualstack.cfg
+++ b/tools/internal_ci/linux/psm-dualstack.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
-timeout_mins: 120
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "artifacts/**/*sponge_log.xml"


### PR DESCRIPTION
Backport of #38894 to v1.66.x.
---
With the current setting of 120 minutes there is the occassional timeout error.