### PR TITLE
[Bazel Test] Exclude `//tools/codegen` from bazel test

### DIFF
--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -67,6 +67,9 @@ EXCLUDED_TARGETS=(
 
   # Also exclude the artifact_gen tooling, which again contains some bazel hackery
   "-//tools/artifact_gen/..."
+
+  # Also exclude the codegen tooling, which again contains some bazel hackery
+  "-//tools/codegen/..."
 )
 
 FAILED_TESTS=""


### PR DESCRIPTION
Exclude `//tools/codegen` from bazel test, which contains some bazel hackery. 




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

