### PR TITLE
[PH2][Bug] Fixing overflow issue in message_assembler.h

### DIFF
--- a/src/core/ext/transport/chttp2/transport/message_assembler.h
+++ b/src/core/ext/transport/chttp2/transport/message_assembler.h
@@ -61,7 +61,9 @@ class GrpcMessageAssembler {
       return ReturnNullOrError();
     }
     GrpcMessageHeader header = ExtractGrpcHeader(message_buffer_);
-    if (message_buffer_.Length() >= header.length + kGrpcHeaderSizeInBytes) {
+    uint64_t total_length =
+        static_cast<uint64_t>(header.length) + kGrpcHeaderSizeInBytes;
+    if (message_buffer_.Length() >= total_length) {
       SliceBuffer discard;
       message_buffer_.MoveFirstNBytesIntoSliceBuffer(kGrpcHeaderSizeInBytes,
                                                      discard);


### PR DESCRIPTION
[PH2][Bug] Fixing overflow issue in message_assembler.h
Will fix fuzz test which is broken on master.
```//third_party/grpc/test/core/transport/chttp2:message_assembler_fuzz_test```
