### PR TITLE
[channelz] Fix type error in ztrace

### DIFF
--- a/src/core/ext/transport/chaotic_good/tcp_ztrace_collector.h
+++ b/src/core/ext/transport/chaotic_good/tcp_ztrace_collector.h
@@ -80,7 +80,7 @@ struct EndpointWriteMetricsTrace {
   absl::Time timestamp;
   grpc_event_engine::experimental::EventEngine::Endpoint::WriteEvent
       write_event;
-  std::vector<std::pair<absl::string_view, size_t>> metrics;
+  std::vector<std::pair<absl::string_view, int64_t>> metrics;
 
   size_t MemoryUsage() const {
     return sizeof(*this) + sizeof(metrics[0]) * metrics.size();


### PR DESCRIPTION
Should resolve Mac compilation issue:
https://btx.cloud.google.com/invocations/d5ad2409-e5b6-4e09-a80a-a56c5e17f05e/targets/github%2Fgrpc%2Ftoplevel_run_tests_invocations%2Frun_tests_c%2B%2B_macos_dbg_native;config=default/tests
