### PR TITLE
[json] Adjust `FromNumber` to accept any arithmetic type

### DIFF
--- a/include/grpc/support/json.h
+++ b/include/grpc/support/json.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -72,27 +73,8 @@ class Json {
     json.value_ = NumberValue{std::move(str)};
     return json;
   }
-  static Json FromNumber(int32_t value) {
-    Json json;
-    json.value_ = NumberValue{absl::StrCat(value)};
-    return json;
-  }
-  static Json FromNumber(uint32_t value) {
-    Json json;
-    json.value_ = NumberValue{absl::StrCat(value)};
-    return json;
-  }
-  static Json FromNumber(int64_t value) {
-    Json json;
-    json.value_ = NumberValue{absl::StrCat(value)};
-    return json;
-  }
-  static Json FromNumber(uint64_t value) {
-    Json json;
-    json.value_ = NumberValue{absl::StrCat(value)};
-    return json;
-  }
-  static Json FromNumber(double value) {
+  template <typename T>
+  static std::enable_if<std::is_arithmetic_v<T>, Json> FromNumber(T value) {
     Json json;
     json.value_ = NumberValue{absl::StrCat(value)};
     return json;

--- a/include/grpc/support/json.h
+++ b/include/grpc/support/json.h
@@ -74,7 +74,7 @@ class Json {
     return json;
   }
   template <typename T>
-  static std::enable_if<std::is_arithmetic_v<T>, Json> FromNumber(T value) {
+  static std::enable_if_t<std::is_arithmetic_v<T>, Json> FromNumber(T value) {
     Json json;
     json.value_ = NumberValue{absl::StrCat(value)};
     return json;


### PR DESCRIPTION
Use C++ type traits to refine `FromNumber` to accept any arithmetic type instead of a pre-canned special set.

Allows us to avoid ambiguities on some platforms where (eg) size_t is special in ways that can't be expressed in the current overload scheme.