### PR TITLE
[interop] Add v1.71.1, v1.72.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -314,7 +314,6 @@ LANG_RELEASE_MATRIX = {
             ("v1.68.2", ReleaseInfo()),
             ("v1.69.4", ReleaseInfo()),
             ("v1.70.0", ReleaseInfo()),
-            ("v1.71.0", ReleaseInfo()),
             ("v1.71.1", ReleaseInfo()),
             ("v1.72.0", ReleaseInfo()),
         ]

--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -315,6 +315,8 @@ LANG_RELEASE_MATRIX = {
             ("v1.69.4", ReleaseInfo()),
             ("v1.70.0", ReleaseInfo()),
             ("v1.71.0", ReleaseInfo()),
+            ("v1.71.1", ReleaseInfo()),
+            ("v1.72.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```
gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.x | grep "v1.71.1"
ca19fe30458c  infrastructure-public-image-v1.71.1,v1.71.1                                                                    2025-04-23T17:15:00  CRITICAL=1,HIGH=1,LOW=96,MEDIUM=3
```

```
gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.x | grep "v1.72.0"
6fba6b448704  infrastructure-public-image-v1.72.0,v1.72.0 
```
