### PR TITLE
added CPP repro example for ping timeout issue

### DIFF
--- a/examples/cpp/ping_timeout_repro/BUILD.bazel
+++ b/examples/cpp/ping_timeout_repro/BUILD.bazel
@@ -1,0 +1,41 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cc_binary(
+    name = "repro_greeter_client",
+    srcs = ["repro_greeter_client.cc"],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "//:grpc++",
+        "//examples/protos:helloworld_cc_grpc",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/log:initialize",
+    ],
+)
+
+cc_binary(
+    name = "greeter_server",
+    srcs = ["greeter_server.cc"],
+    defines = ["BAZEL_BUILD"],
+    deps = [
+        "//:grpc++",
+        "//:grpc++_reflection",
+        "//examples/protos:helloworld_cc_grpc",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/log:initialize",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/examples/cpp/ping_timeout_repro/greeter_server.cc
+++ b/examples/cpp/ping_timeout_repro/greeter_server.cc
@@ -1,0 +1,84 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/log/initialize.h"
+#include "absl/strings/str_format.h"
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/helloworld.grpc.pb.h"
+#else
+#include "helloworld.grpc.pb.h"
+#endif
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+ABSL_FLAG(uint16_t, port, 50051, "Server port for the service");
+
+// Logic and data behind the server's behavior.
+class GreeterServiceImpl final : public Greeter::Service {
+  Status SayHello(ServerContext* context, const HelloRequest* request,
+                  HelloReply* reply) override {
+    std::string prefix("Hello ");
+    reply->set_message(prefix + request->name());
+    return Status::OK;
+  }
+};
+
+void RunServer(uint16_t port) {
+  std::string server_address = absl::StrFormat("0.0.0.0:%d", port);
+  GreeterServiceImpl service;
+
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  ServerBuilder builder;
+  // Listen on the given address without any authentication mechanism.
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  // Register "service" as the instance through which we'll communicate with
+  // clients. In this case it corresponds to an *synchronous* service.
+  builder.RegisterService(&service);
+  // Finally assemble the server.
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  // Wait for the server to shutdown. Note that some other thread must be
+  // responsible for shutting down the server for this call to ever return.
+  server->Wait();
+}
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  absl::InitializeLog();
+  RunServer(absl::GetFlag(FLAGS_port));
+  return 0;
+}

--- a/examples/cpp/ping_timeout_repro/repro_greeter_client.cc
+++ b/examples/cpp/ping_timeout_repro/repro_greeter_client.cc
@@ -1,0 +1,112 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+// #define GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER 1
+
+#include <grpcpp/grpcpp.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+
+#include <thread>
+
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/helloworld.grpc.pb.h"
+#else
+#include "helloworld.grpc.pb.h"
+#endif
+
+ABSL_FLAG(std::string, target, "localhost:50051", "Server address");
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using helloworld::Greeter;
+using helloworld::HelloReply;
+using helloworld::HelloRequest;
+
+class GreeterClient {
+ public:
+  GreeterClient(std::shared_ptr<Channel> channel)
+      : stub_(Greeter::NewStub(channel)) {}
+
+  // Assembles the client's payload, sends it and presents the response back
+  // from the server.
+  std::string SayHello(const std::string& user) {
+    // Data we are sending to the server.
+    HelloRequest request;
+    request.set_name(user);
+
+    // Container for the data we expect from the server.
+    HelloReply reply;
+
+    // Context for the client. It could be used to convey extra information to
+    // the server and/or tweak certain RPC behaviors.
+    ClientContext context;
+
+    // The actual RPC.
+    Status status = stub_->SayHello(&context, request, &reply);
+
+    // Act upon its status.
+    if (status.ok()) {
+      return reply.message();
+    } else {
+      std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+      return "RPC failed";
+    }
+  }
+
+ private:
+  std::unique_ptr<Greeter::Stub> stub_;
+};
+
+int main(int argc, char** argv) {
+  absl::ParseCommandLine(argc, argv);
+  // Instantiate the client. It requires a channel, out of which the actual RPCs
+  // are created. This channel models a connection to an endpoint specified by
+  // the argument "--target=" which is the only expected argument.
+  std::string target_str = absl::GetFlag(FLAGS_target);
+  // We indicate that the channel isn't authenticated (use of
+  // InsecureChannelCredentials()).
+  grpc::ChannelArguments args;
+
+  // Here we are configuring a keepalive time period of 2 seconds, with a 
+  // timeout of 15 seconds. Additionally, the internal channel argument 
+  // ping_timeout_ms is set for 10 seconds, to reproduce the ping timeout errors
+  // quickly.
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 2 * 1000 /*2 sec*/);
+  args.SetInt("grpc.http2.ping_timeout_ms", 10 * 1000);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 1500 /*15 sec*/);
+  args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+  GreeterClient greeter(grpc::CreateCustomChannel(
+      target_str, grpc::InsecureChannelCredentials(), args));
+
+  for (;;) {
+    std::string user("world");
+    std::string reply = greeter.SayHello(user);
+    std::cout << "Greeter received: " << reply << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+  }
+  
+  return 0;
+}


### PR DESCRIPTION
The root cause of the ping timeout issue in Python that was recently reported by Dataflow as well as in issue #38282 was because Python has explicitly disabled the use of EventEngine polling using the `GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER` build flag (Reference: https://github.com/grpc/grpc/pull/33279).
Removing the flag solves this issue, however, considering that it originally was added because of lack of fork support when using EventEngine, the current work in progress to add fork support using EventEngine must be completed before removing this flag.

In addition, it was also found that the issue could not be reproduced when running via Bazel. This was because the `GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER` flag was not getting propagated upstream to the Core layer, unless specifically defined as a compiler option in `tools/bazel.rc` or passed in via command line

This PR hence includes the C++ server and client code to reproduce the ping timeout issue.

Steps to reproduce the ping timeout via Bazel in CPP:
 - `export GRPC_TRACE=tcp,http,http2_keepalive,http2_ping,polling,polling_api`
 - `export GRPC_VERBOSITY=debug`
 - Run `bazel run :greeter_server --copt=-DGRPC_DO_NOT_INSTANTIATE_POSIX_POLLER` to start the CPP server
 - Run `bazel run :repro_greeter_client  --copt=-DGRPC_DO_NOT_INSTANTIATE_POSIX_POLLER` to start the CPP client

NOTE: The issue can only be reproduced when including the `--copt` flag via command line. Running the example as described above with the specific debug trace logs should show log lines such as:
```
I0000 00:00:1745420380.475681 3473830 chttp2_transport.cc:1963] ipv6:%5B::1%5D:50051: Ping timeout. Closing transport.
...
I0000 00:00:1745420380.476151 3473830 chttp2_transport.cc:1844] 0x7ffb90001600 CANCEL PINGS: UNKNOWN:ping timeout {grpc_status:14}
...
I0000 00:00:1745420380.477078 3473830 chttp2_transport.cc:1844] 0x7ffb90001600 CANCEL PINGS: UNKNOWN:goaway sent
...
I0000 00:00:1745420380.477298 3473830 ev_posix.cc:186] (polling-api) fd_shutdown(5)
...
I0000 00:00:1745420380.477517 3473830 tcp_posix.cc:1105] TCP:0x55a33ded8300 got_read: UNKNOWN:FD Shutdown {children:[UNAVAILABLE:endpoint shutdown]}

```