### PR TITLE
[channelz] Further reduce contention

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1256,7 +1256,9 @@ grpc_cc_library(
         "absl/log:check",
         "absl/status:statusor",
         "absl/strings",
+        "absl/container:flat_hash_set",
         "absl/container:inlined_vector",
+        "absl/functional:function_ref",
     ],
     deps = [
         "exec_ctx",

--- a/src/core/channelz/channelz.cc
+++ b/src/core/channelz/channelz.cc
@@ -25,6 +25,8 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdint>
+#include <initializer_list>
+#include <limits>
 #include <string>
 #include <tuple>
 
@@ -357,6 +359,29 @@ const char* ChannelNode::GetChannelConnectivityStateChangeString(
   GPR_UNREACHABLE_CODE(return "UNKNOWN");
 }
 
+namespace {
+
+std::set<intptr_t> ChildIdSet(const BaseNode* parent,
+                              BaseNode::EntityType type) {
+  std::set<intptr_t> ids;
+  auto [children, _] = ChannelzRegistry::GetChildrenOfType(
+      0, parent, type, std::numeric_limits<size_t>::max());
+  for (const auto& node : children) {
+    ids.insert(node->uuid());
+  }
+  return ids;
+}
+
+}  // namespace
+
+std::set<intptr_t> ChannelNode::child_channels() const {
+  return ChildIdSet(this, BaseNode::EntityType::kInternalChannel);
+}
+
+std::set<intptr_t> ChannelNode::child_subchannels() const {
+  return ChildIdSet(this, BaseNode::EntityType::kSubchannel);
+}
+
 std::optional<std::string> ChannelNode::connectivity_state() {
   // Connectivity state.
   // If low-order bit is on, then the field is set.
@@ -400,19 +425,20 @@ Json ChannelNode::RenderJson() {
 }
 
 void ChannelNode::PopulateChildRefs(Json::Object* json) {
-  MutexLock lock(&child_mu_);
-  if (!child_subchannels_.empty()) {
+  auto child_subchannels = this->child_subchannels();
+  auto child_channels = this->child_channels();
+  if (!child_subchannels.empty()) {
     Json::Array array;
-    for (intptr_t subchannel_uuid : child_subchannels_) {
+    for (intptr_t subchannel_uuid : child_subchannels) {
       array.emplace_back(Json::FromObject({
           {"subchannelId", Json::FromString(absl::StrCat(subchannel_uuid))},
       }));
     }
     (*json)["subchannelRef"] = Json::FromArray(std::move(array));
   }
-  if (!child_channels_.empty()) {
+  if (!child_channels.empty()) {
     Json::Array array;
-    for (intptr_t channel_uuid : child_channels_) {
+    for (intptr_t channel_uuid : child_channels) {
       array.emplace_back(Json::FromObject({
           {"channelId", Json::FromString(absl::StrCat(channel_uuid))},
       }));
@@ -425,26 +451,6 @@ void ChannelNode::SetConnectivityState(grpc_connectivity_state state) {
   // Store with low-order bit set to indicate that the field is set.
   int state_field = (state << 1) + 1;
   connectivity_state_.store(state_field, std::memory_order_relaxed);
-}
-
-void ChannelNode::AddChildChannel(intptr_t child_uuid) {
-  MutexLock lock(&child_mu_);
-  child_channels_.insert(child_uuid);
-}
-
-void ChannelNode::RemoveChildChannel(intptr_t child_uuid) {
-  MutexLock lock(&child_mu_);
-  child_channels_.erase(child_uuid);
-}
-
-void ChannelNode::AddChildSubchannel(intptr_t child_uuid) {
-  MutexLock lock(&child_mu_);
-  child_subchannels_.insert(child_uuid);
-}
-
-void ChannelNode::RemoveChildSubchannel(intptr_t child_uuid) {
-  MutexLock lock(&child_mu_);
-  child_subchannels_.erase(child_uuid);
 }
 
 //
@@ -523,51 +529,25 @@ ServerNode::ServerNode(size_t channel_tracer_max_nodes)
 
 ServerNode::~ServerNode() {}
 
-void ServerNode::AddChildSocket(RefCountedPtr<SocketNode> node) {
-  MutexLock lock(&child_mu_);
-  child_sockets_.insert(std::pair(node->uuid(), std::move(node)));
-}
-
-void ServerNode::RemoveChildSocket(intptr_t child_uuid) {
-  MutexLock lock(&child_mu_);
-  child_sockets_.erase(child_uuid);
-}
-
-void ServerNode::AddChildListenSocket(RefCountedPtr<ListenSocketNode> node) {
-  MutexLock lock(&child_mu_);
-  child_listen_sockets_.insert(std::pair(node->uuid(), std::move(node)));
-}
-
-void ServerNode::RemoveChildListenSocket(intptr_t child_uuid) {
-  MutexLock lock(&child_mu_);
-  child_listen_sockets_.erase(child_uuid);
-}
-
 std::string ServerNode::RenderServerSockets(intptr_t start_socket_id,
                                             intptr_t max_results) {
   CHECK_GE(start_socket_id, 0);
   CHECK_GE(max_results, 0);
   // If user does not set max_results, we choose 500.
-  size_t pagination_limit = max_results == 0 ? 500 : max_results;
+  if (max_results == 0) max_results = 500;
   Json::Object object;
-  {
-    MutexLock lock(&child_mu_);
-    size_t sockets_rendered = 0;
-    // Create list of socket refs.
-    Json::Array array;
-    auto it = child_sockets_.lower_bound(start_socket_id);
-    for (; it != child_sockets_.end() && sockets_rendered < pagination_limit;
-         ++it, ++sockets_rendered) {
-      array.emplace_back(Json::FromObject({
-          {"socketId", Json::FromString(absl::StrCat(it->first))},
-          {"name", Json::FromString(it->second->name())},
-      }));
-    }
-    object["socketRef"] = Json::FromArray(std::move(array));
-    if (it == child_sockets_.end()) {
-      object["end"] = Json::FromBool(true);
-    }
+  auto [children, end] = ChannelzRegistry::GetChildrenOfType(
+      start_socket_id, this, BaseNode::EntityType::kSocket, max_results);
+  // Create list of socket refs.
+  Json::Array array;
+  for (const auto& child : children) {
+    array.emplace_back(Json::FromObject({
+        {"socketId", Json::FromString(absl::StrCat(child->uuid()))},
+        {"name", Json::FromString(child->name())},
+    }));
   }
+  object["socketRef"] = Json::FromArray(std::move(array));
+  if (end) object["end"] = Json::FromBool(true);
   return JsonDump(Json::FromObject(std::move(object)));
 }
 
@@ -588,18 +568,18 @@ Json ServerNode::RenderJson() {
       {"data", Json::FromObject(std::move(data))},
   };
   // Render listen sockets.
-  {
-    MutexLock lock(&child_mu_);
-    if (!child_listen_sockets_.empty()) {
-      Json::Array array;
-      for (const auto& it : child_listen_sockets_) {
-        array.emplace_back(Json::FromObject({
-            {"socketId", Json::FromString(absl::StrCat(it.first))},
-            {"name", Json::FromString(it.second->name())},
-        }));
-      }
-      object["listenSocket"] = Json::FromArray(std::move(array));
+  auto [children, _] = ChannelzRegistry::GetChildrenOfType(
+      0, this, BaseNode::EntityType::kListenSocket,
+      std::numeric_limits<size_t>::max());
+  if (!children.empty()) {
+    Json::Array array;
+    for (const auto& child : children) {
+      array.emplace_back(Json::FromObject({
+          {"socketId", Json::FromString(absl::StrCat(child->uuid()))},
+          {"name", Json::FromString(child->name())},
+      }));
     }
+    object["listenSocket"] = Json::FromArray(std::move(array));
   }
   PopulateJsonFromDataSources(object);
   return Json::FromObject(std::move(object));

--- a/src/core/channelz/channelz.h
+++ b/src/core/channelz/channelz.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <initializer_list>
 #include <map>
 #include <optional>
 #include <set>
@@ -34,6 +35,7 @@
 #include <utility>
 
 #include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/container/inlined_vector.h"
 #include "absl/strings/string_view.h"
 #include "src/core/channelz/channel_trace.h"
@@ -126,6 +128,21 @@ class BaseNode : public RefCounted<BaseNode> {
  public:
   ~BaseNode() override;
 
+  bool HasParent(const BaseNode* parent) const {
+    MutexLock lock(&parent_mu_);
+    return parents_.find(parent) != parents_.end();
+  }
+
+  void AddParent(BaseNode* parent) {
+    MutexLock lock(&parent_mu_);
+    parents_.insert(parent->Ref());
+  }
+
+  void RemoveParent(BaseNode* parent) {
+    MutexLock lock(&parent_mu_);
+    parents_.erase(parent);
+  }
+
   static absl::string_view ChannelArgName() {
     return GRPC_ARG_CHANNELZ_CONTAINING_BASE_NODE;
   }
@@ -159,12 +176,16 @@ class BaseNode : public RefCounted<BaseNode> {
   void PopulateJsonFromDataSources(Json::Object& json);
 
  private:
-  intptr_t UuidSlow();
-
   // to allow the ChannelzRegistry to set uuid_ under its lock.
   friend class ChannelzRegistry;
   // allow data source to register/unregister itself
   friend class DataSource;
+  using ParentSet =
+      absl::flat_hash_set<RefCountedPtr<BaseNode>, RefCountedPtrHash<BaseNode>,
+                          RefCountedPtrEq<BaseNode>>;
+
+  intptr_t UuidSlow();
+
   const EntityType type_;
   std::atomic<intptr_t> uuid_;
   std::string name_;
@@ -173,6 +194,8 @@ class BaseNode : public RefCounted<BaseNode> {
       ABSL_GUARDED_BY(data_sources_mu_);
   BaseNode* prev_;
   BaseNode* next_;
+  mutable Mutex parent_mu_;
+  ParentSet parents_ ABSL_GUARDED_BY(parent_mu_);
 };
 
 class ZTrace {
@@ -325,23 +348,11 @@ class ChannelNode final : public BaseNode {
 
   void SetConnectivityState(grpc_connectivity_state state);
 
-  // TODO(roth): take in a RefCountedPtr to the child channel so we can retrieve
-  // the human-readable name.
-  void AddChildChannel(intptr_t child_uuid);
-  void RemoveChildChannel(intptr_t child_uuid);
-
-  // TODO(roth): take in a RefCountedPtr to the child subchannel so we can
-  // retrieve the human-readable name.
-  void AddChildSubchannel(intptr_t child_uuid);
-  void RemoveChildSubchannel(intptr_t child_uuid);
-
   const std::string& target() const { return target_; }
   std::optional<std::string> connectivity_state();
   CallCounts GetCallCounts() const { return call_counter_.GetCallCounts(); }
-  const std::set<intptr_t>& child_channels() const { return child_channels_; }
-  const std::set<intptr_t>& child_subchannels() const {
-    return child_subchannels_;
-  }
+  std::set<intptr_t> child_channels() const;
+  std::set<intptr_t> child_subchannels() const;
   const ChannelTrace& trace() const { return trace_; }
   const ChannelArgs& channel_args() const { return channel_args_; }
 
@@ -356,10 +367,6 @@ class ChannelNode final : public BaseNode {
   // Least significant bit indicates whether the value is set.  Remaining
   // bits are a grpc_connectivity_state value.
   std::atomic<int> connectivity_state_{0};
-
-  Mutex child_mu_;  // Guards sets below.
-  std::set<intptr_t> child_channels_;
-  std::set<intptr_t> child_subchannels_;
 };
 
 // Handles channelz bookkeeping for subchannels
@@ -430,14 +437,6 @@ class ServerNode final : public BaseNode {
   std::string RenderServerSockets(intptr_t start_socket_id,
                                   intptr_t max_results);
 
-  void AddChildSocket(RefCountedPtr<SocketNode> node);
-
-  void RemoveChildSocket(intptr_t child_uuid);
-
-  void AddChildListenSocket(RefCountedPtr<ListenSocketNode> node);
-
-  void RemoveChildListenSocket(intptr_t child_uuid);
-
   // proxy methods to composed classes.
   void AddTraceEvent(ChannelTrace::Severity severity, const grpc_slice& data) {
     trace_.AddTraceEvent(severity, data);
@@ -457,13 +456,9 @@ class ServerNode final : public BaseNode {
 
   CallCounts GetCallCounts() const { return call_counter_.GetCallCounts(); }
 
-  const std::map<intptr_t, RefCountedPtr<ListenSocketNode>>&
-  child_listen_sockets() const {
-    return child_listen_sockets_;
-  }
-  const std::map<intptr_t, RefCountedPtr<SocketNode>>& child_sockets() const {
-    return child_sockets_;
-  }
+  std::map<intptr_t, RefCountedPtr<ListenSocketNode>> child_listen_sockets()
+      const;
+  std::map<intptr_t, RefCountedPtr<SocketNode>> child_sockets() const;
 
   const ChannelTrace& trace() const { return trace_; }
   const ChannelArgs& channel_args() const { return channel_args_; }
@@ -472,9 +467,6 @@ class ServerNode final : public BaseNode {
   PerCpuCallCountingHelper call_counter_;
   ChannelTrace trace_;
   ChannelArgs channel_args_;
-  Mutex child_mu_;  // Guards child maps below.
-  std::map<intptr_t, RefCountedPtr<SocketNode>> child_sockets_;
-  std::map<intptr_t, RefCountedPtr<ListenSocketNode>> child_listen_sockets_;
 };
 
 #define GRPC_ARG_CHANNELZ_SECURITY "grpc.internal.channelz_security"

--- a/src/core/channelz/channelz_registry.cc
+++ b/src/core/channelz/channelz_registry.cc
@@ -241,11 +241,13 @@ ChannelzRegistry::ShardedNodeMap::QueryNodes(
       n->uuid_ = uuid_generator_;
       ++uuid_generator_;
       index_.emplace(n->uuid_, n);
-      if (result.size() == max_results) {
-        node_after_end = std::move(node_ref);
-        return std::tuple(std::move(result), false);
+      if (n->uuid_ >= start_node) {
+        if (result.size() == max_results) {
+          node_after_end = std::move(node_ref);
+          return std::tuple(std::move(result), false);
+        }
+        result.emplace_back(std::move(node_ref));
       }
-      result.emplace_back(std::move(node_ref));
       n = next;
     }
   }

--- a/src/core/channelz/channelz_registry.cc
+++ b/src/core/channelz/channelz_registry.cc
@@ -91,13 +91,9 @@ ChannelzRegistry* ChannelzRegistry::Default() {
 
 std::vector<RefCountedPtr<BaseNode>>
 ChannelzRegistry::InternalGetAllEntities() {
-  std::vector<RefCountedPtr<BaseNode>> nodes;
-  node_map_->IterateNodes(0, std::nullopt,
-                          [&nodes](RefCountedPtr<BaseNode> node) {
-                            nodes.push_back(node);
-                            return true;
-                          });
-  return nodes;
+  return std::get<0>(node_map_->QueryNodes(
+      0, [](const BaseNode*) { return true; },
+      std::numeric_limits<size_t>::max()));
 }
 
 void ChannelzRegistry::InternalLogAllEntities() {
@@ -142,18 +138,26 @@ void ChannelzRegistry::LegacyNodeMap::Unregister(BaseNode* node) {
   node_map_.erase(uuid);
 }
 
-void ChannelzRegistry::LegacyNodeMap::IterateNodes(
-    intptr_t start_node, std::optional<BaseNode::EntityType> entity_type,
-    absl::FunctionRef<bool(RefCountedPtr<BaseNode> node)> callback) {
+std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+ChannelzRegistry::LegacyNodeMap::QueryNodes(
+    intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
+    size_t max_results) {
+  RefCountedPtr<BaseNode> node_after_end;
+  std::vector<RefCountedPtr<BaseNode>> result;
   MutexLock lock(&mu_);
   for (auto it = node_map_.lower_bound(start_node); it != node_map_.end();
        ++it) {
     BaseNode* node = it->second;
-    if (entity_type.has_value() && node->type() != entity_type) continue;
+    if (!filter(node)) continue;
     auto node_ref = node->RefIfNonZero();
     if (node_ref == nullptr) continue;
-    if (!callback(std::move(node_ref))) break;
+    if (result.size() == max_results) {
+      node_after_end = node_ref;
+      break;
+    }
+    result.emplace_back(node_ref);
   }
+  return std::tuple(std::move(result), node_after_end == nullptr);
 }
 
 RefCountedPtr<BaseNode> ChannelzRegistry::LegacyNodeMap::GetNode(
@@ -192,75 +196,87 @@ void ChannelzRegistry::ShardedNodeMap::Unregister(BaseNode* node) {
   index_.erase(node->uuid_);
 }
 
-void ChannelzRegistry::ShardedNodeMap::IterateNodes(
-    intptr_t start_node, std::optional<BaseNode::EntityType> entity_type,
-    absl::FunctionRef<bool(RefCountedPtr<BaseNode> node)> callback) {
+std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+ChannelzRegistry::ShardedNodeMap::QueryNodes(
+    intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
+    size_t max_results) {
   // Mitigate drain hotspotting by randomizing the drain order each query.
   std::vector<size_t> nursery_visitation_order;
   for (size_t i = 0; i < kNodeShards; ++i) {
     nursery_visitation_order.push_back(i);
   }
   absl::c_shuffle(nursery_visitation_order, SharedBitGen());
+  RefCountedPtr<BaseNode> node_after_end;
+  std::vector<RefCountedPtr<BaseNode>> result;
   MutexLock index_lock(&index_mu_);
-  size_t next_nursery_to_number = 0;
-  while (true) {
-    for (auto it = index_.lower_bound(start_node); it != index_.end(); ++it) {
-      BaseNode* node = it->second;
-      start_node = node->uuid_ + 1;
-      if (entity_type.has_value() && node->type() != entity_type) continue;
-      auto node_ref = node->RefIfNonZero();
-      if (node_ref == nullptr) continue;
-      if (!callback(std::move(node_ref))) return;
+  for (auto it = index_.lower_bound(start_node); it != index_.end(); ++it) {
+    BaseNode* node = it->second;
+    if (!filter(node)) continue;
+    auto node_ref = node->RefIfNonZero();
+    if (node_ref == nullptr) continue;
+    if (result.size() == max_results) {
+      node_after_end = std::move(node_ref);
+      return std::tuple(std::move(result), false);
     }
-    if (next_nursery_to_number == kNodeShards) return;
-    if (NumberNurseryNodes(nursery_visitation_order[next_nursery_to_number])) {
-      ++next_nursery_to_number;
+    result.emplace_back(std::move(node_ref));
+  }
+  for (auto nursery_index : nursery_visitation_order) {
+    BaseNodeList& node_shard = node_list_[nursery_index];
+    MutexLock shard_lock(&node_shard.mu);
+    if (node_shard.nursery == nullptr) continue;
+    BaseNode* n = node_shard.nursery;
+    while (n != nullptr) {
+      if (!filter(n)) {
+        n = n->next_;
+        continue;
+      }
+      auto node_ref = n->RefIfNonZero();
+      if (node_ref == nullptr) {
+        n = n->next_;
+        continue;
+      }
+      BaseNode* next = n->next_;
+      RemoveNodeFromHead(n, node_shard.nursery);
+      AddNodeToHead(n, node_shard.numbered);
+      n->uuid_ = uuid_generator_;
+      ++uuid_generator_;
+      index_.emplace(n->uuid_, n);
+      if (result.size() == max_results) {
+        node_after_end = std::move(node_ref);
+        return std::tuple(std::move(result), false);
+      }
+      result.emplace_back(std::move(node_ref));
+      n = next;
     }
   }
+  CHECK(node_after_end == nullptr);
+  return std::tuple(std::move(result), true);
 }
 
 void ChannelzRegistry::ShardedNodeMap::AddNodeToHead(BaseNode* node,
                                                      BaseNode*& head) {
   if (head == nullptr) {
     head = node;
-    node->prev_ = node->next_ = node;
-  } else {
-    node->prev_ = head->prev_;
-    node->next_ = head;
-    node->next_->prev_ = node;
-    node->prev_->next_ = node;
+    node->prev_ = node->next_ = nullptr;
+    return;
   }
+  DCHECK_EQ(head->prev_, nullptr);
+  node->next_ = head;
+  node->prev_ = nullptr;
+  head->prev_ = node;
+  head = node;
 }
 
 void ChannelzRegistry::ShardedNodeMap::RemoveNodeFromHead(BaseNode* node,
                                                           BaseNode*& head) {
-  if (node->next_ == node) {
-    CHECK_EQ(head, node);
-    head = nullptr;
-  } else {
-    node->prev_->next_ = node->next_;
-    node->next_->prev_ = node->prev_;
-    if (head == node) head = node->next_;
+  if (node == head) {
+    DCHECK_EQ(node->prev_, nullptr);
+    head = node->next_;
+    if (head != nullptr) head->prev_ = nullptr;
+    return;
   }
-}
-
-bool ChannelzRegistry::ShardedNodeMap::NumberNurseryNodes(
-    size_t nursery_index) {
-  static constexpr size_t kBatchSize = 64;
-  BaseNodeList& node_shard = node_list_[nursery_index];
-  MutexLock lock(&node_shard.mu);
-  BaseNode*& nursery = node_shard.nursery;
-  size_t count = 0;
-  while (nursery != nullptr && count < kBatchSize) {
-    BaseNode* n = nursery->next_;
-    RemoveNodeFromHead(n, nursery);
-    AddNodeToHead(n, node_shard.numbered);
-    n->uuid_ = uuid_generator_;
-    ++uuid_generator_;
-    index_.emplace(n->uuid_, n);
-    ++count;
-  }
-  return nursery == nullptr;
+  node->prev_->next_ = node->next_;
+  if (node->next_ != nullptr) node->next_->prev_ = node->prev_;
 }
 
 RefCountedPtr<BaseNode> ChannelzRegistry::ShardedNodeMap::GetNode(

--- a/src/core/channelz/channelz_registry.h
+++ b/src/core/channelz/channelz_registry.h
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "absl/container/btree_map.h"
+#include "absl/functional/function_ref.h"
 #include "src/core/channelz/channelz.h"
 #include "src/core/util/json/json_writer.h"
 #include "src/core/util/ref_counted_ptr.h"
@@ -99,6 +100,13 @@ class ChannelzRegistry final {
             start_server_id);
   }
 
+  static std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+  GetChildrenOfType(intptr_t start_node, const BaseNode* parent,
+                    BaseNode::EntityType type, size_t max_results) {
+    return Default()->InternalGetChildrenOfType(start_node, parent, type,
+                                                max_results);
+  }
+
   // Test only helper function to dump the JSON representation to std out.
   // This can aid in debugging channelz code.
   static void LogAllEntities() { Default()->InternalLogAllEntities(); }
@@ -116,6 +124,18 @@ class ChannelzRegistry final {
  private:
   ChannelzRegistry() : node_map_(MakeNodeMap()) {}
 
+  // Takes a callable F: (RefCountedPtr<BaseNode>) -> bool, and returns
+  // a (BaseNode*) -> bool that filters unreffed objects and returns true.
+  // The ref must be unreffed outside the NodeMapInterface iteration.
+  template <typename F>
+  static auto CollectReferences(F fn) {
+    return [fn = std::move(fn)](BaseNode* n) {
+      auto node = n->RefIfNonZero();
+      if (node == nullptr) return true;
+      return fn(std::move(node));
+    };
+  }
+
   class NodeMapInterface {
    public:
     virtual ~NodeMapInterface() = default;
@@ -123,9 +143,9 @@ class ChannelzRegistry final {
     virtual void Register(BaseNode* node) = 0;
     virtual void Unregister(BaseNode* node) = 0;
 
-    virtual void IterateNodes(
-        intptr_t start_node, std::optional<BaseNode::EntityType> entity_type,
-        absl::FunctionRef<bool(RefCountedPtr<BaseNode> node)>) = 0;
+    virtual std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool> QueryNodes(
+        intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
+        size_t max_results) = 0;
     virtual RefCountedPtr<BaseNode> GetNode(intptr_t uuid) = 0;
 
     virtual intptr_t NumberNode(BaseNode* node) = 0;
@@ -136,9 +156,9 @@ class ChannelzRegistry final {
     void Register(BaseNode* node) override;
     void Unregister(BaseNode* node) override;
 
-    void IterateNodes(
-        intptr_t start_node, std::optional<BaseNode::EntityType> entity_type,
-        absl::FunctionRef<bool(RefCountedPtr<BaseNode> node)>) override;
+    std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool> QueryNodes(
+        intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
+        size_t max_results) override;
     RefCountedPtr<BaseNode> GetNode(intptr_t uuid) override;
 
     intptr_t NumberNode(BaseNode* node) override { return node->uuid_; }
@@ -154,9 +174,9 @@ class ChannelzRegistry final {
     void Register(BaseNode* node) override;
     void Unregister(BaseNode* node) override;
 
-    void IterateNodes(
-        intptr_t start_node, std::optional<BaseNode::EntityType> entity_type,
-        absl::FunctionRef<bool(RefCountedPtr<BaseNode> node)>) override;
+    std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool> QueryNodes(
+        intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
+        size_t max_results) override;
     RefCountedPtr<BaseNode> GetNode(intptr_t uuid) override;
 
     intptr_t NumberNode(BaseNode* node) override;
@@ -171,10 +191,6 @@ class ChannelzRegistry final {
     static size_t NodeShardIndex(BaseNode* node);
     static void AddNodeToHead(BaseNode* node, BaseNode*& head);
     static void RemoveNodeFromHead(BaseNode* node, BaseNode*& head);
-    // Number a batch of nodes in the nursery. Returns true if there are no more
-    // nodes to number.
-    bool NumberNurseryNodes(size_t nursery_index)
-        ABSL_EXCLUSIVE_LOCKS_REQUIRED(index_mu_);
 
     static constexpr size_t kNodeShards = 63;
     int64_t uuid_generator_{1};
@@ -205,6 +221,17 @@ class ChannelzRegistry final {
     return node_map_->GetNode(uuid);
   }
 
+  std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+  InternalGetChildrenOfType(intptr_t start_node, const BaseNode* parent,
+                            BaseNode::EntityType type, size_t max_results) {
+    return node_map_->QueryNodes(
+        start_node,
+        [type, parent](const BaseNode* n) {
+          return n->type() == type && n->HasParent(parent);
+        },
+        max_results);
+  }
+
   template <typename T, BaseNode::EntityType entity_type>
   RefCountedPtr<T> InternalGetTyped(intptr_t uuid) {
     RefCountedPtr<BaseNode> node = InternalGet(uuid);
@@ -219,24 +246,14 @@ class ChannelzRegistry final {
       intptr_t start_id) {
     const int kPaginationLimit = 100;
     std::vector<RefCountedPtr<T>> top_level_channels;
-    RefCountedPtr<BaseNode> node_after_pagination_limit;
-    node_map_->IterateNodes(
-        start_id, entity_type, [&](RefCountedPtr<BaseNode> node) {
-          // Check if we are over pagination limit to determine if we need to
-          // set the "end" element. If we don't go through this block, we know
-          // that when the loop terminates, we have <= to kPaginationLimit.
-          // Note that because we have already increased this node's
-          // refcount, we need to decrease it, but we can't unref while
-          // holding the lock, because this may lead to a deadlock.
-          if (top_level_channels.size() == kPaginationLimit) {
-            node_after_pagination_limit = std::move(node);
-            return false;
-          }
-          top_level_channels.emplace_back(node->RefAsSubclass<T>());
-          return true;
-        });
-    return std::tuple(std::move(top_level_channels),
-                      node_after_pagination_limit == nullptr);
+    const auto [nodes, end] = node_map_->QueryNodes(
+        start_id,
+        [](const BaseNode* node) { return node->type() == entity_type; },
+        kPaginationLimit);
+    for (const auto& p : nodes) {
+      top_level_channels.emplace_back(p->template RefAsSubclass<T>());
+    }
+    return std::tuple(std::move(top_level_channels), end);
   }
 
   void InternalLogAllEntities();

--- a/src/core/client_channel/client_channel.cc
+++ b/src/core/client_channel/client_channel.cc
@@ -324,8 +324,7 @@ ClientChannel::SubchannelWrapper::SubchannelWrapper(
       auto it =
           client_channel_->subchannel_refcount_map_.find(subchannel_.get());
       if (it == client_channel_->subchannel_refcount_map_.end()) {
-        client_channel_->channelz_node_->AddChildSubchannel(
-            subchannel_node->uuid());
+        subchannel_node->AddParent(client_channel_->channelz_node_);
         it = client_channel_->subchannel_refcount_map_
                  .emplace(subchannel_.get(), 0)
                  .first;
@@ -360,8 +359,8 @@ void ClientChannel::SubchannelWrapper::Orphaned() {
             CHECK(it != self->client_channel_->subchannel_refcount_map_.end());
             --it->second;
             if (it->second == 0) {
-              self->client_channel_->channelz_node_->RemoveChildSubchannel(
-                  subchannel_node->uuid());
+              subchannel_node->RemoveParent(
+                  self->client_channel_->channelz_node_);
               self->client_channel_->subchannel_refcount_map_.erase(it);
             }
           }

--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -501,7 +501,7 @@ class ClientChannelFilter::SubchannelWrapper final
       if (subchannel_node != nullptr) {
         auto it = chand_->subchannel_refcount_map_.find(subchannel_.get());
         if (it == chand_->subchannel_refcount_map_.end()) {
-          chand_->channelz_node_->AddChildSubchannel(subchannel_node->uuid());
+          subchannel_node->AddParent(chand_->channelz_node_);
           it = chand_->subchannel_refcount_map_.emplace(subchannel_.get(), 0)
                    .first;
         }
@@ -533,8 +533,7 @@ class ClientChannelFilter::SubchannelWrapper final
           CHECK(it != chand_->subchannel_refcount_map_.end());
           --it->second;
           if (it->second == 0) {
-            chand_->channelz_node_->RemoveChildSubchannel(
-                subchannel_node->uuid());
+            subchannel_node->RemoveParent(chand_->channelz_node_);
             chand_->subchannel_refcount_map_.erase(it);
           }
         }

--- a/src/core/ext/transport/chaotic_good_legacy/server/chaotic_good_server.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/server/chaotic_good_server.cc
@@ -26,6 +26,11 @@
 #include <utility>
 #include <vector>
 
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/random/bit_gen_ref.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
 #include "src/core/call/metadata.h"
 #include "src/core/call/metadata_batch.h"
 #include "src/core/config/core_configuration.h"
@@ -64,11 +69,6 @@
 #include "src/core/util/status_helper.h"
 #include "src/core/util/sync.h"
 #include "src/core/util/time.h"
-#include "absl/log/check.h"
-#include "absl/log/log.h"
-#include "absl/random/bit_gen_ref.h"
-#include "absl/status/status.h"
-#include "absl/status/statusor.h"
 
 namespace grpc_core {
 namespace chaotic_good_legacy {

--- a/src/core/load_balancing/grpclb/grpclb.cc
+++ b/src/core/load_balancing/grpclb/grpclb.cc
@@ -1475,7 +1475,7 @@ void GrpcLb::ShutdownLocked() {
     if (parent_channelz_node_ != nullptr) {
       channelz::ChannelNode* child_channelz_node = lb_channel_->channelz_node();
       CHECK_NE(child_channelz_node, nullptr);
-      parent_channelz_node_->RemoveChildChannel(child_channelz_node->uuid());
+      child_channelz_node->RemoveParent(parent_channelz_node_.get());
     }
     lb_channel_.reset();
   }
@@ -1602,7 +1602,7 @@ absl::Status GrpcLb::UpdateBalancerChannelLocked() {
     channelz::ChannelNode* child_channelz_node = lb_channel_->channelz_node();
     auto parent_channelz_node = args_.GetObjectRef<channelz::ChannelNode>();
     if (child_channelz_node != nullptr && parent_channelz_node != nullptr) {
-      parent_channelz_node->AddChildChannel(child_channelz_node->uuid());
+      child_channelz_node->AddParent(parent_channelz_node.get());
       parent_channelz_node_ = std::move(parent_channelz_node);
     }
   }

--- a/src/core/load_balancing/rls/rls.cc
+++ b/src/core/load_balancing/rls/rls.cc
@@ -1558,7 +1558,7 @@ RlsLb::RlsChannel::RlsChannel(RefCountedPtr<RlsLb> lb_policy)
     auto parent_channelz_node =
         lb_policy_->channel_args_.GetObjectRef<channelz::ChannelNode>();
     if (child_channelz_node != nullptr && parent_channelz_node != nullptr) {
-      parent_channelz_node->AddChildChannel(child_channelz_node->uuid());
+      child_channelz_node->AddParent(parent_channelz_node.get());
       parent_channelz_node_ = std::move(parent_channelz_node);
     }
     // Start connectivity watch.
@@ -1579,7 +1579,7 @@ void RlsLb::RlsChannel::Orphan() {
     if (parent_channelz_node_ != nullptr) {
       channelz::ChannelNode* child_channelz_node = channel_->channelz_node();
       CHECK_NE(child_channelz_node, nullptr);
-      parent_channelz_node_->RemoveChildChannel(child_channelz_node->uuid());
+      child_channelz_node->RemoveParent(parent_channelz_node_.get());
     }
     // Stop connectivity watch.
     if (watcher_ != nullptr) {

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1193,8 +1193,7 @@ void Server::AddListener(OrphanablePtr<ListenerInterface> listener) {
   channelz::ListenSocketNode* listen_socket_node =
       listener->channelz_listen_socket_node();
   if (listen_socket_node != nullptr && channelz_node_ != nullptr) {
-    channelz_node_->AddChildListenSocket(
-        listen_socket_node->RefAsSubclass<channelz::ListenSocketNode>());
+    listen_socket_node->AddParent(channelz_node_.get());
   }
   ListenerInterface* ptr = listener.get();
   listener_states_.emplace_back(
@@ -1295,7 +1294,7 @@ grpc_error_handle Server::SetupTransport(Transport* transport,
     intptr_t channelz_socket_uuid = 0;
     if (auto socket_node = transport->GetSocketNode(); socket_node != nullptr) {
       channelz_socket_uuid = socket_node->uuid();
-      channelz_node_->AddChildSocket(socket_node);
+      socket_node->AddParent(channelz_node_.get());
     }
     // Initialize chand.
     chand->InitTransport(Ref(), std::move(*channel), cq_idx, transport,
@@ -1496,8 +1495,7 @@ void Server::StopListening() {
     channelz::ListenSocketNode* channelz_listen_socket_node =
         listener_state->listener()->channelz_listen_socket_node();
     if (channelz_node_ != nullptr && channelz_listen_socket_node != nullptr) {
-      channelz_node_->RemoveChildListenSocket(
-          channelz_listen_socket_node->uuid());
+      channelz_listen_socket_node->RemoveParent(channelz_node_.get());
     }
     listener_state->Stop();
   }
@@ -1649,17 +1647,12 @@ class Server::ChannelData::ConnectivityWatcher
 
 Server::ChannelData::~ChannelData() {
   if (server_ != nullptr) {
-    if (server_->channelz_node_ != nullptr && channelz_socket_uuid_ != 0) {
-      server_->channelz_node_->RemoveChildSocket(channelz_socket_uuid_);
+    MutexLock lock(&server_->mu_global_);
+    if (list_position_.has_value()) {
+      server_->channels_.erase(*list_position_);
+      list_position_.reset();
     }
-    {
-      MutexLock lock(&server_->mu_global_);
-      if (list_position_.has_value()) {
-        server_->channels_.erase(*list_position_);
-        list_position_.reset();
-      }
-      server_->MaybeFinishShutdown();
-    }
+    server_->MaybeFinishShutdown();
   }
 }
 

--- a/src/core/util/ref_counted_ptr.h
+++ b/src/core/util/ref_counted_ptr.h
@@ -404,6 +404,7 @@ struct RefCountedPtrHash {
     return absl::Hash<WeakRefCountedPtr<T>>{}(p);
   }
   size_t operator()(T* p) const { return absl::Hash<T*>{}(p); }
+  size_t operator()(const T* p) const { return absl::Hash<const T*>{}(p); }
 };
 template <typename T>
 struct RefCountedPtrEq {

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -549,7 +549,7 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMiddleUuidCheck) {
   ExecCtx exec_ctx;
   ChannelFixture channels[kNumChannels];
   ChannelzRegistry::GetAllEntities();  // Force uuids to be fresh
-  (void)channels;  // suppress unused variable error
+  (void)channels;                      // suppress unused variable error
   // Only query for the end of the channels.
   std::string json_str = ChannelzRegistry::GetTopChannelsJson(kMidQuery);
   auto parsed_json = JsonParse(json_str);

--- a/test/core/channelz/channelz_test.cc
+++ b/test/core/channelz/channelz_test.cc
@@ -548,6 +548,7 @@ TEST_F(ChannelzRegistryBasedTest, GetTopChannelsMiddleUuidCheck) {
   const intptr_t kMidQuery = 40;
   ExecCtx exec_ctx;
   ChannelFixture channels[kNumChannels];
+  ChannelzRegistry::GetAllEntities();  // Force uuids to be fresh
   (void)channels;  // suppress unused variable error
   // Only query for the end of the channels.
   std::string json_str = ChannelzRegistry::GetTopChannelsJson(kMidQuery);


### PR DESCRIPTION
In #39306 I moved the uuid generation in channelz to be incremental and lazy to reduce contention. It occurred to me today that I could further reduce contention by moving child set management to query time from object creation time: in other words, we should have nodes track their parents, not their children.

By doing so we'll spend some extra CPU on queries (this is fine), and reduce the frequency at which we need to generate a uuid to track a child object - I believe down to zero now.

This gets us *very* close to the point that we can talk about having an always on channelz interface for all outstanding calls in the system - what's left is to think about how to elide the memory allocation required for the call channelz node (and I certainly have some ideas)