### PR TITLE
[Draft] Python repro example for ping timeout issue

### DIFF
--- a/examples/python/ping_timeout_repro/BUILD.bazel
+++ b/examples/python/ping_timeout_repro/BUILD.bazel
@@ -1,0 +1,57 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("//bazel:python_rules.bzl", "py_grpc_library", "py_proto_library")
+
+proto_library(
+    name = "helloworld_proto",
+    srcs = ["helloworld.proto"],
+)
+
+py_proto_library(
+    name = "helloworld_py_pb2",
+    deps = [":helloworld_proto"],
+)
+
+py_grpc_library(
+    name = "helloworld_py_pb2_grpc",
+    srcs = [":helloworld_proto"],
+    deps = [":helloworld_py_pb2"],
+)
+
+py_binary(
+    name = "greeter_server_py",
+    srcs = ["greeter_server.py"],
+    imports = ["."],
+    main = "greeter_server.py",
+    deps = [
+        ":helloworld_py_pb2",
+        ":helloworld_py_pb2_grpc",
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+)
+
+py_binary(
+    name = "repro_greeter_client_py",
+    srcs = ["repro_greeter_client.py"],
+    imports = ["."],
+    main = "repro_greeter_client.py",
+    deps = [
+        ":helloworld_py_pb2",
+        ":helloworld_py_pb2_grpc",
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+)

--- a/examples/python/ping_timeout_repro/greeter_server.py
+++ b/examples/python/ping_timeout_repro/greeter_server.py
@@ -1,0 +1,41 @@
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python implementation of the GRPC helloworld.Greeter server."""
+
+from concurrent import futures
+import logging
+
+import grpc
+import helloworld_pb2
+import helloworld_pb2_grpc
+
+
+class Greeter(helloworld_pb2_grpc.GreeterServicer):
+    def SayHello(self, request, context):
+        return helloworld_pb2.HelloReply(message="Hello, %s!" % request.name)
+
+
+def serve():
+    port = "50051"
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
+    server.add_insecure_port("[::]:" + port)
+    server.start()
+    print("Server started, listening on " + port)
+    server.wait_for_termination()
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    serve()

--- a/examples/python/ping_timeout_repro/helloworld.proto
+++ b/examples/python/ping_timeout_repro/helloworld.proto
@@ -1,0 +1,42 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+
+  rpc SayHelloStreamReply (HelloRequest) returns (stream HelloReply) {}
+
+  rpc SayHelloBidiStream (stream HelloRequest) returns (stream HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/examples/python/ping_timeout_repro/repro_greeter_client.py
+++ b/examples/python/ping_timeout_repro/repro_greeter_client.py
@@ -1,0 +1,62 @@
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python implementation of the GRPC helloworld.Greeter client."""
+
+from __future__ import print_function
+
+import logging
+import sys
+import time
+
+import grpc
+import helloworld_pb2
+import helloworld_pb2_grpc
+
+
+def run():
+    target = (
+        "localhost:50051"  # sys.argv[1] if len(sys.argv) else "localhost:50051"
+    )
+    sleep = 10
+
+    # gRPC 1.68.x: causes FD Shutdown
+    options = [
+        ("grpc.keepalive_time_ms", 2_000),  # default: MAX_INT (disabled)
+        ("grpc.http2.ping_timeout_ms", sleep * 1_000),  # default: 1 minute
+        # these options don't seem to matter with respect to the issue
+        ("grpc.keepalive_timeout_ms", 1_500),  # default: 20_000
+        ("grpc.keepalive_permit_without_calls", 1),  # default: 0 (disabled)
+    ]
+
+    running = True
+    with grpc.insecure_channel(target, options=options) as channel:
+        stub = helloworld_pb2_grpc.GreeterStub(channel)
+        while running:
+            try:
+                logging.info("Will try to greet world ...")
+                response = stub.SayHello(
+                    helloworld_pb2.HelloRequest(name="you")
+                )
+                logging.info(
+                    f"Greeter client received: {response.message}; sleeping {sleep} seconds"
+                )
+            except Exception as err:
+                logging.error(f"gRPC error {err}")
+                running = False
+            time.sleep(sleep)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
+    run()


### PR DESCRIPTION
This PR includes the Python server and client code to reproduce the ping timeout issue that was recently reported by Dataflow as well as in issue #38282. This PR is only meant for reference and doesn't require to be merged to the repo.

Steps to reproduce the ping timeout via Bazel in Python:
 - `export GRPC_TRACE=tcp,http,http2_keepalive,http2_ping,polling,polling_api`
 - `export GRPC_VERBOSITY=debug`
 - Run `bazel run //examples/python/ping_timeout_repro:greeter_server_py --copt=-DGRPC_DO_NOT_INSTANTIATE_POSIX_POLLER` to start the Python server
 - Run `bazel run //examples/python/ping_timeout_repro:repro_greeter_client_py  --copt=-DGRPC_DO_NOT_INSTANTIATE_POSIX_POLLER` to start the Python client

NOTE: The issue can only be reproduced via Bazel when including the `--copt` flag via command line, however running directly via Python doesn't require the flag. Running the example as described above with the specific debug trace logs should show log lines such as:
```
I0000 00:00:1745420380.475681 3473830 chttp2_transport.cc:1963] ipv6:%5B::1%5D:50051: Ping timeout. Closing transport.
...
I0000 00:00:1745420380.476151 3473830 chttp2_transport.cc:1844] 0x7ffb90001600 CANCEL PINGS: UNKNOWN:ping timeout {grpc_status:14}
...
I0000 00:00:1745420380.477078 3473830 chttp2_transport.cc:1844] 0x7ffb90001600 CANCEL PINGS: UNKNOWN:goaway sent
...
I0000 00:00:1745420380.477298 3473830 ev_posix.cc:186] (polling-api) fd_shutdown(5)
...
I0000 00:00:1745420380.477517 3473830 tcp_posix.cc:1105] TCP:0x55a33ded8300 got_read: UNKNOWN:FD Shutdown {children:[UNAVAILABLE:endpoint shutdown]}

```