### PR TITLE
[chttp2] Add an experiment to bound write sizes

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -22,6 +22,7 @@ EXPERIMENT_ENABLES = {
     "call_tracer_transport_fix": "call_tracer_transport_fix",
     "callv3_client_auth_filter": "callv3_client_auth_filter",
     "chaotic_good_framing_layer": "chaotic_good_framing_layer",
+    "chttp2_bound_write_size": "chttp2_bound_write_size",
     "error_flatten": "error_flatten",
     "event_engine_client": "event_engine_client",
     "event_engine_dns": "event_engine_dns",
@@ -75,6 +76,7 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "callv3_client_auth_filter",
+                "chttp2_bound_write_size",
                 "error_flatten",
                 "event_engine_dns_non_client_channel",
                 "event_engine_fork",
@@ -152,6 +154,7 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "callv3_client_auth_filter",
+                "chttp2_bound_write_size",
                 "error_flatten",
                 "event_engine_dns_non_client_channel",
                 "event_engine_fork",
@@ -229,6 +232,7 @@ EXPERIMENTS = {
         "off": {
             "core_end2end_test": [
                 "callv3_client_auth_filter",
+                "chttp2_bound_write_size",
                 "error_flatten",
                 "event_engine_dns_non_client_channel",
                 "event_engine_fork",

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -398,14 +398,14 @@ class DataSendContext {
   }
 
   uint32_t max_outgoing() const {
-    return grpc_core::Clamp<uint32_t>(
+    return grpc_core::Clamp<int64_t>(
         std::min<int64_t>(
             {t_->settings.peer().max_frame_size(), stream_remote_window(),
              t_->flow_control.remote_window(),
              static_cast<int64_t>(write_context_->target_write_size()) -
                  (grpc_core::IsChttp2BoundWriteSizeEnabled()
                       ? static_cast<int64_t>(t_->outbuf.Length())
-                      : 0)}),
+                      : static_cast<int64_t>(0))}),
         0, std::numeric_limits<uint32_t>::max());
   }
 
@@ -559,6 +559,10 @@ class StreamWriteContext {
         grpc_core::global_stats().IncrementHttp2StreamStalls();
         report_stall(t_, s_, "stream");
         grpc_chttp2_list_add_stalled_by_stream(t_, s_);
+      } else if (grpc_core::IsChttp2BoundWriteSizeEnabled()) {
+        GRPC_CHTTP2_STREAM_REF(s_, "chttp2_writing:fork");
+        grpc_chttp2_list_add_writable_stream(t_, s_);
+        stream_became_writable_ = true;
       }
       return;  // early out: nothing to do
     }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -402,7 +402,10 @@ class DataSendContext {
         std::min<int64_t>(
             {t_->settings.peer().max_frame_size(), stream_remote_window(),
              t_->flow_control.remote_window(),
-             static_cast<int64_t>(write_context_->target_write_size())}),
+             static_cast<int64_t>(write_context_->target_write_size()) -
+                 (grpc_core::IsChttp2BoundWriteSizeEnabled()
+                      ? static_cast<int64_t>(t_->outbuf.Length())
+                      : 0)}),
         0, std::numeric_limits<uint32_t>::max());
   }
 

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -38,6 +38,9 @@ const char* const additional_constraints_callv3_client_auth_filter = "{}";
 const char* const description_chaotic_good_framing_layer =
     "Enable the chaotic good framing layer.";
 const char* const additional_constraints_chaotic_good_framing_layer = "{}";
+const char* const description_chttp2_bound_write_size =
+    "Fix a bug where chttp2 can generate very large writes";
+const char* const additional_constraints_chttp2_bound_write_size = "{}";
 const char* const description_error_flatten =
     "Flatten errors to ordinary absl::Status form.";
 const char* const additional_constraints_error_flatten = "{}";
@@ -202,6 +205,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
     {"chaotic_good_framing_layer", description_chaotic_good_framing_layer,
      additional_constraints_chaotic_good_framing_layer, nullptr, 0, true, true},
+    {"chttp2_bound_write_size", description_chttp2_bound_write_size,
+     additional_constraints_chttp2_bound_write_size, nullptr, 0, false, true},
     {"error_flatten", description_error_flatten,
      additional_constraints_error_flatten, nullptr, 0, false, false},
     {"event_engine_client", description_event_engine_client,
@@ -320,6 +325,9 @@ const char* const additional_constraints_callv3_client_auth_filter = "{}";
 const char* const description_chaotic_good_framing_layer =
     "Enable the chaotic good framing layer.";
 const char* const additional_constraints_chaotic_good_framing_layer = "{}";
+const char* const description_chttp2_bound_write_size =
+    "Fix a bug where chttp2 can generate very large writes";
+const char* const additional_constraints_chttp2_bound_write_size = "{}";
 const char* const description_error_flatten =
     "Flatten errors to ordinary absl::Status form.";
 const char* const additional_constraints_error_flatten = "{}";
@@ -484,6 +492,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
     {"chaotic_good_framing_layer", description_chaotic_good_framing_layer,
      additional_constraints_chaotic_good_framing_layer, nullptr, 0, true, true},
+    {"chttp2_bound_write_size", description_chttp2_bound_write_size,
+     additional_constraints_chttp2_bound_write_size, nullptr, 0, false, true},
     {"error_flatten", description_error_flatten,
      additional_constraints_error_flatten, nullptr, 0, false, false},
     {"event_engine_client", description_event_engine_client,
@@ -602,6 +612,9 @@ const char* const additional_constraints_callv3_client_auth_filter = "{}";
 const char* const description_chaotic_good_framing_layer =
     "Enable the chaotic good framing layer.";
 const char* const additional_constraints_chaotic_good_framing_layer = "{}";
+const char* const description_chttp2_bound_write_size =
+    "Fix a bug where chttp2 can generate very large writes";
+const char* const additional_constraints_chttp2_bound_write_size = "{}";
 const char* const description_error_flatten =
     "Flatten errors to ordinary absl::Status form.";
 const char* const additional_constraints_error_flatten = "{}";
@@ -766,6 +779,8 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_callv3_client_auth_filter, nullptr, 0, false, true},
     {"chaotic_good_framing_layer", description_chaotic_good_framing_layer,
      additional_constraints_chaotic_good_framing_layer, nullptr, 0, true, true},
+    {"chttp2_bound_write_size", description_chttp2_bound_write_size,
+     additional_constraints_chttp2_bound_write_size, nullptr, 0, false, true},
     {"error_flatten", description_error_flatten,
      additional_constraints_error_flatten, nullptr, 0, false, false},
     {"event_engine_client", description_event_engine_client,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -66,6 +66,7 @@ inline bool IsCallTracerTransportFixEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CHAOTIC_GOOD_FRAMING_LAYER
 inline bool IsChaoticGoodFramingLayerEnabled() { return true; }
+inline bool IsChttp2BoundWriteSizeEnabled() { return false; }
 inline bool IsErrorFlattenEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
@@ -123,6 +124,7 @@ inline bool IsCallTracerTransportFixEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CHAOTIC_GOOD_FRAMING_LAYER
 inline bool IsChaoticGoodFramingLayerEnabled() { return true; }
+inline bool IsChttp2BoundWriteSizeEnabled() { return false; }
 inline bool IsErrorFlattenEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
@@ -180,6 +182,7 @@ inline bool IsCallTracerTransportFixEnabled() { return true; }
 inline bool IsCallv3ClientAuthFilterEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_CHAOTIC_GOOD_FRAMING_LAYER
 inline bool IsChaoticGoodFramingLayerEnabled() { return true; }
+inline bool IsChttp2BoundWriteSizeEnabled() { return false; }
 inline bool IsErrorFlattenEnabled() { return false; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_CLIENT
 inline bool IsEventEngineClientEnabled() { return true; }
@@ -235,6 +238,7 @@ enum ExperimentIds {
   kExperimentIdCallTracerTransportFix,
   kExperimentIdCallv3ClientAuthFilter,
   kExperimentIdChaoticGoodFramingLayer,
+  kExperimentIdChttp2BoundWriteSize,
   kExperimentIdErrorFlatten,
   kExperimentIdEventEngineClient,
   kExperimentIdEventEngineDns,
@@ -290,6 +294,10 @@ inline bool IsCallv3ClientAuthFilterEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_CHAOTIC_GOOD_FRAMING_LAYER
 inline bool IsChaoticGoodFramingLayerEnabled() {
   return IsExperimentEnabled<kExperimentIdChaoticGoodFramingLayer>();
+}
+#define GRPC_EXPERIMENT_IS_INCLUDED_CHTTP2_BOUND_WRITE_SIZE
+inline bool IsChttp2BoundWriteSizeEnabled() {
+  return IsExperimentEnabled<kExperimentIdChttp2BoundWriteSize>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_ERROR_FLATTEN
 inline bool IsErrorFlattenEnabled() {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -66,6 +66,11 @@
   expiry: 2025/06/01
   owner: ctiller@google.com
   test_tags: [core_end2end_test]
+- name: chttp2_bound_write_size
+  description: Fix a bug where chttp2 can generate very large writes
+  expiry: 2025/09/01
+  owner: ctiller@google.com
+  test_tags: [core_end2end_test]
 - name: error_flatten
   description: Flatten errors to ordinary absl::Status form.
   expiry: 2025/06/01


### PR DESCRIPTION
We've had a mechanism for some time to try and bound an individual write: it hasn't been working due to a slight bug.

Add an experiment to re-enable it.
