### PR TITLE
[Bazel RBE Non-Bazel Tests] Exclude //tools/codegen/core:experiments_compiler_test

### DIFF
--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -70,6 +70,7 @@ EXCLUDED_TARGETS=(
 
   # Exclude the codegen tooling `experiments_compiler`, which contains some bazel hackery
   "-//tools/codegen/core:experiments_compiler"
+  "-//tools/codegen/core:experiments_compiler_test"
 )
 
 FAILED_TESTS=""

--- a/tools/codegen/core/BUILD
+++ b/tools/codegen/core/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 
 exports_files(
     glob(
@@ -48,4 +48,9 @@ grpc_cc_binary(
 # TODO(ladynana): Replace this dummy target with the actual experiments compiler target.
 grpc_cc_library(
     name = "experiments_compiler",
+)
+
+# TODO(ladynana): Replace this dummy test with the actual experiments compiler test.
+grpc_cc_test(
+    name = "experiments_compiler_test",
 )

--- a/tools/codegen/core/BUILD
+++ b/tools/codegen/core/BUILD
@@ -53,4 +53,5 @@ grpc_cc_library(
 # TODO(ladynana): Replace this dummy test with the actual experiments compiler test.
 grpc_cc_test(
     name = "experiments_compiler_test",
+    srcs = ["experiments_compiler_test.cc"],
 )

--- a/tools/codegen/core/experiments_compiler_test.cc
+++ b/tools/codegen/core/experiments_compiler_test.cc
@@ -1,0 +1,18 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(ladynana): Replace this dummy test with the actual experiments compiler test.
+int main(int argc, char** argv) {
+  return 0;
+}


### PR DESCRIPTION
Exclude `//tools/codegen/core:experiments_compiler_test` from Bazel RBE Non-Bazel Tests, which contains some bazel hackery.

The actual `//tools/codegen/core:experiments_compiler_test` is added in https://github.com/grpc/grpc/pull/39133. Since that PR hasn't merged yet, this code uses a dummy test temporarily to allow test checks to pass.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

