### PR TITLE
[channelz] Add an option to keep nodes alive for some seconds after object destruction

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1269,6 +1269,7 @@ grpc_cc_library(
         "sockaddr_utils",
         "uri",
         "//src/core:channel_args",
+        "config_vars",
         "//src/core:connectivity_state",
         "//src/core:json",
         "//src/core:json_reader",

--- a/src/core/channelz/channelz.cc
+++ b/src/core/channelz/channelz.cc
@@ -18,6 +18,7 @@
 
 #include "src/core/channelz/channelz.h"
 
+#include <grpc/event_engine/event_engine.h>
 #include <grpc/support/json.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/time.h>
@@ -36,6 +37,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/strip.h"
 #include "src/core/channelz/channelz_registry.h"
+#include "src/core/config/config_vars.h"
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
 #include "src/core/lib/channel/channel_args.h"
@@ -164,6 +166,10 @@ class ExplicitJsonDataSink final : public DataSink {
 // BaseNode
 //
 
+namespace {
+std::atomic<int32_t> kept_alive_nodes{0};
+}
+
 BaseNode::BaseNode(EntityType type, std::string name)
     : type_(type), uuid_(-1), name_(std::move(name)) {
   // The registry will set uuid_ under its lock.
@@ -172,7 +178,20 @@ BaseNode::BaseNode(EntityType type, std::string name)
 
 BaseNode::~BaseNode() { ChannelzRegistry::Unregister(this); }
 
-void BaseNode::Orphaned() {}
+void BaseNode::Orphaned() {
+  const auto& config = ConfigVars::Get();
+  if (config.ChannelzMaxKeepaliveNodes() <= 0) return;
+  if (config.ChannelzKeepaliveTime() <= 0) return;
+  if (kept_alive_nodes.fetch_add(1, std::memory_order_relaxed) >
+      config.ChannelzMaxKeepaliveNodes()) {
+    kept_alive_nodes.fetch_sub(1, std::memory_order_relaxed);
+    return;
+  }
+  grpc_event_engine::experimental::GetDefaultEventEngine()->RunAfter(
+      Duration::Seconds(config.ChannelzKeepaliveTime()), [node = WeakRef()]() {
+        kept_alive_nodes.fetch_sub(1, std::memory_order_relaxed);
+      });
+}
 
 intptr_t BaseNode::UuidSlow() { return ChannelzRegistry::NumberNode(this); }
 

--- a/src/core/channelz/channelz.cc
+++ b/src/core/channelz/channelz.cc
@@ -172,6 +172,8 @@ BaseNode::BaseNode(EntityType type, std::string name)
 
 BaseNode::~BaseNode() { ChannelzRegistry::Unregister(this); }
 
+void BaseNode::Orphaned() {}
+
 intptr_t BaseNode::UuidSlow() { return ChannelzRegistry::NumberNode(this); }
 
 std::string BaseNode::RenderJsonString() {

--- a/src/core/channelz/channelz.h
+++ b/src/core/channelz/channelz.h
@@ -130,6 +130,8 @@ class BaseNode : public DualRefCounted<BaseNode> {
 
   void Orphaned() override;
 
+  bool WasOrphaned() { return RefIfNonZero() != nullptr; }
+
   bool HasParent(const BaseNode* parent) const {
     MutexLock lock(&parent_mu_);
     return parents_.find(parent) != parents_.end();

--- a/src/core/channelz/channelz.h
+++ b/src/core/channelz/channelz.h
@@ -87,7 +87,7 @@ class SubchannelNodePeer;
 }  // namespace testing
 
 // base class for all channelz entities
-class BaseNode : public RefCounted<BaseNode> {
+class BaseNode : public DualRefCounted<BaseNode> {
  public:
   // There are only four high level channelz entities. However, to support
   // GetTopChannelsRequest, we split the Channel entity into two different
@@ -127,6 +127,8 @@ class BaseNode : public RefCounted<BaseNode> {
 
  public:
   ~BaseNode() override;
+
+  void Orphaned() override;
 
   bool HasParent(const BaseNode* parent) const {
     MutexLock lock(&parent_mu_);

--- a/src/core/channelz/channelz_registry.h
+++ b/src/core/channelz/channelz_registry.h
@@ -45,37 +45,37 @@ class ChannelzRegistry final {
   static void Unregister(BaseNode* node) {
     Default()->InternalUnregister(node);
   }
-  static RefCountedPtr<BaseNode> Get(intptr_t uuid) {
+  static WeakRefCountedPtr<BaseNode> Get(intptr_t uuid) {
     return Default()->InternalGet(uuid);
   }
   static intptr_t NumberNode(BaseNode* node) {
     return Default()->InternalNumberNode(node);
   }
 
-  static RefCountedPtr<SubchannelNode> GetSubchannel(intptr_t uuid) {
+  static WeakRefCountedPtr<SubchannelNode> GetSubchannel(intptr_t uuid) {
     return Default()
         ->InternalGetTyped<SubchannelNode, BaseNode::EntityType::kSubchannel>(
             uuid);
   }
 
-  static RefCountedPtr<ChannelNode> GetChannel(intptr_t uuid) {
+  static WeakRefCountedPtr<ChannelNode> GetChannel(intptr_t uuid) {
     auto node = Default()->InternalGet(uuid);
     if (node == nullptr) return nullptr;
     if (node->type() == BaseNode::EntityType::kTopLevelChannel) {
-      return node->RefAsSubclass<ChannelNode>();
+      return node->WeakRefAsSubclass<ChannelNode>();
     }
     if (node->type() == BaseNode::EntityType::kInternalChannel) {
-      return node->RefAsSubclass<ChannelNode>();
+      return node->WeakRefAsSubclass<ChannelNode>();
     }
     return nullptr;
   }
 
-  static RefCountedPtr<ServerNode> GetServer(intptr_t uuid) {
+  static WeakRefCountedPtr<ServerNode> GetServer(intptr_t uuid) {
     return Default()
         ->InternalGetTyped<ServerNode, BaseNode::EntityType::kServer>(uuid);
   }
 
-  static RefCountedPtr<SocketNode> GetSocket(intptr_t uuid) {
+  static WeakRefCountedPtr<SocketNode> GetSocket(intptr_t uuid) {
     return Default()
         ->InternalGetTyped<SocketNode, BaseNode::EntityType::kSocket>(uuid);
   }
@@ -100,7 +100,7 @@ class ChannelzRegistry final {
             start_server_id);
   }
 
-  static std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+  static std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool>
   GetChildrenOfType(intptr_t start_node, const BaseNode* parent,
                     BaseNode::EntityType type, size_t max_results) {
     return Default()->InternalGetChildrenOfType(start_node, parent, type,
@@ -111,7 +111,7 @@ class ChannelzRegistry final {
   // This can aid in debugging channelz code.
   static void LogAllEntities() { Default()->InternalLogAllEntities(); }
 
-  static std::vector<RefCountedPtr<BaseNode>> GetAllEntities() {
+  static std::vector<WeakRefCountedPtr<BaseNode>> GetAllEntities() {
     return Default()->InternalGetAllEntities();
   }
 
@@ -124,7 +124,7 @@ class ChannelzRegistry final {
  private:
   ChannelzRegistry() : node_map_(MakeNodeMap()) {}
 
-  // Takes a callable F: (RefCountedPtr<BaseNode>) -> bool, and returns
+  // Takes a callable F: (WeakRefCountedPtr<BaseNode>) -> bool, and returns
   // a (BaseNode*) -> bool that filters unreffed objects and returns true.
   // The ref must be unreffed outside the NodeMapInterface iteration.
   template <typename F>
@@ -143,10 +143,11 @@ class ChannelzRegistry final {
     virtual void Register(BaseNode* node) = 0;
     virtual void Unregister(BaseNode* node) = 0;
 
-    virtual std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool> QueryNodes(
-        intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
-        size_t max_results) = 0;
-    virtual RefCountedPtr<BaseNode> GetNode(intptr_t uuid) = 0;
+    virtual std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool>
+    QueryNodes(intptr_t start_node,
+               absl::FunctionRef<bool(const BaseNode*)> filter,
+               size_t max_results) = 0;
+    virtual WeakRefCountedPtr<BaseNode> GetNode(intptr_t uuid) = 0;
 
     virtual intptr_t NumberNode(BaseNode* node) = 0;
   };
@@ -156,10 +157,10 @@ class ChannelzRegistry final {
     void Register(BaseNode* node) override;
     void Unregister(BaseNode* node) override;
 
-    std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool> QueryNodes(
+    std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool> QueryNodes(
         intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
         size_t max_results) override;
-    RefCountedPtr<BaseNode> GetNode(intptr_t uuid) override;
+    WeakRefCountedPtr<BaseNode> GetNode(intptr_t uuid) override;
 
     intptr_t NumberNode(BaseNode* node) override { return node->uuid_; }
 
@@ -174,10 +175,10 @@ class ChannelzRegistry final {
     void Register(BaseNode* node) override;
     void Unregister(BaseNode* node) override;
 
-    std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool> QueryNodes(
+    std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool> QueryNodes(
         intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
         size_t max_results) override;
-    RefCountedPtr<BaseNode> GetNode(intptr_t uuid) override;
+    WeakRefCountedPtr<BaseNode> GetNode(intptr_t uuid) override;
 
     intptr_t NumberNode(BaseNode* node) override;
 
@@ -217,11 +218,11 @@ class ChannelzRegistry final {
 
   // if object with uuid has previously been registered as the correct type,
   // returns the void* associated with that uuid. Else returns nullptr.
-  RefCountedPtr<BaseNode> InternalGet(intptr_t uuid) {
+  WeakRefCountedPtr<BaseNode> InternalGet(intptr_t uuid) {
     return node_map_->GetNode(uuid);
   }
 
-  std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+  std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool>
   InternalGetChildrenOfType(intptr_t start_node, const BaseNode* parent,
                             BaseNode::EntityType type, size_t max_results) {
     return node_map_->QueryNodes(
@@ -233,31 +234,31 @@ class ChannelzRegistry final {
   }
 
   template <typename T, BaseNode::EntityType entity_type>
-  RefCountedPtr<T> InternalGetTyped(intptr_t uuid) {
-    RefCountedPtr<BaseNode> node = InternalGet(uuid);
+  WeakRefCountedPtr<T> InternalGetTyped(intptr_t uuid) {
+    WeakRefCountedPtr<BaseNode> node = InternalGet(uuid);
     if (node == nullptr || node->type() != entity_type) {
       return nullptr;
     }
-    return node->RefAsSubclass<T>();
+    return node->WeakRefAsSubclass<T>();
   }
 
   template <typename T, BaseNode::EntityType entity_type>
-  std::tuple<std::vector<RefCountedPtr<T>>, bool> InternalGetObjects(
+  std::tuple<std::vector<WeakRefCountedPtr<T>>, bool> InternalGetObjects(
       intptr_t start_id) {
     const int kPaginationLimit = 100;
-    std::vector<RefCountedPtr<T>> top_level_channels;
+    std::vector<WeakRefCountedPtr<T>> top_level_channels;
     const auto [nodes, end] = node_map_->QueryNodes(
         start_id,
         [](const BaseNode* node) { return node->type() == entity_type; },
         kPaginationLimit);
     for (const auto& p : nodes) {
-      top_level_channels.emplace_back(p->template RefAsSubclass<T>());
+      top_level_channels.emplace_back(p->template WeakRefAsSubclass<T>());
     }
     return std::tuple(std::move(top_level_channels), end);
   }
 
   void InternalLogAllEntities();
-  std::vector<RefCountedPtr<BaseNode>> InternalGetAllEntities();
+  std::vector<WeakRefCountedPtr<BaseNode>> InternalGetAllEntities();
 
   std::unique_ptr<NodeMapInterface> node_map_;
 };

--- a/src/core/config/config_vars.cc
+++ b/src/core/config/config_vars.cc
@@ -76,6 +76,11 @@ ABSL_FLAG(absl::optional<bool>, grpc_cpp_experimental_disable_reflection, {},
           "EXPERIMENTAL. Only respected when there is a dependency on "
           ":grpc++_reflection. If true, no reflection server will be "
           "automatically added.");
+ABSL_FLAG(
+    absl::optional<int32_t>, grpc_channelz_keepalive_time, {},
+    "How long in seconds to wait before destroying orphaned channelz nodes.");
+ABSL_FLAG(absl::optional<int32_t>, grpc_channelz_max_keepalive_nodes, {},
+          "Maximum number of orphaned channelz nodes to keep alive.");
 
 namespace grpc_core {
 
@@ -84,6 +89,13 @@ ConfigVars::ConfigVars(const Overrides& overrides)
           LoadConfig(FLAGS_grpc_client_channel_backup_poll_interval_ms,
                      "GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS",
                      overrides.client_channel_backup_poll_interval_ms, 5000)),
+      channelz_keepalive_time_(LoadConfig(
+          FLAGS_grpc_channelz_keepalive_time, "GRPC_CHANNELZ_KEEPALIVE_TIME",
+          overrides.channelz_keepalive_time, 0)),
+      channelz_max_keepalive_nodes_(
+          LoadConfig(FLAGS_grpc_channelz_max_keepalive_nodes,
+                     "GRPC_CHANNELZ_MAX_KEEPALIVE_NODES",
+                     overrides.channelz_max_keepalive_nodes, 0)),
       enable_fork_support_(LoadConfig(
           FLAGS_grpc_enable_fork_support, "GRPC_ENABLE_FORK_SUPPORT",
           overrides.enable_fork_support, GRPC_ENABLE_FORK_SUPPORT_DEFAULT)),
@@ -146,7 +158,9 @@ std::string ConfigVars::ToString() const {
       ", not_use_system_ssl_roots: ", NotUseSystemSslRoots() ? "true" : "false",
       ", ssl_cipher_suites: ", "\"", absl::CEscape(SslCipherSuites()), "\"",
       ", cpp_experimental_disable_reflection: ",
-      CppExperimentalDisableReflection() ? "true" : "false");
+      CppExperimentalDisableReflection() ? "true" : "false",
+      ", channelz_keepalive_time: ", ChannelzKeepaliveTime(),
+      ", channelz_max_keepalive_nodes: ", ChannelzMaxKeepaliveNodes());
 }
 
 }  // namespace grpc_core

--- a/src/core/config/config_vars.h
+++ b/src/core/config/config_vars.h
@@ -35,6 +35,8 @@ class GPR_DLL ConfigVars {
  public:
   struct Overrides {
     absl::optional<int32_t> client_channel_backup_poll_interval_ms;
+    absl::optional<int32_t> channelz_keepalive_time;
+    absl::optional<int32_t> channelz_max_keepalive_nodes;
     absl::optional<bool> enable_fork_support;
     absl::optional<bool> abort_on_leaks;
     absl::optional<bool> not_use_system_ssl_roots;
@@ -104,12 +106,20 @@ class GPR_DLL ConfigVars {
   bool CppExperimentalDisableReflection() const {
     return cpp_experimental_disable_reflection_;
   }
+  // How long in seconds to wait before destroying orphaned channelz nodes.
+  int32_t ChannelzKeepaliveTime() const { return channelz_keepalive_time_; }
+  // Maximum number of orphaned channelz nodes to keep alive.
+  int32_t ChannelzMaxKeepaliveNodes() const {
+    return channelz_max_keepalive_nodes_;
+  }
 
  private:
   explicit ConfigVars(const Overrides& overrides);
   static const ConfigVars& Load();
   static std::atomic<ConfigVars*> config_vars_;
   int32_t client_channel_backup_poll_interval_ms_;
+  int32_t channelz_keepalive_time_;
+  int32_t channelz_max_keepalive_nodes_;
   bool enable_fork_support_;
   bool abort_on_leaks_;
   bool not_use_system_ssl_roots_;

--- a/src/core/config/config_vars.yaml
+++ b/src/core/config/config_vars.yaml
@@ -25,7 +25,7 @@
 # behavior for some environment variables.
 #
 # Optionally, fuzz: true can be added to enable fuzzers to explore variations
-# in this config var with their regular fuzzing work - or fuzz: FunctionName 
+# in this config var with their regular fuzzing work - or fuzz: FunctionName
 # can be used to specify that the config space be explored, but FunctionName should be called to pre-format/validate the value for fuzzing.
 # Such functions should be listed in fuzz_config_vars_helpers.h.
 
@@ -68,8 +68,7 @@
     #define GPR_DEFAULT_LOG_VERBOSITY_STRING ""
     #endif  // !GPR_DEFAULT_LOG_VERBOSITY_STRING
   default: $GPR_DEFAULT_LOG_VERBOSITY_STRING
-  description:
-    Logging verbosity.
+  description: Logging verbosity.
   fuzz: true
 - name: enable_fork_support
   type: bool
@@ -84,8 +83,7 @@
   fuzz: true
 - name: poll_strategy
   type: string
-  description:
-    Declares which polling engines to try when starting gRPC.
+  description: Declares which polling engines to try when starting gRPC.
     This is a comma-separated list of engines, which are tried in priority
     order first -> last.
   default: all
@@ -123,3 +121,13 @@
   type: bool
   description: "EXPERIMENTAL. Only respected when there is a dependency on :grpc++_reflection. If true, no reflection server will be automatically added."
   default: false
+- name: channelz_keepalive_time
+  type: int
+  description: How long in seconds to wait before destroying orphaned channelz nodes.
+  default: 0
+  fuzz: true
+- name: channelz_max_keepalive_nodes
+  type: int
+  description: Maximum number of orphaned channelz nodes to keep alive.
+  default: 0
+  fuzz: true

--- a/test/core/channelz/channelz_registry_test.cc
+++ b/test/core/channelz/channelz_registry_test.cc
@@ -67,30 +67,30 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
 
 TEST_F(ChannelzRegistryTest, RegisterGetTest) {
   RefCountedPtr<BaseNode> channelz_channel = CreateTestNode();
-  RefCountedPtr<BaseNode> retrieved =
+  WeakRefCountedPtr<BaseNode> retrieved =
       ChannelzRegistry::Get(channelz_channel->uuid());
-  EXPECT_EQ(channelz_channel, retrieved);
+  EXPECT_EQ(channelz_channel.get(), retrieved.get());
 }
 
 TEST_F(ChannelzRegistryTest, RegisterManyItems) {
   std::vector<RefCountedPtr<BaseNode>> channelz_channels;
   for (int i = 0; i < 100; i++) {
     channelz_channels.push_back(CreateTestNode());
-    RefCountedPtr<BaseNode> retrieved =
+    WeakRefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(channelz_channels[i]->uuid());
-    EXPECT_EQ(channelz_channels[i], retrieved);
+    EXPECT_EQ(channelz_channels[i].get(), retrieved.get());
   }
 }
 
 TEST_F(ChannelzRegistryTest, NullIfNotPresentTest) {
   RefCountedPtr<BaseNode> channelz_channel = CreateTestNode();
   // try to pull out a uuid that does not exist.
-  RefCountedPtr<BaseNode> nonexistent =
+  WeakRefCountedPtr<BaseNode> nonexistent =
       ChannelzRegistry::Get(channelz_channel->uuid() + 1);
   EXPECT_EQ(nonexistent, nullptr);
-  RefCountedPtr<BaseNode> retrieved =
+  WeakRefCountedPtr<BaseNode> retrieved =
       ChannelzRegistry::Get(channelz_channel->uuid());
-  EXPECT_EQ(channelz_channel, retrieved);
+  EXPECT_EQ(channelz_channel.get(), retrieved.get());
 }
 
 TEST_F(ChannelzRegistryTest, TestUnregistration) {
@@ -112,9 +112,9 @@ TEST_F(ChannelzRegistryTest, TestUnregistration) {
   }
   // Check that the even channels are present and the odd channels are not.
   for (int i = 0; i < kLoopIterations; i++) {
-    RefCountedPtr<BaseNode> retrieved =
+    WeakRefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(even_channels[i]->uuid());
-    EXPECT_EQ(even_channels[i], retrieved);
+    EXPECT_EQ(even_channels[i].get(), retrieved.get());
     retrieved = ChannelzRegistry::Get(odd_uuids[i]);
     EXPECT_EQ(retrieved, nullptr);
   }
@@ -124,9 +124,9 @@ TEST_F(ChannelzRegistryTest, TestUnregistration) {
   more_channels.reserve(kLoopIterations);
   for (int i = 0; i < kLoopIterations; i++) {
     more_channels.push_back(CreateTestNode());
-    RefCountedPtr<BaseNode> retrieved =
+    WeakRefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(more_channels[i]->uuid());
-    EXPECT_EQ(more_channels[i], retrieved);
+    EXPECT_EQ(more_channels[i].get(), retrieved.get());
   }
 }
 

--- a/test/core/test_util/fuzz_config_vars.cc
+++ b/test/core/test_util/fuzz_config_vars.cc
@@ -23,6 +23,13 @@ namespace grpc_core {
 ConfigVars::Overrides OverridesFromFuzzConfigVars(
     const grpc::testing::FuzzConfigVars& vars) {
   ConfigVars::Overrides overrides;
+  if (vars.has_channelz_keepalive_time()) {
+    overrides.channelz_keepalive_time = vars.channelz_keepalive_time();
+  }
+  if (vars.has_channelz_max_keepalive_nodes()) {
+    overrides.channelz_max_keepalive_nodes =
+        vars.channelz_max_keepalive_nodes();
+  }
   if (vars.has_enable_fork_support()) {
     overrides.enable_fork_support = vars.enable_fork_support();
   }

--- a/test/core/test_util/fuzz_config_vars.proto
+++ b/test/core/test_util/fuzz_config_vars.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 package grpc.testing;
 
 message FuzzConfigVars {
+  optional int32 channelz_keepalive_time = 253799799;
+  optional int32 channelz_max_keepalive_nodes = 134759602;
   optional bool enable_fork_support = 61008869;
   optional string dns_resolver = 76817901;
   optional string verbosity = 68420950;


### PR DESCRIPTION
Will allow us to develop something that can collect post-mortem traces of failed channels.