### PR TITLE
[Build] Fix use_openssl=true

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -38,7 +38,7 @@ tasks:
     build_flags:
     - '--cxxopt=-std=c++17'
     - '--host_cxxopt=-std=c++17'
-    - '--//third_party:use_openssl=true'
+    - '--define=@grpc//third_party:use_openssl=true'
     build_targets:
       - "@grpc//:grpc"
       - "@grpc//:grpc_unsecure"

--- a/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_with_bzlmod_linux.sh
@@ -53,7 +53,7 @@ tools/bazel \
     --enable_bzlmod=true \
     --enable_workspace=false \
     --ignore_dev_dependency \
-    --//third_party:grpc_use_openssl=true \
+    --define=//third_party:grpc_use_openssl=true \
     -- \
     :all \
     -:grpcpp_csm_observability  # Needs google_cloud_cpp to be added to BCR


### PR DESCRIPTION
Fixed the bug in Bazel Tests passing the parameter incorrectly when enabling `third_party:use_openssl`. (Introduced from https://github.com/grpc/grpc/pull/39188) 