### PR TITLE
[opencensus] Reduce flakiness in tracing tests

### DIFF
--- a/test/cpp/ext/filters/census/library.h
+++ b/test/cpp/ext/filters/census/library.h
@@ -29,6 +29,7 @@
 #include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 #include "opencensus/stats/stats.h"
+#include "opencensus/stats/testing/test_utils.h"
 #include "opencensus/trace/exporter/span_exporter.h"
 #include "src/core/config/core_configuration.h"
 #include "src/cpp/client/client_stats_interceptor.h"
@@ -116,9 +117,18 @@ class ExportedTracesRecorder
     is_recording_ = false;
   }
 
-  std::vector<::opencensus::trace::exporter::SpanData> GetAndClearSpans() {
-    grpc_core::MutexLock lock(&mutex_);
-    return std::move(recorded_spans_);
+  std::vector<::opencensus::trace::exporter::SpanData> GetAndClearSpans(
+      int expected_size = 0, absl::Duration timeout = absl::Seconds(10)) {
+    auto deadline = absl::Now() + timeout;
+    mutex_.Lock();
+    do {
+      mutex_.Unlock();
+      ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+      mutex_.Lock();
+    } while (recorded_spans_.size() != expected_size && absl::Now() < deadline);
+    auto recorded_spans = std::move(recorded_spans_);
+    mutex_.Unlock();
+    return recorded_spans;
   }
 
  private:
@@ -174,8 +184,9 @@ class StatsPluginEnd2EndTest : public ::testing::Test {
     stub_ = EchoTestService::NewStub(grpc::CreateChannel(
         server_address_, grpc::InsecureChannelCredentials()));
 
-    // Clear out any previous spans
+    // Clear out any previous spans and metrics
     ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+    ::opencensus::stats::testing::TestUtils::Flush();
   }
 
   void ResetStub(std::shared_ptr<Channel> channel) {

--- a/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
+++ b/test/cpp/ext/filters/census/stats_plugin_end2end_test.cc
@@ -584,11 +584,8 @@ TEST_F(StatsPluginEnd2EndTest, TestAllSpansAreExported) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(3);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // We never ended the two spans created in the scope above, so we don't
   // expect them to be exported.
   ASSERT_EQ(3, recorded_spans.size());
@@ -653,11 +650,8 @@ TEST_F(StatsPluginEnd2EndTest,
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(3);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // Check presence of trace annotation for removal from channel's pending
   // resolver result queue.
   auto sent_span_data =
@@ -704,11 +698,8 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeAnnotations) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(1000 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(3);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // Check presence of message size annotations in attempt span
   auto attempt_span_data = GetSpanByName(
       recorded_spans, absl::StrCat("Attempt.", client_method_name_));
@@ -767,11 +758,8 @@ TEST_F(StatsPluginEnd2EndTest, TestMessageSizeWithCompressionAnnotations) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(3);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // Check presence of message size annotations in attempt span
   auto attempt_span_data = GetSpanByName(
       recorded_spans, absl::StrCat("Attempt.", client_method_name_));
@@ -821,11 +809,8 @@ TEST_F(StatsPluginEnd2EndTest, TestMetadataSizeAnnotations) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(3);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // Check presence of metadata size annotations in client span.
   auto sent_span_data = GetSpanByName(
       recorded_spans,
@@ -868,11 +853,8 @@ TEST_F(StatsPluginEnd2EndTest, TestHttpAnnotations) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(3);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   auto client_span_data = GetSpanByName(
       recorded_spans,
       absl::StrCat(
@@ -929,11 +911,8 @@ TEST_F(StatsPluginEnd2EndTest, TestObservabilityDisabledChannelArg) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(0);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // The size might be 0 or 1, depending on whether the server-side ends up
   // getting sampled or not.
   ASSERT_LE(recorded_spans.size(), 1);
@@ -999,11 +978,8 @@ TEST_F(StatsPluginEnd2EndTest, TestGlobalEnableOpenCensusTracing) {
     grpc::Status status = stub_->Echo(&context, request, &response);
     EXPECT_TRUE(status.ok());
   }
-  absl::SleepFor(absl::Milliseconds(500 * grpc_test_slowdown_factor()));
-  TestUtils::Flush();
-  ::opencensus::trace::exporter::SpanExporterTestPeer::ExportForTesting();
+  auto recorded_spans = traces_recorder_->GetAndClearSpans(0);
   traces_recorder_->StopRecording();
-  auto recorded_spans = traces_recorder_->GetAndClearSpans();
   // No span should be exported
   ASSERT_EQ(0, recorded_spans.size());
 


### PR DESCRIPTION
Sample flakiness - https://btx.cloud.google.com/invocations/d8b31680-e8ad-490d-937d-d95d88f9b0cd/targets/%2F%2Ftest%2Fcpp%2Fext%2Ffilters%2Fcensus:grpc_opencensus_plugin_test;config=c765e2a5ffb8f9c148ecf742800b5eab4fa68cc283a63446e7cbde8ba0f03a13/log