### PR TITLE
Add grpc build support for s390x arch

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoToolsPlatformTaskTest.cs
@@ -68,6 +68,16 @@ namespace Grpc.Tools.Tests
         }
 
         [Test]
+        public void CpuIss390x()
+        {
+            if (RuntimeInformation.OSArchitecture == Architecture.S390x)
+            {
+                _cpuMatched++;
+                Assert.AreEqual("s390x", _task.Cpu);
+            }
+        }
+
+        [Test]
         public void CpuIsArm64()
         {
             if (RuntimeInformation.OSArchitecture == Architecture.Arm64)

--- a/src/csharp/Grpc.Tools/CommonPlatformDetection.cs
+++ b/src/csharp/Grpc.Tools/CommonPlatformDetection.cs
@@ -29,7 +29,7 @@ namespace Grpc.Core.Internal
     internal static class CommonPlatformDetection
     {
         public enum OSKind { Unknown, Windows, Linux, MacOSX };
-        public enum CpuArchitecture { Unknown, X86, X64, Arm64 };
+        public enum CpuArchitecture { Unknown, X86, X64, Arm64, S390x };
 
         public static OSKind GetOSKind()
         {
@@ -85,6 +85,8 @@ namespace Grpc.Core.Internal
                     return CpuArchitecture.X64;
                 case Architecture.Arm64:
                     return CpuArchitecture.Arm64;
+                case Architecture.S390x:
+                    return CpuArchitecture.S390x;
                 // We do not support other architectures,
                 // so we simply return "unrecognized".
                 default: 

--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -59,6 +59,7 @@
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_ProtoCompiler)linux_x64/protoc" />
     <_Asset PackagePath="tools/linux_arm64/" Include="$(Assets_ProtoCompiler)linux_aarch64/protoc" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_ProtoCompiler)macos_x64/protoc" /> 
+    <_Asset PackagePath="tools/linux_s390x/" Include="$(Assets_ProtoCompiler)linux_s390x/protoc" />
 
     <!-- gRPC protocol buffer compiler plugins -->
     <_Asset PackagePath="tools/windows_x86/" Include="$(Assets_GrpcPlugins)protoc_windows_x86/grpc_csharp_plugin.exe" />
@@ -67,6 +68,7 @@
     <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_GrpcPlugins)protoc_linux_x64/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/linux_arm64/" Include="$(Assets_GrpcPlugins)protoc_linux_aarch64/grpc_csharp_plugin" />
     <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_GrpcPlugins)protoc_macos_x64/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/linux_s390x/" Include="$(Assets_GrpcPlugins)protoc_linux_s390x/grpc_csharp_plugin" />
 
     <None Include="@(_Asset)" Pack="true" Visible="false" />
   </ItemGroup>

--- a/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
+++ b/src/csharp/Grpc.Tools/ProtoToolsPlatform.cs
@@ -57,6 +57,7 @@ namespace Grpc.Tools
                 case CommonPlatformDetection.CpuArchitecture.X86: Cpu = "x86"; break;
                 case CommonPlatformDetection.CpuArchitecture.X64: Cpu = "x64"; break;
                 case CommonPlatformDetection.CpuArchitecture.Arm64: Cpu = "arm64"; break;
+                case CommonPlatformDetection.CpuArchitecture.S390x: Cpu = "s390x"; break;
                 default: Cpu = ""; break;
             }
 

--- a/src/csharp/build_nuget.sh
+++ b/src/csharp/build_nuget.sh
@@ -50,6 +50,14 @@ then
   sed -ibak "s/<\/GrpcCsharpVersion>/-singleplatform<\/GrpcCsharpVersion>/" build/dependencies.props
 fi
 
+cd protoc_plugins
+mkdir protoc_linux_s390x
+cd protoc_linux_s390x
+cp ../../../../bazel-bin/src/compiler/grpc_csharp_plugin ./
+cp ../../../../bazel-bin/external/com_google_protobuf/protoc ./
+cd ..
+cd ..
+
 dotnet restore Grpc.sln
 
 dotnet pack --configuration Release Grpc.Tools --output ../../artifacts


### PR DESCRIPTION
This pull request is to add grpc build support on s390x arch. So, far there was no support to build grpc on s390x and this change would enable it to build without any external patches.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

