### PR TITLE
[PH2] Track slot usage of transport's party

### DIFF
--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.h
@@ -58,6 +58,16 @@ namespace http2 {
 // [PH2][EXT] This is a TODO related to a project unrelated to PH2 but happening
 //            in parallel.
 
+// Http2 Client Transport Spawns Overview
+
+// | Promise Spawn       | Max Duration | Promise Resolution    | Max Spawns |
+// |                     | for Spawn    |                       |            |
+// |---------------------|--------------|-----------------------|------------|
+// | Endpoint Read Loop  | Infinite     | On transport close    | One        |
+// | Endpoint Write Loop | Infinite     | On transport close    | One        |
+
+// Max Party Slots (Always): 2
+
 // Experimental : This is just the initial skeleton of class
 // and it is functions. The code will be written iteratively.
 // Do not use or edit any of these functions unless you are

--- a/src/core/ext/transport/chttp2/transport/ping_promise.h
+++ b/src/core/ext/transport/chttp2/transport/ping_promise.h
@@ -31,6 +31,28 @@
 
 namespace grpc_core {
 namespace http2 {
+
+// Ping Promise Spawns Overview
+
+// | Promise Spawn   | Max Duration | Promise      | Max Spawns              |
+// |                 | for Spawn    | Resolution   |                         |
+// |-----------------|--------------|--------------|-------------------------|
+// | Ping Timeout    | 1 minute     | On Ping ack  | One per inflight ping   |
+// |                 |              | or timeout   |                         |
+// | Delayed Ping    | 2 Hours      | On scheduled | One                     |
+// |                 |              | time         |                         |
+// | Ping Waiter     | 1 minute     | On Ping ack  | One per ping request    |
+// |                 |              | or timeout   |                         |
+// Max Party Slots:
+// - Without multi ping:
+//   - 1 per ping request + 1 (for delayed ping) + 1 (for ping timeout)
+//   - Worst case(3 ping requests): 5
+
+// - With multi ping:
+//   - 1 per ping request + 1 (for delayed ping) + 1 per inflight ping
+//                                                (for ping timeout)
+//   - Worst case(3 ping requests): 7
+
 class PingInterface {
  public:
   struct SendPingArgs {


### PR DESCRIPTION
This PR adds comments to track the slot usage of transport's party. Any new spawns being done in the transport should update the comments accordingly. 