### PR TITLE
Fix Python 3.12 MacOS release artifact

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -58,6 +58,7 @@ brew config
 if $is_sonoma; then
   brew install cmake
   brew install gnupg
+  echo ${PATH}
   export PATH="/opt/homebrew/bin::${PATH}"
   cmake --version
 fi
@@ -140,6 +141,9 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
+  export PATH="/usr/local/bin::${PATH}"
+  echo "${PATH}"
+  
   # python
   time pip install --user -r $DIR/requirements.macos.txt
   time pip install --user --upgrade virtualenv Mako tox setuptools==44.1.1 twisted

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -58,7 +58,6 @@ brew config
 if $is_sonoma; then
   brew install cmake
   brew install gnupg
-  echo ${PATH}
   export PATH="/opt/homebrew/bin::${PATH}"
   cmake --version
 fi
@@ -141,9 +140,9 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
+  # add /usr/local/bin to path to override built in Python version
   export PATH="/usr/local/bin::${PATH}"
-  echo "${PATH}"
-  
+
   # python
   time pip install --user -r $DIR/requirements.macos.txt
   time pip install --user --upgrade virtualenv Mako tox setuptools==44.1.1 twisted

--- a/tools/internal_ci/macos/grpc_distribtests_python.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_python.sh
@@ -26,11 +26,11 @@ source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # TODO(jtattermusch): cleanup this prepare build step (needed for python artifact build)
 # install cython for all python versions
-python3.9 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.10 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.11 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.12 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user --break-system-packages
-python3.13 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user --break-system-packages
+python3.9 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.10 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.11 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.12 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
+python3.13 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
 
 # Build all python macos artifacts (this step actually builds all the binary wheels and source archives)
 tools/run_tests/task_runner.py -f artifact macos python ${TASK_RUNNER_EXTRA_FILTERS} -j 2 -x build_artifacts/sponge_log.xml || FAILED="true"

--- a/tools/internal_ci/macos/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/macos/grpc_run_tests_matrix.sh
@@ -24,7 +24,7 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 python3 --version
-pip install six==1.16.0
+python3 -m pip install six==1.16.0
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
 
 # kill port_server.py to prevent the build from freezing

--- a/tools/internal_ci/macos/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/macos/grpc_run_tests_matrix.sh
@@ -23,6 +23,8 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
+python3 --version
+pip install six==1.16.0
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
 
 # kill port_server.py to prevent the build from freezing

--- a/tools/internal_ci/macos/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/macos/grpc_run_tests_matrix.sh
@@ -23,7 +23,6 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
-python3 --version
 python3 -m pip install six==1.16.0
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
 

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -409,74 +409,74 @@ def targets():
             ProtocArtifact("macos", "x64", presubmit=True),
             ProtocArtifact("windows", "x64", presubmit=True),
             ProtocArtifact("windows", "x86", presubmit=True),
-            PythonArtifact("manylinux2014", "x64", "cp39-cp39", presubmit=True),
-            PythonArtifact("manylinux2014", "x64", "cp310-cp310"),
-            PythonArtifact("manylinux2014", "x64", "cp311-cp311"),
-            PythonArtifact("manylinux2014", "x64", "cp312-cp312"),
-            PythonArtifact(
-                "manylinux2014", "x64", "cp313-cp313", presubmit=True
-            ),
-            PythonArtifact("manylinux2014", "x86", "cp39-cp39", presubmit=True),
-            PythonArtifact("manylinux2014", "x86", "cp310-cp310"),
-            PythonArtifact("manylinux2014", "x86", "cp311-cp311"),
-            PythonArtifact("manylinux2014", "x86", "cp312-cp312"),
-            PythonArtifact(
-                "manylinux2014", "x86", "cp313-cp313", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "aarch64", "cp39-cp39", presubmit=True
-            ),
-            PythonArtifact("manylinux2014", "aarch64", "cp310-cp310"),
-            PythonArtifact("manylinux2014", "aarch64", "cp311-cp311"),
-            PythonArtifact("manylinux2014", "aarch64", "cp312-cp312"),
-            PythonArtifact(
-                "manylinux2014", "aarch64", "cp313-cp313", presubmit=True
-            ),
-            PythonArtifact("linux_extra", "armv7", "cp39-cp39", presubmit=True),
-            PythonArtifact("linux_extra", "armv7", "cp310-cp310"),
-            PythonArtifact("linux_extra", "armv7", "cp311-cp311"),
-            PythonArtifact("linux_extra", "armv7", "cp312-cp312"),
-            PythonArtifact(
-                "linux_extra", "armv7", "cp313-cp313", presubmit=True
-            ),
-            PythonArtifact("musllinux_1_1", "x64", "cp39-cp39", presubmit=True),
-            PythonArtifact("musllinux_1_1", "x64", "cp310-cp310"),
-            PythonArtifact("musllinux_1_1", "x64", "cp311-cp311"),
-            PythonArtifact("musllinux_1_1", "x64", "cp312-cp312"),
-            PythonArtifact(
-                "musllinux_1_1", "x64", "cp313-cp313", presubmit=True
-            ),
-            PythonArtifact("musllinux_1_1", "x86", "cp39-cp39", presubmit=True),
-            PythonArtifact("musllinux_1_1", "x86", "cp310-cp310"),
-            PythonArtifact("musllinux_1_1", "x86", "cp311-cp311"),
-            PythonArtifact("musllinux_1_1", "x86", "cp312-cp312"),
-            PythonArtifact(
-                "musllinux_1_1", "x86", "cp313-cp313", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_1", "aarch64", "cp39-cp39", presubmit=True
-            ),
-            PythonArtifact("musllinux_1_1", "aarch64", "cp310-cp310"),
-            PythonArtifact("musllinux_1_1", "aarch64", "cp311-cp311"),
-            PythonArtifact("musllinux_1_1", "aarch64", "cp312-cp312"),
+            # PythonArtifact("manylinux2014", "x64", "cp39-cp39", presubmit=True),
+            # PythonArtifact("manylinux2014", "x64", "cp310-cp310"),
+            # PythonArtifact("manylinux2014", "x64", "cp311-cp311"),
+            # PythonArtifact("manylinux2014", "x64", "cp312-cp312"),
+            # PythonArtifact(
+            #     "manylinux2014", "x64", "cp313-cp313", presubmit=True
+            # ),
+            # PythonArtifact("manylinux2014", "x86", "cp39-cp39", presubmit=True),
+            # PythonArtifact("manylinux2014", "x86", "cp310-cp310"),
+            # PythonArtifact("manylinux2014", "x86", "cp311-cp311"),
+            # PythonArtifact("manylinux2014", "x86", "cp312-cp312"),
+            # PythonArtifact(
+            #     "manylinux2014", "x86", "cp313-cp313", presubmit=True
+            # ),
+            # PythonArtifact(
+            #     "manylinux2014", "aarch64", "cp39-cp39", presubmit=True
+            # ),
+            # PythonArtifact("manylinux2014", "aarch64", "cp310-cp310"),
+            # PythonArtifact("manylinux2014", "aarch64", "cp311-cp311"),
+            # PythonArtifact("manylinux2014", "aarch64", "cp312-cp312"),
+            # PythonArtifact(
+            #     "manylinux2014", "aarch64", "cp313-cp313", presubmit=True
+            # ),
+            # PythonArtifact("linux_extra", "armv7", "cp39-cp39", presubmit=True),
+            # PythonArtifact("linux_extra", "armv7", "cp310-cp310"),
+            # PythonArtifact("linux_extra", "armv7", "cp311-cp311"),
+            # PythonArtifact("linux_extra", "armv7", "cp312-cp312"),
+            # PythonArtifact(
+            #     "linux_extra", "armv7", "cp313-cp313", presubmit=True
+            # ),
+            # PythonArtifact("musllinux_1_1", "x64", "cp39-cp39", presubmit=True),
+            # PythonArtifact("musllinux_1_1", "x64", "cp310-cp310"),
+            # PythonArtifact("musllinux_1_1", "x64", "cp311-cp311"),
+            # PythonArtifact("musllinux_1_1", "x64", "cp312-cp312"),
+            # PythonArtifact(
+            #     "musllinux_1_1", "x64", "cp313-cp313", presubmit=True
+            # ),
+            # PythonArtifact("musllinux_1_1", "x86", "cp39-cp39", presubmit=True),
+            # PythonArtifact("musllinux_1_1", "x86", "cp310-cp310"),
+            # PythonArtifact("musllinux_1_1", "x86", "cp311-cp311"),
+            # PythonArtifact("musllinux_1_1", "x86", "cp312-cp312"),
+            # PythonArtifact(
+            #     "musllinux_1_1", "x86", "cp313-cp313", presubmit=True
+            # ),
+            # PythonArtifact(
+            #     "musllinux_1_1", "aarch64", "cp39-cp39", presubmit=True
+            # ),
+            # PythonArtifact("musllinux_1_1", "aarch64", "cp310-cp310"),
+            # PythonArtifact("musllinux_1_1", "aarch64", "cp311-cp311"),
+            # PythonArtifact("musllinux_1_1", "aarch64", "cp312-cp312"),
             PythonArtifact(
                 "musllinux_1_1", "aarch64", "cp313-cp313", presubmit=True
             ),
             PythonArtifact("macos", "x64", "python3.9", presubmit=True),
-            PythonArtifact("macos", "x64", "python3.10"),
-            PythonArtifact("macos", "x64", "python3.11"),
-            PythonArtifact("macos", "x64", "python3.12"),
-            PythonArtifact("macos", "x64", "python3.13", presubmit=True),
+            # PythonArtifact("macos", "x64", "python3.10"),
+            # PythonArtifact("macos", "x64", "python3.11"),
+            PythonArtifact("macos", "x64", "python3.12", presubmit=True),
+            # PythonArtifact("macos", "x64", "python3.13", presubmit=True),
             PythonArtifact("windows", "x86", "Python39_32bit", presubmit=True),
-            PythonArtifact("windows", "x86", "Python310_32bit"),
-            PythonArtifact("windows", "x86", "Python311_32bit"),
-            PythonArtifact("windows", "x86", "Python312_32bit"),
-            PythonArtifact("windows", "x86", "Python313_32bit", presubmit=True),
-            PythonArtifact("windows", "x64", "Python39", presubmit=True),
-            PythonArtifact("windows", "x64", "Python310"),
-            PythonArtifact("windows", "x64", "Python311"),
-            PythonArtifact("windows", "x64", "Python312"),
-            PythonArtifact("windows", "x64", "Python313", presubmit=True),
+            # PythonArtifact("windows", "x86", "Python310_32bit"),
+            # PythonArtifact("windows", "x86", "Python311_32bit"),
+            # PythonArtifact("windows", "x86", "Python312_32bit"),
+            # PythonArtifact("windows", "x86", "Python313_32bit", presubmit=True),
+            # PythonArtifact("windows", "x64", "Python39", presubmit=True),
+            # PythonArtifact("windows", "x64", "Python310"),
+            # PythonArtifact("windows", "x64", "Python311"),
+            # PythonArtifact("windows", "x64", "Python312"),
+            # PythonArtifact("windows", "x64", "Python313", presubmit=True),
             RubyArtifact("linux", "x86-mingw32", presubmit=True),
             RubyArtifact("linux", "x64-mingw32"),
             RubyArtifact("linux", "x64-mingw-ucrt", presubmit=True),

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -409,74 +409,74 @@ def targets():
             ProtocArtifact("macos", "x64", presubmit=True),
             ProtocArtifact("windows", "x64", presubmit=True),
             ProtocArtifact("windows", "x86", presubmit=True),
-            # PythonArtifact("manylinux2014", "x64", "cp39-cp39", presubmit=True),
-            # PythonArtifact("manylinux2014", "x64", "cp310-cp310"),
-            # PythonArtifact("manylinux2014", "x64", "cp311-cp311"),
-            # PythonArtifact("manylinux2014", "x64", "cp312-cp312"),
-            # PythonArtifact(
-            #     "manylinux2014", "x64", "cp313-cp313", presubmit=True
-            # ),
-            # PythonArtifact("manylinux2014", "x86", "cp39-cp39", presubmit=True),
-            # PythonArtifact("manylinux2014", "x86", "cp310-cp310"),
-            # PythonArtifact("manylinux2014", "x86", "cp311-cp311"),
-            # PythonArtifact("manylinux2014", "x86", "cp312-cp312"),
-            # PythonArtifact(
-            #     "manylinux2014", "x86", "cp313-cp313", presubmit=True
-            # ),
-            # PythonArtifact(
-            #     "manylinux2014", "aarch64", "cp39-cp39", presubmit=True
-            # ),
-            # PythonArtifact("manylinux2014", "aarch64", "cp310-cp310"),
-            # PythonArtifact("manylinux2014", "aarch64", "cp311-cp311"),
-            # PythonArtifact("manylinux2014", "aarch64", "cp312-cp312"),
-            # PythonArtifact(
-            #     "manylinux2014", "aarch64", "cp313-cp313", presubmit=True
-            # ),
-            # PythonArtifact("linux_extra", "armv7", "cp39-cp39", presubmit=True),
-            # PythonArtifact("linux_extra", "armv7", "cp310-cp310"),
-            # PythonArtifact("linux_extra", "armv7", "cp311-cp311"),
-            # PythonArtifact("linux_extra", "armv7", "cp312-cp312"),
-            # PythonArtifact(
-            #     "linux_extra", "armv7", "cp313-cp313", presubmit=True
-            # ),
-            # PythonArtifact("musllinux_1_1", "x64", "cp39-cp39", presubmit=True),
-            # PythonArtifact("musllinux_1_1", "x64", "cp310-cp310"),
-            # PythonArtifact("musllinux_1_1", "x64", "cp311-cp311"),
-            # PythonArtifact("musllinux_1_1", "x64", "cp312-cp312"),
-            # PythonArtifact(
-            #     "musllinux_1_1", "x64", "cp313-cp313", presubmit=True
-            # ),
-            # PythonArtifact("musllinux_1_1", "x86", "cp39-cp39", presubmit=True),
-            # PythonArtifact("musllinux_1_1", "x86", "cp310-cp310"),
-            # PythonArtifact("musllinux_1_1", "x86", "cp311-cp311"),
-            # PythonArtifact("musllinux_1_1", "x86", "cp312-cp312"),
-            # PythonArtifact(
-            #     "musllinux_1_1", "x86", "cp313-cp313", presubmit=True
-            # ),
-            # PythonArtifact(
-            #     "musllinux_1_1", "aarch64", "cp39-cp39", presubmit=True
-            # ),
-            # PythonArtifact("musllinux_1_1", "aarch64", "cp310-cp310"),
-            # PythonArtifact("musllinux_1_1", "aarch64", "cp311-cp311"),
-            # PythonArtifact("musllinux_1_1", "aarch64", "cp312-cp312"),
+            PythonArtifact("manylinux2014", "x64", "cp39-cp39", presubmit=True),
+            PythonArtifact("manylinux2014", "x64", "cp310-cp310"),
+            PythonArtifact("manylinux2014", "x64", "cp311-cp311"),
+            PythonArtifact("manylinux2014", "x64", "cp312-cp312"),
+            PythonArtifact(
+                "manylinux2014", "x64", "cp313-cp313", presubmit=True
+            ),
+            PythonArtifact("manylinux2014", "x86", "cp39-cp39", presubmit=True),
+            PythonArtifact("manylinux2014", "x86", "cp310-cp310"),
+            PythonArtifact("manylinux2014", "x86", "cp311-cp311"),
+            PythonArtifact("manylinux2014", "x86", "cp312-cp312"),
+            PythonArtifact(
+                "manylinux2014", "x86", "cp313-cp313", presubmit=True
+            ),
+            PythonArtifact(
+                "manylinux2014", "aarch64", "cp39-cp39", presubmit=True
+            ),
+            PythonArtifact("manylinux2014", "aarch64", "cp310-cp310"),
+            PythonArtifact("manylinux2014", "aarch64", "cp311-cp311"),
+            PythonArtifact("manylinux2014", "aarch64", "cp312-cp312"),
+            PythonArtifact(
+                "manylinux2014", "aarch64", "cp313-cp313", presubmit=True
+            ),
+            PythonArtifact("linux_extra", "armv7", "cp39-cp39", presubmit=True),
+            PythonArtifact("linux_extra", "armv7", "cp310-cp310"),
+            PythonArtifact("linux_extra", "armv7", "cp311-cp311"),
+            PythonArtifact("linux_extra", "armv7", "cp312-cp312"),
+            PythonArtifact(
+                "linux_extra", "armv7", "cp313-cp313", presubmit=True
+            ),
+            PythonArtifact("musllinux_1_1", "x64", "cp39-cp39", presubmit=True),
+            PythonArtifact("musllinux_1_1", "x64", "cp310-cp310"),
+            PythonArtifact("musllinux_1_1", "x64", "cp311-cp311"),
+            PythonArtifact("musllinux_1_1", "x64", "cp312-cp312"),
+            PythonArtifact(
+                "musllinux_1_1", "x64", "cp313-cp313", presubmit=True
+            ),
+            PythonArtifact("musllinux_1_1", "x86", "cp39-cp39", presubmit=True),
+            PythonArtifact("musllinux_1_1", "x86", "cp310-cp310"),
+            PythonArtifact("musllinux_1_1", "x86", "cp311-cp311"),
+            PythonArtifact("musllinux_1_1", "x86", "cp312-cp312"),
+            PythonArtifact(
+                "musllinux_1_1", "x86", "cp313-cp313", presubmit=True
+            ),
+            PythonArtifact(
+                "musllinux_1_1", "aarch64", "cp39-cp39", presubmit=True
+            ),
+            PythonArtifact("musllinux_1_1", "aarch64", "cp310-cp310"),
+            PythonArtifact("musllinux_1_1", "aarch64", "cp311-cp311"),
+            PythonArtifact("musllinux_1_1", "aarch64", "cp312-cp312"),
             PythonArtifact(
                 "musllinux_1_1", "aarch64", "cp313-cp313", presubmit=True
             ),
             PythonArtifact("macos", "x64", "python3.9", presubmit=True),
-            # PythonArtifact("macos", "x64", "python3.10"),
-            # PythonArtifact("macos", "x64", "python3.11"),
-            PythonArtifact("macos", "x64", "python3.12", presubmit=True),
-            # PythonArtifact("macos", "x64", "python3.13", presubmit=True),
+            PythonArtifact("macos", "x64", "python3.10"),
+            PythonArtifact("macos", "x64", "python3.11"),
+            PythonArtifact("macos", "x64", "python3.12"),
+            PythonArtifact("macos", "x64", "python3.13", presubmit=True),
             PythonArtifact("windows", "x86", "Python39_32bit", presubmit=True),
-            # PythonArtifact("windows", "x86", "Python310_32bit"),
-            # PythonArtifact("windows", "x86", "Python311_32bit"),
-            # PythonArtifact("windows", "x86", "Python312_32bit"),
-            # PythonArtifact("windows", "x86", "Python313_32bit", presubmit=True),
-            # PythonArtifact("windows", "x64", "Python39", presubmit=True),
-            # PythonArtifact("windows", "x64", "Python310"),
-            # PythonArtifact("windows", "x64", "Python311"),
-            # PythonArtifact("windows", "x64", "Python312"),
-            # PythonArtifact("windows", "x64", "Python313", presubmit=True),
+            PythonArtifact("windows", "x86", "Python310_32bit"),
+            PythonArtifact("windows", "x86", "Python311_32bit"),
+            PythonArtifact("windows", "x86", "Python312_32bit"),
+            PythonArtifact("windows", "x86", "Python313_32bit", presubmit=True),
+            PythonArtifact("windows", "x64", "Python39", presubmit=True),
+            PythonArtifact("windows", "x64", "Python310"),
+            PythonArtifact("windows", "x64", "Python311"),
+            PythonArtifact("windows", "x64", "Python312"),
+            PythonArtifact("windows", "x64", "Python313", presubmit=True),
             RubyArtifact("linux", "x86-mingw32", presubmit=True),
             RubyArtifact("linux", "x64-mingw32"),
             RubyArtifact("linux", "x64-mingw-ucrt", presubmit=True),


### PR DESCRIPTION
PR to fix MacOS Python 3.12 artifact to use custom installed version of Python instead of the default available version