### PR TITLE
[ssl] Only run select SSL tests when built against BoringSSL.

### DIFF
--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1020,6 +1020,7 @@ TEST_P(SslTransportSecurityTest, DoHandshakeWithCustomBioPair) {
   DoHandshake();
 }
 
+// TODO(matthewstevenson88): Make tests below compatible with OpenSSL.
 #if defined(OPENSSL_IS_BORINGSSL)
 TEST_P(SslTransportSecurityTest, Protect) {
   LOG(INFO) << "ssl_tsi_test_protect";

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1020,6 +1020,7 @@ TEST_P(SslTransportSecurityTest, DoHandshakeWithCustomBioPair) {
   DoHandshake();
 }
 
+#if defined(OPENSSL_IS_BORINGSSL)
 TEST_P(SslTransportSecurityTest, Protect) {
   LOG(INFO) << "ssl_tsi_test_protect";
   SetUpSslFixture(tsi_tls_version::TSI_TLS1_3, /*send_client_ca_list=*/false);
@@ -1134,6 +1135,7 @@ TEST_P(SslTransportSecurityTest, ConcurrentlyProtectAndUnprotectOnServer) {
   tsi_frame_protector_destroy(client_protector);
   tsi_frame_protector_destroy(server_protector);
 }
+#endif  // defined(OPENSSL_IS_BORINGSSL)
 
 static const tsi_ssl_handshaker_factory_vtable* original_vtable;
 static bool handshaker_factory_destructor_called;


### PR DESCRIPTION
Currently these tests are checking for numbers (e.g. TLS frame size) that are too specific to the BoringSSL behavior (e.g. because we do not take into account TLS 1.2 vs. TLS 1.3, whether or not session tickets are present, etc.). As a temporary fix, run these tests when built against BoringSSL only, while I fix them up to be OpenSSL compatible.
