### PR TITLE
[Backport][v1.70.x][CI] Used VS2022 for Windows/build_artifact_protoc

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_protoc.bat
+++ b/tools/run_tests/artifacts/build_artifact_protoc.bat
@@ -29,7 +29,7 @@ if "%GRPC_PROTOC_BUILD_COMPILER_JOBS%"=="" (
 
 @rem set cl.exe build environment to build with VS2019 tooling
 @rem this is required for Ninja build to work
-call "%VS160COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %ARCHITECTURE%
+call "%VS170COMNTOOLS%..\..\VC\Auxiliary\Build\vcvarsall.bat" %ARCHITECTURE%
 @rem restore command echo
 echo on
 


### PR DESCRIPTION
*Beep boop. This is an automatically generated backport of #38697.*
gRPC stopped supporting VS2019 so all artifacts need to be built with VS2022 on Windows.