### PR TITLE
[tsi] Clarify concurrency expectations for TSI frame protector's protect and protect_flush methods.

### DIFF
--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -28,8 +28,9 @@
 // Base for tsi_frame_protector implementations.
 // See transport_security_interface.h for documentation.
 // All methods must be implemented.
-// Implementations must guarantee that protect, protect_flush, and unprotect can
-// be called concurrently.
+// Implementations must provide the following thread-safety guarantees:
+// - protect and unprotect can be called concurrently,
+// - protect_flush and unprotect can be called concurrently.
 struct tsi_frame_protector_vtable {
   tsi_result (*protect)(tsi_frame_protector* self,
                         const unsigned char* unprotected_bytes,

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -129,8 +129,8 @@ typedef struct tsi_frame_protector tsi_frame_protector;
 //   to make sure that there are no more protected bytes buffered in the
 //   protector.
 //
-// Can be called concurrently with tsi_frame_protector_protect_flush or
-// tsi_frame_protector_unprotect.
+// Can be called concurrently with tsi_frame_protector_unprotect. Cannot be
+// called concurrently with tsi_frame_protector_protect_flush.
 
 // A typical way to call this method would be:
 
@@ -179,8 +179,8 @@ tsi_result tsi_frame_protector_protect(tsi_frame_protector* self,
 // - still_pending_bytes is an output parameter indicating the number of bytes
 //   that still need to be flushed from the protector.
 //
-// Can be called concurrently with tsi_frame_protector_protect or
-// tsi_frame_protector_unprotect.
+// Can be called concurrently with tsi_frame_protector_unprotect. Cannot be
+// called concurrently with tsi_frame_protector_protect.
 tsi_result tsi_frame_protector_protect_flush(
     tsi_frame_protector* self, unsigned char* protected_output_frames,
     size_t* protected_output_frames_size, size_t* still_pending_size);


### PR DESCRIPTION
This PR clarifies an ambiguity in the interface comments introduced in #39351.

