### PR TITLE
[xds_cluster_impl] Fix a crash in xds_cluster_impl when locality_name is null

### DIFF
--- a/src/core/load_balancing/xds/xds_cluster_impl.cc
+++ b/src/core/load_balancing/xds/xds_cluster_impl.cc
@@ -209,6 +209,10 @@ class XdsClusterImplLb final : public LoadBalancingPolicy {
           [](RefCountedStringValue locality) { return locality; },
           [](const RefCountedPtr<LrsClient::ClusterLocalityStats>&
                  locality_stats) {
+            if (locality_stats == nullptr ||
+                locality_stats->locality_name() == nullptr) {
+              return RefCountedStringValue();
+            }
             return locality_stats->locality_name()->human_readable_string();
           });
     }


### PR DESCRIPTION
Internal bug ref : b/415798636