### PR TITLE
[channelz] Convert BaseNode to be DualRefCounted

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1270,6 +1270,7 @@ grpc_cc_library(
         "uri",
         "//src/core:channel_args",
         "//src/core:connectivity_state",
+        "//src/core:dual_ref_counted",
         "//src/core:json",
         "//src/core:json_reader",
         "//src/core:json_writer",

--- a/src/core/channelz/channelz.h
+++ b/src/core/channelz/channelz.h
@@ -40,6 +40,7 @@
 #include "absl/strings/string_view.h"
 #include "src/core/channelz/channel_trace.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/util/dual_ref_counted.h"
 #include "src/core/util/json/json.h"
 #include "src/core/util/per_cpu.h"
 #include "src/core/util/ref_counted.h"
@@ -87,7 +88,7 @@ class SubchannelNodePeer;
 }  // namespace testing
 
 // base class for all channelz entities
-class BaseNode : public RefCounted<BaseNode> {
+class BaseNode : public DualRefCounted<BaseNode> {
  public:
   // There are only four high level channelz entities. However, to support
   // GetTopChannelsRequest, we split the Channel entity into two different
@@ -127,6 +128,8 @@ class BaseNode : public RefCounted<BaseNode> {
 
  public:
   ~BaseNode() override;
+
+  void Orphaned() final {}
 
   bool HasParent(const BaseNode* parent) const {
     MutexLock lock(&parent_mu_);

--- a/src/core/channelz/channelz_registry.cc
+++ b/src/core/channelz/channelz_registry.cc
@@ -106,7 +106,7 @@ ChannelzRegistry* ChannelzRegistry::Default() {
   return singleton;
 }
 
-std::vector<RefCountedPtr<BaseNode>>
+std::vector<WeakRefCountedPtr<BaseNode>>
 ChannelzRegistry::InternalGetAllEntities() {
   return std::get<0>(node_map_->QueryNodes(
       0, [](const BaseNode*) { return true; },
@@ -155,18 +155,18 @@ void ChannelzRegistry::LegacyNodeMap::Unregister(BaseNode* node) {
   node_map_.erase(uuid);
 }
 
-std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool>
 ChannelzRegistry::LegacyNodeMap::QueryNodes(
     intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
     size_t max_results) {
-  RefCountedPtr<BaseNode> node_after_end;
-  std::vector<RefCountedPtr<BaseNode>> result;
+  WeakRefCountedPtr<BaseNode> node_after_end;
+  std::vector<WeakRefCountedPtr<BaseNode>> result;
   MutexLock lock(&mu_);
   for (auto it = node_map_.lower_bound(start_node); it != node_map_.end();
        ++it) {
     BaseNode* node = it->second;
     if (!filter(node)) continue;
-    auto node_ref = node->RefIfNonZero();
+    auto node_ref = node->WeakRefIfNonZero();
     if (node_ref == nullptr) continue;
     if (result.size() == max_results) {
       node_after_end = node_ref;
@@ -177,7 +177,7 @@ ChannelzRegistry::LegacyNodeMap::QueryNodes(
   return std::tuple(std::move(result), node_after_end == nullptr);
 }
 
-RefCountedPtr<BaseNode> ChannelzRegistry::LegacyNodeMap::GetNode(
+WeakRefCountedPtr<BaseNode> ChannelzRegistry::LegacyNodeMap::GetNode(
     intptr_t uuid) {
   MutexLock lock(&mu_);
   if (uuid < 1 || uuid > uuid_generator_) return nullptr;
@@ -186,7 +186,7 @@ RefCountedPtr<BaseNode> ChannelzRegistry::LegacyNodeMap::GetNode(
   // Found node.  Return only if its refcount is not zero (i.e., when we
   // know that there is no other thread about to destroy it).
   BaseNode* node = it->second;
-  return node->RefIfNonZero();
+  return node->WeakRefIfNonZero();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -213,7 +213,7 @@ void ChannelzRegistry::ShardedNodeMap::Unregister(BaseNode* node) {
   index_.erase(node->uuid_);
 }
 
-std::tuple<std::vector<RefCountedPtr<BaseNode>>, bool>
+std::tuple<std::vector<WeakRefCountedPtr<BaseNode>>, bool>
 ChannelzRegistry::ShardedNodeMap::QueryNodes(
     intptr_t start_node, absl::FunctionRef<bool(const BaseNode*)> filter,
     size_t max_results) {
@@ -232,13 +232,13 @@ ChannelzRegistry::ShardedNodeMap::QueryNodes(
   // so we need to unref it, but we can't do that while holding the lock.
   // So instead, we store it in node_after_end, which will be unreffed
   // after releasing the lock.
-  RefCountedPtr<BaseNode> node_after_end;
-  std::vector<RefCountedPtr<BaseNode>> result;
+  WeakRefCountedPtr<BaseNode> node_after_end;
+  std::vector<WeakRefCountedPtr<BaseNode>> result;
   MutexLock index_lock(&index_mu_);
   for (auto it = index_.lower_bound(start_node); it != index_.end(); ++it) {
     BaseNode* node = it->second;
     if (!filter(node)) continue;
-    auto node_ref = node->RefIfNonZero();
+    auto node_ref = node->WeakRefIfNonZero();
     if (node_ref == nullptr) continue;
     if (result.size() == max_results) {
       node_after_end = std::move(node_ref);
@@ -256,7 +256,7 @@ ChannelzRegistry::ShardedNodeMap::QueryNodes(
         n = n->next_;
         continue;
       }
-      auto node_ref = n->RefIfNonZero();
+      auto node_ref = n->WeakRefIfNonZero();
       if (node_ref == nullptr) {
         n = n->next_;
         continue;
@@ -307,13 +307,13 @@ void ChannelzRegistry::ShardedNodeMap::RemoveNodeFromHead(BaseNode* node,
   if (node->next_ != nullptr) node->next_->prev_ = node->prev_;
 }
 
-RefCountedPtr<BaseNode> ChannelzRegistry::ShardedNodeMap::GetNode(
+WeakRefCountedPtr<BaseNode> ChannelzRegistry::ShardedNodeMap::GetNode(
     intptr_t uuid) {
   MutexLock index_lock(&index_mu_);
   auto it = index_.find(uuid);
   if (it == index_.end()) return nullptr;
   BaseNode* node = it->second;
-  return node->RefIfNonZero();
+  return node->WeakRefIfNonZero();
 }
 
 intptr_t ChannelzRegistry::ShardedNodeMap::NumberNode(BaseNode* node) {
@@ -356,7 +356,7 @@ char* grpc_channelz_get_servers(intptr_t start_server_id) {
 
 char* grpc_channelz_get_server(intptr_t server_id) {
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode> server_node =
+  grpc_core::WeakRefCountedPtr<grpc_core::channelz::BaseNode> server_node =
       grpc_core::channelz::ChannelzRegistry::Get(server_id);
   if (server_node == nullptr ||
       server_node->type() !=
@@ -374,7 +374,7 @@ char* grpc_channelz_get_server_sockets(intptr_t server_id,
                                        intptr_t max_results) {
   grpc_core::ExecCtx exec_ctx;
   // Validate inputs before handing them of to the renderer.
-  grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode> base_node =
+  grpc_core::WeakRefCountedPtr<grpc_core::channelz::BaseNode> base_node =
       grpc_core::channelz::ChannelzRegistry::Get(server_id);
   if (base_node == nullptr ||
       base_node->type() != grpc_core::channelz::BaseNode::EntityType::kServer ||
@@ -391,7 +391,7 @@ char* grpc_channelz_get_server_sockets(intptr_t server_id,
 
 char* grpc_channelz_get_channel(intptr_t channel_id) {
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode> channel_node =
+  grpc_core::WeakRefCountedPtr<grpc_core::channelz::BaseNode> channel_node =
       grpc_core::channelz::ChannelzRegistry::Get(channel_id);
   if (channel_node == nullptr ||
       (channel_node->type() !=
@@ -408,7 +408,7 @@ char* grpc_channelz_get_channel(intptr_t channel_id) {
 
 char* grpc_channelz_get_subchannel(intptr_t subchannel_id) {
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode> subchannel_node =
+  grpc_core::WeakRefCountedPtr<grpc_core::channelz::BaseNode> subchannel_node =
       grpc_core::channelz::ChannelzRegistry::Get(subchannel_id);
   if (subchannel_node == nullptr ||
       subchannel_node->type() !=
@@ -423,7 +423,7 @@ char* grpc_channelz_get_subchannel(intptr_t subchannel_id) {
 
 char* grpc_channelz_get_socket(intptr_t socket_id) {
   grpc_core::ExecCtx exec_ctx;
-  grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode> socket_node =
+  grpc_core::WeakRefCountedPtr<grpc_core::channelz::BaseNode> socket_node =
       grpc_core::channelz::ChannelzRegistry::Get(socket_id);
   if (socket_node == nullptr ||
       (socket_node->type() !=

--- a/src/core/channelz/channelz_registry.h
+++ b/src/core/channelz/channelz_registry.h
@@ -62,10 +62,10 @@ class ChannelzRegistry final {
     auto node = Default()->InternalGet(uuid);
     if (node == nullptr) return nullptr;
     if (node->type() == BaseNode::EntityType::kTopLevelChannel) {
-      return node->RefAsSubclass<ChannelNode>();
+      return node->WeakRefAsSubclass<ChannelNode>();
     }
     if (node->type() == BaseNode::EntityType::kInternalChannel) {
-      return node->RefAsSubclass<ChannelNode>();
+      return node->WeakRefAsSubclass<ChannelNode>();
     }
     return nullptr;
   }

--- a/test/core/channelz/channelz_registry_test.cc
+++ b/test/core/channelz/channelz_registry_test.cc
@@ -67,30 +67,30 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
 
 TEST_F(ChannelzRegistryTest, RegisterGetTest) {
   RefCountedPtr<BaseNode> channelz_channel = CreateTestNode();
-  RefCountedPtr<BaseNode> retrieved =
+  WeakRefCountedPtr<BaseNode> retrieved =
       ChannelzRegistry::Get(channelz_channel->uuid());
-  EXPECT_EQ(channelz_channel, retrieved);
+  EXPECT_EQ(channelz_channel.get(), retrieved.get());
 }
 
 TEST_F(ChannelzRegistryTest, RegisterManyItems) {
   std::vector<RefCountedPtr<BaseNode>> channelz_channels;
   for (int i = 0; i < 100; i++) {
     channelz_channels.push_back(CreateTestNode());
-    RefCountedPtr<BaseNode> retrieved =
+    WeakRefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(channelz_channels[i]->uuid());
-    EXPECT_EQ(channelz_channels[i], retrieved);
+    EXPECT_EQ(channelz_channels[i].get(), retrieved.get());
   }
 }
 
 TEST_F(ChannelzRegistryTest, NullIfNotPresentTest) {
   RefCountedPtr<BaseNode> channelz_channel = CreateTestNode();
   // try to pull out a uuid that does not exist.
-  RefCountedPtr<BaseNode> nonexistent =
+  WeakRefCountedPtr<BaseNode> nonexistent =
       ChannelzRegistry::Get(channelz_channel->uuid() + 1);
-  EXPECT_EQ(nonexistent, nullptr);
-  RefCountedPtr<BaseNode> retrieved =
+  EXPECT_EQ(nonexistent.get(), nullptr);
+  WeakRefCountedPtr<BaseNode> retrieved =
       ChannelzRegistry::Get(channelz_channel->uuid());
-  EXPECT_EQ(channelz_channel, retrieved);
+  EXPECT_EQ(channelz_channel.get(), retrieved.get());
 }
 
 TEST_F(ChannelzRegistryTest, TestUnregistration) {
@@ -112,11 +112,11 @@ TEST_F(ChannelzRegistryTest, TestUnregistration) {
   }
   // Check that the even channels are present and the odd channels are not.
   for (int i = 0; i < kLoopIterations; i++) {
-    RefCountedPtr<BaseNode> retrieved =
+    WeakRefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(even_channels[i]->uuid());
-    EXPECT_EQ(even_channels[i], retrieved);
+    EXPECT_EQ(even_channels[i].get(), retrieved.get());
     retrieved = ChannelzRegistry::Get(odd_uuids[i]);
-    EXPECT_EQ(retrieved, nullptr);
+    EXPECT_EQ(retrieved.get(), nullptr);
   }
   // Add more channels and verify that they get added correctly, to make
   // sure that the unregistration didn't leave the registry in a weird state.
@@ -124,9 +124,9 @@ TEST_F(ChannelzRegistryTest, TestUnregistration) {
   more_channels.reserve(kLoopIterations);
   for (int i = 0; i < kLoopIterations; i++) {
     more_channels.push_back(CreateTestNode());
-    RefCountedPtr<BaseNode> retrieved =
+    WeakRefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(more_channels[i]->uuid());
-    EXPECT_EQ(more_channels[i], retrieved);
+    EXPECT_EQ(more_channels[i].get(), retrieved.get());
   }
 }
 

--- a/test/core/util/dual_ref_counted_test.cc
+++ b/test/core/util/dual_ref_counted_test.cc
@@ -73,6 +73,21 @@ TEST(DualRefCounted, RefIfNonZero) {
   foo->WeakUnref();
 }
 
+TEST(DualRefCounted, WeakRefIfNonZero) {
+  Foo* foo = new Foo();
+  foo->WeakRef().release();
+  {
+    WeakRefCountedPtr<Foo> foop = foo->WeakRefIfNonZero();
+    EXPECT_NE(foop.get(), nullptr);
+  }
+  foo->Unref();
+  {
+    WeakRefCountedPtr<Foo> foop = foo->WeakRefIfNonZero();
+    EXPECT_NE(foop.get(), nullptr);
+  }
+  foo->WeakUnref();
+}
+
 TEST(DualRefCounted, RefAndWeakRefAsSubclass) {
   class Bar : public Foo {};
   Foo* foo = new Bar();


### PR DESCRIPTION
In an upcoming change I'll build out lifetime extension for BaseNode so that some portion of orphaned nodes stay alive past their deletion.

To implement this, we'll use the weak ref count inside the channelz system to query nodes, and strong refs for ownership by grpc objects. In this way the Orphaned() edge will let us know when to enter the lifetime extension phase.

Since there's two or three ways of implementing the lifetime extension, and I've done this step separately for each of them multiple times now... I'm landing this part first to stop the repetition.