### PR TITLE
[Backport][v1.71.x] Protect grpc generated sources from unwanted system macros (#39266)

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1744,20 +1744,15 @@ std::string GetSourceIncludes(grpc_generator::File* file,
     auto printer = file->CreatePrinter(&output);
     std::map<std::string, std::string> vars;
     static const char* headers_strs[] = {
-        "functional",
-        "grpcpp/support/async_stream.h",
-        "grpcpp/support/async_unary_call.h",
-        "grpcpp/impl/channel_interface.h",
-        "grpcpp/impl/client_unary_call.h",
-        "grpcpp/support/client_callback.h",
-        "grpcpp/support/message_allocator.h",
-        "grpcpp/support/method_handler.h",
-        "grpcpp/impl/rpc_service_method.h",
-        "grpcpp/support/server_callback.h",
-        "grpcpp/impl/server_callback_handlers.h",
-        "grpcpp/server_context.h",
-        "grpcpp/impl/service_type.h",
-        "grpcpp/support/sync_stream.h"};
+        "functional", "grpcpp/support/async_stream.h",
+        "grpcpp/support/async_unary_call.h", "grpcpp/impl/channel_interface.h",
+        "grpcpp/impl/client_unary_call.h", "grpcpp/support/client_callback.h",
+        "grpcpp/support/message_allocator.h", "grpcpp/support/method_handler.h",
+        "grpcpp/impl/rpc_service_method.h", "grpcpp/support/server_callback.h",
+        "grpcpp/impl/server_callback_handlers.h", "grpcpp/server_context.h",
+        "grpcpp/impl/service_type.h", "grpcpp/support/sync_stream.h",
+        // ports_def.inc Must be included as last
+        "grpcpp/ports_def.inc"};
     std::vector<std::string> headers(headers_strs, array_end(headers_strs));
     PrintIncludes(printer.get(), headers, params.use_system_headers,
                   params.grpc_search_path);
@@ -2253,6 +2248,8 @@ std::string GetSourceEpilogue(grpc_generator::File* file,
       temp.append(*part);
       temp.append("\n");
     }
+    // Must be included at end of file
+    temp.append("#include <grpcpp/ports_undef.inc>\n");
     temp.append("\n");
   }
 


### PR DESCRIPTION
#38474 added protection from unwanted macros to the header files. This PR adds the same protection to the source files. Without protection both in header and source files the code containing system macros will not compile. Macros will apply to function names in cc files and those will start to differ from the ones in header files.

This solves issues like described here: https://github.com/conda-forge/google-cloud-cpp-feedstock/pull/196

Closes #39266

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/39266 from simia:protect_cc_files 3323fba84ce5a1807dc395f5b268d88be2578402 PiperOrigin-RevId: 751501020

