### PR TITLE
[JSON] allow custom comparators in std::map fields

### DIFF
--- a/src/core/util/json/json_object_loader.h
+++ b/src/core/util/json/json_object_loader.h
@@ -388,6 +388,22 @@ class AutoLoader<std::map<std::string, T>> final : public LoadMap {
   ~AutoLoader() = default;
 };
 
+// Specializations of AutoLoader for maps with a custom comparator.
+template <typename T, typename C>
+class AutoLoader<std::map<std::string, T, C>> final : public LoadMap {
+ private:
+  void* Insert(const std::string& name, void* dst) const final {
+    return &static_cast<std::map<std::string, T, C>*>(dst)
+                ->emplace(name, T())
+                .first->second;
+  };
+  const LoaderInterface* ElementLoader() const final {
+    return LoaderForType<T>();
+  }
+
+  ~AutoLoader() = default;
+};
+
 // Specializations of AutoLoader for std::optional<>.
 template <typename T>
 class AutoLoader<std::optional<T>> final : public LoadWrapped {

--- a/src/core/util/json/json_object_loader.h
+++ b/src/core/util/json/json_object_loader.h
@@ -373,22 +373,6 @@ class AutoLoader<std::vector<bool>> final : public LoaderInterface {
 };
 
 // Specializations of AutoLoader for maps.
-template <typename T>
-class AutoLoader<std::map<std::string, T>> final : public LoadMap {
- private:
-  void* Insert(const std::string& name, void* dst) const final {
-    return &static_cast<std::map<std::string, T>*>(dst)
-                ->emplace(name, T())
-                .first->second;
-  };
-  const LoaderInterface* ElementLoader() const final {
-    return LoaderForType<T>();
-  }
-
-  ~AutoLoader() = default;
-};
-
-// Specializations of AutoLoader for maps with a custom comparator.
 template <typename T, typename C>
 class AutoLoader<std::map<std::string, T, C>> final : public LoadMap {
  private:

--- a/test/core/util/json/json_object_loader_test.cc
+++ b/test/core/util/json/json_object_loader_test.cc
@@ -842,9 +842,6 @@ TEST(JsonObjectLoader, MapWithComparatorFields) {
   EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
   EXPECT_FALSE(test_struct->std_optional_value.has_value());
   EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
-  // .find can be called with an absl::string_view because of the StringCmp
-  // comparator
-  EXPECT_EQ(test_struct->value.find(absl::string_view("a"))->second, 1);
   // Fails if required field is not present.
   test_struct = Parse<TestStruct>("{}");
   EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
@@ -861,19 +858,12 @@ TEST(JsonObjectLoader, MapWithComparatorFields) {
               ::testing::ElementsAre(::testing::Pair("a", 1)));
   EXPECT_THAT(test_struct->optional_value,
               ::testing::ElementsAre(::testing::Pair("b", "foo")));
-  EXPECT_EQ(test_struct->optional_value.find(absl::string_view("b"))->second,
-            "foo");
   ASSERT_TRUE(test_struct->std_optional_value.has_value());
   EXPECT_THAT(*test_struct->std_optional_value,
               ::testing::ElementsAre(::testing::Pair("c", true)));
-  EXPECT_EQ(
-      test_struct->std_optional_value->find(absl::string_view("c"))->second,
-      true);
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_THAT(*test_struct->unique_ptr_value,
               ::testing::ElementsAre(::testing::Pair("d", 4)));
-  EXPECT_EQ(test_struct->unique_ptr_value->find(absl::string_view("d"))->second,
-            4);
   // Optional fields null.
   test_struct = Parse<TestStruct>(
       "{\"value\": {\"a\":1}, \"optional_value\": null, "

--- a/test/core/util/json/json_object_loader_test.cc
+++ b/test/core/util/json/json_object_loader_test.cc
@@ -759,8 +759,8 @@ TEST(JsonObjectLoader, MapFields) {
       "\"std_optional_value\": {\"c\":true}, "
       "\"unique_ptr_value\": {\"d\":4}}");
   ASSERT_TRUE(test_struct.ok()) << test_struct.status();
-  EXPECT_THAT(test_struct->value,
-              ::testing::ElementsAre(::testing::Pair("a", 1)));
+  EXPECT_THAT(test_struct->value, ::testing::ElementsAre(::testing::Pair(
+                                      absl::string_view("a"), 1)));
   EXPECT_THAT(test_struct->optional_value,
               ::testing::ElementsAre(::testing::Pair("b", "foo")));
   ASSERT_TRUE(test_struct->std_optional_value.has_value());
@@ -769,6 +769,111 @@ TEST(JsonObjectLoader, MapFields) {
   ASSERT_NE(test_struct->unique_ptr_value, nullptr);
   EXPECT_THAT(*test_struct->unique_ptr_value,
               ::testing::ElementsAre(::testing::Pair("d", 4)));
+  // Optional fields null.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": {\"a\":1}, \"optional_value\": null, "
+      "\"std_optional_value\": null, \"unique_ptr_value\": null}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_THAT(test_struct->value,
+              ::testing::ElementsAre(::testing::Pair("a", 1)));
+  EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
+  EXPECT_FALSE(test_struct->std_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
+  // Wrong JSON type.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": [], \"optional_value\": true, "
+      "\"std_optional_value\": 1, \"unique_ptr_value\": \"foo\"}");
+  EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(test_struct.status().message(),
+            "errors validating JSON: ["
+            "field:optional_value error:is not an object; "
+            "field:std_optional_value error:is not an object; "
+            "field:unique_ptr_value error:is not an object; "
+            "field:value error:is not an object]")
+      << test_struct.status();
+  // Wrong JSON type for map value.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": {\"a\":\"foo\"}, \"optional_value\": {\"b\":true}, "
+      "\"std_optional_value\": {\"c\":1}}");
+  EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(test_struct.status().message(),
+            "errors validating JSON: ["
+            "field:optional_value[\"b\"] error:is not a string; "
+            "field:std_optional_value[\"c\"] error:is not a boolean; "
+            "field:value[\"a\"] error:failed to parse number]")
+      << test_struct.status();
+}
+
+//
+// map<> with comparator tests
+//
+
+TEST(JsonObjectLoader, MapWithComparatorFields) {
+  struct StringCmp {
+    using is_transparent = void;
+    bool operator()(absl::string_view a, absl::string_view b) const {
+      return a < b;
+    }
+  };
+
+  struct TestStruct {
+    std::map<std::string, int32_t, StringCmp> value;
+    std::map<std::string, std::string, StringCmp> optional_value;
+    std::optional<std::map<std::string, bool, StringCmp>> std_optional_value;
+    std::unique_ptr<std::map<std::string, int32_t, StringCmp>> unique_ptr_value;
+
+    static const JsonLoaderInterface* JsonLoader(const JsonArgs&) {
+      static const auto* loader =
+          JsonObjectLoader<TestStruct>()
+              .Field("value", &TestStruct::value)
+              .OptionalField("optional_value", &TestStruct::optional_value)
+              .OptionalField("std_optional_value",
+                             &TestStruct::std_optional_value)
+              .OptionalField("unique_ptr_value", &TestStruct::unique_ptr_value)
+              .Finish();
+      return loader;
+    }
+  };
+  // Valid map.
+  auto test_struct = Parse<TestStruct>("{\"value\": {\"a\":1}}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_THAT(test_struct->value,
+              ::testing::ElementsAre(::testing::Pair("a", 1)));
+  EXPECT_THAT(test_struct->optional_value, ::testing::ElementsAre());
+  EXPECT_FALSE(test_struct->std_optional_value.has_value());
+  EXPECT_EQ(test_struct->unique_ptr_value, nullptr);
+  // .find can be called with an absl::string_view because of the StringCmp
+  // comparator
+  EXPECT_EQ(test_struct->value.find(absl::string_view("a"))->second, 1);
+  // Fails if required field is not present.
+  test_struct = Parse<TestStruct>("{}");
+  EXPECT_EQ(test_struct.status().code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_EQ(test_struct.status().message(),
+            "errors validating JSON: [field:value error:field not present]")
+      << test_struct.status();
+  // Optional fields present.
+  test_struct = Parse<TestStruct>(
+      "{\"value\": {\"a\":1}, \"optional_value\": {\"b\":\"foo\"}, "
+      "\"std_optional_value\": {\"c\":true}, "
+      "\"unique_ptr_value\": {\"d\":4}}");
+  ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_THAT(test_struct->value,
+              ::testing::ElementsAre(::testing::Pair("a", 1)));
+  EXPECT_THAT(test_struct->optional_value,
+              ::testing::ElementsAre(::testing::Pair("b", "foo")));
+  EXPECT_EQ(test_struct->optional_value.find(absl::string_view("b"))->second,
+            "foo");
+  ASSERT_TRUE(test_struct->std_optional_value.has_value());
+  EXPECT_THAT(*test_struct->std_optional_value,
+              ::testing::ElementsAre(::testing::Pair("c", true)));
+  EXPECT_EQ(
+      test_struct->std_optional_value->find(absl::string_view("c"))->second,
+      true);
+  ASSERT_NE(test_struct->unique_ptr_value, nullptr);
+  EXPECT_THAT(*test_struct->unique_ptr_value,
+              ::testing::ElementsAre(::testing::Pair("d", 4)));
+  EXPECT_EQ(test_struct->unique_ptr_value->find(absl::string_view("d"))->second,
+            4);
   // Optional fields null.
   test_struct = Parse<TestStruct>(
       "{\"value\": {\"a\":1}, \"optional_value\": null, "

--- a/test/core/util/json/json_object_loader_test.cc
+++ b/test/core/util/json/json_object_loader_test.cc
@@ -759,6 +759,8 @@ TEST(JsonObjectLoader, MapFields) {
       "\"std_optional_value\": {\"c\":true}, "
       "\"unique_ptr_value\": {\"d\":4}}");
   ASSERT_TRUE(test_struct.ok()) << test_struct.status();
+  EXPECT_THAT(test_struct->value,
+              ::testing::ElementsAre(::testing::Pair("a", 1)));
   EXPECT_THAT(test_struct->optional_value,
               ::testing::ElementsAre(::testing::Pair("b", "foo")));
   ASSERT_TRUE(test_struct->std_optional_value.has_value());

--- a/test/core/util/json/json_object_loader_test.cc
+++ b/test/core/util/json/json_object_loader_test.cc
@@ -759,8 +759,6 @@ TEST(JsonObjectLoader, MapFields) {
       "\"std_optional_value\": {\"c\":true}, "
       "\"unique_ptr_value\": {\"d\":4}}");
   ASSERT_TRUE(test_struct.ok()) << test_struct.status();
-  EXPECT_THAT(test_struct->value, ::testing::ElementsAre(::testing::Pair(
-                                      absl::string_view("a"), 1)));
   EXPECT_THAT(test_struct->optional_value,
               ::testing::ElementsAre(::testing::Pair("b", "foo")));
   ASSERT_TRUE(test_struct->std_optional_value.has_value());


### PR DESCRIPTION
This adds a json object loader `AutoLoader` for maps with a custom comparator. It is testing by ensuring that `.find()` can be called with an `absl::string_view` for a map with a key of `std::string`.