### PR TITLE
[Backport][v1.72.x] Fix Python 3.12 MacOS release artifact (#39418)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -136,6 +136,9 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
+  # add /usr/local/bin to path to override built in Python version
+  export PATH="/usr/local/bin::${PATH}"
+
   # python
   time pip install --user -r $DIR/requirements.macos.txt
   time pip install --user --upgrade virtualenv Mako tox setuptools==44.1.1 twisted

--- a/tools/internal_ci/macos/grpc_distribtests_python.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_python.sh
@@ -26,11 +26,11 @@ source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # TODO(jtattermusch): cleanup this prepare build step (needed for python artifact build)
 # install cython for all python versions
-python3.9 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.10 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.11 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.12 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.13 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
+python3.9 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.10 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.11 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.12 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
+python3.13 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
 
 # Build all python macos artifacts (this step actually builds all the binary wheels and source archives)
 tools/run_tests/task_runner.py -f artifact macos python ${TASK_RUNNER_EXTRA_FILTERS} -j 2 -x build_artifacts/sponge_log.xml || FAILED="true"

--- a/tools/internal_ci/macos/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/macos/grpc_run_tests_matrix.sh
@@ -23,6 +23,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
+python3 -m pip install six==1.16.0
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
 
 # kill port_server.py to prevent the build from freezing


### PR DESCRIPTION
Fixes Python 3.12 MacOS universal2 artifact and Python 3.10 MacOS artifact to support MacOS 11+

Closes #39418 and #31492

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/39418 from sreenithi:macos_artifact_fix f61ae92e062c5e31eb26727a14043dcab31dbf02 PiperOrigin-RevId: 753991698



