### PR TITLE
[ObjC] Deflak cf stream endpoint connect timeout cancel tests

### DIFF
--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -40,7 +40,7 @@ namespace experimental {
 
 TEST(CFEventEngineTest, TestConnectionTimeout) {
   // use a non-routable IP so connection will timeout
-  auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
+  auto resolved_addr = URIToResolvedAddress("ipv4:8.8.8.8:1234");
   CHECK_OK(resolved_addr);
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");
@@ -62,7 +62,7 @@ TEST(CFEventEngineTest, TestConnectionTimeout) {
 
 TEST(CFEventEngineTest, TestConnectionCancelled) {
   // use a non-routable IP so to cancel connection before timeout
-  auto resolved_addr = URIToResolvedAddress("ipv4:10.255.255.255:1234");
+  auto resolved_addr = URIToResolvedAddress("ipv4:8.8.8.8:1234");
   CHECK_OK(resolved_addr);
 
   grpc_core::MemoryQuota memory_quota("cf_engine_test");

--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -115,6 +115,7 @@ objc_bazel_tests/bazel_wrapper \
   "${BAZEL_REMOTE_CACHE_ARGS[@]}" \
   $BAZEL_FLAGS \
   --cxxopt=-DGRPC_IOS_EVENT_ENGINE_CLIENT=0 \
+  --test_env=GRPC_VERBOSITY=debug --test_env=GRPC_TRACE=event_engine*,api \
   "${OBJC_TEST_ENV_ARGS[@]}" \
   -- \
   "${EXAMPLE_TARGETS[@]}" \


### PR DESCRIPTION
To test connection timeout or cancel, it needs a routable address that the test cannot connect.
Previously used IP started behave weirdly (after the mac environment update?) causing those tests to fail with unknown error, this PR uses a well know IP but a unreachable port for test. A few other PRs are opened to verify it's not flaky anymore but test results are cached, tried kokoro force run and using different base but it's hard to tell as they don't necessarily fail without the fix.

For the EINTR error, retry should not be needed in real world as the [cf network stack](https://github.com/opensource-apple/CF/blob/master/CFSocket.c#L66) is already doing this. The old cfstream implementation for iomgr wasn't doing retry either.