### PR TITLE
[Backport][v1.72.x] Fix Python 3.12 MacOS release artifact (#39418)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # GRPC Python setup requirements
 coverage>=4.0
 cython>=3.0.0
-protobuf>=6.30.0,<7.0dev
+protobuf>=6.30.0,<7.0.0
 wheel>=0.29

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -65,7 +65,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_csds/setup.py
+++ b/src/python/grpcio_csds/setup.py
@@ -41,7 +41,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     f"xds-protos=={grpc_version.VERSION}",
     f"grpcio>={grpc_version.VERSION}",
 )

--- a/src/python/grpcio_csm_observability/setup.py
+++ b/src/python/grpcio_csm_observability/setup.py
@@ -41,7 +41,7 @@ INSTALL_REQUIRES = (
     "opentelemetry-sdk>=1.25.0",
     "opentelemetry-resourcedetector-gcp>=1.6.0a0",
     "grpcio=={version}".format(version=grpc_version.VERSION),
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
 )
 
 setuptools.setup(

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -63,7 +63,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -64,7 +64,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -63,7 +63,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
     "googleapis-common-protos>=1.5.5",
 )

--- a/src/python/grpcio_testing/setup.py
+++ b/src/python/grpcio_testing/setup.py
@@ -49,7 +49,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "grpcio>={version}".format(version=grpc_version.VERSION),
 )
 

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -46,7 +46,7 @@ INSTALL_REQUIRES = (
     "grpcio-observability>={version}".format(version=grpc_version.VERSION),
     "xds-protos>={version}".format(version=grpc_version.VERSION),
     "oauth2client>=1.4.7",
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
     "google-auth>=1.17.2",
     "requests>=2.14.2",
     "absl-py>=1.4.0",

--- a/tools/distrib/docgen/requirements.docs.lock
+++ b/tools/distrib/docgen/requirements.docs.lock
@@ -26,7 +26,7 @@ opentelemetry-sdk==1.25.0
 opentelemetry-semantic-conventions==0.46b0
 prometheus_client==0.20.0
 proto-plus==1.25.0
-protobuf>=5.27.1,<6.0dev
+protobuf>=5.27.1,<6.0.0
 pyasn1-modules==0.3.0
 pyasn1==0.5.0
 requests==2.25.1

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -343,7 +343,7 @@ setuptools.setup(
     packages=setuptools.find_packages("."),
     python_requires=f">={python_version.MIN_PYTHON_VERSION}",
     install_requires=[
-        "protobuf>=6.30.0,<7.0dev",
+        "protobuf>=6.30.0,<7.0.0",
         "grpcio>={version}".format(version=grpc_version.VERSION),
         "setuptools",
     ],

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -40,7 +40,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "grpcio>=1.49.0",
-    "protobuf>=6.30.0,<7.0dev",
+    "protobuf>=6.30.0,<7.0.0",
 ]
 
 SETUP_REQUIRES = INSTALL_REQUIRES + ["grpcio-tools>=1.49.0"]

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -136,6 +136,9 @@ fi
 
 if [ "${PREPARE_BUILD_INSTALL_DEPS_PYTHON}" == "true" ]
 then
+  # add /usr/local/bin to path to override built in Python version
+  export PATH="/usr/local/bin::${PATH}"
+
   # python
   time pip install --user -r $DIR/requirements.macos.txt
   time pip install --user --upgrade virtualenv Mako tox setuptools==44.1.1 twisted

--- a/tools/internal_ci/macos/grpc_distribtests_python.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_python.sh
@@ -26,11 +26,11 @@ source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # TODO(jtattermusch): cleanup this prepare build step (needed for python artifact build)
 # install cython for all python versions
-python3.9 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.10 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.11 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.12 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
-python3.13 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 wheel --user
+python3.9 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.10 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.11 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user
+python3.12 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
+python3.13 -m pip install -U 'cython<4.0.0rc1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
 
 # Build all python macos artifacts (this step actually builds all the binary wheels and source archives)
 tools/run_tests/task_runner.py -f artifact macos python ${TASK_RUNNER_EXTRA_FILTERS} -j 2 -x build_artifacts/sponge_log.xml || FAILED="true"

--- a/tools/internal_ci/macos/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/macos/grpc_run_tests_matrix.sh
@@ -23,6 +23,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
+python3 -m pip install six==1.16.0
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
 
 # kill port_server.py to prevent the build from freezing

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -172,7 +172,7 @@ pip_install_dir_and_deps() {
 pip_install -U gevent
 
 pip_install --upgrade 'cython>=3.0.0'
-pip_install --upgrade six 'protobuf>=6.30.0,<7.0dev'
+pip_install --upgrade six 'protobuf>=6.30.0,<7.0.0'
 
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then


### PR DESCRIPTION
Backport of 2 PRs that do the following:
 - https://github.com/grpc/grpc/pull/39418 - Fixes Python 3.12 MacOS universal2 artifact and Python 3.10 MacOS artifact to support MacOS 11+
   Fixes https://github.com/grpc/grpc/issues/39388 and https://github.com/grpc/grpc/issues/31492
 - Updates Protobuf requirement constraints to remove pre-release/dev versions.
   Fixes https://github.com/grpc/grpc/issues/39381


COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/39418 from sreenithi:macos_artifact_fix f61ae92e062c5e31eb26727a14043dcab31dbf02 PiperOrigin-RevId: 753991698



