### PR TITLE
[latent-see] Use higher precision output when writing timestamps

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -175,6 +175,7 @@ grpc_cc_library(
         "absl/functional:function_ref",
         "absl/log",
         "absl/strings",
+        "absl/strings:str_format",
     ],
     visibility = ["//bazel:latent_see"],
     deps = [

--- a/src/core/util/latent_see.cc
+++ b/src/core/util/latent_see.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
 #include "src/core/util/ring_buffer.h"
 #include "src/core/util/sync.h"
@@ -136,13 +137,17 @@ std::optional<std::string> Log::TryGenerateJson() {
         absl::StrAppend(
             &json, "{\"name\": \"", event.event.metadata->name,
             "\", \"ph\": \"", phase, "\", \"ts\": ",
-            Nanos(event.event.timestamp - start_time).count() / 1000.0,
+            absl::StrFormat(
+                "%.12g",
+                Nanos(event.event.timestamp - start_time).count() / 1000.0),
             ", \"pid\": 0, \"tid\": ", event.thread_id);
       } else {
         absl::StrAppend(
             &json, "{\"name\": ", event.event.metadata->name, ", \"ph\": \"",
             phase, "\", \"ts\": ",
-            Nanos(event.event.timestamp - start_time).count() / 1000.0,
+            absl::StrFormat(
+                "%.12g",
+                Nanos(event.event.timestamp - start_time).count() / 1000.0),
             ", \"pid\": 0, \"tid\": ", event.thread_id);
       }
 


### PR DESCRIPTION
`absl::StrFormat` only prints 6 significant figures when writing doubles - for timestamps running over minutes this means only milliseconds worth of precision is retained in our traces.

This will explain the mysterious 'instantaneous bunch o stuff' next to a long time span, and the odd 'everything takes 100us' artifacts we've been seeing in some traces.

It's probably worth refreshing some of the traces we've taken previously once this lands.