### PR TITLE
[qps] Drop pre-existing latent-see stats before starting to record

### DIFF
--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -130,6 +130,11 @@ class ScopedLatentSee final {
     done_ = std::make_shared<grpc_core::Notification>();
     manager_thread_.emplace(
         "latent_see_manager", [this, done = done_, name = std::move(name)]() {
+          LOG(INFO) << "Starting latent-see";
+          grpc_core::latent_see::Log::Get().TryPullEventsAndFlush(
+              [](absl::Span<const grpc_core::latent_see::Log::RecordedEvent>) {
+              });
+          LOG(INFO) << "Started latent-see";
           int step = 0;
           // Once per second: kick off a thread to collate the latent-see data.
           // Each one of these may fail under contention (that's ok, we just get

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -128,31 +128,30 @@ class ScopedLatentSee final {
   void StartManager(std::string name) {
     CollectManager();
     done_ = std::make_shared<grpc_core::Notification>();
-    manager_thread_.emplace(
-        "latent_see_manager", [this, done = done_, name = std::move(name)]() {
-          LOG(INFO) << "Starting latent-see";
-          grpc_core::latent_see::Log::Get().TryPullEventsAndFlush(
-              [](absl::Span<const grpc_core::latent_see::Log::RecordedEvent>) {
-              });
-          LOG(INFO) << "Started latent-see";
-          int step = 0;
-          // Once per second: kick off a thread to collate the latent-see data.
-          // Each one of these may fail under contention (that's ok, we just get
-          // a subset of the data).
-          while (!done->WaitForNotificationWithTimeout(absl::Seconds(1))) {
-            // Bound the number of collector threads outstanding.
-            while (collector_threads_.size() > 32) {
-              collector_threads_.front().Join();
-              collector_threads_.pop_front();
-            }
-            // Kick off a new thread
-            collector_threads_
-                .emplace_back("latent_see_collector",
-                              [step, name, this]() { Collect(step, name); })
-                .Start();
-            ++step;
-          }
-        });
+    manager_thread_.emplace("latent_see_manager", [this, done = done_,
+                                                   name = std::move(name)]() {
+      LOG(INFO) << "Starting latent-see";
+      grpc_core::latent_see::Log::Get().TryPullEventsAndFlush(
+          [](absl::Span<const grpc_core::latent_see::Log::RecordedEvent>) {});
+      LOG(INFO) << "Started latent-see";
+      int step = 0;
+      // Once per second: kick off a thread to collate the latent-see data.
+      // Each one of these may fail under contention (that's ok, we just get
+      // a subset of the data).
+      while (!done->WaitForNotificationWithTimeout(absl::Seconds(1))) {
+        // Bound the number of collector threads outstanding.
+        while (collector_threads_.size() > 32) {
+          collector_threads_.front().Join();
+          collector_threads_.pop_front();
+        }
+        // Kick off a new thread
+        collector_threads_
+            .emplace_back("latent_see_collector",
+                          [step, name, this]() { Collect(step, name); })
+            .Start();
+        ++step;
+      }
+    });
     manager_thread_->Start();
   }
 


### PR DESCRIPTION
Previously we'd get a big drop of data after warmup and then nothing for some scenarios