### PR TITLE
[latent-see] Improve tracing of promises

### DIFF
--- a/src/core/ext/transport/chaotic_good/control_endpoint.cc
+++ b/src/core/ext/transport/chaotic_good/control_endpoint.cc
@@ -78,8 +78,10 @@ ControlEndpoint::ControlEndpoint(
                       ztrace_collector->Append(
                           WriteBytesToControlChannelTrace{flushing.Length()});
                       return Map(
-                          endpoint->Write(std::move(flushing),
-                                          PromiseEndpoint::WriteArgs{}),
+                          GRPC_LATENT_SEE_PROMISE(
+                              "CtlEndpointWrite",
+                              endpoint->Write(std::move(flushing),
+                                              PromiseEndpoint::WriteArgs{})),
                           [ztrace_collector](absl::Status status) {
                             ztrace_collector->Append([&status]() {
                               return FinishWriteBytesToControlChannelTrace{

--- a/src/core/ext/transport/chaotic_good/control_endpoint.h
+++ b/src/core/ext/transport/chaotic_good/control_endpoint.h
@@ -97,10 +97,15 @@ class ControlEndpoint {
 
   // Read operations are simply passthroughs to the underlying promise endpoint.
   auto ReadSlice(size_t length) {
-    return AddErrorPrefix("CONTROL_CHANNEL: ", endpoint_->ReadSlice(length));
+    return AddErrorPrefix(
+        "CONTROL_CHANNEL: ",
+        GRPC_LATENT_SEE_PROMISE("CtlEndpointReadHdr",
+                                endpoint_->ReadSlice(length)));
   }
   auto Read(size_t length) {
-    return AddErrorPrefix("CONTROL_CHANNEL: ", endpoint_->Read(length));
+    return AddErrorPrefix(
+        "CONTROL_CHANNEL: ",
+        GRPC_LATENT_SEE_PROMISE("CtlEndpointRead", endpoint_->Read(length)));
   }
   auto GetPeerAddress() const { return endpoint_->GetPeerAddress(); }
   auto GetLocalAddress() const { return endpoint_->GetLocalAddress(); }

--- a/src/core/ext/transport/chaotic_good/data_endpoints.cc
+++ b/src/core/ext/transport/chaotic_good/data_endpoints.cc
@@ -546,8 +546,10 @@ auto Endpoint::WriteLoop(uint32_t id,
                             .value_or("peer-unknown"),
                         "#", id);
                   },
-                  endpoint->Write(std::move(next_write.bytes),
-                                  std::move(write_args))),
+                  GRPC_LATENT_SEE_PROMISE(
+                      "DataEndpointWrite",
+                      endpoint->Write(std::move(next_write.bytes),
+                                      std::move(write_args)))),
               [id, output_buffers, ztrace_collector](absl::Status status) {
                 ztrace_collector->Append([id, &status]() {
                   return FinishWriteBytesToEndpointTrace{id, status};
@@ -576,10 +578,12 @@ auto Endpoint::ReadLoop(uint32_t id, uint32_t decode_alignment,
                input_queues = std::move(input_queues),
                ztrace_collector = std::move(ztrace_collector)]() {
     return TrySeq(
-        endpoint->ReadSlice(
-            TcpDataFrameHeader::kFrameHeaderSize +
-            DataConnectionPadding(TcpDataFrameHeader::kFrameHeaderSize,
-                                  decode_alignment)),
+        GRPC_LATENT_SEE_PROMISE(
+            "DataEndpointReadHdr",
+            endpoint->ReadSlice(
+                TcpDataFrameHeader::kFrameHeaderSize +
+                DataConnectionPadding(TcpDataFrameHeader::kFrameHeaderSize,
+                                      decode_alignment))),
         [id](Slice frame_header) {
           auto hdr = TcpDataFrameHeader::Parse(frame_header.data());
           GRPC_TRACE_LOG(chaotic_good, INFO)
@@ -591,11 +595,14 @@ auto Endpoint::ReadLoop(uint32_t id, uint32_t decode_alignment,
         [endpoint, ztrace_collector, id,
          decode_alignment](TcpDataFrameHeader frame_header) {
           ztrace_collector->Append(ReadDataHeaderTrace{frame_header});
-          return Map(TryStaple(endpoint->Read(frame_header.payload_length +
-                                              DataConnectionPadding(
-                                                  frame_header.payload_length,
-                                                  decode_alignment)),
-                               frame_header),
+          return Map(TryStaple(
+                         GRPC_LATENT_SEE_PROMISE(
+                             "DataEndpointRead",
+                             endpoint->Read(frame_header.payload_length +
+                                            DataConnectionPadding(
+                                                frame_header.payload_length,
+                                                decode_alignment))),
+                         frame_header),
                      [id, frame_header](auto x) {
                        GRPC_TRACE_LOG(chaotic_good, INFO)
                            << "CHAOTIC_GOOD: Complete read " << frame_header

--- a/src/core/ext/transport/chaotic_good/data_endpoints.cc
+++ b/src/core/ext/transport/chaotic_good/data_endpoints.cc
@@ -595,21 +595,21 @@ auto Endpoint::ReadLoop(uint32_t id, uint32_t decode_alignment,
         [endpoint, ztrace_collector, id,
          decode_alignment](TcpDataFrameHeader frame_header) {
           ztrace_collector->Append(ReadDataHeaderTrace{frame_header});
-          return Map(TryStaple(
-                         GRPC_LATENT_SEE_PROMISE(
-                             "DataEndpointRead",
-                             endpoint->Read(frame_header.payload_length +
-                                            DataConnectionPadding(
-                                                frame_header.payload_length,
-                                                decode_alignment))),
-                         frame_header),
-                     [id, frame_header](auto x) {
-                       GRPC_TRACE_LOG(chaotic_good, INFO)
-                           << "CHAOTIC_GOOD: Complete read " << frame_header
-                           << " on data connection #" << id
-                           << " status: " << x.status();
-                       return x;
-                     });
+          return Map(
+              TryStaple(GRPC_LATENT_SEE_PROMISE(
+                            "DataEndpointRead",
+                            endpoint->Read(frame_header.payload_length +
+                                           DataConnectionPadding(
+                                               frame_header.payload_length,
+                                               decode_alignment))),
+                        frame_header),
+              [id, frame_header](auto x) {
+                GRPC_TRACE_LOG(chaotic_good, INFO)
+                    << "CHAOTIC_GOOD: Complete read " << frame_header
+                    << " on data connection #" << id
+                    << " status: " << x.status();
+                return x;
+              });
         },
         [endpoint, input_queues, id, decode_alignment](
             std::tuple<SliceBuffer, TcpDataFrameHeader> buffer_frame)

--- a/src/core/util/latent_see.h
+++ b/src/core/util/latent_see.h
@@ -282,9 +282,12 @@ GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION auto Promise(const Metadata* md_poll,
 // scope.
 #define GRPC_LATENT_SEE_MARK(name) \
   grpc_core::latent_see::Mark(GRPC_LATENT_SEE_METADATA(name))
-#define GRPC_LATENT_SEE_PROMISE(name, promise)                           \
-  grpc_core::latent_see::Promise(GRPC_LATENT_SEE_METADATA("Poll:" name), \
-                                 GRPC_LATENT_SEE_METADATA(name), promise)
+#define GRPC_LATENT_SEE_PROMISE(name, promise)                                 \
+  grpc_core::latent_see::Promise(GRPC_LATENT_SEE_METADATA("Poll:" name),       \
+                                 GRPC_LATENT_SEE_METADATA(name), [&]() {       \
+                                   GRPC_LATENT_SEE_INNER_SCOPE("Setup:" name); \
+                                   return promise;                             \
+                                 }())
 #else  // !def(GRPC_ENABLE_LATENT_SEE)
 namespace grpc_core {
 namespace latent_see {


### PR DESCRIPTION
Capture not just the polling time, but the setup time of promises (as this can sometimes be significant).

Use that to capture and categorize chaotic-good writes.