### PR TITLE
Expose channel verbatim target via _get_target() API

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -2249,6 +2249,13 @@ class Channel(grpc.Channel):
     def close(self) -> None:
         self._close()
 
+    def _get_target(self) -> Optional[str]:
+        """Returns the Verbatim Target channel or None if channel is closed."""
+        try:
+            return self._channel.target().decode('utf-8')
+        except Exception:
+            return None    
+
     def __del__(self):
         # TODO(https://github.com/grpc/grpc/issues/12531): Several releases
         # after 1.12 (1.16 or thereabouts?) add a "self._channel.close" call


### PR DESCRIPTION
Partial address - #38519.
python: Expose channel verbatim target via **_get_target()** API

This change introduces a new method "grpc.Channel._get_target()" to retrieve the
verbatim target used during channel creation ( "**dns:///localhost:50051**").

The method wraps the underlying C-core **"grpc_channel_get_target()"** and is useful
for diagnostics, logging, and advanced introspection use cases.




