### PR TITLE
Timeout=90min for macos/grpc_basictests_ruby

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_ruby.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_basictests_ruby.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Frequent timeout failures are causing flakiness in `macos/grpc_basictests_ruby`. The timeout limit should be increased, given that successful runs are already taking 50-55 minutes, close to the current limit.