### PR TITLE
[CI] Timeout=90min for linux/grpc_basictests_ruby

### DIFF
--- a/tools/internal_ci/linux/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_ruby.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Like https://github.com/grpc/grpc/pull/39547, frequent timeout failures are causing flakiness in `linux/grpc_basictests_ruby`. The timeout limit should be increased, given that successful runs are already taking 50-55 minutes, close to the current limit.