### PR TITLE
[OpenCensus] Mark OpenCensus and dependent APIs as deprecated

### DIFF
--- a/include/grpcpp/ext/gcp_observability.h
+++ b/include/grpcpp/ext/gcp_observability.h
@@ -23,8 +23,12 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
-namespace grpc {
+#define GRPC_GCP_OBSERVABILITY_DEPRECATED_REASON                          \
+  "OpenCensus has been sunsetted in favor of OpenTelemetry "              \
+  "https://opentelemetry.io/blog/2023/sunsetting-opencensus/. Given GCP " \
+  "Observability's dependency on OpenCensus, it is deprecated as well."
 
+namespace grpc {
 // WARNING : DO NOT USE. OpenCensus and dependent APIs have been deprecated.
 
 // DEPRECATED: GcpObservability objects follow the RAII idiom and help manage
@@ -33,23 +37,22 @@ namespace grpc {
 // `GcpObservability` instance. Observability data is flushed at regular
 // intervals, and also when this instance goes out of scope and its destructor
 // is invoked.
-class GRPC_DEPRECATED(
-    "OpenCensus has been sunsetted in favor of OpenTelemetry "
-    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
+class GRPC_DEPRECATED(GRPC_GCP_OBSERVABILITY_DEPRECATED_REASON)
     GcpObservability {
  public:
   // Initialize GCP Observability for gRPC.
   // This should be called before any other gRPC operations like creating a
   // channel, server, credentials etc.
   // The return value helps determine whether observability was
-  // successfully enabled or not. On success, an object of class `Observability`
-  // is returned. When this object goes out of scope, GCP Observability stats,
-  // tracing and logging data is flushed. On failure, the status message can be
-  // used to determine the cause of failure. It is up to the applications to
-  // either crash on failure, or continue without GCP observability being
-  // enabled. The status codes do not have any special meaning at present, and
-  // users should not make any assumptions based on the status code, other than
-  // a non-OK status code meaning that observability initialization failed.
+  // successfully enabled or not. On success, an object of class
+  // `Observability` is returned. When this object goes out of scope, GCP
+  // Observability stats, tracing and logging data is flushed. On failure, the
+  // status message can be used to determine the cause of failure. It is up to
+  // the applications to either crash on failure, or continue without GCP
+  // observability being enabled. The status codes do not have any special
+  // meaning at present, and users should not make any assumptions based on
+  // the status code, other than a non-OK status code meaning that
+  // observability initialization failed.
   //
   // The expected usage is to call this at the top (or near the top) in
   // main(), and let it go out of scope after all RPCs and activities that we
@@ -60,21 +63,20 @@ class GRPC_DEPRECATED(
   // for sample usage.
   //
   // It is possible for an initialized GcpObservability object to go out of
-  // scope while RPCs and other gRPC operations are still ongoing. In this case,
-  // GCP Observability tries to flush all observability data collected till that
-  // point.
+  // scope while RPCs and other gRPC operations are still ongoing. In this
+  // case, GCP Observability tries to flush all observability data collected
+  // till that point.
   //
-  // Note that this is a blocking call which properly sets up gRPC Observability
-  // to work with GCP and might take a few seconds to return.  Similarly, the
-  // destruction of a non-moved-from `Observability` object is also blocking
-  // since it flushes the observability data to GCP.
+  // Note that this is a blocking call which properly sets up gRPC
+  // Observability to work with GCP and might take a few seconds to return.
+  // Similarly, the destruction of a non-moved-from `Observability` object is
+  // also blocking since it flushes the observability data to GCP.
   //
-  // As an implementation detail, this properly initializes the OpenCensus stats
-  // and tracing plugin, so applications do not need to perform any additional
-  // gRPC C++ OpenCensus setup/registration to get GCP Observability for gRPC.
-  GRPC_DEPRECATED(
-      "OpenCensus has been sunsetted in favor of OpenTelemetry "
-      "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
+  // As an implementation detail, this properly initializes the OpenCensus
+  // stats and tracing plugin, so applications do not need to perform any
+  // additional gRPC C++ OpenCensus setup/registration to get GCP
+  // Observability for gRPC.
+  GRPC_DEPRECATED(GRPC_GCP_OBSERVABILITY_DEPRECATED_REASON)
   static absl::StatusOr<GcpObservability> Init();
 
   GcpObservability() = default;
@@ -90,17 +92,17 @@ class GRPC_DEPRECATED(
 
  private:
   // Helper class that aids in implementing GCP Observability.
-  // Inheriting from GrpcLibrary makes sure that gRPC is initialized and remains
-  // initialized for the lifetime of GCP Observability. In the future, when gRPC
-  // initialization goes away, we might still want to keep gRPC Event Engine
-  // initialized, just in case, we need to perform some IO operations during
-  // observability close.
-  // Note that the lifetime guarantees are only one way, i.e., GcpObservability
-  // object guarantees that gRPC will not shutdown while the object is still in
-  // scope, but the other way around does not hold true. Even though that is not
-  // the expected usage, GCP Observability can shutdown before gRPC shuts down.
-  // It follows that gRPC should not hold any callbacks from GcpObservability. A
-  // change in this restriction should go through a design review.
+  // Inheriting from GrpcLibrary makes sure that gRPC is initialized and
+  // remains initialized for the lifetime of GCP Observability. In the future,
+  // when gRPC initialization goes away, we might still want to keep gRPC
+  // Event Engine initialized, just in case, we need to perform some IO
+  // operations during observability close. Note that the lifetime guarantees
+  // are only one way, i.e., GcpObservability object guarantees that gRPC will
+  // not shutdown while the object is still in scope, but the other way around
+  // does not hold true. Even though that is not the expected usage, GCP
+  // Observability can shutdown before gRPC shuts down. It follows that gRPC
+  // should not hold any callbacks from GcpObservability. A change in this
+  // restriction should go through a design review.
   class GcpObservabilityImpl : private internal::GrpcLibrary {
    public:
     ~GcpObservabilityImpl() override;

--- a/include/grpcpp/ext/gcp_observability.h
+++ b/include/grpcpp/ext/gcp_observability.h
@@ -25,12 +25,18 @@
 
 namespace grpc {
 
-// GcpObservability objects follow the RAII idiom and help manage the lifetime
-// of gRPC Observability data exporting to GCP. `GcpObservability::Init()`
-// should be invoked instead to return an `GcpObservability` instance.
-// Observability data is flushed at regular intervals, and also when this
-// instance goes out of scope and its destructor is invoked.
-class GcpObservability {
+// WARNING : DO NOT USE. OpenCensus and dependent APIs have been deprecated.
+
+// DEPRECATED: GcpObservability objects follow the RAII idiom and help manage
+// the lifetime of gRPC Observability data exporting to GCP.
+// `GcpObservability::Init()` should be invoked instead to return an
+// `GcpObservability` instance. Observability data is flushed at regular
+// intervals, and also when this instance goes out of scope and its destructor
+// is invoked.
+class GRPC_DEPRECATED(
+    "OpenCensus has been sunsetted in favor of OpenTelemetry "
+    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
+    GcpObservability {
  public:
   // Initialize GCP Observability for gRPC.
   // This should be called before any other gRPC operations like creating a
@@ -66,6 +72,9 @@ class GcpObservability {
   // As an implementation detail, this properly initializes the OpenCensus stats
   // and tracing plugin, so applications do not need to perform any additional
   // gRPC C++ OpenCensus setup/registration to get GCP Observability for gRPC.
+  GRPC_DEPRECATED(
+      "OpenCensus has been sunsetted in favor of OpenTelemetry "
+      "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
   static absl::StatusOr<GcpObservability> Init();
 
   GcpObservability() = default;

--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -19,6 +19,8 @@
 #ifndef GRPCPP_OPENCENSUS_H
 #define GRPCPP_OPENCENSUS_H
 
+#include <grpc/support/port_platform.h>
+
 #include "opencensus/stats/view_descriptor.h"
 #include "opencensus/tags/tag_map.h"
 #include "opencensus/trace/span.h"
@@ -183,7 +185,9 @@ const ::opencensus::stats::ViewDescriptor& ServerCompletedRpcsHour();
 
 // DEPRECATED
 // Thread compatible.
-class CensusContext {
+class GRPC_DEPRECATED(
+    "OpenCensus has been sunsetted in favor of OpenTelemetry "
+    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/") CensusContext {
  public:
   CensusContext() : span_(::opencensus::trace::Span::BlankSpan()), tags_({}) {}
 

--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -24,37 +24,53 @@
 #include "opencensus/trace/span.h"
 #include "opencensus/trace/span_context.h"
 
+// WARNING : DO NOT USE. OpenCensus APIs have been deprecated.
+
+// OpenCensus was sunsetted in May, 2023
+// (https://opentelemetry.io/blog/2023/sunsetting-opencensus/), and the C++
+// OpenCensus repository has been archived
+// (https://github.com/census-instrumentation/opencensus-cpp)/
+
 namespace grpc {
 class ServerContext;
 // These symbols in this file will not be included in the binary unless
 // grpc_opencensus_plugin build target was added as a dependency. At the moment
 // it is only setup to be built with Bazel.
 
-// Registers the OpenCensus plugin with gRPC, so that it will be used for future
-// RPCs. This must be called before any views are created.
+// DEPRECATED: Registers the OpenCensus plugin with gRPC, so that it will be
+// used for future RPCs. This must be called before any views are created.
+GRPC_DEPRECATED(
+    "OpenCensus has been sunsetted in favor of OpenTelemetry "
+    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
 void RegisterOpenCensusPlugin();
 
 // RPC stats definitions, defined by
 // https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md
 
-// Registers the cumulative gRPC views so that they will be exported by any
-// registered stats exporter. For on-task stats, construct a View using the
-// ViewDescriptors below.
+// DEPRECATED: Registers the cumulative gRPC views so that they will be exported
+// by any registered stats exporter. For on-task stats, construct a View using
+// the ViewDescriptors below.
+GRPC_DEPRECATED(
+    "OpenCensus has been sunsetted in favor of OpenTelemetry "
+    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
 void RegisterOpenCensusViewsForExport();
 
-// Returns the tracing Span for the current RPC.
+// DEPRECATED: Returns the tracing Span for the current RPC.
+GRPC_DEPRECATED(
+    "OpenCensus has been sunsetted in favor of OpenTelemetry "
+    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
 ::opencensus::trace::Span GetSpanFromServerContext(ServerContext* context);
 
 namespace experimental {
 
-// The tag keys set when recording RPC stats.
+// DEPRECATED: The tag keys set when recording RPC stats.
 ::opencensus::tags::TagKey ClientMethodTagKey();
 ::opencensus::tags::TagKey ClientStatusTagKey();
 ::opencensus::tags::TagKey ServerMethodTagKey();
 ::opencensus::tags::TagKey ServerStatusTagKey();
 
-// Names of measures used by the plugin--users can create views on these
-// measures but should not record data for them.
+// DEPRECATED: Names of measures used by the plugin--users can create views on
+// these measures but should not record data for them.
 extern const absl::string_view kRpcClientSentMessagesPerRpcMeasureName;
 extern const absl::string_view kRpcClientSentBytesPerRpcMeasureName;
 extern const absl::string_view kRpcClientReceivedMessagesPerRpcMeasureName;
@@ -74,7 +90,7 @@ extern const absl::string_view kRpcServerReceivedBytesPerRpcMeasureName;
 extern const absl::string_view kRpcServerServerLatencyMeasureName;
 extern const absl::string_view kRpcServerStartedRpcsMeasureName;
 
-// Canonical gRPC view definitions.
+// DEPRECATED: Canonical gRPC view definitions.
 const ::opencensus::stats::ViewDescriptor& ClientStartedRpcs();
 const ::opencensus::stats::ViewDescriptor& ClientCompletedRpcs();
 const ::opencensus::stats::ViewDescriptor& ClientRoundtripLatency();
@@ -165,6 +181,7 @@ const ::opencensus::stats::ViewDescriptor& ServerServerLatencyHour();
 const ::opencensus::stats::ViewDescriptor& ServerStartedRpcsHour();
 const ::opencensus::stats::ViewDescriptor& ServerCompletedRpcsHour();
 
+// DEPRECATED
 // Thread compatible.
 class CensusContext {
  public:

--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -33,34 +33,32 @@
 // OpenCensus repository has been archived
 // (https://github.com/census-instrumentation/opencensus-cpp)/
 
+#define GRPC_OPENCENSUS_DEPRECATION_REASON                   \
+  "OpenCensus has been sunsetted in favor of OpenTelemetry " \
+  "https://opentelemetry.io/blog/2023/sunsetting-opencensus/"
+
 namespace grpc {
 class ServerContext;
 // These symbols in this file will not be included in the binary unless
-// grpc_opencensus_plugin build target was added as a dependency. At the moment
-// it is only setup to be built with Bazel.
+// grpc_opencensus_plugin build target was added as a dependency. At the
+// moment it is only setup to be built with Bazel.
 
 // DEPRECATED: Registers the OpenCensus plugin with gRPC, so that it will be
 // used for future RPCs. This must be called before any views are created.
-GRPC_DEPRECATED(
-    "OpenCensus has been sunsetted in favor of OpenTelemetry "
-    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
+GRPC_DEPRECATED(GRPC_OPENCENSUS_DEPRECATION_REASON)
 void RegisterOpenCensusPlugin();
 
 // RPC stats definitions, defined by
 // https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md
 
-// DEPRECATED: Registers the cumulative gRPC views so that they will be exported
-// by any registered stats exporter. For on-task stats, construct a View using
-// the ViewDescriptors below.
-GRPC_DEPRECATED(
-    "OpenCensus has been sunsetted in favor of OpenTelemetry "
-    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
+// DEPRECATED: Registers the cumulative gRPC views so that they will be
+// exported by any registered stats exporter. For on-task stats, construct a
+// View using the ViewDescriptors below.
+GRPC_DEPRECATED(GRPC_OPENCENSUS_DEPRECATION_REASON)
 void RegisterOpenCensusViewsForExport();
 
 // DEPRECATED: Returns the tracing Span for the current RPC.
-GRPC_DEPRECATED(
-    "OpenCensus has been sunsetted in favor of OpenTelemetry "
-    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/")
+GRPC_DEPRECATED(GRPC_OPENCENSUS_DEPRECATION_REASON)
 ::opencensus::trace::Span GetSpanFromServerContext(ServerContext* context);
 
 namespace experimental {
@@ -185,9 +183,7 @@ const ::opencensus::stats::ViewDescriptor& ServerCompletedRpcsHour();
 
 // DEPRECATED
 // Thread compatible.
-class GRPC_DEPRECATED(
-    "OpenCensus has been sunsetted in favor of OpenTelemetry "
-    "https://opentelemetry.io/blog/2023/sunsetting-opencensus/") CensusContext {
+class GRPC_DEPRECATED(GRPC_OPENCENSUS_DEPRECATION_REASON) CensusContext {
  public:
   CensusContext() : span_(::opencensus::trace::Span::BlankSpan()), tags_({}) {}
 


### PR DESCRIPTION
OpenCensus was sunsetted in May, 2023 (https://opentelemetry.io/blog/2023/sunsetting-opencensus/), and the C++ OpenCensus repository has been archived (https://github.com/census-instrumentation/opencensus-cpp)/