### PR TITLE
[Python] Fix Python Linux distribtests copy conflicts

### DIFF
--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -49,12 +49,7 @@ mkdir -p input_artifacts
 cp -r artifacts/* input_artifacts/ || true
 
 # This step simply collects python artifacts from subdirectories of input_artifacts/ and copies them to artifacts/
-if [[ "${IS_AARCH64_MUSL}" == "True" ]]; then
-  # Not using TASK_RUNNER_EXTRA_FILTERS since we don't have a target with presubmit tag.
-  tools/run_tests/task_runner.py -f package linux python musllinux_1_1 aarch64 -x build_packages/sponge_log.xml || FAILED="true"
-else
-  tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml || FAILED="true"
-fi
+tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml || FAILED="true"
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
 # in addition to that, preserve the contents of "artifacts" directory since we want kokoro

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -53,7 +53,7 @@ if [[ "${IS_AARCH64_MUSL}" == "True" ]]; then
   # Not using TASK_RUNNER_EXTRA_FILTERS since we don't have a target with presubmit tag.
   tools/run_tests/task_runner.py -f package linux python musllinux_1_1 aarch64 -x build_packages/sponge_log.xml || FAILED="true"
 else
-  tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml || FAILED="true"
+  tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml -e aarch64 musllinux_1_1 || FAILED="true"
 fi
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -49,10 +49,14 @@ mkdir -p input_artifacts
 cp -r artifacts/* input_artifacts/ || true
 
 # This step simply collects python artifacts from subdirectories of input_artifacts/ and copies them to artifacts/
-# Modifying TASK_RUNNER_EXTRA_FILTERS since we don't have a target with 'presubmit' tag for the package artifacts step
-MODIFIED_TASK_RUNNER_EXTRA_FILTERS="${TASK_RUNNER_EXTRA_FILTERS//presubmit /}"
 
-tools/run_tests/task_runner.py -f package linux python ${MODIFIED_TASK_RUNNER_EXTRA_FILTERS} -x build_packages/sponge_log.xml || FAILED="true"
+# PythonPackage targets do not support the `presubmit` label.
+# For this reason we remove `presubmit` label selector from TASK_RUNNER_EXTRA_FILTERS,
+# which looks like TASK_RUNNER_EXTRA_FILTERS="presubmit -e aarch64 musllinux_1_1"
+# for a presubmit with an exclude filter.
+PACKAGE_TASK_RUNNER_EXTRA_FILTERS="${TASK_RUNNER_EXTRA_FILTERS//presubmit /}"
+
+tools/run_tests/task_runner.py -f package linux python ${PACKAGE_TASK_RUNNER_EXTRA_FILTERS} -x build_packages/sponge_log.xml || FAILED="true"
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
 # in addition to that, preserve the contents of "artifacts" directory since we want kokoro

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -49,7 +49,12 @@ mkdir -p input_artifacts
 cp -r artifacts/* input_artifacts/ || true
 
 # This step simply collects python artifacts from subdirectories of input_artifacts/ and copies them to artifacts/
-tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml || FAILED="true"
+if [[ "${IS_AARCH64_MUSL}" == "True" ]]; then
+  # Not using TASK_RUNNER_EXTRA_FILTERS since we don't have a target with presubmit tag.
+  tools/run_tests/task_runner.py -f package linux python musllinux_1_1 aarch64 -x build_packages/sponge_log.xml || FAILED="true"
+else
+  tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml || FAILED="true"
+fi
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
 # in addition to that, preserve the contents of "artifacts" directory since we want kokoro

--- a/tools/internal_ci/linux/grpc_distribtests_python.sh
+++ b/tools/internal_ci/linux/grpc_distribtests_python.sh
@@ -49,12 +49,10 @@ mkdir -p input_artifacts
 cp -r artifacts/* input_artifacts/ || true
 
 # This step simply collects python artifacts from subdirectories of input_artifacts/ and copies them to artifacts/
-if [[ "${IS_AARCH64_MUSL}" == "True" ]]; then
-  # Not using TASK_RUNNER_EXTRA_FILTERS since we don't have a target with presubmit tag.
-  tools/run_tests/task_runner.py -f package linux python musllinux_1_1 aarch64 -x build_packages/sponge_log.xml || FAILED="true"
-else
-  tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml -e aarch64 musllinux_1_1 || FAILED="true"
-fi
+# Modifying TASK_RUNNER_EXTRA_FILTERS since we don't have a target with 'presubmit' tag for the package artifacts step
+MODIFIED_TASK_RUNNER_EXTRA_FILTERS="${TASK_RUNNER_EXTRA_FILTERS//presubmit /}"
+
+tools/run_tests/task_runner.py -f package linux python ${MODIFIED_TASK_RUNNER_EXTRA_FILTERS} -x build_packages/sponge_log.xml || FAILED="true"
 
 # the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
 # in addition to that, preserve the contents of "artifacts" directory since we want kokoro

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -27,13 +27,9 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -name "${ARTIFACT_PREFIX}*" \
     ! -name "${EXCLUDE_PATTERN}" \
     -exec sh -c '
-        echo "$1" ; cp -r "$1"/* artifacts/ || true
+        cp -r "$1"/* artifacts/ || true
     ' sh {} \;
-
-ls -R artifacts
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up
 # in the artifacts/ directory. They should be all equivalent though.
-
-exit 1

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -19,6 +19,8 @@ cd "$(dirname "$0")/../../.."
 
 mkdir -p artifacts/
 
+uname -a
+
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
 find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
@@ -27,7 +29,7 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -name "${ARTIFACT_PREFIX}*" \
     -not -name "${EXCLUDE_PREFIX}" \
     -print0 \
-        | find -files0-from - -type f -maxdepth 1 -exec cp -v {} ./artifacts \;
+        | find -files0-from - -type f -maxdepth 1 -exec 'cp -v {} ./artifacts || true' \;
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -21,14 +21,18 @@ mkdir -p artifacts/
 
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
-find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
+find_command=(find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -maxdepth 1 \
     -type d \
-    -name "${ARTIFACT_PREFIX}*" \
-    ! -name "${EXCLUDE_PREFIX}*" \
-    -exec sh -c '
-        cp -r "$1"/* artifacts/ || true
-    ' sh {} \;
+    -name "${ARTIFACT_PREFIX}*"
+)
+
+if [[ -n "${EXCLUDE_PREFIX}" ]]
+    find_command+=(! -name "${EXCLUDE_PREFIX}*")
+
+find_command+=(-exec sh -c '
+    cp -r "$1"/* artifacts/ || true
+' sh {} \;)
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -25,10 +25,9 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -maxdepth 1 \
     -type d \
     -name "${ARTIFACT_PREFIX}*" \
-    ! -name "${EXCLUDE_PATTERN}" \
-    -exec sh -c '
-        cp -r "$1"/* artifacts/ || true
-    ' sh {} \;
+    -not -name "${EXCLUDE_PREFIX}" \
+    -print0 \
+        | find -files0-from - -type f -maxdepth 1 -exec cp -v {} ./artifacts \;
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -25,7 +25,7 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -maxdepth 1 \
     -type d \
     -name "${ARTIFACT_PREFIX}*" \
-    -not -name "${EXCLUDE_PREFIX}" \
+    -not -name "${EXCLUDE_PATTERN}" \
     -print0 \
         | xargs -0 -I% find % -type f -maxdepth 1 -exec cp -v {} ./artifacts \;
 

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -21,7 +21,14 @@ mkdir -p artifacts/
 
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
-cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/python_*/* artifacts/ || true
+find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
+    -maxdepth 1 \
+    -type d \
+    -name "${ARTIFACT_PREFIX}*" \
+    ! -name "${EXCLUDE_PREFIX}" \
+    -exec sh -c '
+        cp -r "$1"/* artifacts/ || true
+    ' sh {} \;
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -25,12 +25,12 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -maxdepth 1 \
     -type d \
     -name "${ARTIFACT_PREFIX}*" \
-    ! -name "${EXCLUDE_PREFIX}*" \
+    ! -name "${EXCLUDE_PATTERN}" \
     -exec sh -c '
         echo "$1" ; cp -r "$1"/* artifacts/ || true
     ' sh {} \;
 
-ls -r artifacts
+ls -R artifacts
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -19,7 +19,9 @@ cd "$(dirname "$0")/../../.."
 
 mkdir -p artifacts/
 
-uname -a
+if command -v apk >/dev/null 2>&1; then
+    apk --no-cache add findutils
+fi
 
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -21,18 +21,14 @@ mkdir -p artifacts/
 
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
-find_command=(find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
+find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -maxdepth 1 \
     -type d \
-    -name "${ARTIFACT_PREFIX}*"
-)
-
-if [[ -n "${EXCLUDE_PREFIX}" ]]
-    find_command+=(! -name "${EXCLUDE_PREFIX}*")
-
-find_command+=(-exec sh -c '
-    cp -r "$1"/* artifacts/ || true
-' sh {} \;)
+    -name "${ARTIFACT_PREFIX}*" \
+    ! -name "${EXCLUDE_PREFIX}*" \
+    -exec sh -c '
+        echo "$1" ; cp -r "$1"/* artifacts/ || true
+    ' sh {} \;
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -27,7 +27,7 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -name "${ARTIFACT_PREFIX}*" \
     -not -name "${EXCLUDE_PREFIX}" \
     -print0 \
-        | find -files0-from - -type f -maxdepth 1 -exec 'cp -v {} ./artifacts || true' \;
+        | xargs -0 -I% find % -type f -maxdepth 1 -exec cp -v {} ./artifacts \;
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ex
+set -eux
 
 cd "$(dirname "$0")/../../.."
 

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -19,10 +19,6 @@ cd "$(dirname "$0")/../../.."
 
 mkdir -p artifacts/
 
-if command -v apk >/dev/null 2>&1; then
-    apk --no-cache add findutils
-fi
-
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
 find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -30,6 +30,10 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
         echo "$1" ; cp -r "$1"/* artifacts/ || true
     ' sh {} \;
 
+ls -r artifacts
+
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up
 # in the artifacts/ directory. They should be all equivalent though.
+
+exit 1

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -25,7 +25,7 @@ find "${EXTERNAL_GIT_ROOT}"/input_artifacts/ \
     -maxdepth 1 \
     -type d \
     -name "${ARTIFACT_PREFIX}*" \
-    ! -name "${EXCLUDE_PREFIX}" \
+    ! -name "${EXCLUDE_PREFIX}*" \
     -exec sh -c '
         cp -r "$1"/* artifacts/ || true
     ' sh {} \;

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -165,10 +165,10 @@ class PythonPackage:
         dockerfile_dir = (
             "tools/dockerfile/grpc_artifact_python_manylinux2014_x64"
         )
-        if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
-            dockerfile_dir = (
-                "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
-            )
+        # if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
+        #     dockerfile_dir = (
+        #         "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
+        #     )
         return create_docker_jobspec(
             self.name,
             dockerfile_dir,
@@ -204,6 +204,5 @@ def targets():
         CSharpPackage("windows"),
         RubyPackage(),
         PythonPackage(),
-        PythonPackage("musllinux_1_1", "aarch64"),
         PHPPackage(),
     ]

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -175,7 +175,7 @@ class PythonPackage:
                 "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
             )
             environ["ARTIFACT_PREFIX"] = "python_musllinux_1_1_aarch64_"
-            del environ["EXCLUDE_PATTERN"]
+            environ["EXCLUDE_PATTERN"] = ""
 
         return create_docker_jobspec(
             self.name,

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -168,14 +168,14 @@ class PythonPackage:
         environ = {
             "PYTHON": "/opt/python/cp39-cp39/bin/python",
             "ARTIFACT_PREFIX": "python_",
-            "EXCLUDE_PATTERN": "python_musllinux_1_1_aarch64_*",
+            "EXCLUDE_PREFIX": "python_musllinux_1_1_aarch64_*",
         }
         if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
             dockerfile_dir = (
                 "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
             )
             environ["ARTIFACT_PREFIX"] = "python_musllinux_1_1_aarch64_"
-            environ["EXCLUDE_PATTERN"] = ""
+            environ["EXCLUDE_PREFIX"] = ""
 
         return create_docker_jobspec(
             self.name,

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -168,14 +168,14 @@ class PythonPackage:
         environ = {
             "PYTHON": "/opt/python/cp39-cp39/bin/python",
             "ARTIFACT_PREFIX": "python_",
-            "EXCLUDE_PREFIX": "python_musllinux_1_1_aarch64_*",
+            "EXCLUDE_PATTERN": "python_musllinux_1_1_aarch64_*",
         }
         if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
             dockerfile_dir = (
                 "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
             )
             environ["ARTIFACT_PREFIX"] = "python_musllinux_1_1_aarch64_"
-            environ["EXCLUDE_PREFIX"] = ""
+            environ["EXCLUDE_PATTERN"] = ""
 
         return create_docker_jobspec(
             self.name,

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -165,7 +165,7 @@ class PythonPackage:
         dockerfile_dir = (
             "tools/dockerfile/grpc_artifact_python_manylinux2014_x64"
         )
-        environ={
+        environ = {
             "PYTHON": "/opt/python/cp39-cp39/bin/python",
             "ARTIFACT_PREFIX": "python_",
             "EXCLUDE_PATTERN": "python_musllinux_1_1_aarch64_*",

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -168,14 +168,14 @@ class PythonPackage:
         environ={
             "PYTHON": "/opt/python/cp39-cp39/bin/python",
             "ARTIFACT_PREFIX": "python_",
-            "EXCLUDE_PREFIX": "python_musllinux_1_1_aarch64_",
+            "EXCLUDE_PATTERN": "python_musllinux_1_1_aarch64_*",
         }
         if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
             dockerfile_dir = (
                 "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
             )
             environ["ARTIFACT_PREFIX"] = "python_musllinux_1_1_aarch64_"
-            del environ["EXCLUDE_PREFIX"]
+            del environ["EXCLUDE_PATTERN"]
 
         return create_docker_jobspec(
             self.name,

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -165,10 +165,10 @@ class PythonPackage:
         dockerfile_dir = (
             "tools/dockerfile/grpc_artifact_python_manylinux2014_x64"
         )
-        # if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
-        #     dockerfile_dir = (
-        #         "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
-        #     )
+        if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
+            dockerfile_dir = (
+                "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
+            )
         return create_docker_jobspec(
             self.name,
             dockerfile_dir,
@@ -204,5 +204,6 @@ def targets():
         CSharpPackage("windows"),
         RubyPackage(),
         PythonPackage(),
+        PythonPackage("musllinux_1_1", "aarch64"),
         PHPPackage(),
     ]

--- a/tools/run_tests/artifacts/package_targets.py
+++ b/tools/run_tests/artifacts/package_targets.py
@@ -165,15 +165,23 @@ class PythonPackage:
         dockerfile_dir = (
             "tools/dockerfile/grpc_artifact_python_manylinux2014_x64"
         )
+        environ={
+            "PYTHON": "/opt/python/cp39-cp39/bin/python",
+            "ARTIFACT_PREFIX": "python_",
+            "EXCLUDE_PREFIX": "python_musllinux_1_1_aarch64_",
+        }
         if "musllinux_1_1" in self.platform and "aarch64" in self.arch:
             dockerfile_dir = (
                 "tools/dockerfile/grpc_artifact_python_musllinux_1_1_aarch64"
             )
+            environ["ARTIFACT_PREFIX"] = "python_musllinux_1_1_aarch64_"
+            del environ["EXCLUDE_PREFIX"]
+
         return create_docker_jobspec(
             self.name,
             dockerfile_dir,
             "tools/run_tests/artifacts/build_package_python.sh",
-            environ={"PYTHON": "/opt/python/cp39-cp39/bin/python"},
+            environ=environ,
         )
 
 

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -216,7 +216,7 @@ fi
 # Copy contents of OUTPUT_DIR back under the git repo root
 if [ "${OUTPUT_DIR}" != "" ]
 then
-  cp -r "${TEMP_OUTPUT_DIR}/${OUTPUT_DIR}" "${git_root}" || DOCKER_EXIT_CODE=$?
+  cp -rf "${TEMP_OUTPUT_DIR}/${OUTPUT_DIR}" "${git_root}" || DOCKER_EXIT_CODE=$?
 fi
 
 exit $DOCKER_EXIT_CODE

--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -216,7 +216,7 @@ fi
 # Copy contents of OUTPUT_DIR back under the git repo root
 if [ "${OUTPUT_DIR}" != "" ]
 then
-  cp -rf "${TEMP_OUTPUT_DIR}/${OUTPUT_DIR}" "${git_root}" || DOCKER_EXIT_CODE=$?
+  cp -r "${TEMP_OUTPUT_DIR}/${OUTPUT_DIR}" "${git_root}" || DOCKER_EXIT_CODE=$?
 fi
 
 exit $DOCKER_EXIT_CODE

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -115,8 +115,8 @@ for label in args.build:
 targets = [t for t in targets if all(f in t.labels for f in args.filter)]
 
 # Exclude target if it has ALL of the specified exclude labels.
-# if args.exclude:
-#     targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
+if args.exclude:
+    targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
 
 print("Will build %d targets:" % len(targets))
 for target in targets:

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -116,7 +116,9 @@ targets = [t for t in targets if all(f in t.labels for f in args.filter)]
 
 # Exclude target if it has ALL of the specified exclude labels.
 if args.exclude:
-    targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
+    targets = [
+        t for t in targets if not all(l in t.labels for l in args.exclude)
+    ]
 
 print("Will build %d targets:" % len(targets))
 for target in targets:

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -115,7 +115,7 @@ for label in args.build:
 targets = [t for t in targets if all(f in t.labels for f in args.filter)]
 
 # Exclude target if it has ALL of the specified exclude labels.
-targets = [t for t in targets if not all(l in args.exclude for l in t.labels)]
+targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
 
 print("Will build %d targets:" % len(targets))
 for target in targets:

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -115,7 +115,8 @@ for label in args.build:
 targets = [t for t in targets if all(f in t.labels for f in args.filter)]
 
 # Exclude target if it has ALL of the specified exclude labels.
-targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
+if args.exclude:
+    targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
 
 print("Will build %d targets:" % len(targets))
 for target in targets:

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -115,8 +115,8 @@ for label in args.build:
 targets = [t for t in targets if all(f in t.labels for f in args.filter)]
 
 # Exclude target if it has ALL of the specified exclude labels.
-if args.exclude:
-    targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
+# if args.exclude:
+#     targets = [t for t in targets if not all(l in t.labels for l in args.exclude)]
 
 print("Will build %d targets:" % len(targets))
 for target in targets:


### PR DESCRIPTION
Recently, the Python Linux distribtests have been having flake failures with an error like:
```
+ '[' artifacts '!=' '' ']'
+ cp -r /tmp/tmp.nb7ZJvoaIS/artifacts /tmpfs/altsrc/github/grpc
cp: cannot create regular file '/tmpfs/altsrc/github/grpc/artifacts/grpcio-1.73.0.dev0-cp311-cp311-linux_armv7l.whl': File exists
```

The root cause was found to be one of our recent changes while adding support for musllinux_1_1_aarch64 wheels. 

Some context on the Linux distribtests build - As part of building the Linux artifacts (`.whl` files), we have [3 types of build targets](https://github.com/grpc/grpc/blob/master/tools/run_tests/task_runner.py#L29-L32) - `artifact_targets`, `distrib_targets` and `package_targets`.

Recently in Q1, we added support for `musllinux_1_1_aarch64` wheels and separated the build for these wheels into a separate job by using exclude parameters in the original `distribtests_python` config: [Reference](https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_distribtests_python.cfg#L30).

While both '[artifact_targets](https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_distribtests_python.sh#L44)' and '[distrib_targets](https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_distribtests_python.sh#L73)' use these exclude filters during invocation, these exclude filters were missing for the '[package_targets](https://github.com/grpc/grpc/blob/master/tools/internal_ci/linux/grpc_distribtests_python.sh#L56)' causing both package builds to run as below:
```
tools/run_tests/task_runner.py -f package linux python -x build_packages/sponge_log.xml
2025-05-13 16:08:21,278 START: Building targets.
Will build 2 targets:
  python_package, labels ['package', 'python', 'linux']
  python_package_musllinux_1_1_aarch64, labels ['package', 'python', 'linux', 'musllinux_1_1', 'aarch64']
```

But looking at [build_package_python.sh](https://github.com/grpc/grpc/blob/master/tools/run_tests/artifacts/build_package_python.sh#L24) shows that the job only copies all the built artifacts starting with `python_` with no further filters on the type of architecture, meaning that both jobs were trying to copy all the python built artifacts to the same mounted directory parallely, causing these copy conflicts/race conditions.

To resolve this, the following fixes are done in this PR:
 * add exclude flags for musllinux aarch64 while building package_targets
 * improve package_targets job to include the exclude flag and selectively copy files, such that `python_package_musllinux_1_1_aarch64` job only copies those artifacts and the `python_package` job doesn't copy the musllinux aarch64 artifacts
 * fixed exclude flags logic as it wasn't working as expected 