### PR TITLE
[Python] GitHub templates: assign python team instead of individuals

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.md
@@ -3,8 +3,7 @@ name: Report a gRPC Python bug
 about: Create a report to help us improve
 labels: kind/bug, priority/P2, lang/Python
 assignees:
-  - sergiitk
-  - sreenithi
+  - grpc/grpc-python-team
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request_python.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_python.md
@@ -3,8 +3,7 @@ name: Request a gRPC Python feature
 about: Suggest an idea for this project
 labels: kind/enhancement, priority/P2, lang/Python
 assignees:
-  - sergiitk
-  - sreenithi
+  - grpc/grpc-python-team
 
 ---
 


### PR DESCRIPTION
I've configured auto-assignment for @grpc/grpc-python-team team, which should give use more flexibility in routing the tickets.