### PR TITLE
[Backport][v1.71.x][PSM interop] adds kokoro config files for cloud run csm inbound tests #38958

### DIFF
--- a/tools/internal_ci/linux/psm-cloud-run-python.cfg
+++ b/tools/internal_ci/linux/psm-cloud-run-python.cfg
@@ -1,0 +1,30 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/psm-interop-test-python.sh"
+timeout_mins: 240
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "cloud_run"
+}

--- a/tools/internal_ci/linux/psm-cloud-run.cfg
+++ b/tools/internal_ci/linux/psm-cloud-run.cfg
@@ -1,0 +1,30 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "cloud_run"
+}


### PR DESCRIPTION



Closes #38958

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/38958 from AgraVator:adds-cloud-run-csm-inbound-tests-kokoro-configs be4df9cefc7dc7bfa0f0c205634ba5e636be31e8 PiperOrigin-RevId: 737535797




