### PR TITLE
[http2] Fix GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES for when BDP is disabled

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -534,7 +534,10 @@ static void read_channel_args(grpc_chttp2_transport* t,
   value =
       channel_args.GetInt(GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES).value_or(-1);
   if (value >= 0) {
+    value = std::min(static_cast<unsigned int>(value),
+                     grpc_core::Http2Settings::max_initial_window_size());
     t->settings.mutable_local().SetInitialWindowSize(value);
+    t->flow_control.set_target_initial_window_size(value);
   }
   value = channel_args.GetInt(GRPC_ARG_HTTP2_ENABLE_TRUE_BINARY).value_or(-1);
   if (value >= 0) {

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -534,8 +534,6 @@ static void read_channel_args(grpc_chttp2_transport* t,
   value =
       channel_args.GetInt(GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES).value_or(-1);
   if (value >= 0) {
-    value = std::min(static_cast<unsigned int>(value),
-                     grpc_core::Http2Settings::max_initial_window_size());
     t->settings.mutable_local().SetInitialWindowSize(value);
     t->flow_control.set_target_initial_window_size(value);
   }

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -271,6 +271,10 @@ class TransportFlowControl final {
 
   FlowControlAction SetAckedInitialWindow(uint32_t value);
 
+  void set_target_initial_window_size(int64_t value) {
+    target_initial_window_size_ = value;
+  }
+
   // Getters
   int64_t remote_window() const { return remote_window_; }
   int64_t announced_window() const { return announced_window_; }

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -271,8 +271,9 @@ class TransportFlowControl final {
 
   FlowControlAction SetAckedInitialWindow(uint32_t value);
 
-  void set_target_initial_window_size(int64_t value) {
-    target_initial_window_size_ = value;
+  void set_target_initial_window_size(uint32_t value) {
+    target_initial_window_size_ =
+        std::min(value, grpc_core::Http2Settings::max_initial_window_size());
   }
 
   // Getters

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -273,7 +273,7 @@ class TransportFlowControl final {
 
   void set_target_initial_window_size(uint32_t value) {
     target_initial_window_size_ =
-        std::min(value, grpc_core::Http2Settings::max_initial_window_size());
+        std::min(value, Http2Settings::max_initial_window_size());
   }
 
   // Getters


### PR DESCRIPTION
Fixes b/401598085

`GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES` is supposed to influence the initial window size for a stream. This behavior is effectively disabled if BDP is enabled (default on) and we let BDP decide the initial window size.

We have a bug where if BDP is disabled, we use the value provided by `GRPC_ARG_HTTP2_STREAM_LOOKAHEAD_BYTES` for a very brief period of time. The first settings frame sent out has this overridden value, but we quickly change it back to the default value 65535.

```
I0000 00:00:1747358562.572890 1361251 frame_settings.cc:224] CHTTP2:SVR:ipv6:%5B::1%5D:33960: got setting ENABLE_PUSH = 0
I0000 00:00:1747358562.572964 1361251 frame_settings.cc:224] CHTTP2:SVR:ipv6:%5B::1%5D:33960: got setting MAX_CONCURRENT_STREAMS = 0
I0000 00:00:1747358562.572989 1361251 frame_settings.cc:224] CHTTP2:SVR:ipv6:%5B::1%5D:33960: got setting INITIAL_WINDOW_SIZE = 1000
I0000 00:00:1747358562.573009 1361251 frame_settings.cc:224] CHTTP2:SVR:ipv6:%5B::1%5D:33960: got setting MAX_HEADER_LIST_SIZE = 16384
I0000 00:00:1747358562.573027 1361251 frame_settings.cc:224] CHTTP2:SVR:ipv6:%5B::1%5D:33960: got setting GRPC_ALLOW_TRUE_BINARY_METADATA = 1
I0000 00:00:1747358562.573636 1361245 frame_settings.cc:224] CHTTP2:SVR:ipv6:%5B::1%5D:33960: got setting INITIAL_WINDOW_SIZE = 65535
```

The above is a log from an example server. The example client has bdp disabled and stream lookahead bytes set to 1000. We first see that the server receives `INITIAL_WINDOW_SIZE = 1000` but then it receives another setting `INITIAL_WINDOW_SIZE = 65535` shortly after.