### PR TITLE
Fixes incorrect output directory issue[39583]

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -950,6 +950,7 @@ bool PythonGrpcGenerator::Generate(const FileDescriptor* file,
     std::string base(
         file->name().substr(0, file->name().size() - proto_suffix_length));
     std::replace(base.begin(), base.end(), '-', '_');
+    std::replace(base.begin(), base.end(), '.', '/');
     pb2_file_name = base + "_pb2.py";
     pb2_grpc_file_name = base + "_pb2_grpc.py";
   } else {


### PR DESCRIPTION
This is one possible fix for https://github.com/grpc/grpc/issues/39583

Ref - https://github.com/protocolbuffers/protobuf/blob/8694620342626b208506335396b1fcf4b8449f31/bazel/py_proto_library.bzl#L72

Tested manually on the reported issue protos - 

<img width="1482" alt="Screenshot 2025-05-19 at 6 29 12 PM" src="https://github.com/user-attachments/assets/88b88141-f870-465e-aa44-37827a03e7f4" />




