### PR TITLE
[Ruby] add remove_unused_artifacts to opt build

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -231,7 +231,7 @@ File.rename('Makefile.new', 'Makefile')
 
 if grpc_config == 'opt'
   File.open('Makefile.new', 'w') do |o|
-    o.puts 'hijack: all strip'
+    o.puts 'hijack: all strip remove_unused_artifacts'
     o.puts
     o.write(File.read('Makefile'))
     o.puts


### PR DESCRIPTION
```
gem install ~/Downloads/test_result_public_prod_grpc_core_pull_request_linux_grpc_distribtests_ruby_38191_20250517-180035_github_grpc_artifacts_grpc-1.73.0.dev.gem

du -sh grpc-1.73.0.dev/*
260K	grpc-1.73.0.dev/etc
552K	grpc-1.73.0.dev/include
112K	grpc-1.73.0.dev/Makefile
 33M	grpc-1.73.0.dev/src
 19M	grpc-1.73.0.dev/third_party
 ```


[grpc-native-debug](https://console.cloud.google.com/storage/browser/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/pull_request/linux/grpc_distribtests_ruby/38191/20250517-180035/github/grpc/artifacts;tab=objects?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&inv=1&invt=AbxsXQ&prefix=&forceOnObjectsSortingFiltering=false) still builds.


--
fixes #39038