### PR TITLE
[ObjC] deduplicate dns resulve result in cf event engine test

### DIFF
--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -141,7 +141,10 @@ TEST(CFEventEngineTest, TestResolveRemote) {
   dns_resolver.value()->LookupHostname(
       [&resolve_signal](auto result) {
         EXPECT_TRUE(result.status().ok());
-        EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
+        auto resolved_addresses = ResolvedAddressesToStrings(result.value());
+        // TODO: same IP may be returned multiple times, deduplicate with a set
+        EXPECT_THAT(std::unordered_set<std::string>(resolved_addresses.begin(),
+                                                    resolved_addresses.end()),
                     testing::UnorderedElementsAre("127.0.0.1:80", "[::1]:80"));
 
         resolve_signal.Notify();


### PR DESCRIPTION
Test failure:
```
[test/core/event_engine/cf/cf_engine_test](http://test/core/event_engine/cf/cf_engine_test).cc:145
Value of: ResolvedAddressesToStrings(result.value())
Expected: has 2 elements and there exists some permutation of elements such that:
 - element #0 is equal to "127.0.0.1:80", and
 - element #1 is equal to "[::1]:80"
  Actual: { "[::1]:80", "[::1]:80", "[::1]:80", "127.0.0.1:80" }, which has 4 elements
  
```