### PR TITLE
[CI] push_testing_images.sh: specify platform in the arm64 check

### DIFF
--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -50,7 +50,7 @@ then
     # an emulator.
     # Perform a check that "qemu-user-static" with binfmt-misc hook
     # is installed, to give an early warning (otherwise building arm64 images won't work)
-    docker run --rm -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"' || \
+    docker run --rm --platform=linux/arm64 -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"' || \
         (echo "Error: can't run arm64 images under an emulator. Have you run 'sudo apt-get install qemu-user-static'?" && exit 1)
   fi
 fi


### PR DESCRIPTION
When  image for a non-standard arch variant (`v8` in `linux/arm64/v8`) is not present, docker won't download it unless `--platform` flag is specified explicitly.

```console
$ docker run --rm -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"'
Unable to find image 'arm64v8/debian:11' locally
11: Pulling from arm64v8/debian
11: Pulling from arm64v8/debian
docker: no matching manifest for linux/amd64 in the manifest list entries.
See 'docker run --help'.

$ docker run --rm --platform linux/arm64 -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"'
Unable to find image 'arm64v8/debian:11' locally
11: Pulling from arm64v8/debian
9ce0153b823c: Pull complete
Digest: sha256:082e3f90f4e248ad4bbd4db51a37beb2c44feb3a3bb588857452d5c494bf4d03
Status: Downloaded newer image for arm64v8/debian:11
able to run arm64 docker images with an emulator!
```

After the image is downloaded, Docker only warns about missing platform flag, but works otherwise.

> WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested.

```console
$ docker run --rm  -it arm64v8/debian:11 bash -c 'echo "able to run arm64 docker images with an emulator!"'
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64) and no specific platform was requested
able to run arm64 docker images with an emulator!
```
