### PR TITLE
Add a Bazel config setting to minimize thread pool size.

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -54,6 +54,11 @@ config_setting(
     values = {"define": "GRPC_MAXIMIZE_THREADYNESS=1"},
 )
 
+config_setting(
+    name = "minimize_threadyness",
+    values = {"define": "GRPC_MINIMIZE_THREADYNESS=1"},
+)
+
 grpc_cc_library(
     name = "channel_fwd",
     hdrs = [
@@ -2782,6 +2787,11 @@ grpc_cc_library(
         "lib/event_engine/cf_engine/cftype_unique_ref.h",
         "lib/event_engine/cf_engine/dns_service_resolver.h",
     ],
+    defines = select({
+        ":maximize_threadyness": ["GRPC_CFSTREAM_MAX_THREADPOOL_SIZE=16u"],
+        ":minimize_threadyness": ["GRPC_CFSTREAM_MAX_THREADPOOL_SIZE=2u"],
+        "//conditions:default": [],
+    }),
     external_deps = [
         "absl/container:flat_hash_map",
         "absl/log",

--- a/src/core/lib/event_engine/cf_engine/cf_engine.cc
+++ b/src/core/lib/event_engine/cf_engine/cf_engine.cc
@@ -31,6 +31,7 @@
 #include "src/core/lib/event_engine/thread_pool/thread_pool.h"
 #include "src/core/lib/event_engine/utils.h"
 #include "src/core/util/crash.h"
+#include "src/core/util/useful.h"
 
 #ifndef GRPC_CFSTREAM_MAX_THREADPOOL_SIZE
 #define GRPC_CFSTREAM_MAX_THREADPOOL_SIZE 16u
@@ -58,7 +59,8 @@ struct CFEventEngine::Closure final : public EventEngine::Closure {
 
 CFEventEngine::CFEventEngine()
     : thread_pool_(MakeThreadPool(grpc_core::Clamp(
-          gpr_cpu_num_cores(), 2u, GRPC_CFSTREAM_MAX_THREADPOOL_SIZE))),
+          gpr_cpu_num_cores(), 2u,
+          static_cast<unsigned int>(GRPC_CFSTREAM_MAX_THREADPOOL_SIZE)))),
       timer_manager_(thread_pool_) {}
 
 CFEventEngine::~CFEventEngine() {


### PR DESCRIPTION
There is an existing config setting `GRPC_MAXIMIZE_THREADYNESS`. This change adds a similar `GRPC_MINIMIZE_THREADYNESS` and uses each to apply max thread pool size for the CFEngine.

This is particularly useful for build systems where custom `-copt` flags cannot be provided to the compiler.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

