### PR TITLE
[OTel C++] Add creation of TcpCallTracer

### DIFF
--- a/src/core/lib/surface/filter_stack_call.cc
+++ b/src/core/lib/surface/filter_stack_call.cc
@@ -115,14 +115,6 @@ grpc_error_handle FilterStackCall::Create(grpc_call_create_args* args,
   grpc_slice path = grpc_empty_slice();
   ScopedContext ctx(call);
   Call* parent = Call::FromC(args->parent);
-  // initial refcount dropped by grpc_call_unref
-  grpc_call_element_args call_args = {
-      call->call_stack(), args->server_transport_data,
-      call->start_time(), call->send_deadline(),
-      call->arena(),      &call->call_combiner_};
-  add_init_error(&error, grpc_call_stack_init(channel_stack, 1, DestroyCall,
-                                              call, &call_args));
-
   if (call->is_client()) {
     call->final_op_.client.status_details = nullptr;
     call->final_op_.client.status = nullptr;
@@ -175,6 +167,14 @@ grpc_error_handle FilterStackCall::Create(grpc_call_create_args* args,
     }
     (*channel_stack->stats_plugin_group)->AddServerCallTracers(arena.get());
   }
+
+  // initial refcount dropped by grpc_call_unref
+  grpc_call_element_args call_args = {
+      call->call_stack(), args->server_transport_data,
+      call->start_time(), call->send_deadline(),
+      call->arena(),      &call->call_combiner_};
+  add_init_error(&error, grpc_call_stack_init(channel_stack, 1, DestroyCall,
+                                              call, &call_args));
   // Publish this call to parent only after the call stack has been initialized.
   if (parent != nullptr) {
     call->PublishToParent(parent);

--- a/src/cpp/ext/otel/otel_client_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_client_call_tracer.cc
@@ -62,13 +62,29 @@
 namespace grpc {
 namespace internal {
 
-class OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    TcpCallTracer : public grpc_core::TcpCallTracer {
+template <typename UnrefBehavior>
+class OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::TcpCallTracer : public grpc_core::TcpCallTracer {
  public:
   explicit TcpCallTracer(
-      OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer*
+      grpc_core::RefCountedPtr<OpenTelemetryPluginImpl::ClientCallTracer::
+                                   CallAttemptTracer<UnrefBehavior>>
           call_attempt_tracer)
-      : call_attempt_tracer_(call_attempt_tracer) {}
+      : call_attempt_tracer_(std::move(call_attempt_tracer)) {
+    // Take a ref on the call if tracing is enabled, since TCP traces might
+    // arrive after all the other refs on the call are gone.
+    call_attempt_tracer_->parent_->arena_
+        ->template GetContext<grpc_core::Call>()
+        ->InternalRef(
+            "OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer");
+  }
+
+  ~TcpCallTracer() override {
+    call_attempt_tracer_->parent_->arena_
+        ->template GetContext<grpc_core::Call>()
+        ->InternalUnref(
+            "OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer");
+  }
 
   void RecordEvent(grpc_event_engine::experimental::internal::WriteEvent type,
                    absl::Time time, size_t byte_offset,
@@ -82,20 +98,19 @@ class OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 
  private:
-  OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer*
+  grpc_core::RefCountedPtr<OpenTelemetryPluginImpl::ClientCallTracer::
+                               CallAttemptTracer<UnrefBehavior>>
       call_attempt_tracer_;
 };
 
 //
 // OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer
 //
-
-OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::CallAttemptTracer(
-    const OpenTelemetryPluginImpl::ClientCallTracer* parent,
-    uint64_t attempt_num, bool is_transparent_retry, bool arena_allocated)
-    : parent_(parent),
-      arena_allocated_(arena_allocated),
-      start_time_(absl::Now()) {
+template <typename UnrefBehavior>
+OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<UnrefBehavior>::
+    CallAttemptTracer(const OpenTelemetryPluginImpl::ClientCallTracer* parent,
+                      uint64_t attempt_num, bool is_transparent_retry)
+    : parent_(parent), start_time_(absl::Now()) {
   if (parent_->otel_plugin_->client_.attempt.started != nullptr) {
     std::array<std::pair<absl::string_view, absl::string_view>, 2>
         additional_labels = {
@@ -125,8 +140,18 @@ OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::CallAttemptTracer(
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordReceivedInitialMetadata(grpc_metadata_batch* recv_initial_metadata) {
+template <typename UnrefBehavior>
+OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::~CallAttemptTracer() {
+  if (span_ != nullptr) {
+    span_->End();
+  }
+}
+
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordReceivedInitialMetadata(grpc_metadata_batch*
+                                                      recv_initial_metadata) {
   if (recv_initial_metadata != nullptr &&
       recv_initial_metadata->get(grpc_core::GrpcTrailersOnly())
           .value_or(false)) {
@@ -136,8 +161,10 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   PopulateLabelInjectors(recv_initial_metadata);
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordSendInitialMetadata(grpc_metadata_batch* send_initial_metadata) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordSendInitialMetadata(grpc_metadata_batch*
+                                                  send_initial_metadata) {
   parent_->scope_config_->active_plugin_options_view().ForEach(
       [&](const InternalOpenTelemetryPluginOption& plugin_option,
           size_t /*index*/) {
@@ -156,8 +183,9 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordSendMessage(const grpc_core::Message& send_message) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordSendMessage(const grpc_core::Message& send_message) {
   if (span_ != nullptr) {
     std::array<std::pair<opentelemetry::nostd::string_view,
                          opentelemetry::common::AttributeValue>,
@@ -169,9 +197,10 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordSendCompressedMessage(
-        const grpc_core::Message& send_compressed_message) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordSendCompressedMessage(const grpc_core::Message&
+                                                    send_compressed_message) {
   if (span_ != nullptr) {
     std::array<std::pair<opentelemetry::nostd::string_view,
                          opentelemetry::common::AttributeValue>,
@@ -186,8 +215,10 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordReceivedMessage(const grpc_core::Message& recv_message) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordReceivedMessage(const grpc_core::Message&
+                                              recv_message) {
   if (span_ != nullptr) {
     std::array<std::pair<opentelemetry::nostd::string_view,
                          opentelemetry::common::AttributeValue>,
@@ -207,8 +238,9 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordReceivedDecompressedMessage(
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::
+    CallAttemptTracer<UnrefBehavior>::RecordReceivedDecompressedMessage(
         const grpc_core::Message& recv_decompressed_message) {
   if (span_ != nullptr) {
     std::array<std::pair<opentelemetry::nostd::string_view,
@@ -224,8 +256,9 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordReceivedTrailingMetadata(
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::
+    CallAttemptTracer<UnrefBehavior>::RecordReceivedTrailingMetadata(
         absl::Status status, grpc_metadata_batch* recv_trailing_metadata,
         const grpc_transport_stream_stats* transport_stream_stats) {
   if (is_trailers_only_) {
@@ -277,65 +310,75 @@ void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordIncomingBytes(const TransportByteSize& transport_byte_size) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordIncomingBytes(const TransportByteSize&
+                                            transport_byte_size) {
   incoming_bytes_.fetch_add(transport_byte_size.data_bytes);
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordOutgoingBytes(const TransportByteSize& transport_byte_size) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordOutgoingBytes(const TransportByteSize&
+                                            transport_byte_size) {
   outgoing_bytes_.fetch_add(transport_byte_size.data_bytes);
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::RecordCancel(
-    absl::Status /*cancel_error*/) {}
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordCancel(absl::Status /*cancel_error*/) {}
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::RecordEnd() {
-  if (span_ != nullptr) {
-    span_->End();
-  }
-  if (arena_allocated_) {
-    this->~CallAttemptTracer();
-  } else {
-    delete this;
-  }
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordEnd() {
+  this->Unref(DEBUG_LOCATION, "RecordEnd");
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordAnnotation(absl::string_view annotation) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordAnnotation(absl::string_view annotation) {
   if (span_ != nullptr) {
     span_->AddEvent(AbslStringViewToNoStdStringView(annotation));
   }
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordAnnotation(const Annotation& /*annotation*/) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordAnnotation(const Annotation& /*annotation*/) {
   // Not implemented
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    RecordAnnotation(absl::string_view annotation, absl::Time time) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::RecordAnnotation(absl::string_view annotation,
+                                     absl::Time time) {
   if (span_ != nullptr) {
     span_->AddEvent(AbslStringViewToNoStdStringView(annotation),
                     absl::ToChronoTime(time));
   }
 }
 
+template <typename UnrefBehavior>
 std::shared_ptr<grpc_core::TcpCallTracer> OpenTelemetryPluginImpl::
-    ClientCallTracer::CallAttemptTracer::StartNewTcpTrace() {
-  // No TCP trace.
+    ClientCallTracer::CallAttemptTracer<UnrefBehavior>::StartNewTcpTrace() {
+  if (span_ != nullptr) {
+    return std::make_shared<TcpCallTracer>(
+        this->Ref(DEBUG_LOCATION, "StartNewTcpTrace"));
+  }
   return nullptr;
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    SetOptionalLabel(OptionalLabelKey key,
-                     grpc_core::RefCountedStringValue value) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::SetOptionalLabel(OptionalLabelKey key,
+                                     grpc_core::RefCountedStringValue value) {
   CHECK(key < OptionalLabelKey::kSize);
   optional_labels_[static_cast<size_t>(key)] = std::move(value);
 }
 
-void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::
-    PopulateLabelInjectors(grpc_metadata_batch* metadata) {
+template <typename UnrefBehavior>
+void OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
+    UnrefBehavior>::PopulateLabelInjectors(grpc_metadata_batch* metadata) {
   parent_->scope_config_->active_plugin_options_view().ForEach(
       [&](const InternalOpenTelemetryPluginOption& plugin_option,
           size_t /*index*/) {
@@ -393,7 +436,7 @@ OpenTelemetryPluginImpl::ClientCallTracer::~ClientCallTracer() {
   }
 }
 
-OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer*
+grpc_core::ClientCallTracer::CallAttemptTracer*
 OpenTelemetryPluginImpl::ClientCallTracer::StartNewAttempt(
     bool is_transparent_retry) {
   // We allocate the first attempt on the arena and all subsequent attempts
@@ -414,11 +457,13 @@ OpenTelemetryPluginImpl::ClientCallTracer::StartNewAttempt(
     attempt_num = retries_ - 1;  // Sequence starts at 0
   }
   if (is_first_attempt) {
-    return arena_->New<CallAttemptTracer>(
-        this, attempt_num, is_transparent_retry, /*arena_allocated=*/true);
+    return arena_
+        ->MakeRefCounted<CallAttemptTracer<grpc_core::UnrefCallDtor>>(
+            this, attempt_num, is_transparent_retry)
+        .release();
   }
-  return new CallAttemptTracer(this, attempt_num, is_transparent_retry,
-                               /*arena_allocated=*/false);
+  return new CallAttemptTracer<grpc_core::UnrefDelete>(this, attempt_num,
+                                                       is_transparent_retry);
 }
 
 absl::string_view OpenTelemetryPluginImpl::ClientCallTracer::MethodForStats()

--- a/src/cpp/ext/otel/otel_client_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_client_call_tracer.cc
@@ -142,7 +142,7 @@ OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<UnrefBehavior>::
 
 template <typename UnrefBehavior>
 OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
-    UnrefBehavior>::~CallAttemptTracer() {
+    UnrefBehavior>::~CallAttemptTracer<UnrefBehavior>() {
   if (span_ != nullptr) {
     span_->End();
   }

--- a/src/cpp/ext/otel/otel_plugin.cc
+++ b/src/cpp/ext/otel/otel_plugin.cc
@@ -1052,11 +1052,13 @@ grpc_core::ClientCallTracer* OpenTelemetryPluginImpl::GetClientCallTracer(
 
 grpc_core::ServerCallTracer* OpenTelemetryPluginImpl::GetServerCallTracer(
     std::shared_ptr<grpc_core::StatsPlugin::ScopeConfig> scope_config) {
-  return grpc_core::GetContext<grpc_core::Arena>()
-      ->ManagedNew<ServerCallTracer>(
-          this,
+  auto arena = grpc_core::GetContext<grpc_core::Arena>();
+  return arena
+      ->MakeRefCounted<ServerCallTracer>(
+          this, arena,
           std::static_pointer_cast<OpenTelemetryPluginImpl::ServerScopeConfig>(
-              scope_config));
+              scope_config))
+      .release();
 }
 
 bool OpenTelemetryPluginImpl::IsInstrumentEnabled(

--- a/src/cpp/ext/otel/otel_server_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_server_call_tracer.cc
@@ -95,7 +95,11 @@ OpenTelemetryPluginImpl::ServerCallTracer::ServerCallTracer(
       arena_(arena),
       scope_config_(std::move(scope_config)) {}
 
-OpenTelemetryPluginImpl::ServerCallTracer::~ServerCallTracer() { span_->End(); }
+OpenTelemetryPluginImpl::ServerCallTracer::~ServerCallTracer() {
+  if (span_ != nullptr) {
+    span_->End();
+  }
+}
 
 void OpenTelemetryPluginImpl::ServerCallTracer::RecordReceivedInitialMetadata(
     grpc_metadata_batch* recv_initial_metadata) {

--- a/src/cpp/ext/otel/otel_server_call_tracer.h
+++ b/src/cpp/ext/otel/otel_server_call_tracer.h
@@ -30,18 +30,17 @@ namespace grpc {
 namespace internal {
 
 // OpenTelemetryPluginImpl::ServerCallTracer implementation
-
 class OpenTelemetryPluginImpl::ServerCallTracer
-    : public grpc_core::ServerCallTracer {
+    : public grpc_core::ServerCallTracer,
+      public grpc_core::RefCounted<ServerCallTracer,
+                                   grpc_core::NonPolymorphicRefCount,
+                                   grpc_core::UnrefCallDtor> {
  public:
   ServerCallTracer(
-      OpenTelemetryPluginImpl* otel_plugin,
-      std::shared_ptr<OpenTelemetryPluginImpl::ServerScopeConfig> scope_config)
-      : start_time_(absl::Now()),
-        injected_labels_from_plugin_options_(
-            otel_plugin->plugin_options().size()),
-        otel_plugin_(otel_plugin),
-        scope_config_(std::move(scope_config)) {}
+      OpenTelemetryPluginImpl* otel_plugin, grpc_core::Arena* arena,
+      std::shared_ptr<OpenTelemetryPluginImpl::ServerScopeConfig> scope_config);
+
+  ~ServerCallTracer() override;
 
   std::string TraceId() override {
     return OTelSpanTraceIdToString(span_.get());
@@ -94,10 +93,7 @@ class OpenTelemetryPluginImpl::ServerCallTracer
 
   void RecordAnnotation(absl::string_view annotation, absl::Time time);
 
-  std::shared_ptr<grpc_core::TcpCallTracer> StartNewTcpTrace() override {
-    // No TCP trace.
-    return nullptr;
-  }
+  std::shared_ptr<grpc_core::TcpCallTracer> StartNewTcpTrace() override;
 
  private:
   class TcpCallTracer;
@@ -118,7 +114,8 @@ class OpenTelemetryPluginImpl::ServerCallTracer
   bool registered_method_;
   std::vector<std::unique_ptr<LabelsIterable>>
       injected_labels_from_plugin_options_;
-  OpenTelemetryPluginImpl* otel_plugin_;
+  OpenTelemetryPluginImpl* const otel_plugin_;
+  grpc_core::Arena* const arena_;
   std::shared_ptr<OpenTelemetryPluginImpl::ServerScopeConfig> scope_config_;
   // TODO(roth, ctiller): Won't need atomic here once chttp2 is migrated
   // to promises, after which we can ensure that the transport invokes


### PR DESCRIPTION
Changes -
* Use the TcpCallTracers created in https://github.com/grpc/grpc/pull/39552
* Since the TCP traces might arrive after the call is "done", we need to make sure that we keep the tracers (`CallAttemptTracer` for the client and `ServerCallTracer` for the server) remain alive while there are active TcpCallTraces. 
* We do this by taking a ref on the call from the tcp traces to make sure that the call stack remains alive. The `ClientCallTracer` and the `ServerCallTracer` are allocated from the arena, so this change keeps them alive longer.
* The `CallAttemptTracer` can be allocated either on the arena or on the heap. To account for this, we keep a refcount for the attempt in the TcpCallTracer as well.