### PR TITLE
[retry throttle] stop sharing state across channels

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -3602,6 +3602,7 @@ grpc_cc_library(
     ],
     external_deps = ["absl/base:core_headers"],
     deps = [
+        "blackboard",
         "ref_counted",
         "sync",
         "useful",

--- a/src/core/client_channel/retry_filter.cc
+++ b/src/core/client_channel/retry_filter.cc
@@ -31,7 +31,6 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/iomgr/error.h"
 #include "src/core/service_config/service_config.h"
 #include "src/core/service_config/service_config_call_data.h"
 #include "src/core/util/ref_counted_ptr.h"
@@ -93,8 +92,7 @@ namespace grpc_core {
 // RetryFilter
 //
 
-RetryFilter::RetryFilter(const grpc_channel_element_args& args,
-                         grpc_error_handle* error)
+RetryFilter::RetryFilter(const grpc_channel_element_args& args)
     : client_channel_(args.channel_args.GetObject<ClientChannelFilter>()),
       event_engine_(args.channel_args.GetObject<EventEngine>()),
       per_rpc_retry_buffer_size_(

--- a/src/core/client_channel/retry_filter.cc
+++ b/src/core/client_channel/retry_filter.cc
@@ -106,11 +106,11 @@ RetryFilter::RetryFilter(const grpc_channel_element_args& args)
       service_config->GetGlobalParsedConfig(
           RetryServiceConfigParser::ParserIndex()));
   if (config == nullptr) return;
-  // Get throttle state.
-  retry_throttle_data_ = internal::ServerRetryThrottleData::Create(
+  // Get throttler.
+  retry_throttler_ = internal::RetryThrottler::Create(
       config->max_milli_tokens(), config->milli_token_ratio(),
-      args.old_blackboard->Get<internal::ServerRetryThrottleData>(""));
-  args.new_blackboard->Set("", retry_throttle_data_);
+      args.old_blackboard->Get<internal::RetryThrottler>(""));
+  args.new_blackboard->Set("", retry_throttler_);
 }
 
 const RetryMethodConfig* RetryFilter::GetRetryPolicy(Arena* arena) {

--- a/src/core/client_channel/retry_filter.cc
+++ b/src/core/client_channel/retry_filter.cc
@@ -93,37 +93,26 @@ namespace grpc_core {
 // RetryFilter
 //
 
-RetryFilter::RetryFilter(const ChannelArgs& args, grpc_error_handle* error)
-    : client_channel_(args.GetObject<ClientChannelFilter>()),
-      event_engine_(args.GetObject<EventEngine>()),
-      per_rpc_retry_buffer_size_(GetMaxPerRpcRetryBufferSize(args)),
+RetryFilter::RetryFilter(const grpc_channel_element_args& args,
+                         grpc_error_handle* error)
+    : client_channel_(args.channel_args.GetObject<ClientChannelFilter>()),
+      event_engine_(args.channel_args.GetObject<EventEngine>()),
+      per_rpc_retry_buffer_size_(
+          GetMaxPerRpcRetryBufferSize(args.channel_args)),
       service_config_parser_index_(
           internal::RetryServiceConfigParser::ParserIndex()) {
   // Get retry throttling parameters from service config.
-  auto* service_config = args.GetObject<ServiceConfig>();
+  auto* service_config = args.channel_args.GetObject<ServiceConfig>();
   if (service_config == nullptr) return;
   const auto* config = static_cast<const RetryGlobalConfig*>(
       service_config->GetGlobalParsedConfig(
           RetryServiceConfigParser::ParserIndex()));
   if (config == nullptr) return;
-  // Get server name from target URI.
-  auto server_uri = args.GetString(GRPC_ARG_SERVER_URI);
-  if (!server_uri.has_value()) {
-    *error = GRPC_ERROR_CREATE(
-        "server URI channel arg missing or wrong type in client channel "
-        "filter");
-    return;
-  }
-  absl::StatusOr<URI> uri = URI::Parse(*server_uri);
-  if (!uri.ok() || uri->path().empty()) {
-    *error = GRPC_ERROR_CREATE("could not extract server name from target URI");
-    return;
-  }
-  std::string server_name(absl::StripPrefix(uri->path(), "/"));
-  // Get throttling config for server_name.
-  retry_throttle_data_ =
-      internal::ServerRetryThrottleMap::Get()->GetDataForServer(
-          server_name, config->max_milli_tokens(), config->milli_token_ratio());
+  // Get throttle state.
+  retry_throttle_data_ = internal::ServerRetryThrottleData::Create(
+      config->max_milli_tokens(), config->milli_token_ratio(),
+      args.old_blackboard->Get<internal::ServerRetryThrottleData>(""));
+  args.new_blackboard->Set("", retry_throttle_data_);
 }
 
 const RetryMethodConfig* RetryFilter::GetRetryPolicy(Arena* arena) {

--- a/src/core/client_channel/retry_filter.h
+++ b/src/core/client_channel/retry_filter.h
@@ -80,7 +80,7 @@ class RetryFilter final {
                  0, INT_MAX);
   }
 
-  RetryFilter(const grpc_channel_element_args& args);
+  explicit RetryFilter(const grpc_channel_element_args& args);
 
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* args) {

--- a/src/core/client_channel/retry_filter.h
+++ b/src/core/client_channel/retry_filter.h
@@ -60,8 +60,8 @@ class RetryFilter final {
 
   const internal::RetryMethodConfig* GetRetryPolicy(Arena* arena);
 
-  RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data() const {
-    return retry_throttle_data_;
+  RefCountedPtr<internal::RetryThrottler> retry_throttler() const {
+    return retry_throttler_;
   }
 
   ClientChannelFilter* client_channel() const { return client_channel_; }
@@ -104,7 +104,7 @@ class RetryFilter final {
   ClientChannelFilter* client_channel_;
   grpc_event_engine::experimental::EventEngine* const event_engine_;
   size_t per_rpc_retry_buffer_size_;
-  RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data_;
+  RefCountedPtr<internal::RetryThrottler> retry_throttler_;
   const size_t service_config_parser_index_;
 };
 

--- a/src/core/client_channel/retry_filter.h
+++ b/src/core/client_channel/retry_filter.h
@@ -80,15 +80,14 @@ class RetryFilter final {
                  0, INT_MAX);
   }
 
-  RetryFilter(const grpc_channel_element_args& args, grpc_error_handle* error);
+  RetryFilter(const grpc_channel_element_args& args);
 
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* args) {
     CHECK(args->is_last);
     CHECK(elem->filter == &kVtable);
-    grpc_error_handle error;
-    new (elem->channel_data) RetryFilter(*args, &error);
-    return error;
+    new (elem->channel_data) RetryFilter(*args);
+    return absl::OkStatus();
   }
 
   static void Destroy(grpc_channel_element* elem) {

--- a/src/core/client_channel/retry_filter.h
+++ b/src/core/client_channel/retry_filter.h
@@ -80,14 +80,14 @@ class RetryFilter final {
                  0, INT_MAX);
   }
 
-  RetryFilter(const ChannelArgs& args, grpc_error_handle* error);
+  RetryFilter(const grpc_channel_element_args& args, grpc_error_handle* error);
 
   static grpc_error_handle Init(grpc_channel_element* elem,
                                 grpc_channel_element_args* args) {
     CHECK(args->is_last);
     CHECK(elem->filter == &kVtable);
     grpc_error_handle error;
-    new (elem->channel_data) RetryFilter(args->channel_args, &error);
+    new (elem->channel_data) RetryFilter(*args, &error);
     return error;
   }
 

--- a/src/core/client_channel/retry_filter_legacy_call_data.cc
+++ b/src/core/client_channel/retry_filter_legacy_call_data.cc
@@ -537,8 +537,8 @@ bool RetryFilter::LegacyCallData::CallAttempt::ShouldRetry(
   // Check status.
   if (status.has_value()) {
     if (GPR_LIKELY(*status == GRPC_STATUS_OK)) {
-      if (calld_->retry_throttle_data_ != nullptr) {
-        calld_->retry_throttle_data_->RecordSuccess();
+      if (calld_->retry_throttler_ != nullptr) {
+        calld_->retry_throttler_->RecordSuccess();
       }
       GRPC_TRACE_LOG(retry, INFO)
           << "chand=" << calld_->chand_ << " calld=" << calld_
@@ -562,8 +562,8 @@ bool RetryFilter::LegacyCallData::CallAttempt::ShouldRetry(
   // things like failures due to malformed requests (INVALID_ARGUMENT).
   // Conversely, it's important for this to come before the remaining
   // checks, so that we don't fail to record failures due to other factors.
-  if (calld_->retry_throttle_data_ != nullptr &&
-      !calld_->retry_throttle_data_->RecordFailure()) {
+  if (calld_->retry_throttler_ != nullptr &&
+      !calld_->retry_throttler_->RecordFailure()) {
     GRPC_TRACE_LOG(retry, INFO)
         << "chand=" << calld_->chand_ << " calld=" << calld_
         << " attempt=" << this << ": retries throttled";
@@ -1471,7 +1471,7 @@ void RetryFilter::LegacyCallData::SetPollent(grpc_call_element* elem,
 RetryFilter::LegacyCallData::LegacyCallData(RetryFilter* chand,
                                             const grpc_call_element_args& args)
     : chand_(chand),
-      retry_throttle_data_(chand->retry_throttle_data()),
+      retry_throttler_(chand->retry_throttler()),
       retry_policy_(chand->GetRetryPolicy(args.arena)),
       retry_backoff_(
           BackOff::Options()

--- a/src/core/client_channel/retry_filter_legacy_call_data.h
+++ b/src/core/client_channel/retry_filter_legacy_call_data.h
@@ -370,7 +370,7 @@ class RetryFilter::LegacyCallData final {
 
   RetryFilter* chand_;
   grpc_polling_entity* pollent_;
-  RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data_;
+  RefCountedPtr<internal::RetryThrottler> retry_throttler_;
   const internal::RetryMethodConfig* retry_policy_ = nullptr;
   BackOff retry_backoff_;
 

--- a/src/core/client_channel/retry_interceptor.h
+++ b/src/core/client_channel/retry_interceptor.h
@@ -56,8 +56,9 @@ class RetryState {
   BackOff retry_backoff_;
 };
 
-absl::StatusOr<RefCountedPtr<internal::ServerRetryThrottleData>>
-ServerRetryThrottleDataFromChannelArgs(const ChannelArgs& args);
+RefCountedPtr<internal::ServerRetryThrottleData>
+ServerRetryThrottleDataFromChannelArgs(const ChannelArgs& args,
+                                       const FilterArgs& filter_args);
 }  // namespace retry_detail
 
 class RetryInterceptor : public Interceptor {
@@ -67,7 +68,7 @@ class RetryInterceptor : public Interceptor {
       RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data);
 
   static absl::StatusOr<RefCountedPtr<RetryInterceptor>> Create(
-      const ChannelArgs& args, const FilterArgs&);
+      const ChannelArgs& args, const FilterArgs& filter_args);
 
   void Orphaned() override {}
 

--- a/src/core/client_channel/retry_interceptor.h
+++ b/src/core/client_channel/retry_interceptor.h
@@ -28,9 +28,8 @@ namespace grpc_core {
 namespace retry_detail {
 class RetryState {
  public:
-  RetryState(
-      const internal::RetryMethodConfig* retry_policy,
-      RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data);
+  RetryState(const internal::RetryMethodConfig* retry_policy,
+             RefCountedPtr<internal::RetryThrottler> retry_throttler);
 
   // if nullopt --> commit & don't retry
   // if duration --> retry after duration
@@ -41,31 +40,29 @@ class RetryState {
 
   template <typename Sink>
   friend void AbslStringify(Sink& sink, const RetryState& state) {
-    sink.Append(absl::StrCat(
-        "policy:{",
-        state.retry_policy_ != nullptr ? absl::StrCat(*state.retry_policy_)
-                                       : "none",
-        "} throttle:", state.retry_throttle_data_ != nullptr,
-        " attempts:", state.num_attempts_completed_));
+    sink.Append(absl::StrCat("policy:{",
+                             state.retry_policy_ != nullptr
+                                 ? absl::StrCat(*state.retry_policy_)
+                                 : "none",
+                             "} throttler:", state.retry_throttler_ != nullptr,
+                             " attempts:", state.num_attempts_completed_));
   }
 
  private:
   const internal::RetryMethodConfig* const retry_policy_;
-  RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data_;
+  RefCountedPtr<internal::RetryThrottler> retry_throttler_;
   int num_attempts_completed_ = 0;
   BackOff retry_backoff_;
 };
 
-RefCountedPtr<internal::ServerRetryThrottleData>
-ServerRetryThrottleDataFromChannelArgs(const ChannelArgs& args,
-                                       const FilterArgs& filter_args);
+RefCountedPtr<internal::RetryThrottler> RetryThrottlerFromChannelArgs(
+    const ChannelArgs& args, const FilterArgs& filter_args);
 }  // namespace retry_detail
 
 class RetryInterceptor : public Interceptor {
  public:
-  RetryInterceptor(
-      const ChannelArgs& args,
-      RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data);
+  RetryInterceptor(const ChannelArgs& args,
+                   RefCountedPtr<internal::RetryThrottler> retry_throttler);
 
   static absl::StatusOr<RefCountedPtr<RetryInterceptor>> Create(
       const ChannelArgs& args, const FilterArgs& filter_args);
@@ -150,7 +147,7 @@ class RetryInterceptor : public Interceptor {
 
   const size_t per_rpc_retry_buffer_size_;
   const size_t service_config_parser_index_;
-  const RefCountedPtr<internal::ServerRetryThrottleData> retry_throttle_data_;
+  const RefCountedPtr<internal::RetryThrottler> retry_throttler_;
 };
 
 }  // namespace grpc_core

--- a/src/core/client_channel/retry_throttle.h
+++ b/src/core/client_channel/retry_throttle.h
@@ -30,18 +30,18 @@ namespace grpc_core {
 namespace internal {
 
 /// Tracks retry throttling data for an individual server name.
-class ServerRetryThrottleData final : public Blackboard::Entry {
+class RetryThrottler final : public Blackboard::Entry {
  public:
-  static RefCountedPtr<ServerRetryThrottleData> Create(
+  static RefCountedPtr<RetryThrottler> Create(
       uintptr_t max_milli_tokens, uintptr_t milli_token_ratio,
-      RefCountedPtr<ServerRetryThrottleData> previous);
+      RefCountedPtr<RetryThrottler> previous);
 
   static UniqueTypeName Type();
 
   // Do not instantiate directly -- use Create() instead.
-  ServerRetryThrottleData(uintptr_t max_milli_tokens,
-                          uintptr_t milli_token_ratio, uintptr_t milli_tokens);
-  ~ServerRetryThrottleData() override;
+  RetryThrottler(uintptr_t max_milli_tokens, uintptr_t milli_token_ratio,
+                 uintptr_t milli_tokens);
+  ~RetryThrottler() override;
 
   /// Records a failure.  Returns true if it's okay to send a retry.
   bool RecordFailure();
@@ -57,18 +57,17 @@ class ServerRetryThrottleData final : public Blackboard::Entry {
   }
 
  private:
-  void SetReplacement(RefCountedPtr<ServerRetryThrottleData> replacement);
+  void SetReplacement(RefCountedPtr<RetryThrottler> replacement);
 
-  void GetReplacementThrottleDataIfNeeded(
-      ServerRetryThrottleData** throttle_data);
+  void GetReplacementThrottleDataIfNeeded(RetryThrottler** throttle_data);
 
   const uintptr_t max_milli_tokens_;
   const uintptr_t milli_token_ratio_;
   std::atomic<intptr_t> milli_tokens_;
-  // A pointer to the replacement for this ServerRetryThrottleData entry.
+  // A pointer to the replacement for this RetryThrottler entry.
   // If non-nullptr, then this entry is stale and must not be used.
   // We hold a reference to the replacement.
-  std::atomic<ServerRetryThrottleData*> replacement_{nullptr};
+  std::atomic<RetryThrottler*> replacement_{nullptr};
 };
 
 }  // namespace internal

--- a/src/core/client_channel/retry_throttle.h
+++ b/src/core/client_channel/retry_throttle.h
@@ -19,27 +19,26 @@
 #ifndef GRPC_SRC_CORE_CLIENT_CHANNEL_RETRY_THROTTLE_H
 #define GRPC_SRC_CORE_CLIENT_CHANNEL_RETRY_THROTTLE_H
 
-#include <grpc/support/port_platform.h>
 #include <stdint.h>
 
 #include <atomic>
-#include <map>
-#include <string>
 
-#include "absl/base/thread_annotations.h"
-#include "src/core/util/ref_counted.h"
+#include "src/core/filter/blackboard.h"
 #include "src/core/util/ref_counted_ptr.h"
-#include "src/core/util/sync.h"
 
 namespace grpc_core {
 namespace internal {
 
-class ServerRetryThrottleMap;
-
 /// Tracks retry throttling data for an individual server name.
-class ServerRetryThrottleData final
-    : public RefCounted<ServerRetryThrottleData> {
+class ServerRetryThrottleData final : public Blackboard::Entry {
  public:
+  static RefCountedPtr<ServerRetryThrottleData> Create(
+      uintptr_t max_milli_tokens, uintptr_t milli_token_ratio,
+      RefCountedPtr<ServerRetryThrottleData> previous);
+
+  static UniqueTypeName Type();
+
+  // Do not instantiate directly -- use Create() instead.
   ServerRetryThrottleData(uintptr_t max_milli_tokens,
                           uintptr_t milli_token_ratio, uintptr_t milli_tokens);
   ~ServerRetryThrottleData() override;
@@ -50,6 +49,7 @@ class ServerRetryThrottleData final
   /// Records a success.
   void RecordSuccess();
 
+  // Exposed for testing purposes only.
   uintptr_t max_milli_tokens() const { return max_milli_tokens_; }
   uintptr_t milli_token_ratio() const { return milli_token_ratio_; }
   intptr_t milli_tokens() const {
@@ -57,8 +57,6 @@ class ServerRetryThrottleData final
   }
 
  private:
-  friend ServerRetryThrottleMap;
-
   void SetReplacement(RefCountedPtr<ServerRetryThrottleData> replacement);
 
   void GetReplacementThrottleDataIfNeeded(
@@ -71,25 +69,6 @@ class ServerRetryThrottleData final
   // If non-nullptr, then this entry is stale and must not be used.
   // We hold a reference to the replacement.
   std::atomic<ServerRetryThrottleData*> replacement_{nullptr};
-};
-
-/// Global map of server name to retry throttle data.
-class ServerRetryThrottleMap final {
- public:
-  static ServerRetryThrottleMap* Get();
-
-  /// Returns the failure data for \a server_name, creating a new entry if
-  /// needed.
-  RefCountedPtr<ServerRetryThrottleData> GetDataForServer(
-      const std::string& server_name, uintptr_t max_milli_tokens,
-      uintptr_t milli_token_ratio);
-
- private:
-  using StringToDataMap =
-      std::map<std::string, RefCountedPtr<ServerRetryThrottleData>>;
-
-  Mutex mu_;
-  StringToDataMap map_ ABSL_GUARDED_BY(mu_);
 };
 
 }  // namespace internal

--- a/src/core/filter/filter_args.h
+++ b/src/core/filter/filter_args.h
@@ -71,17 +71,17 @@ class FilterArgs {
         [](const V3Based& v3) { return v3.instance_id; });
   }
 
-  // If a filter state object of type T exists for key from a previous
-  // filter stack, retains it for the new filter stack we're constructing.
-  // Otherwise, invokes create_func() to create a new filter state
-  // object for the new filter stack.  Returns the new filter state object.
+  // Invokes update_func() to update a filter state object of type T
+  // with the specified key.  The existing filter state object, if any,
+  // will be passed to update_func().  The filter state object returned
+  // by update_func() will be saved and returned.
   template <typename T>
   RefCountedPtr<T> GetOrCreateState(
       const std::string& key,
-      absl::FunctionRef<RefCountedPtr<T>()> create_func) {
+      absl::FunctionRef<RefCountedPtr<T>(RefCountedPtr<T>)> update_func) const {
     RefCountedPtr<T> state;
     if (old_blackboard_ != nullptr) state = old_blackboard_->Get<T>(key);
-    if (state == nullptr) state = create_func();
+    state = update_func(std::move(state));
     if (new_blackboard_ != nullptr) new_blackboard_->Set(key, state);
     return state;
   }


### PR DESCRIPTION
Although the original intent of gRFC A6 was that the throttle state would be shared between channels for the same target, the language in the gRFC didn't make that clear, and Java and Go did not implement it that way.  And this sharing adds some complexity and doesn't really seem to provide much benefit: the settings from the service config are more likely to be tuned to multiple clients than to a single client with multiple channels, so it seems reasonable to model each channel as a separate client.  Therefore, I am removing the sharing between channels.

I have kept the logic for retaining the state upon service config update, scaling the initial token value based on the old state.  The state is now retained via the blackboard instead.