### PR TITLE
[ObjC] test existence for grpc_cpp_plugin

### DIFF
--- a/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
@@ -114,6 +114,8 @@ Pod::Spec.new do |s|
   # and, if absent, compile the plugin from the local sources.
   s.prepare_command = <<-CMD
     set -e
-    #{bazel} build //src/compiler:grpc_cpp_plugin
+    if [ ! -f #{plugin} ]; then
+      #{bazel} build //src/compiler:grpc_cpp_plugin
+    fi
   CMD
 end

--- a/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.inja
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.inja
@@ -114,6 +114,8 @@ Pod::Spec.new do |s|
   # and, if absent, compile the plugin from the local sources.
   s.prepare_command = <<-CMD
     set -e
-    #{bazel} build //src/compiler:grpc_cpp_plugin
+    if [ ! -f #{plugin} ]; then
+      #{bazel} build //src/compiler:grpc_cpp_plugin
+    fi
   CMD
 end


### PR DESCRIPTION
Test existence of grpc_cpp_plugin before building one.
This is needed for release where the plugin binary will be downloaded.
It's available in [!ProtoCompiler.podspec](https://github.com/grpc/grpc/blob/v1.72.0/src/objective-c/!ProtoCompiler.podspec#L128) and [!ProtoCompiler-gRPCPlugin.podspec](https://github.com/grpc/grpc/blob/v1.72.0/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec#L122) but not for the cpp plugin.

For https://github.com/grpc/grpc/issues/36801