### PR TITLE
[channelz] Add nullptr check

### DIFF
--- a/src/core/ext/filters/http/message_compress/compression_filter.h
+++ b/src/core/ext/filters/http/message_compress/compression_filter.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <cstddef>
 #include <optional>
 
 #include "absl/status/statusor.h"
@@ -96,8 +97,11 @@ class ChannelCompression {
     if (max_recv_size_.has_value()) {
       object["maxRecvSize"] = Json::FromNumber(*max_recv_size_);
     }
-    object["defaultCompressionAlgorithm"] = Json::FromString(
-        CompressionAlgorithmAsString(default_compression_algorithm_));
+    const char* algorithm =
+        CompressionAlgorithmAsString(default_compression_algorithm_);
+    if (algorithm != nullptr) {
+      object["defaultCompressionAlgorithm"] = Json::FromString(algorithm);
+    }
     object["enabledCompressionAlgorithms"] = Json::FromString(
         std::string(enabled_compression_algorithms_.ToString()));
     object["enableCompression"] = Json::FromBool(enable_compression_);


### PR DESCRIPTION
CompressionAlgorithmAsString can return nullptr - account for that.

https://github.com/grpc/grpc/blob/06841d857561c3e882d404ed745fd38eda750195/src/core/lib/compression/compression_internal.cc#L50

addresses b/420659345