### PR TITLE
Fix a build warning.

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -204,7 +204,7 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
             "@platforms//os:macos": [name + "_universal"],
             "//conditions:default": [name + "_native"],
         }),
-        outs = [name],
+        outs = [name + "_gen"],
         cmd = "cp $< $@",
         executable = True,
     )


### PR DESCRIPTION
Fix a build warning.

```
WARNING: /home/.../external/com_github_grpc_grpc/src/compiler/BUILD:87:18: target 'grpc_cpp_plugin' is both a rule and a file; please choose another name for the rule
```