### PR TITLE
Fix reading of uninitialized bool (cancelled_) upon moving NextResult.

### DIFF
--- a/src/core/lib/promise/pipe.h
+++ b/src/core/lib/promise/pipe.h
@@ -58,9 +58,9 @@ struct Pipe;
 template <typename T>
 class NextResult final {
  public:
-  NextResult() : center_(nullptr) {}
+  NextResult() : center_(nullptr), cancelled_(true) {}
   explicit NextResult(RefCountedPtr<pipe_detail::Center<T>> center)
-      : center_(std::move(center)) {
+      : center_(std::move(center)), cancelled_(false) {
     CHECK(center_ != nullptr);
   }
   explicit NextResult(bool cancelled)


### PR DESCRIPTION
Hello,
This should hopefully fix #35381, or at least eliminate one possible cause.

This is a classical uninitialized variable:
- Not all constructors initialize `cancelled_`.
- We rely on the compiler-provided move operations, which unconditionally copy all non-static data members.
- As a result, a move operation reads from an uninitialized `cancelled_`.

It is probably innocuous in that context, but it is still undefined behavior.
I see two possible ways to fix it:
1. Always initizalize `cancelled_`.
2. Don't rely on the compiler-provided move operations, and implement it manually so it skips the `cancelled_` field when not relevant.

This fix takes path 1, filling in semantically correct values (even though they should not be used). Happy to change it if needed. 
