### PR TITLE
[Backport][v1.72]Added #defined to force disable secure_getenv (#39343)

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -36,6 +36,11 @@ config_setting(
     values = {"define": "GRPC_ENABLE_LATENT_SEE=1"},
 )
 
+config_setting(
+    name = "force_unsecure_getenv",
+    values = {"define": "GRPC_FORCE_UNSECURE_GETENV=1"},
+)
+
 # This is needed as a transitionary mechanism to build the src/core targets in
 # the top-level BUILD file that have not yet been moved here. Should go away
 # once the transition is complete.
@@ -461,6 +466,10 @@ grpc_cc_library(
     hdrs = [
         "util/env.h",
     ],
+    defines = select({
+        ":force_unsecure_getenv": ["GRPC_FORCE_UNSECURE_GETENV"],
+        "//conditions:default": [],
+    }),
     deps = [
         "tchar",
         "//:gpr_platform",

--- a/src/core/util/linux/env.cc
+++ b/src/core/util/linux/env.cc
@@ -37,10 +37,12 @@ namespace grpc_core {
 
 std::optional<std::string> GetEnv(const char* name) {
   char* result = nullptr;
-#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)
+#if (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 17)) && \
+    !defined(GRPC_FORCE_UNSECURE_GETENV)
   result = secure_getenv(name);
 #else
   result = getenv(name);
+
 #endif
   if (result == nullptr) return std::nullopt;
   return result;

--- a/tools/internal_ci/linux/grpc_env_check.sh
+++ b/tools/internal_ci/linux/grpc_env_check.sh
@@ -1,0 +1,70 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For linux we use secure_getenv to read env variable
+# this return null if linux capabilites are added on the executable
+# For customer using linux capability , they need to define "--define GRPC_FORCE_UNSECURE_GETENV=1"
+# to read env variables.
+
+set +e
+set -x
+
+# install pre-requisites for gRPC C core build
+sudo apt update
+sudo apt install -y build-essential autoconf libtool pkg-config cmake python3 python3-pip clang
+
+fail () {
+    echo "$(tput setaf 1) $1 $(tput sgr 0)"
+    if [[ -n $SERVER_PID ]] ; then
+      kill -9 $SERVER_PID || true
+    fi
+    SERVER_PID=
+    exit 1
+}
+
+pass () {
+    echo "$(tput setaf 2) $1 $(tput sgr 0)"
+}
+
+#check presence of bazel
+tools/bazel version
+
+#enable log
+export GRPC_TRACE=http
+# Build without the define , this will use secure_getenv
+tools/bazel build  //examples/cpp/helloworld:greeter_callback_client
+# Add linux capability
+sudo setcap "cap_net_raw=ep" ./bazel-bin/examples/cpp/helloworld/greeter_callback_client
+./bazel-bin/examples/cpp/helloworld/greeter_callback_client &> out.log
+# We should not see log get enabled as secure_getenv will return null in this case
+grep "gRPC Tracers:" out.log
+return_code=$?
+if [[ $return_code -eq 0 ]]; then
+    fail "Able to read env variable with linux capability set"
+fi
+
+# Build using the define to force "getenv" instead of "secure_getenv"
+tools/bazel build  --define GRPC_FORCE_UNSECURE_GETENV=1 //examples/cpp/helloworld:greeter_callback_client
+# Add linux capability
+sudo setcap "cap_net_raw=ep" ./bazel-bin/examples/cpp/helloworld/greeter_callback_client
+ls -lrt ./bazel-bin/examples/cpp/helloworld/greeter_callback_client
+./bazel-bin/examples/cpp/helloworld/greeter_callback_client &> out.log
+grep "gRPC Tracers:" out.log
+return_code=$?
+# check if logs got enabled
+if [[ ! $return_code -eq 0 ]]; then
+    fail "Fail to read env variable with linux capability"
+fi
+
+echo "Test completed"

--- a/tools/internal_ci/linux/grpc_examples_tests_cpp.sh
+++ b/tools/internal_ci/linux/grpc_examples_tests_cpp.sh
@@ -15,7 +15,6 @@
 
 set -ex
 
-
 # change to grpc repo root
 cd $(dirname $0)/../../..
 
@@ -24,3 +23,5 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 export DOCKERFILE_DIR=tools/dockerfile/test/bazel
 export DOCKER_RUN_SCRIPT=tools/internal_ci/linux/grpc_examples_tests_cpp_in_docker.sh
 exec tools/run_tests/dockerize/build_and_run_docker.sh
+
+exec tools/internal_ci/linux/grpc_env_check.sh


### PR DESCRIPTION
Backport #39343 to v1.72.x
---
Problem: [secure_getenv](https://github.com/grpc/grpc/blob/2dd25392e8951c000eee2f35c9fe66862f9c8883/src/core/util/linux/env.cc#L41) return NULL  if linux [capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) are added to the executable.

As a solution, adding the "GRPC_FORCE_INSECURE_GETENV"

We want to discourage its use due to security vulnerabilities mentioned in the [secure_getenv](https://github.com/grpc/grpc/blob/2dd25392e8951c000eee2f35c9fe66862f9c8883/src/core/util/linux/env.cc#L41) man page

Closes #39343

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/39343 from pawbhard:getenv_wa 999f13a441fdfbc54fd3bdd079eb37283e98270c PiperOrigin-RevId: 760926719


