### PR TITLE
[owners] Only python dockerfiles owned by sergiitk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,5 @@
 /src/core/server/xds* @markdroth
 /src/core/service_config/** @markdroth
 /src/core/xds/** @markdroth
-/tools/dockerfile/** @drfloob @apolcyn @sergiitk
+/tools/dockerfile/** @drfloob @apolcyn
+/tools/dockerfile/**/*python* @sergiitk


### PR DESCRIPTION
I'm getting assigned to unrelated dockerfile changes, like Ruby.
This PR fixes it - instead of owning all dockerfiles, I only own those containing `*python*` in the path.

The pattern verified with `git check-ignore`.