### PR TITLE
[Python] Refactor: Update deprecated 'find_module()' to 'find_spec()' 

### DIFF
--- a/bazel/_single_module_tester.py
+++ b/bazel/_single_module_tester.py
@@ -35,7 +35,8 @@ class SingleLoader(object):
                         tests.append(loader.loadTestsFromModule(module))
                 
                 except Exception as e:
-                    raise Exception(f"Error loading module {module_name}: {e}")
+                  raise AssertionError(f"Error loading module {module_name}: {e}")
+
         if len(tests) != 1:            
             raise AssertionError("Expected only 1 test module. Found {}".format(tests))
         self.suite.addTest(tests[0])

--- a/bazel/_single_module_tester.py
+++ b/bazel/_single_module_tester.py
@@ -33,7 +33,6 @@ class SingleLoader(object):
                         module = importlib.util.module_from_spec(spec)
                         spec.loader.exec_module(module)
                         tests.append(loader.loadTestsFromModule(module))
-                
                 except Exception as e:
                   raise AssertionError(f"Error loading module {module_name}: {e}")
 

--- a/bazel/_single_module_tester.py
+++ b/bazel/_single_module_tester.py
@@ -35,7 +35,7 @@ class SingleLoader(object):
                         tests.append(loader.loadTestsFromModule(module))
                 
                 except Exception as e:
-                    print(f"Error loading module {module_name}: {e}")
+                    raise Exception(f"Error loading module {module_name}: {e}")
         if len(tests) != 1:            
             raise AssertionError("Expected only 1 test module. Found {}".format(tests))
         self.suite.addTest(tests[0])

--- a/bazel/_single_module_tester.py
+++ b/bazel/_single_module_tester.py
@@ -17,7 +17,7 @@ from typing import Sequence, Optional
 import unittest
 import sys
 import pkgutil
-
+import importlib.util
 
 class SingleLoader(object):
     def __init__(self, pattern: str, unittest_path: str):
@@ -27,8 +27,15 @@ class SingleLoader(object):
 
         for importer, module_name, is_package in pkgutil.walk_packages([unittest_path]):
             if pattern in module_name:
-                module = importer.find_module(module_name).load_module(module_name)
-                tests.append(loader.loadTestsFromModule(module))
+                try:
+                    spec = importer.find_spec(module_name)
+                    if spec is not None:
+                        module = importlib.util.module_from_spec(spec)
+                        spec.loader.exec_module(module)
+                        tests.append(loader.loadTestsFromModule(module))
+                
+                except Exception as e:
+                    print(f"Error loading module {module_name}: {e}")
         if len(tests) != 1:            
             raise AssertionError("Expected only 1 test module. Found {}".format(tests))
         self.suite.addTest(tests[0])


### PR DESCRIPTION
Replaced `importer.find_module()` with 'importlib.util.find_spec()` and `importlib.util.module_from_spec()` to address its deprecation in Python 3.12 and ensure future compatibility.

