### PR TITLE
[fork] Align error codes between Core and Python

### DIFF
--- a/src/core/lib/event_engine/posix_engine/grpc_polled_fd_posix.h
+++ b/src/core/lib/event_engine/posix_engine/grpc_polled_fd_posix.h
@@ -90,6 +90,9 @@ class GrpcPolledFdPosix : public GrpcPolledFd {
   const char* GetName() const override { return name_.c_str(); }
 
   bool IsCurrent() const override {
+    LOG(INFO) << this << " "
+              << handle_->Poller()->posix_interface().generation() << " "
+              << handle_->WrappedFd().generation();
     return handle_->Poller()->posix_interface().generation() ==
            handle_->WrappedFd().generation();
   }

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -363,8 +363,10 @@ bool PosixEndpointImpl::TcpDoRead(absl::Status& status) {
       // 0 read size ==> end of stream
       incoming_buffer_->Clear();
       if (res.IsWrongGenerationError()) {
-        status = TcpAnnotateError(
-            absl::InternalError("Descriptor was opened before fork"));
+        status = absl::CancelledError("Closed on fork");
+        grpc_core::StatusSetInt(&status,
+                                grpc_core::StatusIntProperty::kRpcStatus,
+                                GRPC_STATUS_CANCELLED);
       } else if (read_bytes == 0) {
         status = TcpAnnotateError(absl::InternalError("Socket closed"));
       } else {

--- a/src/python/grpcio_tests/tests/fork/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/fork/BUILD.bazel
@@ -28,7 +28,6 @@ py_test(
     name = "fork_test",
     srcs = glob(["*.py"]),
     # TODO(yijiem): remove this to test EventEngine fork support
-    env = {"GRPC_EXPERIMENTS": "-event_engine_client"},
     imports = ["../.."],
     main = "_fork_interop_test.py",
     python_version = "PY3",

--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -32,7 +32,7 @@ def _dump_streams(name, streams):
         stream.seek(0)
         sys.stderr.write(
             "{} {}:\n{}\n".format(
-                name, stream_name, stream.read().decode("ascii")
+                name, stream_name, stream.read().decode("UTF-8")
             )
         )
         stream.close()
@@ -67,8 +67,8 @@ _GDB_TIMEOUT_S = 60
 
 
 @unittest.skipUnless(
-    sys.platform.startswith("linux"),
-    "not supported on windows, and fork+exec networking blocked on mac",
+    sys.platform in ["linux", "darwin"],
+    "not supported on windows",
 )
 @unittest.skipUnless(
     os.getenv("GRPC_ENABLE_FORK_SUPPORT") is not None,

--- a/src/python/grpcio_tests/tests/fork/methods.py
+++ b/src/python/grpcio_tests/tests/fork/methods.py
@@ -441,15 +441,10 @@ def _in_progress_bidi_continue_call(channel):
         except ValueError as expected_value_error:
             pass
         inherited_code = parent_bidi_call.code()
-        inherited_details = parent_bidi_call.details()
         if inherited_code != grpc.StatusCode.CANCELLED:
             raise ValueError(
-                "Expected inherited code CANCELLED, got %s" % inherited_code
-            )
-        if "Channel closed due to fork" not in inherited_details:
-            raise ValueError(
-                "Expected inherited details Channel closed due to fork, got %s"
-                % inherited_details
+                "Expected inherited code CANCELLED, got %s (details: %s)"
+                % (inherited_code, parent_bidi_call.details())
             )
 
     # Don't run child_target after closing the parent call, as the call may have

--- a/test/core/event_engine/posix/poller_fork_test.cc
+++ b/test/core/event_engine/posix/poller_fork_test.cc
@@ -368,15 +368,16 @@ TEST_F(PollerForkTest, ListenerInChild) {
   ee()->AfterFork(PosixEventEngine::OnForkRole::kChild);
   LOG(INFO) << "After fork in child";
   EXPECT_THAT(read_status.AwaitStatus(),
-              StatusIs(absl::StatusCode::kUnavailable));
+              StatusIs(absl::StatusCode::kCancelled));
   EXPECT_THAT(write_status.AwaitStatus(),
-              StatusIs(absl::StatusCode::kUnavailable));
+              StatusIs(absl::StatusCode::kCancelled));
   // Starting read and write post-fork will fail asynchronously and return the
   // status.
   ASSERT_FALSE(endpoint->Read(read_status.Setter(), &read_buffer, ReadArgs()));
   ASSERT_FALSE(
       endpoint->Write(write_status.Setter(), &write_buffer, WriteArgs()));
-  EXPECT_THAT(read_status.AwaitStatus(), StatusIs(absl::StatusCode::kInternal));
+  EXPECT_THAT(read_status.AwaitStatus(),
+              StatusIs(absl::StatusCode::kCancelled));
   EXPECT_THAT(write_status.AwaitStatus(), ::testing::Not(IsOk()));
 }
 


### PR DESCRIPTION
1. IO on the file descriptors that were closed on fork will now report Cancelled status.
2. Error messages were change and are not checked in Python tests.
3. Fixes some race conditions in Ares resolver.