### PR TITLE
[PH2] Migrating to the new Http2Status class 

### DIFF
--- a/src/core/ext/transport/chttp2/transport/message_assembler.h
+++ b/src/core/ext/transport/chttp2/transport/message_assembler.h
@@ -73,7 +73,7 @@ class GrpcMessageAssembler {
   // Returns a valid MessageHandle if it has a complete message.
   // Returns a nullptr if it does not have a complete message.
   // Returns an error if an incomplete message is received and the stream ends.
-  absl::StatusOr<MessageHandle> ExtractMessage() {
+  ValueOrHttp2Status<MessageHandle> ExtractMessage() {
     const size_t current_len = message_buffer_.Length();
     if (current_len < kGrpcHeaderSizeInBytes) {
       return ReturnNullOrError();
@@ -81,9 +81,8 @@ class GrpcMessageAssembler {
     GrpcMessageHeader header = ExtractGrpcHeader(message_buffer_);
     if constexpr (sizeof(size_t) == 4) {
       if (GPR_UNLIKELY(header.length > kOneGb)) {
-        // STREAM_ERROR
-        return absl::Status(
-            absl::StatusCode::kInternal,
+        return Http2Status::Http2StreamError(
+            Http2ErrorCode::kInternalError,
             "Stream Error: SliceBuffer overflow for 32 bit platforms.");
       }
     }
@@ -107,12 +106,12 @@ class GrpcMessageAssembler {
   }
 
  private:
-  absl::StatusOr<MessageHandle> ReturnNullOrError() {
-    // TODO(tjagtap) : [PH2][P1] Replace with Http2StatusOr when that PR lands
+  ValueOrHttp2Status<MessageHandle> ReturnNullOrError() {
     if (GPR_UNLIKELY(is_end_stream_ && message_buffer_.Length() > 0)) {
-      return absl::InternalError("Incomplete gRPC frame received");
+      return Http2Status::Http2StreamError(Http2ErrorCode::kInternalError,
+                                           "Incomplete gRPC frame received");
     }
-    return nullptr;
+    return ValueOrHttp2Status<MessageHandle>(nullptr);
   }
   bool is_end_stream_ = false;
   SliceBuffer message_buffer_;

--- a/test/core/transport/chttp2/message_assembler_fuzz_test.cc
+++ b/test/core/transport/chttp2/message_assembler_fuzz_test.cc
@@ -77,7 +77,7 @@ void AssemblerFuzzer(
       // To avoid this test DCHECK, we are always passing is_end_stream as
       // false. Consider computing the index of the last index payload in each
       // step and setting is_end_stream to true for the last payload.
-      absl::Status result =
+      Http2Status result =
           assembler.AppendNewDataFrame(payload, /*is_end_stream=*/false);
       VLOG(3) << "      AssemblerFuzzer AppendNewDataFrame result: " << result;
       EXPECT_EQ(payload.Length(), 0);

--- a/test/core/transport/chttp2/message_assembler_test.cc
+++ b/test/core/transport/chttp2/message_assembler_test.cc
@@ -75,8 +75,8 @@ TEST(GrpcMessageAssemblerTest, MustMakeSliceBufferEmpty) {
   EXPECT_EQ(frame1.Length(), kGrpcHeaderSizeInBytes + kStr1024.size());
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
   // AppendNewDataFrame must empty the original buffer
   EXPECT_EQ(frame1.Length(), 0);
 }
@@ -88,8 +88,8 @@ TEST(GrpcMessageAssemblerTest, OneEmptyMessageInOneFrame) {
   EXPECT_EQ(frame1.Length(), kGrpcHeaderSizeInBytes);
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -106,8 +106,8 @@ TEST(GrpcMessageAssemblerTest, OneMessageInOneFrame) {
   EXPECT_EQ(frame1.Length(), kGrpcHeaderSizeInBytes + kStr1024.size());
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -132,20 +132,20 @@ TEST(GrpcMessageAssemblerTest, OneMessageInThreeFrames) {
   AppendPartialMessage(frame3, kString3);
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(result.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
   EXPECT_EQ(result1->get(), nullptr);
 
-  result = assembler.AppendNewDataFrame(frame2, kNotEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result22 = assembler.AppendNewDataFrame(frame2, kNotEndStream);
+  EXPECT_TRUE(result22.IsOk());
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
   EXPECT_EQ(result2->get(), nullptr);
 
-  result = assembler.AppendNewDataFrame(frame3, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result33 = assembler.AppendNewDataFrame(frame3, kEndStream);
+  EXPECT_TRUE(result33.IsOk());
   absl::StatusOr<MessageHandle> result3 = assembler.ExtractMessage();
   EXPECT_TRUE(result3.ok());
   EXPECT_EQ(result3->get()->payload()->Length(), length);
@@ -165,8 +165,8 @@ TEST(GrpcMessageAssemblerTest, ThreeMessageInOneFrame) {
   EXPECT_EQ(frame1.Length(), length + (3 * kGrpcHeaderSizeInBytes));
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -202,8 +202,8 @@ TEST(GrpcMessageAssemblerTest, ThreeEmptyMessagesInOneFrame) {
   EXPECT_EQ(frame1.Length(), 3 * kGrpcHeaderSizeInBytes);
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -231,8 +231,8 @@ TEST(GrpcMessageAssemblerTest, ThreeMessageInOneFrameMiddleMessageEmpty) {
   EXPECT_EQ(frame1.Length(), length + (3 * kGrpcHeaderSizeInBytes));
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -273,8 +273,9 @@ TEST(GrpcMessageAssemblerTest, FourMessageInThreeFrames) {
   AppendHeaderAndMessage(frame3, kStr1024);  // Message 4 complete
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status append_result1 =
+      assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(append_result1.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -284,8 +285,9 @@ TEST(GrpcMessageAssemblerTest, FourMessageInThreeFrames) {
   EXPECT_TRUE(result11.ok());
   EXPECT_EQ(result11->get(), nullptr);
 
-  result = assembler.AppendNewDataFrame(frame2, kNotEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status append_result2 =
+      assembler.AppendNewDataFrame(frame2, kNotEndStream);
+  EXPECT_TRUE(append_result2.IsOk());
 
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
@@ -296,8 +298,8 @@ TEST(GrpcMessageAssemblerTest, FourMessageInThreeFrames) {
   EXPECT_TRUE(result22.ok());
   EXPECT_EQ(result22->get(), nullptr);
 
-  result = assembler.AppendNewDataFrame(frame3, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status append_result3 = assembler.AppendNewDataFrame(frame3, kEndStream);
+  EXPECT_TRUE(append_result3.IsOk());
 
   absl::StatusOr<MessageHandle> result3 = assembler.ExtractMessage();
   EXPECT_TRUE(result3.ok());
@@ -319,8 +321,9 @@ TEST(GrpcMessageAssemblerTest, IncompleteMessageHeader) {
   frame1.RemoveLastNBytes(1);
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status append_result1 =
+      assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(append_result1.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
   EXPECT_EQ(result1->get(), nullptr);
@@ -332,8 +335,8 @@ TEST(GrpcMessageAssemblerTest, IncompleteMessageHeader) {
   discard.Clear();
   frame2.Append(Slice::FromCopiedString(kStr1024));
 
-  result = assembler.AppendNewDataFrame(frame2, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status append_result2 = assembler.AppendNewDataFrame(frame2, kEndStream);
+  EXPECT_TRUE(append_result2.IsOk());
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
   EXPECT_EQ(result2->get()->payload()->Length(), kStr1024.size());
@@ -350,8 +353,8 @@ TEST(GrpcMessageAssemblerTest, ErrorIncompleteMessageHeader) {
   frame1.RemoveLastNBytes(1);
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_FALSE(result1.ok());
 }
@@ -363,8 +366,8 @@ TEST(GrpcMessageAssemblerTest, ErrorIncompleteMessagePayload) {
   EXPECT_EQ(frame1.Length(), kGrpcHeaderSizeInBytes + kString1.size());
 
   GrpcMessageAssembler assembler;
-  absl::Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
-  EXPECT_TRUE(result.ok());
+  Http2Status result = assembler.AppendNewDataFrame(frame1, kEndStream);
+  EXPECT_TRUE(result.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_FALSE(result1.ok());
 }

--- a/test/core/transport/chttp2/message_assembler_test.cc
+++ b/test/core/transport/chttp2/message_assembler_test.cc
@@ -238,7 +238,6 @@ TEST(GrpcMessageAssemblerTest, ThreeMessageInOneFrameMiddleMessageEmpty) {
   ExpectMessagePayload(std::move(result2), 0, kFlags0);
 
   ValueOrHttp2Status<MessageHandle> result3 = assembler.ExtractMessage();
-  EXPECT_TRUE(result3.IsOk());
   ExpectMessagePayload(std::move(result3), kString3.size(), kFlags0, kString3);
 
   ValueOrHttp2Status<MessageHandle> result4 = assembler.ExtractMessage();

--- a/test/core/transport/chttp2/message_assembler_test.cc
+++ b/test/core/transport/chttp2/message_assembler_test.cc
@@ -132,20 +132,22 @@ TEST(GrpcMessageAssemblerTest, OneMessageInThreeFrames) {
   AppendPartialMessage(frame3, kString3);
 
   GrpcMessageAssembler assembler;
-  Http2Status result = assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(result.IsOk());
+  Http2Status append_result1 =
+      assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(append_result1.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
   EXPECT_EQ(result1->get(), nullptr);
 
-  Http2Status result22 = assembler.AppendNewDataFrame(frame2, kNotEndStream);
-  EXPECT_TRUE(result22.IsOk());
+  Http2Status append_result2 =
+      assembler.AppendNewDataFrame(frame2, kNotEndStream);
+  EXPECT_TRUE(append_result2.IsOk());
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
   EXPECT_EQ(result2->get(), nullptr);
 
-  Http2Status result33 = assembler.AppendNewDataFrame(frame3, kEndStream);
-  EXPECT_TRUE(result33.IsOk());
+  Http2Status append_result3 = assembler.AppendNewDataFrame(frame3, kEndStream);
+  EXPECT_TRUE(append_result3.IsOk());
   absl::StatusOr<MessageHandle> result3 = assembler.ExtractMessage();
   EXPECT_TRUE(result3.ok());
   EXPECT_EQ(result3->get()->payload()->Length(), length);

--- a/test/core/transport/chttp2/message_assembler_test.cc
+++ b/test/core/transport/chttp2/message_assembler_test.cc
@@ -132,22 +132,20 @@ TEST(GrpcMessageAssemblerTest, OneMessageInThreeFrames) {
   AppendPartialMessage(frame3, kString3);
 
   GrpcMessageAssembler assembler;
-  Http2Status append_result1 =
-      assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(append_result1.IsOk());
+  Http2Status append1 = assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(append1.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
   EXPECT_EQ(result1->get(), nullptr);
 
-  Http2Status append_result2 =
-      assembler.AppendNewDataFrame(frame2, kNotEndStream);
-  EXPECT_TRUE(append_result2.IsOk());
+  Http2Status append2 = assembler.AppendNewDataFrame(frame2, kNotEndStream);
+  EXPECT_TRUE(append2.IsOk());
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
   EXPECT_EQ(result2->get(), nullptr);
 
-  Http2Status append_result3 = assembler.AppendNewDataFrame(frame3, kEndStream);
-  EXPECT_TRUE(append_result3.IsOk());
+  Http2Status append3 = assembler.AppendNewDataFrame(frame3, kEndStream);
+  EXPECT_TRUE(append3.IsOk());
   absl::StatusOr<MessageHandle> result3 = assembler.ExtractMessage();
   EXPECT_TRUE(result3.ok());
   EXPECT_EQ(result3->get()->payload()->Length(), length);
@@ -275,9 +273,8 @@ TEST(GrpcMessageAssemblerTest, FourMessageInThreeFrames) {
   AppendHeaderAndMessage(frame3, kStr1024);  // Message 4 complete
 
   GrpcMessageAssembler assembler;
-  Http2Status append_result1 =
-      assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(append_result1.IsOk());
+  Http2Status append1 = assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(append1.IsOk());
 
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
@@ -287,9 +284,8 @@ TEST(GrpcMessageAssemblerTest, FourMessageInThreeFrames) {
   EXPECT_TRUE(result11.ok());
   EXPECT_EQ(result11->get(), nullptr);
 
-  Http2Status append_result2 =
-      assembler.AppendNewDataFrame(frame2, kNotEndStream);
-  EXPECT_TRUE(append_result2.IsOk());
+  Http2Status append2 = assembler.AppendNewDataFrame(frame2, kNotEndStream);
+  EXPECT_TRUE(append2.IsOk());
 
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
@@ -300,8 +296,8 @@ TEST(GrpcMessageAssemblerTest, FourMessageInThreeFrames) {
   EXPECT_TRUE(result22.ok());
   EXPECT_EQ(result22->get(), nullptr);
 
-  Http2Status append_result3 = assembler.AppendNewDataFrame(frame3, kEndStream);
-  EXPECT_TRUE(append_result3.IsOk());
+  Http2Status append3 = assembler.AppendNewDataFrame(frame3, kEndStream);
+  EXPECT_TRUE(append3.IsOk());
 
   absl::StatusOr<MessageHandle> result3 = assembler.ExtractMessage();
   EXPECT_TRUE(result3.ok());
@@ -323,9 +319,8 @@ TEST(GrpcMessageAssemblerTest, IncompleteMessageHeader) {
   frame1.RemoveLastNBytes(1);
 
   GrpcMessageAssembler assembler;
-  Http2Status append_result1 =
-      assembler.AppendNewDataFrame(frame1, kNotEndStream);
-  EXPECT_TRUE(append_result1.IsOk());
+  Http2Status append1 = assembler.AppendNewDataFrame(frame1, kNotEndStream);
+  EXPECT_TRUE(append1.IsOk());
   absl::StatusOr<MessageHandle> result1 = assembler.ExtractMessage();
   EXPECT_TRUE(result1.ok());
   EXPECT_EQ(result1->get(), nullptr);
@@ -337,8 +332,8 @@ TEST(GrpcMessageAssemblerTest, IncompleteMessageHeader) {
   discard.Clear();
   frame2.Append(Slice::FromCopiedString(kStr1024));
 
-  Http2Status append_result2 = assembler.AppendNewDataFrame(frame2, kEndStream);
-  EXPECT_TRUE(append_result2.IsOk());
+  Http2Status append2 = assembler.AppendNewDataFrame(frame2, kEndStream);
+  EXPECT_TRUE(append2.IsOk());
   absl::StatusOr<MessageHandle> result2 = assembler.ExtractMessage();
   EXPECT_TRUE(result2.ok());
   EXPECT_EQ(result2->get()->payload()->Length(), kStr1024.size());


### PR DESCRIPTION
[PH2] Migrating to the new Http2Status class so that I can integrate GrpcMessageAssembler with the read loop