### PR TITLE
[OTel C++] Fix crash when using TcpCallTracer

### DIFF
--- a/src/cpp/ext/otel/otel_client_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_client_call_tracer.cc
@@ -77,14 +77,18 @@ class OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer<
     call_attempt_tracer_->parent_->arena_
         ->template GetContext<grpc_core::Call>()
         ->InternalRef(
-            "OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer");
+            "OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::"
+            "TcpCallTracer");
   }
 
   ~TcpCallTracer() override {
-    call_attempt_tracer_->parent_->arena_
-        ->template GetContext<grpc_core::Call>()
-        ->InternalUnref(
-            "OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer");
+    auto* arena = call_attempt_tracer_->parent_->arena_;
+    // The CallAttemptTracer can be allocated on the arena and hence needs to be
+    // reset before unreffing the call.
+    call_attempt_tracer_.reset();
+    arena->template GetContext<grpc_core::Call>()->InternalUnref(
+        "OpenTelemetryPluginImpl::ClientCallTracer::CallAttemptTracer::~"
+        "TcpCallTracer");
   }
 
   void RecordEvent(grpc_event_engine::experimental::internal::WriteEvent type,

--- a/src/cpp/ext/otel/otel_server_call_tracer.cc
+++ b/src/cpp/ext/otel/otel_server_call_tracer.cc
@@ -66,8 +66,12 @@ class OpenTelemetryPluginImpl::ServerCallTracer::TcpCallTracer
   }
 
   ~TcpCallTracer() override {
-    server_call_tracer_->arena_->GetContext<grpc_core::Call>()->InternalUnref(
-        "OpenTelemetryPluginImpl::ServerCallTracer::TcpCallTracer");
+    auto* arena = server_call_tracer_->arena_;
+    // The ServerCallTracer is allocated on the arena and hence needs to be
+    // reset before unreffing the call.
+    server_call_tracer_.reset();
+    arena->GetContext<grpc_core::Call>()->InternalUnref(
+        "OpenTelemetryPluginImpl::ServerCallTracer::~TcpCallTracer");
   }
 
   void RecordEvent(grpc_event_engine::experimental::internal::WriteEvent type,


### PR DESCRIPTION
Crash noticed on `otel_tracing_test` with internal EventEngine implementation. More details in b/422538146