### PR TITLE
[interop] Add v1.73.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -317,6 +317,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.70.0", ReleaseInfo()),
             ("v1.71.3", ReleaseInfo()),
             ("v1.72.2", ReleaseInfo()),
+            ("v1.73.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
Adding Go version v1.73.0
Ad-hoc run : https://source.cloud.google.com/results/invocations/7b071828-4510-49f4-987e-ff2d118ff318