### PR TITLE
[Python] Resolve absl::InitializeLog warning

### DIFF
--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -35,5 +35,6 @@ pyx_library(
     defines = ["GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER=1"],
     deps = [
         "//:grpc",
+        "@com_google_absl//absl/log:initialize",
     ],
 )

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -87,6 +87,8 @@ cdef extern from "grpc/support/alloc.h":
   void gpr_free(void *ptr) nogil
   void *gpr_realloc(void *p, size_t size) nogil
 
+cdef extern from "absl/log/initialize.h" namespace "absl":
+  void InitializeLog() nogil
 
 cdef extern from "grpc/byte_buffer_reader.h":
 

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -81,6 +81,7 @@ include "_cygrpc/aio/server.pyx.pxi"
 # initialize gRPC
 #
 cdef _initialize():
+  InitializeLog()
   grpc_set_ssl_roots_override_callback(
           <grpc_ssl_roots_override_callback>ssl_roots_override_callback)
 


### PR DESCRIPTION
Fixes #38703 

After Core recently changed its logging system to use absl logging, gRPC python users started seeing the warning log
`WARNING: All log messages before absl::InitializeLog() is called are written to STDERR.`

This issue especially affects users who are indirect users of the gRPC Python  library too, such as Gemini API users.

`absl::InitializeLog()` is a C++ library that cannot directly be called in the Python layer. It is hence added in the Cython layer at the time of initializing.
The Python layer so far did not have a dependency on the absl library, hence this PR also adds an external dependency on `absl/log:initialize`