### PR TITLE
[latent_see] Add always on latent-see, and a service to drive it

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2704,6 +2704,56 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpcpp_latent_see_service",
+    srcs = [
+        "src/cpp/latent_see/latent_see_service.cc",
+    ],
+    hdrs = [
+        "src/cpp/latent_see/latent_see_service.h",
+    ],
+    external_deps = [
+        "protobuf_headers",
+        "absl/log",
+    ],
+    tags = ["nofixdeps"],
+    visibility = ["//bazel:latent_see"],
+    deps = [
+        "gpr",
+        "grpc",
+        "grpc++",
+        "//src/core:latent_see",
+        "grpc++_config_proto",
+        "//src/proto/grpc/latent_see:latent_see_proto",
+    ],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
+    name = "grpcpp_latent_see_client",
+    srcs = [
+        "src/cpp/latent_see/latent_see_client.cc",
+    ],
+    hdrs = [
+        "src/cpp/latent_see/latent_see_client.h",
+    ],
+    external_deps = [
+        "protobuf_headers",
+        "absl/log",
+    ],
+    tags = ["nofixdeps"],
+    visibility = ["//bazel:latent_see"],
+    deps = [
+        "gpr",
+        "grpc",
+        "grpc++",
+        "//src/core:latent_see",
+        "grpc++_config_proto",
+        "//src/proto/grpc/latent_see:latent_see_proto",
+    ],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
     name = "grpcpp_csds",
     srcs = [
         "src/cpp/server/csds/csds.cc",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -32,8 +32,18 @@ package(
 )
 
 config_setting(
-    name = "enable_latent_see",
-    values = {"define": "GRPC_ENABLE_LATENT_SEE=1"},
+    name = "disable_latent_see",
+    values = {"define": "GRPC_LATENT_SEE=none"},
+)
+
+config_setting(
+    name = "extra_latent_see",
+    values = {"define": "GRPC_LATENT_SEE=extra"},
+)
+
+config_setting(
+    name = "default_latent_see",
+    values = {"define": "GRPC_LATENT_SEE=default"},
 )
 
 config_setting(
@@ -193,7 +203,9 @@ grpc_cc_library(
         "util/latent_see.h",
     ],
     defines = select({
-        ":enable_latent_see": ["GRPC_ENABLE_LATENT_SEE"],
+        ":disable_latent_see": ["GRPC_DISABLE_LATENT_SEE"],
+        ":extra_latent_see": ["GRPC_EXTRA_LATENT_SEE"],
+        ":default_latent_see": [],
         "//conditions:default": [],
     }),
     external_deps = [
@@ -203,13 +215,15 @@ grpc_cc_library(
         "absl/log",
         "absl/strings",
         "absl/strings:str_format",
+        "absl/container:flat_hash_map",
+        "absl/time",
     ],
     visibility = ["//bazel:latent_see"],
     deps = [
-        "per_cpu",
-        "ring_buffer",
-        "sync",
+        "notification",
         "//:gpr",
+        "//:backoff",
+        "sync",
     ],
 )
 

--- a/src/core/call/client_call.cc
+++ b/src/core/call/client_call.cc
@@ -127,7 +127,7 @@ ClientCall::ClientCall(grpc_call*, uint32_t, grpc_completion_queue* cq,
 grpc_call_error ClientCall::StartBatch(const grpc_op* ops, size_t nops,
                                        void* notify_tag,
                                        bool is_notify_tag_closure) {
-  GRPC_LATENT_SEE_PARENT_SCOPE("ClientCall::StartBatch");
+  GRPC_LATENT_SEE_SCOPE("ClientCall::StartBatch");
   if (nops == 0) {
     EndOpImmediately(cq_, notify_tag, is_notify_tag_closure);
     return GRPC_CALL_OK;
@@ -183,7 +183,7 @@ void ClientCall::CancelWithError(grpc_error_handle error) {
 
 template <typename Batch>
 void ClientCall::ScheduleCommittedBatch(Batch batch) {
-  GRPC_LATENT_SEE_INNER_SCOPE("ClientCall::ScheduleCommittedBatch");
+  GRPC_LATENT_SEE_SCOPE("ClientCall::ScheduleCommittedBatch");
   auto cur_state = call_state_.load(std::memory_order_acquire);
   while (true) {
     switch (cur_state) {
@@ -226,7 +226,7 @@ void ClientCall::ScheduleCommittedBatch(Batch batch) {
 
 Party::WakeupHold ClientCall::StartCall(
     const grpc_op& send_initial_metadata_op) {
-  GRPC_LATENT_SEE_INNER_SCOPE("ClientCall::StartCall");
+  GRPC_LATENT_SEE_SCOPE("ClientCall::StartCall");
   auto cur_state = call_state_.load(std::memory_order_acquire);
   CToMetadata(send_initial_metadata_op.data.send_initial_metadata.metadata,
               send_initial_metadata_op.data.send_initial_metadata.count,
@@ -279,7 +279,7 @@ bool ClientCall::StartCallMaybeUpdateState(uintptr_t& cur_state,
 
 void ClientCall::CommitBatch(const grpc_op* ops, size_t nops, void* notify_tag,
                              bool is_notify_tag_closure) {
-  GRPC_LATENT_SEE_INNER_SCOPE("ClientCall::CommitBatch");
+  GRPC_LATENT_SEE_SCOPE("ClientCall::CommitBatch");
   if (nops == 1 && ops[0].op == GRPC_OP_SEND_INITIAL_METADATA) {
     StartCall(ops[0]);
     EndOpImmediately(cq_, notify_tag, is_notify_tag_closure);

--- a/src/core/ext/filters/backend_metrics/backend_metric_filter.cc
+++ b/src/core/ext/filters/backend_metrics/backend_metric_filter.cc
@@ -116,8 +116,7 @@ BackendMetricFilter::Create(const ChannelArgs&, ChannelFilter::Args) {
 }
 
 void BackendMetricFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "BackendMetricFilter::Call::OnServerTrailingMetadata");
+  GRPC_LATENT_SEE_SCOPE("BackendMetricFilter::Call::OnServerTrailingMetadata");
   if (md.get(GrpcCallWasCancelled()).value_or(false)) return;
   auto* ctx = MaybeGetContext<BackendMetricProvider>();
   if (ctx == nullptr) {

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -107,8 +107,7 @@ Slice UserAgentFromArgs(const ChannelArgs& args,
 
 void HttpClientFilter::Call::OnClientInitialMetadata(ClientMetadata& md,
                                                      HttpClientFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "HttpClientFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("HttpClientFilter::Call::OnClientInitialMetadata");
   if (filter->test_only_use_put_requests_) {
     md.Set(HttpMethodMetadata(), HttpMethodMetadata::kPut);
   } else {
@@ -122,15 +121,13 @@ void HttpClientFilter::Call::OnClientInitialMetadata(ClientMetadata& md,
 
 absl::Status HttpClientFilter::Call::OnServerInitialMetadata(
     ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "HttpClientFilter::Call::OnServerInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("HttpClientFilter::Call::OnServerInitialMetadata");
   return CheckServerMetadata(&md);
 }
 
 absl::Status HttpClientFilter::Call::OnServerTrailingMetadata(
     ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "HttpClientFilter::Call::OnServerTrailingMetadata");
+  GRPC_LATENT_SEE_SCOPE("HttpClientFilter::Call::OnServerTrailingMetadata");
   return CheckServerMetadata(&md);
 }
 

--- a/src/core/ext/filters/http/client_authority_filter.cc
+++ b/src/core/ext/filters/http/client_authority_filter.cc
@@ -51,8 +51,7 @@ ClientAuthorityFilter::Create(const ChannelArgs& args, ChannelFilter::Args) {
 
 void ClientAuthorityFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ClientAuthorityFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientAuthorityFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("ClientAuthorityFilter::Call::OnClientInitialMetadata");
   // If no authority is set, set the default authority.
   if (md.get_pointer(HttpAuthorityMetadata()) == nullptr) {
     md.Set(HttpAuthorityMetadata(), filter->default_authority_.Ref());

--- a/src/core/ext/filters/http/message_compress/compression_filter.cc
+++ b/src/core/ext/filters/http/message_compress/compression_filter.cc
@@ -229,7 +229,7 @@ ChannelCompression::DecompressArgs ChannelCompression::HandleIncomingMetadata(
 
 void ClientCompressionFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ClientCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientCompressionFilter::Call::OnClientInitialMetadata");
   compression_algorithm_ =
       filter->compression_engine_.HandleOutgoingMetadata(md);
@@ -238,7 +238,7 @@ void ClientCompressionFilter::Call::OnClientInitialMetadata(
 
 MessageHandle ClientCompressionFilter::Call::OnClientToServerMessage(
     MessageHandle message, ClientCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientCompressionFilter::Call::OnClientToServerMessage");
   return filter->compression_engine_.CompressMessage(
       std::move(message), compression_algorithm_, call_tracer_);
@@ -246,7 +246,7 @@ MessageHandle ClientCompressionFilter::Call::OnClientToServerMessage(
 
 void ClientCompressionFilter::Call::OnServerInitialMetadata(
     ServerMetadata& md, ClientCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientCompressionFilter::Call::OnServerInitialMetadata");
   decompress_args_ = filter->compression_engine_.HandleIncomingMetadata(md);
 }
@@ -254,7 +254,7 @@ void ClientCompressionFilter::Call::OnServerInitialMetadata(
 absl::StatusOr<MessageHandle>
 ClientCompressionFilter::Call::OnServerToClientMessage(
     MessageHandle message, ClientCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientCompressionFilter::Call::OnServerToClientMessage");
   return filter->compression_engine_.DecompressMessage(
       /*is_client=*/true, std::move(message), decompress_args_, call_tracer_);
@@ -262,7 +262,7 @@ ClientCompressionFilter::Call::OnServerToClientMessage(
 
 void ServerCompressionFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ServerCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerCompressionFilter::Call::OnClientInitialMetadata");
   decompress_args_ = filter->compression_engine_.HandleIncomingMetadata(md);
 }
@@ -270,7 +270,7 @@ void ServerCompressionFilter::Call::OnClientInitialMetadata(
 absl::StatusOr<MessageHandle>
 ServerCompressionFilter::Call::OnClientToServerMessage(
     MessageHandle message, ServerCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerCompressionFilter::Call::OnClientToServerMessage");
   return filter->compression_engine_.DecompressMessage(
       /*is_client=*/false, std::move(message), decompress_args_,
@@ -279,7 +279,7 @@ ServerCompressionFilter::Call::OnClientToServerMessage(
 
 void ServerCompressionFilter::Call::OnServerInitialMetadata(
     ServerMetadata& md, ServerCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerCompressionFilter::Call::OnServerInitialMetadata");
   compression_algorithm_ =
       filter->compression_engine_.HandleOutgoingMetadata(md);
@@ -287,7 +287,7 @@ void ServerCompressionFilter::Call::OnServerInitialMetadata(
 
 MessageHandle ServerCompressionFilter::Call::OnServerToClientMessage(
     MessageHandle message, ServerCompressionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerCompressionFilter::Call::OnServerToClientMessage");
   return filter->compression_engine_.CompressMessage(
       std::move(message), compression_algorithm_,

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -71,8 +71,7 @@ ServerMetadataHandle MalformedRequest(absl::string_view explanation) {
 
 ServerMetadataHandle HttpServerFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, HttpServerFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "HttpServerFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("HttpServerFilter::Call::OnClientInitialMetadata");
   auto method = md.get(HttpMethodMetadata());
   if (method.has_value()) {
     switch (*method) {
@@ -135,8 +134,7 @@ ServerMetadataHandle HttpServerFilter::Call::OnClientInitialMetadata(
 }
 
 void HttpServerFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "HttpServerFilter::Call::OnServerInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("HttpServerFilter::Call::OnServerInitialMetadata");
   GRPC_TRACE_LOG(call, INFO)
       << GetContext<Activity>()->DebugTag() << "[http-server] Write metadata";
   FilterOutgoingMetadata(&md);
@@ -145,8 +143,7 @@ void HttpServerFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
 }
 
 void HttpServerFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "HttpServerFilter::Call::OnServerTrailingMetadata");
+  GRPC_LATENT_SEE_SCOPE("HttpServerFilter::Call::OnServerTrailingMetadata");
   FilterOutgoingMetadata(&md);
 }
 

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -174,7 +174,7 @@ const char* GetStatusTagForStatus(grpc_status_code status) {
 
 void ServerLoadReportingFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ServerLoadReportingFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerLoadReportingFilter::Call::OnClientInitialMetadata");
   // Gather up basic facts about the request
   Slice service_method;
@@ -200,7 +200,7 @@ void ServerLoadReportingFilter::Call::OnClientInitialMetadata(
 
 void ServerLoadReportingFilter::Call::OnServerTrailingMetadata(
     ServerMetadata& md, ServerLoadReportingFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerLoadReportingFilter::Call::OnServerTrailingMetadata");
   const auto& costs = md.Take(LbCostBinMetadata());
   for (const auto& cost : costs) {
@@ -219,7 +219,7 @@ void ServerLoadReportingFilter::Call::OnServerTrailingMetadata(
 
 void ServerLoadReportingFilter::Call::OnFinalize(
     const grpc_call_final_info* final_info, ServerLoadReportingFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE("ServerLoadReportingFilter::Call::OnFinalize");
+  GRPC_LATENT_SEE_SCOPE("ServerLoadReportingFilter::Call::OnFinalize");
   if (final_info == nullptr) return;
   // After the last bytes have been placed on the wire we record
   // final measurements

--- a/src/core/ext/filters/logging/logging_filter.cc
+++ b/src/core/ext/filters/logging/logging_filter.cc
@@ -354,8 +354,7 @@ ClientLoggingFilter::Create(const ChannelArgs& args,
 
 void ClientLoggingFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ClientLoggingFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientLoggingFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("ClientLoggingFilter::Call::OnClientInitialMetadata");
   call_data_.emplace(true, md, filter->default_authority_);
   if (!call_data_->ShouldLog()) {
     call_data_.reset();
@@ -366,8 +365,7 @@ void ClientLoggingFilter::Call::OnClientInitialMetadata(
 }
 
 void ClientLoggingFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientLoggingFilter::Call::OnServerInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("ClientLoggingFilter::Call::OnServerInitialMetadata");
   if (!call_data_.has_value()) return;
   call_data_->LogServerHeader(
       /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
@@ -375,8 +373,7 @@ void ClientLoggingFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
 }
 
 void ClientLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientLoggingFilter::Call::OnServerTrailingMetadata");
+  GRPC_LATENT_SEE_SCOPE("ClientLoggingFilter::Call::OnServerTrailingMetadata");
   if (!call_data_.has_value()) return;
   if (md.get(GrpcCallWasCancelled()).value_or(false) &&
       md.get(GrpcStatusMetadata()) == GRPC_STATUS_CANCELLED) {
@@ -391,8 +388,7 @@ void ClientLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
 
 void ClientLoggingFilter::Call::OnClientToServerMessage(
     const Message& message) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientLoggingFilter::Call::OnClientToServerMessage");
+  GRPC_LATENT_SEE_SCOPE("ClientLoggingFilter::Call::OnClientToServerMessage");
   if (!call_data_.has_value()) return;
   call_data_->LogClientMessage(
       /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
@@ -400,8 +396,7 @@ void ClientLoggingFilter::Call::OnClientToServerMessage(
 }
 
 void ClientLoggingFilter::Call::OnClientToServerHalfClose() {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientLoggingFilter::Call::OnClientToServerHalfClose");
+  GRPC_LATENT_SEE_SCOPE("ClientLoggingFilter::Call::OnClientToServerHalfClose");
   if (!call_data_.has_value()) return;
   call_data_->LogClientHalfClose(
       /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>());
@@ -409,8 +404,7 @@ void ClientLoggingFilter::Call::OnClientToServerHalfClose() {
 
 void ClientLoggingFilter::Call::OnServerToClientMessage(
     const Message& message) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ClientLoggingFilter::Call::OnServerToClientMessage");
+  GRPC_LATENT_SEE_SCOPE("ClientLoggingFilter::Call::OnServerToClientMessage");
   if (!call_data_.has_value()) return;
   call_data_->LogServerMessage(
       /*is_client=*/true, MaybeGetContext<CallTracerAnnotationInterface>(),
@@ -431,8 +425,7 @@ ServerLoggingFilter::Create(const ChannelArgs& /*args*/,
 
 // Construct a promise for one call.
 void ServerLoggingFilter::Call::OnClientInitialMetadata(ClientMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ServerLoggingFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("ServerLoggingFilter::Call::OnClientInitialMetadata");
   call_data_.emplace(false, md, "");
   if (!call_data_->ShouldLog()) {
     call_data_.reset();
@@ -444,8 +437,7 @@ void ServerLoggingFilter::Call::OnClientInitialMetadata(ClientMetadata& md) {
 }
 
 void ServerLoggingFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ServerLoggingFilter::Call::OnServerInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("ServerLoggingFilter::Call::OnServerInitialMetadata");
   if (!call_data_.has_value()) return;
   call_data_->LogServerHeader(
       /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
@@ -453,8 +445,7 @@ void ServerLoggingFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
 }
 
 void ServerLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ServerLoggingFilter::Call::OnServerTrailingMetadata");
+  GRPC_LATENT_SEE_SCOPE("ServerLoggingFilter::Call::OnServerTrailingMetadata");
   if (!call_data_.has_value()) return;
   if (md.get(GrpcCallWasCancelled()).value_or(false) &&
       md.get(GrpcStatusMetadata()) == GRPC_STATUS_CANCELLED) {
@@ -469,8 +460,7 @@ void ServerLoggingFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
 
 void ServerLoggingFilter::Call::OnClientToServerMessage(
     const Message& message) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ServerLoggingFilter::Call::OnClientToServerMessage");
+  GRPC_LATENT_SEE_SCOPE("ServerLoggingFilter::Call::OnClientToServerMessage");
   if (!call_data_.has_value()) return;
   call_data_->LogClientMessage(
       /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),
@@ -478,8 +468,7 @@ void ServerLoggingFilter::Call::OnClientToServerMessage(
 }
 
 void ServerLoggingFilter::Call::OnClientToServerHalfClose() {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ServerLoggingFilter::Call::OnClientToServerHalfClose");
+  GRPC_LATENT_SEE_SCOPE("ServerLoggingFilter::Call::OnClientToServerHalfClose");
   if (!call_data_.has_value()) return;
   call_data_->LogClientHalfClose(
       /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>());
@@ -487,8 +476,7 @@ void ServerLoggingFilter::Call::OnClientToServerHalfClose() {
 
 void ServerLoggingFilter::Call::OnServerToClientMessage(
     const Message& message) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "ServerLoggingFilter::Call::OnServerToClientMessage");
+  GRPC_LATENT_SEE_SCOPE("ServerLoggingFilter::Call::OnServerToClientMessage");
   if (!call_data_.has_value()) return;
   call_data_->LogServerMessage(
       /*is_client=*/false, MaybeGetContext<CallTracerAnnotationInterface>(),

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -187,7 +187,7 @@ void ClientMessageSizeFilter::Call::OnClientInitialMetadata(
 
 ServerMetadataHandle ServerMessageSizeFilter::Call::OnClientToServerMessage(
     const Message& message, ServerMessageSizeFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerMessageSizeFilter::Call::OnClientToServerMessage");
   return CheckPayload(message, filter->parsed_config_.max_recv_size(),
                       /*is_client=*/false, false);
@@ -195,7 +195,7 @@ ServerMetadataHandle ServerMessageSizeFilter::Call::OnClientToServerMessage(
 
 ServerMetadataHandle ServerMessageSizeFilter::Call::OnServerToClientMessage(
     const Message& message, ServerMessageSizeFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerMessageSizeFilter::Call::OnServerToClientMessage");
   return CheckPayload(message, filter->parsed_config_.max_send_size(),
                       /*is_client=*/false, true);
@@ -203,7 +203,7 @@ ServerMetadataHandle ServerMessageSizeFilter::Call::OnServerToClientMessage(
 
 ServerMetadataHandle ClientMessageSizeFilter::Call::OnClientToServerMessage(
     const Message& message) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientMessageSizeFilter::Call::OnClientToServerMessage");
   return CheckPayload(message, limits_.max_send_size(), /*is_client=*/true,
                       true);
@@ -211,7 +211,7 @@ ServerMetadataHandle ClientMessageSizeFilter::Call::OnClientToServerMessage(
 
 ServerMetadataHandle ClientMessageSizeFilter::Call::OnServerToClientMessage(
     const Message& message) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientMessageSizeFilter::Call::OnServerToClientMessage");
   return CheckPayload(message, limits_.max_recv_size(), /*is_client=*/true,
                       false);

--- a/src/core/ext/filters/rbac/rbac_filter.cc
+++ b/src/core/ext/filters/rbac/rbac_filter.cc
@@ -43,7 +43,7 @@ namespace grpc_core {
 
 absl::Status RbacFilter::Call::OnClientInitialMetadata(ClientMetadata& md,
                                                        RbacFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE("RbacFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("RbacFilter::Call::OnClientInitialMetadata");
   // Fetch and apply the rbac policy from the service config.
   auto* service_config_call_data = GetContext<ServiceConfigCallData>();
   auto* method_params = static_cast<RbacMethodParsedConfig*>(

--- a/src/core/ext/filters/stateful_session/stateful_session_filter.cc
+++ b/src/core/ext/filters/stateful_session/stateful_session_filter.cc
@@ -213,8 +213,7 @@ bool IsConfiguredPath(absl::string_view configured_path,
 
 void StatefulSessionFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, StatefulSessionFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "StatefulSessionFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("StatefulSessionFilter::Call::OnClientInitialMetadata");
   // Get config.
   auto* service_config_call_data = GetContext<ServiceConfigCallData>();
   CHECK_NE(service_config_call_data, nullptr);
@@ -254,8 +253,7 @@ void StatefulSessionFilter::Call::OnClientInitialMetadata(
 }
 
 void StatefulSessionFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "StatefulSessionFilter::Call::OnServerInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("StatefulSessionFilter::Call::OnServerInitialMetadata");
   if (!perform_filtering_) return;
   // Add cookie to server initial metadata if needed.
   MaybeUpdateServerInitialMetadata(cookie_config_, cluster_changed_,
@@ -264,7 +262,7 @@ void StatefulSessionFilter::Call::OnServerInitialMetadata(ServerMetadata& md) {
 }
 
 void StatefulSessionFilter::Call::OnServerTrailingMetadata(ServerMetadata& md) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "StatefulSessionFilter::Call::OnServerTrailingMetadata");
   if (!perform_filtering_) return;
   // If we got a Trailers-Only response, then add the

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1142,7 +1142,7 @@ static const char* begin_writing_desc(bool partial) {
 static void write_action_begin_locked(
     grpc_core::RefCountedPtr<grpc_chttp2_transport> t,
     grpc_error_handle /*error_ignored*/) {
-  GRPC_LATENT_SEE_INNER_SCOPE("write_action_begin_locked");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("write_action_begin_locked");
   CHECK(t->write_state != GRPC_CHTTP2_WRITE_STATE_IDLE);
   grpc_chttp2_begin_write_result r;
   if (!t->closed_with_error.ok()) {
@@ -2903,7 +2903,7 @@ static void read_action(grpc_core::RefCountedPtr<grpc_chttp2_transport> t,
 static void read_action_parse_loop_locked(
     grpc_core::RefCountedPtr<grpc_chttp2_transport> t,
     grpc_error_handle error) {
-  GRPC_LATENT_SEE_INNER_SCOPE("read_action_parse_loop_locked");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("read_action_parse_loop_locked");
   if (t->closed_with_error.ok()) {
     grpc_error_handle errors[3] = {error, absl::OkStatus(), absl::OkStatus()};
     size_t requests_started = 0;

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -212,7 +212,7 @@ std::string FrameTypeString(uint8_t frame_type, uint8_t flags) {
 std::variant<size_t, absl::Status> grpc_chttp2_perform_read(
     grpc_chttp2_transport* t, const grpc_slice& slice,
     size_t& requests_started) {
-  GRPC_LATENT_SEE_INNER_SCOPE("grpc_chttp2_perform_read");
+  GRPC_LATENT_SEE_SCOPE("grpc_chttp2_perform_read");
 
   const uint8_t* beg = GRPC_SLICE_START_PTR(slice);
   const uint8_t* end = GRPC_SLICE_END_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -683,7 +683,7 @@ class StreamWriteContext {
 
 grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
     grpc_chttp2_transport* t) {
-  GRPC_LATENT_SEE_INNER_SCOPE("grpc_chttp2_begin_write");
+  GRPC_LATENT_SEE_SCOPE("grpc_chttp2_begin_write");
 
   int64_t outbuf_relative_start_pos = 0;
   WriteContext ctx(t);
@@ -756,7 +756,7 @@ grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
 }
 
 void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error_handle error) {
-  GRPC_LATENT_SEE_INNER_SCOPE("grpc_chttp2_end_write");
+  GRPC_LATENT_SEE_SCOPE("grpc_chttp2_end_write");
   grpc_chttp2_stream* s;
 
   t->write_flow.End();

--- a/src/core/handshaker/security/legacy_secure_endpoint.cc
+++ b/src/core/handshaker/security/legacy_secure_endpoint.cc
@@ -400,7 +400,7 @@ static void on_write(void* user_data, grpc_error_handle error) {
 static void endpoint_write(
     grpc_endpoint* secure_ep, grpc_slice_buffer* slices, grpc_closure* cb,
     grpc_event_engine::experimental::EventEngine::Endpoint::WriteArgs args) {
-  GRPC_LATENT_SEE_INNER_SCOPE("secure_endpoint write");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("secure_endpoint write");
   unsigned i;
   tsi_result result = TSI_OK;
   secure_endpoint* ep = reinterpret_cast<secure_endpoint*>(secure_ep);

--- a/src/core/handshaker/security/secure_endpoint.cc
+++ b/src/core/handshaker/security/secure_endpoint.cc
@@ -183,7 +183,7 @@ class FrameProtector : public RefCounted<FrameProtector> {
 
   absl::Status Unprotect(absl::Status read_status)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(read_mu_) {
-    GRPC_LATENT_SEE_INNER_SCOPE("unprotect");
+    GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("unprotect");
     bool keep_looping = false;
     tsi_result result = TSI_OK;
 
@@ -312,7 +312,7 @@ class FrameProtector : public RefCounted<FrameProtector> {
 
   tsi_result Protect(grpc_slice_buffer* slices, int max_frame_size)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(write_mu_) {
-    GRPC_LATENT_SEE_INNER_SCOPE("protect");
+    GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("protect");
     uint8_t* cur = GRPC_SLICE_START_PTR(write_staging_buffer_);
     uint8_t* end = GRPC_SLICE_END_PTR(write_staging_buffer_);
 
@@ -570,7 +570,7 @@ static void on_write(void* user_data, grpc_error_handle error) {
 static void endpoint_write(
     grpc_endpoint* secure_ep, grpc_slice_buffer* slices, grpc_closure* cb,
     grpc_event_engine::experimental::EventEngine::Endpoint::WriteArgs args) {
-  GRPC_LATENT_SEE_INNER_SCOPE("secure_endpoint write");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("secure_endpoint write");
   secure_endpoint* ep = reinterpret_cast<secure_endpoint*>(secure_ep);
   tsi_result result;
   {
@@ -773,7 +773,7 @@ class SecureEndpoint final : public EventEngine::Endpoint {
 
     bool Write(absl::AnyInvocable<void(absl::Status)> on_writable,
                SliceBuffer* data, WriteArgs args) {
-      GRPC_LATENT_SEE_INNER_SCOPE("secure_endpoint write");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("secure_endpoint write");
       tsi_result result;
       frame_protector_.TraceOp("Write", data->c_slice_buffer());
       if (grpc_core::IsSecureEndpointOffloadLargeWritesEnabled()) {
@@ -869,7 +869,7 @@ class SecureEndpoint final : public EventEngine::Endpoint {
 
    private:
     bool MaybeFinishReadImmediately() {
-      GRPC_LATENT_SEE_INNER_SCOPE("secure_endpoint maybe finish read");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("secure_endpoint maybe finish read");
       grpc_core::MutexLock lock(frame_protector_.read_mu());
       // If the read is large, since we got the bytes whilst still calling read,
       // offload the decryption to event engine.
@@ -900,7 +900,7 @@ class SecureEndpoint final : public EventEngine::Endpoint {
 
     static void FinishAsyncRead(grpc_core::RefCountedPtr<Impl> impl,
                                 absl::Status status) {
-      GRPC_LATENT_SEE_PARENT_SCOPE("secure endpoint finish async read");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("secure endpoint finish async read");
       {
         grpc_core::MutexLock lock(impl->frame_protector_.read_mu());
         if (status.ok() && impl->wrapped_ep_ == nullptr) {
@@ -935,7 +935,7 @@ class SecureEndpoint final : public EventEngine::Endpoint {
     };
 
     static void FinishAsyncWrite(grpc_core::RefCountedPtr<Impl> impl) {
-      GRPC_LATENT_SEE_PARENT_SCOPE("secure endpoint finish async write");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("secure endpoint finish async write");
       tsi_result result;
       std::unique_ptr<SliceBuffer> data;
       WriteArgs args;

--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -242,8 +242,7 @@ void BaseCallData::CapturedBatch::CancelWith(grpc_error_handle error,
 ///////////////////////////////////////////////////////////////////////////////
 // BaseCallData::Flusher
 
-BaseCallData::Flusher::Flusher(BaseCallData* call, latent_see::Metadata* desc)
-    : latent_see::InnerScope(desc), call_(call) {
+BaseCallData::Flusher::Flusher(BaseCallData* call) : call_(call) {
   GRPC_CALL_STACK_REF(call_->call_stack(), "flusher");
 }
 
@@ -395,7 +394,7 @@ bool BaseCallData::SendMessage::IsIdle() const {
 }
 
 void BaseCallData::SendMessage::OnComplete(absl::Status status) {
-  Flusher flusher(base_, GRPC_LATENT_SEE_METADATA("SendMessage::OnComplete"));
+  Flusher flusher(base_);
   GRPC_TRACE_LOG(channel, INFO)
       << base_->LogTag() << " SendMessage.OnComplete st=" << StateString(state_)
       << " status=" << status;
@@ -705,8 +704,7 @@ void BaseCallData::ReceiveMessage::OnComplete(absl::Status status) {
       break;
   }
   completed_status_ = status;
-  Flusher flusher(base_,
-                  GRPC_LATENT_SEE_METADATA("ReceiveMessage::OnComplete"));
+  Flusher flusher(base_);
   ScopedContext ctx(base_);
   base_->WakeInsideCombiner(&flusher);
 }
@@ -1220,9 +1218,7 @@ class ClientCallData::PollContext {
         auto* next_poll = static_cast<NextPoll*>(p);
         {
           ScopedContext ctx(next_poll->call_data);
-          Flusher flusher(next_poll->call_data,
-                          GRPC_LATENT_SEE_METADATA(
-                              "ClientCallData::PollContext::~PollContext"));
+          Flusher flusher(next_poll->call_data);
           next_poll->call_data->WakeInsideCombiner(&flusher);
         }
         GRPC_CALL_STACK_UNREF(next_poll->call_stack, "re-poll");
@@ -1351,7 +1347,7 @@ void ClientCallData::StartBatch(grpc_transport_stream_op_batch* b) {
   // Fake out the activity based context.
   ScopedContext context(this);
   CapturedBatch batch(b);
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA("ClientCallData::StartBatch"));
+  Flusher flusher(this);
 
   GRPC_TRACE_LOG(channel, INFO) << LogTag() << " StartBatch " << DebugString();
 
@@ -1557,8 +1553,7 @@ void ClientCallData::RecvInitialMetadataReady(grpc_error_handle error) {
       << DebugString() << " error:" << error.ToString()
       << " md:" << recv_initial_metadata_->metadata->DebugString();
   ScopedContext context(this);
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA(
-                            "ClientCallData::RecvInitialMetadataReady"));
+  Flusher flusher(this);
   if (!error.ok()) {
     switch (recv_initial_metadata_->state) {
       case RecvInitialMetadata::kHookedWaitingForPipe:
@@ -1744,8 +1739,7 @@ void ClientCallData::RecvTrailingMetadataReadyCallback(
 }
 
 void ClientCallData::RecvTrailingMetadataReady(grpc_error_handle error) {
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA(
-                            "ClientCallData::RecvTrailingMetadataReady"));
+  Flusher flusher(this);
   GRPC_TRACE_LOG(channel, INFO)
       << LogTag() << " ClientCallData.RecvTrailingMetadataReady "
       << "recv_trailing_state=" << StateString(recv_trailing_state_)
@@ -1796,12 +1790,12 @@ void ClientCallData::SetStatusFromError(grpc_metadata_batch* metadata,
 
 // Wakeup and poll the promise if appropriate.
 void ClientCallData::WakeInsideCombiner(Flusher* flusher) {
-  GRPC_LATENT_SEE_INNER_SCOPE("ClientCallData::WakeInsideCombiner");
+  GRPC_LATENT_SEE_SCOPE("ClientCallData::WakeInsideCombiner");
   PollContext(this, flusher).Run();
 }
 
 void ClientCallData::OnWakeup() {
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA("ClientCallData::OnWakeup"));
+  Flusher flusher(this);
   ScopedContext context(this);
   WakeInsideCombiner(&flusher);
 }
@@ -1877,9 +1871,7 @@ class ServerCallData::PollContext {
       auto run = [](void* p, grpc_error_handle) {
         auto* next_poll = static_cast<NextPoll*>(p);
         {
-          Flusher flusher(next_poll->call_data,
-                          GRPC_LATENT_SEE_METADATA(
-                              "ServerCallData::PollContext::~PollContext"));
+          Flusher flusher(next_poll->call_data);
           ScopedContext context(next_poll->call_data);
           next_poll->call_data->WakeInsideCombiner(&flusher);
         }
@@ -1983,7 +1975,7 @@ void ServerCallData::StartBatch(grpc_transport_stream_op_batch* b) {
   // Fake out the activity based context.
   ScopedContext context(this);
   CapturedBatch batch(b);
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA("ServerCallData::StartBatch"));
+  Flusher flusher(this);
   bool wake = false;
 
   GRPC_TRACE_LOG(channel, INFO) << LogTag() << " StartBatch: " << DebugString();
@@ -2272,8 +2264,7 @@ void ServerCallData::RecvTrailingMetadataReady(grpc_error_handle error) {
   GRPC_TRACE_LOG(channel, INFO)
       << LogTag() << ": RecvTrailingMetadataReady error=" << error
       << " md=" << recv_trailing_metadata_->DebugString();
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA(
-                            "ServerCallData::RecvTrailingMetadataReady"));
+  Flusher flusher(this);
   PollContext poll_ctx(this, &flusher);
   Completed(error, recv_trailing_metadata_->get(GrpcTarPit()).has_value(),
             &flusher);
@@ -2287,8 +2278,7 @@ void ServerCallData::RecvInitialMetadataReadyCallback(void* arg,
 }
 
 void ServerCallData::RecvInitialMetadataReady(grpc_error_handle error) {
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA(
-                            "ServerCallData::RecvInitialMetadataReady"));
+  Flusher flusher(this);
   GRPC_TRACE_LOG(channel, INFO)
       << LogTag() << ": RecvInitialMetadataReady " << error;
   CHECK(recv_initial_state_ == RecvInitialState::kForwarded);
@@ -2351,7 +2341,7 @@ std::string ServerCallData::DebugString() const {
 
 // Wakeup and poll the promise if appropriate.
 void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
-  GRPC_LATENT_SEE_INNER_SCOPE("ServerCallData::WakeInsideCombiner");
+  GRPC_LATENT_SEE_SCOPE("ServerCallData::WakeInsideCombiner");
   PollContext poll_ctx(this, flusher);
   GRPC_TRACE_LOG(channel, INFO)
       << LogTag() << ": WakeInsideCombiner " << DebugString();
@@ -2503,7 +2493,7 @@ void ServerCallData::WakeInsideCombiner(Flusher* flusher) {
 }
 
 void ServerCallData::OnWakeup() {
-  Flusher flusher(this, GRPC_LATENT_SEE_METADATA("ServerCallData::OnWakeup"));
+  Flusher flusher(this);
   ScopedContext context(this);
   WakeInsideCombiner(&flusher);
 }

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1304,11 +1304,9 @@ class BaseCallData : public Activity, private Wakeable {
     }
   };
 
-  class Flusher : public latent_see::InnerScope {
+  class Flusher {
    public:
-    explicit Flusher(BaseCallData* call,
-                     latent_see::Metadata* desc = GRPC_LATENT_SEE_METADATA(
-                         "PromiseBasedFilter::Flusher"));
+    explicit Flusher(BaseCallData* call);
     // Calls closures, schedules batches, relinquishes call combiner.
     ~Flusher();
 

--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -99,7 +99,7 @@ PosixErrorOr<int64_t> TcpSend(EventEnginePosixInterface* posix_interface,
                               const FileDescriptor& fd,
                               const struct msghdr* msg, int* saved_errno,
                               int additional_flags = 0) {
-  GRPC_LATENT_SEE_PARENT_SCOPE("TcpSend");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("TcpSend");
   PosixErrorOr<int64_t> send_result;
   do {
     grpc_core::global_stats().IncrementSyscallWrite();
@@ -290,7 +290,7 @@ absl::Status PosixEndpointImpl::TcpAnnotateError(absl::Status src_error) const {
 
 // Returns true if data available to read or error other than EAGAIN.
 bool PosixEndpointImpl::TcpDoRead(absl::Status& status) {
-  GRPC_LATENT_SEE_INNER_SCOPE("TcpDoRead");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("TcpDoRead");
 
   struct msghdr msg;
   struct iovec iov[MAX_READ_IOVEC];

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -166,7 +166,7 @@ static void queue_offload(grpc_core::Combiner* lock) {
 }
 
 bool grpc_combiner_continue_exec_ctx() {
-  GRPC_LATENT_SEE_PARENT_SCOPE("grpc_combiner_continue_exec_ctx");
+  GRPC_LATENT_SEE_SCOPE("grpc_combiner_continue_exec_ctx");
 
   grpc_core::Combiner* lock =
       grpc_core::ExecCtx::Get()->combiner_data()->active_combiner;

--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -108,23 +108,17 @@ class Combiner;
 ///               since that implies a core re-entry outside of application
 ///               callbacks.
 ///
-class GRPC_DLL ExecCtx : public latent_see::ParentScope {
+class GRPC_DLL ExecCtx {
  public:
   /// Default Constructor
 
-  ExecCtx()
-      : latent_see::ParentScope(GRPC_LATENT_SEE_METADATA("ExecCtx")),
-        flags_(GRPC_EXEC_CTX_FLAG_IS_FINISHED) {
+  ExecCtx() : flags_(GRPC_EXEC_CTX_FLAG_IS_FINISHED) {
     Fork::IncExecCtxCount();
     Set(this);
   }
 
   /// Parameterised Constructor
-  explicit ExecCtx(uintptr_t fl)
-      : ExecCtx(fl, GRPC_LATENT_SEE_METADATA("ExecCtx")) {}
-
-  explicit ExecCtx(uintptr_t fl, latent_see::Metadata* latent_see_metadata)
-      : latent_see::ParentScope(latent_see_metadata), flags_(fl) {
+  explicit ExecCtx(uintptr_t fl) : flags_(fl) {
     if (!(GRPC_EXEC_CTX_FLAG_IS_INTERNAL_THREAD & flags_)) {
       Fork::IncExecCtxCount();
     }

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -894,7 +894,7 @@ static void update_rcvlowat(grpc_tcp* tcp)
 #define MAX_READ_IOVEC 64
 static bool tcp_do_read(grpc_tcp* tcp, grpc_error_handle* error)
     ABSL_EXCLUSIVE_LOCKS_REQUIRED(tcp->read_mu) {
-  GRPC_LATENT_SEE_INNER_SCOPE("tcp_do_read");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("tcp_do_read");
   GRPC_TRACE_LOG(tcp, INFO) << "TCP:" << tcp << " do_read";
   struct msghdr msg;
   struct iovec iov[MAX_READ_IOVEC];
@@ -1184,7 +1184,7 @@ static void tcp_read(grpc_endpoint* ep, grpc_slice_buffer* incoming_buffer,
 // of bytes sent.
 ssize_t tcp_send(int fd, const struct msghdr* msg, int* saved_errno,
                  int additional_flags = 0) {
-  GRPC_LATENT_SEE_INNER_SCOPE("tcp_send");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("tcp_send");
   ssize_t sent_length;
   do {
     // TODO(klempner): Cork if this is a partial write
@@ -1375,7 +1375,7 @@ struct cmsghdr* process_timestamp(grpc_tcp* tcp, msghdr* msg,
 /// messages from the queue.
 ///
 static bool process_errors(grpc_tcp* tcp) {
-  GRPC_LATENT_SEE_INNER_SCOPE("process_errors");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("process_errors");
   bool processed_err = false;
   struct iovec iov;
   iov.iov_base = nullptr;

--- a/src/core/lib/promise/activity.h
+++ b/src/core/lib/promise/activity.h
@@ -565,7 +565,7 @@ class PromiseActivity final
   }
 
   void WakeupAsync(WakeupMask) final {
-    GRPC_LATENT_SEE_INNER_SCOPE("PromiseActivity::WakeupAsync");
+    GRPC_LATENT_SEE_SCOPE("PromiseActivity::WakeupAsync");
     wakeup_flow_.Begin(GRPC_LATENT_SEE_METADATA("Activity::Wakeup"));
     if (!wakeup_scheduled_.exchange(true, std::memory_order_acq_rel)) {
       // Can't safely run, so ask to run later.
@@ -590,7 +590,7 @@ class PromiseActivity final
   // In response to Wakeup, run the Promise state machine again until it
   // settles. Then check for completion, and if we have completed, call on_done.
   void Step() ABSL_LOCKS_EXCLUDED(mu()) {
-    GRPC_LATENT_SEE_PARENT_SCOPE("PromiseActivity::Step");
+    GRPC_LATENT_SEE_SCOPE("PromiseActivity::Step");
     wakeup_flow_.End();
     // Poll the promise until things settle out under a lock.
     mu()->Lock();

--- a/src/core/lib/promise/mpsc.cc
+++ b/src/core/lib/promise/mpsc.cc
@@ -26,7 +26,7 @@ namespace grpc_core::mpscpipe_detail {
 Mpsc::~Mpsc() { Close(false); }
 
 void Mpsc::Enqueue(Node* node) {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::Enqueue");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::Enqueue");
   auto actors = actors_.load(std::memory_order_relaxed);
   while (true) {
     if (actors == 0) {
@@ -66,7 +66,7 @@ void Mpsc::Enqueue(Node* node) {
 }
 
 StatusFlag Mpsc::UnbufferedImmediateSend(Node* node) {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::UnbufferedImmediateSend");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::UnbufferedImmediateSend");
   auto actors = actors_.load(std::memory_order_relaxed);
   while (true) {
     if (actors == 0) {
@@ -117,7 +117,7 @@ Json Mpsc::PollNextJson() const {
 }
 
 Poll<ValueOrFailure<Mpsc::Node*>> Mpsc::PollNext() {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::Next");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::Next");
   Node* accepted_head = accepted_head_;
   if (accepted_head != nullptr) {
     accepted_head_ = accepted_head->spsc_next_;
@@ -147,7 +147,7 @@ Poll<ValueOrFailure<Mpsc::Node*>> Mpsc::PollNext() {
 }
 
 bool Mpsc::AcceptNode(Node* node) {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::AcceptNode");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::AcceptNode");
   DCHECK_NE(node, nullptr);
   if (node->state_.fetch_and(255 - Node::kBlockedState,
                              std::memory_order_relaxed) &
@@ -160,7 +160,7 @@ bool Mpsc::AcceptNode(Node* node) {
 }
 
 bool Mpsc::CheckActiveTokens() {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::CheckActiveTokens");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::CheckActiveTokens");
   // First step: see if the active token count is lower than max_queued_.
   // If it's not, we do not supply any nodes.
   auto active_tokens = active_tokens_.load(std::memory_order_relaxed);
@@ -186,7 +186,7 @@ bool Mpsc::CheckActiveTokens() {
 }
 
 void Mpsc::DrainMpsc() {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::DrainMpsc");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::DrainMpsc");
 #ifndef NDEBUG
   DCHECK(!drained);
   drained = true;
@@ -210,7 +210,7 @@ void Mpsc::DrainMpsc() {
 }
 
 Poll<Mpsc::Node*> Mpsc::Dequeue() {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::Dequeue");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::Dequeue");
   Node* tail = tail_;
   uintptr_t next = tail->next_.load(std::memory_order_acquire);
 retry_all:
@@ -301,7 +301,7 @@ void Mpsc::PushStub() {
 }
 
 Mpsc::Node* Mpsc::DequeueImmediate() {
-  GRPC_LATENT_SEE_INNER_SCOPE("Mpsc::DequeueImmediate");
+  GRPC_LATENT_SEE_SCOPE("Mpsc::DequeueImmediate");
   Node* tail = tail_;
   uintptr_t next = tail->next_.load(std::memory_order_acquire);
   if (tail == &stub_) {

--- a/src/core/lib/promise/party.h
+++ b/src/core/lib/promise/party.h
@@ -429,7 +429,7 @@ class Party : public Activity, private Wakeable {
     }
 
     bool PollParticipantPromise() override {
-      GRPC_LATENT_SEE_INNER_SCOPE(TypeName<SuppliedFactory>());
+      GRPC_LATENT_SEE_SCOPE(TypeName<SuppliedFactory>());
       if (!started_) {
         auto p = factory_.Make();
         Destruct(&factory_);
@@ -499,7 +499,7 @@ class Party : public Activity, private Wakeable {
 
     // Inside party poll: drive from factory -> promise -> result
     bool PollParticipantPromise() override {
-      GRPC_LATENT_SEE_INNER_SCOPE(TypeName<SuppliedFactory>());
+      GRPC_LATENT_SEE_SCOPE(TypeName<SuppliedFactory>());
       switch (state_.load(std::memory_order_relaxed)) {
         case State::kFactory: {
           auto p = factory_.Make();
@@ -615,7 +615,7 @@ class Party : public Activity, private Wakeable {
 
   // Wakeable implementation
   void Wakeup(WakeupMask wakeup_mask) final {
-    GRPC_LATENT_SEE_INNER_SCOPE("Party::Wakeup");
+    GRPC_LATENT_SEE_SCOPE("Party::Wakeup");
     if (Activity::current() == this) {
       wakeup_mask_ |= wakeup_mask;
       Unref();
@@ -627,7 +627,7 @@ class Party : public Activity, private Wakeable {
   template <bool kReffed>
   GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION void WakeupFromState(
       uint64_t cur_state, WakeupMask wakeup_mask) {
-    GRPC_LATENT_SEE_INNER_SCOPE("Party::WakeupFromState");
+    GRPC_LATENT_SEE_SCOPE("Party::WakeupFromState");
     DCHECK_NE(wakeup_mask & kWakeupMask, 0u)
         << "Wakeup mask must be non-zero: " << wakeup_mask;
     while (true) {

--- a/src/core/lib/promise/poll.h
+++ b/src/core/lib/promise/poll.h
@@ -270,6 +270,16 @@ GPR_ATTRIBUTE_ALWAYS_INLINE_FUNCTION inline Poll<T> poll_cast(U poll) {
   return PollCastImpl<T, U>::Cast(std::move(poll));
 }
 
+template <typename T>
+bool IsPending(const T& value) {
+  return false;
+}
+
+template <typename T>
+bool IsPending(const Poll<T>& poll) {
+  return poll.pending();
+}
+
 // Convert a poll to a string
 template <typename T, typename F>
 std::string PollToString(

--- a/src/core/lib/security/authorization/grpc_server_authz_filter.cc
+++ b/src/core/lib/security/authorization/grpc_server_authz_filter.cc
@@ -92,8 +92,7 @@ bool GrpcServerAuthzFilter::IsAuthorized(ClientMetadata& initial_metadata) {
 
 absl::Status GrpcServerAuthzFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, GrpcServerAuthzFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
-      "GrpcServerAuthzFilter::Call::OnClientInitialMetadata");
+  GRPC_LATENT_SEE_SCOPE("GrpcServerAuthzFilter::Call::OnClientInitialMetadata");
   if (!filter->IsAuthorized(md)) {
     return absl::PermissionDeniedError("Unauthorized RPC request rejected.");
   }

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -933,8 +933,7 @@ struct cq_is_finished_arg {
 class ExecCtxNext : public grpc_core::ExecCtx {
  public:
   explicit ExecCtxNext(void* arg)
-      : ExecCtx(0, GRPC_LATENT_SEE_METADATA("ExecCtx for CqNext")),
-        check_ready_to_finish_arg_(arg) {}
+      : ExecCtx(0), check_ready_to_finish_arg_(arg) {}
 
   bool CheckReadyToFinish() override {
     cq_is_finished_arg* a =
@@ -1181,8 +1180,7 @@ static void del_plucker(grpc_completion_queue* cq, void* tag,
 class ExecCtxPluck : public grpc_core::ExecCtx {
  public:
   explicit ExecCtxPluck(void* arg)
-      : ExecCtx(0, GRPC_LATENT_SEE_METADATA("ExecCtx for CqPluck")),
-        check_ready_to_finish_arg_(arg) {}
+      : ExecCtx(0), check_ready_to_finish_arg_(arg) {}
 
   bool CheckReadyToFinish() override {
     cq_is_finished_arg* a =

--- a/src/core/lib/surface/filter_stack_call.cc
+++ b/src/core/lib/surface/filter_stack_call.cc
@@ -737,7 +737,7 @@ void FilterStackCall::BatchControl::FinishBatch(grpc_error_handle error) {
 grpc_call_error FilterStackCall::StartBatch(const grpc_op* ops, size_t nops,
                                             void* notify_tag,
                                             bool is_notify_tag_closure) {
-  GRPC_LATENT_SEE_INNER_SCOPE("FilterStackCall::StartBatch");
+  GRPC_LATENT_SEE_SCOPE("FilterStackCall::StartBatch");
 
   size_t i;
   const grpc_op* op;

--- a/src/core/lib/transport/promise_endpoint.cc
+++ b/src/core/lib/transport/promise_endpoint.cc
@@ -57,7 +57,7 @@ PromiseEndpoint::GetLocalAddress() const {
 
 void PromiseEndpoint::ReadState::Complete(absl::Status status,
                                           const size_t num_bytes_requested) {
-  GRPC_LATENT_SEE_INNER_SCOPE("PromiseEndpoint::ReadState::Complete");
+  GRPC_LATENT_SEE_SCOPE("PromiseEndpoint::ReadState::Complete");
   while (true) {
     if (!status.ok()) {
       // Invalidates all previous reads.
@@ -74,7 +74,7 @@ void PromiseEndpoint::ReadState::Complete(absl::Status status,
                                                   buffer);
     DCHECK(pending_buffer.Count() == 0u);
     if (buffer.Length() < num_bytes_requested) {
-      GRPC_LATENT_SEE_INNER_SCOPE("PromiseEndpoint::ReadState::Continue");
+      GRPC_LATENT_SEE_SCOPE("PromiseEndpoint::ReadState::Continue");
       // A further read is needed.
       // Set read args with number of bytes needed as hint.
       grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs

--- a/src/core/lib/transport/promise_endpoint.h
+++ b/src/core/lib/transport/promise_endpoint.h
@@ -74,7 +74,7 @@ class PromiseEndpoint {
   // `Write()` before the previous write finishes. Doing that results in
   // undefined behavior.
   auto Write(SliceBuffer data, WriteArgs write_args) {
-    GRPC_LATENT_SEE_PARENT_SCOPE("GRPC:Write");
+    GRPC_LATENT_SEE_SCOPE("GRPC:Write");
     // Start write and assert previous write finishes.
     auto prev = write_state_->state.exchange(WriteState::kWriting,
                                              std::memory_order_relaxed);
@@ -136,14 +136,14 @@ class PromiseEndpoint {
   // `Read()` before the previous read finishes. Doing that results in
   // undefined behavior.
   auto Read(size_t num_bytes) {
-    GRPC_LATENT_SEE_PARENT_SCOPE("GRPC:Read");
+    GRPC_LATENT_SEE_SCOPE("GRPC:Read");
     // Assert previous read finishes.
     CHECK(!read_state_->complete.load(std::memory_order_relaxed));
     // Should not have pending reads.
     CHECK_EQ(read_state_->pending_buffer.Count(), 0u);
     bool complete = true;
     while (read_state_->buffer.Length() < num_bytes) {
-      GRPC_LATENT_SEE_INNER_SCOPE("GRPC:Read:Loop");
+      GRPC_LATENT_SEE_SCOPE("GRPC:Read:Loop");
       // Set read args with hinted bytes.
       grpc_event_engine::experimental::EventEngine::Endpoint::ReadArgs
           read_args;

--- a/src/core/load_balancing/grpclb/client_load_reporting_filter.cc
+++ b/src/core/load_balancing/grpclb/client_load_reporting_filter.cc
@@ -50,7 +50,7 @@ ClientLoadReportingFilter::Create(const ChannelArgs&, ChannelFilter::Args) {
 
 void ClientLoadReportingFilter::Call::OnClientInitialMetadata(
     ClientMetadata& client_initial_metadata) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientLoadReportingFilter::Call::OnClientInitialMetadata");
   // Handle client initial metadata.
   // Grab client stats object from metadata.
@@ -62,14 +62,14 @@ void ClientLoadReportingFilter::Call::OnClientInitialMetadata(
 }
 
 void ClientLoadReportingFilter::Call::OnServerInitialMetadata(ServerMetadata&) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientLoadReportingFilter::Call::OnServerInitialMetadata");
   saw_initial_metadata_ = true;
 }
 
 void ClientLoadReportingFilter::Call::OnServerTrailingMetadata(
     ServerMetadata& server_trailing_metadata) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ClientLoadReportingFilter::Call::OnServerTrailingMetadata");
   if (client_stats_ != nullptr) {
     client_stats_->AddCallFinished(

--- a/src/core/server/server.cc
+++ b/src/core/server/server.cc
@@ -1239,7 +1239,7 @@ void Server::Start() {
 grpc_error_handle Server::SetupTransport(Transport* transport,
                                          grpc_pollset* accepting_pollset,
                                          const ChannelArgs& args) {
-  GRPC_LATENT_SEE_INNER_SCOPE("Server::SetupTransport");
+  GRPC_LATENT_SEE_SCOPE("Server::SetupTransport");
   // Create channel.
   global_stats().IncrementServerChannelsCreated();
   // Set up channelz node.

--- a/src/core/server/server_call_tracer_filter.cc
+++ b/src/core/server/server_call_tracer_filter.cc
@@ -57,7 +57,7 @@ class ServerCallTracerFilter
   class Call {
    public:
     void OnClientInitialMetadata(ClientMetadata& client_initial_metadata) {
-      GRPC_LATENT_SEE_INNER_SCOPE(
+      GRPC_LATENT_SEE_SCOPE(
           "ServerCallTracerFilter::Call::OnClientInitialMetadata");
       auto* call_tracer = MaybeGetContext<ServerCallTracer>();
       if (call_tracer == nullptr) return;
@@ -65,7 +65,7 @@ class ServerCallTracerFilter
     }
 
     void OnServerInitialMetadata(ServerMetadata& server_initial_metadata) {
-      GRPC_LATENT_SEE_INNER_SCOPE(
+      GRPC_LATENT_SEE_SCOPE(
           "ServerCallTracerFilter::Call::OnServerInitialMetadata");
       auto* call_tracer = MaybeGetContext<ServerCallTracer>();
       if (call_tracer == nullptr) return;
@@ -73,14 +73,14 @@ class ServerCallTracerFilter
     }
 
     void OnFinalize(const grpc_call_final_info* final_info) {
-      GRPC_LATENT_SEE_INNER_SCOPE("ServerCallTracerFilter::Call::OnFinalize");
+      GRPC_LATENT_SEE_SCOPE("ServerCallTracerFilter::Call::OnFinalize");
       auto* call_tracer = MaybeGetContext<ServerCallTracer>();
       if (call_tracer == nullptr) return;
       call_tracer->RecordEnd(final_info);
     }
 
     void OnServerTrailingMetadata(ServerMetadata& server_trailing_metadata) {
-      GRPC_LATENT_SEE_INNER_SCOPE(
+      GRPC_LATENT_SEE_SCOPE(
           "ServerCallTracerFilter::Call::OnServerTrailingMetadata");
       auto* call_tracer = MaybeGetContext<ServerCallTracer>();
       if (call_tracer == nullptr) return;

--- a/src/core/server/server_config_selector_filter.cc
+++ b/src/core/server/server_config_selector_filter.cc
@@ -144,7 +144,7 @@ void ServerConfigSelectorFilter::Orphan() {
 
 absl::Status ServerConfigSelectorFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ServerConfigSelectorFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServerConfigSelectorFilter::Call::OnClientInitialMetadata");
   auto sel = filter->config_selector();
   if (!sel.ok()) return sel.status();

--- a/src/core/service_config/service_config_channel_arg_filter.cc
+++ b/src/core/service_config/service_config_channel_arg_filter.cc
@@ -95,7 +95,7 @@ class ServiceConfigChannelArgFilter final
 
 void ServiceConfigChannelArgFilter::Call::OnClientInitialMetadata(
     ClientMetadata& md, ServiceConfigChannelArgFilter* filter) {
-  GRPC_LATENT_SEE_INNER_SCOPE(
+  GRPC_LATENT_SEE_SCOPE(
       "ServiceConfigChannelArgFilter::Call::OnClientInitialMetadata");
   const ServiceConfigParser::ParsedConfigVector* method_configs = nullptr;
   if (filter->service_config_ != nullptr) {

--- a/src/core/util/work_serializer.cc
+++ b/src/core/util/work_serializer.cc
@@ -187,7 +187,7 @@ void WorkSerializer::WorkSerializerImpl::Run(
 
 // Implementation of EventEngine::Closure::Run - our actual work loop
 void WorkSerializer::WorkSerializerImpl::Run() {
-  GRPC_LATENT_SEE_PARENT_SCOPE("WorkSerializer::Run");
+  GRPC_LATENT_SEE_SCOPE("WorkSerializer::Run");
   flow_.End();
   // TODO(ctiller): remove these when we can deprecate ExecCtx
   ExecCtx exec_ctx;

--- a/src/cpp/latent_see/latent_see_client.cc
+++ b/src/cpp/latent_see/latent_see_client.cc
@@ -1,0 +1,59 @@
+// Copyright 2025 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/cpp/latent_see/latent_see_client.h"
+
+#include <grpc/support/time.h>
+
+#include <chrono>
+
+namespace grpc {
+
+Status FetchLatentSee(latent_see::v1::LatentSee::Stub* stub, double sample_time,
+                      grpc_core::latent_see::Output* output) {
+  latent_see::v1::GetTraceRequest request;
+  request.set_sample_time(sample_time);
+  ClientContext context;
+  context.set_deadline(
+      std::chrono::system_clock::now() +
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          sample_time * std::chrono::seconds(1) + std::chrono::seconds(30)));
+  auto reader = stub->GetTrace(&context, request);
+  latent_see::v1::LatentSeeTrace trace;
+  while (reader->Read(&trace)) {
+    switch (trace.kind_case()) {
+      case latent_see::v1::LatentSeeTrace::KIND_NOT_SET:
+        continue;
+      case latent_see::v1::LatentSeeTrace::kMark:
+        output->Mark(trace.name(), trace.tid(), trace.timestamp());
+        break;
+      case latent_see::v1::LatentSeeTrace::kFlowBegin:
+        output->FlowBegin(trace.name(), trace.tid(), trace.timestamp(),
+                          trace.flow_begin().id());
+        break;
+      case latent_see::v1::LatentSeeTrace::kFlowEnd:
+        output->FlowEnd(trace.name(), trace.tid(), trace.timestamp(),
+                        trace.flow_end().id());
+        break;
+      case latent_see::v1::LatentSeeTrace::kSpan:
+        output->Span(trace.name(), trace.tid(), trace.timestamp(),
+                     trace.span().duration());
+        break;
+    }
+  }
+  output->Finish();
+  return reader->Finish();
+}
+
+}  // namespace grpc

--- a/src/cpp/latent_see/latent_see_client.h
+++ b/src/cpp/latent_see/latent_see_client.h
@@ -1,0 +1,23 @@
+// Copyright 2025 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/util/latent_see.h"
+#include "src/proto/grpc/latent_see/latent_see.grpc.pb.h"
+
+namespace grpc {
+
+Status FetchLatentSee(latent_see::v1::LatentSee::Stub* stub, double sample_time,
+                      grpc_core::latent_see::Output* output);
+
+}

--- a/src/cpp/latent_see/latent_see_service.cc
+++ b/src/cpp/latent_see/latent_see_service.cc
@@ -1,0 +1,83 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/cpp/latent_see/latent_see_service.h"
+
+#include "src/core/util/latent_see.h"
+
+namespace grpc {
+
+namespace {
+
+class StreamingOutput final : public grpc_core::latent_see::Output {
+ public:
+  explicit StreamingOutput(
+      ServerWriter<latent_see::v1::LatentSeeTrace>* response)
+      : response_(response) {}
+
+  void Mark(absl::string_view name, int64_t tid, int64_t timestamp) override {
+    latent_see::v1::LatentSeeTrace trace;
+    trace.set_name(name);
+    trace.set_tid(tid);
+    trace.set_timestamp(timestamp);
+    trace.mutable_mark();
+    response_->Write(trace);
+  }
+  void FlowBegin(absl::string_view name, int64_t tid, int64_t timestamp,
+                 int64_t flow_id) override {
+    latent_see::v1::LatentSeeTrace trace;
+    trace.set_name(name);
+    trace.set_tid(tid);
+    trace.set_timestamp(timestamp);
+    trace.mutable_flow_begin()->set_id(flow_id);
+    response_->Write(trace);
+  }
+  void FlowEnd(absl::string_view name, int64_t tid, int64_t timestamp,
+               int64_t flow_id) override {
+    latent_see::v1::LatentSeeTrace trace;
+    trace.set_name(name);
+    trace.set_tid(tid);
+    trace.set_timestamp(timestamp);
+    trace.mutable_flow_end()->set_id(flow_id);
+    response_->Write(trace);
+  }
+  void Span(absl::string_view name, int64_t tid, int64_t timestamp_begin,
+            int64_t duration) override {
+    latent_see::v1::LatentSeeTrace trace;
+    trace.set_name(name);
+    trace.set_tid(tid);
+    trace.set_timestamp(timestamp_begin);
+    trace.mutable_span()->set_duration(duration);
+    response_->Write(trace);
+  }
+  void Finish() override {}
+
+ private:
+  ServerWriter<latent_see::v1::LatentSeeTrace>* response_;
+};
+
+}  // namespace
+
+Status LatentSeeService::GetTrace(
+    ServerContext*, const latent_see::v1::GetTraceRequest* request,
+    ServerWriter<latent_see::v1::LatentSeeTrace>* response) {
+  StreamingOutput output(response);
+  grpc_core::latent_see::Collect(
+      nullptr,
+      absl::Seconds(std::min(options_.max_query_time, request->sample_time())),
+      options_.max_memory, &output);
+  return Status::OK;
+}
+
+}  // namespace grpc

--- a/src/cpp/latent_see/latent_see_service.h
+++ b/src/cpp/latent_see/latent_see_service.h
@@ -1,0 +1,50 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_SRC_CPP_SERVER_LATENT_SEE_LATENT_SEE_SERVICE_H
+#define GRPC_SRC_CPP_SERVER_LATENT_SEE_LATENT_SEE_SERVICE_H
+
+#include "src/proto/grpc/latent_see/latent_see.grpc.pb.h"
+
+namespace grpc {
+
+class LatentSeeService final : public latent_see::v1::LatentSee::Service {
+ public:
+  struct Options {
+    double max_query_time = 1.0;
+    size_t max_memory = 1024 * 1024;
+
+    Options& set_max_query_time(double max_query_time) {
+      this->max_query_time = max_query_time;
+      return *this;
+    }
+    Options& set_max_memory(size_t max_memory) {
+      this->max_memory = max_memory;
+      return *this;
+    }
+  };
+
+  explicit LatentSeeService(const Options& options) : options_(options) {}
+
+  Status GetTrace(
+      ServerContext*, const latent_see::v1::GetTraceRequest* request,
+      ServerWriter<latent_see::v1::LatentSeeTrace>* response) override;
+
+ private:
+  Options options_;
+};
+
+}  // namespace grpc
+
+#endif

--- a/src/proto/grpc/latent_see/BUILD
+++ b/src/proto/grpc/latent_see/BUILD
@@ -1,0 +1,39 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
+
+licenses(["notice"])
+
+grpc_package(
+    name = "latent_see",
+    visibility = "public",
+)
+
+# TODO(roth): Migrate this to use separate
+# grpc_internal_proto_library/grpc_cc_proto_library/grpc_cc_grpc_library
+# rules when internal build system limitations are resolved.
+grpc_proto_library(
+    name = "latent_see_proto",
+    srcs = ["latent_see.proto"],
+    has_services = True,
+    well_known_protos = True,
+)
+
+filegroup(
+    name = "latent_see_proto_file",
+    srcs = [
+        "latent_see.proto",
+    ],
+)

--- a/src/proto/grpc/latent_see/latent_see.proto
+++ b/src/proto/grpc/latent_see/latent_see.proto
@@ -1,0 +1,58 @@
+// Copyright 2025 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file defines an interface for exporting monitoring information
+// out of gRPC servers.  See the full design at
+// https://github.com/grpc/proposal/blob/master/A14-channelz.md
+//
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/channelz/v1/channelz.proto
+
+syntax = "proto3";
+
+package grpc.latent_see.v1;
+
+message LatentSeeTrace {
+  message FlowBegin {
+    int64 id = 1;
+  }
+  message FlowEnd {
+    int64 id = 1;
+  }
+  message Mark {}
+  message Span {
+    int64 duration = 1;
+  }
+
+  string name = 1;
+  int64 tid = 2;
+  int64 timestamp = 3;
+  oneof kind {
+    FlowBegin flow_begin = 4;
+    FlowEnd flow_end = 5;
+    Mark mark = 6;
+    Span span = 7;
+  }
+}
+
+message GetTraceRequest {
+  double sample_time = 1;
+}
+
+// LatentSee is a service exposed by gRPC servers that provides high fidelity trace information.
+service LatentSee {
+  // Query for a trace. Note that no traces will be returned until sample_time expires, and so the
+  // deadline for this request must be greater than that.
+  rpc GetTrace(GetTraceRequest) returns (stream LatentSeeTrace);
+}

--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -83,6 +83,17 @@ grpc_cc_benchmark(
     ],
 )
 
+grpc_cc_benchmark(
+    name = "bm_latent_see",
+    srcs = ["bm_latent_see.cc"],
+    external_deps = [
+    ],
+    monitoring = HISTORY,
+    deps = [
+        "//src/core:latent_see",
+    ],
+)
+
 grpc_cc_test(
     name = "examine_stack_test",
     srcs = ["examine_stack_test.cc"],

--- a/test/core/util/bm_latent_see.cc
+++ b/test/core/util/bm_latent_see.cc
@@ -1,0 +1,57 @@
+// Copyright 2024 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <random>
+#include <thread>
+
+#include "src/core/util/latent_see.h"
+
+namespace grpc_core {
+
+static void BM_EmptyDisabledScoped(benchmark::State& state) {
+  for (auto _ : state) {
+    GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("EmptyScoped");
+  }
+}
+BENCHMARK(BM_EmptyDisabledScoped);
+
+static void BM_EmptyEnabledScoped(benchmark::State& state) {
+  Notification n;
+  std::thread collector([&n]() {
+    latent_see::DiscardOutput output;
+    latent_see::Collect(&n, absl::Hours(24), 1024 * 1024 * 1024, &output);
+  });
+  for (auto _ : state) {
+    GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("EmptyScoped");
+  }
+  n.Notify();
+  collector.join();
+}
+BENCHMARK(BM_EmptyEnabledScoped)->MinWarmUpTime(0.5);
+
+}  // namespace grpc_core
+
+// Some distros have RunSpecifiedBenchmarks under the benchmark namespace,
+// and others do not. This allows us to support both modes.
+namespace benchmark {
+void RunTheBenchmarksNamespaced() { RunSpecifiedBenchmarks(); }
+}  // namespace benchmark
+
+int main(int argc, char** argv) {
+  ::benchmark::Initialize(&argc, argv);
+  benchmark::RunTheBenchmarksNamespaced();
+  return 0;
+}

--- a/test/cpp/microbenchmarks/fullstack_unary_ping_pong.h
+++ b/test/cpp/microbenchmarks/fullstack_unary_ping_pong.h
@@ -41,7 +41,7 @@ static void* tag(intptr_t x) { return reinterpret_cast<void*>(x); }
 
 template <class Fixture, class ClientContextMutator, class ServerContextMutator>
 static void BM_UnaryPingPong(benchmark::State& state) {
-  GRPC_LATENT_SEE_PARENT_SCOPE("BM_UnaryPingPong");
+  GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("BM_UnaryPingPong");
   EchoTestService::AsyncService service;
   std::unique_ptr<Fixture> fixture(new Fixture(&service));
   EchoRequest send_request;
@@ -75,7 +75,7 @@ static void BM_UnaryPingPong(benchmark::State& state) {
   std::unique_ptr<EchoTestService::Stub> stub(
       EchoTestService::NewStub(fixture->channel()));
   for (auto _ : state) {
-    GRPC_LATENT_SEE_PARENT_SCOPE("OneRequest");
+    GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("OneRequest");
     recv_response.Clear();
     ClientContext cli_ctx;
     ClientContextMutator cli_ctx_mut(&cli_ctx);
@@ -85,7 +85,7 @@ static void BM_UnaryPingPong(benchmark::State& state) {
     void* t;
     bool ok;
     {
-      GRPC_LATENT_SEE_INNER_SCOPE("WaitForRequest");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("WaitForRequest");
       CHECK(fixture->cq()->Next(&t, &ok));
     }
     CHECK(ok);
@@ -95,7 +95,7 @@ static void BM_UnaryPingPong(benchmark::State& state) {
     ServerContextMutator svr_ctx_mut(&senv->ctx);
     senv->response_writer.Finish(send_response, Status::OK, tag(3));
     {
-      GRPC_LATENT_SEE_INNER_SCOPE("WaitForCqs");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("WaitForCqs");
       for (int i = (1 << 3) | (1 << 4); i != 0;) {
         CHECK(fixture->cq()->Next(&t, &ok));
         CHECK(ok);
@@ -106,7 +106,7 @@ static void BM_UnaryPingPong(benchmark::State& state) {
       CHECK(recv_status.ok());
     }
     {
-      GRPC_LATENT_SEE_INNER_SCOPE("RequestEcho");
+      GRPC_LATENT_SEE_ALWAYS_ON_SCOPE("RequestEcho");
       senv->~ServerEnv();
       senv = new (senv) ServerEnv();
       service.RequestEcho(&senv->ctx, &senv->recv_request,

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -66,6 +66,7 @@ grpc_cc_library(
         "//test/core/test_util:grpc_test_util",
         "//test/cpp/util:test_config",
         "//test/cpp/util:test_util",
+        "//:grpcpp_latent_see_service",
     ],
 )
 
@@ -94,6 +95,7 @@ grpc_cc_library(
         "//src/proto/grpc/testing:worker_service_cc_grpc",
         "//test/core/test_util:grpc_test_util",
         "//test/cpp/util:test_util",
+        "//:grpcpp_latent_see_client",
     ],
 )
 

--- a/test/cpp/qps/driver.h
+++ b/test/cpp/qps/driver.h
@@ -34,7 +34,8 @@ std::unique_ptr<ScenarioResult> RunScenario(
     const std::string& qps_server_target_override,
     const std::string& credential_type,
     const std::map<std::string, std::string>& per_worker_credential_types,
-    bool run_inproc, int32_t median_latency_collection_interval_millis);
+    bool run_inproc, int32_t median_latency_collection_interval_millis,
+    const std::optional<std::string>& latent_see_directory);
 
 bool RunQuit(
     const std::string& credential_type,

--- a/test/cpp/qps/qps_json_driver.cc
+++ b/test/cpp/qps/qps_json_driver.cc
@@ -83,6 +83,8 @@ ABSL_FLAG(
     "Specifies the period between gathering latency medians in "
     "milliseconds. The medians will be logged out on the client at the "
     "end of the benchmark run. If 0, this periodic collection is disabled.");
+ABSL_FLAG(std::optional<std::string>, gather_latent_see_dir, std::nullopt,
+          "Enable latent-see collection and output to this directory.");
 
 namespace grpc {
 namespace testing {
@@ -132,7 +134,8 @@ static std::unique_ptr<ScenarioResult> RunAndReport(
       absl::GetFlag(FLAGS_qps_server_target_override),
       absl::GetFlag(FLAGS_credential_type), per_worker_credential_types,
       absl::GetFlag(FLAGS_run_inproc),
-      absl::GetFlag(FLAGS_median_latency_collection_interval_millis));
+      absl::GetFlag(FLAGS_median_latency_collection_interval_millis),
+      absl::GetFlag(FLAGS_gather_latent_see_dir));
 
   // Amend the result with scenario config. Eventually we should adjust
   // RunScenario contract so we don't need to touch the result here.

--- a/test/cpp/qps/qps_worker.h
+++ b/test/cpp/qps/qps_worker.h
@@ -26,6 +26,7 @@
 
 #include <memory>
 
+#include "src/cpp/latent_see/latent_see_service.h"
 #include "test/cpp/qps/server.h"
 
 namespace grpc {
@@ -51,6 +52,7 @@ class QpsWorker {
 
  private:
   std::unique_ptr<WorkerServiceImpl> impl_;
+  std::unique_ptr<LatentSeeService> latent_see_;
   std::unique_ptr<grpc::Server> server_;
 
   gpr_atm done_;


### PR DESCRIPTION
Change up latent-see so that it's an always-on thing.

Most of the testing code we've got so far should be updated to use `grpc_core::latent_see::Collect()` - there's a JSON exporter there, and I plan to implement a Fuchsia Trace Format one eventually too (much more compact trace representaton!).

Also added is a service (visibility protected!) that we'll be able to share with partners to allow collecting this data from real systems. That part is strictly opt-in for the moment.