### PR TITLE
Fix a few typos in the ruby client

### DIFF
--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -380,7 +380,7 @@ static VALUE grpc_rb_prefork(VALUE self) {
     rb_raise(rb_eRuntimeError,
              "GRPC.prefork and fork need to be called from the same thread "
              "that GRPC was initialized on (GRPC lazy-initializes when when "
-             "the first GRPC object is created");
+             "the first GRPC object is created)");
   }
   if (g_grpc_rb_num_fork_unsafe_threads > 0) {
     rb_raise(

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -60,7 +60,7 @@ module GRPC
     # Minimally, a stub is created with the just the host of the gRPC service
     # it wishes to access, e.g.,
     #
-    #   my_stub = ClientStub.new(example.host.com:50505,
+    #   my_stub = ClientStub.new("example.host.com:50505",
     #                            :this_channel_is_insecure)
     #
     # If a channel_override argument is passed, it will be used as the
@@ -72,7 +72,7 @@ module GRPC
     #
     # - :channel_override
     # when present, this must be a pre-created GRPC::Core::Channel.  If it's
-    # present the host and arbitrary keyword arg areignored, and the RPC
+    # present the host and arbitrary keyword args are ignored, and the RPC
     # connection uses this channel.
     #
     # - :timeout
@@ -118,11 +118,11 @@ module GRPC
     #
     # * it does not return until a response is received.
     #
-    # * the requests is sent only when GRPC core's flow control allows it to
+    # * the request is sent only when GRPC core's flow control allows it to
     #   be sent.
     #
     # == Errors ==
-    # An RuntimeError is raised if
+    # A RuntimeError is raised if
     #
     # * the server responds with a non-OK status
     #


### PR DESCRIPTION
- **Fix typos and a doc syntax error in ruby client client_stub.rb**
- **Close opened paren in error message**
