### PR TITLE
[ruby] enable EE fork support

### DIFF
--- a/src/ruby/end2end/bad_usage_fork_test.rb
+++ b/src/ruby/end2end/bad_usage_fork_test.rb
@@ -16,6 +16,8 @@
 
 ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
 fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+# TODO(apolcyn): remove after this experiment is on by default
+ENV['GRPC_EXPERIMENTS'] = "event_engine_fork"
 
 this_dir = File.expand_path(File.dirname(__FILE__))
 protos_lib_dir = File.join(this_dir, 'lib')

--- a/src/ruby/end2end/fork_test_repro_35489.rb
+++ b/src/ruby/end2end/fork_test_repro_35489.rb
@@ -16,6 +16,8 @@
 
 ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
 fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+# TODO(apolcyn): remove after this experiment is on by default
+ENV['GRPC_EXPERIMENTS'] = "event_engine_fork"
 
 this_dir = File.expand_path(File.dirname(__FILE__))
 protos_lib_dir = File.join(this_dir, 'lib')

--- a/src/ruby/end2end/prefork_postfork_loop_test.rb
+++ b/src/ruby/end2end/prefork_postfork_loop_test.rb
@@ -16,6 +16,8 @@
 
 ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
 fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+# TODO(apolcyn): remove after this experiment is on by default
+ENV['GRPC_EXPERIMENTS'] = "event_engine_fork"
 
 this_dir = File.expand_path(File.dirname(__FILE__))
 protos_lib_dir = File.join(this_dir, 'lib')

--- a/src/ruby/end2end/prefork_without_using_grpc_test.rb
+++ b/src/ruby/end2end/prefork_without_using_grpc_test.rb
@@ -16,6 +16,8 @@
 
 ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
 fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+# TODO(apolcyn): remove after this experiment is on by default
+ENV['GRPC_EXPERIMENTS'] = "event_engine_fork"
 
 this_dir = File.expand_path(File.dirname(__FILE__))
 protos_lib_dir = File.join(this_dir, 'lib')

--- a/src/ruby/end2end/simple_fork_test.rb
+++ b/src/ruby/end2end/simple_fork_test.rb
@@ -16,6 +16,8 @@
 
 ENV['GRPC_ENABLE_FORK_SUPPORT'] = "1"
 fail "forking only supported on linux" unless RUBY_PLATFORM =~ /linux/
+# TODO(apolcyn): remove after this experiment is on by default
+ENV['GRPC_EXPERIMENTS'] = "event_engine_fork"
 
 this_dir = File.expand_path(File.dirname(__FILE__))
 protos_lib_dir = File.join(this_dir, 'lib')

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -114,6 +114,8 @@ env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_NAME_SUFFIX="\"RUBY\""'
 require_relative '../../lib/grpc/version'
 env_append 'CPPFLAGS', '-DGRPC_XDS_USER_AGENT_VERSION_SUFFIX="\"' + GRPC::VERSION + '\""'
 env_append 'CPPFLAGS', '-DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1'
+env_append 'CPPFLAGS', '-DGRPC_ENABLE_FORK_SUPPORT=1'
+env_append 'CPPFLAGS', '-DGRPC_ENABLE_FORK_SUPPORT_DEFAULT=false'
 
 output_dir = File.expand_path(RbConfig::CONFIG['topdir'])
 grpc_lib_dir = File.join(output_dir, 'libs', grpc_config)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -985,6 +985,21 @@ class RubyLanguage(object):
             "src/ruby/end2end/call_credentials_timeout_test.rb",
             "src/ruby/end2end/call_credentials_returning_bad_metadata_doesnt_kill_background_thread_test.rb",
         ]:
+            if (
+                test
+                in [
+                    "src/ruby/end2end/fork_test.rb",
+                    "src/ruby/end2end/simple_fork_test.rb",
+                    "src/ruby/end2end/secure_fork_test.rb",
+                    "src/ruby/end2end/bad_usage_fork_test.rb",
+                    "src/ruby/end2end/prefork_without_using_grpc_test.rb",
+                    "src/ruby/end2end/prefork_postfork_loop_test.rb",
+                    "src/ruby/end2end/fork_test_repro_35489.rb",
+                ]
+                and self.platform == "mac"
+            ):
+                # Fork support only present on linux
+                continue
             tests.append(
                 self.config.job_spec(
                     ["ruby", test],

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -972,6 +972,7 @@ class RubyLanguage(object):
             "src/ruby/end2end/channel_closing_test.rb",
             "src/ruby/end2end/killed_client_thread_test.rb",
             "src/ruby/end2end/forking_client_test.rb",
+            "src/ruby/end2end/fork_test_repro_35489.rb",
             "src/ruby/end2end/multiple_killed_watching_threads_test.rb",
             "src/ruby/end2end/client_memory_usage_test.rb",
             "src/ruby/end2end/package_with_underscore_test.rb",
@@ -984,21 +985,6 @@ class RubyLanguage(object):
             "src/ruby/end2end/call_credentials_timeout_test.rb",
             "src/ruby/end2end/call_credentials_returning_bad_metadata_doesnt_kill_background_thread_test.rb",
         ]:
-            if test in [
-                "src/ruby/end2end/fork_test.rb",
-                "src/ruby/end2end/simple_fork_test.rb",
-                "src/ruby/end2end/secure_fork_test.rb",
-                "src/ruby/end2end/bad_usage_fork_test.rb",
-                "src/ruby/end2end/prefork_without_using_grpc_test.rb",
-                "src/ruby/end2end/prefork_postfork_loop_test.rb",
-                "src/ruby/end2end/fork_test_repro_35489.rb",
-            ]:
-                # Skip fork tests in general until https://github.com/grpc/grpc/issues/34442
-                # is fixed. Otherwise we see too many flakes.
-                # After that's fixed, we should continue to skip on mac
-                # indefinitely, and on "dbg" builds until the Event Engine
-                # migration completes.
-                continue
             tests.append(
                 self.config.job_spec(
                     ["ruby", test],

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -996,7 +996,7 @@ class RubyLanguage(object):
                     "src/ruby/end2end/prefork_postfork_loop_test.rb",
                     "src/ruby/end2end/fork_test_repro_35489.rb",
                 ]
-                and self.platform == "mac"
+                and platform_string() == "mac"
             ):
                 # Fork support only present on linux
                 continue


### PR DESCRIPTION
Now that https://github.com/grpc/grpc/pull/38980 has merged

Re-enable long-disabled tests

