### PR TITLE
[channel] Add experimental API to retrieve channelz uuid

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2385,6 +2385,7 @@ grpc_cc_library(
     tags = ["nofixdeps"],
     visibility = ["//bazel:alt_grpc++_base_legacy"],
     deps = [
+        "channel",
         "channel_arg_names",
         "channel_stack_builder",
         "config",
@@ -2479,6 +2480,7 @@ grpc_cc_library(
     ],
     visibility = ["//bazel:alt_grpc++_base_unsecure_legacy"],
     deps = [
+        "channel",
         "channel_arg_names",
         "channel_stack_builder",
         "config",

--- a/include/grpcpp/channel.h
+++ b/include/grpcpp/channel.h
@@ -48,6 +48,11 @@ namespace experimental {
 /// TODO(roth): Once we see whether this proves useful, either create a gRFC
 /// and change this to be a method of the Channel class, or remove it.
 void ChannelResetConnectionBackoff(Channel* channel);
+
+/// Retrieves a channel's channelz uuid
+/// TODO(ctiller): Once we see whether this proves useful, either create a gRFC
+/// and change this to be a method of the Channel class, or remove it.
+int64_t ChannelGetChannelzUuid(Channel* channel);
 }  // namespace experimental
 
 /// Channels represent a connection to an endpoint. Created by \a CreateChannel.
@@ -74,6 +79,7 @@ class Channel final : public grpc::ChannelInterface,
   friend class grpc::internal::BlockingUnaryCallImpl;
   friend class grpc::testing::ChannelTestPeer;
   friend void experimental::ChannelResetConnectionBackoff(Channel* channel);
+  friend int64_t experimental::ChannelGetChannelzUuid(Channel* channel);
   friend std::shared_ptr<Channel> grpc::CreateChannelInternal(
       const std::string& host, grpc_channel* c_channel,
       std::vector<std::unique_ptr<

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -41,6 +41,7 @@
 
 #include "absl/log/check.h"
 #include "src/core/lib/iomgr/iomgr.h"
+#include "src/core/lib/surface/channel.h"
 
 namespace grpc {
 
@@ -103,6 +104,12 @@ namespace experimental {
 
 void ChannelResetConnectionBackoff(Channel* channel) {
   grpc_channel_reset_connect_backoff(channel->c_channel_);
+}
+
+int64_t ChannelGetChannelzUuid(Channel* channel) {
+  auto* node = grpc_channel_get_channelz_node(channel->c_channel_);
+  if (node == nullptr) return 0;
+  return node->uuid();
 }
 
 }  // namespace experimental


### PR DESCRIPTION
We'll use this for post-mortem debugging failed connections in a few workloads.