### PR TITLE
Support grpc.server.* metric reporting in grpc.aio

### DIFF
--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Optional, Sequence
 import grpc
 from grpc import _common
 from grpc import _compression
+from grpc import _observability
 from grpc._cython import cygrpc
 
 from . import _base_server
@@ -30,8 +31,10 @@ def _augment_channel_arguments(
     base_options: ChannelArgumentType, compression: Optional[grpc.Compression]
 ):
     compression_option = _compression.create_channel_option(compression)
-    return tuple(base_options) + compression_option
-
+    maybe_server_call_tracer_factory_option = (
+        _observability.create_server_call_tracer_factory_option(False)
+    )
+    return tuple(base_options) + compression_option + maybe_server_call_tracer_factory_option
 
 class Server(_base_server.Server):
     """Serves RPCs."""


### PR DESCRIPTION
Fixes #39800.

The fix is rather easy: we were just missing some options.

I tested this on a GCE service that the metrics did show up in GCE metrics explorer after this change.

I copied the local edits via github UI (may need some touch ups)

@XuanWang-Amos 
