### PR TITLE
[channelz] Add a property list type

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4793,6 +4793,7 @@ grpc_cc_library(
         "//src/core:transport_framing_endpoint_extension",
         "//src/core:useful",
         "//src/core:write_size_policy",
+        "//src/core:channelz_property_list"
     ],
 )
 

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -9961,6 +9961,15 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "channelz_property_list",
+    hdrs = ["channelz/property_list.h"],
+    deps = ["json", "time"],
+    external_deps = [
+        "absl/strings",
+    ]
+)
+
+grpc_cc_library(
     name = "ssl_transport_security_utils",
     srcs = [
         "//src/core:tsi/ssl_transport_security_utils.cc",

--- a/src/core/channelz/property_list.h
+++ b/src/core/channelz/property_list.h
@@ -1,0 +1,78 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_SRC_CORE_CHANNELZ_PROPERTY_LIST_H
+#define GRPC_SRC_CORE_CHANNELZ_PROPERTY_LIST_H
+
+#include <type_traits>
+
+#include "absl/strings/string_view.h"
+#include "src/core/util/json/json.h"
+#include "src/core/util/string.h"
+#include "src/core/util/time.h"
+
+namespace grpc_core::channelz {
+
+// PropertyList contains a bag of key->value (for mostly arbitrary value types)
+// for reporting out state from channelz - the big idea is that you should be
+// able to call `PropertyList().Set("a", this->a)` and generate something that
+// channelz presenters can interpret.
+// It's currently defined in terms of JSON, but as we adopt channelz-v2 it's
+// expected we'll change this to capture protobuf directly.
+class PropertyList {
+ public:
+  PropertyList& Set(absl::string_view key, absl::string_view value) {
+    property_list_.emplace(key, Json::FromString(std::string(value)));
+    return *this;
+  }
+
+  PropertyList& Set(absl::string_view key, std::string value) {
+    property_list_.emplace(key, Json::FromString(std::move(value)));
+    return *this;
+  }
+
+  template <typename T>
+  std::enable_if_t<std::is_arithmetic_v<T>, PropertyList&> Set(
+      absl::string_view key, T value) {
+    property_list_.emplace(key, Json::FromNumber(value));
+    return *this;
+  }
+
+  PropertyList& Set(absl::string_view key, Json::Object obj) {
+    property_list_.emplace(key, Json::FromObject(std::move(obj)));
+    return *this;
+  }
+
+  PropertyList& Set(absl::string_view key, Duration dur) {
+    property_list_.emplace(key, Json::FromString(dur.ToJsonString()));
+    return *this;
+  }
+
+  PropertyList& Set(absl::string_view key, Timestamp ts) {
+    property_list_.emplace(key, Json::FromString(gpr_format_timespec(
+                                    ts.as_timespec(GPR_CLOCK_REALTIME))));
+    return *this;
+  }
+
+  // TODO(ctiller): remove soon, switch to something returning a protobuf.
+  Json::Object TakeJsonObject() { return std::move(property_list_); }
+
+ private:
+  // TODO(ctiller): switch to a protobuf representation
+  Json::Object property_list_;
+};
+
+}  // namespace grpc_core::channelz
+
+#endif

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -59,6 +59,7 @@
 #include "absl/time/time.h"
 #include "src/core/call/metadata_batch.h"
 #include "src/core/call/metadata_info.h"
+#include "src/core/channelz/property_list.h"
 #include "src/core/config/config_vars.h"
 #include "src/core/ext/transport/chttp2/transport/call_tracer_wrapper.h"
 #include "src/core/ext/transport/chttp2/transport/flow_control.h"
@@ -602,58 +603,47 @@ void grpc_chttp2_transport::ChannelzDataSource::AddData(
         grpc_core::NewClosure([t, sink = std::move(sink)](
                                   grpc_error_handle) mutable {
           Json::Object http2_info;
-          http2_info["flowControl"] =
-              Json::FromObject(t->flow_control.stats().ToJsonObject());
-          Json::Object misc;
-          misc["maxRequestsPerRead"] =
-              Json::FromNumber(static_cast<int64_t>(t->max_requests_per_read));
-          misc["nextStreamId"] = Json::FromNumber(t->next_stream_id);
-          misc["lastNewStreamId"] = Json::FromNumber(t->last_new_stream_id);
-          misc["numIncomingStreamsBeforeSettingsAck"] =
-              Json::FromNumber(t->num_incoming_streams_before_settings_ack);
-          misc["pingAckCount"] =
-              Json::FromNumber(static_cast<int64_t>(t->ping_ack_count));
-          misc["allowTarpit"] = Json::FromBool(t->allow_tarpit);
-          if (t->allow_tarpit) {
-            misc["minTarpitDurationMs"] =
-                Json::FromNumber(t->min_tarpit_duration_ms);
-            misc["maxTarpitDurationMs"] =
-                Json::FromNumber(t->max_tarpit_duration_ms);
-          }
-          misc["keepaliveTime"] =
-              Json::FromString(t->keepalive_time.ToJsonString());
-          misc["nextAdjustedKeepaliveTimestamp"] =
-              Json::FromString((t->next_adjusted_keepalive_timestamp -
-                                grpc_core::Timestamp::Now())
-                                   .ToJsonString());
-          misc["numMessagesInNextWrite"] =
-              Json::FromNumber(t->num_messages_in_next_write);
-          misc["numPendingInducedFrames"] =
-              Json::FromNumber(t->num_pending_induced_frames);
-          misc["writeBufferSize"] = Json::FromNumber(t->write_buffer_size);
-          misc["readingPausedOnPendingInducedFrames"] =
-              Json::FromBool(t->reading_paused_on_pending_induced_frames);
-          misc["enablePreferredRxCryptoFrameAdvertisement"] =
-              Json::FromBool(t->enable_preferred_rx_crypto_frame_advertisement);
-          misc["keepalivePermitWithoutCalls"] =
-              Json::FromBool(t->keepalive_permit_without_calls);
-          misc["bdpPingBlocked"] = Json::FromBool(t->bdp_ping_blocked);
-          misc["bdpPingStarted"] = Json::FromBool(t->bdp_ping_started);
-          misc["ackPings"] = Json::FromBool(t->ack_pings);
-          misc["keepaliveIncomingDataWanted"] =
-              Json::FromBool(t->keepalive_incoming_data_wanted);
-          misc["maxConcurrentStreamsOverloadProtection"] =
-              Json::FromBool(t->max_concurrent_streams_overload_protection);
-          misc["maxConcurrentStreamsRejectOnClient"] =
-              Json::FromBool(t->max_concurrent_streams_reject_on_client);
-          misc["pingOnRstStreamPercent"] =
-              Json::FromNumber(t->ping_on_rst_stream_percent);
-          misc["lastWindowUpdateAge"] = Json::FromString(
-              (grpc_core::Timestamp::Now() - t->last_window_update_time)
-                  .ToJsonString());
-          http2_info["misc"] = Json::FromObject(std::move(misc));
-          http2_info["settings"] = Json::FromObject(t->settings.ToJsonObject());
-          sink.AddAdditionalInfo("http2", std::move(http2_info));
+          sink.AddAdditionalInfo(
+              "http2",
+              grpc_core::channelz::PropertyList()
+                  .Set("max_requests_per_read", t->max_requests_per_read)
+                  .Set("next_stream_id", t->next_stream_id)
+                  .Set("last_new_stream_id", t->last_new_stream_id)
+                  .Set("num_incoming_streams_before_settings_ack",
+                       t->num_incoming_streams_before_settings_ack)
+                  .Set("ping_ack_count", t->ping_ack_count)
+                  .Set("allow_tarpit", t->allow_tarpit)
+                  .Set("min_tarpit_duration_ms", t->min_tarpit_duration_ms)
+                  .Set("max_tarpit_duration_ms", t->max_tarpit_duration_ms)
+                  .Set("keepalive_time", t->keepalive_time)
+                  .Set("next_adjusted_keepalive_timestamp",
+                       t->next_adjusted_keepalive_timestamp)
+                  .Set("num_messages_in_next_write",
+                       t->num_messages_in_next_write)
+                  .Set("num_pending_induced_frames",
+                       t->num_pending_induced_frames)
+                  .Set("write_buffer_size", t->write_buffer_size)
+                  .Set("reading_paused_on_pending_induced_frames",
+                       t->reading_paused_on_pending_induced_frames)
+                  .Set("enable_preferred_rx_crypto_frame_advertisement",
+                       t->enable_preferred_rx_crypto_frame_advertisement)
+                  .Set("keepalive_permit_without_calls",
+                       t->keepalive_permit_without_calls)
+                  .Set("bdp_ping_blocked", t->bdp_ping_blocked)
+                  .Set("bdp_ping_started", t->bdp_ping_started)
+                  .Set("ack_pings", t->ack_pings)
+                  .Set("keepalive_incoming_data_wanted",
+                       t->keepalive_incoming_data_wanted)
+                  .Set("max_concurrent_streams_overload_protection",
+                       t->max_concurrent_streams_overload_protection)
+                  .Set("max_concurrent_streams_reject_on_client",
+                       t->max_concurrent_streams_reject_on_client)
+                  .Set("ping_on_rst_stream_percent",
+                       t->ping_on_rst_stream_percent)
+                  .Set("last_window_update", t->last_window_update_time)
+                  .Set("settings", t->settings.ToJsonObject())
+                  .Set("flow_control", t->flow_control.stats().ToJsonObject())
+                  .TakeJsonObject());
           std::vector<grpc_core::RefCountedPtr<grpc_core::channelz::BaseNode>>
               children;
           children.reserve(t->stream_map.size());

--- a/test/core/channelz/BUILD
+++ b/test/core/channelz/BUILD
@@ -41,6 +41,18 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "property_list_test",
+    srcs = ["property_list_test.cc"],
+    external_deps = [
+        "gtest",
+        "gtest_main",
+    ],
+    deps = [
+        "//src/core:channelz_property_list"
+    ],
+)
+
+grpc_cc_test(
     name = "channelz_test",
     srcs = ["channelz_test.cc"],
     external_deps = [

--- a/test/core/channelz/property_list_test.cc
+++ b/test/core/channelz/property_list_test.cc
@@ -82,5 +82,32 @@ TEST(PropertyListTest, SetJsonObject) {
   EXPECT_EQ(retrieved_inner_obj.at("inner_key").string(), "inner_value");
 }
 
+TEST(PropertyListTest, SetDuration) {
+  PropertyList props;
+  props.Set("duration_key", Duration::Seconds(5));
+  Json::Object json_obj = props.TakeJsonObject();
+  ASSERT_EQ(json_obj.size(), 1);
+  auto it = json_obj.find("duration_key");
+  ASSERT_NE(it, json_obj.end());
+  EXPECT_EQ(it->second.type(), Json::Type::kString);
+  EXPECT_EQ(it->second.string(), "5.000000000s");
+}
+
+TEST(PropertyListTest, SetTimestamp) {
+  PropertyList props;
+  // Using a known epoch time for consistent testing.
+  // January 1, 2023 00:00:00 UTC
+  gpr_timespec ts_known = {1672531200, 0, GPR_CLOCK_REALTIME};
+  Timestamp timestamp = Timestamp::FromTimespecRoundDown(ts_known);
+  props.Set("timestamp_key", timestamp);
+  Json::Object json_obj = props.TakeJsonObject();
+  ASSERT_EQ(json_obj.size(), 1);
+  auto it = json_obj.find("timestamp_key");
+  ASSERT_NE(it, json_obj.end());
+  EXPECT_EQ(it->second.type(), Json::Type::kString);
+  EXPECT_THAT(it->second.string(),
+              ::testing::StartsWith("2023-01-01T00:00:00.0"));
+}
+
 }  // namespace channelz
 }  // namespace grpc_core

--- a/test/core/channelz/property_list_test.cc
+++ b/test/core/channelz/property_list_test.cc
@@ -1,0 +1,86 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/core/channelz/property_list.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/core/util/json/json.h"
+
+namespace grpc_core {
+namespace channelz {
+
+TEST(PropertyListTest, EmptyList) {
+  PropertyList props;
+  Json::Object json_obj = props.TakeJsonObject();
+  EXPECT_TRUE(json_obj.empty());
+}
+
+TEST(PropertyListTest, SetStringView) {
+  PropertyList props;
+  props.Set("key1", absl::string_view("value1"));
+  Json::Object json_obj = props.TakeJsonObject();
+  ASSERT_EQ(json_obj.size(), 1);
+  auto it = json_obj.find("key1");
+  ASSERT_NE(it, json_obj.end());
+  EXPECT_EQ(it->second.type(), Json::Type::kString);
+  EXPECT_EQ(it->second.string(), "value1");
+}
+
+TEST(PropertyListTest, SetStdString) {
+  PropertyList props;
+  props.Set("key2", std::string("value2"));
+  Json::Object json_obj = props.TakeJsonObject();
+  ASSERT_EQ(json_obj.size(), 1);
+  auto it = json_obj.find("key2");
+  ASSERT_NE(it, json_obj.end());
+  EXPECT_EQ(it->second.type(), Json::Type::kString);
+  EXPECT_EQ(it->second.string(), "value2");
+}
+
+TEST(PropertyListTest, SetArithmetic) {
+  PropertyList props;
+  props.Set("int_key", 123);
+  props.Set("double_key", 45.67);
+  Json::Object json_obj = props.TakeJsonObject();
+  ASSERT_EQ(json_obj.size(), 2);
+
+  auto it_int = json_obj.find("int_key");
+  ASSERT_NE(it_int, json_obj.end());
+  EXPECT_EQ(it_int->second.type(), Json::Type::kNumber);
+  EXPECT_EQ(it_int->second.string(), "123");
+
+  auto it_double = json_obj.find("double_key");
+  ASSERT_NE(it_double, json_obj.end());
+  EXPECT_EQ(it_double->second.type(), Json::Type::kNumber);
+  EXPECT_EQ(it_double->second.string(), "45.67");
+}
+
+TEST(PropertyListTest, SetJsonObject) {
+  PropertyList props;
+  Json::Object inner_obj;
+  inner_obj["inner_key"] = Json::FromString("inner_value");
+  props.Set("obj_key", std::move(inner_obj));
+  Json::Object json_obj = props.TakeJsonObject();
+  ASSERT_EQ(json_obj.size(), 1);
+  auto it_obj = json_obj.find("obj_key");
+  ASSERT_NE(it_obj, json_obj.end());
+  ASSERT_EQ(it_obj->second.type(), Json::Type::kObject);
+  const auto& retrieved_inner_obj = it_obj->second.object();
+  ASSERT_EQ(retrieved_inner_obj.size(), 1);
+  EXPECT_EQ(retrieved_inner_obj.at("inner_key").string(), "inner_value");
+}
+
+}  // namespace channelz
+}  // namespace grpc_core


### PR DESCRIPTION
Starting towards a transition to channelz-v2 - I'm adding this and probably some more container types for variously shaped generic output mechanisms.

The final protobufs we use will be a combination of structures that can back this and structures that are tuned specifically for various subsystems that don't represent cleanly here.

As soon as is practicable I'll be removing the JSON backing and transitioning everything to be implemented directly atop protobufs, and having shims such as this in place will greatly help that effort.