### PR TITLE
DO NOT SUBMIT - testing gRPC gcc7 build with abseil @ HEAD

### DIFF
--- a/src/core/lib/resource_quota/arena.h
+++ b/src/core/lib/resource_quota/arena.h
@@ -406,7 +406,7 @@ class ArenaSpsc {
     T result = std::move(next->value);
     Destruct(&next->value);
     tail_.store(next, std::memory_order_release);
-    return result;
+    return std::move(result);
   }
 
   // Iterate over queued nodes. At most one thread can be calling this at a

--- a/test/core/call/filter_fusion_test.cc
+++ b/test/core/call/filter_fusion_test.cc
@@ -135,12 +135,12 @@ class Test3 : public ImplementChannelFilter<Test3> {
     absl::StatusOr<MessageHandle> OnClientToServerMessage(MessageHandle handle,
                                                           Test3*) {
       history.push_back("Test3::Call::OnClientToServerMessage");
-      return handle;
+      return std::move(handle);
     }
     absl::StatusOr<MessageHandle> OnServerToClientMessage(MessageHandle handle,
                                                           Test3*) {
       history.push_back("Test3::Call::OnServerToClientMessage");
-      return handle;
+      return std::move(handle);
     }
     void OnServerTrailingMetadata(ServerMetadata&) {
       history.push_back("Test3::Call::OnServerTrailingMetadata");

--- a/test/core/xds/xds_metadata_test.cc
+++ b/test/core/xds/xds_metadata_test.cc
@@ -108,7 +108,7 @@ class XdsMetadataTest : public ::testing::Test {
       return errors.status(absl::StatusCode::kInvalidArgument,
                            "validation failed");
     }
-    return metadata_map;
+    return std::move(metadata_map);
   }
 
   absl::StatusOr<XdsMetadataMap> Decode(Metadata proto) {

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -30,7 +30,13 @@ SUBMODULE_NAME="${RUN_TESTS_FLAGS}"
 SUBMODULE_BRANCH_NAME="${BAZEL_FLAGS:-master}"
 
 # Update submodule to be tested at HEAD
-(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout "origin/${SUBMODULE_BRANCH_NAME}")
+
+# DO NOT SUBMIT
+# This is the commit before dmauro's gcc7 fix
+(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout 669459108da9e467949699b2db904e77221a1d98^)
+
+# This is dmauro's gcc7 fix
+#(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout 669459108da9e467949699b2db904e77221a1d98)
 
 echo "This suite tests whether gRPC HEAD builds with HEAD of submodule '${SUBMODULE_NAME}'"
 echo "If a test breaks, either"
@@ -87,4 +93,5 @@ tools/buildgen/generate_projects.sh
 git add -A
 git -c user.name='foo' -c user.email='foo@google.com' commit -m 'Update submodule' --allow-empty
 
-tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg --inner_jobs 16 -j 2 --build_only
+#tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg --inner_jobs 16 -j 2 --build_only
+tools/run_tests/run_tests.py -t -j 16 -x /tmp/sponge_log.xml --report_suite_name cpp_linux_noexcept_native_buildonly -l c++ -c noexcept --compiler=gcc7 --iomgr_platform native --build_only

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -33,10 +33,10 @@ SUBMODULE_BRANCH_NAME="${BAZEL_FLAGS:-master}"
 
 # DO NOT SUBMIT
 # This is the commit before dmauro's gcc7 fix
-(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout 669459108da9e467949699b2db904e77221a1d98^)
+#(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout 669459108da9e467949699b2db904e77221a1d98^)
 
 # This is dmauro's gcc7 fix
-#(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout 669459108da9e467949699b2db904e77221a1d98)
+(cd "third_party/${SUBMODULE_NAME}" && git fetch origin && git checkout 669459108da9e467949699b2db904e77221a1d98)
 
 echo "This suite tests whether gRPC HEAD builds with HEAD of submodule '${SUBMODULE_NAME}'"
 echo "If a test breaks, either"

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -94,4 +94,4 @@ git add -A
 git -c user.name='foo' -c user.email='foo@google.com' commit -m 'Update submodule' --allow-empty
 
 #tools/run_tests/run_tests_matrix.py -f linux --exclude c sanity basictests_arm64 openssl dbg --inner_jobs 16 -j 2 --build_only
-tools/run_tests/run_tests.py -t -j 16 -x /tmp/sponge_log.xml --report_suite_name cpp_linux_noexcept_native_buildonly -l c++ -c noexcept --compiler=gcc7 --iomgr_platform native --build_only
+tools/run_tests/run_tests.py --use_docker -t -j 16 -x /tmp/sponge_log.xml --report_suite_name cpp_linux_noexcept_native_buildonly -l c++ -c noexcept --compiler=gcc7 --iomgr_platform native --build_only

--- a/tools/internal_ci/linux/pull_request/grpc_examples_tests_cpp.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_examples_tests_cpp.cfg
@@ -15,11 +15,17 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_examples_tests_cpp.sh"
-timeout_mins: 30
+build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
+timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
   }
+}
+
+# Tiny hack: misusing an already allowlisted env var to pass submodule name
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "abseil-cpp"
 }

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -561,6 +561,8 @@ class CLanguage(object):
 
         if compiler == "default" or compiler == "cmake":
             return ("debian11", ["-DCMAKE_CXX_STANDARD=17"])
+        elif compiler == "gcc7":
+            return ("gcc_7", ["-DCMAKE_CXX_STANDARD=17"])
         elif compiler == "gcc8":
             return ("gcc_8", ["-DCMAKE_CXX_STANDARD=17"])
         elif compiler == "gcc10.2":
@@ -1715,6 +1717,7 @@ argp.add_argument(
     "--compiler",
     choices=[
         "default",
+        "gcc7",
         "gcc8",
         "gcc10.2",
         "gcc10.2_openssl102",

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -364,6 +364,7 @@ def _create_portability_test_jobs(
 
     # portability C and C++ on x64
     for compiler in [
+        "gcc7",
         "gcc8",
         # TODO(b/283304471): Tests using OpenSSL's engine APIs were broken and removed
         "gcc10.2_openssl102",


### PR DESCRIPTION
I hijacked the `Grpc Examples Tests CPP` test configuration to reintroduce a gcc7 build with different abseil-cpp commits.

The build fails using abseil's https://github.com/abseil/abseil-cpp/commit/9e51ba2d4ef0ee0ab8f6f0091937a0ba7ac15339 commit, just before @derekmauro's fix. The shape of the problem:

```
fastbuild/bin/tools/bazelify_tests/test/runtests_c_linux_dbg_gcc_7_build_only.runfiles/com_github_grpc_grpc/grpc/third_party/abseil-cpp/absl/time/time.h:1873:12: error: call to non-constexpr function ‘int64_t absl::lts_20250512::operator/(absl::lts_20250512::Duration, absl::lts_20250512::Duration)’
   return d / Nanoseconds(1);
          ~~^~~~~~~~~~~~~~~~
```

The build passes @ https://github.com/abseil/abseil-cpp/commit/669459108da9e467949699b2db904e77221a1d98.
