### PR TITLE
[xDS e2e test] change LongRunningRpc to use callback API

### DIFF
--- a/test/cpp/end2end/xds/xds_end2end_test_lib.cc
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.cc
@@ -727,22 +727,26 @@ size_t XdsEnd2endTest::SendRpcsAndCountFailuresWithMessage(
 
 void XdsEnd2endTest::LongRunningRpc::StartRpc(
     grpc::testing::EchoTestService::Stub* stub, const RpcOptions& rpc_options) {
-  sender_thread_ = std::thread([this, stub, rpc_options]() {
-    EchoRequest request;
-    EchoResponse response;
-    rpc_options.SetupRpc(&context_, &request);
-    status_ = stub->Echo(&context_, request, &response);
+  LOG(INFO) << "Starting long-running RPC...";
+  rpc_options.SetupRpc(&context_, &request_);
+  stub->async()->Echo(&context_, &request_, &response_, [this](Status status) {
+    grpc_core::MutexLock lock(&mu_);
+    status_ = std::move(status);
+    cv_.Signal();
   });
 }
 
 void XdsEnd2endTest::LongRunningRpc::CancelRpc() {
   context_.TryCancel();
-  if (sender_thread_.joinable()) sender_thread_.join();
+  GetStatus();
 }
 
 Status XdsEnd2endTest::LongRunningRpc::GetStatus() {
-  if (sender_thread_.joinable()) sender_thread_.join();
-  return status_;
+  grpc_core::MutexLock lock(&mu_);
+  while (!status_.has_value()) {
+    cv_.Wait(&mu_);
+  }
+  return *status_;
 }
 
 std::vector<std::unique_ptr<XdsEnd2endTest::ConcurrentRpc>>

--- a/test/cpp/end2end/xds/xds_end2end_test_lib.h
+++ b/test/cpp/end2end/xds/xds_end2end_test_lib.h
@@ -795,10 +795,7 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
       StatusCode expected_status, absl::string_view expected_message_prefix,
       const RpcOptions& rpc_options = RpcOptions());
 
-  // A class for running a long-running RPC in its own thread.
-  // TODO(roth): Maybe consolidate this and SendConcurrentRpcs()
-  // somehow?  LongRunningRpc has a cleaner API, but SendConcurrentRpcs()
-  // uses the callback API, which is probably better.
+  // A class for running a long-running RPC using the callback API.
   class LongRunningRpc {
    public:
     // Starts the RPC.
@@ -814,12 +811,16 @@ class XdsEnd2endTest : public ::testing::TestWithParam<XdsTestType>,
     Status GetStatus();
 
    private:
-    std::thread sender_thread_;
+    EchoRequest request_;
+    EchoResponse response_;
     ClientContext context_;
-    Status status_;
+    grpc_core::Mutex mu_;
+    grpc_core::CondVar cv_;
+    std::optional<Status> status_ ABSL_GUARDED_BY(&mu_);
   };
 
   // Starts a set of concurrent RPCs.
+  // TODO(roth): Change this to use LongRunningRpc.
   struct ConcurrentRpc {
     ClientContext context;
     Status status;

--- a/test/cpp/end2end/xds/xds_routing_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_routing_end2end_test.cc
@@ -1548,41 +1548,41 @@ TEST_P(LdsRdsTest, XdsRoutingClusterUpdateClusters) {
 }
 
 TEST_P(LdsRdsTest, XdsRoutingClusterUpdateClustersWithPickingDelays) {
-  // Start with only backend 1 up, but the default cluster pointing to
-  // backend 0, which is down.
+  // We create two backends, with one cluster pointing to each backend.
+  // The default cluster points to backend 0, which is down.
+  // We create a new cluster, pointing to backend 1, which is up.
   CreateBackends(2);
   StartBackend(1);
   EdsResourceArgs args({{"locality0", CreateEndpointsForBackends(0, 1)}});
   balancer_->ads_service()->SetEdsResource(BuildEdsResource(args));
-  // Start an RPC with wait_for_ready=true and no deadline.  This will
-  // stay pending until backend 0 is reachable.
-  LongRunningRpc rpc;
-  rpc.StartRpc(stub_.get(),
-               RpcOptions().set_wait_for_ready(true).set_timeout_ms(0));
-  // Send a non-wait_for_ready RPC, which should fail.  This tells us
-  // that the client has received the update and attempted to connect.
-  CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE,
-                      MakeConnectionFailureRegex(
-                          "connections to all backends failing; last error: "));
-  // Now create a new cluster, pointing to backend 1.
+  // Create a new cluster, pointing to backend 1.
   const char* kNewClusterName = "new_cluster";
   const char* kNewEdsServiceName = "new_eds_service_name";
   EdsResourceArgs args1({{"locality0", CreateEndpointsForBackends(1, 2)}});
   balancer_->ads_service()->SetEdsResource(
       BuildEdsResource(args1, kNewEdsServiceName));
-  // Populate new CDS resources.
   Cluster new_cluster = default_cluster_;
   new_cluster.set_name(kNewClusterName);
   new_cluster.mutable_eds_cluster_config()->set_service_name(
       kNewEdsServiceName);
   balancer_->ads_service()->SetCdsResource(new_cluster);
-  // Send a update RouteConfiguration to use backend 1.
+  // Send a non-wait_for_ready RPC, which should fail.  This tells us
+  // that the client has received the update and attempted to connect.
+  CheckRpcSendFailure(DEBUG_LOCATION, StatusCode::UNAVAILABLE,
+                      MakeConnectionFailureRegex(
+                          "connections to all backends failing; last error: "));
+  // Start an RPC with wait_for_ready=true and no deadline.  This will
+  // stay pending until backend 0 is reachable.
+  LongRunningRpc rpc;
+  rpc.StartRpc(stub_.get(),
+               RpcOptions().set_wait_for_ready(true).set_timeout_ms(0));
+  // Send an updated RouteConfiguration that points to the new cluster.
   RouteConfiguration new_route_config = default_route_config_;
   auto* default_route =
       new_route_config.mutable_virtual_hosts(0)->mutable_routes(0);
   default_route->mutable_route()->set_cluster(kNewClusterName);
   SetRouteConfiguration(balancer_.get(), new_route_config);
-  // Wait for RPCs to go to the new backend: 1, this ensures that the client
+  // Wait for RPCs to go to backend 1.  This ensures that the client
   // has processed the update.
   WaitForBackend(
       DEBUG_LOCATION, 1,
@@ -1596,8 +1596,7 @@ TEST_P(LdsRdsTest, XdsRoutingClusterUpdateClustersWithPickingDelays) {
         }
       },
       WaitForBackendOptions().set_reset_counters(false));
-  // Bring up the backend 0.  Yhis will allow the delayed RPC to finally
-  // complete.
+  // Bring up backend 0.  This will allow the delayed RPC to finally complete.
   StartBackend(0);
   Status status = rpc.GetStatus();
   EXPECT_TRUE(status.ok()) << "code=" << status.error_code()


### PR DESCRIPTION
This fixes a flake in the XdsRoutingClusterUpdateClustersWithPickingDelays test, which tests to see that RPCs are tied to the xDS cluster picked when the RPC is started.  The test was starting an RPC in a background thread, which it assumed was tied to the current config, and then checking the config in the main thread.  The flake occurred when the background thread did not actually manage to start the RPC before the main thread changed the config, so the RPC wound up using the new config instead of the original config.

To fix this, I have changed the test framework's `LongRunningRpc` implementation to use the callback API instead of starting a background thread.  This ensures that when a test starts the RPC, the RPC will actually be started immediately, which should both address the flake I describe above and avoid other such flakes that may occur in other tests.

While I was at it, I reordered the steps in the test to make it a little clearer and more debuggable, although those changes don't actually affect the test behavior.