### PR TITLE
[Python] minor syntax improvements; follow up on black upgrade

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1172,10 +1172,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         wait_for_ready: Optional[bool] = None,
         compression: Optional[grpc.Compression] = None,
     ) -> Any:
-        (
-            state,
-            call,
-        ) = self._blocking(
+        state, call = self._blocking(
             request, timeout, metadata, credentials, wait_for_ready, compression
         )
         return _end_unary_response_blocking(state, call, False, None)
@@ -1189,10 +1186,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         wait_for_ready: Optional[bool] = None,
         compression: Optional[grpc.Compression] = None,
     ) -> Tuple[Any, grpc.Call]:
-        (
-            state,
-            call,
-        ) = self._blocking(
+        state, call = self._blocking(
             request, timeout, metadata, credentials, wait_for_ready, compression
         )
         return _end_unary_response_blocking(state, call, True, None)
@@ -1522,10 +1516,7 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         wait_for_ready: Optional[bool] = None,
         compression: Optional[grpc.Compression] = None,
     ) -> Any:
-        (
-            state,
-            call,
-        ) = self._blocking(
+        state, call = self._blocking(
             request_iterator,
             timeout,
             metadata,
@@ -1544,10 +1535,7 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         wait_for_ready: Optional[bool] = None,
         compression: Optional[grpc.Compression] = None,
     ) -> Tuple[Any, grpc.Call]:
-        (
-            state,
-            call,
-        ) = self._blocking(
+        state, call = self._blocking(
             request_iterator,
             timeout,
             metadata,
@@ -1865,10 +1853,7 @@ def _deliveries(
 ) -> List[Callable[[grpc.ChannelConnectivity], None]]:
     callbacks_needing_update = []
     for callback_and_connectivity in state.callbacks_and_connectivities:
-        (
-            callback,
-            callback_connectivity,
-        ) = callback_and_connectivity
+        callback, callback_connectivity = callback_and_connectivity
         if callback_connectivity is not state.connectivity:
             callbacks_needing_update.append(callback)
             callback_and_connectivity[1] = state.connectivity

--- a/tools/codegen/core/gen_grpc_tls_credentials_options.py
+++ b/tools/codegen/core/gen_grpc_tls_credentials_options.py
@@ -32,28 +32,28 @@ import tempfile
 class DataMember:
     name: str  # name of the data member without the trailing '_'
     type: str  # Type (eg. std::string, bool)
+
     test_name: str  # The name to use for the associated test
     test_value_1: str  # Test-specific value to use for comparison
     test_value_2: str  # Test-specific value (different from test_value_1)
-    default_initializer: (
-        str
-    ) = (  # If non-empty, this will be used as the default initialization of this field
-        ""
-    )
-    getter_comment: str = ""  # Comment to add before the getter for this field
-    special_getter_return_type: str = (
-        ""  # Override for the return type of getter (eg. const std::string&)
-    )
-    override_getter: (
-        str
-    ) = (  # Override for the entire getter method. Relevant for certificate_verifier and certificate_provider
-        ""
-    )
-    setter_comment: str = ""  # Commend to add before the setter for this field
+
+    # If non-empty, this will be used as the default initialization
+    # of this field.
+    default_initializer: str = ""
+
+    # Comment to add before the getter for this field
+    getter_comment: str = ""
+    # Override for the return type of getter (eg. const std::string&)
+    special_getter_return_type: str = ""
+    # Override for the entire getter method.
+    # Relevant for certificate_verifier and certificate_provider.
+    override_getter: str = ""
+
+    setter_comment: str = ""  # Comment to add before the setter for this field
     setter_move_semantics: bool = False  # Should the setter use move-semantics
-    special_comparator: str = (
-        ""  # If non-empty, this will be used in `operator==`
-    )
+
+    # If non-empty, this will be used in `operator==`
+    special_comparator: str = ""
 
 
 _DATA_MEMBERS = [

--- a/tools/codegen/core/gen_header_frame.py
+++ b/tools/codegen/core/gen_header_frame.py
@@ -14,10 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Read from stdin a set of colon separated http headers:
-:path: /foo/bar
-content-type: application/grpc
+
+    :path: /foo/bar
+    content-type: application/grpc
+
 Write a set of strings containing a hpack encoded http2 frame that
-represents said headers."""
+represents said headers.
+"""
 
 import argparse
 import json


### PR DESCRIPTION
1. Follow up on comments in #39774.
2. Fix poorly formatted multiple assignment statements in src/python/grpcio/grpc/_channel.py (from the initial black migration).
