### PR TITLE
[channel-trace] Bring tail time of thread stress test down from 120 sec --> 5 sec

### DIFF
--- a/test/core/channelz/channel_trace_test.cc
+++ b/test/core/channelz/channel_trace_test.cc
@@ -208,11 +208,16 @@ TEST(ChannelTracerTest, ThreadSafety) {
   for (size_t i = 0; i < 10; ++i) {
     threads.push_back(std::make_unique<std::thread>([&]() {
       do {
-        tracer.NewNode("trace").Commit();
+        for (int i = 0; i < 100; i++) {
+          if (done.HasBeenNotified()) return;
+          tracer.NewNode("trace").Commit();
+        }
+        absl::SleepFor(absl::Milliseconds(1));
       } while (!done.HasBeenNotified());
     }));
   }
   for (size_t i = 0; i < 10; ++i) {
+    absl::SleepFor(absl::Milliseconds(1));
     tracer.RenderJson();
   }
   done.Notify();


### PR DESCRIPTION
This test manages to show off some terrible unfairness somewhere, but it doesn't matter much.
Introduce some strategic sleeps to take pressure off the system and still have as-good-as a test of what we actually care about.