### PR TITLE
[util] Add a saturating multiply implementation

### DIFF
--- a/src/core/util/useful.h
+++ b/src/core/util/useful.h
@@ -114,6 +114,59 @@ inline T SaturatingAdd(T a, T b) {
   return a + b;
 }
 
+template <typename T>
+inline T SaturatingMul(T a, T b) {
+  if constexpr (std::is_integral_v<T>) {
+    if constexpr (std::is_unsigned_v<T>) {
+      if (a==0 || b==0) return 0;
+      if (b > std::numeric_limits<T>::max() / a) {
+        return std::numeric_limits<T>::max();
+      }
+      return a * b;
+    } else {
+      if (a==0 || b==0) return 0;
+      if (a == std::numeric_limits<T>::min()) {
+        // negation is ub
+        if (b == -1) return std::numeric_limits<T>::max();
+        if (b == 1) return std::numeric_limits<T>::min();
+        if (b > 1) return std::numeric_limits<T>::min();
+        return std::numeric_limits<T>::max();
+      }
+      if (b == std::numeric_limits<T>::min()) {
+        if (a == -1) return std::numeric_limits<T>::max();
+        if (a == 1) return std::numeric_limits<T>::min();
+        if (a > 1) return std::numeric_limits<T>::min();
+        return std::numeric_limits<T>::max();
+      }
+      if (a > 0 && b > 0) {
+        // both positive
+        if (a > std::numeric_limits<T>::max() / b) {
+          return std::numeric_limits<T>::max();
+        }
+      } else if (a < 0 && b < 0) {
+        // both negative
+        if (a < std::numeric_limits<T>::max() / b) {
+          return std::numeric_limits<T>::max();
+        }
+      } else {
+        // one positive, one negative
+        if (a > 0) {
+          if (b < std::numeric_limits<T>::min() / a) {
+            return std::numeric_limits<T>::min();
+          }
+        } else {
+          if (a < std::numeric_limits<T>::min() / b) {
+            return std::numeric_limits<T>::min();
+          }
+        }
+      }
+      return a * b;
+    }
+  } else {
+    static_assert(false, "SaturatingMul is only defined for integral types");
+  }
+}
+
 inline uint32_t MixHash32(uint32_t a, uint32_t b) {
   return absl::rotl(a, 2u) ^ b;
 }

--- a/test/core/util/useful_fuzztest.cc
+++ b/test/core/util/useful_fuzztest.cc
@@ -69,4 +69,38 @@ void SaturatingAddWorksUint8(uint8_t a, uint8_t b) {
 }
 FUZZ_TEST(MyTestSuite, SaturatingAddWorksUint8);
 
-}  // namespace grpc_core
+template <typename T, typename Bigger>
+void SaturatingMulWorks(T a, T b) {
+  T result = SaturatingMul(a, b);
+  Bigger expect = Clamp<Bigger>(static_cast<Bigger>(a) * static_cast<Bigger>(b),
+                                std::numeric_limits<T>::min(),
+                                std::numeric_limits<T>::max());
+  EXPECT_EQ(result, expect);
+}
+
+void SaturatingMulWorksInt32(int32_t a, int32_t b) {
+  SaturatingMulWorks<int32_t, int64_t>(a, b);
+}
+FUZZ_TEST(MyTestSuite, SaturatingMulWorksInt32);
+void SaturatingMulWorksUint32(uint32_t a, uint32_t b) {
+  SaturatingMulWorks<uint32_t, uint64_t>(a, b);
+}
+FUZZ_TEST(MyTestSuite, SaturatingMulWorksUint32);
+void SaturatingMulWorksInt8(int8_t a, int8_t b) {
+  SaturatingMulWorks<int8_t, int16_t>(a, b);
+}
+FUZZ_TEST(MyTestSuite, SaturatingMulWorksInt8);
+void SaturatingMulWorksUint8(uint8_t a, uint8_t b) {
+  SaturatingMulWorks<uint8_t, uint16_t>(a, b);
+}
+FUZZ_TEST(MyTestSuite, SaturatingMulWorksUint8);
+void SaturatingMulWorksInt16(int16_t a, int16_t b) {
+  SaturatingMulWorks<int16_t, int32_t>(a, b);
+}
+FUZZ_TEST(MyTestSuite, SaturatingMulWorksInt16);
+void SaturatingMulWorksUint16(uint16_t a, uint16_t b) {
+  SaturatingMulWorks<uint16_t, uint32_t>(a, b);
+}
+FUZZ_TEST(MyTestSuite, SaturatingMulWorksUint16);
+
+}


### PR DESCRIPTION
This ends up being necessary for a clean movement from millis --> nanos for timestamps
