### PR TITLE
[python] Improve debugging for fork test

### DIFF
--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -23,6 +23,7 @@ import unittest
 
 from grpc._cython import cygrpc
 
+from tests.fork import debugger
 from tests.fork import methods
 
 
@@ -52,7 +53,6 @@ _CLIENT_FORK_SCRIPT_TEMPLATE = """if True:
     native_debug.install_failure_signal_handler()
 
     cygrpc._GRPC_ENABLE_FORK_SUPPORT = True
-    os.environ['GRPC_POLL_STRATEGY'] = 'epoll1'
     os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'true'
     methods.TestCase.%s.run_test({
       'server_host': 'localhost',
@@ -61,7 +61,6 @@ _CLIENT_FORK_SCRIPT_TEMPLATE = """if True:
     })
 """
 _SUBPROCESS_TIMEOUT_S = 80
-_GDB_TIMEOUT_S = 60
 
 
 @unittest.skipUnless(
@@ -179,35 +178,6 @@ class ForkInteropTest(unittest.TestCase):
         for stream in self._streams:
             stream.close()
 
-    def _print_backtraces(self, pid):
-        cmd = [
-            "gdb",
-            "-ex",
-            "set confirm off",
-            "-ex",
-            "echo attaching",
-            "-ex",
-            "attach {}".format(pid),
-            "-ex",
-            "echo print_backtrace",
-            "-ex",
-            "thread apply all bt",
-            "-ex",
-            "echo printed_backtrace",
-            "-ex",
-            "quit",
-        ]
-        streams = tuple(tempfile.TemporaryFile() for _ in range(2))
-        sys.stderr.write("Invoking gdb\n")
-        sys.stderr.flush()
-        process = subprocess.Popen(cmd, stdout=streams[0], stderr=streams[1])
-        try:
-            process.wait(timeout=_GDB_TIMEOUT_S)
-        except subprocess.TimeoutExpired:
-            sys.stderr.write("gdb stacktrace generation timed out.\n")
-        finally:
-            _dump_streams("gdb", streams)
-
     def _verifyTestCase(self, test_case):
         script = _CLIENT_FORK_SCRIPT_TEMPLATE % (test_case.name, self._port)
         streams = tuple(tempfile.TemporaryFile() for _ in range(2))
@@ -218,7 +188,8 @@ class ForkInteropTest(unittest.TestCase):
             process.wait(timeout=_SUBPROCESS_TIMEOUT_S)
             self.assertEqual(0, process.returncode)
         except subprocess.TimeoutExpired:
-            self._print_backtraces(process.pid)
+            sys.stderr.write("Child %d timed out\n" % process.pid)
+            debugger.print_backtraces(process.pid)
             process.kill()
             raise AssertionError("Parent process timed out.")
         finally:

--- a/src/python/grpcio_tests/tests/fork/debugger.py
+++ b/src/python/grpcio_tests/tests/fork/debugger.py
@@ -1,0 +1,65 @@
+import os
+import platform
+import tempfile
+import subprocess
+import sys
+
+
+_GDB_TIMEOUT_S = 60
+
+
+def print_backtraces(pid):
+    # Check if we are on macOS AND the environment variable is set
+    use_lldb = False
+    if platform.system() == "Darwin":
+        use_lldb = bool(os.environ.get("USE_LLDB_ON_DARWIN"))
+        if not use_lldb:
+            sys.stderr.write(
+                "LLDB is recommended for use on Mac.\n"
+                + 'Run "sudo DevToolsSecurity -enable" and set USE_LLDB_ON_DARWIN'
+                + " environment variable to use lldb\n"
+            )
+    # Determine the OS and set debugger specific commands
+    if use_lldb:  # macOS
+        debugger_name = "lldb"
+        cmd = [
+            "lldb",
+            "-b",  # Batch mode: exit after commands are executed
+            "-o",
+            "process attach --pid {}".format(pid),
+            "-o",
+            "thread backtrace all",  # Dumps backtraces of all threads
+            "-o",
+            "quit",
+        ]
+    else:  # Assume Linux/Unix-like for gdb (adjust if other OSes need specific handling)
+        debugger_name = "gdb"
+        cmd = [
+            "gdb",
+            "-ex",
+            "set confirm off",
+            "-ex",
+            "attach {}".format(pid),
+            "-ex",
+            "thread apply all bt",
+            "-ex",
+            "quit",
+        ]
+    streams = tuple(tempfile.TemporaryFile() for _ in range(2))
+    sys.stderr.write("Invoking gdb\n")
+    sys.stderr.flush()
+    process = subprocess.Popen(cmd, stdout=streams[0], stderr=streams[1])
+    try:
+        process.wait(timeout=_GDB_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("{} stacktrace generation timed out.\n".format(debugger_name))
+    finally:
+        for stream_name, stream in zip(("STDOUT", "STDERR"), streams):
+            stream.seek(0)
+            sys.stderr.write(
+                "{} {}:\n{}\n".format(
+                    debugger_name, stream_name, stream.read().decode("ascii")
+                )
+            )
+            stream.close()
+        sys.stderr.flush()


### PR DESCRIPTION
1. Add a way to use LLDB on Mac. It is behind "USE_LLDB_ON_DARWIN" env var since it requires Mac in a debug mode.
2. Add more tracing to better understand child process state.