### PR TITLE
[CI] New docker build test

### DIFF
--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -28,6 +28,7 @@ cd $(dirname $0)/../..
 #  SKIP_UPLOAD: if set, script won't push docker images it built to artifact registry.
 #  HOST_ARCH_ONLY: if set, script will build docker images with the same architecture as the machine running the script.
 #  ALWAYS_BUILD: if set, script will build docker images all the time.
+#  KEEP_GOING: if set, script will not stop in case of docker error
 
 # How to configure docker before running this script for the first time:
 # Configure docker:
@@ -102,6 +103,7 @@ then
   done
 fi
 
+failed_docker_list=()
 for DOCKERFILE_DIR in "${ALL_DOCKERFILE_DIRS[@]}"
 do
   # Generate image name based on Dockerfile checksum. That works well as long
@@ -229,11 +231,19 @@ do
   # Building a docker image with two tags;
   # - one for image identification based on Dockerfile hash
   # - one to exclude it from the GCP Vulnerability Scanner
+  docker_exit_code=0
   docker build \
     ${ALWAYS_BUILD:+--no-cache --pull} \
     -t ${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG} \
     -t ${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:infrastructure-public-image-${DOCKER_IMAGE_TAG} \
-    ${DOCKERFILE_DIR}
+    ${DOCKERFILE_DIR} || docker_exit_code=$?
+  if [ "${docker_exit_code}" -ne 0 ]; then
+    if [ -z "${KEEP_GOING}" ]; then
+      exit "${docker_exit_code}"
+    else
+      failed_docker_list+=(${DOCKER_IMAGE_NAME})
+    fi
+  fi
   echo "=========="
 
   # After building the docker image locally, we don't know the image's RepoDigest (which is distinct from image's "Id" digest) yet
@@ -253,6 +263,16 @@ do
     echo -n "${ARTIFACT_REGISTRY_PREFIX}/${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}@${DOCKER_IMAGE_DIGEST_REMOTE}" >${DOCKERFILE_DIR}.current_version
   fi
 done
+
+if [ ${#failed_docker_list[@]} -gt 0 ]; then
+  echo "Failed docker list"
+  echo "=================="
+  for item in "${failed_docker_list[@]}"; do
+    echo "- $item"
+  done
+  echo "=================="
+  exit 1
+fi
 
 if [ "${CHECK_MODE}" != "" ]
 then

--- a/tools/internal_ci/linux/arm64/grpc_docker_build.cfg
+++ b/tools/internal_ci/linux/arm64/grpc_docker_build.cfg
@@ -1,0 +1,25 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_docker_build.sh"
+timeout_mins: 720
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/tools/internal_ci/linux/grpc_docker_build.cfg
+++ b/tools/internal_ci/linux/grpc_docker_build.cfg
@@ -1,0 +1,25 @@
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_docker_build.sh"
+timeout_mins: 720
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/tools/internal_ci/linux/grpc_docker_build.sh
+++ b/tools/internal_ci/linux/grpc_docker_build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2025 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Enter the gRPC repo root
+cd $(dirname $0)/../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
+
+LOCAL_ONLY_MODE=1 ALWAYS_BUILD=1 HOST_ARCH_ONLY=1 KEEP_GOING=1 tools/dockerfile/push_testing_images.sh


### PR DESCRIPTION
A new Docker build test has been implemented to ensure the continuous buildability of all Docker images. This test, which is based on the existing `tools/dockerfile/push_testing_images.sh script`, now incorporates a `KEEP_GOING` flag. When enabled, the script attempts to build all images and provides a list of any build failures at the end.

This test will be run once a day on master. Kokoro configuration will be added in google3.