### PR TITLE
[testing] fix non-windows test failure surfacing of resolver_component_tests_runner_invoker

### DIFF
--- a/test/cpp/naming/resolver_component_tests_runner_invoker.cc
+++ b/test/cpp/naming/resolver_component_tests_runner_invoker.cc
@@ -168,5 +168,18 @@ int main(int argc, char** argv) {
         "test/cpp/naming/utils/tcp_connect.py");
   }
   grpc_shutdown();
+#ifndef GPR_WINDOWS
+  if (WIFEXITED(result)) {
+    if (WEXITSTATUS(result) != 0) {
+      int error_code = WEXITSTATUS(result);
+      LOG(FATAL) << "DNS test subprocess failed with code: " << error_code;
+    }
+  } else if (WIFSIGNALED(result)) {
+    int signal = WTERMSIG(result);
+    LOG(FATAL) << "DNS test subprocess killed by signal: " << signal;
+  } else {
+    LOG(FATAL) << "DNS test subprocess failed, neither WEXITSTATUS nor WTERMSIG is true";
+  }
+#endif
   return result;
 }

--- a/test/cpp/naming/resolver_component_tests_runner_invoker.cc
+++ b/test/cpp/naming/resolver_component_tests_runner_invoker.cc
@@ -178,7 +178,8 @@ int main(int argc, char** argv) {
     int signal = WTERMSIG(result);
     LOG(FATAL) << "DNS test subprocess killed by signal: " << signal;
   } else {
-    LOG(FATAL) << "DNS test subprocess failed, neither WEXITSTATUS nor WTERMSIG is true";
+    LOG(FATAL) << "DNS test subprocess failed, neither WEXITSTATUS nor "
+                  "WTERMSIG is true";
   }
 #endif
   return result;


### PR DESCRIPTION
I was stumped why the failure mentioned in https://github.com/grpc/grpc/pull/39813 was only showing up on Windows, and I think this may be related.

I was forcing failures of this test on linux in https://github.com/grpc/grpc/pull/39891, and could not actually see a CI failure show up until this adding patch.

