### PR TITLE
[chaotic-good] Various fixes for tcp_frame_transport_test

### DIFF
--- a/src/core/ext/transport/chaotic_good/tcp_frame_transport.h
+++ b/src/core/ext/transport/chaotic_good/tcp_frame_transport.h
@@ -42,7 +42,7 @@ class TcpFrameTransport final : public FrameTransport,
     uint32_t encode_alignment = 64;
     uint32_t decode_alignment = 64;
     uint32_t inlined_payload_size_threshold = 8 * 1024;
-    std::string scheduler_config = "span";
+    std::string scheduler_config = "spanrr";
     bool enable_tracing = false;
   };
 

--- a/src/core/lib/promise/party.cc
+++ b/src/core/lib/promise/party.cc
@@ -210,17 +210,15 @@ void Party::ToJson(absl::AnyInvocable<void(Json::Object)> f) {
   auto event_engine =
       arena_->GetContext<grpc_event_engine::experimental::EventEngine>();
   CHECK(event_engine != nullptr);
-  event_engine->Run([f = std::move(f), self = Ref()]() mutable {
-    self->Spawn(
-        "get-json",
-        [f = std::move(f), self]() mutable {
-          return [f = std::move(f), self]() mutable {
-            f(self->ToJsonLocked());
-            return absl::OkStatus();
-          };
-        },
-        [](absl::Status) {});
-  });
+  Spawn(
+      "get-json",
+      [f = std::move(f), self = Ref()]() mutable {
+        return [f = std::move(f), self]() mutable {
+          f(self->ToJsonLocked());
+          return absl::OkStatus();
+        };
+      },
+      [](absl::Status) {});
 }
 
 Json::Object Party::ToJsonLocked() {

--- a/test/core/test_util/postmortem_emit.cc
+++ b/test/core/test_util/postmortem_emit.cc
@@ -20,18 +20,18 @@
 namespace grpc_core {
 
 void PostMortemEmit() {
-  LOG(INFO) << "===========================================================";
-  LOG(INFO) << "🛑 gRPC Test Postmortem Analysis 🛑";
-  LOG(INFO) << "===========================================================";
+  std::cerr << "===========================================================\n";
+  std::cerr << "🛑 gRPC Test Postmortem Analysis 🛑\n";
+  std::cerr << "===========================================================\n";
 
-  LOG(INFO) << "❗ gRPC Statistics:\n"
-            << StatsAsJson(global_stats().Collect().get());
+  std::cerr << "❗ gRPC Statistics:\n"
+            << StatsAsJson(global_stats().Collect().get()) << "\n";
 
-  LOG(INFO) << "❗ channelz entities:";
+  std::cerr << "❗ channelz entities:\n";
   for (const auto& node : channelz::ChannelzRegistry::GetAllEntities()) {
-    LOG(INFO) << "  🔴 [" << node->uuid() << ":"
+    std::cerr << "  🔴 [" << node->uuid() << ":"
               << channelz::BaseNode::EntityTypeString(node->type())
-              << "]: " << node->RenderJsonString();
+              << "]: " << node->RenderJsonString() << "\n";
   }
 }
 

--- a/test/core/transport/chaotic_good/BUILD
+++ b/test/core/transport/chaotic_good/BUILD
@@ -95,6 +95,7 @@ grpc_fuzz_test(
         "//src/core:inter_activity_latch",
         "//test/core/event_engine/fuzzing_event_engine",
         "//test/core/event_engine/fuzzing_event_engine:fuzzing_event_engine_cc_proto",
+        "//test/core/test_util:postmortem_emit",
     ],
 )
 

--- a/test/core/transport/chaotic_good/tcp_frame_transport_test.cc
+++ b/test/core/transport/chaotic_good/tcp_frame_transport_test.cc
@@ -16,6 +16,7 @@
 
 #include <google/protobuf/text_format.h>
 
+#include <algorithm>
 #include <memory>
 
 #include "fuzztest/fuzztest.h"
@@ -24,6 +25,7 @@
 #include "src/core/lib/promise/inter_activity_latch.h"
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h"
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.pb.h"
+#include "test/core/test_util/postmortem_emit.h"
 #include "test/core/transport/chaotic_good/test_frame.h"
 #include "test/core/transport/chaotic_good/test_frame.pb.h"
 
@@ -45,35 +47,63 @@ std::pair<PromiseEndpoint, PromiseEndpoint> CreatePromiseEndpointPair(
 }
 
 std::pair<PendingConnection, PendingConnection> CreatePendingConnectionPair(
-    const std::shared_ptr<FuzzingEventEngine>& engine) {
+    const std::shared_ptr<FuzzingEventEngine>& engine, size_t i) {
   std::shared_ptr<InterActivityLatch<PromiseEndpoint>> client_latch =
       std::make_shared<InterActivityLatch<PromiseEndpoint>>();
   std::shared_ptr<InterActivityLatch<PromiseEndpoint>> server_latch =
       std::make_shared<InterActivityLatch<PromiseEndpoint>>();
   auto [client, server] = CreatePromiseEndpointPair(engine);
-  engine->Run([client_latch, client = std::move(client)]() mutable {
+  engine->Run([client_latch, client = std::move(client), i]() mutable {
+    GRPC_TRACE_LOG(chaotic_good, INFO) << "mark client " << i << " available";
     client_latch->Set(std::move(client));
   });
-  engine->Run([server_latch, server = std::move(server)]() mutable {
+  engine->Run([server_latch, server = std::move(server), i]() mutable {
+    GRPC_TRACE_LOG(chaotic_good, INFO) << "mark server " << i << " available";
     server_latch->Set(std::move(server));
   });
   return std::pair(
-      PendingConnection("foo", Map(client_latch->Wait(),
-                                   [client_latch](PromiseEndpoint e)
-                                       -> absl::StatusOr<PromiseEndpoint> {
-                                     return std::move(e);
-                                   })),
-      PendingConnection("foo", Map(server_latch->Wait(),
-                                   [server_latch](PromiseEndpoint e)
-                                       -> absl::StatusOr<PromiseEndpoint> {
-                                     return std::move(e);
-                                   })));
+      PendingConnection(
+          "foo", Map(client_latch->Wait(),
+                     [client_latch,
+                      i](PromiseEndpoint e) -> absl::StatusOr<PromiseEndpoint> {
+                       GRPC_TRACE_LOG(chaotic_good, INFO)
+                           << "client " << i << " no longer pending";
+                       return std::move(e);
+                     })),
+      PendingConnection(
+          "foo", Map(server_latch->Wait(),
+                     [server_latch,
+                      i](PromiseEndpoint e) -> absl::StatusOr<PromiseEndpoint> {
+                       GRPC_TRACE_LOG(chaotic_good, INFO)
+                           << "server " << i << " no longer pending";
+                       return std::move(e);
+                     })));
 }
+
+class PartyExposer : public channelz::DataSource {
+ public:
+  PartyExposer(absl::string_view name, RefCountedPtr<channelz::BaseNode> node,
+               RefCountedPtr<Party> party)
+      : DataSource(std::move(node)), party_(std::move(party)) {}
+
+  ~PartyExposer() { ResetDataSource(); }
+
+  void AddData(channelz::DataSink sink) override {
+    party_->ToJson([sink, name = name_](Json::Object obj) mutable {
+      sink.AddAdditionalInfo(name, std::move(obj));
+    });
+  }
+
+ private:
+  absl::string_view name_;
+  RefCountedPtr<Party> party_;
+};
 
 class TestSink : public FrameTransportSink {
  public:
-  TestSink(absl::Span<const Frame> expected_frames, EventEngine* event_engine)
-      : event_engine_(event_engine) {
+  TestSink(absl::Span<const Frame> expected_frames, EventEngine* event_engine,
+           RefCountedPtr<channelz::BaseNode> channelz_node)
+      : event_engine_(event_engine), channelz_node_(std::move(channelz_node)) {
     for (size_t i = 0; i < expected_frames.size(); i++) {
       expected_frames_[i] = &expected_frames[i];
     }
@@ -83,6 +113,8 @@ class TestSink : public FrameTransportSink {
 
   void OnIncomingFrame(IncomingFrame incoming_frame) override {
     const size_t frame_id = next_frame_;
+    GRPC_TRACE_LOG(chaotic_good, INFO)
+        << this << " OnIncomingFrame: " << frame_id;
     ++next_frame_;
     CHECK_EQ(expected_frames_.count(frame_id), 1);
     auto arena = SimpleArenaAllocator()->MakeArena();
@@ -94,6 +126,8 @@ class TestSink : public FrameTransportSink {
          self = RefAsSubclass<TestSink>()]() mutable {
           return Seq(incoming_frame.Payload(),
                      [frame_id, self](absl::StatusOr<Frame> frame) {
+                       GRPC_TRACE_LOG(chaotic_good, INFO)
+                           << self.get() << " Got payload for " << frame_id;
                        CHECK(frame.ok()) << frame.status();
                        auto it = self->expected_frames_.find(frame_id);
                        CHECK(it != self->expected_frames_.end())
@@ -105,7 +139,8 @@ class TestSink : public FrameTransportSink {
                      });
         },
         [](const absl::Status&) {});
-    parties_.push_back(party);
+    parties_.push_back(std::make_unique<PartyExposer>("incoming_frame",
+                                                      channelz_node_, party));
   }
 
   void OnFrameTransportClosed(absl::Status status) override {
@@ -114,10 +149,16 @@ class TestSink : public FrameTransportSink {
 
  private:
   std::map<size_t, const Frame*> expected_frames_;
-  std::vector<RefCountedPtr<Party>> parties_;
+  std::vector<std::unique_ptr<PartyExposer>> parties_;
   size_t next_frame_ = 0;
   EventEngine* const event_engine_;
+  RefCountedPtr<channelz::BaseNode> channelz_node_;
 };
+
+RefCountedPtr<channelz::SocketNode> MakeTestChannelzSocketNode(
+    std::string name) {
+  return MakeRefCounted<channelz::SocketNode>("from", "to", name, nullptr);
+}
 
 void CanSendFrames(size_t num_data_endpoints, uint32_t client_alignment,
                    uint32_t server_alignment,
@@ -133,37 +174,43 @@ void CanSendFrames(size_t num_data_endpoints, uint32_t client_alignment,
   std::vector<PendingConnection> pending_connections_client;
   std::vector<PendingConnection> pending_connections_server;
   for (size_t i = 0; i < num_data_endpoints; i++) {
-    auto [client, server] = CreatePendingConnectionPair(engine);
+    auto [client, server] = CreatePendingConnectionPair(engine, i);
     pending_connections_client.emplace_back(std::move(client));
     pending_connections_server.emplace_back(std::move(server));
   }
   auto [client, server] = CreatePromiseEndpointPair(engine);
+  auto client_node = MakeTestChannelzSocketNode("client");
   auto client_transport = MakeOrphanable<TcpFrameTransport>(
       TcpFrameTransport::Options{server_alignment, client_alignment,
                                  server_inlined_payload_size_threshold},
       std::move(client), std::move(pending_connections_client),
       MakeRefCounted<TransportContext>(
-          std::static_pointer_cast<EventEngine>(engine), nullptr));
+          std::static_pointer_cast<EventEngine>(engine), client_node));
+  auto server_node = MakeTestChannelzSocketNode("server");
   auto server_transport = MakeOrphanable<TcpFrameTransport>(
       TcpFrameTransport::Options{client_alignment, server_alignment,
                                  client_inlined_payload_size_threshold},
       std::move(server), std::move(pending_connections_server),
       MakeRefCounted<TransportContext>(
-          std::static_pointer_cast<EventEngine>(engine), nullptr));
+          std::static_pointer_cast<EventEngine>(engine), server_node));
   auto client_arena = SimpleArenaAllocator()->MakeArena();
   auto server_arena = SimpleArenaAllocator()->MakeArena();
   client_arena->SetContext(static_cast<EventEngine*>(engine.get()));
   server_arena->SetContext(static_cast<EventEngine*>(engine.get()));
   auto client_party = Party::Make(client_arena);
   auto server_party = Party::Make(server_arena);
+  PartyExposer client_party_exposer("client_transport_party", client_node,
+                                    client_party);
+  PartyExposer server_party_exposer("server_transport_party", server_node,
+                                    server_party);
   MpscReceiver<OutgoingFrame> client_receiver(client_max_buffer_hint);
   MpscReceiver<OutgoingFrame> server_receiver(server_max_buffer_hint);
   auto client_sender = client_receiver.MakeSender();
   auto server_sender = server_receiver.MakeSender();
-  auto client_sink =
-      MakeRefCounted<TestSink>(send_on_server_frames, engine.get());
-  auto server_sink =
-      MakeRefCounted<TestSink>(send_on_client_frames, engine.get());
+  auto client_sink = MakeRefCounted<TestSink>(send_on_server_frames,
+                                              engine.get(), client_node);
+  auto server_sink = MakeRefCounted<TestSink>(send_on_client_frames,
+                                              engine.get(), server_node);
   client_transport->Start(client_party.get(), std::move(client_receiver),
                           client_sink);
   server_transport->Start(server_party.get(), std::move(server_receiver),
@@ -179,25 +226,29 @@ void CanSendFrames(size_t num_data_endpoints, uint32_t client_alignment,
   auto deadline = Timestamp::Now() + Duration::Hours(6);
   while (!client_sink->done() || !server_sink->done()) {
     engine->Tick();
-    CHECK(Timestamp::Now() < deadline) << "timeout";
+    if (Timestamp::Now() > deadline) {
+      PostMortemEmit();
+      LOG(FATAL) << "6 hour deadline exceeded";
+    }
   }
   client_transport.reset();
   server_transport.reset();
   engine->TickUntilIdle();
 }
 FUZZ_TEST(TcpFrameTransportTest, CanSendFrames)
-    .WithDomains(/* num_data_endpoints */ InRange<size_t>(0, 64),
-                 /* client_alignment */ InRange<uint32_t>(1, 1024),
-                 /* server_alignment */ InRange<uint32_t>(1, 1024),
-                 /* client_inlined_payload_size_threshold */
-                 InRange<uint32_t>(0, 8 * 1024 * 1024),
-                 /* server_inlined_payload_size_threshold */
-                 InRange<uint32_t>(0, 8 * 1024 * 1024),
-                 /* client_max_buffer_hint */ InRange<uint32_t>(0, 64),
-                 /* server_max_buffer_hint */ InRange<uint32_t>(0, 64),
-                 /* actions */ Arbitrary<fuzzing_event_engine::Actions>(),
-                 /* send_on_client_frames */ VectorOf(AnyFrame()),
-                 /* send_on_server_frames */ VectorOf(AnyFrame()));
+    .WithDomains(
+        /* num_data_endpoints */ InRange<size_t>(0, 64),
+        /* client_alignment */ InRange<uint32_t>(1, 1024),
+        /* server_alignment */ InRange<uint32_t>(1, 1024),
+        /* client_inlined_payload_size_threshold */
+        InRange<uint32_t>(0, 8 * 1024 * 1024),
+        /* server_inlined_payload_size_threshold */
+        InRange<uint32_t>(0, 8 * 1024 * 1024),
+        /* client_max_buffer_hint */ InRange<uint32_t>(1, 1024 * 1024 * 1024),
+        /* server_max_buffer_hint */ InRange<uint32_t>(1, 1024 * 1024 * 1024),
+        /* actions */ Arbitrary<fuzzing_event_engine::Actions>(),
+        /* send_on_client_frames */ VectorOf(AnyFrame()),
+        /* send_on_server_frames */ VectorOf(AnyFrame()));
 
 auto ParseFuzzingEventEngineProto(const std::string& proto) {
   fuzzing_event_engine::Actions msg;
@@ -207,8 +258,36 @@ auto ParseFuzzingEventEngineProto(const std::string& proto) {
 
 auto ParseFrameProto(const std::string& proto) {
   chaotic_good_frame::TestFrame msg;
-  CHECK(google::protobuf::TextFormat::ParseFromString(proto, &msg));
+  CHECK(google::protobuf::TextFormat::ParseFromString(proto, &msg)) << proto;
   return msg;
+}
+
+TEST(TcpFrameTransportTest, CanSendFramesRegression1) {
+  std::vector<Frame> send_on_client_frames;
+  send_on_client_frames.emplace_back(
+      grpc_core::chaotic_good::FrameFromTestFrame(
+          ParseFrameProto(R"pb(
+            settings {
+              max_chunk_size: 2147483647
+              supported_features: UNSPECIFIED
+            })pb")));
+  std::vector<Frame> send_on_server_frames;
+  send_on_server_frames.emplace_back(
+      grpc_core::chaotic_good::FrameFromTestFrame(ParseFrameProto(
+          R"pb(settings { alignment: 1 supported_features: UNSPECIFIED })pb")));
+  send_on_server_frames.emplace_back(
+      grpc_core::chaotic_good::FrameFromTestFrame(
+          ParseFrameProto(R"pb(begin_message { stream_id: 4294967295 })pb")));
+  CanSendFrames(
+      33, 1, 567, 0, 3878004, 36, 10, ParseFuzzingEventEngineProto(R"pb(
+        run_delay: 9223372036854775807
+        endpoint_metrics {}
+        returned_endpoint_metrics {
+          delay_us: 2147483647
+          event: 4010916377
+          returned_endpoint_metrics {}
+        })pb"),
+      std::move(send_on_client_frames), std::move(send_on_server_frames));
 }
 
 }  // namespace


### PR DESCRIPTION
Just getting to the fix:
* ensure we're using the right scheduler
* remove party event engine spawn so that fuzzers can dump party state too in post mortems
* use cerr instead of absl log for post mortems, so that long channelz states are not clipped
* clamp metrics delay length in fuzzing event engine to a reasonable value
* add post mortem support for this test

And finally:
* fix domains on the test so that we don't ask for a zero size mpsc queue (that will never be able to send beyond the first message)