### PR TITLE
[test] only run one test to deflake

### DIFF
--- a/test/cpp/end2end/server_load_reporting_end2end_test.cc
+++ b/test/cpp/end2end/server_load_reporting_end2end_test.cc
@@ -121,8 +121,6 @@ class ServerLoadReportingEnd2endTest : public ::testing::Test {
   EchoTestServiceImpl echo_service_;
 };
 
-TEST_F(ServerLoadReportingEnd2endTest, NoCall) {}
-
 TEST_F(ServerLoadReportingEnd2endTest, BasicReport) {
   auto channel =
       grpc::CreateChannel(server_address_, InsecureChannelCredentials());


### PR DESCRIPTION
This test rarely fails. Could not reproduce but it appears tearing down the first test often overlaps with the next test asynchronously. Sinte the first test is empty we can try disabling it to see.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

