### PR TITLE
[blackboard] split state updates from filter stack construction

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -5776,6 +5776,7 @@ grpc_cc_library(
     ],
     tags = ["nofixdeps"],
     deps = [
+        "blackboard",
         "channel_args",
         "channel_fwd",
         "interception_chain",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -7610,6 +7610,7 @@ grpc_cc_library(
     deps = [
         "arena",
         "arena_promise",
+        "blackboard",
         "channel_args",
         "channel_fwd",
         "client_channel_internal_header",

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -3621,6 +3621,7 @@ grpc_cc_library(
     ],
     deps = [
         "arena",
+        "blackboard",
         "channel_fwd",
         "client_channel_internal_header",
         "grpc_service_config",

--- a/src/core/call/interception_chain.h
+++ b/src/core/call/interception_chain.h
@@ -163,11 +163,8 @@ class InterceptionChainBuilder final {
                                         RefCountedPtr<CallDestination>>;
 
   explicit InterceptionChainBuilder(ChannelArgs args,
-                                    const Blackboard* old_blackboard = nullptr,
-                                    Blackboard* new_blackboard = nullptr)
-      : args_(std::move(args)),
-        old_blackboard_(old_blackboard),
-        new_blackboard_(new_blackboard) {}
+                                    const Blackboard* blackboard = nullptr)
+      : args_(std::move(args)), blackboard_(blackboard) {}
 
   // Add a filter with a `Call` class as an inner member.
   // Call class must be one compatible with the filters described in
@@ -176,8 +173,8 @@ class InterceptionChainBuilder final {
   absl::enable_if_t<sizeof(typename T::Call) != 0, InterceptionChainBuilder&>
   Add() {
     if (!status_.ok()) return *this;
-    auto filter = T::Create(args_, {FilterInstanceId(FilterTypeId<T>()),
-                                    old_blackboard_, new_blackboard_});
+    auto filter =
+        T::Create(args_, {FilterInstanceId(FilterTypeId<T>()), blackboard_});
     if (!filter.ok()) {
       status_ = filter.status();
       return *this;
@@ -193,8 +190,8 @@ class InterceptionChainBuilder final {
   absl::enable_if_t<std::is_base_of<Interceptor, T>::value,
                     InterceptionChainBuilder&>
   Add() {
-    AddInterceptor(T::Create(args_, {FilterInstanceId(FilterTypeId<T>()),
-                                     old_blackboard_, new_blackboard_}));
+    AddInterceptor(
+        T::Create(args_, {FilterInstanceId(FilterTypeId<T>()), blackboard_}));
     return *this;
   };
 
@@ -273,8 +270,7 @@ class InterceptionChainBuilder final {
   absl::Status status_;
   std::map<size_t, size_t> filter_type_counts_;
   static std::atomic<size_t> next_filter_id_;
-  const Blackboard* old_blackboard_ = nullptr;
-  Blackboard* new_blackboard_ = nullptr;
+  const Blackboard* blackboard_ = nullptr;
 };
 
 }  // namespace grpc_core

--- a/src/core/client_channel/config_selector.h
+++ b/src/core/client_channel/config_selector.h
@@ -30,6 +30,7 @@
 #include "src/core/call/interception_chain.h"
 #include "src/core/call/metadata_batch.h"
 #include "src/core/client_channel/client_channel_internal.h"
+#include "src/core/filter/blackboard.h"
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/lib/resource_quota/arena.h"
 #include "src/core/lib/slice/slice.h"
@@ -61,9 +62,14 @@ class ConfigSelector : public RefCounted<ConfigSelector> {
 
   // The channel will call this when the resolver returns a new ConfigSelector
   // to determine what set of dynamic filters will be configured.
-  virtual void AddFilters(InterceptionChainBuilder& /*builder*/) {}
+  virtual void AddFilters(InterceptionChainBuilder& /*builder*/,
+                          const Blackboard* /*old_blackboard*/,
+                          Blackboard* /*new_blackboard*/) {}
   // TODO(roth): Remove this once the legacy filter stack goes away.
-  virtual std::vector<const grpc_channel_filter*> GetFilters() { return {}; }
+  virtual std::vector<const grpc_channel_filter*> GetFilters(
+      const Blackboard* /*old_blackboard*/, Blackboard* /*new_blackboard*/) {
+    return {};
+  }
 
   // Gets the configuration for the call and stores it in service config
   // call data.

--- a/src/core/client_channel/dynamic_filters.cc
+++ b/src/core/client_channel/dynamic_filters.cc
@@ -137,9 +137,9 @@ namespace {
 
 absl::StatusOr<RefCountedPtr<grpc_channel_stack>> CreateChannelStack(
     const ChannelArgs& args, std::vector<const grpc_channel_filter*> filters,
-    const Blackboard* old_blackboard, Blackboard* new_blackboard) {
+    const Blackboard* blackboard) {
   ChannelStackBuilderImpl builder("DynamicFilters", GRPC_CLIENT_DYNAMIC, args);
-  builder.SetBlackboards(old_blackboard, new_blackboard);
+  builder.SetBlackboard(blackboard);
   for (auto filter : filters) {
     builder.AppendFilter(filter);
   }
@@ -150,16 +150,15 @@ absl::StatusOr<RefCountedPtr<grpc_channel_stack>> CreateChannelStack(
 
 RefCountedPtr<DynamicFilters> DynamicFilters::Create(
     const ChannelArgs& args, std::vector<const grpc_channel_filter*> filters,
-    const Blackboard* old_blackboard, Blackboard* new_blackboard) {
+    const Blackboard* blackboard) {
   // Attempt to create channel stack from requested filters.
-  auto p = CreateChannelStack(args, std::move(filters), old_blackboard,
-                              new_blackboard);
+  auto p = CreateChannelStack(args, std::move(filters), blackboard);
   if (!p.ok()) {
     // Channel stack creation failed with requested filters.
     // Create with lame filter instead.
     auto error = p.status();
     p = CreateChannelStack(args.Set(MakeLameClientErrorArg(&error)),
-                           {&LameClientFilter::kFilter}, nullptr, nullptr);
+                           {&LameClientFilter::kFilter}, nullptr);
   }
   return MakeRefCounted<DynamicFilters>(std::move(p.value()));
 }

--- a/src/core/client_channel/dynamic_filters.h
+++ b/src/core/client_channel/dynamic_filters.h
@@ -90,7 +90,7 @@ class DynamicFilters final : public RefCounted<DynamicFilters> {
 
   static RefCountedPtr<DynamicFilters> Create(
       const ChannelArgs& args, std::vector<const grpc_channel_filter*> filters,
-      const Blackboard* old_blackboard, Blackboard* new_blackboard);
+      const Blackboard* blackboard);
 
   explicit DynamicFilters(RefCountedPtr<grpc_channel_stack> channel_stack)
       : channel_stack_(std::move(channel_stack)) {}

--- a/src/core/client_channel/retry_filter.cc
+++ b/src/core/client_channel/retry_filter.cc
@@ -92,26 +92,33 @@ namespace grpc_core {
 // RetryFilter
 //
 
+void RetryFilter::UpdateBlackboard(const ServiceConfig& service_config,
+                                   const Blackboard* old_blackboard,
+                                   Blackboard* new_blackboard) {
+  // Get retry throttling parameters from service config.
+  const auto* config = static_cast<const RetryGlobalConfig*>(
+      service_config.GetGlobalParsedConfig(
+          RetryServiceConfigParser::ParserIndex()));
+  if (config == nullptr) return;
+  // Get throttler.
+  RefCountedPtr<internal::RetryThrottler> throttler;
+  if (old_blackboard != nullptr) {
+    throttler = old_blackboard->Get<internal::RetryThrottler>("");
+  }
+  throttler = internal::RetryThrottler::Create(config->max_milli_tokens(),
+                                               config->milli_token_ratio(),
+                                               std::move(throttler));
+  new_blackboard->Set("", std::move(throttler));
+}
+
 RetryFilter::RetryFilter(const grpc_channel_element_args& args)
     : client_channel_(args.channel_args.GetObject<ClientChannelFilter>()),
       event_engine_(args.channel_args.GetObject<EventEngine>()),
       per_rpc_retry_buffer_size_(
           GetMaxPerRpcRetryBufferSize(args.channel_args)),
+      retry_throttler_(args.blackboard->Get<internal::RetryThrottler>("")),
       service_config_parser_index_(
-          internal::RetryServiceConfigParser::ParserIndex()) {
-  // Get retry throttling parameters from service config.
-  auto* service_config = args.channel_args.GetObject<ServiceConfig>();
-  if (service_config == nullptr) return;
-  const auto* config = static_cast<const RetryGlobalConfig*>(
-      service_config->GetGlobalParsedConfig(
-          RetryServiceConfigParser::ParserIndex()));
-  if (config == nullptr) return;
-  // Get throttler.
-  retry_throttler_ = internal::RetryThrottler::Create(
-      config->max_milli_tokens(), config->milli_token_ratio(),
-      args.old_blackboard->Get<internal::RetryThrottler>(""));
-  args.new_blackboard->Set("", retry_throttler_);
-}
+          internal::RetryServiceConfigParser::ParserIndex()) {}
 
 const RetryMethodConfig* RetryFilter::GetRetryPolicy(Arena* arena) {
   auto* svc_cfg_call_data = arena->GetContext<ServiceConfigCallData>();

--- a/src/core/client_channel/retry_filter.h
+++ b/src/core/client_channel/retry_filter.h
@@ -45,6 +45,10 @@ class RetryFilter final {
  public:
   static const grpc_channel_filter kVtable;
 
+  static void UpdateBlackboard(const ServiceConfig& service_config,
+                               const Blackboard* old_blackboard,
+                               Blackboard* blackboard);
+
  private:
   // Old filter-stack style call implementation, in
   // retry_filter_legacy_call_data.{h,cc}

--- a/src/core/client_channel/retry_interceptor.h
+++ b/src/core/client_channel/retry_interceptor.h
@@ -26,6 +26,7 @@
 namespace grpc_core {
 
 namespace retry_detail {
+
 class RetryState {
  public:
   RetryState(const internal::RetryMethodConfig* retry_policy,
@@ -55,8 +56,6 @@ class RetryState {
   BackOff retry_backoff_;
 };
 
-RefCountedPtr<internal::RetryThrottler> RetryThrottlerFromChannelArgs(
-    const ChannelArgs& args, const FilterArgs& filter_args);
 }  // namespace retry_detail
 
 class RetryInterceptor : public Interceptor {
@@ -68,6 +67,10 @@ class RetryInterceptor : public Interceptor {
       const ChannelArgs& args, const FilterArgs& filter_args);
 
   void Orphaned() override {}
+
+  static void UpdateBlackboard(const ServiceConfig& service_config,
+                               const Blackboard* old_blackboard,
+                               Blackboard* new_blackboard);
 
  protected:
   void InterceptCall(UnstartedCallHandler unstarted_call_handler) override;

--- a/src/core/ext/filters/gcp_authentication/gcp_authentication_filter.cc
+++ b/src/core/ext/filters/gcp_authentication/gcp_authentication_filter.cc
@@ -167,17 +167,11 @@ GcpAuthenticationFilter::Create(const ChannelArgs& args,
     return absl::InvalidArgumentError(
         "gcp_auth: xds config not found in channel args");
   }
-  // Get existing cache or create new one.
-  auto cache = filter_args.GetOrCreateState<CallCredentialsCache>(
-      filter_config->filter_instance_name,
-      [&](RefCountedPtr<CallCredentialsCache> existing) {
-        if (existing != nullptr) {
-          // Update size, in case it's changed.
-          existing->SetMaxSize(filter_config->cache_size);
-          return existing;
-        }
-        return MakeRefCounted<CallCredentialsCache>(filter_config->cache_size);
-      });
+  // Get cache from blackboard.  This must have been populated
+  // previously by the XdsConfigSelector.
+  auto cache = filter_args.GetState<CallCredentialsCache>(
+      filter_config->filter_instance_name);
+  CHECK_NE(cache.get(), nullptr);
   // Instantiate filter.
   return std::unique_ptr<GcpAuthenticationFilter>(
       new GcpAuthenticationFilter(std::move(service_config), filter_config,

--- a/src/core/ext/filters/gcp_authentication/gcp_authentication_filter.cc
+++ b/src/core/ext/filters/gcp_authentication/gcp_authentication_filter.cc
@@ -171,7 +171,10 @@ GcpAuthenticationFilter::Create(const ChannelArgs& args,
   // previously by the XdsConfigSelector.
   auto cache = filter_args.GetState<CallCredentialsCache>(
       filter_config->filter_instance_name);
-  CHECK_NE(cache.get(), nullptr);
+  if (cache == nullptr) {
+    return absl::InvalidArgumentError(
+        "gcp_auth: cache object not found in filter state");
+  }
   // Instantiate filter.
   return std::unique_ptr<GcpAuthenticationFilter>(
       new GcpAuthenticationFilter(std::move(service_config), filter_config,

--- a/src/core/filter/filter_args.h
+++ b/src/core/filter/filter_args.h
@@ -31,23 +31,18 @@ class FilterArgs {
              grpc_channel_element* channel_element,
              size_t (*channel_stack_filter_instance_number)(
                  grpc_channel_stack*, grpc_channel_element*),
-             const Blackboard* old_blackboard = nullptr,
-             Blackboard* new_blackboard = nullptr)
+             const Blackboard* blackboard = nullptr)
       : impl_(ChannelStackBased{channel_stack, channel_element,
                                 channel_stack_filter_instance_number}),
-        old_blackboard_(old_blackboard),
-        new_blackboard_(new_blackboard) {}
+        blackboard_(blackboard) {}
   // While we're moving to call-v3 we need to have access to
   // grpc_channel_stack & friends here. That means that we can't rely on this
   // type signature from interception_chain.h, which means that we need a way
   // of constructing this object without naming it ===> implicit construction.
   // TODO(ctiller): remove this once we're fully on call-v3
   // NOLINTNEXTLINE(google-explicit-constructor)
-  FilterArgs(size_t instance_id, const Blackboard* old_blackboard = nullptr,
-             Blackboard* new_blackboard = nullptr)
-      : impl_(V3Based{instance_id}),
-        old_blackboard_(old_blackboard),
-        new_blackboard_(new_blackboard) {}
+  FilterArgs(size_t instance_id, const Blackboard* blackboard = nullptr)
+      : impl_(V3Based{instance_id}), blackboard_(blackboard) {}
 
   ABSL_DEPRECATED("Direct access to channel stack is deprecated")
   grpc_channel_stack* channel_stack() const {
@@ -71,19 +66,11 @@ class FilterArgs {
         [](const V3Based& v3) { return v3.instance_id; });
   }
 
-  // Invokes update_func() to update a filter state object of type T
-  // with the specified key.  The existing filter state object, if any,
-  // will be passed to update_func().  The filter state object returned
-  // by update_func() will be saved and returned.
+  // Gets the filter state associated with a particular type and key.
   template <typename T>
-  RefCountedPtr<T> GetOrCreateState(
-      const std::string& key,
-      absl::FunctionRef<RefCountedPtr<T>(RefCountedPtr<T>)> update_func) const {
-    RefCountedPtr<T> state;
-    if (old_blackboard_ != nullptr) state = old_blackboard_->Get<T>(key);
-    state = update_func(std::move(state));
-    if (new_blackboard_ != nullptr) new_blackboard_->Set(key, state);
-    return state;
+  RefCountedPtr<T> GetState(const std::string& key) const {
+    if (blackboard_ == nullptr) return nullptr;
+    return blackboard_->Get<T>(key);
   }
 
  private:
@@ -103,8 +90,7 @@ class FilterArgs {
   using Impl = std::variant<ChannelStackBased, V3Based>;
   Impl impl_;
 
-  const Blackboard* old_blackboard_ = nullptr;
-  Blackboard* new_blackboard_ = nullptr;
+  const Blackboard* blackboard_ = nullptr;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/channel/channel_stack.cc
+++ b/src/core/lib/channel/channel_stack.cc
@@ -115,8 +115,7 @@ grpc_error_handle grpc_channel_stack_init(
     int initial_refs, grpc_iomgr_cb_func destroy, void* destroy_arg,
     const grpc_channel_filter** filters, size_t filter_count,
     const grpc_core::ChannelArgs& channel_args, const char* name,
-    grpc_channel_stack* stack, const grpc_core::Blackboard* old_blackboard,
-    grpc_core::Blackboard* new_blackboard) {
+    grpc_channel_stack* stack, const grpc_core::Blackboard* blackboard) {
   if (GRPC_TRACE_FLAG_ENABLED(channel_stack)) {
     LOG(INFO) << "CHANNEL_STACK: init " << name;
     for (size_t i = 0; i < filter_count; i++) {
@@ -145,8 +144,7 @@ grpc_error_handle grpc_channel_stack_init(
                                              sizeof(grpc_channel_element));
 
   // init per-filter data
-  args.old_blackboard = old_blackboard;
-  args.new_blackboard = new_blackboard;
+  args.blackboard = blackboard;
   grpc_error_handle first_error;
   for (i = 0; i < filter_count; i++) {
     args.channel_stack = stack;

--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -75,8 +75,7 @@ struct grpc_channel_element_args {
   grpc_core::ChannelArgs channel_args;
   int is_first;
   int is_last;
-  const grpc_core::Blackboard* old_blackboard;
-  grpc_core::Blackboard* new_blackboard;
+  const grpc_core::Blackboard* blackboard;
 };
 struct grpc_call_element_args {
   grpc_call_stack* call_stack;
@@ -269,8 +268,7 @@ grpc_error_handle grpc_channel_stack_init(
     const grpc_channel_filter** filters, size_t filter_count,
     const grpc_core::ChannelArgs& args, const char* name,
     grpc_channel_stack* stack,
-    const grpc_core::Blackboard* old_blackboard = nullptr,
-    grpc_core::Blackboard* new_blackboard = nullptr);
+    const grpc_core::Blackboard* blackboard = nullptr);
 // Destroy a channel stack
 void grpc_channel_stack_destroy(grpc_channel_stack* stack);
 

--- a/src/core/lib/channel/channel_stack_builder_impl.cc
+++ b/src/core/lib/channel/channel_stack_builder_impl.cc
@@ -75,7 +75,7 @@ ChannelStackBuilderImpl::Build() {
         gpr_free(stk);
       },
       channel_stack, stack.data(), stack.size(), channel_args(), name(),
-      channel_stack, old_blackboard_, new_blackboard_);
+      channel_stack, blackboard_);
 
   if (!error.ok()) {
     grpc_channel_stack_destroy(channel_stack);

--- a/src/core/lib/channel/channel_stack_builder_impl.h
+++ b/src/core/lib/channel/channel_stack_builder_impl.h
@@ -35,11 +35,7 @@ class ChannelStackBuilderImpl final : public ChannelStackBuilder {
  public:
   using ChannelStackBuilder::ChannelStackBuilder;
 
-  void SetBlackboards(const Blackboard* old_blackboard,
-                      Blackboard* new_blackboard) {
-    old_blackboard_ = old_blackboard;
-    new_blackboard_ = new_blackboard;
-  }
+  void SetBlackboard(const Blackboard* blackboard) { blackboard_ = blackboard; }
 
   // Build the channel stack.
   // After success, *result holds the new channel stack,
@@ -49,8 +45,7 @@ class ChannelStackBuilderImpl final : public ChannelStackBuilder {
   absl::StatusOr<RefCountedPtr<grpc_channel_stack>> Build() override;
 
  private:
-  const Blackboard* old_blackboard_ = nullptr;
-  Blackboard* new_blackboard_ = nullptr;
+  const Blackboard* blackboard_ = nullptr;
 };
 
 }  // namespace grpc_core

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1979,11 +1979,11 @@ struct ChannelFilterWithFlagsMethods {
   static absl::Status InitChannelElem(grpc_channel_element* elem,
                                       grpc_channel_element_args* args) {
     CHECK(args->is_last == ((kFlags & kFilterIsLast) != 0));
-    auto status = F::Create(
-        args->channel_args,
-        ChannelFilter::Args(args->channel_stack, elem,
-                            grpc_channel_stack_filter_instance_number,
-                            args->old_blackboard, args->new_blackboard));
+    auto status =
+        F::Create(args->channel_args,
+                  ChannelFilter::Args(args->channel_stack, elem,
+                                      grpc_channel_stack_filter_instance_number,
+                                      args->blackboard));
     if (!status.ok()) {
       new (elem->channel_data) F*(nullptr);
       return absl_status_to_grpc_error(status.status());

--- a/src/core/service_config/service_config.h
+++ b/src/core/service_config/service_config.h
@@ -72,7 +72,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
   /// lifetime of the returned object is tied to the lifetime of the
   /// ServiceConfig object.
   virtual ServiceConfigParser::ParsedConfig* GetGlobalParsedConfig(
-      size_t index) = 0;
+      size_t index) const = 0;
 
   /// Retrieves the vector of parsed configs for the method identified
   /// by \a path.  The lifetime of the returned vector and contained objects

--- a/src/core/service_config/service_config_impl.h
+++ b/src/core/service_config/service_config_impl.h
@@ -86,7 +86,7 @@ class ServiceConfigImpl final : public ServiceConfig {
   /// lifetime of the returned object is tied to the lifetime of the
   /// ServiceConfig object.
   ServiceConfigParser::ParsedConfig* GetGlobalParsedConfig(
-      size_t index) override {
+      size_t index) const override {
     DCHECK(index < parsed_global_configs_.size());
     return parsed_global_configs_[index].get();
   }

--- a/src/core/xds/grpc/xds_http_filter.h
+++ b/src/core/xds/grpc/xds_http_filter.h
@@ -24,6 +24,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "src/core/call/interception_chain.h"
+#include "src/core/filter/blackboard.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/channel_fwd.h"
 #include "src/core/util/json/json.h"
@@ -118,6 +119,12 @@ class XdsHttpFilterImpl {
   // Currently used only on the client side.
   virtual absl::StatusOr<ServiceConfigJsonEntry> GenerateServiceConfig(
       const FilterConfig& hcm_filter_config) const = 0;
+
+  // Adds state to new_blackboard if needed for the specified filter
+  // config.  Copies existing state from old_blackboard as appropriate.
+  virtual void UpdateBlackboard(const FilterConfig& /*hcm_filter_config*/,
+                                const Blackboard* /*old_blackboard*/,
+                                Blackboard* /*new_blackboard*/) const {}
 
   // Returns true if the filter is supported on clients; false otherwise
   virtual bool IsSupportedOnClients() const = 0;

--- a/src/core/xds/grpc/xds_http_gcp_authn_filter.h
+++ b/src/core/xds/grpc/xds_http_gcp_authn_filter.h
@@ -52,6 +52,9 @@ class XdsHttpGcpAuthnFilter final : public XdsHttpFilterImpl {
       const FilterConfig* filter_config_override) const override;
   absl::StatusOr<ServiceConfigJsonEntry> GenerateServiceConfig(
       const FilterConfig& hcm_filter_config) const override;
+  void UpdateBlackboard(const FilterConfig& hcm_filter_config,
+                        const Blackboard* old_blackboard,
+                        Blackboard* new_blackboard) const override;
   bool IsSupportedOnClients() const override { return true; }
   bool IsSupportedOnServers() const override { return false; }
 };

--- a/test/core/client_channel/client_channel_test.cc
+++ b/test/core/client_channel/client_channel_test.cc
@@ -319,7 +319,9 @@ class TestConfigSelector : public ConfigSelector {
     return kFactory.Create();
   }
 
-  void AddFilters(InterceptionChainBuilder& builder) override {
+  void AddFilters(InterceptionChainBuilder& builder,
+                  const Blackboard* /*old_blackboard*/,
+                  Blackboard* /*new_blackboard*/) override {
     builder.Add<TestFilter>();
   }
 

--- a/test/core/client_channel/retry_interceptor_test.cc
+++ b/test/core/client_channel/retry_interceptor_test.cc
@@ -40,7 +40,7 @@ class RetryInterceptorTest : public YodelTest {
 
   void InitInterceptor(const ChannelArgs& args) {
     CHECK(destination_under_test_ == nullptr);
-    InterceptionChainBuilder builder(args, nullptr, nullptr);
+    InterceptionChainBuilder builder(args, nullptr);
     builder.Add<RetryInterceptor>();
     destination_under_test_ = builder.Build(call_destination_).value();
   }

--- a/test/core/filters/filter_test.h
+++ b/test/core/filters/filter_test.h
@@ -218,8 +218,10 @@ class FilterTest : public FilterTestBase {
     using FilterTestBase::Channel::Channel;
   };
 
-  absl::StatusOr<Channel> MakeChannel(const ChannelArgs& args) {
-    auto filter = Filter::Create(args, ChannelFilter::Args(/*instance_id=*/0));
+  absl::StatusOr<Channel> MakeChannel(const ChannelArgs& args,
+                                      const Blackboard* blackboard = nullptr) {
+    auto filter = Filter::Create(
+        args, ChannelFilter::Args(/*instance_id=*/0, blackboard));
     if (!filter.ok()) return filter.status();
     return Channel(std::move(*filter), this);
   }


### PR DESCRIPTION
Prepare for adding blackboard support on the server side by splitting blackboard updates from filter stack construction.  On the server side, we will do the blackboard updates when receiving the xDS update, not when constructing the filter stack for an incoming connection.

For now, the blackboard updates are done as an xDS-specific thing rather than a generic filter stack mechanism, because the blackboard state update behavior depends on the filter config in the service config, and that logic is fairly xDS-specific.  I've added a special case for the retry filter, which is the only non-xDS filter that needs to retain state and is already being handled specially by the client channel code.

CC @pawbhard 