### PR TITLE
[EventEngine] Use pollset_alternative for HttpRequests

### DIFF
--- a/src/core/util/http_client/httpcli.cc
+++ b/src/core/util/http_client/httpcli.cc
@@ -200,8 +200,10 @@ HttpRequest::HttpRequest(
   GRPC_CLOSURE_INIT(&continue_done_write_after_schedule_on_exec_ctx_,
                     ContinueDoneWriteAfterScheduleOnExecCtx, this,
                     grpc_schedule_on_exec_ctx);
-  CHECK(pollent);
-  grpc_polling_entity_add_to_pollset_set(pollent, pollset_set_);
+  if (!grpc_event_engine::experimental::UsePollsetAlternative()) {
+    CHECK(pollent);
+    grpc_polling_entity_add_to_pollset_set(pollent, pollset_set_);
+  }
 }
 
 HttpRequest::~HttpRequest() {

--- a/src/core/util/http_client/httpcli.h
+++ b/src/core/util/http_client/httpcli.h
@@ -35,6 +35,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "src/core/handshaker/handshaker.h"
+#include "src/core/lib/event_engine/shim.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/error.h"
@@ -180,7 +181,9 @@ class HttpRequest : public InternallyRefCounted<HttpRequest> {
 
  private:
   void Finish(grpc_error_handle error) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
-    grpc_polling_entity_del_from_pollset_set(pollent_, pollset_set_);
+    if (!grpc_event_engine::experimental::UsePollsetAlternative()) {
+      grpc_polling_entity_del_from_pollset_set(pollent_, pollset_set_);
+    }
     ExecCtx::Run(DEBUG_LOCATION, on_done_, error);
   }
 


### PR DESCRIPTION
If enabled, EventEngine polling is assumed, and HttpRequests should work fine without the use of pollsets.

```
$ bazel test --config=dbg //test/core/util/http_client:all --test_env=GRPC_EXPERIMENTS=pollset_alternative

INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.0.1 will be used instead of system-wide bazel installation.
WARNING: Build option --test_env has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed 21 targets (0 packages loaded, 5963 targets configured).
INFO: Found 10 targets and 11 test targets...
INFO: Elapsed time: 12.453s, Critical Path: 11.63s
INFO: 12 processes: 5861 action cache hit, 1 internal, 11 linux-sandbox.
INFO: Build completed successfully, 12 total actions
//test/core/util/http_client:format_request_test                         PASSED in 0.9s
//test/core/util/http_client:format_request_test@poller=epoll1           PASSED in 0.9s
//test/core/util/http_client:format_request_test@poller=poll             PASSED in 0.9s
//test/core/util/http_client:fuzzer                                      PASSED in 3.1s
//test/core/util/http_client:httpcli_test                                PASSED in 11.5s
//test/core/util/http_client:httpcli_test@poller=epoll1                  PASSED in 11.5s
//test/core/util/http_client:httpcli_test@poller=poll                    PASSED in 10.5s
//test/core/util/http_client:httpscli_test                               PASSED in 8.5s
//test/core/util/http_client:httpscli_test@poller=epoll1                 PASSED in 8.5s
//test/core/util/http_client:httpscli_test@poller=poll                   PASSED in 7.5s
//test/core/util/http_client:parser_test                                 PASSED in 0.9s

Executed 11 out of 11 tests: 11 tests pass.
```