### PR TITLE
[EventEngine] Use pollset_alternative for EnvironmentAutoDetect

### DIFF
--- a/src/cpp/ext/gcp/BUILD
+++ b/src/cpp/ext/gcp/BUILD
@@ -180,6 +180,7 @@ grpc_cc_library(
         "//src/core:default_event_engine",
         "//src/core:env",
         "//src/core:error",
+        "//src/core:event_engine_shim",
         "//src/core:gcp_metadata_query",
         "//src/core:iomgr_fwd",
         "//src/core:load_file",

--- a/src/cpp/ext/gcp/environment_autodetect.cc
+++ b/src/cpp/ext/gcp/environment_autodetect.cc
@@ -33,7 +33,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/event_engine/default_event_engine.h"
+#include "src/core/lib/event_engine/shim.h"
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -134,15 +134,18 @@ class EnvironmentAutoDetectHelper
         project_id_(std::move(project_id)),
         on_done_(std::move(on_done)),
         event_engine_(std::move(event_engine)) {
-    grpc_core::ExecCtx exec_ctx;
-    // TODO(yashykt): The pollset stuff should go away once the HTTP library is
-    // ported over to use EventEngine.
-    pollset_ = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
-    grpc_pollset_init(pollset_, &mu_poll_);
-    pollent_ = grpc_polling_entity_create_from_pollset(pollset_);
-    // TODO(yashykt): Note that using EventEngine::Run is not fork-safe. If we
-    // want to make this fork-safe, we might need some re-work here.
-    event_engine_->Run([this] { PollLoop(); });
+    // The pollset_alternative experiment does not need pollsets
+    if (!grpc_event_engine::experimental::UsePollsetAlternative()) {
+      grpc_core::ExecCtx exec_ctx;
+      // TODO(yashykt): The pollset stuff should go away once the HTTP library
+      // is ported over to use EventEngine.
+      pollset_ = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));
+      grpc_pollset_init(pollset_, &mu_poll_);
+      pollent_ = grpc_polling_entity_create_from_pollset(pollset_);
+      // TODO(yashykt): Note that using EventEngine::Run is not fork-safe. If we
+      // want to make this fork-safe, we might need some re-work here.
+      event_engine_->Run([this] { PollLoop(); });
+    }
     AutoDetect();
   }
 
@@ -282,9 +285,11 @@ class EnvironmentAutoDetectHelper
               }
             }
             if (resource.has_value()) {
-              gpr_mu_lock(mu_poll_);
-              notify_poller_ = true;
-              gpr_mu_unlock(mu_poll_);
+              if (!grpc_event_engine::experimental::UsePollsetAlternative()) {
+                gpr_mu_lock(mu_poll_);
+                notify_poller_ = true;
+                gpr_mu_unlock(mu_poll_);
+              }
               auto on_done = std::move(on_done_);
               Unref();
               on_done(std::move(resource).value());


### PR DESCRIPTION
Builds on https://github.com/grpc/grpc/pull/39978, which allows null pollents to be provided to HttpRequests.

If enabled, EventEngine polling is assumed, and the detector can skip creating a background thread that calls `grpc_pollset_work`.

poll poller test:

```
$ bazel test --config=dbg //test/cpp/ext/gcp:environment_autodetect_test@poller=poll --test_env=GRPC_EXPERIMENTS=pollset_alternative

INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.0.1 will be used instead of system-wide bazel installation.
INFO: Analyzed target //test/cpp/ext/gcp:environment_autodetect_test@poller=poll (0 packages loaded, 1 target configured).
INFO: Found 1 test target...
Target //test/cpp/ext/gcp:environment_autodetect_test@poller=poll up-to-date:
  bazel-bin/test/cpp/ext/gcp/environment_autodetect_test@poller=poll
INFO: Elapsed time: 14.515s, Critical Path: 14.20s
INFO: 6 processes: 4 internal, 2 linux-sandbox.
INFO: Build completed successfully, 6 total actions
//test/cpp/ext/gcp:environment_autodetect_test@poller=poll               PASSED in 10.1s

Executed 1 out of 1 test: 1 test passes.
```

epoll poller test:

```
$ bazel test --config=dbg //test/cpp/ext/gcp:environment_autodetect_test@poller=epoll1 --test_env=GRPC_EXPERIMENTS=pollset_alternative

INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.0.1 will be used instead of system-wide bazel installation.
INFO: Analyzed target //test/cpp/ext/gcp:environment_autodetect_test@poller=epoll1 (1 packages loaded, 9 targets configured).
INFO: Found 1 test target...
Target //test/cpp/ext/gcp:environment_autodetect_test@poller=epoll1 up-to-date:
  bazel-bin/test/cpp/ext/gcp/environment_autodetect_test@poller=epoll1
INFO: Elapsed time: 22.016s, Critical Path: 21.75s
INFO: 19 processes: 117 action cache hit, 1 internal, 18 linux-sandbox.
INFO: Build completed successfully, 19 total actions
//test/cpp/ext/gcp:environment_autodetect_test@poller=epoll1             PASSED in 10.1s

Executed 1 out of 1 test: 1 test passes.
```