### PR TITLE
[Python] Resolve aio segfaults for Nogil mode support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,4 +94,4 @@ pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 
 use_repo(pip, "grpc_python_dependencies")
 
-bazel_dep(name = "cython", version = "3.0.11-1")
+bazel_dep(name = "cython", version = "3.1.1")

--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -38,9 +38,9 @@ def grpc_python_deps():
         http_archive(
             name = "cython",
             build_file = "@com_github_grpc_grpc//third_party:cython.BUILD",
-            sha256 = "2ec7d66d23d6da2328fb24f5c1bec6c63a59ec2e91027766ab904f417e1078aa",
-            strip_prefix = "cython-3.0.11",
+            sha256 = "d0f7bba6bea6b9eace344b587f38e1a3bbd50d896a8529d4215b5ce6f1461566",
+            strip_prefix = "cython-3.1.1",
             urls = [
-                "https://github.com/cython/cython/archive/3.0.11.tar.gz",
+                "https://github.com/cython/cython/archive/refs/tags/3.1.1.tar.gz",
             ],
         )

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pxd.pxi
@@ -48,5 +48,5 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
     cdef object _write_socket   # socket.socket
     cdef dict _loops            # Mapping[asyncio.AbstractLoop, _BoundEventLoop]
 
-    cdef void _poll(self) nogil
+    cdef int _poll(self) noexcept nogil
     cdef shutdown(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/completion_queue.pyx.pxi
@@ -94,7 +94,7 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
         else:
             self._loops[loop] = _BoundEventLoop(loop, self._read_socket, self._handle_events)
 
-    cdef void _poll(self) nogil:
+    cdef int _poll(self) noexcept nogil:
         cdef grpc_event event
         cdef CallbackContext *context
 
@@ -102,10 +102,8 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
             event = grpc_completion_queue_next(self._cq,
                                                _GPR_INF_FUTURE,
                                                NULL)
-
             if event.type == GRPC_QUEUE_TIMEOUT:
-                with gil:
-                    raise AssertionError("Core should not return GRPC_QUEUE_TIMEOUT!")
+                return 1
             elif event.type == GRPC_QUEUE_SHUTDOWN:
                 self._shutdown = True
             else:
@@ -120,10 +118,14 @@ cdef class PollerCompletionQueue(BaseCompletionQueue):
                         # instead of delegate to any thread, the polling thread
                         # should handle the distribution of the event.
                         self._handle_events(None)
+        return 0
 
     def _poll_wrapper(self):
+        cdef int poll_result 
         with nogil:
-            self._poll()
+            poll_result = self._poll()
+        if poll_result == 1:
+            raise AssertionError("Core should not return GRPC_QUEUE_TIMEOUT!")
 
     cdef shutdown(self):
         # Removes the socket hook from loops


### PR DESCRIPTION
Marked function as noexcept to resolve test segfaults in Python 3.13t free-threaded mode, upgraded to Cython version 3.1.1 due to compatibility issues.
Refer:  https://github.com/grpc/proposal/pull/502
@shivaspeaks 
