### PR TITLE
Fully qualify stdClass with global namespace

### DIFF
--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -52,7 +52,7 @@ class UnaryCall extends AbstractCall
     /**
      * Wait for the server to respond with data and a status.
      *
-     * @return array{0: T|null, 1: stdClass} [response data, status]
+     * @return array{0: T|null, 1: \stdClass} [response data, status]
      */
     public function wait()
     {


### PR DESCRIPTION
This PR addresses the following review comment: https://github.com/grpc/grpc/pull/37563#discussion_r2166825714

Changed `stdClass` to `\stdClass` to explicitly reference the global namespace.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

