### PR TITLE
[Maintainers] Move Daniel Born to Emeritus Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,7 +16,6 @@ for general contribution guidelines.
 - [arjunroy](https://github.com/arjunroy), Google LLC
 - [asheshvidyut](https://github.com/asheshvidyut), Google LLC
 - [ctiller](https://github.com/ctiller), Google LLC
-- [daniel-j-born](https://github.com/daniel-j-born), Google LLC
 - [dfawley](https://github.com/dfawley), Google LLC
 - [dklempner](https://github.com/dklempner), Google LLC
 - [drfloob](https://github.com/drfloob), Google LLC


### PR DESCRIPTION
This PR moves the following inactive maintainers to Emeritus:
- Daniel Born (@daniel-j-born)

This PR must remain open until July 11th, 2025 to allow time for response.