### PR TITLE
[chaotic-good] Fix lock ordering bug

### DIFF
--- a/src/core/ext/transport/chaotic_good/server_transport.cc
+++ b/src/core/ext/transport/chaotic_good/server_transport.cc
@@ -292,12 +292,12 @@ ChaoticGoodServerTransport::StreamDispatch::StreamDispatch(
 
 void ChaoticGoodServerTransport::StreamDispatch::AddData(
     channelz::DataSink sink) {
+  party_->ExportToChannelz("transport_party", sink);
   MutexLock lock(&mu_);
   sink.AddData("transport_state",
                channelz::PropertyList()
                    .Set("stream_map_size", stream_map_.size())
                    .Set("last_seen_new_stream_id", last_seen_new_stream_id_));
-  party_->ExportToChannelz("transport_party", sink);
 }
 
 void ChaoticGoodServerTransport::SetCallDestination(


### PR DESCRIPTION
Observed here: https://btx.cloud.google.com/invocations/c0a52bda-eedf-4d1a-bb62-7f20ededd82a/targets/%2F%2Ftest%2Fcore%2Fend2end:end2end_chaotic_good_test@poller%3Depoll1@experiment%3Devent_engine_fork;config=89d7583551730171f4a3ebfe2997bc50af6d8b94afe343117fdf8e9ccc31ced4/log
