### PR TITLE
[channelz] Fix nullptr access

### DIFF
--- a/src/core/ext/transport/chaotic_good/client_transport.cc
+++ b/src/core/ext/transport/chaotic_good/client_transport.cc
@@ -244,11 +244,11 @@ ChaoticGoodClientTransport::ChaoticGoodClientTransport(
 }
 
 ChaoticGoodClientTransport::~ChaoticGoodClientTransport() {
-  SourceDestructing();
-  party_.reset();
+  DCHECK(party_.get() == nullptr);
 }
 
 void ChaoticGoodClientTransport::Orphan() {
+  SourceDestructing();
   stream_dispatch_->OnFrameTransportClosed(
       absl::UnavailableError("Transport closed"));
   party_.reset();


### PR DESCRIPTION
Avoid resetting party until after the data source is marked destructing - avoids AddData from accessing it, fixing a nullptr crash we've seen in unit tests.