### PR TITLE
[build] Remove warning for c++20 extensions

### DIFF
--- a/bazel/copts.bzl
+++ b/bazel/copts.bzl
@@ -28,7 +28,6 @@ GRPC_LLVM_WARNING_FLAGS = [
     # Ignore unknown warning flags
     "-Wno-unknown-warning-option",
     # A list of enabled flags coming from internal build system
-    "-Wc++20-extensions",
     "-Wctad-maybe-unsupported",
     "-Wdeprecated-increment-bool",
     "-Wfloat-overflow-conversion",


### PR DESCRIPTION
Strict builds currently fail due to this warning. The new absl version apparently makes use of these extensions. Refer b/422624399