### PR TITLE
[build] Enable bazel profiling

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe.sh
+++ b/tools/internal_ci/linux/grpc_bazel_rbe.sh
@@ -33,5 +33,7 @@ bazel_rbe/bazel_wrapper \
   --output_user_root=/tmpfs/bazel \
   test \
   $BAZEL_FLAGS \
+  --generate_json_trace_profile \
+  --profile=bazel_rbe/profile.json \
   "$@" \
   -- ${BAZEL_TESTS:-//test/...}


### PR DESCRIPTION
Generates a perfetto readable json file for every bazel build that can be used to diagnose why things took as long as they did.