### PR TITLE
[Test] Fixed unused warnings

### DIFF
--- a/src/cpp/server/channelz/channelz_service.h
+++ b/src/cpp/server/channelz/channelz_service.h
@@ -72,6 +72,8 @@ class ChannelzV2Service final : public channelz::v2::Channelz::Service {
   Status QueryTrace(
       ServerContext*, const channelz::v2::QueryTraceRequest* request,
       ServerWriter<channelz::v2::QueryTraceResponse>* writer) override {
+    (void)request;
+    (void)writer;
     return Status(StatusCode::UNIMPLEMENTED, "Not implemented");
   }
 };


### PR DESCRIPTION
Fixed this unused warning

```
In file included from src/cpp/server/channelz/channelz_service_plugin.cc:28:
./src/cpp/server/channelz/channelz_service.h:73:62: error: unused parameter 'request' [-Werror,-Wunused-parameter]
      ServerContext*, const channelz::v2::QueryTraceRequest* request,
                                                             ^
./src/cpp/server/channelz/channelz_service.h:74:55: error: unused parameter 'writer' [-Werror,-Wunused-parameter]
      ServerWriter* writer) override {
```