### PR TITLE
[event_engine] Fix race conditions in the timer manager shutdown.

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -217,8 +217,9 @@ void RegisterResolver(
 #else  // GRPC_ENABLE_FORK_SUPPORT && GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
 
 void RegisterEventEngineForFork(
-    std::shared_ptr<PosixEventEngine> /* posix_engine */,
-    const std::shared_ptr<ThreadPool>& /* executor */) {}
+    const std::shared_ptr<PosixEventEngine>& /* posix_engine */,
+    const std::shared_ptr<ThreadPool>& /* executor */,
+    const std::shared_ptr<TimerManager>& /* timer_manager */) {}
 
 #endif  // GRPC_ENABLE_FORK_SUPPORT && GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
 

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -91,10 +91,14 @@ template <template <typename> typename PtrType>
 struct ForkHandlerPointers {
   PtrType<PosixEventEngine> event_engine;
   PtrType<ThreadPool> executor;
+  PtrType<TimerManager> timer_manager;
 
   ForkHandlerPointers(PtrType<PosixEventEngine> ee,
-                      PtrType<ThreadPool> thread_pool)
-      : event_engine(std::move(ee)), executor(std::move(thread_pool)) {}
+                      PtrType<ThreadPool> thread_pool,
+                      PtrType<TimerManager> timers)
+      : event_engine(std::move(ee)),
+        executor(std::move(thread_pool)),
+        timer_manager(std::move(timers)) {}
 };
 
 // Fork support - mutex and global list of event engines
@@ -112,16 +116,21 @@ std::vector<ForkHandlerPointers<std::shared_ptr>> LockForkHandlers() {
   // on a mutex in DeregisterEventEngineForFork but the weak pointer will not
   // be lockable here.
   locked.reserve(fork_handlers->size());
-  for (const auto& [event_engine, executor] : *fork_handlers) {
-    locked.emplace_back(event_engine.lock(), executor.lock());
+  for (const auto& [event_engine, executor, timer_manager] : *fork_handlers) {
+    locked.emplace_back(event_engine.lock(), executor.lock(),
+                        timer_manager.lock());
   }
   return locked;
 }
 
 void PrepareFork() {
-  for (const auto& [event_engine, executor] : LockForkHandlers()) {
+  for (const auto& [event_engine, executor, timer_manager] :
+       LockForkHandlers()) {
     if (event_engine != nullptr) {
       event_engine->BeforeFork();
+    }
+    if (timer_manager != nullptr) {
+      timer_manager->PrepareFork();
     }
     if (executor != nullptr) {
       executor->PrepareFork();
@@ -130,9 +139,13 @@ void PrepareFork() {
 }
 
 void PostForkInParent() {
-  for (const auto& [event_engine, executor] : LockForkHandlers()) {
+  for (const auto& [event_engine, executor, timer_manager] :
+       LockForkHandlers()) {
     if (executor != nullptr) {
       executor->PostFork();
+    }
+    if (timer_manager) {
+      timer_manager->PostFork();
     }
     if (event_engine != nullptr) {
       event_engine->AfterFork(PosixEventEngine::OnForkRole::kParent);
@@ -141,9 +154,13 @@ void PostForkInParent() {
 }
 
 void PostForkInChild() {
-  for (const auto& [event_engine, executor] : LockForkHandlers()) {
+  for (const auto& [event_engine, executor, timer_manager] :
+       LockForkHandlers()) {
     if (executor != nullptr) {
       executor->PostFork();
+    }
+    if (timer_manager) {
+      timer_manager->PostFork();
     }
     if (event_engine != nullptr) {
       event_engine->AfterFork(PosixEventEngine::OnForkRole::kChild);
@@ -153,7 +170,8 @@ void PostForkInChild() {
 
 void RegisterEventEngineForFork(
     const std::shared_ptr<PosixEventEngine>& posix_engine,
-    const std::shared_ptr<ThreadPool>& executor) {
+    const std::shared_ptr<ThreadPool>& executor,
+    const std::shared_ptr<TimerManager>& timer_manager) {
   if (!grpc_core::Fork::Enabled()) {
     return;
   }
@@ -166,7 +184,8 @@ void RegisterEventEngineForFork(
                               ptr.executor.expired();
                      }),
       fork_handlers->end());
-  fork_handlers->emplace_back(posix_engine, executor);
+  fork_handlers->emplace_back(std::move(posix_engine), std::move(executor),
+                              std::move(timer_manager));
   static bool handlers_installed = false;
   if (!handlers_installed) {
     pthread_atfork(PrepareFork, PostForkInParent, PostForkInChild);
@@ -531,7 +550,7 @@ void PosixEnginePollerManager::TriggerShutdown() {
 std::shared_ptr<PosixEventEngine> PosixEventEngine::MakePosixEventEngine() {
   // Can't use make_shared as ctor is private
   std::shared_ptr<PosixEventEngine> engine(new PosixEventEngine());
-  RegisterEventEngineForFork(engine, engine->executor_);
+  RegisterEventEngineForFork(engine, engine->executor_, engine->timer_manager_);
   return engine;
 }
 
@@ -541,7 +560,7 @@ PosixEventEngine::MakeTestOnlyPosixEventEngine(
         test_only_poller) {
   std::shared_ptr<PosixEventEngine> engine(
       new PosixEventEngine(std::move(test_only_poller)));
-  RegisterEventEngineForFork(engine, engine->executor_);
+  RegisterEventEngineForFork(engine, engine->executor_, engine->timer_manager_);
   return engine;
 }
 
@@ -551,7 +570,7 @@ PosixEventEngine::PosixEventEngine(std::shared_ptr<PosixEventPoller> poller)
 #if GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
       poller_manager_(poller),
 #endif
-      timer_manager_(executor_) {
+      timer_manager_(std::make_shared<TimerManager>(executor_)) {
 }
 
 PosixEventEngine::PosixEventEngine()
@@ -559,10 +578,10 @@ PosixEventEngine::PosixEventEngine()
       executor_(MakeThreadPool(grpc_core::Clamp(gpr_cpu_num_cores(), 4u, 16u))),
 #if GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
       poller_manager_(executor_),
-      timer_manager_(executor_) {
+      timer_manager_(std::make_shared<TimerManager>(executor_)) {
   SchedulePoller();
 #else   // GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
-      timer_manager_(executor_) {
+      timer_manager_(std::make_shared<TimerManager>(executor_)) {
 #endif  // GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
 }
 
@@ -602,7 +621,7 @@ PosixEventEngine::~PosixEventEngine() {
   polling_cycle_.reset();
   poller_manager_.TriggerShutdown();
 #endif  // GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
-  timer_manager_.Shutdown();
+  timer_manager_->Shutdown();
   executor_->Quiesce();
 }
 
@@ -610,7 +629,7 @@ bool PosixEventEngine::Cancel(EventEngine::TaskHandle handle) {
   grpc_core::MutexLock lock(&mu_);
   if (!known_handles_.contains(handle)) return false;
   auto* cd = reinterpret_cast<ClosureData*>(handle.keys[0]);
-  bool r = timer_manager_.TimerCancel(&cd->timer);
+  bool r = timer_manager_->TimerCancel(&cd->timer);
   known_handles_.erase(handle);
   if (r) delete cd;
   return r;
@@ -640,7 +659,7 @@ EventEngine::TaskHandle PosixEventEngine::RunAfterInternal(
     Run(std::move(cb));
     return TaskHandle::kInvalid;
   }
-  auto when_ts = ToTimestamp(timer_manager_.Now(), when);
+  auto when_ts = ToTimestamp(timer_manager_->Now(), when);
   auto* cd = new ClosureData;
   cd->cb = std::move(cb);
   cd->engine = this;
@@ -651,7 +670,7 @@ EventEngine::TaskHandle PosixEventEngine::RunAfterInternal(
   cd->handle = handle;
   GRPC_TRACE_LOG(event_engine, INFO)
       << "PosixEventEngine:" << this << " scheduling callback:" << handle;
-  timer_manager_.TimerInit(&cd->timer, when_ts, cd);
+  timer_manager_->TimerInit(&cd->timer, when_ts, cd);
   return handle;
 }
 
@@ -894,7 +913,6 @@ PosixEventEngine::CreatePosixListener(
     GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
 
 void PosixEventEngine::AfterFork(OnForkRole on_fork_role) {
-  timer_manager_.PostFork();
   if (on_fork_role == OnForkRole::kChild) {
     if (grpc_core::IsEventEngineForkEnabled()) {
       AfterForkInChild();
@@ -914,7 +932,6 @@ void PosixEventEngine::BeforeFork() {
 #if GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
   ResetPollCycle();
 #endif  // GRPC_PLATFORM_SUPPORTS_POSIX_POLLING
-  timer_manager_.PrepareFork();
 }
 
 void PosixEventEngine::AfterForkInChild() {

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -93,12 +93,12 @@ struct ForkHandlerPointers {
   PtrType<ThreadPool> executor;
   PtrType<TimerManager> timer_manager;
 
-  ForkHandlerPointers(PtrType<PosixEventEngine> ee,
-                      PtrType<ThreadPool> thread_pool,
-                      PtrType<TimerManager> timers)
-      : event_engine(std::move(ee)),
-        executor(std::move(thread_pool)),
-        timer_manager(std::move(timers)) {}
+  ForkHandlerPointers(PtrType<PosixEventEngine> event_engine,
+                      PtrType<ThreadPool> executor,
+                      PtrType<TimerManager> timer_manager)
+      : event_engine(std::move(event_engine)),
+        executor(std::move(executor)),
+        timer_manager(std::move(timer_manager)) {}
 };
 
 // Fork support - mutex and global list of event engines

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -299,7 +299,7 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport {
 #endif  // defined(GRPC_POSIX_SOCKET_TCP) &&
         // !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
 
-  TimerManager timer_manager_;
+  std::shared_ptr<TimerManager> timer_manager_;
 };
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/posix_engine/timer_manager.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.cc
@@ -155,8 +155,9 @@ void TimerManager::SuspendOrShutdown(bool shutdown) {
     cv_wait_.Signal();
   }
   main_loop_exit_signal_->WaitForNotification();
-  GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this
-                              << (shutdown ? " shutdown complete" : " suspend complete");
+  GRPC_TRACE_VLOG(timer, 2)
+      << "TimerManager::" << this
+      << (shutdown ? " shutdown complete" : " suspend complete");
 }
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/posix_engine/timer_manager.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.cc
@@ -46,7 +46,7 @@ void TimerManager::RunSomeTimers(
 // shutdown)
 bool TimerManager::WaitUntil(grpc_core::Timestamp next) {
   grpc_core::MutexLock lock(&mu_);
-  if (shutdown_) return false;
+  if (state_ != TimerManager::State::kRunning) return false;
   // If kicked_ is true at this point, it means there was a kick from the timer
   // system that the timer-manager threads here missed. We cannot trust 'next'
   // here any longer (since there might be an earlier deadline). So if kicked_
@@ -99,7 +99,7 @@ void TimerManager::TimerInit(Timer* timer, grpc_core::Timestamp deadline,
                              experimental::EventEngine::Closure* closure) {
   if (GRPC_TRACE_FLAG_ENABLED(timer)) {
     grpc_core::MutexLock lock(&mu_);
-    if (shutdown_) {
+    if (state_ != TimerManager::State::kRunning) {
       LOG(ERROR) << "WARNING: TimerManager::" << this
                  << ": scheduling Closure::" << closure
                  << " after TimerManager has been shut down.";
@@ -112,18 +112,7 @@ bool TimerManager::TimerCancel(Timer* timer) {
   return timer_list_->TimerCancel(timer);
 }
 
-void TimerManager::Shutdown() {
-  {
-    grpc_core::MutexLock lock(&mu_);
-    if (shutdown_) return;
-    GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this << " shutting down";
-    shutdown_ = true;
-    // Wait on the main loop to exit.
-    cv_wait_.Signal();
-  }
-  main_loop_exit_signal_->WaitForNotification();
-  GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this << " shutdown complete";
-}
+void TimerManager::Shutdown() { SuspendOrShutdown(true); }
 
 TimerManager::~TimerManager() { Shutdown(); }
 
@@ -137,15 +126,36 @@ void TimerManager::Kick() {
 
 void TimerManager::RestartPostFork() {
   grpc_core::MutexLock lock(&mu_);
-  CHECK(GPR_LIKELY(shutdown_));
+  CHECK(state_ != TimerManager::State::kRunning);
   GRPC_TRACE_VLOG(timer, 2)
-      << "TimerManager::" << this << " restarting after shutdown";
-  shutdown_ = false;
-  main_loop_exit_signal_.emplace();
-  thread_pool_->Run([this]() { MainLoop(); });
+      << "TimerManager::" << this << " restarting after suspend";
+  if (state_ == TimerManager::State::kSuspended) {
+    state_ = TimerManager::State::kRunning;
+    main_loop_exit_signal_.emplace();
+    thread_pool_->Run([this]() { MainLoop(); });
+  }
 }
 
-void TimerManager::PrepareFork() { Shutdown(); }
+void TimerManager::PrepareFork() { SuspendOrShutdown(false); }
+
 void TimerManager::PostFork() { RestartPostFork(); }
+
+void TimerManager::SuspendOrShutdown(bool shutdown) {
+  {
+    grpc_core::MutexLock lock(&mu_);
+    if (shutdown) {
+      // Pool will become shut down whether it was running or suspended
+      state_ = TimerManager::State::kShutdown;
+    } else if (state_ == TimerManager::State::kRunning) {
+      state_ = TimerManager::State::kSuspended;
+    }
+    GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this
+                              << (shutdown ? " shutting down" : " suspending");
+    // Wait on the main loop to exit.
+    cv_wait_.Signal();
+  }
+  main_loop_exit_signal_->WaitForNotification();
+  GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this << " shutdown complete";
+}
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/posix_engine/timer_manager.cc
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.cc
@@ -155,7 +155,8 @@ void TimerManager::SuspendOrShutdown(bool shutdown) {
     cv_wait_.Signal();
   }
   main_loop_exit_signal_->WaitForNotification();
-  GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this << " shutdown complete";
+  GRPC_TRACE_VLOG(timer, 2) << "TimerManager::" << this
+                              << (shutdown ? " shutdown complete" : " suspend complete");
 }
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/posix_engine/timer_manager.h
+++ b/src/core/lib/event_engine/posix_engine/timer_manager.h
@@ -95,13 +95,9 @@ class TimerManager final {
   // thread.
   grpc_core::CondVar cv_wait_;
   Host host_;
-  // are we shutting down?
-  State state_ ABSL_GUARDED_BY(mu_) = {State::kRunning};
-  // are we shutting down?
+  State state_ ABSL_GUARDED_BY(mu_) = State::kRunning;
   bool kicked_ ABSL_GUARDED_BY(mu_) = false;
-  // number of timer wakeups
   uint64_t wakeups_ ABSL_GUARDED_BY(mu_) = false;
-  // actual timer implementation
   std::unique_ptr<TimerList> timer_list_;
   std::shared_ptr<grpc_event_engine::experimental::ThreadPool> thread_pool_;
   std::optional<grpc_core::Notification> main_loop_exit_signal_;


### PR DESCRIPTION
1. Shutdown now will always wait for the timer manager to shut down, even if already waiting on another thread.
2. New state was introduced - suspended. Post fork will only restart suspended thread pools.
3. Timer manager lifespan is untied from an event engine lifespan for cases when thread pool is shutting down at the fork time. This change ensures the thread pool stays active while the timer manager is shutting down.