### PR TITLE
[pick_first] fix bug that caused us to stop attempting to connect

### DIFF
--- a/src/core/load_balancing/pick_first/pick_first.cc
+++ b/src/core/load_balancing/pick_first/pick_first.cc
@@ -875,11 +875,18 @@ void PickFirst::SubchannelList::SubchannelData::OnConnectivityStateChange(
   // Otherwise, process connectivity state change.
   switch (*connectivity_state_) {
     case GRPC_CHANNEL_TRANSIENT_FAILURE: {
-      bool prev_seen_transient_failure =
-          std::exchange(seen_transient_failure_, true);
       // If this is the first failure we've seen on this subchannel,
       // then we're still in the Happy Eyeballs pass.
-      if (!prev_seen_transient_failure && seen_transient_failure_) {
+      if (!seen_transient_failure_) {
+        // Only set seen_transient_failure_ on subchannels that we've
+        // already gotten to in this Happy Eyeballs pass.  We don't want
+        // to do this if a subchannel that we haven't yet gotten to reports
+        // TF, since that connection attempt might have been triggered by a
+        // different channel, and the subchannel may already be back in IDLE
+        // by the time we get there later in our Happy Eyeballs pass.
+        if (index_ <= subchannel_list_->attempting_index_) {
+          seen_transient_failure_ = true;
+        }
         // If a connection attempt fails before the timer fires, then
         // cancel the timer and start connecting on the next subchannel.
         if (index_ == subchannel_list_->attempting_index_) {
@@ -890,8 +897,8 @@ void PickFirst::SubchannelList::SubchannelData::OnConnectivityStateChange(
           ++subchannel_list_->attempting_index_;
           subchannel_list_->StartConnectingNextSubchannel();
         } else {
-          // If this was the last subchannel to fail, check if the Happy
-          // Eyeballs pass is complete.
+          // In case this was the last subchannel to fail, check if the
+          // Happy Eyeballs pass is complete.
           subchannel_list_->MaybeFinishHappyEyeballsPass();
         }
       } else if (subchannel_list_->IsHappyEyeballsPassComplete()) {

--- a/test/core/load_balancing/pick_first_test.cc
+++ b/test/core/load_balancing/pick_first_test.cc
@@ -1285,6 +1285,63 @@ TEST_F(PickFirstTest,
   });
 }
 
+// This exercizes a bug seen in the wild that caused us to silently stop
+// triggering connection attempts at the end of the Happy Eyeballs pass.
+TEST_F(PickFirstTest,
+       SubchannelReportsTransientFailureButIsIdleForHappyEyeballs) {
+  constexpr std::array<absl::string_view, 2> kAddresses = {
+      "ipv4:127.0.0.1:443", "ipv4:127.0.0.1:444"};
+  // Pre-initialize the second subchannel to report CONNECTING as
+  // its initial state.
+  auto* subchannel2 = CreateSubchannel(kAddresses[1]);
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_CONNECTING);
+  // Send an update containing two addresses.
+  absl::Status status = ApplyUpdate(
+      BuildUpdate(kAddresses, MakePickFirstConfig(false)), lb_policy());
+  EXPECT_TRUE(status.ok()) << status;
+  // LB policy should have created a subchannel for the first address.
+  auto* subchannel = FindSubchannel(kAddresses[0]);
+  ASSERT_NE(subchannel, nullptr);
+  // When the LB policy receives the first subchannel's initial connectivity
+  // state notification (IDLE), it will request a connection.
+  EXPECT_TRUE(subchannel->ConnectionRequested());
+  // This causes the subchannel to start to connect, so it reports CONNECTING.
+  subchannel->SetConnectivityState(GRPC_CHANNEL_CONNECTING);
+  // LB policy should have reported CONNECTING state.
+  ExpectConnectingUpdate();
+  // Second subchannel reports TF.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_TRANSIENT_FAILURE,
+                                    absl::UnavailableError("failed to connect"),
+                                    /*validate_state_transition=*/false);
+  // Second subchannel finishes backoff.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_IDLE);
+  // First subchannel fails.
+  subchannel->SetConnectivityState(GRPC_CHANNEL_TRANSIENT_FAILURE,
+                                   absl::UnavailableError("ugh"));
+  // This triggers a connection attempt on the second subchannel.
+  EXPECT_TRUE(subchannel2->ConnectionRequested());
+  // This causes the subchannel to start to connect, so it reports CONNECTING.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_CONNECTING);
+  // LB policy should have reported CONNECTING state.
+  ExpectConnectingUpdate();
+  // First subchannel finishes backoff.
+  subchannel->SetConnectivityState(GRPC_CHANNEL_IDLE);
+  // Second subchannel fails.
+  subchannel2->SetConnectivityState(GRPC_CHANNEL_TRANSIENT_FAILURE,
+                                    absl::UnavailableError("ugh2"));
+  // The Happy Eyeballs pass is now complete.
+  // The LB policy should request re-resolution.
+  ExpectReresolutionRequest();
+  // The LB policy will report TRANSIENT_FAILURE.
+  WaitForConnectionFailed([&](const absl::Status& status) {
+    EXPECT_EQ(status,
+              absl::UnavailableError("failed to connect to all addresses; "
+                                     "last error: UNAVAILABLE: ugh2"));
+  });
+  // We should immediately start connecting on the first subchannel again.
+  EXPECT_TRUE(subchannel->ConnectionRequested());
+}
+
 TEST_F(PickFirstTest, WithShuffle) {
   constexpr std::array<absl::string_view, 6> kAddresses = {
       "ipv4:127.0.0.1:443", "ipv4:127.0.0.1:444", "ipv4:127.0.0.1:445",


### PR DESCRIPTION
The bug was triggered in a fairly rare sequence of events: The subchannel needed to report CONNECTING as its initial state but then transition to TRANSIENT_FAILURE and back to IDLE before Happy Eyeballs got to it. Because we had recorded that the subchannel already saw TRANSIENT_FAILURE state before Happy Eyeballs got to it, it was not considered a new failure, which broke the logic we use to trigger exiting from the initial Happy Eyeballs pass and continue connecting. The fix is to not record that the subchannel saw TRANSIENT_FAILURE state until we get to it in the Happy Eyeballs pass.

b/428689461