### PR TITLE
[Python][Part 6] - Introducing Ruff

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -77,7 +77,6 @@ ignore = [
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names
     "F811",    # Redefinition of unused {name} from {row}
-    "F821",    # Undefined name {name}. {tip}
     "F841",    # Local variable {name} is assigned to but never used
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition

--- a/ruff.toml
+++ b/ruff.toml
@@ -64,8 +64,11 @@ ignore = [
     "E713",    # Test for membership should be not in
     "E722",    # Do not use bare except
     "E731",    # Do not assign a lambda expression, use a def
+<<<<<<< HEAD
     "EM101",   # Exception must not use a string literal, assign to variable first
     "EM102",   # Exception must not use an f-string literal, assign to variable first
+=======
+>>>>>>> 2fffd49b13 (removed suppression for EM102)
     "EM103",   # Exception must not use a .format() string directly, assign to variable first
     "ERA001",  # Found commented-out code
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,7 +81,6 @@ ignore = [
     "FBT002",  # Boolean default positional argument in function definition
     "FBT003",  # Boolean positional value in function call
     "FIX002",  # Line contains TODO, consider resolving the issue
-    "FLY002",  # Consider {expression} instead of string join
     "FURB188", # Prefer str.removeprefix() over conditionally replacing with slice.
     "G003",    # Logging statement uses +
     "I001",    # Import block is un-sorted or un-formatted

--- a/ruff.toml
+++ b/ruff.toml
@@ -69,6 +69,7 @@ ignore = [
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names
     "F811",    # Redefinition of unused {name} from {row}
+    "F821",    # Undefined name {name}. {tip}
     "F841",    # Local variable {name} is assigned to but never used
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition

--- a/ruff.toml
+++ b/ruff.toml
@@ -84,7 +84,6 @@ ignore = [
     "I001",    # Import block is un-sorted or un-formatted
     "ISC003",  # Explicitly concatenated string should be implicitly concatenated
     "N802",    # Function name {name} should be lowercase
-    "N803",    # Argument name {name} should be lowercase
     "N806",    # Variable {name} in function should be lowercase
     "N818",    # Exception name {name} should be named with an Error suffix
     "PERF102", # When using only the {subset} of a dict use the {subset}() method

--- a/ruff.toml
+++ b/ruff.toml
@@ -76,7 +76,6 @@ ignore = [
     "ERA001",  # Found commented-out code
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names
-    "F541",    # f-string without any placeholders
     "F811",    # Redefinition of unused {name} from {row}
     "F821",    # Undefined name {name}. {tip}
     "F841",    # Local variable {name} is assigned to but never used

--- a/ruff.toml
+++ b/ruff.toml
@@ -83,7 +83,6 @@ ignore = [
     "FIX002",  # Line contains TODO, consider resolving the issue
     "I001",    # Import block is un-sorted or un-formatted
     "ICN001",  # {name} should be imported as {asname}
-    "INP001",  # File {filename} is part of an implicit namespace package. Add an __init__.py.
     "ISC003",  # Explicitly concatenated string should be implicitly concatenated
     "LOG015",  # {}() call on root logger
     "N802",    # Function name {name} should be lowercase

--- a/ruff.toml
+++ b/ruff.toml
@@ -82,7 +82,6 @@ ignore = [
     "FBT003",  # Boolean positional value in function call
     "FIX002",  # Line contains TODO, consider resolving the issue
     "I001",    # Import block is un-sorted or un-formatted
-    "ICN001",  # {name} should be imported as {asname}
     "ISC003",  # Explicitly concatenated string should be implicitly concatenated
     "LOG015",  # {}() call on root logger
     "N802",    # Function name {name} should be lowercase

--- a/ruff.toml
+++ b/ruff.toml
@@ -65,11 +65,14 @@ ignore = [
     "E722",    # Do not use bare except
     "E731",    # Do not assign a lambda expression, use a def
 <<<<<<< HEAD
+<<<<<<< HEAD
     "EM101",   # Exception must not use a string literal, assign to variable first
     "EM102",   # Exception must not use an f-string literal, assign to variable first
 =======
 >>>>>>> 2fffd49b13 (removed suppression for EM102)
     "EM103",   # Exception must not use a .format() string directly, assign to variable first
+=======
+>>>>>>> cbc85cffdd (removed suppression for EM103)
     "ERA001",  # Found commented-out code
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names

--- a/ruff.toml
+++ b/ruff.toml
@@ -83,7 +83,6 @@ ignore = [
     "FIX002",  # Line contains TODO, consider resolving the issue
     "I001",    # Import block is un-sorted or un-formatted
     "ISC003",  # Explicitly concatenated string should be implicitly concatenated
-    "LOG015",  # {}() call on root logger
     "N802",    # Function name {name} should be lowercase
     "N803",    # Argument name {name} should be lowercase
     "N806",    # Variable {name} in function should be lowercase

--- a/ruff.toml
+++ b/ruff.toml
@@ -77,7 +77,6 @@ ignore = [
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names
     "F811",    # Redefinition of unused {name} from {row}
-    "F841",    # Local variable {name} is assigned to but never used
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition
     "FBT003",  # Boolean positional value in function call

--- a/ruff.toml
+++ b/ruff.toml
@@ -64,19 +64,12 @@ ignore = [
     "E713",    # Test for membership should be not in
     "E722",    # Do not use bare except
     "E731",    # Do not assign a lambda expression, use a def
-<<<<<<< HEAD
-<<<<<<< HEAD
     "EM101",   # Exception must not use a string literal, assign to variable first
-    "EM102",   # Exception must not use an f-string literal, assign to variable first
-=======
->>>>>>> 2fffd49b13 (removed suppression for EM102)
-    "EM103",   # Exception must not use a .format() string directly, assign to variable first
-=======
->>>>>>> cbc85cffdd (removed suppression for EM103)
     "ERA001",  # Found commented-out code
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names
     "F811",    # Redefinition of unused {name} from {row}
+    "F841",    # Local variable {name} is assigned to but never used
     "FBT001",  # Boolean-typed positional argument in function definition
     "FBT002",  # Boolean default positional argument in function definition
     "FBT003",  # Boolean positional value in function call

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,7 +81,6 @@ ignore = [
     "FBT002",  # Boolean default positional argument in function definition
     "FBT003",  # Boolean positional value in function call
     "FIX002",  # Line contains TODO, consider resolving the issue
-    "FURB188", # Prefer str.removeprefix() over conditionally replacing with slice.
     "G003",    # Logging statement uses +
     "I001",    # Import block is un-sorted or un-formatted
     "ICN001",  # {name} should be imported as {asname}

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,7 +81,6 @@ ignore = [
     "FBT002",  # Boolean default positional argument in function definition
     "FBT003",  # Boolean positional value in function call
     "FIX002",  # Line contains TODO, consider resolving the issue
-    "FIX004",  # Line contains HACK, consider resolving the issue
     "FLY002",  # Consider {expression} instead of string join
     "FURB188", # Prefer str.removeprefix() over conditionally replacing with slice.
     "G003",    # Logging statement uses +

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,7 +81,6 @@ ignore = [
     "FBT002",  # Boolean default positional argument in function definition
     "FBT003",  # Boolean positional value in function call
     "FIX002",  # Line contains TODO, consider resolving the issue
-    "G003",    # Logging statement uses +
     "I001",    # Import block is un-sorted or un-formatted
     "ICN001",  # {name} should be imported as {asname}
     "INP001",  # File {filename} is part of an implicit namespace package. Add an __init__.py.

--- a/ruff.toml
+++ b/ruff.toml
@@ -76,7 +76,6 @@ ignore = [
     "ERA001",  # Found commented-out code
     "F401",    # {name} imported but unused; consider using importlib.util.find_spec to test for availability
     "F403",    # from {name} import * used; unable to detect undefined names
-    "F523",    # .format call has unused arguments at position(s): {message}
     "F541",    # f-string without any placeholders
     "F811",    # Redefinition of unused {name} from {row}
     "F821",    # Undefined name {name}. {tip}

--- a/src/python/grpcio/grpc/_auth.py
+++ b/src/python/grpcio/grpc/_auth.py
@@ -37,7 +37,7 @@ class GoogleCallCredentials(grpc.AuthMetadataPlugin):
     # TODO(xuanwn): Give credentials an actual type.
     def __init__(self, credentials: Any):
         self._credentials = credentials
-        # Hack to determine if these are JWT creds and we need to pass
+        # Hack to determine if these are JWT creds and we need to pass # noqa: FIX004
         # additional_claims when getting a token
         self._is_jwt = (
             "additional_claims"

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -246,7 +246,7 @@ def _event_handler(
             except Exception as e:  # pylint: disable=broad-except
                 # NOTE(rbellevi): We suppress but log errors here so as not to
                 # kill the channel spin thread.
-                logging.error(
+                logging.error( # noqa: LOG015
                     "Exception in callback %s: %s", repr(callback.func), repr(e)
                 )
         return done and state.fork_epoch >= cygrpc.get_fork_epoch()

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -246,7 +246,7 @@ def _event_handler(
             except Exception as e:  # pylint: disable=broad-except
                 # NOTE(rbellevi): We suppress but log errors here so as not to
                 # kill the channel spin thread.
-                logging.error(  # noqa: LOG015
+                _LOGGER.error(
                     "Exception in callback %s: %s", repr(callback.func), repr(e)
                 )
         return done and state.fork_epoch >= cygrpc.get_fork_epoch()

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -246,7 +246,7 @@ def _event_handler(
             except Exception as e:  # pylint: disable=broad-except
                 # NOTE(rbellevi): We suppress but log errors here so as not to
                 # kill the channel spin thread.
-                logging.error( # noqa: LOG015
+                logging.error(  # noqa: LOG015
                     "Exception in callback %s: %s", repr(callback.func), repr(e)
                 )
         return done and state.fork_epoch >= cygrpc.get_fork_epoch()

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -66,9 +66,7 @@ class _AuthMetadataPluginCallback(grpc.AuthMetadataPluginCallback):
                     self._state.called = True
             else:
                 error_msg = f'AuthMetadataPluginCallback raised exception "{self._state.exception}"!'
-                raise RuntimeError(
-                    error_msg
-                )
+                raise RuntimeError(error_msg)
         if error is None:
             self._callback(metadata, cygrpc.StatusCode.ok, None)
         else:

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -66,7 +66,7 @@ class _AuthMetadataPluginCallback(grpc.AuthMetadataPluginCallback):
                     self._state.called = True
             else:
                 error_msg = (
-                    f"AuthMetadataPluginCallback"
+                    "AuthMetadataPluginCallback"
                     'raised exception "{self._state.exception}"!'
                 )
                 raise RuntimeError(error_msg)

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -65,10 +65,9 @@ class _AuthMetadataPluginCallback(grpc.AuthMetadataPluginCallback):
                 else:
                     self._state.called = True
             else:
+                error_msg = f'AuthMetadataPluginCallback raised exception "{self._state.exception}"!'
                 raise RuntimeError(
-                    'AuthMetadataPluginCallback raised exception "{}"!'.format(
-                        self._state.exception
-                    )
+                    error_msg
                 )
         if error is None:
             self._callback(metadata, cygrpc.StatusCode.ok, None)

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -65,7 +65,10 @@ class _AuthMetadataPluginCallback(grpc.AuthMetadataPluginCallback):
                 else:
                     self._state.called = True
             else:
-                error_msg = f'AuthMetadataPluginCallback raised exception "{self._state.exception}"!'
+                error_msg = (
+                    f"AuthMetadataPluginCallback"
+                    'raised exception "{self._state.exception}"!'
+                )
                 raise RuntimeError(error_msg)
         if error is None:
             self._callback(metadata, cygrpc.StatusCode.ok, None)

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -1395,9 +1395,9 @@ def _validate_generic_rpc_handlers(
     for generic_rpc_handler in generic_rpc_handlers:
         service_attribute = getattr(generic_rpc_handler, "service", None)
         if service_attribute is None:
+            error_msg = f'"{generic_rpc_handler}" must conform to grpc.GenericRpcHandler type but does not have "service" method!'
             raise AttributeError(
-                '"{}" must conform to grpc.GenericRpcHandler type but does '
-                'not have "service" method!'.format(generic_rpc_handler)
+                error_msg
             )
 
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -1396,9 +1396,7 @@ def _validate_generic_rpc_handlers(
         service_attribute = getattr(generic_rpc_handler, "service", None)
         if service_attribute is None:
             error_msg = f'"{generic_rpc_handler}" must conform to grpc.GenericRpcHandler type but does not have "service" method!'
-            raise AttributeError(
-                error_msg
-            )
+            raise AttributeError(error_msg)
 
 
 def _augment_options(

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -1395,7 +1395,10 @@ def _validate_generic_rpc_handlers(
     for generic_rpc_handler in generic_rpc_handlers:
         service_attribute = getattr(generic_rpc_handler, "service", None)
         if service_attribute is None:
-            error_msg = f'"{generic_rpc_handler}" must conform to grpc.GenericRpcHandler type but does not have "service" method!'
+            error_msg = (
+                f'"{generic_rpc_handler}" must conform to'
+                'grpc.GenericRpcHandler type but does not have "service" method!'
+            )
             raise AttributeError(error_msg)
 
 

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -80,8 +80,8 @@ def _create_channel(
     compression: Optional[grpc.Compression],
 ) -> grpc.Channel:
     _LOGGER.debug(
-        f"Creating secure channel with credentials '{channel_credentials}', "
-        + f"options '{options}' and compression '{compression}'"
+      f"Creating secure channel with credentials '{channel_credentials}', "
+      f"options '{options}' and compression '{compression}'"
     )
     return grpc.secure_channel(
         target,

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -79,9 +79,12 @@ def _create_channel(
     channel_credentials: Optional[grpc.ChannelCredentials],
     compression: Optional[grpc.Compression],
 ) -> grpc.Channel:
+    debug_msg = (
+        f"Creating secure channel with credentials '{channel_credentials}', "
+        f"options '{options}' and compression '{compression}'"
+    )
     _LOGGER.debug(
-      f"Creating secure channel with credentials '{channel_credentials}', "
-      f"options '{options}' and compression '{compression}'"
+      debug_msg
     )
     return grpc.secure_channel(
         target,

--- a/src/python/grpcio/grpc/_simple_stubs.py
+++ b/src/python/grpcio/grpc/_simple_stubs.py
@@ -83,9 +83,7 @@ def _create_channel(
         f"Creating secure channel with credentials '{channel_credentials}', "
         f"options '{options}' and compression '{compression}'"
     )
-    _LOGGER.debug(
-      debug_msg
-    )
+    _LOGGER.debug(debug_msg)
     return grpc.secure_channel(
         target,
         credentials=channel_credentials,

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -434,8 +434,9 @@ class Channel(_base_channel.Channel):
                             continue
                     else:
                         # Unidentified Call object
+                        error_msg = f"Unrecognized call object: {candidate}"
                         raise cygrpc.InternalError(
-                            f"Unrecognized call object: {candidate}"
+                            error_msg
                         )
 
                     calls.append(candidate)

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -435,9 +435,7 @@ class Channel(_base_channel.Channel):
                     else:
                         # Unidentified Call object
                         error_msg = f"Unrecognized call object: {candidate}"
-                        raise cygrpc.InternalError(
-                            error_msg
-                        )
+                        raise cygrpc.InternalError(error_msg)
 
                     calls.append(candidate)
                     call_tasks.append(task)

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -61,7 +61,8 @@ class Metadata(abc.Collection):
         try:
             return self._metadata[key][0]
         except (ValueError, IndexError) as e:
-            raise KeyError("{0!r}".format(key)) from e
+            error_msg = f"{key!r}"
+            raise KeyError(error_msg) from e
 
     def __setitem__(self, key: MetadataKey, value: MetadataValue) -> None:
         """Calling metadata[<key>] = <value>

--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -53,7 +53,10 @@ class Server(_base_server.Server):
                 if not isinstance(interceptor, ServerInterceptor)
             ]
             if invalid_interceptors:
-                error_msg = "Interceptor must be ServerInterceptor, the following are invalid: {invalid_interceptors}"
+                error_msg = (
+                    f"Interceptor must be ServerInterceptor,"
+                    "the following are invalid: {invalid_interceptors}"
+                )
                 raise ValueError(error_msg)
         self._server = cygrpc.AioServer(
             self._loop,

--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -54,9 +54,7 @@ class Server(_base_server.Server):
             ]
             if invalid_interceptors:
                 error_msg = "Interceptor must be ServerInterceptor, the following are invalid: {invalid_interceptors}"
-                raise ValueError(
-                  error_msg
-                )
+                raise ValueError(error_msg)
         self._server = cygrpc.AioServer(
             self._loop,
             thread_pool,

--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -54,7 +54,7 @@ class Server(_base_server.Server):
             ]
             if invalid_interceptors:
                 error_msg = (
-                    f"Interceptor must be ServerInterceptor,"
+                    "Interceptor must be ServerInterceptor,"
                     "the following are invalid: {invalid_interceptors}"
                 )
                 raise ValueError(error_msg)

--- a/src/python/grpcio/grpc/aio/_server.py
+++ b/src/python/grpcio/grpc/aio/_server.py
@@ -53,9 +53,9 @@ class Server(_base_server.Server):
                 if not isinstance(interceptor, ServerInterceptor)
             ]
             if invalid_interceptors:
+                error_msg = "Interceptor must be ServerInterceptor, the following are invalid: {invalid_interceptors}"
                 raise ValueError(
-                    "Interceptor must be ServerInterceptor, the "
-                    f"following are invalid: {invalid_interceptors}"
+                  error_msg
                 )
         self._server = cygrpc.AioServer(
             self._loop,

--- a/src/python/grpcio_observability/grpc_observability/_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_observability.py
@@ -63,7 +63,7 @@ class StatsData:
     """
 
     # type disabled reason: forward reference, circular import.
-    name: "grpc_observability._cyobservability.MetricsName"  # pytype: disable=name-error
+    name: "grpc_observability._cyobservability.MetricsName"  # pytype: disable=name-error # noqa: F821
     measure_double: bool
     value_int: int = 0
     value_float: float = 0.0

--- a/src/python/grpcio_observability/grpc_observability/_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_observability.py
@@ -63,9 +63,7 @@ class StatsData:
     """
 
     # type disabled reason: forward reference, circular import.
-    name: (
-        "grpc_observability._cyobservability.MetricsName"  # pytype: disable=name-error
-    )
+    name: "grpc_observability._cyobservability.MetricsName"  # pytype: disable=name-error
     measure_double: bool
     value_int: int = 0
     value_float: float = 0.0

--- a/src/python/grpcio_observability/grpc_observability/_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_observability.py
@@ -63,7 +63,9 @@ class StatsData:
     """
 
     # type disabled reason: forward reference, circular import.
-    name: "grpc_observability._cyobservability.MetricsName"  # pytype: disable=name-error # noqa: F821
+    name: (
+        "grpc_observability._cyobservability.MetricsName"  # pytype: disable=name-error
+    )
     measure_double: bool
     value_int: int = 0
     value_float: float = 0.0

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -379,7 +379,8 @@ class OpenTelemetryObservability(grpc._observability.ObservabilityPlugin):
             _cyobservability.activate_stats()
             self.set_stats(True)
         except Exception as e:  # pylint: disable=broad-except
-            raise ValueError(f"Activate observability metrics failed with: {e}")
+            error_msg = f"Activate observability metrics failed with: {e}"
+            raise ValueError(error_msg)
 
         try:
             _cyobservability.cyobservability_init(self._exporter)

--- a/src/python/grpcio_testing/grpc_testing/_channel/_rpc_state.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_rpc_state.py
@@ -189,9 +189,7 @@ class State(_common.ChannelRpcHandler):
                     self._condition.wait()
                 else:
                     error_msg = f"Status code unexpectedly {self._code}!"
-                    raise ValueError(
-                        error_msg
-                    )
+                    raise ValueError(error_msg)
 
     def is_active(self):
         raise NotImplementedError()

--- a/src/python/grpcio_testing/grpc_testing/_channel/_rpc_state.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_rpc_state.py
@@ -188,8 +188,9 @@ class State(_common.ChannelRpcHandler):
                 elif self._code is None:
                     self._condition.wait()
                 else:
+                    error_msg = f"Status code unexpectedly {self._code}!"
                     raise ValueError(
-                        "Status code unexpectedly {}!".format(self._code)
+                        error_msg
                     )
 
     def is_active(self):


### PR DESCRIPTION
### Description

## Part 6 of Introducing Ruff

* In this PR - the suppression for `EM102`, `EM103`, `F523`, `F541`, `F821`, `FIX004`, `FLY002`, `FURB188`, `G003`, `G004`, `INP001`, `ICN001`, `LOG015` and `N803` has been removed on the root `ruff.toml`