### PR TITLE
[Build] Added missing useful to cf_event_engine

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2980,6 +2980,7 @@ grpc_cc_library(
         "ref_counted",
         "strerror",
         "sync",
+        "useful",
         "//:event_engine_base_hdrs",
         "//:gpr",
         "//:parse_address",


### PR DESCRIPTION
Fixed the layering issue found in https://github.com/bazelbuild/bazel-central-registry/pull/5139

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/grpc~/src/core/lib/event_engine/cf_engine/cf_engine.cc:34:10: error: module grpc~//src/core:cf_event_engine does not depend on a module exporting 'src/core/util/useful.h'
   34 | #include "src/core/util/useful.h"
      |          ^
```
