### PR TITLE
[Backport-to-1.74.x] Added missing useful to cf_event_engine

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2979,6 +2979,7 @@ grpc_cc_library(
         "ref_counted",
         "strerror",
         "sync",
+        "useful",
         "//:event_engine_base_hdrs",
         "//:gpr",
         "//:parse_address",


### PR DESCRIPTION
Backport of https://github.com/grpc/grpc/pull/40209