### PR TITLE
[Python][Typeguard] Part 2 - Add Typeguard to AIO stack in tests 

### DIFF
--- a/bazel/_run_time_type_check_main.py
+++ b/bazel/_run_time_type_check_main.py
@@ -31,20 +31,8 @@ install_import_hook('grpc.aio._interceptor')
 # install_import_hook('grpc.aio._base_server')
 # install_import_hook('grpc.aio._typing')
 # install_import_hook('grpc.aio._call')
-# install_import_hook('grpc.aio._cython')
 # install_import_hook('grpc.aio._metadata')
-# install_import_hook('grpc.aio._compression')
-# install_import_hook('grpc.aio._credentials')
-# install_import_hook('grpc.aio._ssl_channel_credentials')
-# install_import_hook('grpc.aio._ssl_server_credentials')
-# install_import_hook('grpc.aio._status')
-# install_import_hook('grpc.aio._stream')
-# install_import_hook('grpc.aio._cancel')
-# install_import_hook('grpc.aio._logging')
-# install_import_hook('grpc.aio._ref')
-# install_import_hook('grpc.aio._resource')
-# install_import_hook('grpc.aio._timeout')
-# install_import_hook('grpc.aio._trace')
+
 
 
 class SingleLoader(object):

--- a/bazel/_run_time_type_check_main.py
+++ b/bazel/_run_time_type_check_main.py
@@ -24,7 +24,7 @@ from typeguard import install_import_hook
 # Temporarily disable most hooks due to type annotation issues
 # install_import_hook('grpc.aio')
 # install_import_hook('grpc.aio._channel')
-install_import_hook('grpc.aio._server')  # Keep this one to test our type error
+install_import_hook('grpc.aio._server')
 install_import_hook('grpc.aio._utils')
 install_import_hook('grpc.aio._interceptor')
 # install_import_hook('grpc.aio._base_channel')

--- a/bazel/_run_time_type_check_main.py
+++ b/bazel/_run_time_type_check_main.py
@@ -25,8 +25,8 @@ from typeguard import install_import_hook
 # install_import_hook('grpc.aio')
 # install_import_hook('grpc.aio._channel')
 install_import_hook('grpc.aio._server')  # Keep this one to test our type error
-# install_import_hook('grpc.aio._utils')
-# install_import_hook('grpc.aio._interceptor')
+install_import_hook('grpc.aio._utils')
+install_import_hook('grpc.aio._interceptor')
 # install_import_hook('grpc.aio._base_channel')
 # install_import_hook('grpc.aio._base_server')
 # install_import_hook('grpc.aio._typing')

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -55,139 +55,139 @@ _LOCAL_CANCELLATION_DETAILS = "Locally cancelled by application!"
 
 
 class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
-  """Final UnaryUnaryCall class finished with a response."""
+    """Final UnaryUnaryCall class finished with a response."""
 
-  _response: ResponseType
+    _response: ResponseType
 
-  def __init__(self, response: ResponseType) -> None:
-    self._response = response
+    def __init__(self, response: ResponseType) -> None:
+        self._response = response
 
-  def cancel(self) -> bool:
-    return False
+    def cancel(self) -> bool:
+        return False
 
-  def cancelled(self) -> bool:
-    return False
+    def cancelled(self) -> bool:
+        return False
 
-  def done(self) -> bool:
-    return True
+    def done(self) -> bool:
+        return True
 
-  def add_done_callback(self, unused_callback) -> None:
-    raise NotImplementedError()
+    def add_done_callback(self, unused_callback) -> None:
+        raise NotImplementedError()
 
-  def time_remaining(self) -> Optional[float]:
-    raise NotImplementedError()
+    def time_remaining(self) -> Optional[float]:
+        raise NotImplementedError()
 
-  async def initial_metadata(self) -> Optional[Metadata]:
-    return None
+    async def initial_metadata(self) -> Optional[Metadata]:
+        return None
 
-  async def trailing_metadata(self) -> Optional[Metadata]:
-    return None
+    async def trailing_metadata(self) -> Optional[Metadata]:
+        return None
 
-  async def code(self) -> grpc.StatusCode:
-    return grpc.StatusCode.OK
+    async def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.OK
 
-  async def details(self) -> str:
-    return ""
+    async def details(self) -> str:
+        return ""
 
-  async def debug_error_string(self) -> Optional[str]:
-    return None
+    async def debug_error_string(self) -> Optional[str]:
+        return None
 
-  def __await__(self):
-    if False:  # pylint: disable=using-constant-test
-      # This code path is never used, but a yield statement is needed
-      # for telling the interpreter that __await__ is a generator.
-      yield None
-    return self._response
+    def __await__(self):
+        if False:  # pylint: disable=using-constant-test
+            # This code path is never used, but a yield statement is needed
+            # for telling the interpreter that __await__ is a generator.
+            yield None
+        return self._response
 
-  async def wait_for_connection(self) -> None:
-    pass
+    async def wait_for_connection(self) -> None:
+        pass
 
 
 class _StreamCallResponseIterator:
-  _call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall]
-  _response_iterator: AsyncIterable[ResponseType]
+    _call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall]
+    _response_iterator: AsyncIterable[ResponseType]
 
-  def __init__(
-    self,
-    call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall],
-    response_iterator: AsyncIterable[ResponseType],
-  ) -> None:
-    self._response_iterator = response_iterator
-    self._call = call
+    def __init__(
+        self,
+        call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall],
+        response_iterator: AsyncIterable[ResponseType],
+    ) -> None:
+        self._response_iterator = response_iterator
+        self._call = call
 
-  def cancel(self) -> bool:
-    return self._call.cancel()
+    def cancel(self) -> bool:
+        return self._call.cancel()
 
-  def cancelled(self) -> bool:
-    return self._call.cancelled()
+    def cancelled(self) -> bool:
+        return self._call.cancelled()
 
-  def done(self) -> bool:
-    return self._call.done()
+    def done(self) -> bool:
+        return self._call.done()
 
-  def add_done_callback(self, callback) -> None:
-    self._call.add_done_callback(callback)
+    def add_done_callback(self, callback) -> None:
+        self._call.add_done_callback(callback)
 
-  def time_remaining(self) -> Optional[float]:
-    return self._call.time_remaining()
+    def time_remaining(self) -> Optional[float]:
+        return self._call.time_remaining()
 
-  async def initial_metadata(self) -> Optional[Metadata]:
-    return await self._call.initial_metadata()
+    async def initial_metadata(self) -> Optional[Metadata]:
+        return await self._call.initial_metadata()
 
-  async def trailing_metadata(self) -> Optional[Metadata]:
-    return await self._call.trailing_metadata()
+    async def trailing_metadata(self) -> Optional[Metadata]:
+        return await self._call.trailing_metadata()
 
-  async def code(self) -> grpc.StatusCode:
-    return await self._call.code()
+    async def code(self) -> grpc.StatusCode:
+        return await self._call.code()
 
-  async def details(self) -> str:
-    return await self._call.details()
+    async def details(self) -> str:
+        return await self._call.details()
 
-  async def debug_error_string(self) -> Optional[str]:
-    return await self._call.debug_error_string()
+    async def debug_error_string(self) -> Optional[str]:
+        return await self._call.debug_error_string()
 
-  def __aiter__(self):
-    return self._response_iterator.__aiter__()
+    def __aiter__(self):
+        return self._response_iterator.__aiter__()
 
-  async def wait_for_connection(self) -> None:
-    return await self._call.wait_for_connection()
+    async def wait_for_connection(self) -> None:
+        return await self._call.wait_for_connection()
 
 
 class UnaryStreamCallResponseIterator(
-  _StreamCallResponseIterator, _base_call.UnaryStreamCall
+    _StreamCallResponseIterator, _base_call.UnaryStreamCall
 ):
-  """UnaryStreamCall class which uses an alternative response iterator."""
+    """UnaryStreamCall class which uses an alternative response iterator."""
 
-  async def read(self) -> Union[EOFType, ResponseType]:
-    # Behind the scenes everything goes through the
-    # async iterator. So this path should not be reached.
-    raise NotImplementedError()
+    async def read(self) -> Union[EOFType, ResponseType]:
+        # Behind the scenes everything goes through the
+        # async iterator. So this path should not be reached.
+        raise NotImplementedError()
 
 
 class StreamStreamCallResponseIterator(
-  _StreamCallResponseIterator, _base_call.StreamStreamCall
+    _StreamCallResponseIterator, _base_call.StreamStreamCall
 ):
-  """StreamStreamCall class which uses an alternative response iterator."""
+    """StreamStreamCall class which uses an alternative response iterator."""
 
-  async def read(self) -> Union[EOFType, ResponseType]:
-    # Behind the scenes everything goes through the
-    # async iterator. So this path should not be reached.
-    raise NotImplementedError()
+    async def read(self) -> Union[EOFType, ResponseType]:
+        # Behind the scenes everything goes through the
+        # async iterator. So this path should not be reached.
+        raise NotImplementedError()
 
-  async def write(self, request: RequestType) -> None:
-    # Behind the scenes everything goes through the
-    # async iterator provided by the InterceptedStreamStreamCall.
-    # So this path should not be reached.
-    raise NotImplementedError()
+    async def write(self, request: RequestType) -> None:
+        # Behind the scenes everything goes through the
+        # async iterator provided by the InterceptedStreamStreamCall.
+        # So this path should not be reached.
+        raise NotImplementedError()
 
-  async def done_writing(self) -> None:
-    # Behind the scenes everything goes through the
-    # async iterator provided by the InterceptedStreamStreamCall.
-    # So this path should not be reached.
-    raise NotImplementedError()
+    async def done_writing(self) -> None:
+        # Behind the scenes everything goes through the
+        # async iterator provided by the InterceptedStreamStreamCall.
+        # So this path should not be reached.
+        raise NotImplementedError()
 
-  @property
-  def _done_writing_flag(self) -> bool:
-    return self._call._done_writing_flag
+    @property
+    def _done_writing_flag(self) -> bool:
+        return self._call._done_writing_flag
 
 
 class ServerInterceptor(metaclass=ABCMeta):
@@ -679,7 +679,9 @@ class _InterceptedStreamRequestMixin:
             yield value
 
     async def _write_to_iterator_queue_interruptible(
-        self, request: RequestType, call: Union[InterceptedCall, _base_call.Call]
+        self,
+        request: RequestType,
+        call: Union[InterceptedCall, _base_call.Call],
     ):
         # Write the specified 'request' to the request iterator queue using the
         # specified 'call' to allow for interruption of the write in the case
@@ -812,7 +814,7 @@ class InterceptedUnaryUnaryCall(
                     continuation, client_call_details, request
                 )
 
-                if isinstance(call_or_response, UnaryUnaryCall):
+                if isinstance(call_or_response, _base_call.UnaryUnaryCall):
                     return call_or_response
                 else:
                     return UnaryUnaryCallResponse(call_or_response)
@@ -917,7 +919,7 @@ class InterceptedUnaryStreamCall(
                 )
 
                 if isinstance(
-                    call_or_response_iterator, UnaryStreamCall
+                    call_or_response_iterator, _base_call.UnaryStreamCall
                 ):
                     self._last_returned_call_from_interceptors = (
                         call_or_response_iterator
@@ -1139,7 +1141,7 @@ class InterceptedStreamStreamCall(
                 )
 
                 if isinstance(
-                    call_or_response_iterator, StreamStreamCall
+                    call_or_response_iterator, _base_call.StreamStreamCall
                 ):
                     self._last_returned_call_from_interceptors = (
                         call_or_response_iterator

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -1023,7 +1023,7 @@ class InterceptedStreamUnaryCall(
         """Run the RPC call wrapped in interceptors"""
 
         async def _run_interceptor(
-            interceptors: Iterator[StreamUnaryClientInterceptor],
+            interceptors: Sequence[StreamUnaryClientInterceptor],
             client_call_details: ClientCallDetails,
             request_iterator: RequestIterableType,
         ) -> _base_call.StreamUnaryCall:

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -546,7 +546,7 @@ class _InterceptedStreamRequestMixin:
     async def _write_to_iterator_queue_interruptible(
         self,
         request: RequestType,
-        call: Union[InterceptedCall, _base_call.Call],
+        call: _base_call.Call,
     ):
         # Write the specified 'request' to the request iterator queue using the
         # specified 'call' to allow for interruption of the write in the case

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -53,6 +53,8 @@ from ._typing import SerializingFunction
 from ._utils import _timeout_to_deadline
 
 _LOCAL_CANCELLATION_DETAILS = "Locally cancelled by application!"
+
+
 class ServerInterceptor(metaclass=ABCMeta):
     """Affords intercepting incoming RPCs on the service-side.
 

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -19,6 +19,7 @@ import collections
 import functools
 from typing import (
     AsyncIterable,
+    AnyStr,
     Awaitable,
     Callable,
     List,
@@ -246,7 +247,7 @@ class ClientCallDetails(
         wait_for_ready: An optional flag to enable :term:`wait_for_ready` mechanism.
     """
 
-    method: bytes
+    method: AnyStr
     timeout: Optional[float]
     metadata: Optional[Metadata]
     credentials: Optional[grpc.CallCredentials]

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -269,7 +269,7 @@ class UnaryUnaryClientInterceptor(ClientInterceptor, metaclass=ABCMeta):
         ],
         client_call_details: ClientCallDetails,
         request: RequestType,
-    ) -> UnaryUnaryCall:
+    ) -> Union[UnaryUnaryCall, ResponseType]:
         """Intercepts a unary-unary invocation asynchronously.
 
         Args:

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -21,7 +21,6 @@ from typing import (
     AsyncIterable,
     Awaitable,
     Callable,
-    Iterator,
     List,
     Optional,
     Sequence,

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -1042,6 +1042,7 @@ class InterceptedStreamStreamCall(
     def time_remaining(self) -> Optional[float]:
         raise NotImplementedError()
 
+
 class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
     """Final UnaryUnaryCall class finished with a response."""
 

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -54,140 +54,140 @@ from ._utils import _timeout_to_deadline
 _LOCAL_CANCELLATION_DETAILS = "Locally cancelled by application!"
 
 
-class UnaryUnaryCallResponse(UnaryUnaryCall):
-    """Final UnaryUnaryCall class finished with a response."""
+class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
+  """Final UnaryUnaryCall class finished with a response."""
 
-    _response: ResponseType
+  _response: ResponseType
 
-    def __init__(self, response: ResponseType) -> None:
-        self._response = response
+  def __init__(self, response: ResponseType) -> None:
+    self._response = response
 
-    def cancel(self) -> bool:
-        return False
+  def cancel(self) -> bool:
+    return False
 
-    def cancelled(self) -> bool:
-        return False
+  def cancelled(self) -> bool:
+    return False
 
-    def done(self) -> bool:
-        return True
+  def done(self) -> bool:
+    return True
 
-    def add_done_callback(self, unused_callback) -> None:
-        raise NotImplementedError()
+  def add_done_callback(self, unused_callback) -> None:
+    raise NotImplementedError()
 
-    def time_remaining(self) -> Optional[float]:
-        raise NotImplementedError()
+  def time_remaining(self) -> Optional[float]:
+    raise NotImplementedError()
 
-    async def initial_metadata(self) -> Optional[Metadata]:
-        return None
+  async def initial_metadata(self) -> Optional[Metadata]:
+    return None
 
-    async def trailing_metadata(self) -> Optional[Metadata]:
-        return None
+  async def trailing_metadata(self) -> Optional[Metadata]:
+    return None
 
-    async def code(self) -> grpc.StatusCode:
-        return grpc.StatusCode.OK
+  async def code(self) -> grpc.StatusCode:
+    return grpc.StatusCode.OK
 
-    async def details(self) -> str:
-        return ""
+  async def details(self) -> str:
+    return ""
 
-    async def debug_error_string(self) -> Optional[str]:
-        return None
+  async def debug_error_string(self) -> Optional[str]:
+    return None
 
-    def __await__(self):
-        if False:  # pylint: disable=using-constant-test
-            # This code path is never used, but a yield statement is needed
-            # for telling the interpreter that __await__ is a generator.
-            yield None
-        return self._response
+  def __await__(self):
+    if False:  # pylint: disable=using-constant-test
+      # This code path is never used, but a yield statement is needed
+      # for telling the interpreter that __await__ is a generator.
+      yield None
+    return self._response
 
-    async def wait_for_connection(self) -> None:
-        pass
+  async def wait_for_connection(self) -> None:
+    pass
 
 
 class _StreamCallResponseIterator:
-    _call: Union[UnaryStreamCall, StreamStreamCall]
-    _response_iterator: AsyncIterable[ResponseType]
+  _call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall]
+  _response_iterator: AsyncIterable[ResponseType]
 
-    def __init__(
-        self,
-        call: Union[UnaryStreamCall, StreamStreamCall],
-        response_iterator: AsyncIterable[ResponseType],
-    ) -> None:
-        self._response_iterator = response_iterator
-        self._call = call
+  def __init__(
+    self,
+    call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall],
+    response_iterator: AsyncIterable[ResponseType],
+  ) -> None:
+    self._response_iterator = response_iterator
+    self._call = call
 
-    def cancel(self) -> bool:
-        return self._call.cancel()
+  def cancel(self) -> bool:
+    return self._call.cancel()
 
-    def cancelled(self) -> bool:
-        return self._call.cancelled()
+  def cancelled(self) -> bool:
+    return self._call.cancelled()
 
-    def done(self) -> bool:
-        return self._call.done()
+  def done(self) -> bool:
+    return self._call.done()
 
-    def add_done_callback(self, callback) -> None:
-        self._call.add_done_callback(callback)
+  def add_done_callback(self, callback) -> None:
+    self._call.add_done_callback(callback)
 
-    def time_remaining(self) -> Optional[float]:
-        return self._call.time_remaining()
+  def time_remaining(self) -> Optional[float]:
+    return self._call.time_remaining()
 
-    async def initial_metadata(self) -> Optional[Metadata]:
-        return await self._call.initial_metadata()
+  async def initial_metadata(self) -> Optional[Metadata]:
+    return await self._call.initial_metadata()
 
-    async def trailing_metadata(self) -> Optional[Metadata]:
-        return await self._call.trailing_metadata()
+  async def trailing_metadata(self) -> Optional[Metadata]:
+    return await self._call.trailing_metadata()
 
-    async def code(self) -> grpc.StatusCode:
-        return await self._call.code()
+  async def code(self) -> grpc.StatusCode:
+    return await self._call.code()
 
-    async def details(self) -> str:
-        return await self._call.details()
+  async def details(self) -> str:
+    return await self._call.details()
 
-    async def debug_error_string(self) -> Optional[str]:
-        return await self._call.debug_error_string()
+  async def debug_error_string(self) -> Optional[str]:
+    return await self._call.debug_error_string()
 
-    def __aiter__(self):
-        return self._response_iterator.__aiter__()
+  def __aiter__(self):
+    return self._response_iterator.__aiter__()
 
-    async def wait_for_connection(self) -> None:
-        return await self._call.wait_for_connection()
+  async def wait_for_connection(self) -> None:
+    return await self._call.wait_for_connection()
 
 
 class UnaryStreamCallResponseIterator(
-    _StreamCallResponseIterator, UnaryStreamCall
+  _StreamCallResponseIterator, _base_call.UnaryStreamCall
 ):
-    """UnaryStreamCall class which uses an alternative response iterator."""
+  """UnaryStreamCall class which uses an alternative response iterator."""
 
-    async def read(self) -> Union[EOFType, ResponseType]:
-        # Behind the scenes everything goes through the
-        # async iterator. So this path should not be reached.
-        raise NotImplementedError()
+  async def read(self) -> Union[EOFType, ResponseType]:
+    # Behind the scenes everything goes through the
+    # async iterator. So this path should not be reached.
+    raise NotImplementedError()
 
 
 class StreamStreamCallResponseIterator(
-    _StreamCallResponseIterator, StreamStreamCall
+  _StreamCallResponseIterator, _base_call.StreamStreamCall
 ):
-    """StreamStreamCall class which uses an alternative response iterator."""
+  """StreamStreamCall class which uses an alternative response iterator."""
 
-    async def read(self) -> Union[EOFType, ResponseType]:
-        # Behind the scenes everything goes through the
-        # async iterator. So this path should not be reached.
-        raise NotImplementedError()
+  async def read(self) -> Union[EOFType, ResponseType]:
+    # Behind the scenes everything goes through the
+    # async iterator. So this path should not be reached.
+    raise NotImplementedError()
 
-    async def write(self, request: RequestType) -> None:
-        # Behind the scenes everything goes through the
-        # async iterator provided by the InterceptedStreamStreamCall.
-        # So this path should not be reached.
-        raise NotImplementedError()
+  async def write(self, request: RequestType) -> None:
+    # Behind the scenes everything goes through the
+    # async iterator provided by the InterceptedStreamStreamCall.
+    # So this path should not be reached.
+    raise NotImplementedError()
 
-    async def done_writing(self) -> None:
-        # Behind the scenes everything goes through the
-        # async iterator provided by the InterceptedStreamStreamCall.
-        # So this path should not be reached.
-        raise NotImplementedError()
+  async def done_writing(self) -> None:
+    # Behind the scenes everything goes through the
+    # async iterator provided by the InterceptedStreamStreamCall.
+    # So this path should not be reached.
+    raise NotImplementedError()
 
-    @property
-    def _done_writing_flag(self) -> bool:
-        return self._call._done_writing_flag
+  @property
+  def _done_writing_flag(self) -> bool:
+    return self._call._done_writing_flag
 
 
 class ServerInterceptor(metaclass=ABCMeta):

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Interceptors implementation of gRPC Asyncio Python."""
+from __future__ import annotations
+
 from abc import ABCMeta
 from abc import abstractmethod
 import asyncio
@@ -51,144 +53,6 @@ from ._typing import SerializingFunction
 from ._utils import _timeout_to_deadline
 
 _LOCAL_CANCELLATION_DETAILS = "Locally cancelled by application!"
-
-
-class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
-    """Final UnaryUnaryCall class finished with a response."""
-
-    _response: ResponseType
-
-    def __init__(self, response: ResponseType) -> None:
-        self._response = response
-
-    def cancel(self) -> bool:
-        return False
-
-    def cancelled(self) -> bool:
-        return False
-
-    def done(self) -> bool:
-        return True
-
-    def add_done_callback(self, unused_callback) -> None:
-        raise NotImplementedError()
-
-    def time_remaining(self) -> Optional[float]:
-        raise NotImplementedError()
-
-    async def initial_metadata(self) -> Optional[Metadata]:
-        return None
-
-    async def trailing_metadata(self) -> Optional[Metadata]:
-        return None
-
-    async def code(self) -> grpc.StatusCode:
-        return grpc.StatusCode.OK
-
-    async def details(self) -> str:
-        return ""
-
-    async def debug_error_string(self) -> Optional[str]:
-        return None
-
-    def __await__(self):
-        if False:  # pylint: disable=using-constant-test
-            # This code path is never used, but a yield statement is needed
-            # for telling the interpreter that __await__ is a generator.
-            yield None
-        return self._response
-
-    async def wait_for_connection(self) -> None:
-        pass
-
-
-class _StreamCallResponseIterator:
-    _call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall]
-    _response_iterator: AsyncIterable[ResponseType]
-
-    def __init__(
-        self,
-        call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall],
-        response_iterator: AsyncIterable[ResponseType],
-    ) -> None:
-        self._response_iterator = response_iterator
-        self._call = call
-
-    def cancel(self) -> bool:
-        return self._call.cancel()
-
-    def cancelled(self) -> bool:
-        return self._call.cancelled()
-
-    def done(self) -> bool:
-        return self._call.done()
-
-    def add_done_callback(self, callback) -> None:
-        self._call.add_done_callback(callback)
-
-    def time_remaining(self) -> Optional[float]:
-        return self._call.time_remaining()
-
-    async def initial_metadata(self) -> Optional[Metadata]:
-        return await self._call.initial_metadata()
-
-    async def trailing_metadata(self) -> Optional[Metadata]:
-        return await self._call.trailing_metadata()
-
-    async def code(self) -> grpc.StatusCode:
-        return await self._call.code()
-
-    async def details(self) -> str:
-        return await self._call.details()
-
-    async def debug_error_string(self) -> Optional[str]:
-        return await self._call.debug_error_string()
-
-    def __aiter__(self):
-        return self._response_iterator.__aiter__()
-
-    async def wait_for_connection(self) -> None:
-        return await self._call.wait_for_connection()
-
-
-class UnaryStreamCallResponseIterator(
-    _StreamCallResponseIterator, _base_call.UnaryStreamCall
-):
-    """UnaryStreamCall class which uses an alternative response iterator."""
-
-    async def read(self) -> Union[EOFType, ResponseType]:
-        # Behind the scenes everything goes through the
-        # async iterator. So this path should not be reached.
-        raise NotImplementedError()
-
-
-class StreamStreamCallResponseIterator(
-    _StreamCallResponseIterator, _base_call.StreamStreamCall
-):
-    """StreamStreamCall class which uses an alternative response iterator."""
-
-    async def read(self) -> Union[EOFType, ResponseType]:
-        # Behind the scenes everything goes through the
-        # async iterator. So this path should not be reached.
-        raise NotImplementedError()
-
-    async def write(self, request: RequestType) -> None:
-        # Behind the scenes everything goes through the
-        # async iterator provided by the InterceptedStreamStreamCall.
-        # So this path should not be reached.
-        raise NotImplementedError()
-
-    async def done_writing(self) -> None:
-        # Behind the scenes everything goes through the
-        # async iterator provided by the InterceptedStreamStreamCall.
-        # So this path should not be reached.
-        raise NotImplementedError()
-
-    @property
-    def _done_writing_flag(self) -> bool:
-        return self._call._done_writing_flag
-
-
 class ServerInterceptor(metaclass=ABCMeta):
     """Affords intercepting incoming RPCs on the service-side.
 
@@ -1177,3 +1041,138 @@ class InterceptedStreamStreamCall(
 
     def time_remaining(self) -> Optional[float]:
         raise NotImplementedError()
+
+class UnaryUnaryCallResponse(_base_call.UnaryUnaryCall):
+    """Final UnaryUnaryCall class finished with a response."""
+
+    _response: ResponseType
+
+    def __init__(self, response: ResponseType) -> None:
+        self._response = response
+
+    def cancel(self) -> bool:
+        return False
+
+    def cancelled(self) -> bool:
+        return False
+
+    def done(self) -> bool:
+        return True
+
+    def add_done_callback(self, unused_callback) -> None:
+        raise NotImplementedError()
+
+    def time_remaining(self) -> Optional[float]:
+        raise NotImplementedError()
+
+    async def initial_metadata(self) -> Optional[Metadata]:
+        return None
+
+    async def trailing_metadata(self) -> Optional[Metadata]:
+        return None
+
+    async def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.OK
+
+    async def details(self) -> str:
+        return ""
+
+    async def debug_error_string(self) -> Optional[str]:
+        return None
+
+    def __await__(self):
+        if False:  # pylint: disable=using-constant-test
+            # This code path is never used, but a yield statement is needed
+            # for telling the interpreter that __await__ is a generator.
+            yield None
+        return self._response
+
+    async def wait_for_connection(self) -> None:
+        pass
+
+
+class _StreamCallResponseIterator:
+    _call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall]
+    _response_iterator: AsyncIterable[ResponseType]
+
+    def __init__(
+        self,
+        call: Union[_base_call.UnaryStreamCall, _base_call.StreamStreamCall],
+        response_iterator: AsyncIterable[ResponseType],
+    ) -> None:
+        self._response_iterator = response_iterator
+        self._call = call
+
+    def cancel(self) -> bool:
+        return self._call.cancel()
+
+    def cancelled(self) -> bool:
+        return self._call.cancelled()
+
+    def done(self) -> bool:
+        return self._call.done()
+
+    def add_done_callback(self, callback) -> None:
+        self._call.add_done_callback(callback)
+
+    def time_remaining(self) -> Optional[float]:
+        return self._call.time_remaining()
+
+    async def initial_metadata(self) -> Optional[Metadata]:
+        return await self._call.initial_metadata()
+
+    async def trailing_metadata(self) -> Optional[Metadata]:
+        return await self._call.trailing_metadata()
+
+    async def code(self) -> grpc.StatusCode:
+        return await self._call.code()
+
+    async def details(self) -> str:
+        return await self._call.details()
+
+    async def debug_error_string(self) -> Optional[str]:
+        return await self._call.debug_error_string()
+
+    def __aiter__(self):
+        return self._response_iterator.__aiter__()
+
+    async def wait_for_connection(self) -> None:
+        return await self._call.wait_for_connection()
+
+
+class UnaryStreamCallResponseIterator(
+    _StreamCallResponseIterator, _base_call.UnaryStreamCall
+):
+    """UnaryStreamCall class which uses an alternative response iterator."""
+
+    async def read(self) -> Union[EOFType, ResponseType]:
+        # Behind the scenes everything goes through the
+        # async iterator. So this path should not be reached.
+        raise NotImplementedError()
+
+
+class StreamStreamCallResponseIterator(
+    _StreamCallResponseIterator, _base_call.StreamStreamCall
+):
+    """StreamStreamCall class which uses an alternative response iterator."""
+
+    async def read(self) -> Union[EOFType, ResponseType]:
+        # Behind the scenes everything goes through the
+        # async iterator. So this path should not be reached.
+        raise NotImplementedError()
+
+    async def write(self, request: RequestType) -> None:
+        # Behind the scenes everything goes through the
+        # async iterator provided by the InterceptedStreamStreamCall.
+        # So this path should not be reached.
+        raise NotImplementedError()
+
+    async def done_writing(self) -> None:
+        # Behind the scenes everything goes through the
+        # async iterator provided by the InterceptedStreamStreamCall.
+        # So this path should not be reached.
+        raise NotImplementedError()
+
+    @property
+    def _done_writing_flag(self) -> bool:
+        return self._call._done_writing_flag

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -18,7 +18,6 @@ import asyncio
 import collections
 import functools
 from typing import (
-    AnyStr,
     AsyncIterable,
     Awaitable,
     Callable,
@@ -247,7 +246,7 @@ class ClientCallDetails(
         wait_for_ready: An optional flag to enable :term:`wait_for_ready` mechanism.
     """
 
-    method: AnyStr
+    method: bytes
     timeout: Optional[float]
     metadata: Optional[Metadata]
     credentials: Optional[grpc.CallCredentials]

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -18,8 +18,8 @@ import asyncio
 import collections
 import functools
 from typing import (
-    AsyncIterable,
     AnyStr,
+    AsyncIterable,
     Awaitable,
     Callable,
     List,


### PR DESCRIPTION
### Description

Part 2 of Add Typeguard to AIO stack - runs only in tests, fixes type hints for  `grpc.aio._interceptor` and `grpc.aio._utils`

### Type hint for Public API change for Experimental API

**Fixing the error in public API** - `ClientCallDetails` where `method` was `str` but actually it should be `bytes`.
The change is done because the code flow actually sends `bytes` instead of `str` see - https://github.com/grpc/grpc/blob/master/src/python/grpcio/grpc/aio/_interceptor.py#L655

It was detected by `typeguard` as well.

### Testing

CI

### Related Work
- Part 1: #40201
- Part 3: #40217
- b/423755915
