### PR TITLE
[ruby] bump timeout for ruby artifact build on 1.74.x branch

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -283,7 +283,7 @@ class RubyArtifact:
                 self.gem_platform,
             ],
             use_workspace=True,
-            timeout_seconds=180 * 60,
+            timeout_seconds=240 * 60,
             environ=environ,
         )
 


### PR DESCRIPTION
backport https://github.com/grpc/grpc/pull/40229

