### PR TITLE
Fix bazel query //src/python/...

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -33,3 +33,6 @@ tools/distrib/python/grpcio_tools/protobuf/
 tools/distrib/python/grpcio_tools/grpc_plugin/
 tools/distrib/python/grpcio_tools/grpc_root/
 tools/distrib/python/grpcio_tools/third_party/
+src/python/grpcio_observability/build/
+src/python/grpcio_observability/grpc_root/
+src/python/grpcio_observability/third_party/


### PR DESCRIPTION
Exclude generated directories in grpcio_observability that prevent bazel recursive queries.

Same as #40236