### PR TITLE
[Backport][v1.74.x][Python] Fix for windows distribtest

### DIFF
--- a/tools/internal_ci/windows/grpc_distribtests_python.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_python.bat
@@ -29,7 +29,7 @@ set PREPARE_BUILD_INSTALL_DEPS_PYTHON=true
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat || exit /b 1
 
 @rem Build all python windows artifacts
-python tools/run_tests/task_runner.py -f artifact windows python %TASK_RUNNER_EXTRA_FILTERS% -j 4 --inner_jobs 3 -x build_artifacts_python/sponge_log.xml || set FAILED=true
+python tools/run_tests/task_runner.py -f artifact windows python %TASK_RUNNER_EXTRA_FILTERS% -j 3 --inner_jobs 2 -x build_artifacts_python/sponge_log.xml || set FAILED=true
 
 @rem the next step expects to find the artifacts from the previous step in the "input_artifacts" folder.
 bash -c "rm -rf input_artifacts; mkdir -p input_artifacts; cp -r artifacts/* input_artifacts/ || true"

--- a/tools/internal_ci/windows/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 240
+timeout_mins: 480
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/release/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/windows/release/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_distribtests_python.bat"
-timeout_mins: 240
+timeout_mins: 480
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Backport of #40151 to v1.74.x.
---
Recently the windows internal distribtest that builds all 10 different Windows artifacts have been having flaky failures. This PR fixes it.

**Investigation / Observations:**
1. It was found that the failures happen when building the grpcio_tools package, specifically when running `python tools\distrib\python\grpcio_tools\setup.py build_ext -c msvc` at this line: https://github.com/grpc/grpc/blob/master/tools/run_tests/artifacts/build_artifact_python.bat#L48
2. Another observation was that, the build didn't fail at an exact file or library but failed at different places in different runs.
3. GitHub presubmit tests where we build only 2 windows targets are actually passing without any issue.

All the above observations indicate that the failure isn't an actual build configuration related issue, but is most probably due to an Out of Memory issue that is occurring when we build multiple artifacts together.

**Proposed Fix:**
Hence this PR reduces the number of concurrent workers and jobs to ease memory usage. However this will increase the time needed by the overall test to run, hence it also requires bumping the test timeout.
