### PR TITLE
Fix Bazel CI

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -31,7 +31,7 @@ grpc_cc_library(
         "absl/log:check",
         "absl/synchronization",
     ],
-    visibility = ["//bazel:end2end_test_utils"],
+    visibility = ["//bazel:xds_end2end_test_utils"],
     deps = [
         "//src/proto/grpc/testing:echo_cc_grpc",
         "//test/core/test_util:grpc_test_util",


### PR DESCRIPTION
#40232 has broken Bazel RBE tests in CI as the added target name is invalid: https://source.cloud.google.com/results/invocations/d246e9c8-0702-4750-b0f9-b8df9ab0afbb

The only target similar to it is `xds_end2end_test_utils`. Hence updated the target name accordingly.
