### PR TITLE
[CI] Mark some old docker images not buildable

### DIFF
--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -70,7 +70,12 @@ ALL_DOCKERFILE_DIRS=(
 # These Docker directories contain obsolete images that cannot be built.
 # They are excluded from build processes, but the Dockerfiles are retained for archival purposes.
 EXCLUDE_DIRS=(
+  tools/dockerfile/distribtest/csharp_dotnet31_x64
+  tools/dockerfile/distribtest/csharp_dotnet5_x64
   tools/dockerfile/interoptest/grpc_interop_go1.8
+  tools/dockerfile/interoptest/grpc_interop_go1.11
+  tools/dockerfile/test/cxx_gcc_7_x64
+  tools/dockerfile/test/cxx_gcc_8_x64
 )
 
 # a list of docker directories that are based on ARM64 base images


### PR DESCRIPTION
Following docker images based on `Debian:10` are failing to build because the base image has reached its EOL and no longer receives security updates. I'm marking these images as unbuildable to prevent build failures. Our CI can continue using the existing docker images. Those images are reflecting old environments that gRPC still supports but will be unnecessary when gRPC bumps them so this should be acceptable. (e.g. gcc_7 is no longer relevant when gRPC drops it)

- cxx_gcc_7_x64
- cxx_gcc_8_x64
- grpc_interop_go1.11
- csharp_dotnet31_x64
- csharp_dotnet5_x64
