### PR TITLE
[ci] Use Black 24.8.0

### DIFF
--- a/tools/distrib/black_code.sh
+++ b/tools/distrib/black_code.sh
@@ -33,5 +33,5 @@ VIRTUALENV=venv_black_code
 python3 -m virtualenv $VIRTUALENV
 source $VIRTUALENV/bin/activate
 
-python3 -m pip install black==25.1.0
+python3 -m pip install black==24.8.0
 python3 -m black --config=grpc-style-config.toml $ACTION "${DIRS[@]}"


### PR DESCRIPTION
Python 3.8 can't use 25.1 - [failure](https://github.com/eugeneo/grpc/actions/runs/16379797115/job/46288506812#step:14:2808).

