### PR TITLE
[CI] Fix PR AutoFix GitHub action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,5 @@ bazel-out
 build
 .cache
 .git
-*/.venv-*
+# python virtual environments
+*/.venv*

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,4 @@ bazel-out
 build
 .cache
 .git
-*/venv-*
+*/.venv-*

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ bazel-out
 build
 .cache
 .git
+*/venv-*

--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Python Interpreter
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install Python Packages
         run: |
           pip install pyyaml mako virtualenv absl-py

--- a/.github/workflows/pr-auto-fix.yaml
+++ b/.github/workflows/pr-auto-fix.yaml
@@ -72,8 +72,7 @@ jobs:
       - name: Install Python Packages
         run: |
           pip install pyyaml mako virtualenv absl-py
-          sudo apt-get update
-          sudo apt-get install python3-dev
+          pip list
       - name: Check out repository code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -18,13 +18,16 @@ dist/
 htmlcov/
 py3*/
 pyb/
-python_pylint_venv/
 src/python/grpcio_*/=*
 src/python/grpcio_*/build/
 src/python/grpcio_*/LICENSE
 src/python/grpcio_status/grpc_status/google/rpc/status.proto
+.venv
+# all "named" virtual environments to be conformed to .venv-*
+python_pylint_venv/
 black_virtual_environment/
 isort_virtual_environment/
+.venv-*
 
 # Node installation output
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,11 @@ src/python/grpcio_*/build/
 src/python/grpcio_*/LICENSE
 src/python/grpcio_status/grpc_status/google/rpc/status.proto
 .venv
-# all "named" virtual environments to be conformed to .venv-*
+# TODO(sergiitk): conform all "named" virtual environments to .venv-*
+.venv-*
 python_pylint_venv/
 black_virtual_environment/
 isort_virtual_environment/
-.venv-*
 
 # Node installation output
 node_modules


### PR DESCRIPTION
Previously broken by requiring black version that dropped py3.8 support.
Gitignore/dockerignore changes made to prevent ruff checking virtualenv directories.

Related:
- #40256 
- #40139