### PR TITLE
[build] Exclude tools/codegen/core from bazel version tests

### DIFF
--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -69,7 +69,7 @@ EXCLUDED_TARGETS=(
   "-//tools/artifact_gen/..."
 
   # Exclude the codegen gen_experiments tooling, which contains some bazel hackery
-  "-//tools/codegen/core/gen_experiments/..."
+  "-//tools/codegen/core/..."
 )
 
 FAILED_TESTS=""


### PR DESCRIPTION
We only need head for these to work.