### PR TITLE
[Python] Fix bazel tests compatibility with python 3.11

### DIFF
--- a/examples/python/cancellation/BUILD.bazel
+++ b/examples/python/cancellation/BUILD.bazel
@@ -39,6 +39,7 @@ py_grpc_library(
 py_binary(
     name = "client",
     srcs = ["client.py"],
+    imports = ["."],
     python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [
@@ -60,6 +61,7 @@ py_library(
 py_binary(
     name = "server",
     srcs = ["server.py"],
+    imports = ["."],
     python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [

--- a/examples/python/compression/BUILD.bazel
+++ b/examples/python/compression/BUILD.bazel
@@ -17,6 +17,7 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 py_binary(
     name = "server",
     srcs = ["server.py"],
+    imports = ["../../protos"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [
@@ -29,6 +30,7 @@ py_binary(
 py_binary(
     name = "client",
     srcs = ["client.py"],
+    imports = ["../../examples/protos"],
     python_version = "PY3",
     srcs_version = "PY2AND3",
     deps = [

--- a/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py
@@ -126,26 +126,32 @@ def _test_static_dynamic_combo():
 
 @_collect_errors
 def _test_combined_import():
-    from grpc_tools import protoc
+    with _augmented_syspath(
+        ("tools/distrib/python/grpcio_tools/grpc_tools/test/",)
+    ):
+        from grpc_tools import protoc
 
-    protos, services = protoc._protos_and_services("simple.proto")
-    assert protos.SimpleMessage is not None
-    assert services.SimpleMessageServiceStub is not None
+        protos, services = protoc._protos_and_services("simple.proto")
+        assert protos.SimpleMessage is not None
+        assert services.SimpleMessageServiceStub is not None
 
 
 @_collect_errors
 def _test_syntax_errors():
-    from grpc_tools import protoc
+    with _augmented_syspath(
+        ("tools/distrib/python/grpcio_tools/grpc_tools/test/",)
+    ):
+        from grpc_tools import protoc
 
-    try:
-        protos = protoc._protos("flawed.proto")
-    except Exception as e:
-        error_str = str(e)
-        assert "flawed.proto" in error_str
-        assert "17:23" in error_str
-        assert "21:23" in error_str
-    else:
-        assert False, "Compile error expected. None occurred."
+        try:
+            protos = protoc._protos("flawed.proto")
+        except Exception as e:
+            error_str = str(e)
+            assert "flawed.proto" in error_str
+            assert "17:23" in error_str
+            assert "21:23" in error_str
+        else:
+            assert False, "Compile error expected. None occurred."
 
 
 class ProtocTest(unittest.TestCase):


### PR DESCRIPTION
Fix python import paths in bazel tests:
- `//tools/distrib/python/grpcio_tools/grpc_tools/test:protoc_test`
- `//examples/python/cancellation:test/_cancellation_example_test`
- `//examples/python/compression:test/compression_example_test`

Previously paths were set incorrectly. With bazel + python 3.11, this resulted in the following errors:

<details>
<summary>error examples for posterity</summary>

#### `//tools/distrib/python/grpcio_tools/grpc_tools/test:protoc_test`
```
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/3073/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.runfiles/com_github_grpc_grpc/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py", line 141, in _test_syntax_errors
    protos = protoc._protos("flawed.proto")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/3073/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.runfiles/com_github_grpc_grpc/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py", line 110, in _protos
    module = importlib.import_module(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "", line 1204, in _gcd_import
  File "", line 1176, in _find_and_load
  File "", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'flawed_pb2'

Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/3073/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.runfiles/com_github_grpc_grpc/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py", line 168, in test_combined_import
    _run_in_subprocess(_test_combined_import)
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/3073/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.runfiles/com_github_grpc_grpc/tools/distrib/python/grpcio_tools/grpc_tools/test/protoc_test.py", line 48, in _run_in_subprocess
    raise error_queue.get()
ModuleNotFoundError: No module named 'simple_pb2'
```

#### `//examples/python/cancellation:test/_cancellation_example_test`
```
test_graceful_sigint (__main__.CancellationExampleTest.test_graceful_sigint) ... Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/3027/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/examples/python/cancellation/test/_cancellation_example_test.runfiles/com_github_grpc_grpc/examples/python/cancellation/server.py", line 26, in 
    import search
ModuleNotFoundError: No module named 'search'
```

#### `//examples/python/compression:test/compression_example_test`
```
test_compression_example (__main__.CompressionExampleTest.test_compression_example) ... Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/2906/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/examples/python/compression/test/compression_example_test.runfiles/com_github_grpc_grpc/examples/python/compression/client.py", line 24, in 
    import helloworld_pb2
ModuleNotFoundError: No module named 'helloworld_pb2'
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/2906/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/examples/python/compression/test/compression_example_test.runfiles/com_github_grpc_grpc/examples/python/compression/server.py", line 26, in 
    import helloworld_pb2
ModuleNotFoundError: No module named 'helloworld_pb2'
FAIL

======================================================================
FAIL: test_compression_example (__main__.CompressionExampleTest.test_compression_example)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/.cache/bazel/_bazel_root/954bb7512d44d20015390af6e76121c6/sandbox/processwrapper-sandbox/2906/execroot/com_github_grpc_grpc/bazel-out/k8-fastbuild/bin/examples/python/compression/test/compression_example_test.runfiles/com_github_grpc_grpc/examples/python/compression/test/compression_example_test.py", line 68, in test_compression_example
    self.assertEqual(0, client_return_code)
AssertionError: 0 != 1
```
</details>

The main difference is as of Python 3.11 bazel no longer appends the directory of the file to the sys.path. For example, compression test sys.path:

1. Contains `examples/python/compression/test` in 3.10
2. Doesn't contain `examples/python/compression/test` in 3.11
