### PR TITLE
[Python] Fix/Upgarde Typeguard version

### DIFF
--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -89,7 +89,7 @@ tomli==2.2.1
     # via incremental
 twisted==24.11.0
     # via -r requirements.bazel.txt
-typeguard==4.0.1
+typeguard==4.2.1
     # via -r requirements.bazel.txt
 typing-extensions==4.13.2
     # via

--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -4,21 +4,21 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.bazel.lock requirements.bazel.txt
 #
-absl-py==2.3.1
+absl-py==2.1.0
     # via -r requirements.bazel.txt
-attrs==25.3.0
+attrs==25.1.0
     # via twisted
 automat==24.8.1
     # via twisted
-cachetools==5.5.2
+cachetools==5.5.1
     # via google-auth
-certifi==2025.7.14
+certifi==2025.1.31
     # via
     #   -r requirements.bazel.txt
     #   requests
 chardet==5.2.0
     # via -r requirements.bazel.txt
-charset-normalizer==3.4.2
+charset-normalizer==3.4.1
     # via requests
 constantly==23.10.4
     # via twisted
@@ -28,9 +28,9 @@ deprecated==1.2.18
     #   opentelemetry-semantic-conventions
 gevent==24.2.1
     # via -r requirements.bazel.txt
-google-auth==2.40.3
+google-auth==2.38.0
     # via -r requirements.bazel.txt
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.66.0
     # via -r requirements.bazel.txt
 greenlet==3.1.1
     # via gevent
@@ -47,27 +47,27 @@ importlib-metadata==8.5.0
     #   typeguard
 incremental==24.7.2
     # via twisted
-opentelemetry-api==1.33.1
+opentelemetry-api==1.30.0
     # via
     #   -r requirements.bazel.txt
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-prometheus==0.54b1
+opentelemetry-exporter-prometheus==0.51b0
     # via -r requirements.bazel.txt
 opentelemetry-resourcedetector-gcp==1.9.0a0
     # via -r requirements.bazel.txt
-opentelemetry-sdk==1.33.1
+opentelemetry-sdk==1.30.0
     # via
     #   -r requirements.bazel.txt
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.54b1
+opentelemetry-semantic-conventions==0.51b0
     # via opentelemetry-sdk
 prometheus-client==0.21.1
     # via opentelemetry-exporter-prometheus
-protobuf==5.29.5
+protobuf==5.29.3
     # via
     #   -r requirements.bazel.txt
     #   googleapis-common-protos
@@ -75,21 +75,21 @@ pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.2
+pyasn1-modules==0.4.1
     # via google-auth
 pyyaml==6.0.2
     # via -r requirements.bazel.txt
-requests==2.32.4
+requests==2.32.3
     # via
     #   -r requirements.bazel.txt
     #   opentelemetry-resourcedetector-gcp
-rsa==4.9.1
+rsa==4.9
     # via google-auth
 tomli==2.2.1
     # via incremental
-twisted==25.5.0
+twisted==24.11.0
     # via -r requirements.bazel.txt
-typeguard==4.2.1
+typeguard==4.0.1
     # via -r requirements.bazel.txt
 typing-extensions==4.13.2
     # via
@@ -115,7 +115,7 @@ zope-interface==7.2
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.3.2
+setuptools==75.3.0
     # via
     #   incremental
     #   zope-event

--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -4,21 +4,21 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements.bazel.lock requirements.bazel.txt
 #
-absl-py==2.1.0
+absl-py==2.3.1
     # via -r requirements.bazel.txt
-attrs==25.1.0
+attrs==25.3.0
     # via twisted
 automat==24.8.1
     # via twisted
-cachetools==5.5.1
+cachetools==5.5.2
     # via google-auth
-certifi==2025.1.31
+certifi==2025.7.14
     # via
     #   -r requirements.bazel.txt
     #   requests
 chardet==5.2.0
     # via -r requirements.bazel.txt
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 constantly==23.10.4
     # via twisted
@@ -28,9 +28,9 @@ deprecated==1.2.18
     #   opentelemetry-semantic-conventions
 gevent==24.2.1
     # via -r requirements.bazel.txt
-google-auth==2.38.0
+google-auth==2.40.3
     # via -r requirements.bazel.txt
-googleapis-common-protos==1.66.0
+googleapis-common-protos==1.70.0
     # via -r requirements.bazel.txt
 greenlet==3.1.1
     # via gevent
@@ -47,27 +47,27 @@ importlib-metadata==8.5.0
     #   typeguard
 incremental==24.7.2
     # via twisted
-opentelemetry-api==1.30.0
+opentelemetry-api==1.33.1
     # via
     #   -r requirements.bazel.txt
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-resourcedetector-gcp
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-prometheus==0.51b0
+opentelemetry-exporter-prometheus==0.54b1
     # via -r requirements.bazel.txt
 opentelemetry-resourcedetector-gcp==1.9.0a0
     # via -r requirements.bazel.txt
-opentelemetry-sdk==1.30.0
+opentelemetry-sdk==1.33.1
     # via
     #   -r requirements.bazel.txt
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-resourcedetector-gcp
-opentelemetry-semantic-conventions==0.51b0
+opentelemetry-semantic-conventions==0.54b1
     # via opentelemetry-sdk
 prometheus-client==0.21.1
     # via opentelemetry-exporter-prometheus
-protobuf==5.29.3
+protobuf==5.29.5
     # via
     #   -r requirements.bazel.txt
     #   googleapis-common-protos
@@ -75,21 +75,21 @@ pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via google-auth
 pyyaml==6.0.2
     # via -r requirements.bazel.txt
-requests==2.32.3
+requests==2.32.4
     # via
     #   -r requirements.bazel.txt
     #   opentelemetry-resourcedetector-gcp
-rsa==4.9
+rsa==4.9.1
     # via google-auth
 tomli==2.2.1
     # via incremental
-twisted==24.11.0
+twisted==25.5.0
     # via -r requirements.bazel.txt
-typeguard==4.0.1
+typeguard==4.2.1
     # via -r requirements.bazel.txt
 typing-extensions==4.13.2
     # via
@@ -115,7 +115,7 @@ zope-interface==7.2
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.3.0
+setuptools==75.3.2
     # via
     #   incremental
     #   zope-event

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -29,7 +29,7 @@
 #   $ python3.8 -m venv .venv-bazel
 #   $ source .venv-bazel/bin/activate
 #   $ pip install pip-tools
-#   $ pip install -r requirements.bazel.lock
+#   $ pip install -r requirements.bazel.lock # make the change to version in requirements.bazel.txt after this
 #   $ pip-compile --no-upgrade --allow-unsafe requirements.bazel.txt -o requirements.bazel.lock
 #   $ deactivate
 

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -47,7 +47,7 @@ opentelemetry-sdk
 protobuf
 pyyaml  # for DNS test
 requests
-# Currently our CI uses Python < 3.8, hence <4.14.0 was added
+# Currently our CI uses Python < 3.8, hence <4.4.1 was added
 # TODO(asheshvidyut): remove the <4.4.1, when CI uses python >= 3.9
 typeguard~=4.2.0,<4.4.1
 typing-extensions~=4.13

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -48,8 +48,8 @@ protobuf
 pyyaml  # for DNS test
 requests
 # Currently our CI uses Python < 3.8, hence <4.14.0 was added
-# TODO(asheshvidyut): remove the <4.14.0, when CI uses python >= 3.9
-typeguard~=4.0.0,<4.14.0
+# TODO(asheshvidyut): remove the <4.4.1, when CI uses python >= 3.9
+typeguard~=4.2.0,<4.4.1
 typing-extensions~=4.13
 twisted  # for DNS test
 urllib3


### PR DESCRIPTION
### Description 

Previous typeguard version had this issue - https://github.com/agronholm/typeguard/pull/387

Basically any file having `from __future__ import annotations` was failing because of this issue.

This issue got fixed in typeguard - `4.1.3` https://github.com/agronholm/typeguard/blob/master/docs/versionhistory.rst

Also typeguard - `4.4.1` supports only python `3.9` or above, so fix the upper version of typeguard to `4.4.1`.

Previously it had incorrect version.
