### PR TITLE
[interop] Add v1.74.2 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -319,6 +319,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.71.3", ReleaseInfo()),
             ("v1.72.2", ReleaseInfo()),
             ("v1.73.0", ReleaseInfo()),
+            ("v1.74.2", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
Ad-hoc interop matrix: https://source.cloud.google.com/results/invocations/0c55375b-c438-484b-884d-78f474282a3c
