### PR TITLE
[Python] Change typing extensions version to 4.12.2

### DIFF
--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -37,9 +37,9 @@ def grpc_python_deps():
     http_archive(
         name = "typing_extensions",
         build_file = "@com_github_grpc_grpc//third_party:typing_extensions.BUILD",
-        sha256 = "39f1d1e0a85f92bdbfa9f0315c6fbf662ba1a4d9e38b561cef97bfa3b242356a",
-        strip_prefix = "typing_extensions-4.13.2",
-        url = "https://github.com/python/typing_extensions/archive/4.13.2.tar.gz",
+        sha256 = "bf6f56b36d8bc9156e518eb1cc37a146284082fa53522033f772aefbecfd15fc",
+        strip_prefix = "typing_extensions-4.12.2",
+        url = "https://github.com/python/typing_extensions/archive/4.12.2.tar.gz",
     )
 
     if "cython" not in native.existing_rules():

--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -91,7 +91,7 @@ twisted==24.11.0
     # via -r requirements.bazel.txt
 typeguard==4.2.1
     # via -r requirements.bazel.txt
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via
     #   -r requirements.bazel.txt
     #   automat

--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -91,7 +91,7 @@ twisted==24.11.0
     # via -r requirements.bazel.txt
 typeguard==4.2.1
     # via -r requirements.bazel.txt
-typing-extensions==4.13.2
+typing-extensions==4.12.0
     # via
     #   -r requirements.bazel.txt
     #   automat

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -50,6 +50,6 @@ requests
 # Currently our CI uses Python < 3.8, hence <4.4.1 was added
 # TODO(asheshvidyut): remove the <4.4.1, when CI uses python >= 3.9
 typeguard~=4.2.0,<4.4.1
-typing-extensions~=4.13
+typing-extensions~=4.12
 twisted  # for DNS test
 urllib3

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -50,6 +50,6 @@ requests
 # Currently our CI uses Python < 3.8, hence <4.4.1 was added
 # TODO(asheshvidyut): remove the <4.4.1, when CI uses python >= 3.9
 typeguard~=4.2.0,<4.4.1
-typing-extensions==4.12
+typing-extensions==4.12.2
 twisted  # for DNS test
 urllib3

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -50,6 +50,6 @@ requests
 # Currently our CI uses Python < 3.8, hence <4.4.1 was added
 # TODO(asheshvidyut): remove the <4.4.1, when CI uses python >= 3.9
 typeguard~=4.2.0,<4.4.1
-typing-extensions~=4.12
+typing-extensions==4.12
 twisted  # for DNS test
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -542,7 +542,7 @@ PACKAGE_DIRECTORIES = {
     "": PYTHON_STEM,
 }
 
-INSTALL_REQUIRES = ("typing-extensions~=4.13",)
+INSTALL_REQUIRES = ("typing-extensions~=4.12",)
 
 EXTRAS_REQUIRES = {
     "protobuf": "grpcio-tools>={version}".format(version=grpc_version.VERSION),

--- a/setup.py
+++ b/setup.py
@@ -542,7 +542,7 @@ PACKAGE_DIRECTORIES = {
     "": PYTHON_STEM,
 }
 
-INSTALL_REQUIRES = ("typing-extensions~=4.12",)
+INSTALL_REQUIRES = ("typing-extensions==4.12.2",)
 
 EXTRAS_REQUIRES = {
     "protobuf": "grpcio-tools>={version}".format(version=grpc_version.VERSION),


### PR DESCRIPTION
### Description 

Change typing extensions version to 4.12.2 which is same as in G3

### Testing

CI 

