### PR TITLE
[PHP] Fix runtime error with PHp8.5 alpha because zend_exception_get_defaul…

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -84,7 +84,11 @@ zval *grpc_parse_metadata_array(grpc_metadata_array
     if (php_grpc_zend_hash_find(array_hash, str_key, key_len, (void **)&data)
         == SUCCESS) {
       if (Z_TYPE_P(data) != IS_ARRAY) {
+#if PHP_VERSION_ID >= 80500
+        zend_throw_exception(zend_ce_exception,
+#else
         zend_throw_exception(zend_exception_get_default(TSRMLS_C),
+#endif
                              "Metadata hash somehow contains wrong types.",
                              1 TSRMLS_CC);
         efree(str_key);


### PR DESCRIPTION
…t is remvoed


PHP 8.5 removed zend_exception_get_default().
See php updates
https://github.com/php/php-src/blob/747ecce51f2d55a424547d6ae852e2f7f3766e41/UPGRADING.INTERNALS#L51



