### PR TITLE
[PH2] Remove locks from SimpleQueue

### DIFF
--- a/src/core/ext/transport/chttp2/transport/stream_data_queue.h
+++ b/src/core/ext/transport/chttp2/transport/stream_data_queue.h
@@ -32,23 +32,44 @@ namespace http2 {
 #define GRPC_STREAM_DATA_QUEUE_DEBUG VLOG(2)
 
 template <typename T>
-class Center : public RefCounted<Center<T>> {
+class SimpleQueue {
  public:
   struct EnqueueResult {
     absl::Status status;
     bool became_non_empty;
   };
 
-  explicit Center(const uint32_t max_tokens) : max_tokens_(max_tokens) {}
+  explicit SimpleQueue(const uint32_t max_tokens) : max_tokens_(max_tokens) {}
+  SimpleQueue(SimpleQueue&& rhs) = default;
+  SimpleQueue& operator=(SimpleQueue&& rhs) = default;
+  SimpleQueue(const SimpleQueue&) = delete;
+  SimpleQueue& operator=(const SimpleQueue&) = delete;
 
+  auto Enqueue(T& data, const uint32_t tokens) {
+    return PollEnqueue(data, tokens);
+  }
+
+  std::optional<T> Dequeue(const uint32_t allowed_dequeue_tokens,
+                           const bool allow_oversized_dequeue) {
+    return DequeueInternal(allowed_dequeue_tokens, allow_oversized_dequeue);
+  }
+
+  // Dequeues the next entry immediately ignoring the tokens. If the queue is
+  // empty, returns nullopt.
+  std::optional<T> ImmediateDequeue() {
+    return DequeueInternal(std::numeric_limits<uint32_t>::max(), true);
+  }
+
+  bool TestOnlyIsEmpty() const { return IsEmpty(); }
+
+ private:
   // A promise that resolves when the data is enqueued.
   // If tokens_consumed_ is 0 or the new tokens fit within max_tokens_, then
   // allow the enqueue to go through. Otherwise, return pending. Here, we are
   // using tokens_consumed over queue_.empty() because there can be enqueues
   // with tokens = 0. Enqueues with tokens = 0 are primarily for sending
   // metadata as flow control does not apply to them.
-  Poll<EnqueueResult> Enqueue(T& data, const uint32_t tokens) {
-    MutexLock lock(&mu_);
+  Poll<EnqueueResult> PollEnqueue(T& data, const uint32_t tokens) {
     GRPC_STREAM_DATA_QUEUE_DEBUG << "Enqueueing data. Data tokens: " << tokens;
     const uint32_t max_tokens_consumed_threshold =
         max_tokens_ >= tokens ? max_tokens_ - tokens : 0;
@@ -78,9 +99,8 @@ class Center : public RefCounted<Center<T>> {
   // than allowed_dequeue_tokens. It does not cause the item itself to be
   // partially dequeued; either the entire item is returned or nullopt is
   // returned.
-  std::optional<T> Dequeue(const uint32_t allowed_dequeue_tokens,
-                           const bool allow_oversized_dequeue) {
-    ReleasableMutexLock lock(&mu_);
+  std::optional<T> DequeueInternal(const uint32_t allowed_dequeue_tokens,
+                                   const bool allow_oversized_dequeue) {
     if (queue_.empty() || (queue_.front().tokens > allowed_dequeue_tokens &&
                            !allow_oversized_dequeue)) {
       GRPC_STREAM_DATA_QUEUE_DEBUG
@@ -100,7 +120,6 @@ class Center : public RefCounted<Center<T>> {
     GRPC_STREAM_DATA_QUEUE_DEBUG
         << "Dequeue successful. Data tokens released: " << entry.tokens
         << " Current tokens consumed: " << tokens_consumed_;
-    lock.Release();
 
     // TODO(akshitpatel) : [PH2][P2] : Investigate a mechanism to only wake up
     // if the sender will be able to send more data. There is a high chance that
@@ -110,18 +129,15 @@ class Center : public RefCounted<Center<T>> {
     return std::move(entry.data);
   }
 
-  bool IsEmpty() {
-    MutexLock lock(&mu_);
-    return queue_.empty();
-  }
+  bool IsEmpty() const { return queue_.empty(); }
 
  private:
   struct Entry {
     T data;
     uint32_t tokens;
   };
-  Mutex mu_;
-  std::queue<Entry> queue_ ABSL_GUARDED_BY(mu_);
+
+  std::queue<Entry> queue_;
   // The maximum number of tokens that can be enqueued. This limit is used to
   // exert back pressure on the sender. If the sender tries to enqueue more
   // tokens than this limit, the enqueue promise will not resolve until the
@@ -129,47 +145,11 @@ class Center : public RefCounted<Center<T>> {
   // exception to this rule: if the sender tries to enqueue an item when the
   // queue has 0 tokens, the enqueue will always go through regardless of the
   // number of tokens.
-  uint32_t max_tokens_ ABSL_GUARDED_BY(mu_);
+  uint32_t max_tokens_;
   // The number of tokens that have been enqueued in the queue but not yet
   // dequeued.
-  uint32_t tokens_consumed_ ABSL_GUARDED_BY(mu_) = 0;
-  Waker waker_ ABSL_GUARDED_BY(mu_);
-};
-
-// TODO(akshitpatel) : [PH2][P2] : This queue needs to be replaced with a
-// fast lock free queue.
-template <typename T>
-class SimpleQueue {
- public:
-  explicit SimpleQueue(uint32_t max_tokens)
-      : center_(MakeRefCounted<Center<T>>(max_tokens)) {}
-
-  SimpleQueue(SimpleQueue&& rhs) = default;
-  SimpleQueue& operator=(SimpleQueue&& rhs) = default;
-  SimpleQueue(const SimpleQueue&) = delete;
-  SimpleQueue& operator=(const SimpleQueue&) = delete;
-
-  auto Enqueue(T& data, const uint32_t tokens) {
-    return center_->Enqueue(data, tokens);
-  }
-
-  std::optional<T> Dequeue(const uint32_t allowed_dequeue_tokens,
-                           const bool allow_oversized_dequeue) {
-    return center_->Dequeue(allowed_dequeue_tokens, allow_oversized_dequeue);
-  }
-
-  // Dequeues the next entry immediately ignoring the tokens. If the queue is
-  // empty, returns nullopt.
-  std::optional<T> ImmediateDequeue() {
-    return center_->Dequeue(std::numeric_limits<uint32_t>::max(), true);
-  }
-
-  bool TestOnlyIsEmpty() const { return center_->IsEmpty(); }
-
- private:
-  // This is solely added to handle race conditions between the class destructor
-  // and the pending enqueue promises.
-  RefCountedPtr<Center<T>> center_;
+  uint32_t tokens_consumed_ = 0;
+  Waker waker_;
 };
 
 template <typename MetadataHandle>

--- a/src/core/ext/transport/chttp2/transport/stream_data_queue.h
+++ b/src/core/ext/transport/chttp2/transport/stream_data_queue.h
@@ -40,8 +40,8 @@ class SimpleQueue {
   };
 
   explicit SimpleQueue(const uint32_t max_tokens) : max_tokens_(max_tokens) {}
-  SimpleQueue(SimpleQueue&& rhs) = default;
-  SimpleQueue& operator=(SimpleQueue&& rhs) = default;
+  SimpleQueue(SimpleQueue&& rhs) = delete;
+  SimpleQueue& operator=(SimpleQueue&& rhs) = delete;
   SimpleQueue(const SimpleQueue&) = delete;
   SimpleQueue& operator=(const SimpleQueue&) = delete;
 

--- a/test/core/transport/chttp2/stream_data_queue_fuzz_test.cc
+++ b/test/core/transport/chttp2/stream_data_queue_fuzz_test.cc
@@ -43,15 +43,6 @@ class SimpleQueueFuzzTest : public YodelTest {
     party_ = Party::Make(std::move(party_arena));
   }
 
-  Party* GetParty2() { return party2_.get(); }
-
-  void InitParty2() {
-    auto party_arena = SimpleArenaAllocator(0)->MakeArena();
-    party_arena->SetContext<grpc_event_engine::experimental::EventEngine>(
-        event_engine().get());
-    party2_ = Party::Make(std::move(party_arena));
-  }
-
   auto EnqueueAndCheckSuccess(SimpleQueue<int>& queue, int data, int tokens) {
     return Map([&queue, data,
                 tokens]() mutable { return queue.Enqueue(data, tokens); },
@@ -73,17 +64,10 @@ class SimpleQueueFuzzTest : public YodelTest {
 
  private:
   void InitCoreConfiguration() override {}
-  void InitTest() override {
-    InitParty();
-    InitParty2();
-  }
-  void Shutdown() override {
-    party_.reset();
-    party2_.reset();
-  }
+  void InitTest() override { InitParty(); }
+  void Shutdown() override { party_.reset(); }
 
   RefCountedPtr<Party> party_;
-  RefCountedPtr<Party> party2_;
 };
 
 YODEL_TEST(SimpleQueueFuzzTest, NoOp) {}
@@ -94,8 +78,6 @@ YODEL_TEST(SimpleQueueFuzzTest, EnqueueAndDequeueMultiPartyTest) {
   // 1. All enqueues and dequeues are successful.
   // 2. The dequeue data is the same as the enqueue data.
   SimpleQueue<int> queue(/*max_tokens=*/100);
-  auto* party = GetParty();
-  auto* party2 = GetParty2();
   StrictMock<MockFunction<void(absl::Status)>> on_done;
   StrictMock<MockFunction<void(absl::Status)>> on_dequeue_done;
   EXPECT_CALL(on_done, Call(absl::OkStatus()));
@@ -105,7 +87,7 @@ YODEL_TEST(SimpleQueueFuzzTest, EnqueueAndDequeueMultiPartyTest) {
   int current_enqueue_count = 0;
   int current_dequeue_count = 0;
 
-  party->Spawn(
+  GetParty()->Spawn(
       "EnqueueTest",
       Loop([this, &queue, &on_done, &current_enqueue_count]() mutable {
         return If(
@@ -124,30 +106,30 @@ YODEL_TEST(SimpleQueueFuzzTest, EnqueueAndDequeueMultiPartyTest) {
       }),
       [](auto) { LOG(INFO) << "Reached end of EnqueueTest"; });
 
-  party2->Spawn("DequeueTest",
-                Loop([&on_dequeue_done, this, &queue, &current_dequeue_count] {
-                  return If(
-                      DequeueAndCheck(queue, /*data=*/current_dequeue_count,
-                                      /*allow_oversized_dequeue=*/false,
-                                      /*allowed_dequeue_tokens=*/10),
-                      [&current_dequeue_count, &on_dequeue_done,
-                       &queue]() -> LoopCtl<absl::Status> {
-                        if (++current_dequeue_count == dequeue_count) {
-                          on_dequeue_done.Call(absl::OkStatus());
-                          EXPECT_TRUE(queue.TestOnlyIsEmpty());
-                          return absl::OkStatus();
-                        } else {
-                          return Continue();
-                        }
-                      },
-                      [] {
-                        return Map(Sleep(Duration::Seconds(1)),
-                                   [](auto) -> LoopCtl<absl::Status> {
-                                     return Continue();
-                                   });
-                      });
-                }),
-                [](auto) { LOG(INFO) << "Reached end of DequeueTest"; });
+  GetParty()->Spawn(
+      "DequeueTest",
+      Loop([&on_dequeue_done, this, &queue, &current_dequeue_count] {
+        return If(
+            DequeueAndCheck(queue, /*data=*/current_dequeue_count,
+                            /*allow_oversized_dequeue=*/false,
+                            /*allowed_dequeue_tokens=*/10),
+            [&current_dequeue_count, &on_dequeue_done,
+             &queue]() -> LoopCtl<absl::Status> {
+              if (++current_dequeue_count == dequeue_count) {
+                on_dequeue_done.Call(absl::OkStatus());
+                EXPECT_TRUE(queue.TestOnlyIsEmpty());
+                return absl::OkStatus();
+              } else {
+                return Continue();
+              }
+            },
+            [] {
+              return Map(
+                  Sleep(Duration::Seconds(1)),
+                  [](auto) -> LoopCtl<absl::Status> { return Continue(); });
+            });
+      }),
+      [](auto) { LOG(INFO) << "Reached end of DequeueTest"; });
 
   WaitForAllPendingWork();
   event_engine()->TickUntilIdle();


### PR DESCRIPTION
With the new changes, a mutex has been added for StreamDataQueue which makes the mutex in SimpleQueue redundant.