### PR TITLE
[posix_engine] Remove PosixPollerManager

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -2371,6 +2371,7 @@ grpc_cc_library(
         "absl/status",
     ],
     deps = [
+        "event_engine_thread_pool",
         "gpr_atm",
         "posix_event_engine_closure",
         "posix_event_engine_event_poller",
@@ -2479,6 +2480,7 @@ grpc_cc_library(
     ],
     deps = [
         "event_engine_poller",
+        "event_engine_thread_pool",
         "event_engine_time_util",
         "iomgr_port",
         "posix_event_engine_closure",
@@ -2519,6 +2521,7 @@ grpc_cc_library(
     deps = [
         "common_event_engine_closures",
         "event_engine_poller",
+        "event_engine_thread_pool",
         "event_engine_time_util",
         "iomgr_port",
         "posix_event_engine_closure",

--- a/src/core/lib/event_engine/cf_engine/cf_engine.h
+++ b/src/core/lib/event_engine/cf_engine/cf_engine.h
@@ -30,7 +30,7 @@
 
 namespace grpc_event_engine::experimental {
 
-class CFEventEngine : public EventEngine, public Scheduler {
+class CFEventEngine : public EventEngine {
  public:
   CFEventEngine();
   ~CFEventEngine() override;
@@ -57,6 +57,7 @@ class CFEventEngine : public EventEngine, public Scheduler {
   TaskHandle RunAfter(Duration when,
                       absl::AnyInvocable<void()> closure) override;
   bool Cancel(TaskHandle handle) override;
+  ThreadPool* thread_pool() const { return thread_pool_.get(); }
 
  private:
   struct Closure;

--- a/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
+++ b/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
@@ -223,9 +223,9 @@ CFStreamEndpointImpl::CFStreamEndpointImpl(
     std::shared_ptr<CFEventEngine> engine, MemoryAllocator memory_allocator)
     : engine_(std::move(engine)),
       memory_allocator_(std::move(memory_allocator)),
-      open_event_(engine_.get()),
-      read_event_(engine_.get()),
-      write_event_(engine_.get()) {
+      open_event_(engine_->thread_pool()),
+      read_event_(engine_->thread_pool()),
+      write_event_(engine_->thread_pool()) {
   open_event_.InitEvent();
   read_event_.InitEvent();
   write_event_.InitEvent();

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -60,9 +60,9 @@ class Epoll1EventHandle : public EventHandle {
   Epoll1EventHandle(const FileDescriptor& fd, Epoll1Poller* poller)
       : fd_(fd),
         poller_(poller),
-        read_closure_(poller->GetScheduler()),
-        write_closure_(poller->GetScheduler()),
-        error_closure_(poller->GetScheduler()) {
+        read_closure_(poller->GetThreadPool()),
+        write_closure_(poller->GetThreadPool()),
+        error_closure_(poller->GetThreadPool()) {
     read_closure_.InitEvent();
     write_closure_.InitEvent();
     error_closure_.InitEvent();
@@ -217,7 +217,7 @@ void Epoll1EventHandle::OrphanHandle(PosixEngineClosure* on_done,
   }
   if (on_done != nullptr) {
     on_done->SetStatus(absl::OkStatus());
-    poller_->GetScheduler()->Run(on_done);
+    poller_->GetThreadPool()->Run(on_done);
   }
 }
 
@@ -243,8 +243,8 @@ void Epoll1EventHandle::HandleShutdownInternal(absl::Status why,
   }
 }
 
-Epoll1Poller::Epoll1Poller(Scheduler* scheduler)
-    : scheduler_(scheduler), was_kicked_(false), closed_(false) {
+Epoll1Poller::Epoll1Poller(std::shared_ptr<ThreadPool> thread_pool)
+    : thread_pool_(thread_pool), was_kicked_(false), closed_(false) {
   g_epoll_set_.epfd = posix_interface().EpollCreateAndCloexec().value();
   wakeup_fd_ = CreateWakeupFd(&posix_interface()).value();
   CHECK(wakeup_fd_ != nullptr);
@@ -493,10 +493,11 @@ void Epoll1Poller::ResetKickState() {
   was_kicked_ = false;
 }
 
-std::shared_ptr<Epoll1Poller> MakeEpoll1Poller(Scheduler* scheduler) {
+std::shared_ptr<Epoll1Poller> MakeEpoll1Poller(
+    std::shared_ptr<ThreadPool> thread_pool) {
   static bool kEpoll1PollerSupported = InitEpoll1PollerLinux();
   if (kEpoll1PollerSupported) {
-    return std::make_shared<Epoll1Poller>(scheduler);
+    return std::make_shared<Epoll1Poller>(std::move(thread_pool));
   }
   return nullptr;
 }

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.cc
@@ -512,7 +512,7 @@ namespace grpc_event_engine::experimental {
 using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::Poller;
 
-Epoll1Poller::Epoll1Poller(Scheduler* /* engine */) {
+Epoll1Poller::Epoll1Poller(std::shared_ptr<ThreadPool> /* thread_pool */) {
   grpc_core::Crash("unimplemented");
 }
 
@@ -549,7 +549,8 @@ void Epoll1Poller::ResetKickState() { grpc_core::Crash("unimplemented"); }
 
 // If GRPC_LINUX_EPOLL is not defined, it means epoll is not available. Return
 // nullptr.
-std::shared_ptr<Epoll1Poller> MakeEpoll1Poller(Scheduler* /*scheduler*/) {
+std::shared_ptr<Epoll1Poller> MakeEpoll1Poller(
+    std::shared_ptr<ThreadPool> /*thread_pool*/) {
   return nullptr;
 }
 

--- a/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.h
+++ b/src/core/lib/event_engine/posix_engine/ev_epoll1_linux.h
@@ -30,6 +30,7 @@
 #include "src/core/lib/event_engine/posix_engine/event_poller.h"
 #include "src/core/lib/event_engine/posix_engine/internal_errqueue.h"
 #include "src/core/lib/event_engine/posix_engine/wakeup_fd_posix.h"
+#include "src/core/lib/event_engine/thread_pool/thread_pool.h"
 #include "src/core/lib/iomgr/port.h"
 #include "src/core/util/sync.h"
 
@@ -46,7 +47,7 @@ class Epoll1EventHandle;
 // Definition of epoll1 based poller.
 class Epoll1Poller : public PosixEventPoller {
  public:
-  explicit Epoll1Poller(Scheduler* scheduler);
+  explicit Epoll1Poller(std::shared_ptr<ThreadPool> thread_pool);
   EventHandle* CreateHandle(FileDescriptor fd, absl::string_view name,
                             bool track_err) override;
   Poller::WorkResult Work(
@@ -54,7 +55,7 @@ class Epoll1Poller : public PosixEventPoller {
       absl::FunctionRef<void()> schedule_poll_again) override;
   std::string Name() override { return "epoll1"; }
   void Kick() override;
-  Scheduler* GetScheduler() { return scheduler_; }
+  ThreadPool* GetThreadPool() { return thread_pool_.get(); }
   bool CanTrackErrors() const override {
 #ifdef GRPC_POSIX_SOCKET_TCP
     return KernelSupportsErrqueue();
@@ -109,7 +110,7 @@ class Epoll1Poller : public PosixEventPoller {
   struct EpollSet {};
 #endif
   grpc_core::Mutex mu_;
-  Scheduler* scheduler_;
+  std::shared_ptr<ThreadPool> thread_pool_;
   // A singleton epoll set
   EpollSet g_epoll_set_;
   bool was_kicked_ ABSL_GUARDED_BY(mu_);
@@ -123,7 +124,8 @@ class Epoll1Poller : public PosixEventPoller {
 
 // Return an instance of a epoll1 based poller tied to the specified event
 // engine.
-std::shared_ptr<Epoll1Poller> MakeEpoll1Poller(Scheduler* scheduler);
+std::shared_ptr<Epoll1Poller> MakeEpoll1Poller(
+    std::shared_ptr<ThreadPool> thread_pool);
 
 }  // namespace grpc_event_engine::experimental
 

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -789,8 +789,8 @@ void PollPoller::Kick() { grpc_core::Crash("unimplemented"); }
 
 // If GRPC_LINUX_EPOLL is not defined, it means epoll is not available. Return
 // nullptr.
-std::shared_ptr<PollPoller> MakePollPoller(Scheduler* /*scheduler*/,
-                                           bool /* use_phony_poll */) {
+std::shared_ptr<PollPoller> MakePollPoller(
+    std::shared_ptr<ThreadPool> /*thread_pool*/, bool /* use_phony_poll */) {
   return nullptr;
 }
 

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.cc
@@ -72,7 +72,7 @@ class PollEventHandle : public EventHandle {
       : fd_(fd),
         pending_actions_(0),
         poller_handles_list_(this),
-        scheduler_(poller->GetScheduler()),
+        thread_pool_(poller->GetThreadPool()),
         poller_(std::move(poller)),
         is_orphaned_(false),
         is_shutdown_(false),
@@ -175,7 +175,7 @@ class PollEventHandle : public EventHandle {
   void Unref() {
     if (ref_count_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
       if (on_done_ != nullptr) {
-        scheduler_->Run(on_done_);
+        thread_pool_->Run(on_done_);
       }
       delete this;
     }
@@ -200,7 +200,7 @@ class PollEventHandle : public EventHandle {
   FileDescriptor fd_;
   int pending_actions_;
   PollPoller::HandlesList poller_handles_list_;
-  Scheduler* scheduler_;
+  ThreadPool* thread_pool_;
   std::shared_ptr<PollPoller> poller_;
   bool is_orphaned_;
   bool is_shutdown_;
@@ -293,7 +293,7 @@ int PollEventHandle::NotifyOnLocked(PosixEngineClosure** st,
                                     PosixEngineClosure* closure) {
   if (is_shutdown_ || pollhup_) {
     closure->SetStatus(shutdown_error_);
-    scheduler_->Run(closure);
+    thread_pool_->Run(closure);
   } else if (*st == reinterpret_cast<PosixEngineClosure*>(kClosureNotReady)) {
     // not ready ==> switch to a waiting state by setting the closure
     *st = closure;
@@ -302,7 +302,7 @@ int PollEventHandle::NotifyOnLocked(PosixEngineClosure** st,
     // already ready ==> queue the closure to run immediately
     *st = reinterpret_cast<PosixEngineClosure*>(kClosureNotReady);
     closure->SetStatus(shutdown_error_);
-    scheduler_->Run(closure);
+    thread_pool_->Run(closure);
     return 1;
   } else {
     // upcallptr was set to a different closure.  This is an error!
@@ -327,7 +327,7 @@ int PollEventHandle::SetReadyLocked(PosixEngineClosure** st) {
     PosixEngineClosure* closure = *st;
     *st = reinterpret_cast<PosixEngineClosure*>(kClosureNotReady);
     closure->SetStatus(shutdown_error_);
-    scheduler_->Run(closure);
+    thread_pool_->Run(closure);
     return 1;
   }
 }
@@ -402,7 +402,7 @@ void PollEventHandle::NotifyOnError(PosixEngineClosure* on_error) {
   on_error->SetStatus(
       absl::Status(absl::StatusCode::kCancelled,
                    "Polling engine does not support tracking errors"));
-  scheduler_->Run(on_error);
+  thread_pool_->Run(on_error);
 }
 
 void PollEventHandle::SetReadable() {
@@ -503,8 +503,9 @@ void PollPoller::PollerHandlesListRemoveHandle(PollEventHandle* handle) {
   --num_poll_handles_;
 }
 
-PollPoller::PollPoller(Scheduler* scheduler, bool use_phony_poll)
-    : scheduler_(scheduler),
+PollPoller::PollPoller(std::shared_ptr<ThreadPool> thread_pool,
+                       bool use_phony_poll)
+    : thread_pool_(std::move(thread_pool)),
       use_phony_poll_(use_phony_poll),
       was_kicked_(false),
       was_kicked_ext_(false),
@@ -752,12 +753,12 @@ void PollPoller::ResetKickState() {
   was_kicked_ext_ = false;
 }
 
-std::shared_ptr<PollPoller> MakePollPoller(Scheduler* scheduler,
-                                           bool use_phony_poll) {
+std::shared_ptr<PollPoller> MakePollPoller(
+    std::shared_ptr<ThreadPool> thread_pool, bool use_phony_poll) {
   static bool kPollPollerSupported =
       grpc_event_engine::experimental::SupportsWakeupFd();
   if (kPollPollerSupported) {
-    return std::make_shared<PollPoller>(scheduler, use_phony_poll);
+    return std::make_shared<PollPoller>(std::move(thread_pool), use_phony_poll);
   }
   return nullptr;
 }

--- a/src/core/lib/event_engine/posix_engine/ev_poll_posix.h
+++ b/src/core/lib/event_engine/posix_engine/ev_poll_posix.h
@@ -27,6 +27,7 @@
 #include "src/core/lib/event_engine/poller.h"
 #include "src/core/lib/event_engine/posix_engine/event_poller.h"
 #include "src/core/lib/event_engine/posix_engine/wakeup_fd_posix.h"
+#include "src/core/lib/event_engine/thread_pool/thread_pool.h"
 #include "src/core/util/sync.h"
 
 namespace grpc_event_engine::experimental {
@@ -37,7 +38,8 @@ class PollEventHandle;
 class PollPoller : public PosixEventPoller,
                    public std::enable_shared_from_this<PollPoller> {
  public:
-  explicit PollPoller(Scheduler* scheduler, bool use_phony_poll = false);
+  explicit PollPoller(std::shared_ptr<ThreadPool> thread_pool,
+                      bool use_phony_poll = false);
   EventHandle* CreateHandle(FileDescriptor fd, absl::string_view name,
                             bool track_err) override;
   Poller::WorkResult Work(
@@ -45,7 +47,7 @@ class PollPoller : public PosixEventPoller,
       absl::FunctionRef<void()> schedule_poll_again) override;
   std::string Name() override { return "poll"; }
   void Kick() override;
-  Scheduler* GetScheduler() { return scheduler_; }
+  ThreadPool* GetThreadPool() { return thread_pool_.get(); }
   bool CanTrackErrors() const override { return false; }
   ~PollPoller() override;
 
@@ -71,7 +73,7 @@ class PollPoller : public PosixEventPoller,
     PollEventHandle* prev = nullptr;
   };
   grpc_core::Mutex mu_;
-  Scheduler* scheduler_;
+  std::shared_ptr<ThreadPool> thread_pool_;
   bool use_phony_poll_;
   bool was_kicked_ ABSL_GUARDED_BY(mu_);
   bool was_kicked_ext_ ABSL_GUARDED_BY(mu_);
@@ -85,8 +87,8 @@ class PollPoller : public PosixEventPoller,
 // It use_phony_poll is true, it implies that the poller is declared
 // non-polling and any attempt to schedule a blocking poll will result in a
 // crash failure.
-std::shared_ptr<PollPoller> MakePollPoller(Scheduler* scheduler,
-                                           bool use_phony_poll);
+std::shared_ptr<PollPoller> MakePollPoller(
+    std::shared_ptr<ThreadPool> thread_pool, bool use_phony_poll);
 
 }  // namespace grpc_event_engine::experimental
 

--- a/src/core/lib/event_engine/posix_engine/event_poller.h
+++ b/src/core/lib/event_engine/posix_engine/event_poller.h
@@ -19,7 +19,6 @@
 
 #include <string>
 
-#include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "src/core/lib/event_engine/poller.h"
@@ -27,13 +26,6 @@
 #include "src/core/lib/event_engine/posix_engine/posix_interface.h"
 
 namespace grpc_event_engine::experimental {
-
-class Scheduler {
- public:
-  virtual void Run(experimental::EventEngine::Closure* closure) = 0;
-  virtual void Run(absl::AnyInvocable<void()>) = 0;
-  virtual ~Scheduler() = default;
-};
 
 class PosixEventPoller;
 

--- a/src/core/lib/event_engine/posix_engine/event_poller_posix_default.cc
+++ b/src/core/lib/event_engine/posix_engine/event_poller_posix_default.cc
@@ -15,6 +15,7 @@
 #include <grpc/support/port_platform.h>
 
 #include <memory>
+#include <utility>
 
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
@@ -34,22 +35,26 @@ bool PollStrategyMatches(absl::string_view strategy, absl::string_view want) {
 }
 }  // namespace
 
-std::shared_ptr<PosixEventPoller> MakeDefaultPoller(Scheduler* scheduler) {
+std::shared_ptr<PosixEventPoller> MakeDefaultPoller(
+    std::shared_ptr<ThreadPool> thread_pool) {
+  // Note that Make*Poller are allowed to return nullptr - e.g. MakeEpoll1Poller
+  // would return nullptr if an epoll poller is requested on unsupported
+  // platform.
   std::shared_ptr<PosixEventPoller> poller;
   auto strings =
       absl::StrSplit(grpc_core::ConfigVars::Get().PollStrategy(), ',');
   for (auto it = strings.begin(); it != strings.end() && poller == nullptr;
        it++) {
     if (PollStrategyMatches(*it, "epoll1")) {
-      poller = MakeEpoll1Poller(scheduler);
+      poller = MakeEpoll1Poller(thread_pool);
     }
     if (poller == nullptr && PollStrategyMatches(*it, "poll")) {
       // If epoll1 fails and if poll strategy matches "poll", use Poll poller
-      poller = MakePollPoller(scheduler, /*use_phony_poll=*/false);
+      poller = MakePollPoller(thread_pool, /*use_phony_poll=*/false);
     } else if (poller == nullptr && PollStrategyMatches(*it, "none")) {
       // If epoll1 fails and if poll strategy matches "none", use phony poll
       // poller.
-      poller = MakePollPoller(scheduler, /*use_phony_poll=*/true);
+      poller = MakePollPoller(thread_pool, /*use_phony_poll=*/true);
     }
   }
   return poller;

--- a/src/core/lib/event_engine/posix_engine/event_poller_posix_default.cc
+++ b/src/core/lib/event_engine/posix_engine/event_poller_posix_default.cc
@@ -62,7 +62,8 @@ std::shared_ptr<PosixEventPoller> MakeDefaultPoller(
 
 #else  // GRPC_POSIX_SOCKET_TCP
 
-std::shared_ptr<PosixEventPoller> MakeDefaultPoller(Scheduler* /*scheduler*/) {
+std::shared_ptr<PosixEventPoller> MakeDefaultPoller(
+    std::shared_ptr<ThreadPool> /*thread_pool*/) {
   return nullptr;
 }
 

--- a/src/core/lib/event_engine/posix_engine/event_poller_posix_default.h
+++ b/src/core/lib/event_engine/posix_engine/event_poller_posix_default.h
@@ -22,11 +22,12 @@
 namespace grpc_event_engine::experimental {
 
 class PosixEventPoller;
-class Scheduler;
+class ThreadPool;
 
 // Return an instance of an event poller which is tied to the specified
 // scheduler.
-std::shared_ptr<PosixEventPoller> MakeDefaultPoller(Scheduler* scheduler);
+std::shared_ptr<PosixEventPoller> MakeDefaultPoller(
+    std::shared_ptr<ThreadPool> thread_pool);
 
 }  // namespace grpc_event_engine::experimental
 

--- a/src/core/lib/event_engine/posix_engine/grpc_polled_fd_posix.h
+++ b/src/core/lib/event_engine/posix_engine/grpc_polled_fd_posix.h
@@ -118,6 +118,7 @@ class GrpcPolledFdFactoryPosix : public GrpcPolledFdFactory {
       ares_socket_t as) override {
     grpc_core::MutexLock lock(&mu_);
     owned_fds_.insert(as);
+    CHECK_NE(poller_, nullptr);
     FileDescriptor fd(as, poller_->posix_interface().generation());
     return std::make_unique<GrpcPolledFdPosix>(
         as,

--- a/src/core/lib/event_engine/posix_engine/lockfree_event.h
+++ b/src/core/lib/event_engine/posix_engine/lockfree_event.h
@@ -21,14 +21,13 @@
 
 #include "absl/status/status.h"
 #include "src/core/lib/event_engine/posix_engine/posix_engine_closure.h"
+#include "src/core/lib/event_engine/thread_pool/thread_pool.h"
 
 namespace grpc_event_engine::experimental {
 
-class Scheduler;
-
 class LockfreeEvent {
  public:
-  explicit LockfreeEvent(Scheduler* scheduler) : scheduler_(scheduler) {}
+  explicit LockfreeEvent(ThreadPool* thread_pool) : thread_pool_(thread_pool) {}
 
   LockfreeEvent(const LockfreeEvent&) = delete;
   LockfreeEvent& operator=(const LockfreeEvent&) = delete;
@@ -62,7 +61,7 @@ class LockfreeEvent {
   enum State { kClosureNotReady = 0, kClosureReady = 2, kShutdownBit = 1 };
 
   std::atomic<intptr_t> state_;
-  Scheduler* scheduler_;
+  ThreadPool* thread_pool_;
 };
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -70,13 +70,6 @@
 
 // IWYU pragma: no_include <ratio>
 
-#if defined(GRPC_POSIX_SOCKET_TCP) && \
-    !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
-#define GRPC_PLATFORM_SUPPORTS_POSIX_POLLING true
-#else
-#define GRPC_PLATFORM_SUPPORTS_POSIX_POLLING false
-#endif
-
 using namespace std::chrono_literals;
 
 namespace grpc_event_engine::experimental {

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -676,7 +676,8 @@ PosixEventEngine::GetDNSResolver(
   GRPC_TRACE_LOG(event_engine_dns, INFO)
       << "PosixEventEngine::" << this << " creating AresResolver";
   auto ares_resolver = AresResolver::CreateAresResolver(
-      options.dns_server, std::make_unique<GrpcPolledFdFactoryPosix>(poller_),
+      options.dns_server,
+      std::make_unique<GrpcPolledFdFactoryPosix>(poller_.get()),
       shared_from_this());
   if (!ares_resolver.ok()) {
     return ares_resolver.status();

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -676,8 +676,7 @@ PosixEventEngine::GetDNSResolver(
   GRPC_TRACE_LOG(event_engine_dns, INFO)
       << "PosixEventEngine::" << this << " creating AresResolver";
   auto ares_resolver = AresResolver::CreateAresResolver(
-      options.dns_server,
-      std::make_unique<GrpcPolledFdFactoryPosix>(GetPollerChecked()),
+      options.dns_server, std::make_unique<GrpcPolledFdFactoryPosix>(poller_),
       shared_from_this());
   if (!ares_resolver.ok()) {
     return ares_resolver.status();

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -268,6 +268,11 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport {
   void SchedulePoller();
   void ResetPollCycle();
 
+  PosixEventPoller* GetPollerChecked() const {
+    CHECK_NE(poller_, nullptr);
+    return poller_.get();
+  }
+
   std::shared_ptr<grpc_event_engine::experimental::PosixEventPoller> poller_;
 
   // Ensures there's ever only one of these.

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -187,14 +187,16 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport {
 
   PosixEventEngine();
 
-#ifdef GRPC_POSIX_SOCKET_TCP
+#if defined(GRPC_POSIX_SOCKET_TCP) && \
+    !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
   // Constructs an EventEngine which has a shared ownership of the poller. Use
   // the MakeTestOnlyPosixEventEngine static method to call this. Its expected
   // to be used only in tests.
   explicit PosixEventEngine(
       std::shared_ptr<grpc_event_engine::experimental::PosixEventPoller>
           poller);
-#endif  // GRPC_POSIX_SOCKET_TCP
+#endif  // defined(GRPC_POSIX_SOCKET_TCP) &&
+  // !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
 
   EventEngine::TaskHandle RunAfterInternal(Duration when,
                                            absl::AnyInvocable<void()> cb);

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -242,21 +242,6 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport {
 #if defined(GRPC_POSIX_SOCKET_TCP) && \
     !defined(GRPC_DO_NOT_INSTANTIATE_POSIX_POLLER)
 
-  // A helper class to manage lifetime of the poller associated with the
-  // posix EventEngine.
-  class ThreadPoolSchedulerAdapter
-      : public grpc_event_engine::experimental::Scheduler {
-   public:
-    explicit ThreadPoolSchedulerAdapter(std::shared_ptr<ThreadPool> executor)
-        : executor_(std::move(executor)) {}
-
-    void Run(experimental::EventEngine::Closure* closure) override;
-    void Run(absl::AnyInvocable<void()>) override;
-
-   private:
-    std::shared_ptr<ThreadPool> executor_;
-  };
-
   // RAII wrapper for a polling cycle. Starts a new one in ctor and stops
   // in dtor.
   class PollingCycle {
@@ -281,7 +266,6 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport {
   void SchedulePoller();
   void ResetPollCycle();
 
-  ThreadPoolSchedulerAdapter scheduler_adapter_;
   std::shared_ptr<grpc_event_engine::experimental::PosixEventPoller> poller_;
 
   // Ensures there's ever only one of these.

--- a/src/core/lib/event_engine/posix_engine/posix_engine.h
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.h
@@ -173,7 +173,7 @@ class PosixEventEngine final : public PosixEventEngineWithFdSupport {
 #ifdef GRPC_POSIX_SOCKET_TCP
 
 #ifdef GRPC_ENABLE_FORK_SUPPORT
-  enum class OnForkRole{kChild, kParent};
+  enum class OnForkRole { kChild, kParent };
   void AfterFork(OnForkRole on_fork_role);
   void BeforeFork();
 #endif  // GRPC_ENABLE_FORK_SUPPORT

--- a/test/core/event_engine/posix/BUILD
+++ b/test/core/event_engine/posix/BUILD
@@ -118,6 +118,7 @@ grpc_cc_benchmark(
         "//src/core:posix_event_engine_closure",
         "//src/core:posix_event_engine_event_poller",
         "//src/core:posix_event_engine_lockfree_event",
+        "//test/core/event_engine/posix:posix_engine_test_utils",
         "//test/core/test_util:grpc_test_util",
     ],
 )

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -379,23 +379,23 @@ class EventPollerTest : public ::testing::Test {
   void SetUp() override {
     engine_ = PosixEventEngine::MakePosixEventEngine();
     EXPECT_NE(engine_, nullptr);
-    scheduler_ = std::make_unique<TestScheduler>(engine_.get());
-    EXPECT_NE(scheduler_, nullptr);
-    g_event_poller = MakeDefaultPoller(scheduler_.get());
+    thread_pool_ = std::make_shared<TestThreadPool>(engine_.get());
+    EXPECT_NE(thread_pool_, nullptr);
+    g_event_poller = MakeDefaultPoller(thread_pool_);
     engine_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(g_event_poller);
     EXPECT_NE(engine_, nullptr);
-    scheduler_->ChangeCurrentEventEngine(engine_.get());
+    thread_pool_->ChangeCurrentEventEngine(engine_.get());
     if (g_event_poller != nullptr) {
       LOG(INFO) << "Using poller: " << g_event_poller->Name();
     }
   }
 
  public:
-  TestScheduler* Scheduler() { return scheduler_.get(); }
+  TestThreadPool* thread_pool() const { return thread_pool_.get(); }
 
  private:
   std::shared_ptr<PosixEventEngine> engine_;
-  std::unique_ptr<TestScheduler> scheduler_;
+  std::shared_ptr<TestThreadPool> thread_pool_;
 };
 
 // Test grpc_fd. Start an upload server and client, upload a stream of bytes
@@ -524,10 +524,10 @@ std::atomic<int> kTotalActiveWakeupFdHandles{0};
 // a specified number of read events.
 class WakeupFdHandle : public grpc_core::DualRefCounted<WakeupFdHandle> {
  public:
-  WakeupFdHandle(int num_wakeups, Scheduler* scheduler,
+  WakeupFdHandle(int num_wakeups, ThreadPool* thread_pool,
                  PosixEventPoller* poller)
       : num_wakeups_(num_wakeups),
-        scheduler_(scheduler),
+        thread_pool_(thread_pool),
         poller_(poller),
         on_read_(
             PosixEngineClosure::ToPermanentClosure([this](absl::Status status) {
@@ -555,7 +555,7 @@ class WakeupFdHandle : public grpc_core::DualRefCounted<WakeupFdHandle> {
                 Ref().release();
                 // Schedule next wakeup to trigger the registered NotifyOnRead
                 // callback.
-                scheduler_->Run(SelfDeletingClosure::Create([this]() {
+                thread_pool_->Run(SelfDeletingClosure::Create([this]() {
                   // Send next wakeup.
                   EXPECT_TRUE(wakeup_fd_->Wakeup().ok());
                   Unref();
@@ -565,7 +565,7 @@ class WakeupFdHandle : public grpc_core::DualRefCounted<WakeupFdHandle> {
     WeakRef().release();
     ++kTotalActiveWakeupFdHandles;
     EXPECT_GT(num_wakeups_, 0);
-    EXPECT_NE(scheduler_, nullptr);
+    EXPECT_NE(thread_pool_, nullptr);
     EXPECT_NE(poller_, nullptr);
     wakeup_fd_ = *PipeWakeupFd::CreatePipeWakeupFd(&poller_->posix_interface());
     handle_ = poller_->CreateHandle(wakeup_fd_->ReadFd(), "test", false);
@@ -619,7 +619,7 @@ class WakeupFdHandle : public grpc_core::DualRefCounted<WakeupFdHandle> {
     }
   }
   int num_wakeups_;
-  Scheduler* scheduler_;
+  ThreadPool* thread_pool_;
   PosixEventPoller* poller_;
   PosixEngineClosure* on_read_;
   std::unique_ptr<WakeupFd> wakeup_fd_;
@@ -632,20 +632,20 @@ class WakeupFdHandle : public grpc_core::DualRefCounted<WakeupFdHandle> {
 // pending events. This continues until all Fds have orphaned themselves.
 class Worker : public grpc_core::DualRefCounted<Worker> {
  public:
-  Worker(Scheduler* scheduler, PosixEventPoller* poller, int num_handles,
+  Worker(ThreadPool* thread_pool, PosixEventPoller* poller, int num_handles,
          int num_wakeups_per_handle)
-      : scheduler_(scheduler), poller_(poller) {
+      : thread_pool_(thread_pool), poller_(poller) {
     handles_.reserve(num_handles);
     for (int i = 0; i < num_handles; i++) {
       handles_.push_back(
-          new WakeupFdHandle(num_wakeups_per_handle, scheduler_, poller_));
+          new WakeupFdHandle(num_wakeups_per_handle, thread_pool_, poller_));
     }
     WeakRef().release();
   }
   void Orphaned() override { signal.Notify(); }
   void Start() {
     // Start executing Work(..).
-    scheduler_->Run([this]() { Work(); });
+    thread_pool_->Run([this]() { Work(); });
   }
 
   void Wait() {
@@ -659,7 +659,7 @@ class Worker : public grpc_core::DualRefCounted<Worker> {
       // Schedule next work instantiation immediately and take a Ref for
       // the next instantiation.
       Ref().release();
-      scheduler_->Run([this]() { Work(); });
+      thread_pool_->Run([this]() { Work(); });
     });
     ASSERT_TRUE(result == Poller::WorkResult::kOk ||
                 result == Poller::WorkResult::kKicked);
@@ -669,7 +669,7 @@ class Worker : public grpc_core::DualRefCounted<Worker> {
     // been deleted.
     Unref();
   }
-  Scheduler* scheduler_;
+  ThreadPool* thread_pool_;
   PosixEventPoller* poller_;
   grpc_core::Notification signal;
   std::vector<WakeupFdHandle*> handles_;
@@ -687,7 +687,7 @@ TEST_F(EventPollerTest, TestMultipleHandles) {
   if (g_event_poller == nullptr) {
     return;
   }
-  Worker* worker = new Worker(Scheduler(), g_event_poller.get(), kNumHandles,
+  Worker* worker = new Worker(thread_pool(), g_event_poller.get(), kNumHandles,
                               kNumWakeupsPerHandle);
   worker->Start();
   worker->Wait();

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -379,12 +379,12 @@ class EventPollerTest : public ::testing::Test {
   void SetUp() override {
     engine_ = PosixEventEngine::MakePosixEventEngine();
     EXPECT_NE(engine_, nullptr);
-    thread_pool_ = std::make_shared<TestThreadPool>(engine_.get());
+    thread_pool_ = std::make_shared<TestThreadPool>(engine_);
     EXPECT_NE(thread_pool_, nullptr);
     g_event_poller = MakeDefaultPoller(thread_pool_);
     engine_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(g_event_poller);
     EXPECT_NE(engine_, nullptr);
-    thread_pool_->ChangeCurrentEventEngine(engine_.get());
+    thread_pool_->ChangeCurrentEventEngine(engine_);
     if (g_event_poller != nullptr) {
       LOG(INFO) << "Using poller: " << g_event_poller->Name();
     }

--- a/test/core/event_engine/posix/event_poller_posix_test.cc
+++ b/test/core/event_engine/posix/event_poller_posix_test.cc
@@ -379,12 +379,12 @@ class EventPollerTest : public ::testing::Test {
   void SetUp() override {
     engine_ = PosixEventEngine::MakePosixEventEngine();
     EXPECT_NE(engine_, nullptr);
-    thread_pool_ = std::make_shared<TestThreadPool>(engine_);
+    thread_pool_ = std::make_shared<TestThreadPool>(engine_.get());
     EXPECT_NE(thread_pool_, nullptr);
     g_event_poller = MakeDefaultPoller(thread_pool_);
     engine_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(g_event_poller);
     EXPECT_NE(engine_, nullptr);
-    thread_pool_->ChangeCurrentEventEngine(engine_);
+    thread_pool_->ChangeCurrentEventEngine(engine_.get());
     if (g_event_poller != nullptr) {
       LOG(INFO) << "Using poller: " << g_event_poller->Name();
     }

--- a/test/core/event_engine/posix/lock_free_event_test.cc
+++ b/test/core/event_engine/posix/lock_free_event_test.cc
@@ -16,24 +16,19 @@
 #include <grpc/event_engine/event_engine.h>
 #include <grpc/grpc.h>
 
-#include <algorithm>
 #include <memory>
 #include <thread>
-#include <utility>
 #include <vector>
 
 #include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/time/time.h"
 #include "gtest/gtest.h"
-#include "src/core/lib/event_engine/default_event_engine.h"
-#include "src/core/lib/event_engine/posix_engine/event_poller.h"
 #include "src/core/lib/event_engine/posix_engine/lockfree_event.h"
 #include "src/core/lib/event_engine/posix_engine/posix_engine_closure.h"
 #include "src/core/util/sync.h"
 #include "test/core/event_engine/posix/posix_engine_test_utils.h"
 
-using ::grpc_event_engine::experimental::EventEngine;
 using ::grpc_event_engine::experimental::TestThreadPool;
 
 namespace {

--- a/test/core/event_engine/posix/lock_free_event_test.cc
+++ b/test/core/event_engine/posix/lock_free_event_test.cc
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
   // until we clear out the iomgr shutdown code.
   grpc_init();
   g_thread_pool = new TestThreadPool(
-      grpc_event_engine::experimental::GetDefaultEventEngine().get());
+      grpc_event_engine::experimental::GetDefaultEventEngine());
   int r = RUN_ALL_TESTS();
   benchmark::RunTheBenchmarksNamespaced();
   grpc_shutdown();

--- a/test/core/event_engine/posix/lock_free_event_test.cc
+++ b/test/core/event_engine/posix/lock_free_event_test.cc
@@ -174,10 +174,13 @@ int main(int argc, char** argv) {
   // TODO(ctiller): EventEngine temporarily needs grpc to be initialized first
   // until we clear out the iomgr shutdown code.
   grpc_init();
-  g_thread_pool = new TestThreadPool(
-      grpc_event_engine::experimental::GetDefaultEventEngine());
+  // Variable here to ensure lifetime
+  auto ee = grpc_event_engine::experimental::GetDefaultEventEngine();
+  g_thread_pool = new TestThreadPool(ee.get());
   int r = RUN_ALL_TESTS();
   benchmark::RunTheBenchmarksNamespaced();
+  // Time to let EE go.
+  ee.reset();
   grpc_shutdown();
   return r;
 }

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -199,14 +199,14 @@ class Worker : public grpc_core::DualRefCounted<Worker> {
 class PosixEndpointTest : public ::testing::TestWithParam<bool> {
   void SetUp() override {
     oracle_ee_ = std::make_shared<PosixOracleEventEngine>();
-    scheduler_ =
-        std::make_unique<grpc_event_engine::experimental::TestScheduler>(
+    thread_pool_ =
+        std::make_shared<grpc_event_engine::experimental::TestThreadPool>(
             posix_ee_.get());
-    EXPECT_NE(scheduler_, nullptr);
-    poller_ = MakeDefaultPoller(scheduler_.get());
+    EXPECT_NE(thread_pool_, nullptr);
+    poller_ = MakeDefaultPoller(thread_pool_);
     posix_ee_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(poller_);
     EXPECT_NE(posix_ee_, nullptr);
-    scheduler_->ChangeCurrentEventEngine(posix_ee_.get());
+    thread_pool_->ChangeCurrentEventEngine(posix_ee_.get());
     if (poller_ != nullptr) {
       LOG(INFO) << "Using poller: " << poller_->Name();
     }
@@ -218,7 +218,7 @@ class PosixEndpointTest : public ::testing::TestWithParam<bool> {
   }
 
  public:
-  TestScheduler* Scheduler() { return scheduler_.get(); }
+  TestThreadPool* thread_pool() const { return thread_pool_.get(); }
 
   std::shared_ptr<EventEngine> GetPosixEE() { return posix_ee_; }
 
@@ -228,7 +228,7 @@ class PosixEndpointTest : public ::testing::TestWithParam<bool> {
 
  private:
   std::shared_ptr<PosixEventPoller> poller_;
-  std::unique_ptr<TestScheduler> scheduler_;
+  std::shared_ptr<TestThreadPool> thread_pool_;
   std::shared_ptr<EventEngine> posix_ee_;
   std::shared_ptr<EventEngine> oracle_ee_;
 };

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -201,12 +201,12 @@ class PosixEndpointTest : public ::testing::TestWithParam<bool> {
     oracle_ee_ = std::make_shared<PosixOracleEventEngine>();
     thread_pool_ =
         std::make_shared<grpc_event_engine::experimental::TestThreadPool>(
-            posix_ee_);
+            posix_ee_.get());
     EXPECT_NE(thread_pool_, nullptr);
     poller_ = MakeDefaultPoller(thread_pool_);
     posix_ee_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(poller_);
     EXPECT_NE(posix_ee_, nullptr);
-    thread_pool_->ChangeCurrentEventEngine(posix_ee_);
+    thread_pool_->ChangeCurrentEventEngine(posix_ee_.get());
     if (poller_ != nullptr) {
       LOG(INFO) << "Using poller: " << poller_->Name();
     }

--- a/test/core/event_engine/posix/posix_endpoint_test.cc
+++ b/test/core/event_engine/posix/posix_endpoint_test.cc
@@ -201,12 +201,12 @@ class PosixEndpointTest : public ::testing::TestWithParam<bool> {
     oracle_ee_ = std::make_shared<PosixOracleEventEngine>();
     thread_pool_ =
         std::make_shared<grpc_event_engine::experimental::TestThreadPool>(
-            posix_ee_.get());
+            posix_ee_);
     EXPECT_NE(thread_pool_, nullptr);
     poller_ = MakeDefaultPoller(thread_pool_);
     posix_ee_ = PosixEventEngine::MakeTestOnlyPosixEventEngine(poller_);
     EXPECT_NE(posix_ee_, nullptr);
-    thread_pool_->ChangeCurrentEventEngine(posix_ee_.get());
+    thread_pool_->ChangeCurrentEventEngine(posix_ee_);
     if (poller_ != nullptr) {
       LOG(INFO) << "Using poller: " << poller_->Name();
     }

--- a/test/core/event_engine/posix/posix_engine_test_utils.h
+++ b/test/core/event_engine/posix/posix_engine_test_utils.h
@@ -20,20 +20,22 @@
 #include <utility>
 
 #include "absl/functional/any_invocable.h"
-#include "src/core/lib/event_engine/posix_engine/event_poller.h"
+#include "src/core/lib/event_engine/thread_pool/thread_pool.h"
 
 namespace grpc_event_engine {
 namespace experimental {
 
-class TestScheduler : public Scheduler {
+class TestThreadPool final : public ThreadPool {
  public:
-  explicit TestScheduler(grpc_event_engine::experimental::EventEngine* engine)
+  TestThreadPool() = default;
+  explicit TestThreadPool(grpc_event_engine::experimental::EventEngine* engine)
       : engine_(engine) {}
-  TestScheduler() : engine_(nullptr) {};
+
   void ChangeCurrentEventEngine(
       grpc_event_engine::experimental::EventEngine* engine) {
     engine_ = engine;
   }
+
   void Run(experimental::EventEngine::Closure* closure) override {
     if (engine_ != nullptr) {
       engine_->Run(closure);
@@ -49,6 +51,13 @@ class TestScheduler : public Scheduler {
       cb();
     }
   }
+
+  void Quiesce() override {}
+
+#if GRPC_ENABLE_FORK_SUPPORT
+  void PrepareFork() override {}
+  void PostFork() override {}
+#endif  // GRPC_ENABLE_FORK_SUPPORT
 
  private:
   grpc_event_engine::experimental::EventEngine* engine_;

--- a/test/core/event_engine/posix/posix_engine_test_utils.h
+++ b/test/core/event_engine/posix/posix_engine_test_utils.h
@@ -28,13 +28,12 @@ namespace experimental {
 class TestThreadPool final : public ThreadPool {
  public:
   TestThreadPool() = default;
-  explicit TestThreadPool(
-      std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine)
-      : engine_(std::move(engine)) {}
+  explicit TestThreadPool(grpc_event_engine::experimental::EventEngine* engine)
+      : engine_(engine) {}
 
   void ChangeCurrentEventEngine(
-      std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine) {
-    engine_ = std::move(engine);
+      grpc_event_engine::experimental::EventEngine* engine) {
+    engine_ = engine;
   }
 
   void Run(experimental::EventEngine::Closure* closure) override {
@@ -61,7 +60,7 @@ class TestThreadPool final : public ThreadPool {
 #endif  // GRPC_ENABLE_FORK_SUPPORT
 
  private:
-  std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine_;
+  grpc_event_engine::experimental::EventEngine* engine_ = nullptr;
 };
 
 // Creates a client socket and blocks until it connects to the specified

--- a/test/core/event_engine/posix/posix_engine_test_utils.h
+++ b/test/core/event_engine/posix/posix_engine_test_utils.h
@@ -28,12 +28,13 @@ namespace experimental {
 class TestThreadPool final : public ThreadPool {
  public:
   TestThreadPool() = default;
-  explicit TestThreadPool(grpc_event_engine::experimental::EventEngine* engine)
-      : engine_(engine) {}
+  explicit TestThreadPool(
+      std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine)
+      : engine_(std::move(engine)) {}
 
   void ChangeCurrentEventEngine(
-      grpc_event_engine::experimental::EventEngine* engine) {
-    engine_ = engine;
+      std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine) {
+    engine_ = std::move(engine);
   }
 
   void Run(experimental::EventEngine::Closure* closure) override {
@@ -60,7 +61,7 @@ class TestThreadPool final : public ThreadPool {
 #endif  // GRPC_ENABLE_FORK_SUPPORT
 
  private:
-  grpc_event_engine::experimental::EventEngine* engine_;
+  std::shared_ptr<grpc_event_engine::experimental::EventEngine> engine_;
 };
 
 // Creates a client socket and blocks until it connects to the specified

--- a/test/cpp/ext/otel/otel_tracing_test.cc
+++ b/test/cpp/ext/otel/otel_tracing_test.cc
@@ -681,7 +681,8 @@ TEST_F(OTelTracingTest, PropagationParentToChild) {
 #ifdef GRPC_LINUX_ERRQUEUE
 // Test presence of TCP write annotations
 TEST_F(OTelTracingTest, TcpWriteAnnotations) {
-  if (!grpc_event_engine::experimental::MakeDefaultPoller(/*scheduler=*/nullptr)
+  if (!grpc_event_engine::experimental::MakeDefaultPoller(
+           /*thread_pool=*/nullptr)
            ->CanTrackErrors()) {
     GTEST_SKIP() << "Test disabled if poller doesn't support errqueue";
   }


### PR DESCRIPTION
PosixEngine now directly owns the poller, which will streamline change for poller enablement experiment.