### PR TITLE
Ruby: Mark credential object in channel

### DIFF
--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -62,6 +62,7 @@ static VALUE grpc_rb_cChannelArgs;
 /* grpc_rb_channel wraps a grpc_channel. */
 typedef struct grpc_rb_channel {
   grpc_channel* channel;
+  VALUE mark;
 } grpc_rb_channel;
 
 static void grpc_rb_channel_free(void* p) {
@@ -76,9 +77,13 @@ static void grpc_rb_channel_free(void* p) {
   xfree(p);
 }
 
+static void grpc_rb_channel_mark(void *p) {
+  rb_gc_mark(((grpc_rb_channel *)p)->mark);
+}
+
 static rb_data_type_t grpc_channel_data_type = {
     "grpc_channel",
-    {NULL, grpc_rb_channel_free, GRPC_RB_MEMSIZE_UNAVAILABLE, {NULL, NULL}},
+    {grpc_rb_channel_mark, grpc_rb_channel_free, GRPC_RB_MEMSIZE_UNAVAILABLE, {NULL, NULL}},
     NULL,
     NULL,
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
@@ -91,6 +96,7 @@ static VALUE grpc_rb_channel_alloc(VALUE cls) {
   grpc_ruby_init();
   grpc_rb_channel* wrapper = ALLOC(grpc_rb_channel);
   wrapper->channel = NULL;
+  wrapper->mark = Qnil;
   return TypedData_Wrap_Struct(cls, &grpc_channel_data_type, wrapper);
 }
 
@@ -139,6 +145,7 @@ static VALUE grpc_rb_channel_init(int argc, VALUE* argv, VALUE self) {
       return Qnil;
     }
     wrapper->channel = grpc_channel_create(target_chars, creds, &channel_args);
+    wrapper->mark = rb_credentials;
   }
   grpc_rb_channel_args_destroy(&channel_args);
   if (wrapper->channel == NULL) {


### PR DESCRIPTION
The credentials object potentially holds a reference to a proc when composed with CallCredentials.

We need the proc to live so that when requests build the credentials the proc can still be invoked.  For the proc to live we need the credentials object to live so it needs to be marked by the channel.

This addresses #40368