### PR TITLE
[PSM Interop] Legacy driver: freeze pip deps

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_python_test_in_docker.sh
@@ -13,22 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-trap 'date' DEBUG
-set -ex -o igncr || set -ex
-
+PS4='+ $(date "+[%H:%M:%S %Z]")\011 '
+set -ex
 
 mkdir -p /var/local/git
 git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git /var/local/git/grpc
 cd /var/local/git/grpc
 
 python3 -m pip install virtualenv
-VIRTUAL_ENV=$(mktemp -d)
-python3 -m virtualenv "$VIRTUAL_ENV" -p python3
-PYTHON="$VIRTUAL_ENV"/bin/python
-"$PYTHON" -m pip install --upgrade pip==19.3.1
-# TODO(sergiitk): Unpin grpcio-tools when a version of xds-protos
-#   compatible with protobuf 4.X is uploaded to PyPi.
-"$PYTHON" -m pip install --upgrade grpcio-tools==1.48.1 google-api-python-client google-auth-httplib2 oauth2client xds-protos
+VIRTUAL_ENV="$(mktemp -d)"
+python3 -m virtualenv "${VIRTUAL_ENV}"
+
+# Activate venv without printing garbage.
+{ set +x; } 2>/dev/null
+echo "Activating Python venv"
+source "${VIRTUAL_ENV}/bin/activate"
+set -x
+
+python -VV
+pip install --upgrade pip==25.2
+# Note that these are only test driver's dependencies. gRPC version
+# shouldn't matter, as it's only used for getting the LB stats from the client.
+pip install --upgrade \
+    grpcio-tools==1.74.0 \
+    grpcio==1.74.0 \
+    xds-protos==1.74.0 \
+    google-api-python-client==2.179.0 \
+    google-auth-httplib2==0.2.0 \
+    oauth2client==4.1.3
+pip list
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests
@@ -40,7 +53,7 @@ touch "$TOOLS_DIR"/src/proto/__init__.py
 touch "$TOOLS_DIR"/src/proto/grpc/__init__.py
 touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
 
-"$PYTHON" -m grpc_tools.protoc \
+python -m grpc_tools.protoc \
     --proto_path=. \
     --python_out="$TOOLS_DIR" \
     --grpc_python_out="$TOOLS_DIR" \
@@ -54,7 +67,7 @@ mkdir -p ${HEALTH_PROTO_DEST_DIR}
 touch "$TOOLS_DIR"/src/proto/grpc/health/__init__.py
 touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
 
-"$PYTHON" -m grpc_tools.protoc \
+python -m grpc_tools.protoc \
     --proto_path=. \
     --python_out=${TOOLS_DIR} \
     --grpc_python_out=${TOOLS_DIR} \
@@ -63,11 +76,10 @@ touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
 cd /var/local/jenkins/grpc/
 bazel build //src/python/grpcio_tests/tests_py3_only/interop:xds_interop_client
 
-# Test cases "path_matching" and "header_matching" are not included in "all",
-# because not all interop clients in all languages support these new tests.
-export PYTHONUNBUFFERED=true
-GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
-  /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
+# Run legacy ping_pong test. All tests are migrated to
+# https://github.com/grpc/psm-interop
+GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb \
+  python /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
     --test_case="ping_pong" \
     --project_id=grpc-testing \

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -14,20 +14,32 @@
 # limitations under the License.
 
 trap 'date' DEBUG
-set -ex -o igncr || set -ex
+set -ex
 
 mkdir -p /var/local/git
 git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git /var/local/git/grpc
 cd /var/local/git/grpc
 
 python3 -m pip install virtualenv
-VIRTUAL_ENV=$(mktemp -d)
-python3 -m virtualenv "$VIRTUAL_ENV" -p python3
-PYTHON="$VIRTUAL_ENV"/bin/python
-"$PYTHON" -m pip install --upgrade pip==19.3.1
-# TODO(sergiitk): Unpin grpcio-tools when a version of xds-protos
-#   compatible with protobuf 4.X is uploaded to PyPi.
-"$PYTHON" -m pip install --upgrade grpcio grpcio-tools==1.48.1 google-api-python-client google-auth-httplib2 oauth2client xds-protos
+VIRTUAL_ENV="$(mktemp -d)"
+python3 -m virtualenv "${VIRTUAL_ENV}"
+
+# Activate venv without printing garbage.
+{ set +x; } 2>/dev/null
+echo "Activating Python venv"
+source "${VIRTUAL_ENV}/bin/activate"
+set -x
+
+python -VV
+pip install --upgrade pip==25.2
+pip install --upgrade \
+    grpcio-tools==1.74.0 \
+    grpcio==1.74.0 \
+    xds-protos==1.74.0 \
+    google-api-python-client==2.179.0 \
+    google-auth-httplib2==0.2.0 \
+    oauth2client==4.1.3
+pip list
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests
@@ -39,7 +51,7 @@ touch "$TOOLS_DIR"/src/proto/__init__.py
 touch "$TOOLS_DIR"/src/proto/grpc/__init__.py
 touch "$TOOLS_DIR"/src/proto/grpc/testing/__init__.py
 
-"$PYTHON" -m grpc_tools.protoc \
+python -m grpc_tools.protoc \
     --proto_path=. \
     --python_out="$TOOLS_DIR" \
     --grpc_python_out="$TOOLS_DIR" \
@@ -53,7 +65,7 @@ mkdir -p ${HEALTH_PROTO_DEST_DIR}
 touch "$TOOLS_DIR"/src/proto/grpc/health/__init__.py
 touch "$TOOLS_DIR"/src/proto/grpc/health/v1/__init__.py
 
-"$PYTHON" -m grpc_tools.protoc \
+python -m grpc_tools.protoc \
     --proto_path=. \
     --python_out=${TOOLS_DIR} \
     --grpc_python_out=${TOOLS_DIR} \
@@ -67,7 +79,7 @@ bazel build test/cpp/interop:xds_interop_client
 #
 # TODO: remove "path_matching" and "header_matching" from --test_case after
 # they are added into "all".
-GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb "$PYTHON" \
+GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb python \
    /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
     --test_case="ping_pong" \

--- a/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_xds_bazel_test_in_docker.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-trap 'date' DEBUG
+PS4='+ $(date "+[%H:%M:%S %Z]")\011 '
 set -ex
 
 mkdir -p /var/local/git
@@ -32,6 +32,8 @@ set -x
 
 python -VV
 pip install --upgrade pip==25.2
+# Note that these are only test driver's dependencies. gRPC version
+# shouldn't matter, as it's only used for getting the LB stats from the client.
 pip install --upgrade \
     grpcio-tools==1.74.0 \
     grpcio==1.74.0 \
@@ -74,13 +76,10 @@ python -m grpc_tools.protoc \
 cd /var/local/jenkins/grpc/
 bazel build test/cpp/interop:xds_interop_client
 
-# Test cases "path_matching" and "header_matching" are not included in "all",
-# because not all interop clients in all languages support these new tests.
-#
-# TODO: remove "path_matching" and "header_matching" from --test_case after
-# they are added into "all".
-GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb python \
-   /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
+# Run legacy ping_pong test. All tests are migrated to
+# https://github.com/grpc/psm-interop
+GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,cds_lb,xds_cluster_resolver_lb,priority_lb,xds_cluster_impl_lb,weighted_target_lb \
+  python /var/local/git/grpc/tools/run_tests/run_xds_tests.py \
     --halt_after_fail \
     --test_case="ping_pong" \
     --project_id=grpc-testing \
@@ -90,6 +89,4 @@ GRPC_VERBOSITY=debug GRPC_TRACE=xds_client,xds_resolver,xds_cluster_manager_lb,c
     --gcp_suffix=$(date '+%s') \
     --verbose \
     ${XDS_V3_OPT-} \
-    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps} {fail_on_failed_rpc} \
-      {rpcs_to_send} \
-      {metadata_to_send}'
+    --client_cmd='bazel-bin/test/cpp/interop/xds_interop_client --server=xds:///{server_uri} --stats_port={stats_port} --qps={qps} {fail_on_failed_rpc} {rpcs_to_send} {metadata_to_send}'

--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -19,33 +19,30 @@ set -ex
 # change to grpc repo root
 pushd "${KOKORO_ARTIFACTS_DIR}/github/grpc"
 
-# needrestart checks which daemons need to be restarted after library
-# upgrades. It's useless to us in non-interactive mode.
-sudo DEBIAN_FRONTEND=noninteractive apt-get -qq remove needrestart
-sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
-sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --auto-remove python3-venv
+# Note: we don't use venv here because then per-language build files would need
+#   to source this script to have venv python be on the PATH. This would require
+#   backport this change to ~30 branches. Instead, we just install pip packages
+#   globally here. If this ever breaks, uncomment the following lines, remove
+#   sudo from pip install, and do the backports.
+#
+# sudo DEBIAN_FRONTEND=noninteractive apt-get -qq remove needrestart
+# sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
+# sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --auto-remove python3-venv
+# VIRTUAL_ENV="$(mktemp -d)"
+# python3 -m venv "${VIRTUAL_ENV}"
 
-VIRTUAL_ENV="$(mktemp -d)"
-python3 -m venv "${VIRTUAL_ENV}"
-
-# Activate venv without printing garbage.
-{ set +x; } 2>/dev/null
-echo "Activating Python venv"
-source "${VIRTUAL_ENV}/bin/activate"
-set -x
-
-python -VV
-pip install --upgrade pip==25.2
-# Note that these are only test driver's dependencies. gRPC version
-# shouldn't matter, as it's only used for getting the LB stats from the client.
-pip install --upgrade \
+python3 -VV
+sudo python3 -m pip install --upgrade pip==25.2
+# TODO(sergiitk): Unpin grpcio-tools when a version of xds-protos
+#   compatible with protobuf 4.X is uploaded to PyPi.
+sudo python3 -m pip install --upgrade \
     grpcio-tools==1.74.0 \
     grpcio==1.74.0 \
     xds-protos==1.74.0 \
     google-api-python-client==2.179.0 \
     google-auth-httplib2==0.2.0 \
     oauth2client==4.1.3
-pip list
+python3 -m pip list
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests
@@ -53,7 +50,7 @@ PROTO_SOURCE_DIR=src/proto/grpc/testing
 PROTO_DEST_DIR=${TOOLS_DIR}/${PROTO_SOURCE_DIR}
 mkdir -p ${PROTO_DEST_DIR}
 
-python -m grpc_tools.protoc \
+python3 -m grpc_tools.protoc \
     --proto_path=. \
     --python_out=${TOOLS_DIR} \
     --grpc_python_out=${TOOLS_DIR} \
@@ -65,7 +62,7 @@ HEALTH_PROTO_SOURCE_DIR=src/proto/grpc/health/v1
 HEALTH_PROTO_DEST_DIR=${TOOLS_DIR}/${HEALTH_PROTO_SOURCE_DIR}
 mkdir -p ${HEALTH_PROTO_DEST_DIR}
 
-python -m grpc_tools.protoc \
+python3 -m grpc_tools.protoc \
     --proto_path=. \
     --python_out=${TOOLS_DIR} \
     --grpc_python_out=${TOOLS_DIR} \

--- a/tools/run_tests/helper_scripts/prep_xds.sh
+++ b/tools/run_tests/helper_scripts/prep_xds.sh
@@ -13,28 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-trap 'date' DEBUG
+PS4='+ $(date "+[%H:%M:%S %Z]")\011 '
 set -ex
 
 # change to grpc repo root
 pushd "${KOKORO_ARTIFACTS_DIR}/github/grpc"
 
-# Note: we don't use venv here because then per-language build files would need
-#   to source this script to have venv python be on the PATH. This would require
-#   backport this change to ~30 branches. Instead, we just install pip packages
-#   globally here. If this ever breaks, uncomment the following lines, remove
-#   sudo from pip install, and do the backports.
-#
-# sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
-# sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install --auto-remove "python3.10-venv"
-# VIRTUAL_ENV=$(mktemp -d)
-# python3 -m venv "${VIRTUAL_ENV}"
-# source "${VIRTUAL_ENV}/bin/activate"
+# needrestart checks which daemons need to be restarted after library
+# upgrades. It's useless to us in non-interactive mode.
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq remove needrestart
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --auto-remove python3-venv
 
-sudo python3 -m pip install --upgrade pip==19.3.1
-# TODO(sergiitk): Unpin grpcio-tools when a version of xds-protos
-#   compatible with protobuf 4.X is uploaded to PyPi.
-sudo python3 -m pip install --upgrade grpcio grpcio-tools==1.48.1 google-api-python-client google-auth-httplib2 oauth2client xds-protos
+VIRTUAL_ENV="$(mktemp -d)"
+python3 -m venv "${VIRTUAL_ENV}"
+
+# Activate venv without printing garbage.
+{ set +x; } 2>/dev/null
+echo "Activating Python venv"
+source "${VIRTUAL_ENV}/bin/activate"
+set -x
+
+python -VV
+pip install --upgrade pip==25.2
+# Note that these are only test driver's dependencies. gRPC version
+# shouldn't matter, as it's only used for getting the LB stats from the client.
+pip install --upgrade \
+    grpcio-tools==1.74.0 \
+    grpcio==1.74.0 \
+    xds-protos==1.74.0 \
+    google-api-python-client==2.179.0 \
+    google-auth-httplib2==0.2.0 \
+    oauth2client==4.1.3
+pip list
 
 # Prepare generated Python code.
 TOOLS_DIR=tools/run_tests
@@ -42,7 +53,7 @@ PROTO_SOURCE_DIR=src/proto/grpc/testing
 PROTO_DEST_DIR=${TOOLS_DIR}/${PROTO_SOURCE_DIR}
 mkdir -p ${PROTO_DEST_DIR}
 
-python3 -m grpc_tools.protoc \
+python -m grpc_tools.protoc \
     --proto_path=. \
     --python_out=${TOOLS_DIR} \
     --grpc_python_out=${TOOLS_DIR} \
@@ -54,7 +65,7 @@ HEALTH_PROTO_SOURCE_DIR=src/proto/grpc/health/v1
 HEALTH_PROTO_DEST_DIR=${TOOLS_DIR}/${HEALTH_PROTO_SOURCE_DIR}
 mkdir -p ${HEALTH_PROTO_DEST_DIR}
 
-python3 -m grpc_tools.protoc \
+python -m grpc_tools.protoc \
     --proto_path=. \
     --python_out=${TOOLS_DIR} \
     --grpc_python_out=${TOOLS_DIR} \


### PR DESCRIPTION
Fixes pip dependency conflicts in the legacy test driver install script:

```
/tmp/tmp.wkky1LYPKI/bin/python -m pip install --upgrade grpcio grpcio-tools==1.48.1 google-api-python-client google-auth-httplib2 oauth2client xds-protos
. . . 
Collecting xds-protos
  Downloading https://files.pythonhosted.org/packages/c7/a3/bf45208f2c18e59ef3d2093e4a972481f7f8485951ec31b5009163fc64d9/xds_protos-1.74.0-py3-none-any.whl (1.2MB)
. . . 
ERROR: xds-protos 1.74.0 has requirement protobuf<7.0.0,>=6.31.1, but you'll have protobuf 3.20.3 which is incompatible.
    Running setup.py install for grpcio-tools: started
    Running setup.py install for grpcio-tools: finished with status 'error'
```

This PR:
- Freezes legacy driver's pip dependencies
- Synchronizes grpc_xds_bazel_test_in_docker.sh, grpc_xds_bazel_python_test_in_docker.sh, prep_xds.sh
- Improves command date logging

ref b/438434981