### PR TITLE
Add support for loading systems roots on NetBSD and OpenBSD

### DIFF
--- a/src/core/credentials/transport/tls/load_system_roots_fallback.cc
+++ b/src/core/credentials/transport/tls/load_system_roots_fallback.cc
@@ -19,7 +19,8 @@
 #include <grpc/support/port_platform.h>
 
 #if !defined(GPR_LINUX) && !defined(GPR_ANDROID) && !defined(GPR_FREEBSD) && \
-    !defined(GPR_APPLE) && !defined(GPR_WINDOWS)
+    !defined(GPR_APPLE) && !defined(GPR_NETBSD) && !defined(GPR_OPENBSD) &&  \
+    !defined(GPR_WINDOWS)
 
 #include <grpc/slice.h>
 #include <grpc/slice_buffer.h>
@@ -33,4 +34,4 @@ grpc_slice LoadSystemRootCerts() { return grpc_empty_slice(); }
 }  // namespace grpc_core
 
 #endif  // !(GPR_LINUX || GPR_ANDROID || GPR_FREEBSD || GPR_APPLE ||
-        // GPR_WINDOWS)
+        // GPR_NETBSD || GPR_OPENBSD || GPR_WINDOWS)

--- a/src/core/credentials/transport/tls/load_system_roots_supported.cc
+++ b/src/core/credentials/transport/tls/load_system_roots_supported.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 #if defined(GPR_LINUX) || defined(GPR_ANDROID) || defined(GPR_FREEBSD) || \
-    defined(GPR_APPLE)
+    defined(GPR_APPLE) || defined(GPR_NETBSD) || defined(GPR_OPENBSD)
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -59,7 +59,13 @@ const char* kCertDirectories[] = {""};
 #elif defined(GPR_APPLE)    // endif GPR_FREEBSD
 const char* kCertFiles[] = {"/etc/ssl/cert.pem"};
 const char* kCertDirectories[] = {""};
-#endif                      // GPR_APPLE
+#elif defined(GPR_NETBSD)   // endif GPR_APPLE
+const char* kCertFiles[] = {"/etc/openssl/certs/ca-certificates.crt"};
+const char* kCertDirectories[] = {"/etc/openssl/certs"};
+#elif defined(GPR_OPENBSD)  // endif GPR_NETBSD
+const char* kCertFiles[] = {"/etc/ssl/cert.pem"};
+const char* kCertDirectories[] = {""};
+#endif                      // GPR_OPENBSD
 
 grpc_slice GetSystemRootCerts() {
   size_t num_cert_files_ = GPR_ARRAY_SIZE(kCertFiles);
@@ -163,4 +169,5 @@ grpc_slice LoadSystemRootCerts() {
 
 }  // namespace grpc_core
 
-#endif  // GPR_LINUX || GPR_ANDROID || GPR_FREEBSD || GPR_APPLE
+#endif  // GPR_LINUX || GPR_ANDROID || GPR_FREEBSD || GPR_APPLE ||
+        // GPR_NETNSD || GPR_OPENBSD

--- a/test/core/credentials/transport/tls/system_roots_test.cc
+++ b/test/core/credentials/transport/tls/system_roots_test.cc
@@ -20,11 +20,13 @@
 #include <stdio.h>
 
 #if defined(GPR_LINUX) || defined(GPR_FREEBSD) || defined(GPR_APPLE) || \
-    defined(GPR_WINDOWS)
+    defined(GPR_NETBSD) || defined(GPR_OPENBSD) || defined(GPR_WINDOWS)
 #include <string.h>
-#if defined(GPR_LINUX) || defined(GPR_FREEBSD) || defined(GPR_APPLE)
+#if defined(GPR_LINUX) || defined(GPR_FREEBSD) || defined(GPR_APPLE) || \
+    defined(GPR_NETBSD) || defined(GPR_OPENBSD)
 #include <sys/param.h>
-#endif  // GPR_LINUX || GPR_FREEBSD || GPR_APPLE
+#endif  // GPR_LINUX || GPR_FREEBSD || GPR_APPLE || GPR_NETBSD ||
+        // GPR_OPENBSD
 
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
@@ -52,7 +54,8 @@ namespace {
 // The GetAbsoluteFilePath and CreateRootCertsBundle helper functions are only
 // defined on some platforms. On other platforms (e.g. Windows), we rely on
 // built-in helper functions to play similar (but not exactly the same) roles.
-#if defined(GPR_LINUX) || defined(GPR_FREEBSD) || defined(GPR_APPLE)
+#if defined(GPR_LINUX) || defined(GPR_FREEBSD) || defined(GPR_APPLE) || \
+    defined(GPR_NETBSD) || defined(GPR_OPENBSD)
 TEST(AbsoluteFilePathTest, ConcatenatesCorrectly) {
   const char* directory = "nonexistent/test/directory";
   const char* filename = "doesnotexist.txt";
@@ -88,7 +91,8 @@ TEST(CreateRootCertsBundleTest, BundlesCorrectly) {
       << "Expected: \"" << result_slice.as_string_view() << "\"\n"
       << "Actual:   \"" << roots_bundle_str << "\"";
 }
-#endif  // GPR_LINUX || GPR_FREEBSD || GPR_APPLE
+#endif  // GPR_LINUX || GPR_FREEBSD || GPR_APPLE || GPR_NETBSD ||
+        // GPR_OPENBSD
 
 #if defined(GPR_WINDOWS)
 TEST(LoadSystemRootCertsTest, Success) {
@@ -113,4 +117,5 @@ int main() {
       "systems ***\n");
   return 0;
 }
-#endif  // GPR_LINUX || GPR_FREEBSD || GPR_APPLE || GPR_WINDOWS
+#endif  // GPR_LINUX || GPR_FREEBSD || GPR_APPLE || GPR_NETBSD ||
+        // GPR_OPENBSD || GPR_WINDOWS


### PR DESCRIPTION
NetBSD

https://man.netbsd.org/hier.7

```
openssl/       OpenSSL TLS trust anchors, configuration file,
               private keys, and more.  Returned by
               X509_get_default_cert_area(3).
               certs/  Hashed directory of trust anchors for
                       TLS certificate validation.
               certs/ca-certificates.crt
                       Bundle of TLS anchors in PEM format
                       formed by concatenation of PEM-format
                       certificates.
```

OpenBSD

https://github.com/openbsd/src/commit/b029bdbe101a51146ab958fe7480630693d57d37