### PR TITLE
[subchannel] make sure internal subchannel is unreffed in WorkSerializer

### DIFF
--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -538,6 +538,18 @@ class ClientChannelFilter::SubchannelWrapper final
           }
         }
       }
+      // We need to make sure that the internal subchannel gets unreffed
+      // inside of the WorkSerializer, so that updates to the local
+      // subchannel pool are properly synchronized.  To that end, we
+      // drop our ref to the internal subchannel here.  We also cancel
+      // any watchers that were not properly cancelled, in case any of
+      // them are holding a ref to the internal subchannel.
+      for (const auto& [_, watcher] : watcher_map_) {
+        subchannel_->CancelConnectivityStateWatch(watcher);
+      }
+      watcher_map_.clear();
+      data_watchers_.clear();
+      subchannel_.reset();
       WeakUnref(DEBUG_LOCATION, "subchannel map cleanup");
     });
   }
@@ -549,7 +561,7 @@ class ClientChannelFilter::SubchannelWrapper final
     CHECK_EQ(watcher_wrapper, nullptr);
     watcher_wrapper = new WatcherWrapper(
         std::move(watcher),
-        RefAsSubclass<SubchannelWrapper>(DEBUG_LOCATION, "WatcherWrapper"));
+        WeakRefAsSubclass<SubchannelWrapper>(DEBUG_LOCATION, "WatcherWrapper"));
     subchannel_->WatchConnectivityState(
         RefCountedPtr<Subchannel::ConnectivityStateWatcherInterface>(
             watcher_wrapper));
@@ -609,7 +621,7 @@ class ClientChannelFilter::SubchannelWrapper final
     WatcherWrapper(
         std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>
             watcher,
-        RefCountedPtr<SubchannelWrapper> parent)
+        WeakRefCountedPtr<SubchannelWrapper> parent)
         : watcher_(std::move(watcher)), parent_(std::move(parent)) {}
 
     ~WatcherWrapper() override {
@@ -682,7 +694,7 @@ class ClientChannelFilter::SubchannelWrapper final
 
     std::unique_ptr<SubchannelInterface::ConnectivityStateWatcherInterface>
         watcher_;
-    RefCountedPtr<SubchannelWrapper> parent_;
+    WeakRefCountedPtr<SubchannelWrapper> parent_;
   };
 
   // A heterogenous lookup comparator for data watchers that allows

--- a/src/core/load_balancing/health_check_client.cc
+++ b/src/core/load_balancing/health_check_client.cc
@@ -295,7 +295,7 @@ class HealthProducer::ConnectivityWatcher final
 // HealthProducer
 //
 
-void HealthProducer::Start(RefCountedPtr<Subchannel> subchannel) {
+void HealthProducer::Start(WeakRefCountedPtr<Subchannel> subchannel) {
   GRPC_TRACE_LOG(health_check_client, INFO)
       << "HealthProducer " << this << ": starting with subchannel "
       << subchannel.get();
@@ -419,7 +419,7 @@ void HealthWatcher::SetSubchannel(Subchannel* subchannel) {
   // This needs to be done outside of the lambda passed to
   // GetOrAddDataProducer() to avoid deadlocking by re-acquiring the
   // subchannel lock while already holding it.
-  if (created) producer_->Start(subchannel->Ref());
+  if (created) producer_->Start(subchannel->WeakRef());
   // Register ourself with the producer.
   producer_->AddWatcher(this, health_check_service_name_);
   GRPC_TRACE_LOG(health_check_client, INFO)

--- a/src/core/load_balancing/health_check_client_internal.h
+++ b/src/core/load_balancing/health_check_client_internal.h
@@ -55,7 +55,7 @@ class HealthProducer final : public Subchannel::DataProducerInterface {
   HealthProducer() : interested_parties_(grpc_pollset_set_create()) {}
   ~HealthProducer() override { grpc_pollset_set_destroy(interested_parties_); }
 
-  void Start(RefCountedPtr<Subchannel> subchannel);
+  void Start(WeakRefCountedPtr<Subchannel> subchannel);
 
   static UniqueTypeName Type() {
     static UniqueTypeName::Factory kFactory("health_check");
@@ -137,7 +137,7 @@ class HealthProducer final : public Subchannel::DataProducerInterface {
                                  const absl::Status& status);
   void Orphaned() override;
 
-  RefCountedPtr<Subchannel> subchannel_;
+  WeakRefCountedPtr<Subchannel> subchannel_;
   ConnectivityWatcher* connectivity_watcher_;
   grpc_pollset_set* interested_parties_;
 

--- a/src/core/load_balancing/oob_backend_metric.cc
+++ b/src/core/load_balancing/oob_backend_metric.cc
@@ -201,7 +201,7 @@ class OrcaProducer::OrcaStreamEventHandler final
 // OrcaProducer
 //
 
-void OrcaProducer::Start(RefCountedPtr<Subchannel> subchannel) {
+void OrcaProducer::Start(WeakRefCountedPtr<Subchannel> subchannel) {
   subchannel_ = std::move(subchannel);
   connected_subchannel_ = subchannel_->connected_subchannel();
   auto connectivity_watcher =
@@ -313,7 +313,7 @@ void OrcaWatcher::SetSubchannel(Subchannel* subchannel) {
   // This needs to be done outside of the lambda passed to
   // GetOrAddDataProducer() to avoid deadlocking by re-acquiring the
   // subchannel lock while already holding it.
-  if (created) producer_->Start(subchannel->Ref());
+  if (created) producer_->Start(subchannel->WeakRef());
   // Register ourself with the producer.
   producer_->AddWatcher(this);
 }

--- a/src/core/load_balancing/oob_backend_metric_internal.h
+++ b/src/core/load_balancing/oob_backend_metric_internal.h
@@ -46,7 +46,7 @@ class OrcaWatcher;
 // registered watchers.
 class OrcaProducer final : public Subchannel::DataProducerInterface {
  public:
-  void Start(RefCountedPtr<Subchannel> subchannel);
+  void Start(WeakRefCountedPtr<Subchannel> subchannel);
 
   static UniqueTypeName Type() {
     static UniqueTypeName::Factory kFactory("orca");
@@ -79,7 +79,7 @@ class OrcaProducer final : public Subchannel::DataProducerInterface {
   // Called to notify watchers of a new backend metric report.
   void NotifyWatchers(const BackendMetricData& backend_metric_data);
 
-  RefCountedPtr<Subchannel> subchannel_;
+  WeakRefCountedPtr<Subchannel> subchannel_;
   RefCountedPtr<ConnectedSubchannel> connected_subchannel_;
   ConnectivityWatcher* connectivity_watcher_;
   Mutex mu_;


### PR DESCRIPTION
In b/435721210, there is a suspicion (not proven) that the internal subchannel is not being unreffed within the channel's `WorkSerializer`.  This PR cleans up a few edge cases that could conceivably result in the internal subchannel being unreffed from outside the `WorkSerializer`.