### PR TITLE
Fix ssl cmake msvc nasm detection

### DIFF
--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -22,7 +22,7 @@ if(gRPC_SSL_PROVIDER STREQUAL "module")
   endif()
 
   if(EXISTS "${BORINGSSL_ROOT_DIR}/CMakeLists.txt")
-    if(MSVC)
+    if(CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Ninja")
       if(CMAKE_VERSION VERSION_LESS 3.13)
         # Visual Studio build with assembly optimizations is broken for older
         # version of CMake (< 3.13).

--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -22,7 +22,7 @@ if(gRPC_SSL_PROVIDER STREQUAL "module")
   endif()
 
   if(EXISTS "${BORINGSSL_ROOT_DIR}/CMakeLists.txt")
-    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+    if(MSVC)
       if(CMAKE_VERSION VERSION_LESS 3.13)
         # Visual Studio build with assembly optimizations is broken for older
         # version of CMake (< 3.13).


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

Using Ninja generator with Visual Studio, the `ssl.cmake` will fail to detect visual studio and it will require a NASM causing the build to fail.