### PR TITLE
[Python] xds-protos: sync required grpcio version with gRPC gencode

### DIFF
--- a/tools/buildgen/generate_projects.sh
+++ b/tools/buildgen/generate_projects.sh
@@ -53,6 +53,15 @@ if [[ ! -d generate_projects_virtual_environment ]]; then
   python3 -m virtualenv generate_projects_virtual_environment
 fi
 
+# Keep grpcio-tools version in sync with XDS_PROTOS_GENCODE_GRPC_VERSION
+# in tools/distrib/python/xds_protos/setup.py.
+#
+# Explanation: since PR #40518, xds-protos grpc gencode contains a poison pill
+# that enforces grpcio runtime version to be equal or greater
+# to the grpcio-tools version that generated the code.
+#
+# Note: this version needs to be updated periodically to keep up with mainstream
+# python releases, as older grpcio-tools release may not support them.
 generate_projects_virtual_environment/bin/pip install --upgrade --ignore-installed grpcio-tools==1.74.0
 generate_projects_virtual_environment/bin/python tools/distrib/python/xds_protos/build.py
 generate_projects_virtual_environment/bin/python tools/distrib/python/make_grpcio_tools.py

--- a/tools/distrib/python/xds_protos/setup.py
+++ b/tools/distrib/python/xds_protos/setup.py
@@ -38,13 +38,18 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",
 ]
+
+# Keep this in sync with XDS_PROTOS_GENCODE_GRPC_VERSION
+# in tools/buildgen/generate_projects.sh.
+XDS_PROTOS_GENCODE_GRPC_VERSION = "1.74.0"
+
 INSTALL_REQUIRES = [
-    "grpcio>=1.49.0",
+    f"grpcio>={XDS_PROTOS_GENCODE_GRPC_VERSION}",
     "protobuf>=6.31.1,<7.0.0",
 ]
-
-SETUP_REQUIRES = INSTALL_REQUIRES + ["grpcio-tools>=1.49.0"]
-
+SETUP_REQUIRES = INSTALL_REQUIRES + [
+    f"grpcio-tools>={XDS_PROTOS_GENCODE_GRPC_VERSION}"
+]
 
 setuptools.setup(
     name="xds-protos",


### PR DESCRIPTION
A follow up on #40518, which regenerated xds-protos with protobuf 6.x.

Since PR #40518, xds-protos grpc gencode contains a poison pill that enforces grpcio runtime version to be equal or greater to the grpcio-tools version that generated the code.

This PR:
- Locks xds-protos grpcio dependencies to the same version as specified in generate_projects.sh
- Documents the need to keep these in sync