### PR TITLE
[PH2] Fix ResetPingClock

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame.cc
+++ b/src/core/ext/transport/chttp2/transport/frame.cc
@@ -206,9 +206,11 @@ class SerializeExtraBytesRequired {
 
 class SerializeHeaderAndPayload {
  public:
-  SerializeHeaderAndPayload(size_t extra_bytes, SliceBuffer& out)
+  SerializeHeaderAndPayload(size_t extra_bytes, SliceBuffer& out,
+                            SerializeReturn& serialize_return)
       : out_(out),
-        extra_bytes_(MutableSlice::CreateUninitialized(extra_bytes)) {}
+        extra_bytes_(MutableSlice::CreateUninitialized(extra_bytes)),
+        serialize_return_(serialize_return) {}
 
   void operator()(Http2DataFrame& frame) {
     auto hdr = extra_bytes_.TakeFirst(kFrameHeaderSize);
@@ -219,6 +221,7 @@ class SerializeHeaderAndPayload {
         .Serialize(hdr.begin());
     out_.AppendIndexed(Slice(std::move(hdr)));
     out_.TakeAndAppend(frame.payload);
+    serialize_return_.reset_ping_clock = true;
   }
 
   void operator()(Http2HeaderFrame& frame) {
@@ -232,6 +235,7 @@ class SerializeHeaderAndPayload {
         .Serialize(hdr.begin());
     out_.AppendIndexed(Slice(std::move(hdr)));
     out_.TakeAndAppend(frame.payload);
+    serialize_return_.reset_ping_clock = true;
   }
 
   void operator()(Http2ContinuationFrame& frame) {
@@ -244,6 +248,7 @@ class SerializeHeaderAndPayload {
         .Serialize(hdr.begin());
     out_.AppendIndexed(Slice(std::move(hdr)));
     out_.TakeAndAppend(frame.payload);
+    serialize_return_.reset_ping_clock = true;
   }
 
   void operator()(Http2RstStreamFrame& frame) {
@@ -311,6 +316,7 @@ class SerializeHeaderAndPayload {
     }
     Write31bits(frame.increment, hdr_and_payload.begin() + kFrameHeaderSize);
     out_.AppendIndexed(Slice(std::move(hdr_and_payload)));
+    serialize_return_.reset_ping_clock = true;
   }
 
   void operator()(Http2SecurityFrame& frame) {
@@ -329,6 +335,7 @@ class SerializeHeaderAndPayload {
  private:
   SliceBuffer& out_;
   MutableSlice extra_bytes_;
+  SerializeReturn& serialize_return_;
 };
 
 Http2Status StripPadding(const Http2FrameHeader& hdr, SliceBuffer& payload) {
@@ -642,18 +649,21 @@ std::string Http2FrameHeader::ToString() const {
                       ", length=", length, "}");
 }
 
-void Serialize(absl::Span<Http2Frame> frames, SliceBuffer& out) {
+SerializeReturn Serialize(absl::Span<Http2Frame> frames, SliceBuffer& out) {
   size_t buffer_needed = 0;
+  SerializeReturn serialize_return{/*reset_ping_clock=*/false};
   for (auto& frame : frames) {
     // Bytes needed for framing
     buffer_needed += kFrameHeaderSize;
     // Bytes needed for frame payload
     buffer_needed += std::visit(SerializeExtraBytesRequired(), frame);
   }
-  SerializeHeaderAndPayload serialize(buffer_needed, out);
+  SerializeHeaderAndPayload serialize(buffer_needed, out, serialize_return);
   for (auto& frame : frames) {
     std::visit(serialize, frame);
   }
+
+  return serialize_return;
 }
 
 http2::ValueOrHttp2Status<Http2Frame> ParseFramePayload(

--- a/src/core/ext/transport/chttp2/transport/frame.h
+++ b/src/core/ext/transport/chttp2/transport/frame.h
@@ -224,6 +224,10 @@ struct Http2FrameHeader {
 ///////////////////////////////////////////////////////////////////////////////
 // Parsing & serialization
 
+struct SerializeReturn {
+  bool reset_ping_clock;
+};
+
 // Given a frame header and a payload, parse the payload into a frame and
 // return it.
 // If this function returns an error, that should be considered a connection
@@ -236,7 +240,7 @@ http2::ValueOrHttp2Status<Http2Frame> ParseFramePayload(
 
 // Serialize frame and append to out, leaves frames in an unknown state (may
 // move things out of frames)
-void Serialize(absl::Span<Http2Frame> frames, SliceBuffer& out);
+SerializeReturn Serialize(absl::Span<Http2Frame> frames, SliceBuffer& out);
 
 http2::Http2ErrorCode Http2ErrorCodeFromRstFrameErrorCode(uint32_t error_code);
 

--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.h
@@ -544,7 +544,7 @@ class Http2ClientTransport final : public ClientTransport {
     GPR_UNREACHABLE_CODE(return absl::InternalError("Invalid error type"));
   }
 
-  bool bytes_sent_in_last_write_;
+  bool reset_ping_clock_;
   bool incoming_header_in_progress_;
   bool incoming_header_end_stream_;
   bool is_first_write_;


### PR DESCRIPTION
ResetPingClock is supposed to be called only when the transport write Data/Header/WindowUpdate frames to the endpoint.