### PR TITLE
[PH2] Fix a keepalive bug

### DIFF
--- a/src/core/ext/transport/chttp2/transport/http2_client_transport.h
+++ b/src/core/ext/transport/chttp2/transport/http2_client_transport.h
@@ -642,7 +642,7 @@ class Http2ClientTransport final : public ClientTransport {
       // and update the error code.
       return Immediate(
           transport_->HandleError(Http2Status::Http2ConnectionError(
-              Http2ErrorCode::kRefusedStream, "Ping timeout")));
+              Http2ErrorCode::kRefusedStream, "ping timeout")));
     }
 
    private:

--- a/src/core/ext/transport/chttp2/transport/keepalive.h
+++ b/src/core/ext/transport/chttp2/transport/keepalive.h
@@ -69,6 +69,7 @@ class KeepaliveManager {
   }
 
   void CloseKeepAliveLoop() {
+    DCHECK(!keepalive_loop_closed_);
     keepalive_loop_closed_ = true;
     Waker close_waker = std::move(close_keepalive_waker_);
     close_waker.Wakeup();


### PR DESCRIPTION
Added a mechanism to preempt the keepalive loop. This is needed as Sleep holds a ref on the party and will be used only when transport is shutting down.