### PR TITLE
[PSM Interop] Revert #40549 to fix cleanup of zonal clusters

### DIFF
--- a/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
+++ b/tools/internal_ci/linux/grpc_xds_resource_cleanup.sh
@@ -23,11 +23,8 @@ readonly KEEP_HOURS="${KEEP_HOURS:-48}"
 
 cleanup::activate_cluster() {
   activate_gke_cluster "$1"
-  if [[ -n "${GKE_CLUSTER_REGION}" ]]; then
-    gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --region "${GKE_CLUSTER_REGION}"
-  else
-    gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
-  fi
+  gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" \
+    --zone "${GKE_CLUSTER_ZONE}"
   CLEANUP_KUBE_CONTEXT="$(kubectl config current-context)"
 }
 


### PR DESCRIPTION
The #40549 breaks cleanup of zonal clusters. It checks for `GKE_CLUSTER_REGION` to be set. If a regional clusters is used, the variable remains set forever. As a result all the remaining clusters are treated as regional.


This reverts commit 0d1818ce3d4118555d9a64e6f65c57591b06c218.

