### PR TITLE
[Fix][Python][CI] Exclude aarch64 from GCP distribtests

### DIFF
--- a/tools/internal_ci/linux/grpc_distribtests_gcp_python.cfg
+++ b/tools/internal_ci/linux/grpc_distribtests_gcp_python.cfg
@@ -25,8 +25,9 @@ action {
   }
 }
 
-# TODO: Move arm64 GCP distribtests to a new job running on ARM hardware:
-#       grpc/core/master/linux/arm64/grpc_distribtests_gcp_python_arm64
+# TODO(b/441764156): Move aarch64 GCP Python distribtests to a new job
+#      running on ARM hardware:
+#      grpc/core/master/linux/arm64/grpc_distribtests_gcp_python_arm64
 env_vars {
   key: "TASK_RUNNER_EXTRA_FILTERS"
   value: "-e aarch64"


### PR DESCRIPTION
In #40354, we moved all PR/release aarch64 distribtests to the native ARM hardware (`grpc-arm64-small` Kokoro pool).

However, we missed the fact there's a separate Python distribtest job that specific to GCP: [`grpc/core/master/linux/grpc_distribtests_gcp_python`](https://github.com/grpc/grpc/blob/957c045d9aaeaba607cd7883fbb0e2474e3e07f6/tools/internal_ci/linux/grpc_distribtests_gcp_python.cfg).

As the result, arm64 manulinux jobs build_artifact tasks started timing out ([fail example](https://source.cloud.google.com/results/invocations/2d1bd13c-0e24-4f78-9366-c95ec5c761d4)):
```
TIMEOUT: build_artifact.python_manylinux2014_aarch64_cp310-cp310 [pid=7029, time=7207.9sec]
TIMEOUT: build_artifact.python_manylinux2014_aarch64_cp313-cp313 [pid=134112, time=7205.3sec]
TIMEOUT: build_artifact.python_manylinux2014_aarch64_cp311-cp311 [pid=134104, time=7205.4sec]
TIMEOUT: build_artifact.python_manylinux2014_aarch64_cp312-cp312 [pid=134105, time=7205.5sec]
```

In #40568, we excluded aarch64 tests from `grpc/core/master/linux/grpc_distribtests_gcp_python`.

Similar to [`grpc/core/master/linux/arm64/grpc_distribtests_python_arm64`](https://github.com/grpc/grpc/blob/957c045d9aaeaba607cd7883fbb0e2474e3e07f6/tools/internal_ci/linux/arm64/grpc_distribtests_python_arm64.cfg) (master distribtest ARM64) job, we should create a new Kokoro job, `grpc/core/master/linux/arm64/grpc_distribtests_gcp_python_arm64`, and move aarch64 GCP Python distribtests to it. Tracking: b/441764156.