### PR TITLE
[Backport][v1.75.x][Python] Updating rules_python to 1.5.4

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,7 @@ bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 # Python dependencies
 # ===================
 
-bazel_dep(name = "rules_python", version = "0.37.1")
+bazel_dep(name = "rules_python", version = "1.5.4")
 
 PYTHON_VERSIONS = [
     "3.9",

--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -22,9 +22,9 @@ def grpc_python_deps():
     if "rules_python" not in native.existing_rules():
         http_archive(
             name = "rules_python",
-            sha256 = "4f7e2aa1eb9aa722d96498f5ef514f426c1f55161c3c9ae628c857a7128ceb07",
-            strip_prefix = "rules_python-1.0.0",
-            url = "https://github.com/bazelbuild/rules_python/releases/download/1.0.0/rules_python-1.0.0.tar.gz",
+            sha256 = "13671d304cfe43350302213a60d93a5fc0b763b0a6de17397e3e239253b61b73",
+            strip_prefix = "rules_python-1.5.4",
+            url = "https://github.com/bazel-contrib/rules_python/releases/download/1.5.4/rules_python-1.5.4.tar.gz",
         )
 
     python_configure(name = "local_config_python")

--- a/templates/MODULE.bazel.inja
+++ b/templates/MODULE.bazel.inja
@@ -60,7 +60,7 @@ bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 # Python dependencies
 # ===================
 
-bazel_dep(name = "rules_python", version = "0.37.1")
+bazel_dep(name = "rules_python", version = "1.5.4")
 
 PYTHON_VERSIONS = [
     "3.9",


### PR DESCRIPTION
Backport of #40602 to v1.75.x.
---
Changelog: everything above https://rules-python.readthedocs.io/en/stable/changelog.html#v1-0-0 till https://rules-python.readthedocs.io/en/stable/changelog.html#id2 (1.5.3).