### PR TITLE
[Fix] Extend grpc_bazel_rbe_nonbazel PR timeout by 30 minutes

### DIFF
--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_nonbazel.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_nonbazel.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_rbe.sh"
-timeout_mins: 120
+timeout_mins: 150
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
`grpc/core/pull_request/linux/bazel_rbe/grpc_bazel_rbe_nonbazel` job keeps timing out. Looks like its runtime, even for passes, slowly creeped in to the 2h limit: https://btx.cloud.google.com/invocations;p=830293263384?q=exact_target:grpc%2Fcore%2Fpull_request%2Flinux%2Fbazel_rbe%2Fgrpc_bazel_rbe_nonbazel%20status:passed

<img width="1001" height="535" alt="image" src="https://github.com/user-attachments/assets/abd60a2e-fa49-415f-8575-27b19972f5e8" />

This PR increases the timeout from 2h to 2.5h Note that this PR job has corresponding master job (`grpc/core/master/linux/bazel_rbe/grpc_bazel_rbe_nonbazel`), and its timeout is already set to 3h:
https://github.com/grpc/grpc/blob/fd1d6e0911adbd230cad412a3846d8d86f0c56a4/tools/internal_ci/linux/grpc_bazel_rbe_nonbazel.cfg#L19

To better visualize if specific commits cause increased job runtime, I will add the master job to the testgrid for plotting.
