### PR TITLE
[Fix][Bazel] bump gevent to 25.8.2 to support modern python

### DIFF
--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -26,13 +26,13 @@ deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-gevent==24.2.1
+gevent==25.8.2
     # via -r requirements.bazel.txt
 google-auth==2.38.0
     # via -r requirements.bazel.txt
 googleapis-common-protos==1.66.0
     # via -r requirements.bazel.txt
-greenlet==3.1.1
+greenlet==3.2.4
     # via gevent
 hyperlink==21.0.0
     # via twisted

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -36,7 +36,8 @@
 absl-py
 certifi
 chardet
-gevent
+# Note: this is a temporary for local builds until CI is running py3.9+
+gevent~=25.8
 google-auth
 googleapis-common-protos
 idna


### PR DESCRIPTION
> [!CAUTION]
> DO NOT MERGE

This is to provide a temporary patch for local builds until CIs are upgraded.
I believe this will break CIs a the moment.