### PR TITLE
[build] Fix objective-C v1.75 build issue

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1338,7 +1338,8 @@ absl::Status ConfigureSpiffeRoots(
     return absl::InvalidArgumentError(
         "spiffe: root stack in the SPIFFE Bundle Map is nullptr.");
   }
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+// the boringSSL library objective-C used did not have this function defined
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_APPLE)
   X509_STORE_CTX_set0_trusted_stack(ctx, *root_stack);
 #else
   X509_STORE_CTX_trusted_stack(ctx, *root_stack);


### PR DESCRIPTION
Trying to fix #40665 

The boringSSL library Objective-C used ([firebase/boringSSL-SwiftPM](https://github.com/firebase/boringSSL-SwiftPM)) somehow did not have this function `X509_STORE_CTX_set0_trusted_stack` defined. So here we are trying to add another include guard just for objective-C. Need to backport this to `v1.75.x` branch.