### PR TITLE
[Python] Some examples to test multiple import scenarios with absl::InitializeLog()

### DIFF
--- a/examples/python/repro_multi_import/fork_import_in_parent_single_child.py
+++ b/examples/python/repro_multi_import/fork_import_in_parent_single_child.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import time
+import grpc  # <--- Import *before* fork
+
+print(f"--- Parent (PID: {os.getpid()}) ---")
+print("Parent: Imported 'grpc'.")
+print("Parent: Your 'once-only' function ran here (Call #1).")
+print("Parent: Now forking...")
+
+# Flush stdout to prevent this buffer from being
+# copied and printed again by the child
+sys.stdout.flush()
+
+try:
+    # os.fork() returns 0 in the child, and the child's PID in the parent
+    pid = os.fork()
+except OSError as e:
+    print(f"os.fork() failed: {e}")
+    sys.exit(1)
+
+if pid == 0:
+    # --- This is the Child Process ---
+    child_pid = os.getpid()
+    print(f"\n--- Child (PID: {child_pid}) ---")
+    print("Child: Process started.")
+    print("Child: gRPC's 'postfork_child' handler just ran,")
+    print("Child: ...which re-ran the C-core init.")
+    print("Child: Your 'once-only' function just ran here (Call #2).")
+
+    # We can prove gRPC is working (not hung) by using it
+    try:
+        print("Child: Testing gRPC functionality (creating channel)...")
+        channel = grpc.insecure_channel('localhost:12345')
+        print("Child: gRPC channel created successfully.")
+        channel.close()
+        print("Child: Exiting normally.")
+
+        # Exit the child process with success
+        os._exit(0)
+
+    except Exception as e:
+        print(f"Child: gRPC operation failed! {e}")
+        # Exit with a failure code
+        os._exit(1)
+
+else:
+    # --- This is the Parent Process ---
+    print(f"Parent: Forked child with PID {pid}.")
+    print("Parent: Waiting for child to complete...")
+
+    # Wait for the child to exit and get its status
+    try:
+        # We can prove gRPC is working (not hung) by using it
+        try:
+            print("Parent: Testing gRPC functionality (creating channel)...")
+            channel = grpc.insecure_channel('localhost:50051')
+            print("Parent: gRPC channel created successfully.")
+            channel.close()
+            print("Parent: Exiting normally.")
+
+            # Exit the Parent process with success
+            os._exit(0)
+
+        except Exception as e:
+            print(f"Parent: gRPC operation failed! {e}")
+            # Exit with a failure code
+            os._exit(1)
+
+        exited_pid, exit_status = os.waitpid(pid, 0)
+
+        print(f"\nParent: Child {exited_pid} has exited.")
+
+        if os.WIFEXITED(exit_status):
+            exit_code = os.WEXITSTATUS(exit_status)
+            print(f"Parent: Child exit code was: {exit_code}")
+            if exit_code == 0:
+                print("Parent: ✅ Test shows the function was called twice with no error.")
+            else:
+                print("Parent: ❌ Test shows the child failed (this is unexpected).")
+
+        elif os.WIFSIGNALED(exit_status):
+            # This would happen if you *did* have your counter
+            # and it raised an unhandled exception.
+            print(f"Parent: ❌ Child was terminated by signal: {os.WTERMSIG(exit_status)}")
+            print("Parent: (This would happen if your guarded function raised an error!)")
+
+    except OSError as e:
+        print(f"Parent: os.waitpid() failed: {e}")
+
+    print("Parent: Test complete.")

--- a/examples/python/repro_multi_import/fork_import_multi_child.py
+++ b/examples/python/repro_multi_import/fork_import_multi_child.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import time
+
+# --- NO 'import grpc' in the parent ---
+
+print(f"--- Parent (PID: {os.getpid()}) ---")
+print(f"Parent: 'grpc' is in sys.modules? {'grpc' in sys.modules}")
+
+num_children = 3
+child_pids = []
+
+print(f"Parent: Forking {num_children} children...")
+sys.stdout.flush() # Flush print buffer before forking
+
+for i in range(num_children):
+    try:
+        pid = os.fork()
+    except OSError as e:
+        print(f"Parent: os.fork() failed: {e}")
+        continue
+
+    if pid == 0:
+        # --- This is the Child Process ---
+        child_pid = os.getpid()
+        print(f"\n  --- Child {i+1} (PID: {child_pid}) ---")
+        print(f"  Child {i+1}: Started. 'grpc' is not in sys.modules.")
+
+        # Each child imports grpc for itself
+        import grpc
+
+        print(f"  Child {i+1}: 'grpc' imported.")
+        print(f"  Child {i+1}: Your 'once-only' function ran here (Call #1 *in this child*).")
+        print(f"  Child {i+1}: Exiting.")
+
+        # Use os._exit() in children after a fork to prevent
+        # running the parent's cleanup code
+        os._exit(0)
+
+    else:
+        # --- This is the Parent Process ---
+        # Parent just records the child's PID
+        child_pids.append(pid)
+
+# --- Parent waits for all children to finish ---
+print(f"\nParent: Waiting for all {len(child_pids)} children to exit...")
+
+for pid in child_pids:
+    try:
+        # Wait for the specific child PID to exit
+        exited_pid, exit_status = os.waitpid(pid, 0)
+
+        if os.WIFEXITED(exit_status):
+            print(f"Parent: Child {exited_pid} exited cleanly.")
+        else:
+            print(f"Parent: Child {exited_pid} exited abnormally.")
+    except OSError as e:
+        print(f"Parent: Error waiting for {pid}: {e}")
+
+print("Parent: Test complete.")

--- a/examples/python/repro_multi_import/manual_reload.py
+++ b/examples/python/repro_multi_import/manual_reload.py
@@ -1,0 +1,71 @@
+import importlib
+import sys
+
+# --- 1. Initial Import ---
+print("--- Initial Import ---")
+
+# Import grpc and print its initial state
+import grpc
+
+# Get the memory ID of the module object itself
+module_id_before = id(grpc)
+print(f"Module ID (before reload): {module_id_before}")
+
+# Get the memory ID of a class *inside* the module
+channel_class_before = grpc.Channel
+class_id_before = id(channel_class_before)
+print(f"grpc.Channel Class ID (before reload): {class_id_before}")
+
+# This simulates another file doing 'from grpc import Channel'
+# It's an "old reference" that won't be updated.
+old_channel_reference = grpc.Channel
+
+print("\n--- Manual Reload ---")
+print("Executing 'importlib.reload(grpc)'...")
+
+
+# # --- 2. The Reload ---
+# # This re-runs all of gRPC's top-level code.
+reloaded_grpc = importlib.reload(grpc)
+
+print("'reload' complete.")
+
+# --- 3. Analysis ---
+print("\n--- After Reload Analysis ---")
+
+# Check the module ID: It will be THE SAME.
+module_id_after = id(reloaded_grpc)
+print(f"Module ID (after reload):  {module_id_after}")
+print(f"-> Module IDs are the same? {module_id_before == module_id_after}")
+
+# Check the class ID: It will be DIFFERENT.
+# reload created a new Channel class and replaced the old one.
+channel_class_after = reloaded_grpc.Channel
+class_id_after = id(channel_class_after)
+print(f"\ngrpc.Channel Class ID (after reload):  {class_id_after}")
+print(f"-> Class IDs are the same? {class_id_before == class_id_after}")
+
+
+# --- 4. The "Danger" Demonstrated ---
+print("\n--- The 'Danger' of Reloading ---")
+print(f"ID of our 'old_channel_reference': {id(old_channel_reference)}")
+print(f"ID of the 'reloaded_grpc.Channel': {id(reloaded_grpc.Channel)}")
+
+# This will be False. They are two different class objects.
+are_same = old_channel_reference is reloaded_grpc.Channel
+print(f"\nIs the old reference the same as the new class? {are_same}")
+
+# Create a new channel using the *reloaded* module
+# This channel's type is the *new* grpc.Channel
+new_channel_obj = reloaded_grpc.insecure_channel('localhost:12345')
+
+print(f"\nCreated a new channel object: {type(new_channel_obj)}")
+
+# This is where bugs hide. An `isinstance` check against
+# the *old* class reference will fail!
+print(f"isinstance(new_channel_obj, old_channel_reference)? {isinstance(new_channel_obj, old_channel_reference)}")
+
+# The check against the *new* class reference will pass.
+print(f"isinstance(new_channel_obj, reloaded_grpc.Channel)? {isinstance(new_channel_obj, reloaded_grpc.Channel)}")
+
+new_channel_obj.close()

--- a/examples/python/repro_multi_import/manual_reload_cygrpc.py
+++ b/examples/python/repro_multi_import/manual_reload_cygrpc.py
@@ -1,0 +1,19 @@
+import importlib
+import grpc
+
+# This import is just to make sure the name
+# 'grpc._cython.cygrpc' is easily accessible.
+# The 'import grpc' above already loaded it.
+import grpc._cython.cygrpc
+
+print("Initial import is done. Your function has been called once.")
+
+# Now, we *specifically* reload the Cython module...
+print("Attempting to reload grpc._cython.cygrpc...")
+
+try:
+    # This will re-run the init code in your .pyx file
+    # and call your "once-only" function a second time.
+    importlib.reload(grpc._cython.cygrpc)
+except Exception as e:
+    print(f"\nSuccessfully caught expected error on reload: {e}") # 💥

--- a/examples/python/repro_multi_import/mp_import_in_parent_single_child.py
+++ b/examples/python/repro_multi_import/mp_import_in_parent_single_child.py
@@ -1,0 +1,58 @@
+import multiprocessing
+import os
+import sys
+import time
+
+def child_worker():
+    """This function is executed by the child process."""
+    child_pid = os.getpid()
+    print(f"\n  --- Child (PID: {child_pid}) ---")
+    print(f"  Child: Process started.")
+
+    # On 'fork' systems, the gRPC 'at_fork' handler has
+    # *already run* right after the fork, and your function
+    # was called a second time.
+
+    # On 'spawn' systems, this import will be the first
+    # time gRPC is loaded in this process.
+
+    print(f"  Child: 'grpc' in sys.modules *before* import? {'grpc' in sys.modules}")
+
+    import grpc
+
+    print(f"  Child: 'grpc' import finished.")
+    print(f"  Child: Your 'once-only' function was called either:")
+    print(f"  Child:   a) just now (on 'spawn')")
+    print(f"  Child:   b) during the 'at_fork' handler (on 'fork')")
+    print(f"  Child: Exiting.")
+
+# The 'if __name__ == "__main__":' guard is essential
+if __name__ == "__main__":
+
+    # --- Parent imports gRPC *before* starting the child ---
+    print(f"--- Parent (PID: {os.getpid()}) ---")
+    print("Parent: Importing 'grpc'...")
+
+    import grpc # <--- Parent import
+
+    print("Parent: 'grpc' imported.")
+    print("Parent: Your 'once-only' function ran here (Call #1).")
+
+    # We explicitly set the start method to 'fork' to test this
+    # scenario, as it's the more complex one.
+    try:
+        multiprocessing.set_start_method('fork')
+        print("Parent: Start method set to 'fork'.")
+    except (ValueError, AttributeError, RuntimeError):
+        print("Parent: Could not set start method to 'fork'.")
+        print("Parent: Continuing with default (likely 'spawn').")
+
+    print("\nParent: Starting child process...")
+    p = multiprocessing.Process(target=child_worker)
+    p.start()
+
+    # Wait for the child to finish
+    p.join()
+
+    print("\nParent: Child process has joined.")
+    print("Parent: Test complete.")

--- a/examples/python/repro_multi_import/mp_import_multi_child.py
+++ b/examples/python/repro_multi_import/mp_import_multi_child.py
@@ -1,0 +1,54 @@
+import multiprocessing
+import os
+import sys
+import time
+
+# --- NO 'import grpc' in the global scope ---
+
+def child_worker(child_num):
+    """
+    This function is the target for each child process.
+    """
+    child_pid = os.getpid()
+    print(f"\n  --- Child {child_num} (PID: {child_pid}) ---")
+    print(f"  Child {child_num}: Started. 'grpc' is not in sys.modules.")
+
+    # Each child imports grpc for itself
+    import grpc
+
+    print(f"  Child {child_num}: 'grpc' imported.")
+    print(f"  Child {child_num}: Your 'once-only' function ran here (Call #1 *in this child*).")
+
+    # Do some minimal work to simulate a real task
+    time.sleep(0.5)
+    print(f"  Child {child_num}: Exiting.")
+
+# This guard is required for 'spawn' and 'forkserver' start methods
+# (default on Windows and macOS)
+if __name__ == "__main__":
+
+    print(f"--- Parent (PID: {os.getpid()}) ---")
+    print(f"Parent: 'grpc' is in sys.modules? {'grpc' in sys.modules}")
+
+    num_children = 3
+    processes = []
+
+    print(f"Parent: Starting {num_children} child processes...")
+
+    for i in range(num_children):
+        # 1. Create the process object
+        p = multiprocessing.Process(target=child_worker, args=(i + 1,))
+        processes.append(p)
+
+        # 2. Start the process
+        p.start()
+        print(f"Parent: Started child {i+1} (PID: {p.pid}).")
+
+    print(f"\nParent: Waiting for all {len(processes)} children to finish...")
+
+    for p in processes:
+        # 3. Join the process (wait for it to terminate)
+        p.join()
+
+    print("\nParent: All children have joined.")
+    print("Parent: Test complete.")

--- a/examples/python/repro_multi_import/thread_multi_import.py
+++ b/examples/python/repro_multi_import/thread_multi_import.py
@@ -1,0 +1,73 @@
+import threading
+import time
+import sys
+import grpc  # <-- Main thread import
+
+# We use a lock for print statements to prevent
+# garbled output from the two threads printing at once.
+print_lock = threading.Lock()
+
+def locked_print(message):
+    """A thread-safe print function."""
+    with print_lock:
+        print(message)
+
+def worker_thread_importer():
+    """
+    This function will run in a separate thread and
+    try to import grpc *again*.
+    """
+    thread_name = threading.current_thread().name
+    locked_print(f"[{thread_name}] Thread started.")
+
+    # Give the main thread a moment to print its info
+    time.sleep(0.5)
+
+    locked_print(f"[{thread_name}] Checking 'sys.modules' *before* import...")
+
+    # This check will be True, because the main thread
+    # already imported it.
+    if 'grpc' in sys.modules:
+        locked_print(f"[{thread_name}] 'grpc' is *already* in sys.modules.")
+    else:
+        # This line should never be reached
+        locked_print(f"[{thread_name}] 'grpc' is NOT in sys.modules.")
+
+    locked_print(f"[{thread_name}] Executing 'import grpc'...")
+
+    # --- The "Second" Import ---
+    # This is just a fast lookup in the sys.modules cache.
+    # The grpc module's code is NOT executed again.
+    import grpc
+
+    locked_print(f"[{thread_name}] 'import grpc' is complete.")
+
+    # --- The Proof ---
+    # We print the memory address (id) of the module.
+    # It will be the same as the one in the main thread.
+    locked_print(f"[{thread_name}] Module ID: {id(grpc)}")
+    locked_print(f"[{thread_name}] Thread finished.")
+
+
+# --- Main Program Execution ---
+if __name__ == "__main__":
+    main_name = threading.current_thread().name
+    locked_print(f"[{main_name}] Program started.")
+
+    # We imported 'grpc' at the top level (line 4)
+    locked_print(f"[{main_name}] 'grpc' was imported at the top level.")
+    locked_print(f"[{main_name}] Module ID: {id(grpc)}")
+
+    locked_print(f"[{main_name}] Starting worker thread...")
+
+    # Create and start the new thread
+    worker = threading.Thread(
+        target=worker_thread_importer,
+        name="WorkerThread"
+    )
+    worker.start()
+
+    # Wait for the worker thread to complete
+    worker.join()
+
+    locked_print(f"[{main_name}] Program finished.")

--- a/examples/python/repro_multi_import/type_check_server.py
+++ b/examples/python/repro_multi_import/type_check_server.py
@@ -1,0 +1,70 @@
+import typing
+import sys
+
+# --- 1. Conditional Import for Type Checking ---
+
+# This 'if' block is *False* at runtime, so the code inside
+# is never executed by the Python interpreter.
+# However, static type checkers (like mypy) are programmed
+# to read and execute the code inside this block.
+if typing.TYPE_CHECKING:
+    print(">>> (This line will only print when mypy runs, not python)")
+    # Import heavy modules here for type hints
+    import grpc
+    from grpc._channel import Channel  # A specific type from grpc
+
+
+# --- 2. Function with Forward Reference Type Hint ---
+
+# We use a string "Channel" as the type hint. This is called a
+# "forward reference". It tells the type checker: "The type for
+# this argument is named 'Channel', but it might not be defined *yet*."
+#
+# This is necessary because at runtime, the `if typing.TYPE_CHECKING:`
+# block was skipped, so the name 'Channel' doesn't exist.
+def check_channel(channel: "Channel") -> bool:
+    """
+    Checks if the provided object is a gRPC Channel.
+    Demonstrates lazy-importing for runtime logic.
+    """
+    print("\n--- Inside check_channel ---")
+
+    # --- 3. Runtime Import ---
+
+    # Because the 'if' block was skipped, we must import 'grpc'
+    # here to use it in our actual program logic.
+    # This is often called a "lazy import" or "local import".
+    print("Importing 'grpc' for runtime logic...")
+    import grpc
+
+    # Now we can safely use the 'grpc' module at runtime
+    is_valid = isinstance(channel, grpc.Channel)
+    print(f"Object is a real grpc.Channel: {is_valid}")
+    return is_valid
+
+# --- 4. Demonstration ---
+
+if __name__ == "__main__":
+    print("--- Running script with Python ---")
+
+    # Check if 'grpc' is in sys.modules *before* the function call
+    # It shouldn't be (unless imported by another module)
+    print(f"Is 'grpc' in sys.modules *before* call? {'grpc' in sys.modules}")
+
+    # We must import grpc here *anyway* just to create a
+    # channel object to pass to our function for the demo.
+    import grpc
+
+    print(f"Is 'grpc' in sys.modules *after* main import? {'grpc' in sys.modules}")
+
+    # Create a real channel object
+    real_channel = grpc.insecure_channel('localhost:12345')
+
+    # Call the function
+    check_channel(real_channel)
+
+    # Call with a fake object
+    print("\nCalling with a fake object...")
+    check_channel("not a channel")
+
+    print("\n--- Script finished ---")


### PR DESCRIPTION
Given that `absl::InitializeLog()` must be called exactly once ([Reference issue](https://github.com/abseil/abseil-cpp/issues/1656)), we wanted to consider if the current implementation of calling `absl::InitializeLog()` in `cygrpc.pyx` (#39779) can cause any issues with multiple calls to `import grpc`. This PR includes all the examples that were used to test the following scenarios:

1. multiple imports for type checking (type_check_demo.py)
2. multiple imports in a multi-threaded scenario (thread_multi_import.py)
3. consequent imports to `grpc` and `grpc.experimental` (which implicitly imports cygrpc again) 
4. manual reload of the imported modules (manual_reload.py and manual_reload_cython.py)
5. multiprocessing environments with imports to grpc in the parent and child process. (using os.fork and using multiprocessing.Process)
6. multiprocessing environments with imports to grpc only in multiple child processes. (using os.fork and using multiprocessing.Process)

All the above scenarios work well without calling `InitializeLog()` function twice. Following is the explanation of why each scenario works.

**Scenarios 1-3** work because of Python's import system behaviour. Python's import
system populates a **global** and **thread-safe** dict `sys.modules` with the imported module details the first time an `import` statement is called, and any subsequent imports uses the `sys.modules` cache and doesn't re-import the module or execute `InitializeLog()` again.

**Scenario 4 (manual reload case)** doesn't have a problem because this `InitializeLog()` call is in the Cython layer which at runtime is already compiled to a C binary and hence any manual reload of the Python modules doesn't affect or re-run this C binary.

**Multiprocessing scenario 5** works as gRPC Python's fork handlers are designed in a way that will only fixes the C core state at fork but doesn't re-run `PyInit_cygrpc` causing it to run `InitializeLog()` exactly once in the parent process.

In **multiprocessing scenario 6**, it was found that `InitializeLog()` was called once in each child process. But, though they're called multiple times, each process holds a separate state of its own and hence still works without any problems.