### PR TITLE
[Fix][Python] Add validation for incomplete SSL key-cert pairs

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -191,6 +191,13 @@ cdef class SSLChannelCredentials(ChannelCredentials):
   def __cinit__(self, pem_root_certificates, private_key, certificate_chain, private_key_signer=None):
     if pem_root_certificates is not None and not isinstance(pem_root_certificates, bytes):
       raise TypeError('expected certificate to be bytes, got %s' % (type(pem_root_certificates)))
+    # Validate arguments to avoid runtime crashes due to asserts.
+    if private_key is not None and certificate_chain is None:
+      raise ValueError('certificate_chain must be provided when private_key is specified')
+    if private_key_signer is not None and certificate_chain is None:
+      raise ValueError('certificate_chain must be provided when private_key_signer is specified')
+    if certificate_chain is not None and private_key is None and private_key_signer is None:
+      raise ValueError('private_key or private_key_signer must be provided when certificate_chain is specified')
     self._pem_root_certificates = pem_root_certificates
     self._private_key = private_key
     self._certificate_chain = certificate_chain

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -17,6 +17,11 @@ import logging
 import unittest
 
 import grpc
+import grpc.experimental
+
+
+def _private_key_signer(data, algorithm, on_complete):
+    return b"signature"
 
 
 class CredentialsTest(unittest.TestCase):
@@ -26,9 +31,7 @@ class CredentialsTest(unittest.TestCase):
         third = grpc.access_token_call_credentials("ghi")
 
         first_and_second = grpc.composite_call_credentials(first, second)
-        first_second_and_third = grpc.composite_call_credentials(
-            first, second, third
-        )
+        first_second_and_third = grpc.composite_call_credentials(first, second, third)
 
         self.assertIsInstance(first_and_second, grpc.CallCredentials)
         self.assertIsInstance(first_second_and_third, grpc.CallCredentials)
@@ -54,9 +57,7 @@ class CredentialsTest(unittest.TestCase):
 
         self.assertIsInstance(channel_and_first, grpc.ChannelCredentials)
         self.assertIsInstance(channel_first_and_second, grpc.ChannelCredentials)
-        self.assertIsInstance(
-            channel_first_second_and_third, grpc.ChannelCredentials
-        )
+        self.assertIsInstance(channel_first_second_and_third, grpc.ChannelCredentials)
 
     def test_invalid_string_certificate(self):
         self.assertRaises(
@@ -66,6 +67,87 @@ class CredentialsTest(unittest.TestCase):
             private_key=None,
             certificate_chain=None,
         )
+
+    def test_with_cert_but_no_key(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "private_key or private_key_signer must be provided",
+        ):
+            grpc.ssl_channel_credentials(certificate_chain=b"cert")
+
+    def test_with_key_but_no_cert(self):
+        with self.assertRaisesRegex(ValueError, "certificate_chain must be provided"):
+            grpc.ssl_channel_credentials(private_key=b"key")
+
+    def test_with_key_and_empty_cert(self):
+        creds = grpc.ssl_channel_credentials(certificate_chain=b"", private_key=b"key")
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_with_cert_and_empty_key(self):
+        creds = grpc.ssl_channel_credentials(certificate_chain=b"cert", private_key=b"")
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_with_signer_but_no_cert(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "certificate_chain must be provided when private_key_signer is specified",
+        ):
+            grpc.experimental.ssl_channel_credentials_with_custom_signer(
+                private_key_sign_fn=_private_key_signer,
+                certificate_chain=None,
+            )
+
+    def test_with_signer_and_empty_cert(self):
+        creds = grpc.experimental.ssl_channel_credentials_with_custom_signer(
+            private_key_sign_fn=_private_key_signer,
+            certificate_chain=b"",
+        )
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_default_none_credentials(self):
+        creds = grpc.ssl_channel_credentials()
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_empty_key_and_cert(self):
+        creds = grpc.ssl_channel_credentials(certificate_chain=b"", private_key=b"")
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_empty_cert_and_none_key(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "private_key or private_key_signer must be provided",
+        ):
+            grpc.ssl_channel_credentials(certificate_chain=b"", private_key=None)
+
+    def test_none_cert_and_empty_key(self):
+        with self.assertRaisesRegex(ValueError, "certificate_chain must be provided"):
+            grpc.ssl_channel_credentials(certificate_chain=None, private_key=b"")
+
+    def test_provided_key_and_cert(self):
+        creds = grpc.ssl_channel_credentials(
+            private_key=b"fake_private_key",
+            certificate_chain=b"fake_certificate_chain",
+        )
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_provided_signer_and_cert(self):
+        creds = grpc.experimental.ssl_channel_credentials_with_custom_signer(
+            private_key_sign_fn=_private_key_signer,
+            certificate_chain=b"fake_certificate_chain",
+        )
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_only_root_certificates(self):
+        creds = grpc.ssl_channel_credentials(root_certificates=b"fake_root_certs")
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
+
+    def test_all_parameters_provided(self):
+        creds = grpc.ssl_channel_credentials(
+            root_certificates=b"fake_root_certs",
+            private_key=b"fake_private_key",
+            certificate_chain=b"fake_certificate_chain",
+        )
+        self.assertIsInstance(creds, grpc.ChannelCredentials)
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -42,6 +42,10 @@ def _metadata_plugin(context, callback):
     )
 
 
+def _private_key_signer(data, algorithm, on_complete):
+    return b"signature"
+
+
 class TypeSmokeTest(unittest.TestCase):
     def testCompletionQueueUpDown(self):
         completion_queue = cygrpc.CompletionQueue()
@@ -69,6 +73,13 @@ class TypeSmokeTest(unittest.TestCase):
         cygrpc.MetadataPluginCallCredentials(
             _metadata_plugin, b"test plugin name!"
         )
+
+    def test_ssl_channel_credentials_reject_signer_without_cert(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "certificate_chain must be provided when private_key_signer is specified",
+        ):
+            cygrpc.SSLChannelCredentials(None, None, None, _private_key_signer)
 
     def testServerStartNoExplicitShutdown(self):
         server = cygrpc.Server(


### PR DESCRIPTION
When creating a secure channel using `ssl_channel_credentials()` with an incomplete pair (missing `private_key` or `certificate_chain`), the code will reach a `assert()` in the C code and crash the interpreter.

```python
>>> import grpc
>>> cred = grpc.ssl_channel_credentials(certificate_chain="")
>>> grpc.secure_channel("localhost:2939", cred)
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1758093790.598166  410706 ssl_credentials.cc:146] Check failed: pem_key_cert_pair->private_key != nullptr ((null) vs. (null))
*** Check failure stack trace: ***
Aborted (core dumped)
```

```python
>>> import grpc
>>> cred = grpc.ssl_channel_credentials(private_key=b"asdfsdfsfsfafasfga")
>>> grpc.secure_channel("localhost:2939", cred)
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1758094169.125008  411890 ssl_credentials.cc:147] Check failed: pem_key_cert_pair->cert_chain != nullptr ((null) vs. (null))
*** Check failure stack trace: ***
Aborted (core dumped)
```

This PR fixes this by adding validation in the Python layer to raise a `ValueError` if either `private_key` or `certificate_chain` is missing when the other is provided.
