### PR TITLE
[Python] Fork test: fix exit code output, configure better logging

### DIFF
--- a/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
+++ b/src/python/grpcio_tests/tests/fork/_fork_interop_test.py
@@ -51,6 +51,7 @@ _CLIENT_FORK_SCRIPT_TEMPLATE = """if True:
     from src.python.grpcio_tests.tests.fork import native_debug
 
     native_debug.install_failure_signal_handler()
+    methods.setup_logger()
 
     cygrpc._GRPC_ENABLE_FORK_SUPPORT = True
     os.environ['GRPC_ENABLE_FORK_SUPPORT'] = 'true'


### PR DESCRIPTION
A minor fix.

Python `_fork_interop_test` was logging out `waitstatus` instead of the exit code.

> [`os.wait()`](https://docs.python.org/3.9/library/os.html#os.wait) \
> Wait for completion of a child process, and return a tuple containing its pid and exit status indication: a 16-bit number, whose low byte is the signal number that killed the process, and whose high byte is the exit status (if the signal number is zero); the high bit of the low byte is set if a core file was produced. 
>
> [`waitstatus_to_exitcode()`](https://docs.python.org/3.9/library/os.html#os.waitstatus_to_exitcode) can be used to convert the exit status into an exit code.

This PR:
- Logs exit code and the wait status, with a clear distinction what's what.
- Configures log format to be absl-like, just but prefixes thread id with the pid (which is more relevant in our case).
