### PR TITLE
[Backport][v1.75.x][Python] Handle python3.14 get_event_loop behavior changes

### DIFF
--- a/src/python/grpcio_tests/tests_aio/unit/_common.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 from typing import AsyncIterable, Union
 
 import grpc
@@ -25,6 +26,18 @@ from grpc.experimental import aio
 from tests.unit.framework.common import test_constants
 
 ADHOC_METHOD = "/test/AdHoc"
+
+
+def setup_absl_like_logging(level=logging.DEBUG):
+    logging.basicConfig(
+        level=level,
+        style="{",
+        format=(
+            "{levelname[0]}{asctime}.{msecs:03.0f} {thread} "
+            "{filename}:{lineno}] {message}"
+        ),
+        datefmt="%m%d %H:%M:%S",
+    )
 
 
 def seen_metadata(expected: Metadata, actual: Metadata):

--- a/src/python/grpcio_tests/tests_aio/unit/init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/init_test.py
@@ -12,28 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import sys
 import unittest
 
+from typing_extensions import override
 
-@unittest.skipIf(
-    sys.version_info >= (3, 14),
-    "Skip for Python 3.14+ until https://github.com/grpc/grpc/pull/40293 is merged",
-)
+from tests_aio.unit import _common
+
+
 class TestInit(unittest.TestCase):
+    @classmethod
+    @override
+    def setUpClass(cls):
+        # Logging config in setUpClass compatible with bazel-based runner.
+        _common.setup_absl_like_logging()
+
     def test_grpc(self):
         import grpc  # pylint: disable=wrong-import-position
 
         channel = grpc.aio.insecure_channel("phony")
+        logging.info(f"Created grpc Channel<{id(channel._loop)=}>")
         self.assertIsInstance(channel, grpc.aio.Channel)
 
     def test_grpc_dot_aio(self):
         import grpc.aio  # pylint: disable=wrong-import-position
 
         channel = grpc.aio.insecure_channel("phony")
+        logging.info(f"Created grpc.aio Channel<{id(channel._loop)=}>")
         self.assertIsInstance(channel, grpc.aio.Channel)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests_aio/unit/outside_init_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/outside_init_test.py
@@ -20,19 +20,23 @@ import unittest
 
 import grpc
 from grpc.experimental import aio
+from typing_extensions import override
 
 from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2_grpc
+from tests_aio.unit import _common
 from tests_aio.unit._test_server import start_test_server
 
 _NUM_OF_LOOPS = 50
 
 
-@unittest.skipIf(
-    sys.version_info >= (3, 14),
-    "Skip for Python 3.14+ until https://github.com/grpc/grpc/pull/40293 is merged",
-)
 class TestOutsideInit(unittest.TestCase):
+    @classmethod
+    @override
+    def setUpClass(cls):
+        # Logging config in setUpClass compatible with bazel-based runner.
+        _common.setup_absl_like_logging()
+
     def test_behavior_outside_asyncio(self):
         # Ensures non-AsyncIO object can be initiated
         channel_creds = grpc.ssl_channel_credentials()
@@ -55,6 +59,8 @@ class TestOutsideInit(unittest.TestCase):
         async def ping_pong():
             address, server = await start_test_server()
             channel = aio.insecure_channel(address)
+            logging.info(f"Channel loop: {id(channel._loop)=}")
+
             stub = test_pb2_grpc.TestServiceStub(channel)
 
             await stub.UnaryCall(messages_pb2.SimpleRequest())
@@ -63,10 +69,17 @@ class TestOutsideInit(unittest.TestCase):
             await server.stop(None)
 
         for i in range(_NUM_OF_LOOPS):
-            old_loop = asyncio.get_event_loop()
-            old_loop.close()
+            # In python 3.14+, the first time we attempt getting the old loop,
+            # it won't exist: get_event_loop() now raises error when there's
+            # no running loop.
+            # TODO(sergiitk): revisit after getting rid of the loop policies.
+            if sys.version_info < (3, 14) or i > 0:
+                old_loop = asyncio.get_event_loop()
+                logging.info(f"Closing old loop: {id(old_loop)}")
+                old_loop.close()
 
             loop = asyncio.new_event_loop()
+            logging.info(f"Created new loop: {id(loop)}")
             loop.set_debug(True)
             asyncio.set_event_loop(loop)
 
@@ -76,5 +89,4 @@ class TestOutsideInit(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
     unittest.main(verbosity=2)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -876,6 +876,7 @@ class PythonLanguage(object):
                 # Default set tested on master. Test oldest and newest.
                 return (
                     python39_config,
+                    python312_config,
                     python314_config,
                 )
         elif args.compiler == "python3.9":


### PR DESCRIPTION
Backport of #40750 to v1.75.x.
---
> [!IMPORTANT]
> **This fix is only needed to support the use of grpc.aio outside of a running event loop.** This approach is [strongly discouraged](https://docs.python.org/3.14/library/asyncio-policy.html#asyncio-policies) by Python, and will be deprecated in future gRPC releases.
>
> Please use the [asyncio.run()](https://docs.python.org/3.14/library/asyncio-runner.html#asyncio.run) function or the [asyncio.Runner](https://docs.python.org/3.14/library/asyncio-runner.html#asyncio.Runner). If you see this in Python REPL, use the dedicated [asyncio REPL](https://docs.python.org/3/library/asyncio.html#asyncio-cli) by running `python -m asyncio`.

This PR handles the following [asyncio behavioral changes](https://docs.python.org/3.14/whatsnew/3.14.html#id11) introduced in python3.14:
- [asyncio.get_event_loop()](https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.get_event_loop) now raises a `RuntimeError` if there is no current event loop, and no longer implicitly creates an event loop.
- [Deprecations](https://docs.python.org/3.14/whatsnew/3.14.html#deprecated): [asyncio.get_event_loop_policy()](https://docs.python.org/3.14/library/asyncio-policy.html#asyncio.get_event_loop_policy), [asyncio.AbstractEventLoopPolicy](https://docs.python.org/3.14/library/asyncio-policy.html#asyncio.AbstractEventLoopPolicy), [asyncio.DefaultEventLoopPolicy](https://docs.python.org/3.14/library/asyncio-policy.html#asyncio.DefaultEventLoopPolicy). Note that this PR preserves the existing behavior and does not migrate off of [asyncio policy system](https://docs.python.org/3.14/library/asyncio-policy.html) yet. This will be done separately, see #39518.

To support 3.14, this PR:
1. Fixes #39507 by handling the call to deprecated `asyncio.get_event_loop_policy()` when calling `new_event_loop()`.  This was necessary because all warnings were elevated to errors within the context manager, and the newly deprecated policy caused an unhandled exception.
2. Handles the `BaseDefaultEventLoopPolicy.get_event_loop()` behavior change. [Before](https://github.com/python/cpython/blob/v3.13.7/Lib/asyncio/events.py#L695) python 3.14, it would only throw `RuntimeError` when there's no loop in non-main threads. [After](https://github.com/python/cpython/blob/v3.14.0rc3/Lib/asyncio/events.py#L714) python 3.14, it removes the special handling of the main thread. This PR preserves preserves the pre-3.14 grpc.aio behavior for 3.14.
