### PR TITLE
Fix config_vars yaml file, and the generation script

### DIFF
--- a/src/core/config/config_vars.cc
+++ b/src/core/config/config_vars.cc
@@ -86,16 +86,14 @@ ABSL_FLAG(
     "EXPERIMENTAL: If non-zero, extend the lifetime of channelz nodes past the "
     "underlying object lifetime, up to this many nodes. The value may be "
     "adjusted slightly to account for implementation limits.");
-
 ABSL_FLAG(absl::optional<double>, grpc_experimental_target_memory_pressure, {},
           "EXPERIMENTAL: The target pressure for the memory quota pressure "
           "controller. This is a value between 0 and 1.");
-
-ABSL_FLAG(
-    absl::optional<double>, grpc_experimental_memory_pressure_threshold, {},
-    "EXPERIMENTAL: The threshold for the memory quota pressure controller. "
-    "This is a value between 0 and 1, and must always be greater than the "
-    "target pressure.");
+ABSL_FLAG(absl::optional<double>, grpc_experimental_memory_pressure_threshold,
+          {},
+          "EXPERIMENTAL: The threshold for the memory quota pressure "
+          "controller. This is a value between 0 and 1, and must always be "
+          "greater than the target pressure.");
 
 namespace grpc_core {
 
@@ -108,6 +106,14 @@ ConfigVars::ConfigVars(const Overrides& overrides)
           LoadConfig(FLAGS_grpc_channelz_max_orphaned_nodes,
                      "GRPC_CHANNELZ_MAX_ORPHANED_NODES",
                      overrides.channelz_max_orphaned_nodes, 0)),
+      experimental_target_memory_pressure_(
+          LoadConfig(FLAGS_grpc_experimental_target_memory_pressure,
+                     "GRPC_EXPERIMENTAL_TARGET_MEMORY_PRESSURE",
+                     overrides.experimental_target_memory_pressure, 0.95)),
+      experimental_memory_pressure_threshold_(
+          LoadConfig(FLAGS_grpc_experimental_memory_pressure_threshold,
+                     "GRPC_EXPERIMENTAL_MEMORY_PRESSURE_THRESHOLD",
+                     overrides.experimental_memory_pressure_threshold, 0.99)),
       enable_fork_support_(LoadConfig(
           FLAGS_grpc_enable_fork_support, "GRPC_ENABLE_FORK_SUPPORT",
           overrides.enable_fork_support, GRPC_ENABLE_FORK_SUPPORT_DEFAULT)),
@@ -143,15 +149,7 @@ ConfigVars::ConfigVars(const Overrides& overrides)
       trace_(LoadConfig(FLAGS_grpc_trace, "GRPC_TRACE", overrides.trace, "")),
       override_system_ssl_roots_dir_(overrides.system_ssl_roots_dir),
       override_default_ssl_roots_file_path_(
-          overrides.default_ssl_roots_file_path),
-      experimental_target_memory_pressure_(
-          LoadConfig(FLAGS_grpc_experimental_target_memory_pressure,
-                     "GRPC_EXPERIMENTAL_TARGET_MEMORY_PRESSURE",
-                     overrides.experimental_target_memory_pressure, 0.95)),
-      experimental_memory_pressure_threshold_(
-          LoadConfig(FLAGS_grpc_experimental_memory_pressure_threshold,
-                     "GRPC_EXPERIMENTAL_MEMORY_PRESSURE_THRESHOLD",
-                     overrides.experimental_memory_pressure_threshold, 0.99)) {}
+          overrides.default_ssl_roots_file_path) {}
 
 std::string ConfigVars::SystemSslRootsDir() const {
   return LoadConfig(FLAGS_grpc_system_ssl_roots_dir,
@@ -179,6 +177,8 @@ std::string ConfigVars::ToString() const {
       ", system_ssl_roots_dir: ", "\"", absl::CEscape(SystemSslRootsDir()),
       "\"", ", default_ssl_roots_file_path: ", "\"",
       absl::CEscape(DefaultSslRootsFilePath()), "\"",
+      ", use_system_roots_over_language_callback: ",
+      UseSystemRootsOverLanguageCallback() ? "true" : "false",
       ", not_use_system_ssl_roots: ", NotUseSystemSslRoots() ? "true" : "false",
       ", ssl_cipher_suites: ", "\"", absl::CEscape(SslCipherSuites()), "\"",
       ", cpp_experimental_disable_reflection: ",

--- a/src/core/config/config_vars.h
+++ b/src/core/config/config_vars.h
@@ -36,6 +36,8 @@ class GPR_DLL ConfigVars {
   struct Overrides {
     absl::optional<int32_t> client_channel_backup_poll_interval_ms;
     absl::optional<int32_t> channelz_max_orphaned_nodes;
+    absl::optional<double> experimental_target_memory_pressure;
+    absl::optional<double> experimental_memory_pressure_threshold;
     absl::optional<bool> enable_fork_support;
     absl::optional<bool> abort_on_leaks;
     absl::optional<bool> use_system_roots_over_language_callback;
@@ -49,8 +51,6 @@ class GPR_DLL ConfigVars {
     absl::optional<std::string> ssl_cipher_suites;
     absl::optional<std::string> experiments;
     absl::optional<std::string> trace;
-    absl::optional<double> experimental_target_memory_pressure;
-    absl::optional<double> experimental_memory_pressure_threshold;
   };
   ConfigVars(const ConfigVars&) = delete;
   ConfigVars& operator=(const ConfigVars&) = delete;
@@ -98,7 +98,7 @@ class GPR_DLL ConfigVars {
   std::string SystemSslRootsDir() const;
   // Path to the default SSL roots file.
   std::string DefaultSslRootsFilePath() const;
-  // Prefer loading system root certificates over using installed callback.
+  // Prefer loading system root certificates over language callback.
   bool UseSystemRootsOverLanguageCallback() const {
     return use_system_roots_over_language_callback_;
   }
@@ -118,16 +118,14 @@ class GPR_DLL ConfigVars {
   int32_t ChannelzMaxOrphanedNodes() const {
     return channelz_max_orphaned_nodes_;
   }
-
   // EXPERIMENTAL: The target pressure for the memory quota pressure controller.
   // This is a value between 0 and 1.
   double ExperimentalTargetMemoryPressure() const {
     return experimental_target_memory_pressure_;
   }
-
-  // EXPERIMENTAL: The threshold for the memory quota pressure controller.
-  // This is a value between 0 and 1, and must always be greater than the
-  // target pressure.
+  // EXPERIMENTAL: The threshold for the memory quota pressure controller. This
+  // is a value between 0 and 1, and must always be greater than the target
+  // pressure.
   double ExperimentalMemoryPressureThreshold() const {
     return experimental_memory_pressure_threshold_;
   }
@@ -138,6 +136,8 @@ class GPR_DLL ConfigVars {
   static std::atomic<ConfigVars*> config_vars_;
   int32_t client_channel_backup_poll_interval_ms_;
   int32_t channelz_max_orphaned_nodes_;
+  double experimental_target_memory_pressure_;
+  double experimental_memory_pressure_threshold_;
   bool enable_fork_support_;
   bool abort_on_leaks_;
   bool use_system_roots_over_language_callback_;
@@ -151,8 +151,6 @@ class GPR_DLL ConfigVars {
   std::string trace_;
   absl::optional<std::string> override_system_ssl_roots_dir_;
   absl::optional<std::string> override_default_ssl_roots_file_path_;
-  double experimental_target_memory_pressure_;
-  double experimental_memory_pressure_threshold_;
 };
 
 }  // namespace grpc_core

--- a/src/core/config/config_vars.yaml
+++ b/src/core/config/config_vars.yaml
@@ -105,6 +105,10 @@
   default:
   description: Path to the default SSL roots file.
   force-load-on-access: true
+- name: use_system_roots_over_language_callback
+  type: bool
+  default: false
+  description: Prefer loading system root certificates over language callback.
 - name: not_use_system_ssl_roots
   type: bool
   default: false

--- a/test/core/test_util/fuzz_config_vars.cc
+++ b/test/core/test_util/fuzz_config_vars.cc
@@ -26,6 +26,14 @@ ConfigVars::Overrides OverridesFromFuzzConfigVars(
   if (vars.has_channelz_max_orphaned_nodes()) {
     overrides.channelz_max_orphaned_nodes = vars.channelz_max_orphaned_nodes();
   }
+  if (vars.has_experimental_target_memory_pressure()) {
+    overrides.experimental_target_memory_pressure =
+        vars.experimental_target_memory_pressure();
+  }
+  if (vars.has_experimental_memory_pressure_threshold()) {
+    overrides.experimental_memory_pressure_threshold =
+        vars.experimental_memory_pressure_threshold();
+  }
   if (vars.has_enable_fork_support()) {
     overrides.enable_fork_support = vars.enable_fork_support();
   }

--- a/test/core/test_util/fuzz_config_vars.proto
+++ b/test/core/test_util/fuzz_config_vars.proto
@@ -22,6 +22,8 @@ package grpc.testing;
 
 message FuzzConfigVars {
   optional int32 channelz_max_orphaned_nodes = 475973073;
+  optional double experimental_target_memory_pressure = 172375146;
+  optional double experimental_memory_pressure_threshold = 402942472;
   optional bool enable_fork_support = 61008869;
   optional string dns_resolver = 76817901;
   optional string verbosity = 68420950;

--- a/tools/codegen/core/gen_config_vars.py
+++ b/tools/codegen/core/gen_config_vars.py
@@ -156,10 +156,12 @@ def int_default_value(x, name):
         return x[1:]
     return x
 
+
 def double_default_value(x, name):
     if isinstance(x, str) and x.startswith("$"):
         return x[1:]
     return x
+
 
 def string_default_value(x, name):
     if x is None:

--- a/tools/codegen/core/gen_config_vars.py
+++ b/tools/codegen/core/gen_config_vars.py
@@ -102,6 +102,7 @@ def put_copyright(file):
 
 RETURN_TYPE = {
     "int": "int32_t",
+    "double": "double",
     "string": "absl::string_view",
     "comma_separated_string": "absl::string_view",
     "bool": "bool",
@@ -109,6 +110,7 @@ RETURN_TYPE = {
 
 MEMBER_TYPE = {
     "int": "int32_t",
+    "double": "double",
     "string": "std::string",
     "comma_separated_string": "std::string",
     "bool": "bool",
@@ -116,6 +118,7 @@ MEMBER_TYPE = {
 
 FLAG_TYPE = {
     "int": "absl::optional<int32_t>",
+    "double": "absl::optional<double>",
     "string": "absl::optional<std::string>",
     "comma_separated_string": "std::vector<std::string>",
     "bool": "absl::optional<bool>",
@@ -123,6 +126,7 @@ FLAG_TYPE = {
 
 PROTO_TYPE = {
     "int": "int32",
+    "double": "double",
     "string": "string",
     "comma_separated_string": "string",
     "bool": "bool",
@@ -130,9 +134,10 @@ PROTO_TYPE = {
 
 SORT_ORDER_FOR_PACKING = {
     "int": 0,
-    "bool": 1,
-    "string": 2,
-    "comma_separated_string": 3,
+    "double": 1,
+    "bool": 2,
+    "string": 3,
+    "comma_separated_string": 4,
 }
 
 
@@ -151,6 +156,10 @@ def int_default_value(x, name):
         return x[1:]
     return x
 
+def double_default_value(x, name):
+    if isinstance(x, str) and x.startswith("$"):
+        return x[1:]
+    return x
 
 def string_default_value(x, name):
     if x is None:
@@ -162,6 +171,7 @@ def string_default_value(x, name):
 
 DEFAULT_VALUE = {
     "int": int_default_value,
+    "double": double_default_value,
     "bool": bool_default_value,
     "string": string_default_value,
     "comma_separated_string": string_default_value,
@@ -169,6 +179,7 @@ DEFAULT_VALUE = {
 
 TO_STRING = {
     "int": "$",
+    "double": "$",
     "bool": '$?"true":"false"',
     "string": '"\\"", absl::CEscape($), "\\""',
     "comma_separated_string": '"\\"", absl::CEscape($), "\\""',


### PR DESCRIPTION
Add the missing use_system_roots_over_language_callback in the config_vars.yaml file, and add support for double types in the generation script.