### PR TITLE
[Fix] Skip flaky active_call_spec.rb on linux arm64

### DIFF
--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -37,6 +37,16 @@ describe GRPC::ActiveCall do
     active_call.instance_variable_get(:@call)
   end
 
+  before(:all) do
+    linux = RUBY_PLATFORM =~ /linux/
+    arm = RUBY_PLATFORM =~ /(aarch64|arm64)/
+    if linux && arm
+      # TODO(stanleycheung): fix test timing out on linux arch, see
+      # prod:grpc/core/master/linux/arm64/grpc_basictests_ruby
+      skip "Flaky: this tests times out randomly when running on arm64 linux"
+    end
+  end
+
   before(:each) do
     @pass_through = proc { |x| x }
     host = '0.0.0.0:0'


### PR DESCRIPTION
On linux arm the test is sometimes randomly hangs until the 20min timeout. Normally it takes just a few seconds to pass.

Fail: https://source.cloud.google.com/results/invocations/e0038f3c-5d32-405e-9e99-c28c9328a3b7
```
TIMEOUT: src/ruby/spec/generic/active_call_spec.rb [pid=23381, time=1201.4sec]
```

Pass: https://source.cloud.google.com/results/invocations/7be4b597-a7bd-48e2-a631-83695020fef3
```
PASSED: src/ruby/spec/generic/active_call_spec.rb [time=2.9sec, retries=0:0; cpu_cost=1.0; estimated=1.0]
```

This PR selectively skip this test on linux arm, until the root cause is determined.