### PR TITLE
[Fix] Extend kokoro timeout for master Basic Tests Ruby Linux

### DIFF
--- a/tools/internal_ci/linux/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_ruby.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 60
+timeout_mins: 90
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Extends `prod:grpc/core/master/linux/grpc_basictests_ruby` timeout by 30 minutes. 

Test runtime even for successful job runs is around 1h, just sometime the last few minutes are taken by Kokoro itself, and won't count.

<img width="1146" height="331" alt="image" src="https://github.com/user-attachments/assets/3faf119f-b32a-4e26-a75a-9b60b71c91ce" />


