### PR TITLE
[Backport][v1.75.x][Fix] PHP macOS build: composer sha sum update, harden install script

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -234,10 +234,20 @@ then
   php --version
 
   if $is_sonoma; then
-    php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }"
+    # For updated hash checksums https://composer.github.io/pubkeys.html
+    EXPECTED_COMPOSER_SHA384_SUM="ed0feb545ba87161262f2d45a633e34f591ebb3381f2e0063c345ebea4d228dd0043083717770234ec00c5a9f9593792"
+    echo "Expected composer-setup.php sha384 sum: ${EXPECTED_COMPOSER_SHA384_SUM}"
+
+    curl --retry 3 -sL -o composer-setup.php https://getcomposer.org/installer
+    echo "Downloaded composer-setup.php sha384 sum: $(sha384sum composer-setup.php)"
+
+    # https://getcomposer.org/download "Download Composer" snippet from here,
+    # modified for simpler updates hash updates.
+    php -r "if (hash_file('sha384', 'composer-setup.php') === '${EXPECTED_COMPOSER_SHA384_SUM}') { echo 'Installer verified'.PHP_EOL; } else { echo 'Installer corrupt'.PHP_EOL; unlink('composer-setup.php'); exit(1); }"
     php composer-setup.php --install-dir /tmp
     php -r "unlink('composer-setup.php');"
+
+    # install composer deps
     php /tmp/composer.phar global require phpunit/phpunit:9.5.9
   else
     # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081


### PR DESCRIPTION
Backport of #40769 to v1.75.x.
---
Composer sha sum updated, see https://composer.github.io/pubkeys.html

> Installer Checksum (SHA-384) `ed0feb545ba87161262f2d45a633e34f591ebb3381f2e0063c345ebea4d228dd0043083717770234ec00c5a9f9593792`
> Last Updated: 2025-09-18

Also hardens the install script.