### PR TITLE
[Tools] Set git log config defaults in release_notes.py

### DIFF
--- a/tools/release/release_notes.py
+++ b/tools/release/release_notes.py
@@ -93,6 +93,9 @@ def get_commit_detail(commit):
     glg_command = [
         "git",
         "log",
+        "--no-abbrev-commit",
+        "--no-color",
+        "--pretty=full",
         "-n 1",
         "%s" % commit,
     ]
@@ -125,6 +128,8 @@ def get_commit_log(prevRelLabel, relBranch):
     glg_command = [
         "git",
         "log",
+        "--no-abbrev-commit",
+        "--no-color",
         "--pretty=oneline",
         "%s..%s" % (prevRelLabel, relBranch),
     ]


### PR DESCRIPTION
I have these settings overridden in my git config, which breaks release_notes.py. Let's make sure release_notes.py sets the them directly.
