### PR TITLE
[Python] Bazel tests: allow to pass standard unittest cmd args

### DIFF
--- a/bazel/_run_time_type_check_main.py
+++ b/bazel/_run_time_type_check_main.py
@@ -76,9 +76,10 @@ def _arg_parser() -> argparse.ArgumentParser:
     parser.add_argument('--locals', dest='tb_locals',
                         action='store_true',
                         help='Show local variables in tracebacks')
-    parser.add_argument('--durations', dest='durations', type=int,
-                        default=None, metavar="N",
-                        help='Show the N slowest test cases (N=0 for all)')
+    if sys.version_info >= (3, 12):
+        parser.add_argument('--durations', dest='durations', type=int,
+                            default=None, metavar="N",
+                            help='Show the N slowest test cases (N=0 for all)')
     parser.add_argument('-f', '--failfast', dest='failfast',
                         action='store_true',
                         help='Stop on first fail or error')


### PR DESCRIPTION
Allows to pass [standard unittest command line options](https://docs.python.org/3/library/unittest.html#command-line-options) through our _run_time_type_check_main.py wrapper.

For example, this filters out tests down to `test_delete_values` and enable local variables in the traceback
```console
$ bazel test --test_output=streamed --config=python //src/python/grpcio_tests/tests_aio/unit:_metadata_test --test_arg='--locals' --test_arg='-k=test_delete_values'
INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.0.1 will be used instead of system-wide bazel installation.
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //src/python/grpcio_tests/tests_aio/unit:_metadata_test (0 packages loaded, 0 targets configured).
test_delete_values (src.python.grpcio_tests.tests_aio.unit._metadata_test.TestTypeMetadata.test_delete_values) ... ERROR

======================================================================
ERROR: test_delete_values (src.python.grpcio_tests.tests_aio.unit._metadata_test.TestTypeMetadata.test_delete_values)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/python/grpcio_tests/tests_aio/unit/_metadata_test.py", line 186, in test_delete_values
    self.assertEqual(metadata.get("key1"), "other value 1")
                     ~~~~~~~~~~~~^^^^^^^^
    metadata = Metadata((('key1', 'other value 1'), ('key2', 'value2')))
    self = <src.python.grpcio_tests.tests_aio.unit._metadata_test.TestTypeMetadata testMethod=test_delete_values>
  File "src/python/grpcio/grpc/aio/_metadata.py", line 102, in get
    def get(
    ...<5 lines>...
            return default
    default = None
    key = 'key1'
    memo = <typeguard.TypeCheckMemo object at 0x10e189880>
    self = Metadata((('key1', 'other value 1'), ('key2', 'value2')))
  File "site-packages/typeguard/_functions.py", line 136, in check_argument_types
...
```

Also works via `bazel run`

```console
$ bazel run --config=python //src/python/grpcio_tests/tests_aio/unit:_metadata_test -- --locals -k=test_delete_values
INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.0.1 will be used instead of system-wide bazel installation.
INFO: Analyzed target //src/python/grpcio_tests/tests_aio/unit:_metadata_test (0 packages loaded, 8 targets configured).
INFO: Found 1 target...
Target //src/python/grpcio_tests/tests_aio/unit:_metadata_test up-to-date:
  bazel-bin/src/python/grpcio_tests/tests_aio/unit/_metadata_test
INFO: Elapsed time: 1.018s, Critical Path: 0.01s
INFO: 1 process: 5 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh src/python/grpcio_tests/tests_aio/unit/_metadata_test _metadata_test <args omitted>
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //src/python/grpcio_tests/tests_aio/unit:_metadata_test
-----------------------------------------------------------------------------
test_delete_values (src.python.grpcio_tests.tests_aio.unit._metadata_test.TestTypeMetadata.test_delete_values) ... ERROR

======================================================================
ERROR: test_delete_values (src.python.grpcio_tests.tests_aio.unit._metadata_test.TestTypeMetadata.test_delete_values)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "src/python/grpcio_tests/tests_aio/unit/_metadata_test.py", line 186, in test_delete_values
    self.assertEqual(metadata.get("key1"), "other value 1")
                     ~~~~~~~~~~~~^^^^^^^^
    metadata = Metadata((('key1', 'other value 1'), ('key2', 'value2')))
    self = <src.python.grpcio_tests.tests_aio.unit._metadata_test.TestTypeMetadata testMethod=test_delete_values>
  File "src/python/grpcio/grpc/aio/_metadata.py", line 102, in get
    def get(
    ...<5 lines>...
            return default
    default = None
    key = 'key1'
    memo = <typeguard.TypeCheckMemo object at 0x10dd99340>
...
```

(file paths in traces trimmed down)