### PR TITLE
[C++] Silence -Wunused-parameter warning in global_callback_hook.h

### DIFF
--- a/include/grpcpp/support/global_callback_hook.h
+++ b/include/grpcpp/support/global_callback_hook.h
@@ -45,7 +45,7 @@ class GlobalCallbackHook {
 
 class DefaultGlobalCallbackHook final : public GlobalCallbackHook {
  public:
-  void RunCallback(grpc_call* call,
+  void RunCallback(grpc_call* /* call */,
                    absl::FunctionRef<void()> callback) override {
     CatchingCallback(callback);
   }


### PR DESCRIPTION
This fixes this warning:
```
/data/mwrep/res/osp/Grpc/grpcxx/25-0-0-0/include/grpcpp/support/global_callback_hook.h: In member function 'virtual void grpc::DefaultGlobalCallbackHook::RunCallback(grpc_call*, absl::lts_20250814::FunctionRef<void()>)': /data/mwrep/res/osp/Grpc/grpcxx/25-0-0-0/include/grpcpp/support/global_callback_hook.h:48:31: warning: unused parameter 'call' [-Wunused-parameter]
   48 |   void RunCallback(grpc_call* call,
      |                    ~~~~~~~~~~~^~~~
```