### PR TITLE
[grpcpp][cmake] Skip installing otel plugin pkgconfig if not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52015,13 +52015,15 @@ generate_pkgconfig(
   "-laddress_sorting -lupb_textformat_lib -lupb_reflection_lib -lupb_wire_lib -lupb_message_lib -lutf8_range_lib -lupb_mini_descriptor_lib -lupb_mini_table_lib -lupb_hash_lib -lupb_mem_lib -lupb_base_lib -lupb_lex_lib"
   "grpc++_unsecure.pc")
 
-# grpcpp_otel_plugin .pc file
-generate_pkgconfig(
-  "gRPC++ OpenTelemetry Plugin"
-  "OpenTelemetry Plugin for gRPC C++"
-  "${gRPC_CPP_VERSION}"
-  "absl_absl_check absl_absl_log absl_algorithm_container absl_any_invocable absl_base absl_bind_front absl_bits absl_btree absl_check absl_cleanup absl_config absl_cord absl_core_headers absl_dynamic_annotations absl_flags absl_flags_marshalling absl_flat_hash_map absl_flat_hash_set absl_function_ref absl_hash absl_inlined_vector absl_layout absl_log absl_log_globals absl_log_severity absl_memory absl_no_destructor absl_node_hash_map absl_optional absl_prefetch absl_random_bit_gen_ref absl_random_distributions absl_random_random absl_span absl_status absl_statusor absl_str_format absl_string_view absl_strings absl_strings_internal absl_synchronization absl_time absl_type_traits absl_utility gpr grpc grpc++ opentelemetry_api"
-  "libcares openssl re2 zlib"
-  "-lgrpcpp_otel_plugin"
-  "-laddress_sorting -lupb_textformat_lib -lupb_json_lib -lupb_reflection_lib -lupb_wire_lib -lupb_message_lib -lutf8_range_lib -lupb_mini_descriptor_lib -lupb_mini_table_lib -lupb_hash_lib -lupb_mem_lib -lupb_base_lib -lupb_lex_lib"
-  "grpcpp_otel_plugin.pc")
+if(gRPC_BUILD_GRPCPP_OTEL_PLUGIN)
+  # grpcpp_otel_plugin .pc file
+  generate_pkgconfig(
+    "gRPC++ OpenTelemetry Plugin"
+    "OpenTelemetry Plugin for gRPC C++"
+    "${gRPC_CPP_VERSION}"
+    "absl_absl_check absl_absl_log absl_algorithm_container absl_any_invocable absl_base absl_bind_front absl_bits absl_btree absl_check absl_cleanup absl_config absl_cord absl_core_headers absl_dynamic_annotations absl_flags absl_flags_marshalling absl_flat_hash_map absl_flat_hash_set absl_function_ref absl_hash absl_inlined_vector absl_layout absl_log absl_log_globals absl_log_severity absl_memory absl_no_destructor absl_node_hash_map absl_optional absl_prefetch absl_random_bit_gen_ref absl_random_distributions absl_random_random absl_span absl_status absl_statusor absl_str_format absl_string_view absl_strings absl_strings_internal absl_synchronization absl_time absl_type_traits absl_utility gpr grpc grpc++ opentelemetry_api"
+    "libcares openssl re2 zlib"
+    "-lgrpcpp_otel_plugin"
+    "-laddress_sorting -lupb_textformat_lib -lupb_json_lib -lupb_reflection_lib -lupb_wire_lib -lupb_message_lib -lutf8_range_lib -lupb_mini_descriptor_lib -lupb_mini_table_lib -lupb_hash_lib -lupb_mem_lib -lupb_base_lib -lupb_lex_lib"
+    "grpcpp_otel_plugin.pc")
+endif()

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -1160,13 +1160,15 @@
     "${" ".join(get_pkgconfig_libs_private("grpc++_unsecure"))}"
     "grpc++_unsecure.pc")
 
-  # grpcpp_otel_plugin .pc file
-  generate_pkgconfig(
-    "gRPC++ OpenTelemetry Plugin"
-    "OpenTelemetry Plugin for gRPC C++"
-    "<%text>${gRPC_CPP_VERSION}</%text>"
-    "${" ".join(get_pkgconfig_requires("grpcpp_otel_plugin"))}"
-    "${" ".join(get_pkgconfig_requires_private("grpcpp_otel_plugin"))}"
-    "${" ".join(get_pkgconfig_libs("grpcpp_otel_plugin"))}"
-    "${" ".join(get_pkgconfig_libs_private("grpcpp_otel_plugin"))}"
-    "grpcpp_otel_plugin.pc")
+  if(gRPC_BUILD_GRPCPP_OTEL_PLUGIN)
+    # grpcpp_otel_plugin .pc file
+    generate_pkgconfig(
+      "gRPC++ OpenTelemetry Plugin"
+      "OpenTelemetry Plugin for gRPC C++"
+      "<%text>${gRPC_CPP_VERSION}</%text>"
+      "${" ".join(get_pkgconfig_requires("grpcpp_otel_plugin"))}"
+      "${" ".join(get_pkgconfig_requires_private("grpcpp_otel_plugin"))}"
+      "${" ".join(get_pkgconfig_libs("grpcpp_otel_plugin"))}"
+      "${" ".join(get_pkgconfig_libs_private("grpcpp_otel_plugin"))}"
+      "grpcpp_otel_plugin.pc")
+  endif()


### PR DESCRIPTION
Trivial change:
do not install `pkgconfig/grpcpp_otel_plugin.pc` if `gRPC_BUILD_GRPCPP_OTEL_PLUGIN` is false.