### PR TITLE
[interop] Add v1.76.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -322,6 +322,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.73.1", ReleaseInfo()),
             ("v1.74.3", ReleaseInfo()),
             ("v1.75.1", ReleaseInfo()),
+            ("v1.76.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```
easwars@minetop: grpc$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.x

DIGEST        TAGS                                         TIMESTAMP            VULNERABILITIES
aa5081509e42  infrastructure-public-image-v1.76.0,v1.76.0  2025-10-06T22:34:20  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
706779879f22  infrastructure-public-image-v1.72.3,v1.72.3  2025-09-10T09:53:08  CRITICAL=1,HIGH=8,LOW=113,MEDIUM=9
cd6ff9704672  infrastructure-public-image-v1.73.1,v1.73.1  2025-09-10T09:08:06  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
b1ce9dcb8e77  infrastructure-public-image-v1.74.3,v1.74.3  2025-09-10T08:47:41  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
cc4d38dfd6bc  infrastructure-public-image-v1.75.1,v1.75.1  2025-09-10T07:01:45  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
debefa297d2f  infrastructure-public-image-v1.75.0,v1.75.0  2025-08-20T07:11:42  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
a99d95a96a4e  infrastructure-public-image-v1.74.2,v1.74.2  2025-07-23T04:56:36  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
d13fbd1dafdb  infrastructure-public-image-v1.73.0,v1.73.0  2025-06-06T08:46:49  CRITICAL=1,HIGH=6,LOW=113,MEDIUM=6
96e88fdea1a5  infrastructure-public-image-v1.72.2,v1.72.2  2025-05-27T05:09:30  CRITICAL=1,HIGH=8,LOW=113,MEDIUM=9
0adaf47ee513  infrastructure-public-image-v1.71.3,v1.71.3  2025-05-27T05:07:54  CRITICAL=1,HIGH=7,LOW=113,MEDIUM=8
```
