### PR TITLE
[security][Python] migrate ssl_channel_credentials to use advanced tls API

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -204,29 +204,24 @@ cdef class SSLChannelCredentials(ChannelCredentials):
     cdef grpc_tls_certificate_provider* c_tls_certificate_provider
 
     c_tls_credentials_options = grpc_tls_credentials_options_create()
-    if self._pem_root_certificates is None:
-      c_pem_root_certificates = NULL
-    else:
-      c_pem_root_certificates = self._pem_root_certificates
+    c_pem_root_certificates = self._pem_root_certificates or <const char*>NULL
+
     if self._private_key or self._certificate_chain:
       c_tls_identity_pairs = grpc_tls_identity_pairs_create()
-      if self._private_key:
-        c_private_key = self._private_key
-      else:
-        c_private_key = NULL
-      if self._certificate_chain:
-        c_cert_chain = self._certificate_chain
-      else:
-        c_cert_chain = NULL
+      c_private_key = self._private_key or <const char*>NULL
+      c_cert_chain = self._certificate_chain or <const char*>NULL
       grpc_tls_identity_pairs_add_pair(c_tls_identity_pairs, c_private_key, c_cert_chain)
+
     if c_pem_root_certificates != NULL or c_tls_identity_pairs != NULL:
-      c_tls_certificate_provider = grpc_tls_certificate_provider_static_data_create(c_pem_root_certificates, c_tls_identity_pairs)
+      c_tls_certificate_provider = grpc_tls_certificate_provider_static_data_create(
+        c_pem_root_certificates, c_tls_identity_pairs)
       grpc_tls_credentials_options_set_certificate_provider(c_tls_credentials_options, c_tls_certificate_provider)
       grpc_tls_certificate_provider_release(c_tls_certificate_provider)
       if c_pem_root_certificates != NULL:
         grpc_tls_credentials_options_watch_root_certs(c_tls_credentials_options)
       if c_tls_identity_pairs != NULL:
         grpc_tls_credentials_options_watch_identity_key_cert_pairs(c_tls_credentials_options)
+
     with nogil:
       return grpc_tls_credentials_create(c_tls_credentials_options)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -595,33 +595,36 @@ cdef extern from "grpc/credentials.h":
     # We don't care about the internals (and in fact don't know them)
     pass
 
-  void grpc_tls_credentials_options_set_certificate_provider(grpc_tls_credentials_options* options, grpc_tls_certificate_provider* provider) nogil
+  void grpc_tls_credentials_options_set_certificate_provider(
+    grpc_tls_credentials_options *options,
+    grpc_tls_certificate_provider *provider) nogil
 
   ctypedef struct grpc_tls_identity_pairs:
     # We don't care about the internals (and in fact don't know them)
     pass
 
-  grpc_tls_identity_pairs* grpc_tls_identity_pairs_create() nogil
+  grpc_tls_identity_pairs *grpc_tls_identity_pairs_create() nogil
 
-  void grpc_tls_identity_pairs_add_pair(grpc_tls_identity_pairs* pairs,
-                                              const char* private_key,
-                                              const char* cert_chain) nogil
+  void grpc_tls_identity_pairs_add_pair(
+    grpc_tls_identity_pairs *pairs,
+    const char *private_key,
+    const char *cert_chain) nogil
 
-  grpc_tls_certificate_provider* grpc_tls_certificate_provider_static_data_create(
-    const char* root_certificate, grpc_tls_identity_pairs* pem_key_cert_pairs) nogil
+  grpc_tls_certificate_provider *grpc_tls_certificate_provider_static_data_create(
+    const char *root_certificate, grpc_tls_identity_pairs *pem_key_cert_pairs) nogil
 
   void grpc_tls_credentials_options_set_certificate_provider(
-    grpc_tls_credentials_options* options,
-    grpc_tls_certificate_provider* provider) nogil
-  
+    grpc_tls_credentials_options *options,
+    grpc_tls_certificate_provider *provider) nogil
+
   void grpc_tls_credentials_options_watch_root_certs(
-    grpc_tls_credentials_options* options) nogil
+    grpc_tls_credentials_options *options) nogil
 
   void grpc_tls_credentials_options_watch_identity_key_cert_pairs(
-    grpc_tls_credentials_options* options) nogil
+    grpc_tls_credentials_options *options) nogil
 
   void grpc_tls_certificate_provider_release(
-    grpc_tls_certificate_provider* provider) nogil
+    grpc_tls_certificate_provider *provider) nogil
 
   ctypedef struct grpc_channel_credentials:
     # We don't care about the internals (and in fact don't know them)
@@ -640,8 +643,10 @@ cdef extern from "grpc/credentials.h":
   grpc_channel_credentials *grpc_ssl_credentials_create(
       const char *pem_root_certs, grpc_ssl_pem_key_cert_pair *pem_key_cert_pair,
       verify_peer_options *verify_options, void *reserved) nogil
-  grpc_channel_credentials* grpc_tls_credentials_create(
-    grpc_tls_credentials_options* options) nogil
+
+  grpc_channel_credentials *grpc_tls_credentials_create(
+    grpc_tls_credentials_options *options) nogil
+
   grpc_channel_credentials *grpc_composite_channel_credentials_create(
       grpc_channel_credentials *creds1, grpc_call_credentials *creds2,
       void *reserved) nogil


### PR DESCRIPTION
Switch to use the new [TLS Credentials API](https://github.com/grpc/proposal/pull/422) in Python's SSL channel credentials API.