### PR TITLE
[Fix][Python] Add parameters for CreateCollectionScope() in gRPC Observability

### DIFF
--- a/src/python/grpcio_observability/grpc_observability/observability_util.cc
+++ b/src/python/grpcio_observability/grpc_observability/observability_util.cc
@@ -95,7 +95,8 @@ void RecordSpan(const SpanCensusData& span_census_data) {
 
 void NativeObservabilityInit() {
   g_census_data_buffer = new std::queue<CensusData>;
-  grpc_core::CreateCollectionScope();  // Forces linking of instrument library
+  // Forces linking of instrument library
+  grpc_core::CreateCollectionScope(nullptr, {});
 }
 
 void* CreateClientCallTracer(const char* method, const char* target,


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/40851 Introduced a change with mandatory parameters for `CreateCollectionScope()`.
While gRPC Python observability doesn't use it for functionality, it is invoked in `observability_util.cc` to force linking the instrument package and avoid build errors.

The change in #40851 to include has started causing Python tests to fail with the following error:
```
grpc_observability/observability_util.cc:98:36: error: too few arguments to function ‘grpc_core::RefCountedPtr grpc_core::CreateCollectionScope(grpc_core::RefCountedPtr, absl::lts_20250512::Span >, size_t, size_t)’
   98 |   grpc_core::CreateCollectionScope();  // Forces linking of instrument library
      |                                    ^
In file included from grpc_root/src/core/lib/resource_quota/telemetry.h:18,
                 from grpc_root/src/core/lib/resource_quota/memory_quota.h:44,
                 from grpc_root/src/core/lib/resource_quota/arena.h:39,
                 from grpc_root/src/core/lib/promise/arena_promise.h:29,
                 from grpc_root/src/core/lib/channel/channel_stack.h:58,
                 from grpc_observability/python_observability_context.h:33,
                 from grpc_observability/observability_util.h:31,
                 from grpc_observability/observability_util.cc:15:
```

This PR hence adds empty parameters to fix the breakage.