### PR TITLE
[Experiments] Move event_engine_fork expiration to the future

### DIFF
--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -118,7 +118,7 @@
     ]
 - name: event_engine_fork
   description: Enables event engine fork handling, including onfork events and file descriptor generations
-  expiry: 2025/10/01
+  expiry: 2026/01/15
   owner: mlumish@google.com
   test_tags: ["core_end2end_test", "event_engine_fork_test"]
   uses_polling: true


### PR DESCRIPTION
It is unlikely that I will resolve this before November, and the tool said that experiment expiration between Nov 1 and Jan 15 is not allowed, so I set it to Jan 15.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

