### PR TITLE
Fix race conditions in C++ end2end tests caused by timed sleeps

### DIFF
--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -1170,8 +1170,10 @@ TEST_P(End2endTest, DiffPackageServices) {
 
 template <class ServiceType>
 void CancelRpc(ClientContext* context, int delay_us, ServiceType* service) {
-  while (!service->signal_client()) {
-  }
+  // Wait until the server signals that the RPC has actually started.
+  service->WaitUntilRpcStarted();
+
+  // Perform client-side cancellation and notify the server-side waiter.
   context->TryCancel();
   service->NotifyCancellationCheck();
 }

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -252,10 +252,8 @@ ServerUnaryReactor* CallbackTestServiceImpl::Echo(
         resp_->mutable_param()->set_host(std::move(authority_str));
       }
       if (req_->has_param() && req_->param().client_cancel_after_us()) {
-        {
-          std::unique_lock<std::mutex> lock(service_->mu_);
-          service_->signal_client_ = true;
-        }
+        // Signal client-side CancelRpc thread that the RPC has started.
+        service_->NotifyRpcStarted();
         FinishWhenCancelledAsync();
         cancel_notifier_ = std::thread([this] {
           while (!ctx_->IsCancelled()) {
@@ -382,7 +380,7 @@ ServerReadReactor<EchoRequest>* CallbackTestServiceImpl::RequestStream(
     // Don't need to provide a reactor since the RPC is canceled
     return nullptr;
   }
-
+//09/30, 04/30, 03/18, 05/6
   class Reactor : public grpc::ServerReadReactor<EchoRequest> {
    public:
     Reactor(CallbackServerContext* ctx, EchoResponse* response,


### PR DESCRIPTION
## Related Issue
https://github.com/grpc/grpc/issues/21263

## Summary

This PR addresses test flakiness in C++ end2end_test by replacing timed sleeps with condition variable-based synchronization for CancelRPC() calls. The end2end_test.cc use fixed-duration timed sleeps to coordinate RPC cancellation between client and server:
- Client sleeps for a fixed duration (e.g., 10ms), hoping the server has started the RPC
- If server is slower than expected → client cancels before RPC starts → test fails
- Server polls for cancellation using repeated timed sleeps. Unnecessary sleep-based delay makes test slower.

## Fix
Replace timed sleeps with condition variables for deterministic synchronization.
Change:
- Removed ``gpr_sleep_until(delay_us)`` in CancelRPC() to eliminate arbitrary timing assumption.
- Client now waits for actual server readiness signal
- Removed spin-wait in CancelRPC()
- Server now waits deterministically for cancellation event

## Benefits
1. Eliminates race conditions by removing timing-dependent test behavior.
2. Make test execution by removing fixed sleeps.
3. Avoids test flakiness.

## Testing
This fix is verified locally running the following command:
python tools/run_tests/run_tests.py -l c++ -r end2end_test -n 100

## Impact
- Scope: Internal test infrastructure only. No changes to production code.
- Risk: Low. Changes only affect test synchronization logic
- Backward compatibility: N/A (test-only changes)

