### PR TITLE
[Backport][v1.76.x][Python] Update setuptools min version to 77.0.1 

### DIFF
--- a/requirements.bazel.lock
+++ b/requirements.bazel.lock
@@ -115,8 +115,10 @@ zope-interface==7.2
     #   twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.3.0
+setuptools==77.0.1 ; python_version > "3.8" # Manually added for python > 3.8, until Bazel RBE jobs support Python >= 3.9 (Tech debt: b/427881645)
+setuptools==75.3.2 ; python_version <= "3.8"
     # via
+    #   -r requirements.bazel.txt
     #   incremental
     #   zope-event
     #   zope-interface

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -53,3 +53,5 @@ typeguard~=4.2.0,<4.4.1
 typing-extensions==4.12.2
 twisted  # for DNS test
 urllib3
+setuptools>=77.0.1; python_version > "3.8"
+setuptools>=75.3.2; python_version <= "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ cython==3.1.1
 protobuf>=6.31.1,<7.0.0
 typing-extensions==4.12.2
 wheel>=0.29
+setuptools>=77.0.1

--- a/src/python/grpcio_observability/setup.py
+++ b/src/python/grpcio_observability/setup.py
@@ -308,7 +308,7 @@ setuptools.setup(
     python_requires=f">={python_version.MIN_PYTHON_VERSION}",
     install_requires=[
         "grpcio=={version}".format(version=grpc_version.VERSION),
-        "setuptools>=59.6.0",
+        "setuptools>=77.0.1",
         "opentelemetry-api>=1.21.0",
     ],
     cmdclass={

--- a/tools/distrib/docgen/requirements.docs.lock
+++ b/tools/distrib/docgen/requirements.docs.lock
@@ -31,7 +31,7 @@ pyasn1-modules==0.3.0
 pyasn1==0.5.0
 requests==2.25.1
 rsa==4.9
-setuptools==44.1.1
+setuptools==77.0.1
 typing-extensions==4.9.0
 urllib3==1.26.18
 wheel==0.38.1

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -23,6 +23,7 @@ import subprocess
 from subprocess import PIPE
 import sys
 import sysconfig
+import tempfile
 
 import setuptools
 from setuptools import Extension
@@ -130,6 +131,20 @@ class BuildExt(build_ext.build_ext):
         return filename
 
     def build_extensions(self):
+
+        # use short temp directory to avoid linker command file errors caused by
+        # exceeding 131071 characters in Windows.
+        # TODO(ssreenithi): Remove once we have a better solution: b/454497076
+        use_short_temp = os.environ.get(
+            "GRPC_PYTHON_BUILD_USE_SHORT_TEMP_DIR_NAME", 0
+        )
+        if use_short_temp == "1":
+            if not os.path.exists("pyb"):
+                os.mkdir("pyb")
+
+            self.build_temp = tempfile.mkdtemp(dir="pyb")
+            print(f"Using temp build directory: {self.build_temp}")
+
         # This is to let UnixCompiler get either C or C++ compiler options depending on the source.
         # Note that this doesn't work for MSVCCompiler and will be handled by _spawn_patch.py.
         old_compile = self.compiler._compile
@@ -349,7 +364,7 @@ setuptools.setup(
     install_requires=[
         "protobuf>=6.31.1,<7.0.0",
         "grpcio>={version}".format(version=grpc_version.VERSION),
-        "setuptools",
+        "setuptools>=77.0.1",
     ],
     package_data=package_data(),
     cmdclass={

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -145,7 +145,7 @@ then
 
   # python
   time pip install --user -r $DIR/requirements.macos.txt
-  time pip install --user --upgrade virtualenv Mako tox setuptools==44.1.1 twisted
+  time pip install --user --upgrade virtualenv Mako tox setuptools==77.0.1 twisted
 
   # Install Python 3.9 if it doesn't exist
   if [ ! -f "/usr/local/bin/python3.9" ]; then
@@ -202,7 +202,7 @@ then
   export NUGET_XMLDOC_MODE=skip
   export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
   export DOTNET_CLI_TELEMETRY_OPTOUT=true
-  
+
   # Installed versions should be kept in sync with
   # templates/tools/dockerfile/csharp_dotnetcli_deps.include
   time curl -O https://download.visualstudio.microsoft.com/download/pr/e0fe8c99-e33c-4d75-bd4e-2478ed3ee35a/ff06e47afc7c13bdbbaa50a9713ac772/dotnet-sdk-3.1.415-osx-x64.pkg

--- a/tools/internal_ci/macos/grpc_distribtests_python.sh
+++ b/tools/internal_ci/macos/grpc_distribtests_python.sh
@@ -26,12 +26,12 @@ source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 # TODO(jtattermusch): cleanup this prepare build step (needed for python artifact build)
 # install cython for all python versions
-python3.9 -m pip install -U 'cython==3.1.1' setuptools==65.4.1 six==1.16.0 wheel --user
-python3.10 -m pip install -U 'cython==3.1.1' setuptools==65.4.1 six==1.16.0 wheel --user
-python3.11 -m pip install -U 'cython==3.1.1' setuptools==65.4.1 six==1.16.0 wheel --user
-python3.12 -m pip install -U 'cython==3.1.1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
-python3.13 -m pip install -U 'cython==3.1.1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
-python3.14 -m pip install -U 'cython==3.1.1' setuptools==65.4.1 six==1.16.0 wheel --user --break-system-packages
+python3.9 -m pip install -U 'cython==3.1.1' setuptools==77.0.1 six==1.16.0 wheel --user
+python3.10 -m pip install -U 'cython==3.1.1' setuptools==77.0.1 six==1.16.0 wheel --user
+python3.11 -m pip install -U 'cython==3.1.1' setuptools==77.0.1 six==1.16.0 wheel --user
+python3.12 -m pip install -U 'cython==3.1.1' setuptools==77.0.1 six==1.16.0 wheel --user --break-system-packages
+python3.13 -m pip install -U 'cython==3.1.1' setuptools==77.0.1 six==1.16.0 wheel --user --break-system-packages
+python3.14 -m pip install -U 'cython==3.1.1' setuptools==77.0.1 six==1.16.0 wheel --user --break-system-packages
 
 # Build all python macos artifacts (this step actually builds all the binary wheels and source archives)
 tools/run_tests/task_runner.py -f artifact macos python ${TASK_RUNNER_EXTRA_FILTERS} -j 2 -x build_artifacts/sponge_log.xml || FAILED="true"

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -21,7 +21,7 @@ set PATH=C:\msys64\mingw%2\bin;C:\tools\msys64\mingw%2\bin;%PATH%
 
 python -m pip install --upgrade pip six
 @rem Ping to a single version to make sure we're building the same artifacts
-python -m pip install setuptools==69.5.1 wheel==0.43.0
+python -m pip install setuptools==77.0.1 wheel==0.43.0
 python -m pip install --upgrade "cython==3.1.1"
 python -m pip install -rrequirements.txt --user
 
@@ -38,11 +38,16 @@ if "%GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS%"=="" (
 mkdir -p %ARTIFACTS_OUT%
 set ARTIFACT_DIR=%cd%\%ARTIFACTS_OUT%
 
-@rem Set up gRPC Python tools
-python tools\distrib\python\make_grpcio_tools.py
+@rem use short temp directory to avoid linker command file errors caused by
+@rem exceeding 131071 characters.
+@rem TODO(ssreenithi): Remove once we have a better solution: b/454497076
+set "GRPC_PYTHON_BUILD_USE_SHORT_TEMP_DIR_NAME=1"
 
 @rem Build gRPC Python extensions
 python setup.py build_ext -c %EXT_COMPILER% || goto :error
+
+@rem Set up and build gRPC Python tools
+python tools\distrib\python\make_grpcio_tools.py
 
 pushd tools\distrib\python\grpcio_tools
 python setup.py build_ext -c %EXT_COMPILER% || goto :error

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -28,7 +28,7 @@ source tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
 # Needed for building binary distribution wheels -- bdist_wheel
 "${PYTHON}" -m pip install --upgrade pip
 # Ping to a single version to make sure we're building the same artifacts
-"${PYTHON}" -m pip install setuptools==69.5.1 wheel==0.43.0
+"${PYTHON}" -m pip install setuptools==77.0.1 wheel==0.43.0
 
 if [ "$GRPC_SKIP_PIP_CYTHON_UPGRADE" == "" ]
 then

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -87,11 +87,11 @@ function toolchain() {
 }
 
 # When we mount and reuse the existing repo from host machine inside docker
-# container, the `tools/bazel.rc` file is shared to the docker container and 
-# the Bazel override written to `bazel.rc` from tools/.../grpc_build_submodule_at_head.sh 
+# container, the `tools/bazel.rc` file is shared to the docker container and
+# the Bazel override written to `bazel.rc` from tools/.../grpc_build_submodule_at_head.sh
 # (outside docker container) forces bazel to look for the same host location
 # inside the docker container, which doesn't exist.
-# Hence overriding it again with the working directory inside the container 
+# Hence overriding it again with the working directory inside the container
 # should solve this issue
 BAZEL_DEP_PATH="$(pwd)/third_party/protobuf"
 BAZEL_DEP_NAME="com_google_protobuf"
@@ -149,7 +149,7 @@ pip_install() {
 
 pip_install --upgrade pip
 pip_install --upgrade wheel
-pip_install --upgrade setuptools==70.1.1
+pip_install --upgrade setuptools==77.0.1
 
 # pip-installs the directory specified. Used because on MSYS the vanilla Windows
 # Python gets confused when parsing paths.


### PR DESCRIPTION
Backport of #40931 to v1.76.x.
---
This PR updates the minimum version of `setuptools` package required across different Python setup files to v77.0.1. This version contains Python 3.14 support as well as deprecates a format for defining project license in `pyproject.toml` files ([Reference](https://setuptools.pypa.io/en/stable/history.html#id71)) which is a prerequisite for #40833 