### PR TITLE
[Fix][Python] Pin pip version to 25.2 in Python tests

### DIFF
--- a/test/distrib/python/test_packages.sh
+++ b/test/distrib/python/test_packages.sh
@@ -42,7 +42,7 @@ TESTING_ARCHIVES=("$EXTERNAL_GIT_ROOT"/input_artifacts/grpcio[_-]*testing[-_0-9a
 VIRTUAL_ENV=$(mktemp -d)
 python3 -m virtualenv "$VIRTUAL_ENV"
 PYTHON=$VIRTUAL_ENV/bin/python
-"$PYTHON" -m pip install --upgrade six pip wheel setuptools
+"$PYTHON" -m pip install --upgrade six pip==25.2 wheel setuptools
 
 function validate_wheel_hashes() {
   for file in "$@"; do

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -19,7 +19,7 @@ set PATH=C:\%1;C:\%1\scripts;%PATH%
 set PATH=C:\msys64\mingw%2\bin;C:\tools\msys64\mingw%2\bin;%PATH%
 :end_mingw64_installation
 
-python -m pip install --upgrade pip six
+python -m pip install --upgrade pip==25.2 six
 @rem Ping to a single version to make sure we're building the same artifacts
 python -m pip install setuptools==77.0.1 wheel==0.43.0
 python -m pip install --upgrade "cython==3.1.1"

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -26,7 +26,7 @@ export AUDITWHEEL=${AUDITWHEEL:-auditwheel}
 source tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
 
 # Needed for building binary distribution wheels -- bdist_wheel
-"${PYTHON}" -m pip install --upgrade pip
+"${PYTHON}" -m pip install --upgrade pip==25.2
 # Ping to a single version to make sure we're building the same artifacts
 "${PYTHON}" -m pip install setuptools==77.0.1 wheel==0.43.0
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -147,7 +147,7 @@ pip_install() {
   $VENV_PYTHON -m pip install "$@"
 }
 
-pip_install --upgrade pip
+pip_install --upgrade pip==25.2
 pip_install --upgrade wheel
 pip_install --upgrade setuptools==77.0.1
 


### PR DESCRIPTION
Pip released [v25.3](https://pip.pypa.io/en/stable/news/#v25-3) a few days back which doesn't support `setup.py` builds anymore, while we are yet to migrate to use the `pyproject.toml` build system in #40833.

Hence some of our Python tests using the most recent versions of pip for the build have started to fail with errors like:
```
  ERROR: Failed building wheel for grpcio
Failed to build grpcio
error: failed-wheel-build-for-install

× Failed to build installable wheels for some pyproject.toml based projects
```

This PR hence pins the pip version to 25.2 which still supports setup.py build until #40833 is submitted.