### PR TITLE
[interop] Add v1.76.0 for C++, Ruby, PHP

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -892,12 +892,15 @@ LANG_RELEASE_MATRIX = {
                     runtimes=["python"], testcases_file="python__master"
                 ),
             ),
-            (
-                "v1.76.0",
-                ReleaseInfo(
-                    runtimes=["python"], testcases_file="python__master"
-                ),
-            ),
+            # Python images can't be anymore built without #40959 temporary fix,
+            # or #40833 proper pyproject migration.
+            # TODO(sreenithi): update this once v1.76.1 is out.
+            # (
+            #     "v1.76.0",
+            #     ReleaseInfo(
+            #         runtimes=["python"], testcases_file="python__master"
+            #     ),
+            # ),
         ]
     ),
     "node": OrderedDict(


### PR DESCRIPTION
Python version not updated because the image build is broken by a runtime dependency issue. The fix #40959 can't be backported retroactively to the tag.