### PR TITLE
[Ruby] Fix Ruby Distribution Test Linux

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov',          '~> 0.22'
   s.add_development_dependency 'rake',               '~> 13.0'
   s.add_development_dependency 'rake-compiler',      '~> 1.2.1'
-  s.add_development_dependency 'rake-compiler-dock', '== 1.9.1'
+  s.add_development_dependency 'rake-compiler-dock', '= 1.9.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 1.41.0'
   s.add_development_dependency 'signet',             '~> 0.7'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -44,7 +44,7 @@
     s.add_development_dependency 'simplecov',          '~> 0.22'
     s.add_development_dependency 'rake',               '~> 13.0'
     s.add_development_dependency 'rake-compiler',      '~> 1.2.1'
-    s.add_development_dependency 'rake-compiler-dock', '== 1.9.1'
+    s.add_development_dependency 'rake-compiler-dock', '= 1.9.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 1.41.0'
     s.add_development_dependency 'signet',             '~> 0.7'


### PR DESCRIPTION
### Description

Since `October 25, 2025` Distribution Tests Ruby Linux started failing. On the same day a new version of [rake-compiler-dock](https://rubygems.org/gems/rake-compiler-dock) was released - `1.10.0`.

To temporarily fix the Distribution Tests Ruby Linux - fixing the `rake-compiler-dock` to previous version `1.9.1`

### Testing
CI

