### PR TITLE
[Python] Exclude test files in grpcio_tools wheels

### DIFF
--- a/tools/distrib/python/grpcio_tools/pyproject.toml
+++ b/tools/distrib/python/grpcio_tools/pyproject.toml
@@ -53,6 +53,7 @@ exclude = [
     "dist*",
     "grpc_root*",
     "third_party*",
+    "grpc_tools.test*"
 ]
 
 [tool.setuptools.exclude-package-data]
@@ -62,4 +63,7 @@ exclude = [
     "*.cpp",
     "*.cc",
     "*.h",
+]
+"grpc_tools" = [
+    "test/**"
 ]


### PR DESCRIPTION
This PR removes some additional files that were included in the grpcio_tools package wheels after migrating to pyproject.toml build system in #40833 