### PR TITLE
[Fix][Python] Increase timeout for linux distribtests jobs for release and master branch

### DIFF
--- a/tools/internal_ci/linux/pull_request/grpc_distribtests_python.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_distribtests_python.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_distribtests_python.sh"
-timeout_mins: 480
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -406,34 +406,18 @@ def targets():
             ProtocArtifact("windows", "x64", presubmit=True),
             ProtocArtifact("windows", "x86", presubmit=True),
             PythonArtifact("manylinux2014", "x64", "cp39-cp39", presubmit=True),
-            PythonArtifact(
-                "manylinux2014", "x64", "cp310-cp310", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "x64", "cp311-cp311", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "x64", "cp312-cp312", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "x64", "cp313-cp313", presubmit=True
-            ),
+            PythonArtifact("manylinux2014", "x64", "cp310-cp310"),
+            PythonArtifact("manylinux2014", "x64", "cp311-cp311"),
+            PythonArtifact("manylinux2014", "x64", "cp312-cp312"),
+            PythonArtifact("manylinux2014", "x64", "cp313-cp313"),
             PythonArtifact(
                 "manylinux2014", "x64", "cp314-cp314", presubmit=True
             ),
             PythonArtifact("manylinux2014", "x86", "cp39-cp39", presubmit=True),
-            PythonArtifact(
-                "manylinux2014", "x86", "cp310-cp310", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "x86", "cp311-cp311", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "x86", "cp312-cp312", presubmit=True
-            ),
-            PythonArtifact(
-                "manylinux2014", "x86", "cp313-cp313", presubmit=True
-            ),
+            PythonArtifact("manylinux2014", "x86", "cp310-cp310"),
+            PythonArtifact("manylinux2014", "x86", "cp311-cp311"),
+            PythonArtifact("manylinux2014", "x86", "cp312-cp312"),
+            PythonArtifact("manylinux2014", "x86", "cp313-cp313"),
             PythonArtifact(
                 "manylinux2014", "x86", "cp314-cp314", presubmit=True
             ),
@@ -448,50 +432,26 @@ def targets():
                 "manylinux2014", "aarch64", "cp314-cp314", presubmit=True
             ),
             PythonArtifact("linux_extra", "armv7", "cp39-cp39", presubmit=True),
-            PythonArtifact(
-                "linux_extra", "armv7", "cp310-cp310", presubmit=True
-            ),
-            PythonArtifact(
-                "linux_extra", "armv7", "cp311-cp311", presubmit=True
-            ),
-            PythonArtifact(
-                "linux_extra", "armv7", "cp312-cp312", presubmit=True
-            ),
-            PythonArtifact(
-                "linux_extra", "armv7", "cp313-cp313", presubmit=True
-            ),
+            PythonArtifact("linux_extra", "armv7", "cp310-cp310"),
+            PythonArtifact("linux_extra", "armv7", "cp311-cp311"),
+            PythonArtifact("linux_extra", "armv7", "cp312-cp312"),
+            PythonArtifact("linux_extra", "armv7", "cp313-cp313"),
             PythonArtifact(
                 "linux_extra", "armv7", "cp314-cp314", presubmit=True
             ),
             PythonArtifact("musllinux_1_2", "x64", "cp39-cp39", presubmit=True),
-            PythonArtifact(
-                "musllinux_1_2", "x64", "cp310-cp310", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_2", "x64", "cp311-cp311", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_2", "x64", "cp312-cp312", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_2", "x64", "cp313-cp313", presubmit=True
-            ),
+            PythonArtifact("musllinux_1_2", "x64", "cp310-cp310"),
+            PythonArtifact("musllinux_1_2", "x64", "cp311-cp311"),
+            PythonArtifact("musllinux_1_2", "x64", "cp312-cp312"),
+            PythonArtifact("musllinux_1_2", "x64", "cp313-cp313"),
             PythonArtifact(
                 "musllinux_1_2", "x64", "cp314-cp314", presubmit=True
             ),
             PythonArtifact("musllinux_1_2", "x86", "cp39-cp39", presubmit=True),
-            PythonArtifact(
-                "musllinux_1_2", "x86", "cp310-cp310", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_2", "x86", "cp311-cp311", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_2", "x86", "cp312-cp312", presubmit=True
-            ),
-            PythonArtifact(
-                "musllinux_1_2", "x86", "cp313-cp313", presubmit=True
-            ),
+            PythonArtifact("musllinux_1_2", "x86", "cp310-cp310"),
+            PythonArtifact("musllinux_1_2", "x86", "cp311-cp311"),
+            PythonArtifact("musllinux_1_2", "x86", "cp312-cp312"),
+            PythonArtifact("musllinux_1_2", "x86", "cp313-cp313"),
             PythonArtifact(
                 "musllinux_1_2", "x86", "cp314-cp314", presubmit=True
             ),


### PR DESCRIPTION
The newly migrated pyproject.toml build system (in #40833) seems to have much slower build times compared to the previous setup.py builds. This difference has also been noted by few users ([Ref1](https://github.com/pypa/pip/issues/7294), [Ref2](https://zameermanji.com/blog/2021/6/14/building-wheels-with-pip-is-getting-slower/)) most likely due to the overhead of creating isolated build environments for each build. 

Some new runtimes for each variant target noted from different recent runs below:
```
2025-11-01 10:19:02,937 PASSED: build_artifact.python_musllinux_1_2_x86_cp312-cp312 [time=4267.1sec, retries=0:0]
2025-11-01 10:19:05,501 PASSED: build_artifact.python_musllinux_1_2_x86_cp311-cp311 [time=4269.7sec, retries=0:0]
2025-11-01 10:19:07,152 PASSED: build_artifact.python_musllinux_1_2_x86_cp310-cp310 [time=4287.0sec, retries=0:0]

2025-11-01 11:43:22,269 PASSED: build_artifact.python_manylinux2014_x86_cp312-cp312 [time=4644.4sec, retries=0:0]
2025-11-01 11:43:37,257 PASSED: build_artifact.python_manylinux2014_x86_cp314-cp314 [time=4659.4sec, retries=0:0]
2025-11-01 11:43:37,525 PASSED: build_artifact.python_manylinux2014_x86_cp311-cp311 [time=4659.7sec, retries=0:0]
2025-11-01 11:43:40,671 PASSED: build_artifact.python_manylinux2014_x86_cp310-cp310 [time=4662.8sec, retries=0:0]
2025-11-01 11:43:51,663 PASSED: build_artifact.python_manylinux2014_x86_cp39-cp39 [time=4673.8sec, retries=0:0]
2025-11-01 11:43:51,708 PASSED: build_artifact.python_manylinux2014_x86_cp313-cp313 [time=4673.8sec, retries=0:0]

2025-11-01 04:59:11,117 PASSED: build_artifact.python_linux_extra_armv7_cp311-cp311 [time=5172.2sec, retries=0:0]
2025-11-01 04:59:31,002 PASSED: build_artifact.python_linux_extra_armv7_cp314-cp314 [time=5157.0sec, retries=0:0]
2025-11-01 04:59:53,485 PASSED: build_artifact.python_linux_extra_armv7_cp39-cp39 [time=5221.7sec, retries=0:0]
```

The builds take anywhere between 70-90 minutes for each target. We have a total of 30 targets currently and 12 targets  are built parallelly in a batch. So for about 3 batches of 12 targets each and a worst case time of 90 minutes per batch, the `build_artifact` phase itself should take about 4.5 hours to complete, followed by the remaining `package` and `distribtest` phases which should be comparatively shorter. 

So, I believe about 7 hours should be enough, but just keeping an extra buffer and increasing the timeout to 8 hours.