### PR TITLE
[BCR] Update BCR maintainers in the metadata template.

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -36,7 +36,7 @@
             "github": "asheshvidyut",
             "name": "Ashesh Vidyut",
             "github_user_id": 134911583
-        }
+        },
         {
             "email": "ssreenithi@google.com",
             "github": "sreenithi",


### PR DESCRIPTION
Update the template used to export BCR releases. Fixes the issue with emeritus owners getting pinged/assigned for BCR gRPC PRs.

Once this is merged, @yuanweiz will manually update corresponding https://github.com/bazelbuild/bazel-central-registry/blob/1c61954df7e15bfbd03eef8accc7ae4e98ec548b/modules/grpc/metadata.json

- Offboard @veblush, @eugeneo, @hork, @yashkt, @apolcyn, @stanleycheung
- Add @yuanweiz, BCR integration owner
- Add @asheshvidyut, now owns Ruby and other wrapped languages
