### PR TITLE
[CI] Add a github workflow for publishing to bcr.

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -8,11 +8,13 @@ on:
       tag_name:
         required: true
         type: string
+
   # In case of problems, let release engineers retry by manually dispatching
   # the workflow from the GitHub UI
   workflow_dispatch:
     inputs:
       tag_name:
+        description: "gRPC tag to deploy"
         required: true
         type: string
 
@@ -25,9 +27,7 @@ jobs:
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: grpc/bazel-central-registry
     permissions:
-      attestations: write
       contents: write
-      id-token: write
     secrets:
       # Necessary to push to the BCR fork, and to open a pull request against a registry
       publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
Based on https://github.com/bazel-contrib/publish-to-bcr.