### PR TITLE
[Experiment][Python] Verifying GRPC_POSTMORTEM_CHECKS set on CI - BASELINE

### DIFF
--- a/src/core/util/grpc_check.h
+++ b/src/core/util/grpc_check.h
@@ -16,6 +16,8 @@
 #define GRPC_SRC_CORE_UTIL_GRPC_CHECK_H
 
 #ifdef GRPC_POSTMORTEM_CHECKS
+#error Verifying GRPC_POSTMORTEM_CHECKS set on CI
+
 #include <limits.h>
 
 #include "src/core/util/postmortem_emit.h"


### PR DESCRIPTION
> [!CAUTION]
> DO NOT MERGE

To compare the list of failed jobs with #41038, where `GRPC_POSTMORTEM_CHECKS` set via `tools/remote_build/include/test_config_common.bazelrc`