### PR TITLE
[subchannel] remove no-op code to remove channelz linkage

### DIFF
--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -422,12 +422,6 @@ class Subchannel::ConnectedSubchannelStateWatcher final
             << ": Connected subchannel " << connected_subchannel.get()
             << " reports " << ConnectivityStateName(new_state) << ": "
             << status;
-        if (c->channelz_node() != nullptr) {
-          if (connected_subchannel->channelz_node() != nullptr) {
-            connected_subchannel->channelz_node()->RemoveParent(
-                c->channelz_node());
-          }
-        }
         // If the subchannel was created from an endpoint, then we report
         // TRANSIENT_FAILURE here instead of IDLE. The subchannel will never
         // leave TRANSIENT_FAILURE state, because there is no way for us to


### PR DESCRIPTION
This code appears to be a no-op.  It removes the `Subchannel`'s channelz node as a parent of the `ConnectedSubchannel`'s channelz node when the `ConnectedSubchannel` becomes disconnected.  However, the `ConnectedSubchannel`'s channelz node [is exactly the same node as the `Subchannel`'s channelz node](https://github.com/grpc/grpc/blob/4a97f0950a5fbe422f8cc2965c3055fa2d70444e/src/core/client_channel/subchannel.cc#L842), so this is attempting to remove a node from its own parent list -- and it should never be present in its own parent list in the first place, so this will be a no-op.

This code was originally intended to remove the linkage between the subchannel node and the *socket* node (owned by the transport, not the `ConnectedSubchannel`) when the transport reports disconnection to the subchannel.  However, it looks like it was accidentally broken in c675ef88599d9a86684c68ff90cb5420b38f9703 (cl/786454401) as part of switching from recording children to recording parents.

Rather than fixing this, however, I think we should just remove this code.  The transport will report a "disconnection" to the subchannel when it receives a GOAWAY, but the connection will actually remain alive for a short time afterwards if there are still RPCs in flight on the connection, and I think we want channelz to show the connection as still being associated with the subchannel until it actually gets closed, since that provides useful context about where the connection came from.  (That behavior would have been hard to achieve when we were still recording children instead of parents.)

Note that the subchannel may wind up creating a new connection before the old connection is actually closed, but the channelz data model allows multiple sockets per subchannel for exactly this case.  Java and Go both keep the socket associated with the subchannel until it's closed, so this change makes the behavior consistent across languages.