### PR TITLE
[ruby] Fix version comparison for the `ruby_abi_version` symbol for ruby 4 compatibility 

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -161,7 +161,7 @@ def have_ruby_abi_version()
   end
   major = m[1].to_i
   minor = m[2].to_i
-  if major >= 3 and minor >= 2
+  if ([major, minor] <=> [3, 2]) >= 0
     puts "Ruby version #{RUBY_VERSION} >= 3.2. Assuming ruby_abi_version symbol is present."
     return true
   end


### PR DESCRIPTION
The next version of Ruby will be 4.0.0. Previously, development versions didn't load properly due to grpc.so not exporting the `ruby_abi_version` symbol. Correct the version comparison logic so we export the symbol on version 4.0.



Note:
```
irb(main):001> [4, 0] <=> [3, 2]
=> 1
irb(main):002> [3, 2] <=> [3, 2]
=> 0
irb(main):003> [3, 0] <=> [3, 2]
=> -1
irb(main):004> [2, 7] <=> [3, 2]
=> -1
```
