### PR TITLE
[ruby] Fix version comparison for the ruby_abi_version symbol for ruby 4 compatibility

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -14,7 +14,6 @@
 
 require 'etc'
 require 'mkmf'
-require 'rubygems'
 require_relative '../../lib/grpc/version.rb'
 
 windows = RUBY_PLATFORM =~ /mingw|mswin/
@@ -167,7 +166,7 @@ def have_ruby_abi_version()
       false
     end
   rescue ArgumentError
-    puts "Failed to parse ruby version  #{RUBY_VERSION}."
+    puts "Failed to parse ruby version  #{RUBY_VERSION}. Assuming ruby_abi_version symbol is NOT present."
     false
   end
 end


### PR DESCRIPTION
The next version of Ruby will be 4.0.0. Previously, development versions didn't load properly due to grpc.so not exporting the ruby_abi_version symbol. Correct the version comparison logic so we export the symbol on version 4.0.
