### PR TITLE
fix trigraph warning in function_signature.h

### DIFF
--- a/src/core/util/function_signature.h
+++ b/src/core/util/function_signature.h
@@ -31,7 +31,9 @@
 #elif defined(__GNUC__)
 #define GRPC_FUNCTION_SIGNATURE __PRETTY_FUNCTION__
 #else
-#define GRPC_FUNCTION_SIGNATURE "??""?()"
+#define GRPC_FUNCTION_SIGNATURE \
+  "??"                          \
+  "?()"
 #endif
 
 namespace grpc_core {


### PR DESCRIPTION
Depending on the compiler, using a trigraph may warn; it's easily avoided.

See our patch in [tensorstore](https://github.com/google/tensorstore/blob/master/third_party/grpc/patches/fix_trigraph.diff)

