### PR TITLE
[Bazel]: replace native calls with corresponding rule functions in Bazel files

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,8 +38,9 @@ bazel_dep(name = "protobuf", version = "31.1", repo_name = "com_google_protobuf"
 bazel_dep(name = "protoc-gen-validate", version = "1.2.1.bcr.1", repo_name = "com_envoyproxy_protoc_gen_validate")  # Not needed directly
 bazel_dep(name = "re2", version = "2024-07-02", repo_name = "com_googlesource_code_re2")  # mistmached 2022-04-01
 bazel_dep(name = "rules_apple", version = "3.16.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_cc", version = "0.2.13")
 bazel_dep(name = "rules_proto", version = "7.0.2")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "xds", version = "0.0.0-20240423-555b57e", repo_name = "com_github_cncf_xds")  # mismatched 20231116
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 
@@ -55,7 +56,6 @@ switched_rules.use_languages(
 
 bazel_dep(name = "fuzztest", version = "20241028.0", dev_dependency = True, repo_name = "com_google_fuzztest")  # mistmached 2023-05-16
 bazel_dep(name = "google_benchmark", version = "1.9.0", dev_dependency = True, repo_name = "com_github_google_benchmark")
-bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 
 # Python dependencies
 # ===================

--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -14,6 +14,7 @@
 """Generates and compiles C++ grpc stubs from proto_library rules."""
 
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//bazel:generate_cc.bzl", "generate_cc")
 load("//bazel:protobuf.bzl", "well_known_proto_libs")
@@ -112,7 +113,7 @@ def cc_grpc_library(
             **kwargs
         )
 
-        native.cc_library(
+        cc_library(
             name = name,
             srcs = [":" + codegen_grpc_target],
             hdrs = [":" + codegen_grpc_target],

--- a/bazel/cython_library.bzl
+++ b/bazel/cython_library.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Custom rules for gRPC Python"""
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_python//python:defs.bzl", "py_library")
 
 # Adapted with modifications from
@@ -71,7 +72,7 @@ def pyx_library(name, deps = [], py_deps = [], srcs = [], **kwargs):
     for src in pyx_srcs:
         stem = src.split(".")[0]
         shared_object_name = stem + ".so"
-        native.cc_binary(
+        cc_binary(
             name = shared_object_name,
             srcs = [stem + ".cpp"],
             deps = deps + ["@local_config_python//:python_headers"],

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -32,8 +32,14 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
 load("@com_google_protobuf//bazel:upb_proto_library.bzl", "upb_proto_library", "upb_proto_reflection_library")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
 load("//bazel:copts.bzl", "GRPC_DEFAULT_COPTS")
 load("//bazel:experiments.bzl", "EXPERIMENTS", "EXPERIMENT_ENABLES", "EXPERIMENT_POLLERS")
@@ -151,7 +157,7 @@ def grpc_cc_library(
     # See b/391433873.
     if "fuzztest" in external_deps and "grpc-fuzztest" not in tags:
         tags = tags + ["grpc-fuzztest"]
-    native.cc_library(
+    cc_library(
         name = name,
         srcs = srcs,
         defines = defines +
@@ -186,7 +192,7 @@ def grpc_cc_library(
     )
 
 def grpc_proto_plugin(name, srcs = [], deps = []):
-    native.cc_binary(
+    cc_binary(
         name = name + "_native",
         srcs = srcs,
         deps = deps,
@@ -289,7 +295,7 @@ def ios_cc_test(
         device_type = "iPhone X",
     )
     if not any([t for t in tags if t.startswith("no_test_ios")]):
-        native.objc_library(
+        objc_library(
             name = test_lib_ios,
             srcs = kwargs.get("srcs"),
             deps = kwargs.get("deps"),
@@ -582,7 +588,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
             **test_args
         )
 
-    native.cc_library(
+    cc_library(
         name = "%s_TEST_LIBRARY" % name,
         testonly = 1,
         srcs = srcs,
@@ -596,7 +602,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
             fail("srcs changed")
         if poller_config["deps"] != core_deps:
             fail("deps changed: %r --> %r" % (deps, poller_config["deps"]))
-        native.cc_test(
+        cc_test(
             name = poller_config["name"],
             deps = ["%s_TEST_LIBRARY" % name],
             tags = poller_config["tags"],
@@ -625,7 +631,7 @@ def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], da
     """
     visibility = _update_visibility(visibility)
     copts = []
-    native.cc_binary(
+    cc_binary(
         name = name,
         srcs = srcs,
         args = args,
@@ -691,7 +697,7 @@ def grpc_sh_test(name, srcs = [], args = [], data = [], uses_polling = True, siz
     }
 
     for poller_config in expand_tests(name, srcs, [], tags, args, exclude_pollers, uses_polling, uses_event_engine, flaky):
-        native.sh_test(
+        sh_test(
             name = poller_config["name"],
             srcs = poller_config["srcs"],
             deps = poller_config["deps"],
@@ -703,7 +709,7 @@ def grpc_sh_test(name, srcs = [], args = [], data = [], uses_polling = True, siz
         )
 
 def grpc_sh_binary(name, srcs, data = []):
-    native.sh_binary(
+    sh_binary(
         name = name,
         srcs = srcs,
         data = data,
@@ -791,7 +797,7 @@ def grpc_objc_library(
         visibility: visibility, default to public
     """
 
-    native.objc_library(
+    objc_library(
         name = name,
         hdrs = hdrs,
         srcs = srcs,

--- a/bazel/objc_grpc_library.bzl
+++ b/bazel/objc_grpc_library.bzl
@@ -15,6 +15,7 @@
 Contains the objc_grpc_library rule.
 """
 
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
     "//bazel:generate_objc.bzl",
     "generate_objc",
@@ -63,7 +64,7 @@ def objc_grpc_library(name, deps, srcs = [], use_well_known_protos = False, **kw
         )
         arc_srcs = [":" + objc_grpc_library_name + "_srcs"]
 
-    native.objc_library(
+    objc_library(
         name = name,
         hdrs = [":" + objc_grpc_library_name + "_hdrs"],
         non_arc_srcs = [":" + objc_grpc_library_name + "_non_arc_srcs"],

--- a/grpc.bzl
+++ b/grpc.bzl
@@ -20,6 +20,8 @@ This file declares two macros:
 - objc_grpc_library
 """
 
+load("@rules_cc//cc:objc_library.bzl", "objc_library")
+
 def _lower_underscore_to_upper_camel(str):
     humps = []
     for hump in str.split("_"):
@@ -73,7 +75,7 @@ def objc_proto_library(name, srcs, visibility = None):
         outs = h_files + m_files,
         cmd = _protoc_invocation(srcs, protoc_flags),
     )
-    native.objc_library(
+    objc_library(
         name = name,
         hdrs = h_files,
         includes = ["."],
@@ -114,7 +116,7 @@ def objc_grpc_library(name, services, other_messages, visibility = None):
         outs = h_files + m_files,
         cmd = _protoc_invocation(services, protoc_flags),
     )
-    native.objc_library(
+    objc_library(
         name = name,
         hdrs = h_files,
         includes = ["."],

--- a/third_party/address_sorting/address_sorting.bzl
+++ b/third_party/address_sorting/address_sorting.bzl
@@ -28,8 +28,10 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 
-def address_sorting_cc_library(name, srcs, hdrs, copts, includes, linkopts=[]):
-    native.cc_library(
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+def address_sorting_cc_library(name, srcs, hdrs, copts, includes, linkopts = []):
+    cc_library(
         name = name,
         srcs = srcs,
         hdrs = hdrs,

--- a/tools/bazelify_tests/build_defs.bzl
+++ b/tools/bazelify_tests/build_defs.bzl
@@ -17,6 +17,7 @@ Contains macros used for running bazelified tests.
 """
 
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(":dockerimage_current_versions.bzl", "DOCKERIMAGE_CURRENT_VERSIONS")
 
 def _dockerized_sh_test(name, srcs = [], args = [], data = [], size = "medium", timeout = None, tags = [], exec_compatible_with = [], flaky = None, docker_image_version = None, docker_run_as_root = False, env = {}):
@@ -59,7 +60,7 @@ def _dockerized_sh_test(name, srcs = [], args = [], data = [], size = "medium", 
         "exec_properties": exec_properties,
     }
 
-    native.sh_test(
+    sh_test(
         **test_args
     )
 


### PR DESCRIPTION
#### Description

Replace native calls with corresponding rule functions in Bazel files for Bazel 9 compliance