### PR TITLE
Fix: Semgrep missing-user

### DIFF
--- a/src/php/docker/alpine/Dockerfile
+++ b/src/php/docker/alpine/Dockerfile
@@ -33,6 +33,10 @@ COPY . .
 RUN pear package && \
   find . -name grpc-*.tgz | xargs -I{} pecl install {}
 
+RUN adduser -D -s /bin/sh grpcuser && \
+  chown -R grpcuser:grpcuser /github/grpc
+
+USER grpcuser
 
 CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests", \
      "--ignore-valgrind-undef-errors"]


### PR DESCRIPTION
## Summary
This pull request resolves the Semgrep finding `missing-user`, which warns that the Dockerfile does not explicitly specify a non-root user. Running containers as `root` introduces significant security risks, making it easier for an attacker to escalate privileges if they gain access to the running process.

## Change Details
### Modified File
`src/php/docker/alpine/Dockerfile`

### Updates
- Added creation of a dedicated non-root user:
  ```dockerfile
  RUN adduser -D -s /bin/sh grpcuser && \
      chown -R grpcuser:grpcuser /github/grpc
Set the final active user for the Docker image::
`USER grpcuser
`
Ensures that the command executed at runtime: `CMD ["/github/grpc/src/php/bin/run_tests.sh", ...]` is now executed under the non-root grpcuser.

## Rationale

By default, Docker containers run as root unless a USER is explicitly defined. This presents a security hazard if any part of the process becomes compromised. Introducing a dedicated, limited-privilege user aligns with Docker security best practices and satisfies the Semgrep rule requirement.

## Verification

Semgrep warning fully resolved.
Dockerfile remains functional and buildable after introducing the new user.
Permission adjustments (chown) ensure the container has appropriate access under the new user.
