### PR TITLE
[Python] Disable layering check in grpc_tools:protoc_lib

### DIFF
--- a/tools/distrib/python/grpcio_tools/BUILD.bazel
+++ b/tools/distrib/python/grpcio_tools/BUILD.bazel
@@ -32,6 +32,10 @@ cc_library(
     name = "protoc_lib",
     srcs = ["grpc_tools/main.cc"],
     hdrs = ["grpc_tools/main.h"],
+    # TODO(rishesh007): fix once grpc_plugin_support also has layering_check enabled
+    features = [
+        "-layering_check",
+    ],
     includes = ["."],
     deps = [
         "//src/compiler:grpc_plugin_support",


### PR DESCRIPTION
Python Bazel tests have been failing since yesterday after layering check was enabled in grpcio_tools build in commit: https://github.com/grpc/grpc/commit/756389e9e75ba93d7316ef9eae2ca83126ad9f94

Temporarily disabling it after discussing IRL with @rishesh007 