### PR TITLE
[Python] Clarify fork requirements in Python multiprocessing example

### DIFF
--- a/examples/python/multiprocessing/server.py
+++ b/examples/python/multiprocessing/server.py
@@ -109,16 +109,16 @@ def main():
         sys.stdout.flush()
         workers = []
         for _ in range(_PROCESS_COUNT):
-            # NOTE: It is imperative that the parent process forks child processes
-            # BEFORE the parent process creates a gRPC server. See
+            # NOTE: It is imperative that the parent process fork child processes
+            # BEFORE the parent process starts a gRPC server. See
             # https://github.com/grpc/grpc/issues/16001 for more details.
             #
-            # In this example, the parent process never creates a gRPC server
+            # In this example, the parent process never starts a gRPC server
             # for its own use - it only forks worker processes.
-            # Each forked child then independently creates its own server.
+            # Each forked child then independently starts its own server.
             # Since forked processes have independent address spaces, it doesn't matter
             # if some children start their servers while others are still being forked.
-            # The crucial point is that THIS (parent) process hasn't created a gRPC server.
+            # The crucial point is that THIS (parent) process hasn't started a gRPC server.
             worker = multiprocessing.Process(
                 target=_run_server, args=(bind_address,)
             )


### PR DESCRIPTION
The previous comment could be misinterpreted to mean that all child processes must be forked before any of them start their gRPC servers.

This commit clarifies that the actual requirement is that the parent process must fork before IT loads the gRPC library. In this example, the parent never loads gRPC and only forks workers, and each child independently loads gRPC after being forked.

Since forked processes have independent address spaces, it doesn't matter if some children start servers while others are being forked.

Addresses confusion identified in #41082.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

