### PR TITLE
[PHP] Fix Maximum Call Stack Size errors

### DIFF
--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -23,6 +23,7 @@
 
 #include "call_credentials.h"
 
+#include <ext/standard/php_var.h>
 #include <ext/spl/spl_exceptions.h>
 #include <zend_exceptions.h>
 


### PR DESCRIPTION
### Description

This PR is one possible fix for https://github.com/grpc/grpc/issues/39509 and https://github.com/googleapis/google-cloud-php/issues/8015

**Note** - This might not be the best possible fix, but this should fix the issue at hand.

#### Details 

Inspecting the source code of [php](https://github.com/php/php-src) this is the place where the stack memory is checked and this exception is thrown.
https://github.com/php/php-src/blob/master/Zend/zend_execute.c#L2618

This PR sets `EG(stack_limit)` to `NULL`, just before the `zend_call_function` call, and then sets it back to its original value after the call_function is done.

This is where the check happens - 

https://github.com/php/php-src/blob/master/Zend/zend_call_stack.h#L56-L58

```c
static zend_always_inline bool zend_call_stack_overflowed(void *stack_limit) {
	return (uintptr_t) zend_call_stack_position() <= (uintptr_t) stack_limit;
}
```

Since in this PR, we are setting `stack_limit` to `NULL`, the above check always return `false`, but this is only disabled until the callback is run. 

### Rationale

This is basically equivalent to setting `zend.max_allowed_stack_size = -1`, but instead of setting it for the entire application, this disables the stack limit check for the call back and for limited execution of code. 

### Testing

Testing using below Dockerfile - 

```DockerFile
FROM php:8.4-cli-alpine

RUN apk add --no-cache git grpc-cpp grpc-dev $PHPIZE_DEPS

COPY . /tmp/grpc

RUN cd /tmp/grpc/src/php/ext/grpc && \
    phpize && \
    ./configure && \
    make && \
    make install && \
    rm -rf /tmp/grpc && \
    echo "extension=grpc.so" > /usr/local/etc/php/conf.d/grpc.ini

RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

WORKDIR /app
RUN git clone https://github.com/GoogleCloudPlatform/php-docs-samples .

RUN if [ -f firestore/composer.json ]; then cd firestore && composer install; fi

COPY application_default_credentials.json /app/credentials.json
ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json


ENV GOOGLE_CLOUD_PROJECT=<project>
CMD sh -c "php /app/firestore/src/setup_dataset.php <project> && php /app/firestore/src/query_filter_eq_string.php <project>"
```

The same DockerFile fails on `master` branch with `Maximum call stack size` exception but works fine on this branch.

Output - 

```shell
asheshvidyut@asheshvidyut:~/grpc$ docker run --rm grpc-php-fix
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1764863621.201325      21 call_credentials.c:168] GRPC_PHP: call credentials plugin function - begin
I0000 00:00:1764863621.270335      21 call_credentials.c:176] GRPC_PHP: call credentials plugin function - end
Added data to the lovelace document in the users collection.
I0000 00:00:1764863622.698260       7 call_credentials.c:168] GRPC_PHP: call credentials plugin function - begin
I0000 00:00:1764863622.698319       7 call_credentials.c:176] GRPC_PHP: call credentials plugin function - end
Added data to the aturing document in the users collection.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1764863623.201971      38 call_credentials.c:168] GRPC_PHP: call credentials plugin function - begin
I0000 00:00:1764863623.269525      38 call_credentials.c:176] GRPC_PHP: call credentials plugin function - end
asheshvidyut@asheshvidyut:~/grpc$
```
 