### PR TITLE
[Fix][CI] Skip tests build in gcc-8 portability tests

### DIFF
--- a/tools/bazelify_tests/test/portability_tests.bzl
+++ b/tools/bazelify_tests/test/portability_tests.bzl
@@ -55,7 +55,6 @@ def generate_run_tests_portability_tests(name):
         compiler_configs = [
             # Some gRPC tests have an issue with gcc-7 so gcc-7 portability test won't build any gRPC tests
             ["gcc_7", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=17 --cmake_configure_extra_args=-DgRPC_BUILD_TESTS=OFF", "tools/dockerfile/test/cxx_gcc_7_x64.current_version"],
-
             # With gcc-8, building gRPC buildtests_cxx target either times out,
             # or fails with collect2: fatal error: ld terminated with signal 9.
             # We investigated this as an OOM issue, but increasing memory limits
@@ -72,7 +71,6 @@ def generate_run_tests_portability_tests(name):
             #
             # See build_cxx.sh for details on make targets built when
             # -DgRPC_BUILD_TESTS=OFF is set.
-
             ["gcc_8", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=17 --cmake_configure_extra_args=-DgRPC_BUILD_TESTS=OFF", "tools/dockerfile/test/cxx_gcc_8_x64.current_version"],
             ["gcc_14_cxx20", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=20", "tools/dockerfile/test/cxx_gcc_14_x64.current_version"],
             ["gcc10.2_openssl102", "--cmake_configure_extra_args=-DCMAKE_CXX_STANDARD=17 --cmake_configure_extra_args=-DgRPC_SSL_PROVIDER=package", "tools/dockerfile/test/cxx_debian11_openssl102_x64.current_version"],


### PR DESCRIPTION
Fixes "Bazel RBE Non-Bazel Tests" job timeouts. This affects:

- [`grpc/core/master/linux/bazel_rbe/grpc_bazel_rbe_nonbazel`](https://btx.cloud.google.com/invocations;p=830293263384?q=JOB_NAME:grpc%2Fcore%2Fmaster%2Flinux%2Fbazel_rbe%2Fgrpc_bazel_rbe_nonbazel)
- [`grpc/core/pull_request/linux/bazel_rbe/grpc_bazel_rbe_nonbazel`](https://btx.cloud.google.com/invocations;p=830293263384?q=JOB_NAME:grpc%2Fcore%2Fpull_request%2Flinux%2Fbazel_rbe%2Fgrpc_bazel_rbe_nonbazel)

The issue is with the `//tools/bazelify_tests/test:runtests_cpp_linux_dbg_gcc_8_build_only` target, which is a part of the portability suite (`//tools/bazelify_tests/test:portability_tests_linux`). With gcc-8, building `buildtests_cxx` make target either times out, or fails with `collect2: fatal error: ld terminated with signal 9`. 

I've investigated this as an OOM issue (a common cause of `collect2: fatal error: ld terminated`), but increasing memory limits does not help. I've updated RBE stack from `n1-standard-16` (60 GB RAM) to `e2-standard-32` (128 GB RAM) with no effect. Increasing various job timeouts (kokoro, bazel, target, etc) didn't help either. See PR #41028 for more details and other attempts at root-causing. 

The most important part of portability tests is to verify that gRPC can be built with all supported compilers. Since we are having a problem with building the tests with gcc-8, we've decided to stop covering the tests for that compiler..

Specifically, this PR changes `runtests_c*_linux_dbg_gcc_8_build_only` bazel target to skip building test make targets (via `--cmake_configure_extra_args=-DgRPC_BUILD_TESTS=OFF`), and only build `grpc++` make target. See `build_cxx.sh`: https://github.com/grpc/grpc/blob/cb2db8fc21b31ac322d463dff5b7eff9fbbab97d/tools/run_tests/helper_scripts/build_cxx.sh#L49-L55

Notes and observations:
- Only gcc-8 and only cpp version is affected:
   - Portability tests for other gcc versions have no problems building `buildtests_cxx` of their corresponding `runtests_c*_linux_dbg_gcc_*_build_only`.
   - The C version of gcc-8 portability test (`runtests_c_linux_dbg_gcc_8_build_only`) has not issues building tests ([sample run with full target log](https://btx.cloud.google.com/invocations/0b3d41e7-3cf2-4ff8-b6d5-2bc0d52179cd/targets/%2F%2Ftools%2Fbazelify_tests%2Ftest:runtests_c_linux_dbg_gcc_8_build_only;config=815e4ca9071c7e1d8ca72b9c87c1347399a51eb1246eb9c49dd54d9a24ef5cba/tests)).
- However, unfortunately, this change skips the test targets for `runtests_c_linux_dbg_gcc_8_build_only` too.
- We already had the logic to skip tests for gcc-7, but for a different reason: #37257