### PR TITLE
[Fix][CI] grpc_bazel_rbe_nonbazel job: align kokoro and bazel timeouts

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe_nonbazel.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_nonbazel.cfg
@@ -16,7 +16,10 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_rbe.sh"
+
+# When updating Kokoro timeout_mins, update RBE test_timeout as well!
 timeout_mins: 210
+
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
@@ -37,7 +40,12 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation
   key: "BAZEL_FLAGS"
-  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --cache_test_results=no --test_timeout=5400"
+  # RBE test_timeout = Kokoro timeout_mins - 30 minutes.
+  value:
+    " --genrule_strategy=remote,local"
+    " --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh"
+    " --cache_test_results=no"
+    " --test_timeout=10800"
 }
 
 env_vars {

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_nonbazel.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_nonbazel.cfg
@@ -16,7 +16,10 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_bazel_rbe.sh"
-timeout_mins: 150
+
+# When updating Kokoro timeout_mins, update RBE test_timeout as well!
+timeout_mins: 150  # 2.5 hours
+
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
@@ -37,7 +40,11 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation
   key: "BAZEL_FLAGS"
-  value: "--genrule_strategy=remote,local --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh --test_timeout=5400"
+  # RBE test_timeout = Kokoro timeout_mins - 30 minutes.
+  value:
+    " --genrule_strategy=remote,local"
+    " --workspace_status_command=tools/bazelify_tests/workspace_status_cmd.sh"
+    " --test_timeout=7200"
 }
 
 env_vars {


### PR DESCRIPTION
Target `//tools/bazelify_tests/test:cpp_distribtest_cmake_aarch64_cross_linux` seems to go over Bazel's `--test_timeout` limit from time to time.

Bazel `--test_timeout` flag was initially introduced in #38123 and set to 30 minutes below Kokoro's job `timeout_mins`. Since then, we've increased Kokoro's timeout several times without making corresponding changes to bazel's `test_timeout`.

This PR updates Bazel's test timeout to aligned with Kokoro's job timeout, and adds a reminder to keep those in sync. In addition, I've broken `BAZEL_FLAGS` in multiple lines for better readability, proto text format spec [allows it](https://protobuf.dev/reference/protobuf/textformat-spec/#string).