### PR TITLE
[Security - Test] Fix OpenSSL 1.0.2 tests that incorrectly assume TLS 1.3 is negotiated.

### DIFF
--- a/test/core/tsi/spiffe_ssl_transport_security_test.cc
+++ b/test/core/tsi/spiffe_ssl_transport_security_test.cc
@@ -113,9 +113,23 @@ class SpiffeSslTransportSecurityTest
         CHECK(client_map.ok());
         client_spiffe_bundle_map_ = std::make_shared<RootCertInfo>(*client_map);
       }
+      // In TLS 1.3, the client-side handshake succeeds even if the client sends
+      // a bad certificate. In such a case, the server would fail the TLS
+      // handshake and send an alert to the client as the first application data
+      // message. In TLS 1.2, the client-side handshake will fail if the client
+      // sends a bad certificate.
+      //
+      // For OpenSSL versions < 1.1, TLS 1.3 is not supported, so the
+      // client-side handshake should succeed precisely when the server-side
+      // handshake succeeds. Thus, the expect_client_success_1_3_ is set to
+      // expect_client_success_1_2 in this case.
       expect_server_success_ = expect_server_success;
       expect_client_success_1_2_ = expect_client_success_1_2;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000
       expect_client_success_1_3_ = expect_client_success_1_3;
+#else
+      expect_client_success_1_3_ = expect_client_success_1_2;
+#endif
 
       server_pem_key_cert_pairs_ = static_cast<tsi_ssl_pem_key_cert_pair*>(
           gpr_malloc(sizeof(tsi_ssl_pem_key_cert_pair)));


### PR DESCRIPTION
OpenSSL1.0.2 doesn't support TLS1.3, so the assumption on this test was wrong - it falls back to TLS1.2 behavior.