### PR TITLE
[Fix][CI] Fix master Bazel RBE jobs running on vanilla Ubuntu 22

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe.sh
+++ b/tools/internal_ci/linux/grpc_bazel_rbe.sh
@@ -26,6 +26,11 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 # make sure bazel is available
 tools/bazel version
 
+# Needed for upload_rbe_results.py big_query_utils called by bazel_report_helper.py
+# Note: the versions are locked to the ones supporting python3.10.
+# Google will drop Python 3.10 once it reaches its end of life (2026-10-04)
+pip install --user google-api-python-client==2.187.0 oauth2client==4.1.3
+
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_rbe
 
 bazel_rbe/bazel_wrapper \


### PR DESCRIPTION
Fixes

```pytb
+ python3 ./tools/run_tests/python_utils/upload_rbe_results.py --invocation_id=c9453d05-8c0a-43bc-abb8-1b5d34a163b8
Traceback (most recent call last):
  File "/tmpfs/altsrc/github/grpc/./tools/run_tests/python_utils/upload_rbe_results.py", line 31, in <module>
    import big_query_utils
  File "/tmpfs/altsrc/github/grpc/tools/gcp/utils/big_query_utils.py", line 21, in <module>
    from apiclient import discovery
ModuleNotFoundError: No module named 'apiclient'
```

