### PR TITLE
[Flaky Test] Fix flakiness in test/core/end2end/fuzzers:client_fuzzer

### DIFF
--- a/src/core/lib/channel/promise_based_filter.cc
+++ b/src/core/lib/channel/promise_based_filter.cc
@@ -26,6 +26,7 @@
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/error.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/promise/seq.h"
 #include "src/core/lib/slice/slice.h"
 #include "src/core/util/crash.h"
@@ -157,6 +158,7 @@ std::string BaseCallData::LogTag() const {
 
 void BaseCallData::AddData(channelz::DataSink sink) {
   auto add = [sink, this](grpc_error_handle) mutable {
+    grpc_core::ExecCtx exec_ctx;
     sink.AddData(elem_->filter->name.name(), ChannelzProperties());
     GRPC_CALL_COMBINER_STOP(call_combiner(), "channelz_add_data");
     GRPC_CALL_STACK_UNREF(call_stack_, "channelz_add_data");


### PR DESCRIPTION
Should fix segfaults such as: [link](https://btx.cloud.google.com/invocations/2a7ff9f5-1288-4eb1-af7f-8156c2c73195/targets/%2F%2Ftest%2Fcore%2Fend2end%2Ffuzzers:client_fuzzer;config=d7b7b645eca0f0f72544bd605e83f58b106ac7dc3249fbbe06536134f1eb62b4/log)

