### PR TITLE
[Python][Bazel] bump rules_python to 1.6.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,7 +60,7 @@ bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 # Python dependencies
 # ===================
 
-bazel_dep(name = "rules_python", version = "1.5.4")
+bazel_dep(name = "rules_python", version = "1.6.3")
 
 PYTHON_VERSIONS = [
     "3.9",
@@ -68,7 +68,7 @@ PYTHON_VERSIONS = [
     "3.11",
     "3.12",
     "3.13",
-    "3.14.0b2",
+    "3.14",
 ]
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -22,9 +22,9 @@ def grpc_python_deps():
     if "rules_python" not in native.existing_rules():
         http_archive(
             name = "rules_python",
-            sha256 = "13671d304cfe43350302213a60d93a5fc0b763b0a6de17397e3e239253b61b73",
-            strip_prefix = "rules_python-1.5.4",
-            url = "https://github.com/bazel-contrib/rules_python/releases/download/1.5.4/rules_python-1.5.4.tar.gz",
+            sha256 = "2f5c284fbb4e86045c2632d3573fc006facbca5d1fa02976e89dc0cd5488b590",
+            strip_prefix = "rules_python-1.6.3",
+            url = "https://github.com/bazel-contrib/rules_python/releases/download/1.6.3/rules_python-1.6.3.tar.gz",
         )
 
     python_configure(name = "local_config_python")

--- a/templates/MODULE.bazel.inja
+++ b/templates/MODULE.bazel.inja
@@ -60,7 +60,7 @@ bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 # Python dependencies
 # ===================
 
-bazel_dep(name = "rules_python", version = "1.5.4")
+bazel_dep(name = "rules_python", version = "1.6.3")
 
 PYTHON_VERSIONS = [
     "3.9",
@@ -68,7 +68,7 @@ PYTHON_VERSIONS = [
     "3.11",
     "3.12",
     "3.13",
-    "3.14.0b2",
+    "3.14",
 ]
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")


### PR DESCRIPTION
rules_python changelog:
- https://rules-python.readthedocs.io/en/latest/changelog.html#v1-6-0
- https://rules-python.readthedocs.io/en/latest/changelog.html#v1-6-3

Notably, this fixes [rules_python repl](https://rules-python.readthedocs.io/en/latest/repl.html):

```
$ bazel --quiet run @rules_python//python/bin:repl
INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.0.1 will be used instead of system-wide bazel installation.
Target @@rules_python//python/bin:repl up-to-date:
  bazel-bin/external/rules_python/python/bin/repl
  bazel-bin/external/rules_python/python/bin/repl_py.py
Python 3.13.11 (main, Dec  6 2025, 02:15:39) [Clang 17.0.0 (clang-1700.3.19.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

This was previously broken in 1.5.4.