### PR TITLE
Avoid multimap::find unspecified behavior

### DIFF
--- a/include/grpcpp/impl/metadata_map.h
+++ b/include/grpcpp/impl/metadata_map.h
@@ -39,9 +39,9 @@ class MetadataMap {
   std::string GetBinaryErrorDetails() {
     // if filled_, extract from the multimap for O(log(n))
     if (filled_) {
-      auto iter = map_.find(kBinaryErrorDetailsKey);
-      if (iter != map_.end()) {
-        return std::string(iter->second.begin(), iter->second.length());
+      auto [it, end] = map_.equal_range(kBinaryErrorDetailsKey);
+      if (it != end) {
+        return std::string(it->second.begin(), it->second.length());
       }
     }
     // if not yet filled, take the O(n) lookup to avoid allocating the

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -972,12 +972,15 @@ TEST_P(AsyncEnd2endTest, ClientInitialMetadataRpc) {
   Verifier().Expect(2, true).Verify(cq_.get());
   EXPECT_EQ(send_request.message(), recv_request.message());
   const auto& client_initial_metadata = srv_ctx.client_metadata();
-  EXPECT_EQ(meta1.second,
-            ToString(client_initial_metadata.find(meta1.first)->second));
-  EXPECT_EQ(meta2.second,
-            ToString(client_initial_metadata.find(meta2.first)->second));
-  EXPECT_EQ(meta3.second,
-            ToString(client_initial_metadata.find(meta3.first)->second));
+  EXPECT_EQ(
+      meta1.second,
+      ToString(client_initial_metadata.equal_range(meta1.first).first->second));
+  EXPECT_EQ(
+      meta2.second,
+      ToString(client_initial_metadata.equal_range(meta2.first).first->second));
+  EXPECT_EQ(
+      meta3.second,
+      ToString(client_initial_metadata.equal_range(meta3.first).first->second));
   EXPECT_GE(client_initial_metadata.size(), 2);
 
   send_response.set_message(recv_request.message());
@@ -1018,10 +1021,12 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataRpc) {
   response_writer.SendInitialMetadata(tag(3));
   Verifier().Expect(3, true).Expect(4, true).Verify(cq_.get());
   const auto& server_initial_metadata = cli_ctx.GetServerInitialMetadata();
-  EXPECT_EQ(meta1.second,
-            ToString(server_initial_metadata.find(meta1.first)->second));
-  EXPECT_EQ(meta2.second,
-            ToString(server_initial_metadata.find(meta2.first)->second));
+  EXPECT_EQ(
+      meta1.second,
+      ToString(server_initial_metadata.equal_range(meta1.first).first->second));
+  EXPECT_EQ(
+      meta2.second,
+      ToString(server_initial_metadata.equal_range(meta2.first).first->second));
   EXPECT_EQ(2, server_initial_metadata.size());
 
   send_response.set_message(recv_request.message());
@@ -1061,10 +1066,12 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataServerStreaming) {
   srv_stream.SendInitialMetadata(tag(10));
   Verifier().Expect(10, true).Expect(11, true).Verify(cq_.get());
   auto server_initial_metadata = cli_ctx.GetServerInitialMetadata();
-  EXPECT_EQ(meta1.second,
-            ToString(server_initial_metadata.find(meta1.first)->second));
-  EXPECT_EQ(meta2.second,
-            ToString(server_initial_metadata.find(meta2.first)->second));
+  EXPECT_EQ(
+      meta1.second,
+      ToString(server_initial_metadata.equal_range(meta1.first).first->second));
+  EXPECT_EQ(
+      meta2.second,
+      ToString(server_initial_metadata.equal_range(meta2.first).first->second));
   EXPECT_EQ(2, server_initial_metadata.size());
 
   srv_stream.Write(send_response, tag(3));
@@ -1121,10 +1128,12 @@ TEST_P(AsyncEnd2endTest, ServerInitialMetadataServerStreamingImplicit) {
   EXPECT_EQ(send_response.message(), recv_response.message());
 
   auto server_initial_metadata = cli_ctx.GetServerInitialMetadata();
-  EXPECT_EQ(meta1.second,
-            ToString(server_initial_metadata.find(meta1.first)->second));
-  EXPECT_EQ(meta2.second,
-            ToString(server_initial_metadata.find(meta2.first)->second));
+  EXPECT_EQ(
+      meta1.second,
+      ToString(server_initial_metadata.equal_range(meta1.first).first->second));
+  EXPECT_EQ(
+      meta2.second,
+      ToString(server_initial_metadata.equal_range(meta2.first).first->second));
   EXPECT_EQ(2, server_initial_metadata.size());
 
   srv_stream.Write(send_response, tag(5));
@@ -1179,10 +1188,14 @@ TEST_P(AsyncEnd2endTest, ServerTrailingMetadataRpc) {
   EXPECT_EQ(send_response.message(), recv_response.message());
   EXPECT_TRUE(recv_status.ok());
   const auto& server_trailing_metadata = cli_ctx.GetServerTrailingMetadata();
-  EXPECT_EQ(meta1.second,
-            ToString(server_trailing_metadata.find(meta1.first)->second));
-  EXPECT_EQ(meta2.second,
-            ToString(server_trailing_metadata.find(meta2.first)->second));
+  EXPECT_EQ(
+      meta1.second,
+      ToString(
+          server_trailing_metadata.equal_range(meta1.first).first->second));
+  EXPECT_EQ(
+      meta2.second,
+      ToString(
+          server_trailing_metadata.equal_range(meta2.first).first->second));
   EXPECT_EQ(2, server_trailing_metadata.size());
 }
 
@@ -1227,10 +1240,12 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
   Verifier().Expect(2, true).Verify(cq_.get());
   EXPECT_EQ(send_request.message(), recv_request.message());
   const auto& client_initial_metadata = srv_ctx.client_metadata();
-  EXPECT_EQ(meta1.second,
-            ToString(client_initial_metadata.find(meta1.first)->second));
-  EXPECT_EQ(meta2.second,
-            ToString(client_initial_metadata.find(meta2.first)->second));
+  EXPECT_EQ(
+      meta1.second,
+      ToString(client_initial_metadata.equal_range(meta1.first).first->second));
+  EXPECT_EQ(
+      meta2.second,
+      ToString(client_initial_metadata.equal_range(meta2.first).first->second));
   EXPECT_GE(client_initial_metadata.size(), 2);
 
   srv_ctx.AddInitialMetadata(meta3.first, meta3.second);
@@ -1238,10 +1253,12 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
   response_writer.SendInitialMetadata(tag(3));
   Verifier().Expect(3, true).Expect(4, true).Verify(cq_.get());
   const auto& server_initial_metadata = cli_ctx.GetServerInitialMetadata();
-  EXPECT_EQ(meta3.second,
-            ToString(server_initial_metadata.find(meta3.first)->second));
-  EXPECT_EQ(meta4.second,
-            ToString(server_initial_metadata.find(meta4.first)->second));
+  EXPECT_EQ(
+      meta3.second,
+      ToString(server_initial_metadata.equal_range(meta3.first).first->second));
+  EXPECT_EQ(
+      meta4.second,
+      ToString(server_initial_metadata.equal_range(meta4.first).first->second));
   EXPECT_GE(server_initial_metadata.size(), 2);
 
   send_response.set_message(recv_request.message());
@@ -1255,10 +1272,14 @@ TEST_P(AsyncEnd2endTest, MetadataRpc) {
   EXPECT_EQ(send_response.message(), recv_response.message());
   EXPECT_TRUE(recv_status.ok());
   const auto& server_trailing_metadata = cli_ctx.GetServerTrailingMetadata();
-  EXPECT_EQ(meta5.second,
-            ToString(server_trailing_metadata.find(meta5.first)->second));
-  EXPECT_EQ(meta6.second,
-            ToString(server_trailing_metadata.find(meta6.first)->second));
+  EXPECT_EQ(
+      meta5.second,
+      ToString(
+          server_trailing_metadata.equal_range(meta5.first).first->second));
+  EXPECT_EQ(
+      meta6.second,
+      ToString(
+          server_trailing_metadata.equal_range(meta6.first).first->second));
   EXPECT_GE(server_trailing_metadata.size(), 2);
 }
 

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -202,9 +202,10 @@ class ClientCallbackEnd2endTest
             if (with_binary_metadata) {
               EXPECT_EQ(
                   1u, cli_ctx.GetServerTrailingMetadata().count("custom-bin"));
-              EXPECT_EQ(val, ToString(cli_ctx.GetServerTrailingMetadata()
-                                          .find("custom-bin")
-                                          ->second));
+              auto [it, end] =
+                  cli_ctx.GetServerTrailingMetadata().equal_range("custom-bin");
+              ASSERT_NE(it, end);
+              EXPECT_EQ(val, ToString(it->second));
             }
             std::lock_guard<std::mutex> l(mu);
             done = true;
@@ -803,13 +804,15 @@ TEST_P(ClientCallbackEnd2endTest, UnaryReactor) {
     void OnReadInitialMetadataDone(bool ok) override {
       EXPECT_TRUE(ok);
       EXPECT_EQ(1u, cli_ctx_.GetServerInitialMetadata().count("key1"));
-      EXPECT_EQ(
-          "val1",
-          ToString(cli_ctx_.GetServerInitialMetadata().find("key1")->second));
+      auto [it1, end1] =
+          cli_ctx_.GetServerInitialMetadata().equal_range("key1");
+      ASSERT_NE(it1, end1);
+      EXPECT_EQ("val1", ToString(it1->second));
       EXPECT_EQ(1u, cli_ctx_.GetServerInitialMetadata().count("key2"));
-      EXPECT_EQ(
-          "val2",
-          ToString(cli_ctx_.GetServerInitialMetadata().find("key2")->second));
+      auto [it2, end2] =
+          cli_ctx_.GetServerInitialMetadata().equal_range("key2");
+      ASSERT_NE(it2, end2);
+      EXPECT_EQ("val2", ToString(it2->second));
       initial_metadata_done_ = true;
     }
     void OnDone(const Status& s) override {
@@ -869,13 +872,15 @@ TEST_P(ClientCallbackEnd2endTest, GenericUnaryReactor) {
     void OnReadInitialMetadataDone(bool ok) override {
       EXPECT_TRUE(ok);
       EXPECT_EQ(1u, cli_ctx_.GetServerInitialMetadata().count("key1"));
-      EXPECT_EQ(
-          "val1",
-          ToString(cli_ctx_.GetServerInitialMetadata().find("key1")->second));
+      auto [it1, end1] =
+          cli_ctx_.GetServerInitialMetadata().equal_range("key1");
+      ASSERT_NE(it1, end1);
+      EXPECT_EQ("val1", ToString(it1->second));
       EXPECT_EQ(1u, cli_ctx_.GetServerInitialMetadata().count("key2"));
-      EXPECT_EQ(
-          "val2",
-          ToString(cli_ctx_.GetServerInitialMetadata().find("key2")->second));
+      auto [it2, end2] =
+          cli_ctx_.GetServerInitialMetadata().equal_range("key2");
+      ASSERT_NE(it2, end2);
+      EXPECT_EQ("val2", ToString(it2->second));
       initial_metadata_done_ = true;
     }
     void OnDone(const Status& s) override {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -224,9 +224,9 @@ class TestAuthMetadataProcessor : public AuthMetadataProcessor {
     EXPECT_TRUE(consumed_auth_metadata != nullptr);
     EXPECT_TRUE(context != nullptr);
     EXPECT_TRUE(response_metadata != nullptr);
-    auto auth_md =
-        auth_metadata.find(TestMetadataCredentialsPlugin::kGoodMetadataKey);
-    EXPECT_NE(auth_md, auth_metadata.end());
+    auto [auth_md, auth_md_end] = auth_metadata.equal_range(
+        TestMetadataCredentialsPlugin::kGoodMetadataKey);
+    EXPECT_NE(auth_md, auth_md_end);
     string_ref auth_md_value = auth_md->second;
     if (auth_md_value == kGoodGuy) {
       context->AddProperty(kIdentityPropName, kGoodGuy);
@@ -828,8 +828,8 @@ TEST_P(End2endTest, SimpleRpcWithCustomUserAgentPrefix) {
   EXPECT_EQ(response.message(), request.message());
   EXPECT_TRUE(s.ok());
   const auto& trailing_metadata = context.GetServerTrailingMetadata();
-  auto iter = trailing_metadata.find("user-agent");
-  EXPECT_TRUE(iter != trailing_metadata.end());
+  auto [iter, end] = trailing_metadata.equal_range("user-agent");
+  EXPECT_TRUE(iter != end);
   std::string expected_prefix = user_agent_prefix_ + " grpc-c++/";
   EXPECT_TRUE(iter->second.starts_with(expected_prefix)) << iter->second;
 }
@@ -1474,7 +1474,8 @@ TEST_P(End2endTest, BinaryTrailerTest) {
   EXPECT_FALSE(s.ok());
   auto trailers = context.GetServerTrailingMetadata();
   EXPECT_EQ(1u, trailers.count(kDebugInfoTrailerKey));
-  auto iter = trailers.find(kDebugInfoTrailerKey);
+  auto [iter, end] = trailers.equal_range(kDebugInfoTrailerKey);
+  EXPECT_TRUE(iter != end);
   EXPECT_EQ(expected_string, iter->second);
   // Parse the returned trailer into a DebugInfo proto.
   DebugInfo returned_info;

--- a/test/cpp/end2end/server_early_return_test.cc
+++ b/test/cpp/end2end/server_early_return_test.cc
@@ -99,8 +99,8 @@ class TestServiceImpl : public grpc::testing::EchoTestService::Service {
   int GetIntValueFromMetadata(ServerContext* context, const char* key,
                               int default_value) {
     auto metadata = context->client_metadata();
-    if (metadata.find(key) != metadata.end()) {
-      std::istringstream iss(ToString(metadata.find(key)->second));
+    if (auto [it, end] = metadata.equal_range(key); it != end) {
+      std::istringstream iss(ToString(it->second));
       iss >> default_value;
     }
     return default_value;

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -90,8 +90,8 @@ int GetIntValueFromMetadataHelper(
     const char* key,
     const std::multimap<grpc::string_ref, grpc::string_ref>& metadata,
     int default_value) {
-  if (metadata.find(key) != metadata.end()) {
-    std::istringstream iss(ToString(metadata.find(key)->second));
+  if (auto [it, end] = metadata.equal_range(key); it != end) {
+    std::istringstream iss(ToString(it->second));
     iss >> default_value;
     LOG(INFO) << key << " : " << default_value;
   }

--- a/test/cpp/end2end/xds/xds_core_end2end_test.cc
+++ b/test/cpp/end2end/xds/xds_core_end2end_test.cc
@@ -193,8 +193,8 @@ class XdsServerTlsTest : public XdsEnd2endTest {
     // Add a callback to save the JWT token seen on the xDS server.
     balancer_->ads_service()->SetCallCredsCallback(
         [&](const AdsServiceImpl::ClientMetadataType& md) {
-          auto it = md.find("authorization");
-          ASSERT_TRUE(it != md.end());
+          auto [it, end] = md.equal_range("authorization");
+          ASSERT_TRUE(it != end);
           absl::string_view value(it->second.data(), it->second.size());
           grpc_core::MutexLock lock(&mu_);
           seen_token_ = std::string(absl::StripPrefix(value, "Bearer "));

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -1105,13 +1105,15 @@ bool InteropClient::DoCustomMetadata() {
     }
 
     const auto& server_initial_metadata = context.GetServerInitialMetadata();
-    auto iter = server_initial_metadata.find(kEchoInitialMetadataKey);
-    GRPC_CHECK(iter != server_initial_metadata.end());
+    auto [iter, end] =
+        server_initial_metadata.equal_range(kEchoInitialMetadataKey);
+    GRPC_CHECK(iter != end);
     GRPC_CHECK(iter->second == kInitialMetadataValue);
     const auto& server_trailing_metadata = context.GetServerTrailingMetadata();
-    iter = server_trailing_metadata.find(kEchoTrailingBinMetadataKey);
-    GRPC_CHECK(iter != server_trailing_metadata.end());
-    GRPC_CHECK(std::string(iter->second.begin(), iter->second.end()) ==
+    auto [iter2, end2] =
+        server_trailing_metadata.equal_range(kEchoTrailingBinMetadataKey);
+    GRPC_CHECK(iter2 != end2);
+    GRPC_CHECK(std::string(iter2->second.begin(), iter2->second.end()) ==
                kTrailingBinValue);
 
     VLOG(2) << "Done testing RPC with custom metadata";
@@ -1156,13 +1158,15 @@ bool InteropClient::DoCustomMetadata() {
     }
 
     const auto& server_initial_metadata = context.GetServerInitialMetadata();
-    auto iter = server_initial_metadata.find(kEchoInitialMetadataKey);
-    GRPC_CHECK(iter != server_initial_metadata.end());
+    auto [iter, end] =
+        server_initial_metadata.equal_range(kEchoInitialMetadataKey);
+    GRPC_CHECK(iter != end);
     GRPC_CHECK(iter->second == kInitialMetadataValue);
     const auto& server_trailing_metadata = context.GetServerTrailingMetadata();
-    iter = server_trailing_metadata.find(kEchoTrailingBinMetadataKey);
-    GRPC_CHECK(iter != server_trailing_metadata.end());
-    GRPC_CHECK(std::string(iter->second.begin(), iter->second.end()) ==
+    auto [iter2, end2] =
+        server_trailing_metadata.equal_range(kEchoTrailingBinMetadataKey);
+    GRPC_CHECK(iter2 != end2);
+    GRPC_CHECK(std::string(iter2->second.begin(), iter2->second.end()) ==
                kTrailingBinValue);
 
     VLOG(2) << "Done testing stream with custom metadata";

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -78,24 +78,24 @@ void MaybeEchoMetadata(ServerContext* context) {
   GRPC_CHECK_LE(client_metadata.count(kEchoInitialMetadataKey), 1u);
   GRPC_CHECK_LE(client_metadata.count(kEchoTrailingBinMetadataKey), 1u);
 
-  auto iter = client_metadata.find(kEchoInitialMetadataKey);
-  if (iter != client_metadata.end()) {
+  if (auto [iter, end] = client_metadata.equal_range(kEchoInitialMetadataKey);
+      iter != end) {
     context->AddInitialMetadata(
         kEchoInitialMetadataKey,
         std::string(iter->second.begin(), iter->second.end()));
   }
-  iter = client_metadata.find(kEchoTrailingBinMetadataKey);
-  if (iter != client_metadata.end()) {
+  if (auto [iter, end] =
+          client_metadata.equal_range(kEchoTrailingBinMetadataKey);
+      iter != end) {
     context->AddTrailingMetadata(
         kEchoTrailingBinMetadataKey,
         std::string(iter->second.begin(), iter->second.end()));
   }
   // Check if client sent a magic key in the header that makes us echo
   // back the user-agent (for testing purpose)
-  iter = client_metadata.find(kEchoUserAgentKey);
-  if (iter != client_metadata.end()) {
-    iter = client_metadata.find("user-agent");
-    if (iter != client_metadata.end()) {
+  if (client_metadata.count(kEchoUserAgentKey) > 0) {
+    if (auto [iter, end] = client_metadata.equal_range("user-agent");
+        iter != end) {
       context->AddInitialMetadata(
           kEchoUserAgentKey,
           std::string(iter->second.begin(), iter->second.end()));

--- a/test/cpp/microbenchmarks/callback_test_service.cc
+++ b/test/cpp/microbenchmarks/callback_test_service.cc
@@ -33,8 +33,8 @@ int GetIntValueFromMetadataHelper(
     const char* key,
     const std::multimap<grpc::string_ref, grpc::string_ref>& metadata,
     int default_value) {
-  if (metadata.find(key) != metadata.end()) {
-    std::istringstream iss(ToString(metadata.find(key)->second));
+  if (auto [it, end] = metadata.equal_range(key); it != end) {
+    std::istringstream iss(ToString(it->second));
     iss >> default_value;
   }
 


### PR DESCRIPTION
When a `std::multimap` has multiple entries with the same key, calling `m.find(key)` returns an unspecified element.

Historically, this returns the first matching element. However, this is not guaranteed, and recent libc++ changes make this return an arbitrary element.

Using `m.equal_range(key)` is a replacement that will preserve the current behavior. The behavior of this is guaranteed to return a range of all matching elements in insertion order, and the beginning of the range is the same element as what's normally returned by `m.find(key)`.