### PR TITLE
[BCR] Mark BCR Release PRs as ready by default

### DIFF
--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -23,7 +23,9 @@ jobs:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0
     with:
       attest: false
-      # Mark the created PR as Ready for Review, otherwise it can't be auto-approved by BCR reviewer bot.
+      # Mark the created PR as ready for review, since it can't be marked ready by gRPC maintainers and subsequently
+      # can't be auto-merged by BCR reviewer bot.
+      #
       # See https://github.com/bazel-contrib/publish-to-bcr/blob/748dc7186bc60d0e24a81ee30aba8aa543794767/.github/workflows/publish.yaml#L76
       draft: false
       tag_name: ${{ inputs.tag_name }}


### PR DESCRIPTION
In our current settings, a draft pull request is created with author set to `grpc-bot`, making it impossible to auto-merge. An example here https://github.com/bazelbuild/bazel-central-registry/pull/6872.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

