### PR TITLE
[bzlmod] Include bazel_build_with_bzlmod_linux into RBE non-bazel tests.

### DIFF
--- a/tools/bazelify_tests/test/BUILD
+++ b/tools/bazelify_tests/test/BUILD
@@ -238,9 +238,15 @@ grpc_run_simple_command_test(
 )
 
 test_suite(
-    name = "bazel_build_tests_linux",
+    name = "bzlmod_tests_linux",
     tests = [
         ":bazel_build_with_bzlmod_linux",
+    ],
+)
+
+test_suite(
+    name = "bazel_build_tests_linux",
+    tests = [
         ":bazel_build_with_grpc_no_xds_linux",
         ":bazel_build_with_grpc_no_xds_negative_test_linux",
         ":bazel_build_with_strict_warnings_linux",
@@ -443,6 +449,7 @@ test_suite(
         ":basic_tests_linux",
         ":bazel_build_tests_linux",
         ":bazel_distribtests_linux",
+        ":bzlmod_tests_linux",
         ":cpp_distribtests_linux",
         ":csharp_distribtests_linux",
         ":php_distribtests_linux",


### PR DESCRIPTION
Currently bzlmod tests are excluded from RBE non-bazel tests (via exclusion of `:bazel_build_tests_linux`).

The exclusion logic: https://github.com/grpc/grpc/blob/688a2868b8dc6cabba89670d71e2df4fa3d1f9f7/tools/internal_ci/linux/grpc_bazel_rbe_nonbazel.cfg#L54

An example run from CI: https://btx.cloud.google.com/invocations/6d22bc1d-562c-4876-bb7e-a7c3e75cbe17/targets;showStatuses=passed,built Note that `//tools/bazelify_tests/test:bazel_build_with_bzlmod_linux` is marked as "built" instead of "passed".




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

