### PR TITLE
Add plugin toolchains

### DIFF
--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -105,7 +105,7 @@ def cc_grpc_library(
         generate_cc(
             name = codegen_grpc_target,
             srcs = proto_targets,
-            plugin = Label("//src/compiler:grpc_cpp_plugin"),
+            plugin = Label("//bazel/private:maybe_grpc_cpp_plugin"),
             well_known_protos = well_known_protos,
             generate_mocks = generate_mocks,
             allow_deprecated = allow_deprecated,

--- a/bazel/private/BUILD
+++ b/bazel/private/BUILD
@@ -1,0 +1,46 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+config_setting(
+    name = "plugin_toolchain_resolution_enabled",
+    flag_values = {
+        "//bazel/toolchains:enable_plugin_toolchain_resolution": "True",
+    },
+)
+
+# Whereas the Protobuf toolchain migration made use of an internal Bazel setting
+# (`--incompatible_enable_proto_toolchain_resolution`) that can be read during the loading phase,
+# the gRPC toolchain migration only makes use of a standard Bazel config setting
+# (`//bazel/toolchains:enable_plugin_toolchain_resolution`).
+# This requires using `select` to make the fallback plugins (built from source) optional.
+# When resolution is enabled, swap the real fallback plugins out for this empty "dummy executable".
+# In that case, the dummy fallback plugin, which is not a valid executable,
+# must be ignored during the analysis phase.
+write_file(
+    name = "dummy_executable",
+    out = "dummy_executable",
+    is_executable = True,
+)
+
+alias(
+    name = "maybe_grpc_cpp_plugin",
+    actual = select({
+        ":plugin_toolchain_resolution_enabled": ":dummy_executable",
+        "//conditions:default": "//src/compiler:grpc_cpp_plugin",
+    }),
+)
+
+alias(
+    name = "maybe_grpc_objective_c_plugin",
+    actual = select({
+        ":plugin_toolchain_resolution_enabled": ":dummy_executable",
+        "//conditions:default": "//src/compiler:grpc_objective_c_plugin",
+    }),
+)
+
+alias(
+    name = "maybe_grpc_python_plugin",
+    actual = select({
+        ":plugin_toolchain_resolution_enabled": ":dummy_executable",
+        "//conditions:default": "//src/compiler:grpc_python_plugin",
+    }),
+)

--- a/bazel/private/plugin_toolchain_helpers.bzl
+++ b/bazel/private/plugin_toolchain_helpers.bzl
@@ -1,0 +1,46 @@
+"""
+Protobuf compiler plugin helpers.
+
+Similar to `proto_toolchain_helpers`,
+this library contains helper methods to be used for a graceful migration to toolchains
+for language-specific gRPC plugins.
+
+The `find_toolchain` and `options` methods must be called from rules
+that have a label attribute named `_enable_plugin_toolchain_resolution`
+which references the boolean flag `//bazel/toolchains:enable_plugin_toolchain_resolution`.
+"""
+
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+_toolchains_enabled_setting = Label("//bazel/toolchains:enable_plugin_toolchain_resolution")
+
+cpp_plugin_toolchain = Label("//bazel/toolchains:cpp_plugin_toolchain_type")
+objective_c_plugin_toolchain = Label("//bazel/toolchains:objective_c_plugin_toolchain_type")
+python_plugin_toolchain = Label("//bazel/toolchains:python_plugin_toolchain_type")
+
+def _find_toolchain(ctx, legacy_attr, toolchain_type):
+    if ctx.attr._enable_plugin_toolchain_resolution[BuildSettingInfo].value:
+        toolchain = ctx.toolchains[toolchain_type]
+        if not toolchain:
+            fail("No toolchains registered for '%s'." % toolchain_type)
+        return toolchain.plugin.bin
+    else:
+        return getattr(ctx.executable, legacy_attr)
+
+def _options(ctx, default_options, toolchain_type):
+    if ctx.attr._enable_plugin_toolchain_resolution[BuildSettingInfo].value:
+        toolchain = ctx.toolchains[toolchain_type]
+        if not toolchain:
+            fail("No toolchains registered for '%s'." % toolchain_type)
+        return toolchain.plugin.options
+    else:
+        return default_options
+
+def _use_toolchain(toolchain_type):
+    return [config_common.toolchain_type(toolchain_type, mandatory = False)]
+
+toolchains = struct(
+    find_toolchain = _find_toolchain,
+    options = _options,
+    use_toolchain = _use_toolchain,
+)

--- a/bazel/toolchains/BUILD
+++ b/bazel/toolchains/BUILD
@@ -1,0 +1,11 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+bool_flag(
+    name = "enable_plugin_toolchain_resolution",
+)
+
+toolchain_type(name = "cpp_plugin_toolchain_type")
+toolchain_type(name = "objective_c_plugin_toolchain_type")
+toolchain_type(name = "python_plugin_toolchain_type")

--- a/bazel/toolchains/plugins.bzl
+++ b/bazel/toolchains/plugins.bzl
@@ -1,0 +1,36 @@
+"""Rules for defining Bazel toolchains for Protobuf plugins for gRPC."""
+
+GrpcPluginInfo = provider(
+    doc = "Information about how to invoke a Protobuf compiler plugin for gRPC.",
+    fields = [
+        # File object of a platform-specific plugin executable.
+        "bin",
+        # List of string-valued command-line options to pass to the plugin.
+        "options",
+    ],
+)
+
+def _plugin_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        plugin = GrpcPluginInfo(
+            bin = ctx.executable.bin,
+            options = ctx.attr.options,
+        ),
+    )
+    return [toolchain_info]
+
+plugin_toolchain = rule(
+    implementation = _plugin_toolchain_impl,
+    attrs = {
+        "bin": attr.label(
+            doc = "Plugin executable.",
+            mandatory = True,
+            executable = True,
+            cfg = "exec",
+            allow_single_file = True,
+        ),
+        "options": attr.string_list(
+            doc = "Options to pass to the plugin.",
+        ),
+    },
+)


### PR DESCRIPTION
Closes #41275.

This is a draft that adds toolchain types for each of the languages for which this repo provides gRPC library generation rules (C++, Objective C, and Python). It does not add toolchain types for C#, PHP, or Ruby because those languages appear to provide gRPC library rules elsewhere.

I realized once I was mostly done drafting this that I would also be happy just making the `_grpc_plugin` attribute of Python's `_generate_pb2_grpc_src` rule non-private (get rid of the leading underscore) so it can be manually overridden like the rules for C++ and Objective C, but keep the default value that builds from source. That would be a way smaller change. But since I was almost done drafting this anyway, figured I might as well put up the diff for your consideration. Happy to add tests and incorporate any feedback if you'd rather continue down the toolchain route.

The C++ and Objective C rules have some slightly strange behavior in the current draft because toolchain resolution would only occur if `plugin` is specified, but that plugin might be ignored. In the case of `cc_grpc_library`, it's [always specified](https://github.com/grpc/grpc/blob/v1.76.0/bazel/cc_grpc_library.bzl#L108), so it's not that weird. But, in the case of [`objc_grpc_library`](https://github.com/grpc/grpc/blob/v1.76.0/bazel/objc_grpc_library.bzl#L26), it's always up to the user to specify it, so if a user wanted to use toolchain resolution, they would have to specify a "dummy" plugin for it to work, which is almost certainly not the API we want.