### PR TITLE
[do-not-merge] Python Docs Revamp trial with read-the-docs theme

### DIFF
--- a/doc/python/sphinx/_static/custom.css
+++ b/doc/python/sphinx/_static/custom.css
@@ -1,43 +1,36 @@
-dl.field-list > dt {
-    word-break: keep-all !important;
-}
-.document {
-  width: 90% !important;
-  margin: 0 auto;
-  display: flex;
-}
-.sphinxsidebar {
-    overflow-y: scroll;
-    top: 0;
-    bottom: 0;
-    width: 35% !important;
-    flex-shrink: 0 !important;
-    min-width: 340px !important;
-    position: unset !important;
-}
-.bodywrapper {
-  margin: auto !important;
-}
-.body {
-  max-width: 100% !important;
-  min-width: 800px !important;
-}
-.footer {
-  margin: 20px 50px 30px auto !important;
+dl.field-list>dt {
+  word-break: keep-all !important;
 }
 
-@media (max-width: 875px) {
-  .document {
-    flex-direction: column;
+/* Sticky Navigation Header for Mobile View */
+@media screen and (max-width: 875px) {
+
+  /* Aggressively ensure no parent container restricts the sticky position or clips it */
+  html,
+  body,
+  .wy-grid-for-nav,
+  .wy-nav-content-wrap {
+    overflow: visible !important;
+    height: auto !important;
+    /* Prevent parent height constraints */
   }
-  .sphinxsidebar {
+
+  /* Fixed/Sticky Mobile Header */
+  .wy-nav-top {
+    position: fixed !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    /* z-index: 1000 !important;
     width: 100% !important;
-    background: white !important;
+    margin: 0 !important;
+    left: 0 !important;
+    height: 50px !important;
+    display: flex !important;
+    align-items: center !important; */
   }
-  .sphinxsidebar a {
-    color: #444 !important;
-  }
-  .sphinxsidebar h3, .sphinxsidebar h4, .sphinxsidebar p, .sphinxsidebar h3 a {
-    color: #444 !important;
-  }
+
+  /* Adjust content padding to compensate for fixed header */
+  /* .wy-nav-content-wrap {
+    padding-top: 50px !important;
+  } */
 }

--- a/doc/python/sphinx/conf.py
+++ b/doc/python/sphinx/conf.py
@@ -58,6 +58,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.coverage',
     'sphinx.ext.autodoc.typehints',
+    'sphinx_rtd_theme'
 ]
 
 napoleon_google_docstring = True
@@ -68,22 +69,26 @@ autodoc_default_options = {
     'members': None,
 }
 
-autodoc_mock_imports = ["envoy"]
+# autodoc_mock_imports = ["envoy"]
+autodoc_mock_imports = [
+    "envoy",
+    # "grpc._cython", # TODO: Verify if this is only needed to run locally or everywhere
+    # "grpc_observability._cyobservability",
+]
 
 autodoc_typehints = 'description'
 
 # -- HTML Configuration -------------------------------------------------
 
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
-    'fixed_sidebar': True,
-    'page_width': 'auto',
-    'show_related': True,
     'analytics_id': 'UA-60127042-1',
-    'description': grpc_version.VERSION,
-    'show_powered_by': False,
+    'sticky_navigation': True,
 }
 html_static_path = ["_static"]
+html_css_files = [
+    'custom.css',
+]
 
 # -- Options for manual page output ------------------------------------------
 

--- a/doc/python/sphinx/index.rst
+++ b/doc/python/sphinx/index.rst
@@ -8,6 +8,7 @@ API Reference
 
 .. toctree::
    :caption: Contents:
+   :maxdepth: 2
 
    grpc
    grpc_asyncio


### PR DESCRIPTION
This PR tries using the `sphinx-rtd-theme` for the docs revamp

[Screen recording 2025-12-23 6.28.59 PM.webm](https://github.com/user-attachments/assets/1d4b3821-f43e-478f-a2d6-bfaa8decb3a2)

Some problems with this though, 
 - The navigation bar seems a little hard to navigate, you need to manually click and expand an auxiliary package, followed by 'Module Contents' further followed by each subheading to expand it. The expansion is also limited to the small '+' icon next to each heading, if you click outside it, it navigates to that part directly instead of expanding the menu . This is still okay in desktop view, but I feel it is easy to click slightly wrong in the mobile view.
 - Secondly, the sticky header menu in the mobile view doesn't seem to be constant too, you have to scroll a little to make the sticky header visible. That doesn't feel very intuitive too. I also tried fixing this in CSS by setting attributes lile 'position: fixed'. But it didn't work out. Besides, quoting from the theme's docs `By default, the navigation will “stick” to the screen as you scroll. However if your TOC is not tall enough, it will revert to static positioning. To disable the sticky navigation altogether, change the sticky_navigation theme option.` Since this a setting from the theme itself, it doesn't look like the overriding works.

Hence, for all these reasons, I think the `pydata_sphinx_theme` used in https://github.com/grpc/grpc/pull/41287 is possibly better and more user-friendly.