### PR TITLE
fixing bug that type of function mismatch with type of callback and a…

### DIFF
--- a/include/grpc/event_engine/memory_request.h
+++ b/include/grpc/event_engine/memory_request.h
@@ -18,6 +18,7 @@
 #include <stddef.h>
 
 #include "absl/strings/string_view.h"
+#include <string>
 
 namespace grpc_event_engine {
 namespace experimental {

--- a/src/core/lib/event_engine/ares_resolver.cc
+++ b/src/core/lib/event_engine/ares_resolver.cc
@@ -374,7 +374,8 @@ void AresResolver::LookupHostname(
     // ::1).
     resolver_arg->pending_requests = 2;
     ares_gethostbyname(channel_, std::string(host).c_str(), AF_INET,
-                       &AresResolver::OnHostbynameDoneLocked, resolver_arg);
+
+      &AresResolver::OnHostbynameDoneLocked, resolver_arg);
     ares_gethostbyname(channel_, std::string(host).c_str(), AF_INET6,
                        &AresResolver::OnHostbynameDoneLocked, resolver_arg);
   } else {
@@ -648,7 +649,7 @@ void AresResolver::OnAresBackupPollAlarm() {
 
 void AresResolver::OnHostbynameDoneLocked(void* arg, int status,
                                           int /*timeouts*/,
-                                          struct hostent* hostent) {
+                                          const struct hostent* hostent) {
   auto* hostname_qa = static_cast<HostnameQueryArg*>(arg);
   GRPC_CHECK_GT(hostname_qa->pending_requests--, 0);
   auto* ares_resolver = hostname_qa->ares_resolver;
@@ -744,7 +745,7 @@ void AresResolver::OnHostbynameDoneLocked(void* arg, int status,
 }
 
 void AresResolver::OnSRVQueryDoneLocked(void* arg, int status, int /*timeouts*/,
-                                        unsigned char* abuf, int alen) {
+                                        const unsigned char* abuf, int alen) {
   std::unique_ptr<QueryArg> qa(static_cast<QueryArg*>(arg));
   auto* ares_resolver = qa->ares_resolver;
   auto nh = ares_resolver->callback_map_.extract(qa->callback_map_id);
@@ -808,7 +809,7 @@ void AresResolver::OnSRVQueryDoneLocked(void* arg, int status, int /*timeouts*/,
 }
 
 void AresResolver::OnTXTDoneLocked(void* arg, int status, int /*timeouts*/,
-                                   unsigned char* buf, int len) {
+                                   const unsigned char* buf, int len) {
   std::unique_ptr<QueryArg> qa(static_cast<QueryArg*>(arg));
   auto* ares_resolver = qa->ares_resolver;
   auto nh = ares_resolver->callback_map_.extract(qa->callback_map_id);

--- a/src/core/lib/event_engine/ares_resolver.h
+++ b/src/core/lib/event_engine/ares_resolver.h
@@ -132,13 +132,13 @@ class AresResolver : public RefCountedDNSResolverInterface {
   // These callbacks are invoked from the c-ares library, so disable thread
   // safety analysis. We are guaranteed to be holding mutex_.
   static void OnHostbynameDoneLocked(void* arg, int status, int /*timeouts*/,
-                                     struct hostent* hostent)
+                                     const struct hostent* hostent)
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
   static void OnSRVQueryDoneLocked(void* arg, int status, int /*timeouts*/,
-                                   unsigned char* abuf,
+                                   const unsigned char* abuf,
                                    int alen) ABSL_NO_THREAD_SAFETY_ANALYSIS;
   static void OnTXTDoneLocked(void* arg, int status, int /*timeouts*/,
-                              unsigned char* buf,
+                              const unsigned char* buf,
                               int len) ABSL_NO_THREAD_SAFETY_ANALYSIS;
 #ifdef GRPC_ENABLE_FORK_SUPPORT
   // Is executed on fork before the poller is restarted. Cleans up the resources

--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -676,7 +676,7 @@ static void destroy_hostbyname_request_locked(grpc_ares_hostbyname_request* hr)
 }
 
 static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
-                                      struct hostent* hostent)
+                                      const struct hostent* hostent)
     ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // This callback is invoked from the c-ares library, so disable thread safety
   // analysis. Note that we are guaranteed to be holding r->mu, though.
@@ -750,7 +750,7 @@ static void on_hostbyname_done_locked(void* arg, int status, int /*timeouts*/,
 }
 
 static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
-                                     unsigned char* abuf,
+                                     const unsigned char* abuf,
                                      int alen) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // This callback is invoked from the c-ares library, so disable thread safety
   // analysis. Note that we are guaranteed to be holding r->mu, though.
@@ -800,7 +800,7 @@ static void on_srv_query_done_locked(void* arg, int status, int /*timeouts*/,
 static const char g_service_config_attribute_prefix[] = "grpc_config=";
 
 static void on_txt_done_locked(void* arg, int status, int /*timeouts*/,
-                               unsigned char* buf,
+                               const unsigned char* buf,
                                int len) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   // This callback is invoked from the c-ares library, so disable thread safety
   // analysis. Note that we are guaranteed to be holding r->mu, though.

--- a/src/core/util/glob.cc
+++ b/src/core/util/glob.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "absl/strings/string_view.h"
+#include <algorithm>
 
 namespace grpc_core {
 


### PR DESCRIPTION
### What does this PR do?

Fixes type of function which missing const-qualifier mismatch with callback in previous declaration.Additional, adding missing header file, which will be reported errror by msvc.

### Why is this change needed?

msvc report error during compilation of grpc

### How was this tested?

- Windows 11
- MSVC 2022
- CMake 3.29
