### PR TITLE
[Python] Aux packages: require at least one proto to compile

### DIFF
--- a/src/python/grpcio_health_checking/health_commands.py
+++ b/src/python/grpcio_health_checking/health_commands.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Provides setuptools command classes for the GRPC Python setup process."""
 
+import logging
 import os
+import pathlib
 import shutil
 
 import setuptools
@@ -40,13 +42,25 @@ class Preprocess(setuptools.Command):
 
     def run(self):
         # TODO: Can skip copy proto part.
+        health_proto_dst = os.path.join(
+            ROOT_REL_DIR, "grpc_health/v1/health.proto"
+        )
         if os.path.isfile(HEALTH_PROTO):
-            shutil.copyfile(
-                HEALTH_PROTO,
-                os.path.join(ROOT_REL_DIR, "grpc_health/v1/health.proto"),
+            shutil.copyfile(HEALTH_PROTO, health_proto_dst)
+        else:
+            self.announce(
+                f"Copy '{HEALTH_PROTO}' -> '{health_proto_dst}' failed: file not found",
+                level=logging.WARNING,
             )
+
+        license_dst = os.path.join(ROOT_REL_DIR, "LICENSE")
         if os.path.isfile(LICENSE):
-            shutil.copyfile(LICENSE, os.path.join(ROOT_REL_DIR, "LICENSE"))
+            shutil.copyfile(LICENSE, license_dst)
+        else:
+            self.announce(
+                f"Copy '{LICENSE}' -> '{license_dst}' failed: file not found",
+                level=logging.WARNING,
+            )
 
 
 class BuildPackageProtos(setuptools.Command):
@@ -64,5 +78,11 @@ class BuildPackageProtos(setuptools.Command):
     def run(self):
         from grpc_tools import command
 
+        protos_search_dir = pathlib.Path(__file__).parent / "grpc_health"
+
+        protos = protos_search_dir.glob("**/*.proto")
+        if not next(protos, None):
+            raise RuntimeError("No protos found")
+
         # find and build all protos in the current package
-        command.build_package_protos(ROOT_REL_DIR)
+        command.build_package_protos(protos_search_dir)


### PR DESCRIPTION
WIP

The health checking library build silently ignores when no protos found, which could results in missing files in packaged distributions.




