### PR TITLE
[Backport][v1.78.x][PHP] Fix runtime error with PHp8.5 alpha because zend_exception_get_…

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -84,7 +84,11 @@ zval *grpc_parse_metadata_array(grpc_metadata_array
     if (php_grpc_zend_hash_find(array_hash, str_key, key_len, (void **)&data)
         == SUCCESS) {
       if (Z_TYPE_P(data) != IS_ARRAY) {
+#if PHP_VERSION_ID >= 80500
+        zend_throw_exception(zend_ce_exception,
+#else
         zend_throw_exception(zend_exception_get_default(TSRMLS_C),
+#endif
                              "Metadata hash somehow contains wrong types.",
                              1 TSRMLS_CC);
         efree(str_key);


### PR DESCRIPTION
### Back port of PR : https://github.com/grpc/grpc/pull/40337

PHP 8.5 removed zend_exception_get_default().
See php updates
https://github.com/php/php-src/blob/747ecce51f2d55a424547d6ae852e2f7f3766e41/UPGRADING.INTERNALS#L51

Closes #40337

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/40337 from HeenaBansal20:master 4134a5ac820c07a10c62428eaefa55eba64a2030 PiperOrigin-RevId: 852624644




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

