### PR TITLE
[Backport][v1.78.x][Fix][Compiler] Plugins fall back to the edition 2023 for older protobuf

### DIFF
--- a/src/compiler/cpp_plugin.h
+++ b/src/compiler/cpp_plugin.h
@@ -45,7 +45,13 @@ class CppGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     return grpc::protobuf::Edition::EDITION_PROTO2;
   }
   grpc::protobuf::Edition GetMaximumEdition() const override {
+    // TODO(yuanweiz): Remove when the protobuf is updated to a version
+    //      that supports edition 2024.
+#if !defined(GOOGLE_PROTOBUF_VERSION) || GOOGLE_PROTOBUF_VERSION >= 6032000
     return grpc::protobuf::Edition::EDITION_2024;
+#else
+    return grpc::protobuf::Edition::EDITION_2023;
+#endif
   }
 #endif
 

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -42,7 +42,13 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     return grpc::protobuf::Edition::EDITION_PROTO2;
   }
   grpc::protobuf::Edition GetMaximumEdition() const override {
+    // TODO(yuanweiz): Remove when the protobuf is updated to a version
+    //      that supports edition 2024.
+#if !defined(GOOGLE_PROTOBUF_VERSION) || GOOGLE_PROTOBUF_VERSION >= 6032000
     return grpc::protobuf::Edition::EDITION_2024;
+#else
+    return grpc::protobuf::Edition::EDITION_2023;
+#endif
   }
 #endif
 

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -93,7 +93,13 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     return grpc::protobuf::Edition::EDITION_PROTO2;
   }
   grpc::protobuf::Edition GetMaximumEdition() const override {
+    // TODO(yuanweiz): Remove when the protobuf is updated to a version
+    //      that supports edition 2024.
+#if !defined(GOOGLE_PROTOBUF_VERSION) || GOOGLE_PROTOBUF_VERSION >= 6032000
     return grpc::protobuf::Edition::EDITION_2024;
+#else
+    return grpc::protobuf::Edition::EDITION_2023;
+#endif
   }
 #endif
 

--- a/src/compiler/php_plugin.cc
+++ b/src/compiler/php_plugin.cc
@@ -46,7 +46,13 @@ class PHPGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     return grpc::protobuf::Edition::EDITION_PROTO2;
   }
   grpc::protobuf::Edition GetMaximumEdition() const override {
+    // TODO(yuanweiz): Remove when the protobuf is updated to a version
+    //      that supports edition 2024.
+#if !defined(GOOGLE_PROTOBUF_VERSION) || GOOGLE_PROTOBUF_VERSION >= 6032000
     return grpc::protobuf::Edition::EDITION_2024;
+#else
+    return grpc::protobuf::Edition::EDITION_2023;
+#endif
   }
 #endif
 

--- a/src/compiler/python_generator.h
+++ b/src/compiler/python_generator.h
@@ -59,7 +59,13 @@ class PythonGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     return grpc::protobuf::Edition::EDITION_PROTO2;
   }
   grpc::protobuf::Edition GetMaximumEdition() const override {
+    // TODO(yuanweiz): Remove when the protobuf is updated to a version
+    //      that supports edition 2024.
+#if !defined(GOOGLE_PROTOBUF_VERSION) || GOOGLE_PROTOBUF_VERSION >= 6032000
     return grpc::protobuf::Edition::EDITION_2024;
+#else
+    return grpc::protobuf::Edition::EDITION_2023;
+#endif
   }
 #endif
 

--- a/src/compiler/ruby_plugin.cc
+++ b/src/compiler/ruby_plugin.cc
@@ -42,7 +42,13 @@ class RubyGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     return grpc::protobuf::Edition::EDITION_PROTO2;
   }
   grpc::protobuf::Edition GetMaximumEdition() const override {
+    // TODO(yuanweiz): Remove when the protobuf is updated to a version
+    //      that supports edition 2024.
+#if !defined(GOOGLE_PROTOBUF_VERSION) || GOOGLE_PROTOBUF_VERSION >= 6032000
     return grpc::protobuf::Edition::EDITION_2024;
+#else
+    return grpc::protobuf::Edition::EDITION_2023;
+#endif
   }
 #endif
 


### PR DESCRIPTION
Backport of #41357 to v1.78.x.
---
Fixes the issue with gRPC protobuf plugins declaring the support for `protobuf::Edition::EDITION_2024`, which is higher than the one supported by the protobuf we're using at the moment: `EDITION_2023` at google/protobuf@74211c0dfc2777318ab53c2cd2c317a2ef9012de.

Related:
- Effectively undoes #40957 