### PR TITLE
[python] get rid of the dependency on six

### DIFF
--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -18,8 +18,6 @@ from __future__ import print_function
 import re
 import subprocess
 
-import six
-
 
 class TestSuite:
     """
@@ -124,7 +122,7 @@ _ALLOWLIST_DICT = {
 _ALL_TRIGGERS = "(" + ")|(".join(list(_ALLOWLIST_DICT.keys())) + ")"
 
 # Add all triggers to their respective test suites
-for trigger, test_suites in six.iteritems(_ALLOWLIST_DICT):
+for trigger, test_suites in _ALLOWLIST_DICT.items():
     for test_suite in test_suites:
         test_suite.add_trigger(trigger)
 

--- a/tools/run_tests/python_utils/report_utils.py
+++ b/tools/run_tests/python_utils/report_utils.py
@@ -24,8 +24,6 @@ import os
 import string
 import xml.etree.cElementTree as ET
 
-import six
-
 
 def _filter_msg(msg, output_format):
     """Filters out nonprintable and illegal characters from the message."""
@@ -71,7 +69,7 @@ def render_junit_xml_report(
     else:
         # To have each test result displayed as a separate target by the Resultstore/Sponge UI,
         # we generate a separate XML report file for each test result
-        for shortname, results in six.iteritems(resultset):
+        for shortname, results in resultset.items():
             one_result = {shortname: results}
             tree = new_junit_xml_tree()
             append_junit_xml_results(
@@ -122,7 +120,7 @@ def append_junit_xml_results(
     )
     failure_count = 0
     error_count = 0
-    for shortname, results in six.iteritems(resultset):
+    for shortname, results in resultset.items():
         for result in results:
             xml_test = ET.SubElement(testsuite, "testcase", name=shortname)
             if result.elapsed_time:

--- a/tools/run_tests/python_utils/start_port_server.py
+++ b/tools/run_tests/python_utils/start_port_server.py
@@ -21,8 +21,7 @@ import subprocess
 import sys
 import tempfile
 import time
-
-import six.moves.urllib.request as request
+import urllib.request as request
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import jobset

--- a/tools/run_tests/python_utils/upload_test_results.py
+++ b/tools/run_tests/python_utils/upload_test_results.py
@@ -21,8 +21,6 @@ import sys
 import time
 import uuid
 
-import six
-
 gcp_utils_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../../gcp/utils")
 )
@@ -140,7 +138,7 @@ def upload_results_to_bq(resultset, bq_table, extra_fields):
     )
 
     bq_rows = []
-    for shortname, results in six.iteritems(resultset):
+    for shortname, results in resultset.items():
         for result in results:
             test_results = {}
             _get_build_metadata(test_results)
@@ -151,7 +149,7 @@ def upload_results_to_bq(resultset, bq_table, extra_fields):
             test_results["return_code"] = result.returncode
             test_results["test_name"] = shortname
             test_results["timestamp"] = time.strftime("%Y-%m-%d %H:%M:%S")
-            for field_name, field_value in six.iteritems(extra_fields):
+            for field_name, field_value in extra_fields.items():
                 test_results[field_name] = field_value
             row = big_query_utils.make_row(str(uuid.uuid4()), test_results)
             bq_rows.append(row)
@@ -178,7 +176,7 @@ def upload_interop_results_to_bq(resultset, bq_table):
     )
 
     bq_rows = []
-    for shortname, results in six.iteritems(resultset):
+    for shortname, results in resultset.items():
         for result in results:
             test_results = {}
             _get_build_metadata(test_results)

--- a/tools/run_tests/run_grpclb_interop_tests.py
+++ b/tools/run_tests/run_grpclb_interop_tests.py
@@ -30,8 +30,6 @@ import time
 import traceback
 import uuid
 
-import six
-
 import python_utils.dockerjob as dockerjob
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
@@ -676,7 +674,7 @@ def run_one_scenario(scenario_config):
                 print('Server "%s" has exited prematurely.' % server)
         suppress_failure = suppress_server_logs and not args.verbose
         dockerjob.finish_jobs(
-            [j for j in six.itervalues(server_jobs)],
+            [j for j in server_jobs.values()],
             suppress_failure=suppress_failure,
         )
 

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -30,8 +30,6 @@ import time
 import traceback
 import uuid
 
-import six
-
 import python_utils.dockerjob as dockerjob
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
@@ -1470,7 +1468,7 @@ if not args.use_docker and servers:
 
 # we want to include everything but objc in 'all'
 # because objc won't run on non-mac platforms
-all_but_objc = set(six.iterkeys(_LANGUAGES)) - set(["objc"])
+all_but_objc = set(s_LANGUAGES.keys()) - set(["objc"])
 languages = set(
     _LANGUAGES[l]
     for l in itertools.chain.from_iterable(
@@ -1546,7 +1544,7 @@ if args.use_docker:
                 "Failed to build interop docker images.",
                 do_newline=True,
             )
-            for image in six.itervalues(docker_images):
+            for image in docker_images.values():
                 dockerjob.remove_image(image, skip_nonexistent=True)
             sys.exit(1)
 
@@ -1801,7 +1799,7 @@ try:
 
     if not jobs:
         print("No jobs to run.")
-        for image in six.itervalues(docker_images):
+        for image in docker_images.values():
             dockerjob.remove_image(image, skip_nonexistent=True)
         sys.exit(1)
 
@@ -1847,9 +1845,9 @@ finally:
         if not job.is_running():
             print('Server "%s" has exited prematurely.' % server)
 
-    dockerjob.finish_jobs([j for j in six.itervalues(server_jobs)])
+    dockerjob.finish_jobs([j for j in server_jobs.values()])
 
-    for image in six.itervalues(docker_images):
+    for image in docker_images.values():
         if not args.manual_run:
             print("Removing docker image %s" % image)
             dockerjob.remove_image(image)

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+!/usr/bin/env python3
 # Copyright 2016 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +25,6 @@ import re
 import shlex
 import sys
 import time
-
-import six
 
 import performance.scenario_config as scenario_config
 import python_utils.jobset as jobset
@@ -692,7 +690,7 @@ def main():
     languages = set(
         scenario_config.LANGUAGES[l]
         for l in itertools.chain.from_iterable(
-            six.iterkeys(scenario_config.LANGUAGES) if x == "all" else [x]
+            scenario_config.LANGUAGES.keys() if x == "all" else [x]
             for x in args.language
         )
     )
@@ -782,8 +780,8 @@ def main():
                 total_scenario_failures += scenario_failures
                 merged_resultset = dict(
                     itertools.chain(
-                        six.iteritems(merged_resultset),
-                        six.iteritems(resultset),
+                        merged_resultset.items(),
+                        resultset.items(),
                     )
                 )
             finally:

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -36,10 +36,8 @@ import sys
 import tempfile
 import time
 import traceback
+import urllib
 import uuid
-
-import six
-from six.moves import urllib
 
 import python_utils.jobset as jobset
 import python_utils.report_utils as report_utils
@@ -1090,7 +1088,7 @@ class CSharpLanguage(object):
             else:
                 raise Exception('Illegal runtime "%s" was specified.')
 
-            for assembly in six.iterkeys(tests_by_assembly):
+            for assembly in tests_by_assembly.keys():
                 assembly_file = "src/csharp/%s/%s/%s%s" % (
                     assembly,
                     assembly_subdir,


### PR DESCRIPTION
Python2 is a thing of the past, it's time to let it go. This PR removes the usage of six. Once/if merged, another one can be done to stop installing it/declaring it as a dependency on metadata/project files.

The motivation for the work is to get rid of py3-six in Alpine Linux: https://gitlab.alpinelinux.org/alpine/aports/-/work_items/17822


CC: @jtattermusch, as there are a bunch of related TODO assigned to this name in the code.