### PR TITLE
Remove `test_timeout_test` from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1854,7 +1854,6 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx test_cpp_server_credentials_test)
   add_dependencies(buildtests_cxx test_cpp_util_slice_test)
   add_dependencies(buildtests_cxx test_cpp_util_time_test)
-  add_dependencies(buildtests_cxx test_timeout_test)
   add_dependencies(buildtests_cxx thd_test)
   add_dependencies(buildtests_cxx thread_manager_test)
   add_dependencies(buildtests_cxx thread_pool_test)
@@ -34669,48 +34668,6 @@ target_link_libraries(test_cpp_util_time_test
   gtest
   grpc++_test_config
   grpc++_test_util
-)
-
-
-endif()
-if(gRPC_BUILD_TESTS)
-
-add_executable(test_timeout_test
-  test/core/test_util/test_timeout_test.cc
-)
-if(WIN32 AND MSVC)
-  if(BUILD_SHARED_LIBS)
-    target_compile_definitions(test_timeout_test
-    PRIVATE
-      "GPR_DLL_IMPORTS"
-      "GRPC_DLL_IMPORTS"
-    )
-  endif()
-endif()
-target_compile_features(test_timeout_test PUBLIC cxx_std_17)
-target_include_directories(test_timeout_test
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
-    ${_gRPC_RE2_INCLUDE_DIR}
-    ${_gRPC_SSL_INCLUDE_DIR}
-    ${_gRPC_UPB_GENERATED_DIR}
-    ${_gRPC_UPB_GRPC_GENERATED_DIR}
-    ${_gRPC_UPB_INCLUDE_DIR}
-    ${_gRPC_XXHASH_INCLUDE_DIR}
-    ${_gRPC_ZLIB_INCLUDE_DIR}
-    third_party/googletest/googletest/include
-    third_party/googletest/googletest
-    third_party/googletest/googlemock/include
-    third_party/googletest/googlemock
-    ${_gRPC_PROTO_GENS_DIR}
-)
-
-target_link_libraries(test_timeout_test
-  ${_gRPC_ALLTARGETS_LIBRARIES}
-  gtest
-  grpc
 )
 
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -24925,17 +24925,6 @@ targets:
   - grpc++_test_config
   - grpc++_test_util
   uses_polling: false
-- name: test_timeout_test
-  gtest: true
-  build: test
-  language: c++
-  headers:
-  - test/core/test_util/test_timeout.h
-  src:
-  - test/core/test_util/test_timeout_test.cc
-  deps:
-  - gtest
-  - grpc
 - name: thd_test
   gtest: true
   build: test

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -677,7 +677,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
-    tags = ["grpc:no-internal-poller"],
+    tags = ["grpc:no-internal-poller", "bazel_only"],
     deps = [
         ":test_timeout",
         "//:grpc",

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -9646,30 +9646,6 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
-    "name": "test_timeout_test",
-    "platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "uses_polling": true
-  },
-  {
-    "args": [],
-    "benchmark": false,
-    "ci_platforms": [
-      "linux",
-      "mac",
-      "posix",
-      "windows"
-    ],
-    "cpu_cost": 1.0,
-    "exclude_configs": [],
-    "exclude_iomgrs": [],
-    "flaky": false,
-    "gtest": true,
-    "language": "c++",
     "name": "thd_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
Remove `test_timeout_test` from CMake, build_autogenerated.yaml, and generated tests.json, and mark it as `bazel_only` in its BUILD file.

We were consistently failing the death test there, and it's uninteresting to debug why.