### PR TITLE
deps: Make ssl/crypto libs configurable

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -30,8 +30,20 @@ config_setting(
     flag_values = {":grpc_use_openssl": "true"},
 )
 
+label_flag(
+    name = "ssl_lib",
+    build_setting_default = ":_default_ssl",
+    visibility = ["//visibility:public"],
+)
+
+label_flag(
+    name = "crypto_lib",
+    build_setting_default = ":_default_crypto",
+    visibility = ["//visibility:public"],
+)
+
 alias(
-    name = "libssl",
+    name = "_default_ssl",
     actual = select({
         ":grpc_use_openssl_setting": "@openssl//:ssl",
         "//conditions:default": "@boringssl//:ssl",
@@ -40,11 +52,23 @@ alias(
 )
 
 alias(
-    name = "libcrypto",
+    name = "_default_crypto",
     actual = select({
         ":grpc_use_openssl_setting": "@openssl//:crypto",
         "//conditions:default": "@boringssl//:crypto",
     }),
+    tags = ["manual"],
+)
+
+alias(
+    name = "libssl",
+    actual = ":ssl_lib",
+    tags = ["manual"],
+)
+
+alias(
+    name = "libcrypto",
+    actual = ":crypto_lib",
     tags = ["manual"],
 )
 


### PR DESCRIPTION
Envoy uses a different build of boringssl when building in FIPS mode.

historically we resolved that by injecting our ssl targets via a patch.

with bzlmod that becomes more difficult, and the better way would be to set which libs are used via a flag.

with this pr - you can set the libs with:

```
  --@grpc//third_party:ssl_lib=@custom_ssl//:ssl
  --@grpc//third_party:crypto_lib=@custom_crypto//:crypto
```


