### PR TITLE
Enable Control Flow Guard (CFG) for MSVC Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,10 @@ if(MSVC)
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /wd4503")
   # Tell MSVC to build grpc using utf-8
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /utf-8")
+  # Enable Control Flow Guard for security hardening
+  set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /guard:cf")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
 endif()
 if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)


### PR DESCRIPTION
This change enables Control Flow Guard security feature for Windows MSVC builds by adding the /guard:cf compiler and linker flags. CFG is a security feature that helps prevent memory corruption vulnerabilities by validating indirect function calls at runtime.

Changes:
- Add /guard:cf to compiler flags (_gRPC_C_CXX_FLAGS)
- Add /guard:cf to CMAKE_EXE_LINKER_FLAGS for executables
- Add /guard:cf to CMAKE_SHARED_LINKER_FLAGS for shared libraries (grpc_csharp_ext)

This addresses security scanner warnings (e.g., binskim BA2008: EnableControlFlowGuard) for grpc_csharp_ext.dll and other Windows binaries.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

