### PR TITLE
Validate grpc_status_code values at all entry points

### DIFF
--- a/src/core/call/client_call.cc
+++ b/src/core/call/client_call.cc
@@ -40,6 +40,7 @@
 #include <utility>
 
 #include "src/core/call/metadata.h"
+#include "src/core/call/status_util.h"
 #include "src/core/lib/event_engine/event_engine_context.h"
 #include "src/core/lib/promise/all_ok.h"
 #include "src/core/lib/promise/status_flag.h"
@@ -415,7 +416,7 @@ void ClientCall::CommitBatch(const grpc_op* ops, size_t nops, void* notify_tag,
              out_trailing_metadata]() {
               auto* status = cancel_status_.Get();
               GRPC_CHECK_NE(status, nullptr);
-              *out_status = static_cast<grpc_status_code>(status->code());
+              grpc_status_code_from_int(status->raw_code(), out_status);
               *out_status_details =
                   Slice::FromCopiedString(status->message()).TakeCSlice();
               if (out_error_string != nullptr) {

--- a/src/core/call/metadata_batch.h
+++ b/src/core/call/metadata_batch.h
@@ -446,7 +446,7 @@ struct GrpcStatusMetadata {
       on_error("negative value", value);
       return GRPC_STATUS_UNKNOWN;
     }
-    if (wire_value >= GRPC_STATUS__DO_NOT_USE) {
+    if (wire_value > 16) {
       on_error("out of range", value);
       return GRPC_STATUS_UNKNOWN;
     }

--- a/src/core/call/status_util.cc
+++ b/src/core/call/status_util.cc
@@ -113,6 +113,16 @@ bool grpc_status_code_from_int(int status_int, grpc_status_code* status) {
   return true;
 }
 
+grpc_status_code grpc_status_code_clamp_to_valid(grpc_status_code status) {
+  return status < GRPC_STATUS_OK || status > GRPC_STATUS_UNAUTHENTICATED
+             ? GRPC_STATUS_UNKNOWN
+             : status;
+}
+
+absl::StatusCode grpc_status_code_to_absl_status_code(grpc_status_code status) {
+  return static_cast<absl::StatusCode>(grpc_status_code_clamp_to_valid(status));
+}
+
 namespace grpc_core {
 
 namespace internal {

--- a/src/core/call/status_util.h
+++ b/src/core/call/status_util.h
@@ -40,6 +40,19 @@ const char* grpc_status_code_to_string(grpc_status_code status);
 // true.
 bool grpc_status_code_from_int(int status_int, grpc_status_code* status);
 
+// Clamps a grpc_status_code value to the valid range [0-16].
+// If the given value is outside this range, returns GRPC_STATUS_UNKNOWN.
+// This function is used to sanitize status codes received from external sources
+// (e.g., network, plugins, user code) to ensure they fall within the valid
+// range defined by the gRPC specification.
+grpc_status_code grpc_status_code_clamp_to_valid(grpc_status_code status);
+
+// Converts a grpc_status_code to absl::StatusCode, clamping to valid range
+// first. If the grpc_status_code is not valid (outside range [0-16]), it is
+// first clamped to GRPC_STATUS_UNKNOWN before conversion. Returns the
+// corresponding absl::StatusCode for the (possibly clamped) status.
+absl::StatusCode grpc_status_code_to_absl_status_code(grpc_status_code status);
+
 namespace grpc_core {
 namespace internal {
 

--- a/src/core/credentials/transport/tls/grpc_tls_certificate_verifier.cc
+++ b/src/core/credentials/transport/tls/grpc_tls_certificate_verifier.cc
@@ -24,6 +24,7 @@
 #include <string>
 #include <utility>
 
+#include "src/core/call/status_util.h"
 #include "src/core/credentials/transport/tls/tls_utils.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -53,8 +54,8 @@ bool ExternalCertificateVerifier::Verify(
                                             &status_code, &error_details);
   if (is_done) {
     if (status_code != GRPC_STATUS_OK) {
-      *sync_status = absl::Status(static_cast<absl::StatusCode>(status_code),
-                                  error_details);
+      *sync_status = absl::Status(
+          grpc_status_code_to_absl_status_code(status_code), error_details);
     }
     MutexLock lock(&mu_);
     request_map_.erase(request);
@@ -85,8 +86,8 @@ void ExternalCertificateVerifier::OnVerifyDone(
   if (callback != nullptr) {
     absl::Status return_status;
     if (status != GRPC_STATUS_OK) {
-      return_status =
-          absl::Status(static_cast<absl::StatusCode>(status), error_details);
+      return_status = absl::Status(grpc_status_code_to_absl_status_code(status),
+                                   error_details);
     }
     callback(return_status);
   }

--- a/src/core/filter/auth/server_auth_filter.cc
+++ b/src/core/filter/auth/server_auth_filter.cc
@@ -32,6 +32,7 @@
 
 #include "src/core/call/metadata_batch.h"
 #include "src/core/call/security_context.h"
+#include "src/core/call/status_util.h"
 #include "src/core/credentials/transport/transport_credentials.h"
 #include "src/core/filter/auth/auth_filters.h"  // IWYU pragma: keep
 #include "src/core/lib/channel/channel_args.h"
@@ -165,7 +166,8 @@ void ServerAuthFilter::RunApplicationCode::OnMdProcessingDone(
       error_details = "Authentication metadata processing failed.";
     }
     state->client_metadata = grpc_error_set_int(
-        absl::Status(static_cast<absl::StatusCode>(status), error_details),
+        absl::Status(grpc_status_code_to_absl_status_code(status),
+                     error_details),
         StatusIntProperty::kRpcStatus, status);
   }
 

--- a/src/core/lib/surface/channel_create.cc
+++ b/src/core/lib/surface/channel_create.cc
@@ -21,6 +21,7 @@
 #include <grpc/impl/channel_arg_names.h>
 #include <grpc/support/port_platform.h>
 
+#include "src/core/call/status_util.h"
 #include "src/core/channelz/channelz.h"
 #include "src/core/client_channel/client_channel.h"
 #include "src/core/client_channel/direct_channel.h"
@@ -221,7 +222,13 @@ grpc_channel* grpc_lame_client_channel_create(const char* target,
       << "grpc_lame_client_channel_create(target=" << target
       << ", error_code=" << (int)error_code
       << ", error_message=" << error_message << ")";
-  if (error_code == GRPC_STATUS_OK) error_code = GRPC_STATUS_UNKNOWN;
+
+  if (!grpc_status_code_from_int(static_cast<int>(error_code), &error_code)) {
+    GRPC_TRACE_LOG(api, WARNING)
+        << "error_code=" << (int)error_code
+        << ": input error code is out of valid range, converting to UNKNOWN";
+  }
+
   grpc_core::ChannelArgs args =
       grpc_core::CoreConfiguration::Get()
           .channel_args_preconditioning()

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -24,6 +24,7 @@
 
 #include <vector>
 
+#include "src/core/call/status_util.h"
 #include "src/core/lib/experiments/experiments.h"
 #include "src/core/lib/transport/status_conversion.h"
 #include "src/core/util/status_helper.h"
@@ -73,7 +74,7 @@ void grpc_error_get_status(grpc_error_handle error,
           http_error_code.has_value()) {
         *code = grpc_http2_error_to_grpc_status(*http_error_code, deadline);
       } else {
-        *code = static_cast<grpc_status_code>(error.code());
+        grpc_status_code_from_int(error.raw_code(), code);
       }
     }
     if (message != nullptr) *message = std::string(error.message());
@@ -137,14 +138,14 @@ void grpc_error_get_status(grpc_error_handle error,
   intptr_t integer;
   if (grpc_error_get_int(found_error, grpc_core::StatusIntProperty::kRpcStatus,
                          &integer)) {
-    status = static_cast<grpc_status_code>(integer);
+    grpc_status_code_from_int(integer, &status);
   } else if (grpc_error_get_int(found_error,
                                 grpc_core::StatusIntProperty::kHttp2Error,
                                 &integer)) {
     status = grpc_http2_error_to_grpc_status(
         static_cast<Http2ErrorCode>(integer), deadline);
   } else {
-    status = static_cast<grpc_status_code>(found_error.code());
+    grpc_status_code_from_int(found_error.raw_code(), &status);
   }
   if (code != nullptr) *code = status;
 


### PR DESCRIPTION
Ensure status codes stay within valid range [0-16] by adding validation at:
- Wire protocol parsing (clamp out-of-range values to UNKNOWN)
- Call API (SEND_STATUS_FROM_SERVER, cancel operations, lame channels)
- Security components (plugin credentials, TLS verifiers, auth filters)

Invalid codes are converted to GRPC_STATUS_UNKNOWN to prevent out-of-spec values from external sources (network, plugins, user code).




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

