### PR TITLE
Fix PHP Extension building error for Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1455,7 +1455,7 @@ if (PHP_GRPC != "no") {
     ""
     , null,
     "/DOPENSSL_NO_ASM /D_GNU_SOURCE /DWIN32_LEAN_AND_MEAN "+
-    "/D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 "+
+    "/D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 /FS /std:c++17 "+
     "/I"+configure_module_dirname+" "+
     "/I"+configure_module_dirname+"\\include "+
     "/I"+configure_module_dirname+"\\src\\core\\ext\\upb-gen "+


### PR DESCRIPTION
Unable to build gRPC PHP Extension without apply this patch.