### PR TITLE
[interop] Add v1.77.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -325,6 +325,7 @@ LANG_RELEASE_MATRIX = {
             ("v1.74.3", ReleaseInfo()),
             ("v1.75.1", ReleaseInfo()),
             ("v1.76.0", ReleaseInfo()),
+            ("v1.77.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION
```
$ gcloud beta container images list-tags us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_interop_go1.x
DIGEST        TAGS                                         TIMESTAMP            VULNERABILITIES
a7734f9a23a4  infrastructure-public-image-v1.77.0,v1.77.0  2025-11-17T23:41:17  CRITICAL=1,HIGH=8,LOW=34,MEDIUM=6,MINIMAL=98
aa5081509e42  infrastructure-public-image-v1.76.0,v1.76.0  2025-10-06T22:34:20  CRITICAL=1,HIGH=10,LOW=41,MEDIUM=8,MINIMAL=108
706779879f22  infrastructure-public-image-v1.72.3,v1.72.3  2025-09-10T09:53:08  CRITICAL=1,HIGH=12,LOW=41,MEDIUM=13,MINIMAL=108
cd6ff9704672  infrastructure-public-image-v1.73.1,v1.73.1  2025-09-10T09:08:06  CRITICAL=1,HIGH=10,LOW=41,MEDIUM=10,MINIMAL=108
b1ce9dcb8e77  infrastructure-public-image-v1.74.3,v1.74.3  2025-09-10T08:47:41  CRITICAL=1,HIGH=10,LOW=41,MEDIUM=10,MINIMAL=108
cc4d38dfd6bc  infrastructure-public-image-v1.75.1,v1.75.1  2025-09-10T07:01:45  CRITICAL=1,HIGH=10,LOW=41,MEDIUM=8,MINIMAL=108
debefa297d2f  infrastructure-public-image-v1.75.0,v1.75.0  2025-08-20T07:11:42
a99d95a96a4e  infrastructure-public-image-v1.74.2,v1.74.2  2025-07-23T04:56:36
d13fbd1dafdb  infrastructure-public-image-v1.73.0,v1.73.0  2025-06-06T08:46:49
96e88fdea1a5  infrastructure-public-image-v1.72.2,v1.72.2  2025-05-27T05:09:30
```