### PR TITLE
Re-scope secondary licenses listed in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -203,6 +203,16 @@
 
 -----------------------------------------------------------
 
+Following applies to:
+./src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec
+./src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+./src/objective-c/!ProtoCompiler.podspec
+./src/objective-c/BoringSSL-GRPC.podspec
+./templates/src/objective-c/!ProtoCompiler-gRPCCppPlugin.podspec.inja
+./templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.inja
+./templates/src/objective-c/!ProtoCompiler.podspec.inja
+./templates/src/objective-c/BoringSSL-GRPC.podspec.template
+
 BSD 3-Clause License
 
 Copyright 2016, Google Inc.
@@ -234,6 +244,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------------------------------------------------------
+
+Following applies to:
+./etc/roots.pem
 
 Mozilla Public License Version 2.0
 ==================================


### PR DESCRIPTION
The gRPC project is primarily covered by the Apache License v2.0. Over the years, several files were added to the repo carrying other licenses, Mozilla Public License Version 2.0, and BSD 3-Clause License. These additional licenses were never
intended to cover the entire repository, and were intended to be scoped to the specific files that carried in those different licenses. This change clarifies the scoping of which files are covered by either the MPL v2.0 or BSD 3-Clause License.