### PR TITLE
[WIP] Add custom per-call metric labels for open telemetry

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -476,6 +476,7 @@ GRPCXX_PUBLIC_HDRS = [
     "include/grpcpp/impl/completion_queue_tag.h",
     "include/grpcpp/impl/create_auth_context.h",
     "include/grpcpp/impl/delegating_channel.h",
+    "include/grpcpp/impl/enabled_call_options.h",
     "include/grpcpp/impl/generic_stub_internal.h",
     "include/grpcpp/impl/grpc_library.h",
     "include/grpcpp/impl/intercepted_channel.h",
@@ -1691,6 +1692,16 @@ grpc_cc_library(
         "//src/core:useful",
         "//src/core:windows_event_engine",
         "//src/core:windows_event_engine_listener",
+    ],
+)
+
+grpc_cc_library(
+    name = "telemetry_label",
+    hdrs = [
+        "//src/core:telemetry/telemetry_label.h",
+    ],
+    deps = [
+        "//src/core:arena",
     ],
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4054,6 +4054,7 @@ libs:
   - include/grpcpp/impl/completion_queue_tag.h
   - include/grpcpp/impl/create_auth_context.h
   - include/grpcpp/impl/delegating_channel.h
+  - include/grpcpp/impl/enabled_call_options.h
   - include/grpcpp/impl/generic_serialize.h
   - include/grpcpp/impl/generic_stub_internal.h
   - include/grpcpp/impl/grpc_library.h
@@ -4434,6 +4435,7 @@ libs:
   - include/grpcpp/impl/completion_queue_tag.h
   - include/grpcpp/impl/create_auth_context.h
   - include/grpcpp/impl/delegating_channel.h
+  - include/grpcpp/impl/enabled_call_options.h
   - include/grpcpp/impl/generic_serialize.h
   - include/grpcpp/impl/generic_stub_internal.h
   - include/grpcpp/impl/grpc_library.h

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -367,6 +367,10 @@ typedef struct grpc_call_credentials grpc_call_credentials;
 GRPCAPI grpc_call_error grpc_call_set_credentials(grpc_call* call,
                                                   grpc_call_credentials* creds);
 
+/** Sets a custom label for applications to define their own dimension for per-call
+metrics */
+GRPCAPI void grpc_call_context_set_telemetry_label(grpc_call* call, const char* label, size_t len);
+
 /** Request notification of a new call.
     Once a call is received, a notification tagged with \a tag_new is added to
     \a cq_for_notification. \a call, \a details and \a request_metadata are

--- a/include/grpcpp/client_context.h
+++ b/include/grpcpp/client_context.h
@@ -37,6 +37,7 @@
 #include <grpc/impl/compression_types.h>
 #include <grpc/impl/propagation_bits.h>
 #include <grpcpp/impl/create_auth_context.h>
+#include <grpcpp/impl/enabled_call_options.h>
 #include <grpcpp/impl/metadata_map.h>
 #include <grpcpp/impl/rpc_method.h>
 #include <grpcpp/impl/sync.h>
@@ -366,6 +367,11 @@ class ClientContext {
   ///
   /// \return The call's peer URI.
   std::string peer() const;
+
+  template <typename T>
+  std::enable_if_t<impl::kIsEnabled<T>> SetCallOption(T option) {
+    grpc::SetCallOptionsInternal(option);
+  }
 
   /// Sets the census context.
   /// It is only valid to call this before the client call is created. A common

--- a/include/grpcpp/impl/enabled_call_options.h
+++ b/include/grpcpp/impl/enabled_call_options.h
@@ -1,0 +1,35 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPCPP_IMPL_ENABLED_CALL_OPTIONS_H
+#define GRPCPP_IMPL_ENABLED_CALL_OPTIONS_H
+
+#include <string_view>
+
+namespace grpc {
+namespace impl {
+
+struct TelemetryLabel {
+  std::string_view value;
+};
+
+template <typename T>
+constexpr bool kIsEnabled = false;
+template <>
+constexpr bool kIsEnabled<TelemetryLabel> = true;
+
+}  // namespace impl
+}  // namespace grpc
+
+#endif  // GRPCPP_IMPL_ENABLED_CALL_OPTIONS_H

--- a/src/core/telemetry/telemetry_label.h
+++ b/src/core/telemetry/telemetry_label.h
@@ -1,0 +1,34 @@
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRPC_SRC_CORE_TELEMETRY_TELEMETRY_LABEL_H
+#define GRPC_SRC_CORE_TELEMETRY_TELEMETRY_LABEL_H
+
+#include <string_view>
+#include "src/core/lib/resource_quota/arena.h"
+
+namespace grpc_core {
+
+struct TelemetryLabel {
+  std::string_view value;
+};
+
+template <>
+struct ArenaContextType<TelemetryLabel> {
+  static void Destroy(TelemetryLabel*) {}
+};
+
+}  // namespace grpc_core
+
+#endif  // GRPC_SRC_CORE_TELEMETRY_TELEMETRY_LABEL_H


### PR DESCRIPTION
- Add a public C++ API definition for call options
- Add an allowlist for call options that can be set on context. Currently only TelemetryLabel will be allowed.
- Add a C-core API definition to set telemetry label in arena.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

