### PR TITLE
[Core] Fix completion queue shutdown race on weak memory models (ARM)

### DIFF
--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -331,7 +331,7 @@ struct cq_next_data {
   std::atomic<intptr_t> pending_events{1};
 
   /// 0 initially. 1 once we initiated shutdown
-  bool shutdown_called = false;
+  std::atomic<bool> shutdown_called{false};
 };
 
 struct cq_pluck_data {
@@ -369,7 +369,7 @@ struct cq_pluck_data {
   std::atomic<bool> shutdown{false};
 
   /// 0 initially. 1 once we initiated shutdown
-  bool shutdown_called = false;
+  std::atomic<bool> shutdown_called{false};
 
   int num_pluckers = 0;
   plucker pluckers[GRPC_MAX_COMPLETION_QUEUE_PLUCKERS];
@@ -396,7 +396,7 @@ struct cq_callback_data {
   std::atomic<intptr_t> pending_events{1};
 
   /// 0 initially. 1 once we initiated shutdown
-  bool shutdown_called = false;
+  std::atomic<bool> shutdown_called{false};
 
   /// A callback that gets invoked when the CQ completes shutdown
   grpc_completion_queue_functor* shutdown_callback;
@@ -1122,7 +1122,7 @@ static grpc_event cq_next(grpc_completion_queue* cq, gpr_timespec deadline,
 static void cq_finish_shutdown_next(grpc_completion_queue* cq) {
   cq_next_data* cqd = static_cast<cq_next_data*> DATA_FROM_CQ(cq);
 
-  GRPC_CHECK(cqd->shutdown_called);
+  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_relaxed));
   GRPC_CHECK_EQ(cqd->pending_events.load(std::memory_order_relaxed), 0);
 
   cq->poller_vtable->shutdown(POLLSET_FROM_CQ(cq), &cq->pollset_shutdown_done);
@@ -1139,12 +1139,12 @@ static void cq_shutdown_next(grpc_completion_queue* cq) {
   // this function is still active
   GRPC_CQ_INTERNAL_REF(cq, "shutting_down");
   gpr_mu_lock(cq->mu);
-  if (cqd->shutdown_called) {
+  if (cqd->shutdown_called.load(std::memory_order_relaxed)) {
     gpr_mu_unlock(cq->mu);
     GRPC_CQ_INTERNAL_UNREF(cq, "shutting_down");
     return;
   }
-  cqd->shutdown_called = true;
+  cqd->shutdown_called.store(true, std::memory_order_relaxed);
   // Doing acq/release fetch_sub here to match with
   // cq_begin_op_for_next and cq_end_op_for_next functions which read/write
   // on this counter without necessarily holding a lock on cq
@@ -1347,7 +1347,7 @@ grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,
 static void cq_finish_shutdown_pluck(grpc_completion_queue* cq) {
   cq_pluck_data* cqd = static_cast<cq_pluck_data*> DATA_FROM_CQ(cq);
 
-  GRPC_CHECK(cqd->shutdown_called);
+  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_relaxed));
   GRPC_CHECK(!cqd->shutdown.load(std::memory_order_relaxed));
   cqd->shutdown.store(true, std::memory_order_relaxed);
 
@@ -1367,12 +1367,12 @@ static void cq_shutdown_pluck(grpc_completion_queue* cq) {
   // this function is still active
   GRPC_CQ_INTERNAL_REF(cq, "shutting_down (pluck cq)");
   gpr_mu_lock(cq->mu);
-  if (cqd->shutdown_called) {
+  if (cqd->shutdown_called.load(std::memory_order_relaxed)) {
     gpr_mu_unlock(cq->mu);
     GRPC_CQ_INTERNAL_UNREF(cq, "shutting_down (pluck cq)");
     return;
   }
-  cqd->shutdown_called = true;
+  cqd->shutdown_called.store(true, std::memory_order_relaxed);
   if (cqd->pending_events.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     cq_finish_shutdown_pluck(cq);
   }
@@ -1384,7 +1384,7 @@ static void cq_finish_shutdown_callback(grpc_completion_queue* cq) {
   cq_callback_data* cqd = static_cast<cq_callback_data*> DATA_FROM_CQ(cq);
   auto* callback = cqd->shutdown_callback;
 
-  GRPC_CHECK(cqd->shutdown_called);
+  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_relaxed));
 
   cq->poller_vtable->shutdown(POLLSET_FROM_CQ(cq), &cq->pollset_shutdown_done);
 
@@ -1405,12 +1405,12 @@ static void cq_shutdown_callback(grpc_completion_queue* cq) {
   // this function is still active
   GRPC_CQ_INTERNAL_REF(cq, "shutting_down (callback cq)");
   gpr_mu_lock(cq->mu);
-  if (cqd->shutdown_called) {
+  if (cqd->shutdown_called.load(std::memory_order_relaxed)) {
     gpr_mu_unlock(cq->mu);
     GRPC_CQ_INTERNAL_UNREF(cq, "shutting_down (callback cq)");
     return;
   }
-  cqd->shutdown_called = true;
+  cqd->shutdown_called.store(true, std::memory_order_relaxed);
   if (cqd->pending_events.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     gpr_mu_unlock(cq->mu);
     cq_finish_shutdown_callback(cq);

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -1122,7 +1122,7 @@ static grpc_event cq_next(grpc_completion_queue* cq, gpr_timespec deadline,
 static void cq_finish_shutdown_next(grpc_completion_queue* cq) {
   cq_next_data* cqd = static_cast<cq_next_data*> DATA_FROM_CQ(cq);
 
-  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_relaxed));
+  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_acquire));
   GRPC_CHECK_EQ(cqd->pending_events.load(std::memory_order_relaxed), 0);
 
   cq->poller_vtable->shutdown(POLLSET_FROM_CQ(cq), &cq->pollset_shutdown_done);
@@ -1144,7 +1144,10 @@ static void cq_shutdown_next(grpc_completion_queue* cq) {
     GRPC_CQ_INTERNAL_UNREF(cq, "shutting_down");
     return;
   }
-  cqd->shutdown_called.store(true, std::memory_order_relaxed);
+  // Using memory_order_release to ensure shutdown_called is visible to all
+  // threads on weak memory models like ARM64. This synchronizes-with the
+  // acquire load in cq_finish_shutdown_next and cq_end_op_for_next.
+  cqd->shutdown_called.store(true, std::memory_order_release);
   // Doing acq/release fetch_sub here to match with
   // cq_begin_op_for_next and cq_end_op_for_next functions which read/write
   // on this counter without necessarily holding a lock on cq
@@ -1347,7 +1350,7 @@ grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,
 static void cq_finish_shutdown_pluck(grpc_completion_queue* cq) {
   cq_pluck_data* cqd = static_cast<cq_pluck_data*> DATA_FROM_CQ(cq);
 
-  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_relaxed));
+  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_acquire));
   GRPC_CHECK(!cqd->shutdown.load(std::memory_order_relaxed));
   cqd->shutdown.store(true, std::memory_order_relaxed);
 
@@ -1372,7 +1375,7 @@ static void cq_shutdown_pluck(grpc_completion_queue* cq) {
     GRPC_CQ_INTERNAL_UNREF(cq, "shutting_down (pluck cq)");
     return;
   }
-  cqd->shutdown_called.store(true, std::memory_order_relaxed);
+  cqd->shutdown_called.store(true, std::memory_order_release);
   if (cqd->pending_events.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     cq_finish_shutdown_pluck(cq);
   }
@@ -1384,7 +1387,7 @@ static void cq_finish_shutdown_callback(grpc_completion_queue* cq) {
   cq_callback_data* cqd = static_cast<cq_callback_data*> DATA_FROM_CQ(cq);
   auto* callback = cqd->shutdown_callback;
 
-  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_relaxed));
+  GRPC_CHECK(cqd->shutdown_called.load(std::memory_order_acquire));
 
   cq->poller_vtable->shutdown(POLLSET_FROM_CQ(cq), &cq->pollset_shutdown_done);
 
@@ -1410,7 +1413,7 @@ static void cq_shutdown_callback(grpc_completion_queue* cq) {
     GRPC_CQ_INTERNAL_UNREF(cq, "shutting_down (callback cq)");
     return;
   }
-  cqd->shutdown_called.store(true, std::memory_order_relaxed);
+  cqd->shutdown_called.store(true, std::memory_order_release);
   if (cqd->pending_events.fetch_sub(1, std::memory_order_acq_rel) == 1) {
     gpr_mu_unlock(cq->mu);
     cq_finish_shutdown_callback(cq);


### PR DESCRIPTION
On ARM64, server shutdown could hang for 20+ minutes due to a memory visibility issue in the C-core completion queue. The shutdown_called flag lacks memory barriers, causing blocked threads to never wake up on ARM's weak memory model.

A  workaround fix was created for ruby that sent a dummy RPC before shutdown to unblock the completion queue from the I/O side. [41223](https://github.com/grpc/grpc/pull/41223).

This PR addresses the issue in the core; such that all wrapped languages can reap the benefit; as well as the root cause is addressed.  Converted the `shutdown_called` flag from bool to `std::atomic<bool>` in all internal completion queue data structures. This guarantees that the shutdown state transition is atomically visible across threads, preventing race conditions and ensuring the completion queue drains and shuts down correctly on all architectures.

The PR addresses the issue skipped in [40770](https://github.com/grpc/grpc/pull/40770)