### PR TITLE
[PHP] ignore PHPUnit security advisory in Mac build (backport to 1.78.x)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -261,6 +261,10 @@ then
     rm composer-setup.php
 
     # Install PHP test dependencies.
+    # Using --no-security-blocking to install in spite of security advisory
+    # PKSA-z3gr-8qht-p93v which impacts the function cleanupForCoverage()
+    # TODO(pawbhard): Remove --no-security-blocking once the dependency is
+    # updated to a newer version.
     php /tmp/composer.phar global require phpunit/phpunit:9.5.9 --no-security-blocking
   else
     # Workaround for https://github.com/Homebrew/homebrew-core/issues/41081


### PR DESCRIPTION
I need this to do the 1.78.x release build. Original message:

> This should fix a build problem we are seeing with the error message
>
>> Root composer.json requires phpunit/phpunit 9.5.9 (exact version match: 9.5.9 or 9.5.9.0), found phpunit/phpunit[9.5.9] but these were not loaded, because they are affected by security advisories ("PKSA-z3gr-8qht-p93v"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
>
> [The referenced vulnerability](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) says that the impacted function is `cleanupForCoverage()`, which we don't call as far as I can tell, so we shouldn't be impacted by this. In the long run, it would probably be good to upgrade to a newer version of PHPUnit, but this should get the build to work in the short term.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

