### PR TITLE
Update push_testing_images.sh README.md

### DIFF
--- a/tools/dockerfile/README.md
+++ b/tools/dockerfile/README.md
@@ -49,7 +49,7 @@ that are already in artifact registry)
 
 ```
 # Install qemu, binformat, and configure binfmt interpreters
-sudo apt-get install binfmt-support qemu-user-static
+sudo apt-get install binfmt-support qemu-user-binfmt
 
 # Enable different multi-architecture containers by QEMU with Docker
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
Looks like we need to install `qemu-user-binfmt` now.

```
$ apt info qemu-user-static
Package: qemu-user-static
State: not a real package (virtual)
Notice: Can't select candidate version from package qemu-user-static as it has no candidate
Notice: Can't select versions from package 'qemu-user-static' as it is purely virtual
Notice: No packages found

$ apt info qemu-user-binfmt
Package: qemu-user-binfmt
Version: 1:10.1.3+ds-1
Priority: optional
Section: otherosfs
Source: qemu
Maintainer: Debian QEMU Team 
Installed-Size: 39.9 kB
Provides: qemu-user-static
Depends: qemu-user (= 1:10.1.3+ds-1)
Recommends: systemd
Breaks: qemu-user-static
Replaces: qemu-user-static (<< 1:9.1.0)
Homepage: http://www.qemu.org/
Download-Size: 1,768 B
APT-Manual-Installed: yes
Packages
Description: QEMU user mode binfmt registration for qemu-user
 QEMU is a fast processor emulator: currently the package supports Alpha, ARM,
 CRIS, i386, LoongArch, M68k (ColdFire), MicroBlaze, MIPS, PowerPC, RISC-V,
 S390x, SH4, SPARC, x86-64, Xtensa and other emulations. By using dynamic
 translation it achieves reasonable speed while being easy to port on new host
 CPUs.
 .
 This package provides binfmt support registration for the user-mode emulation
 binaries from qemu-user.  This package does not contain additional binaries,
 just (sym)links to binfmt registration data in /usr/lib/binfmt.d/ so it is
 picked up automatically by, eg, systemd.  Actual files are provided by
 qemu-user package.
```