### PR TITLE
Fix MSB4259 by removing whitespace in Google.Protobuf.Tools.props

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.props
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.props
@@ -8,9 +8,9 @@
 
 
     <!-- Tools - protocol buffers compiler and plugins -->
-    <Protobuf_PackagedToolsPath>$( [System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../../tools) )</Protobuf_PackagedToolsPath>
+    <Protobuf_PackagedToolsPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../../tools))</Protobuf_PackagedToolsPath>
     <!-- Protocol buffers Well Known Types -->
-    <Protobuf_StandardImportsPath>$( [System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../native/include) )</Protobuf_StandardImportsPath>
+    <Protobuf_StandardImportsPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../native/include))</Protobuf_StandardImportsPath>
   </PropertyGroup>
 
   <!-- NET SDK projects only: include proto files by default. Other project


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/41548

Grpc.Tools 2.76.0 currently contains a property function invocation in:

build/_protobuf/Google.Protobuf.Tools.props
that triggers the following error:

Unexpected space at position "3" of property reference "$( [System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)../../tools) )". Did you forget to remove a space?

This PR removes the invalid whitespace from that property reference so that projects consuming Grpc.Tools load and build correctly under the newer MSBuild validation.

Reference: dotnet/msbuild PR introducing the validation/error: https://github.com/dotnet/msbuild/pull/13076




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

