### PR TITLE
Fix artifact_gen using yaml-cpp@0.9.0

### DIFF
--- a/tools/artifact_gen/MODULE.bazel
+++ b/tools/artifact_gen/MODULE.bazel
@@ -15,7 +15,7 @@
 bazel_dep(name = "pugixml", version = "1.15")
 bazel_dep(name = "abseil-cpp", version = "20240722.0")
 bazel_dep(name = "nlohmann_json", version = "3.11.3.bcr.1")
-bazel_dep(name = "yaml-cpp", version = "0.8.0")
+bazel_dep(name = "yaml-cpp", version = "0.9.0")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 


### PR DESCRIPTION
yaml-cpp@0.9.0 is released at https://github.com/bazelbuild/bazel-central-registry/pull/7443

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

