### PR TITLE
Remove pre-release Python version from list of supported Python versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -68,7 +68,6 @@ PYTHON_VERSIONS = [
     "3.11",
     "3.12",
     "3.13",
-    "3.14.0b2",
 ]
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")


### PR DESCRIPTION
`rules_python` v1.6.0 removed `3.14.0b2` from the list of supported versions (see https://github.com/bazel-contrib/rules_python/commit/89e0f63c576d152293d5c866394f31b08a569ad3). Since Bzlmod performs version resolution, any repository which (transitively) uses a newer version of `rules_python` fails to use it. Remove the pre-release version from the `v1.78.x` series.

The issue manifests in the following error when trying to upgrade grpc to `1.78.0` in our repo:
```
(11:18:37) ERROR: /home/runner/.cache/bazel/_bazel_runner/80ee21f5abd5872fd13fbc92e73e36c7/external/rules_python+/python/private/python_register_toolchains.bzl:121:31: Traceback (most recent call last):
	File "/home/runner/.cache/bazel/_bazel_runner/80ee21f5abd5872fd13fbc92e73e36c7/external/rules_python+/python/private/python.bzl", line 327, column 53, in _python_impl
		register_result = python_register_toolchains(
	File "/home/runner/.cache/bazel/_bazel_runner/80ee21f5abd5872fd13fbc92e73e36c7/external/rules_python+/python/private/python_register_toolchains.bzl", line 121, column 31, in python_register_toolchains
		sha256 = tool_versions[python_version]["sha256"].get(platform, None)
Error: key "3.14.0b2" not found in dictionary
(11:18:37) ERROR: @rules_python//python/config_settings:bootstrap_impl :: Error loading option @rules_python//python/config_settings:bootstrap_impl: error evaluating module extension @@rules_python+//python/extensions:python.bzl%python
```