### PR TITLE
[Backport][v1.78.x][Python] Align GRPC_ENABLE_FORK_SUPPORT env defaults in core and python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -452,6 +452,17 @@ else:
     DEFINE_MACROS += (
         ("HAVE_CONFIG_H", 1),
         ("GRPC_ENABLE_FORK_SUPPORT", 1),
+        # Set runtime GRPC_ENABLE_FORK_SUPPORT setting in core to "off".
+        #
+        # By default, gRPC core GRPC_ENABLE_FORK_SUPPORT runtime config_var
+        # is "on" when it's compiled with GRPC_ENABLE_FORK_SUPPORT macro.
+        # However, in python GRPC_ENABLE_FORK_SUPPORT by default is "off".
+        # Compare config_vars.cc and fork_posix.pyx.pxi.
+        # This leads to an inconsistent and broken behavior.
+        #
+        # Important! This must by in sync with the default value for the
+        # GRPC_ENABLE_FORK_SUPPORT env var parsed in fork_posix.pyx.pxi
+        ("GRPC_ENABLE_FORK_SUPPORT_DEFAULT", "false"),
     )
 
 # Fix for multiprocessing support on Apple devices.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -29,6 +29,10 @@ _TRUE_VALUES = ['yes',  'Yes',  'YES', 'true', 'True', 'TRUE', '1']
 #
 # This flag is not supported on Windows.
 # This flag is also not supported for non-native IO manager.
+#
+# Important: when changing the default, GRPC_ENABLE_FORK_SUPPORT_DEFAULT
+# macro in the setup.py needs to be updated to the same value.
+# TODO(sergiitk): reconsider enabling this by default.
 _GRPC_ENABLE_FORK_SUPPORT = (
     os.environ.get('GRPC_ENABLE_FORK_SUPPORT', '0')
         .lower() in _TRUE_VALUES)


### PR DESCRIPTION
Backport of #41455 to v1.78.x.
---
In the core, the default value of the `GRPC_ENABLE_FORK_SUPPORT` environment variable is determined by the value of the `GRPC_ENABLE_FORK_SUPPORT_DEFAULT` macro, which is by default derived from the value of the `GRPC_ENABLE_FORK_SUPPORT` macro. Python sets `GRPC_ENABLE_FORK_SUPPORT`, so the feature is enabled there by default. However, Python also reads the value of the `GRPC_ENABLE_FORK_SUPPORT` environment variable and sets its own default in `fork_posix.pyx.pxi`, and the feature is disabled there by default. The result is a mixed state that causes problems.

This change fixes that by disabling the feature by default in both places. In the long run we want to enable it by default everywhere, but for now we don't have confidence in its stability.