### PR TITLE
[Python] Add Macosx Bazel Python tests for Pull Requests

### DIFF
--- a/tools/internal_ci/macos/pull_request/grpc_bazel_python_test.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_bazel_python_test.cfg
@@ -1,0 +1,27 @@
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_python_bazel_test.sh"
+timeout_mins: 120
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"


### PR DESCRIPTION
### Description

Add MacOS Python Bazel tests run for pull requests. This new `.cfg` file added in this is copy of `tools/internal_ci/macos/grpc_python_bazel_test.cfg` 

### Testing

Internally tested.

Internal ref: cl/867407007, b/423766424