### PR TITLE
[interop] Add v1.79.1 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -334,68 +334,98 @@ LANG_RELEASE_MATRIX = {
         [
             (
                 "v1.0.3",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.1.2",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.2.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.3.1",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.4.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.5.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.6.1",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             ("v1.7.1", ReleaseInfo(testcases_file="java__v1.0.3")),
             (
                 "v1.8.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.9.1",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.10.1",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.11.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             ("v1.12.1", ReleaseInfo(testcases_file="java__v1.0.3")),
             ("v1.13.2", ReleaseInfo(testcases_file="java__v1.0.3")),
             (
                 "v1.14.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             ("v1.15.1", ReleaseInfo(testcases_file="java__v1.0.3")),
             (
                 "v1.16.1",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             ("v1.17.2", ReleaseInfo(testcases_file="java__v1.0.3")),
             (
                 "v1.18.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             (
                 "v1.19.0",
-                ReleaseInfo(runtimes=["java_oracle8"], testcases_file="java__v1.0.3"),
+                ReleaseInfo(
+                    runtimes=["java_oracle8"], testcases_file="java__v1.0.3"
+                ),
             ),
             ("v1.20.0", ReleaseInfo(runtimes=["java_oracle8"])),
             ("v1.21.1", ReleaseInfo()),
@@ -462,275 +492,411 @@ LANG_RELEASE_MATRIX = {
         [
             (
                 "v1.0.x",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.1.4",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.2.5",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.3.9",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.4.2",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.6.6",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.7.2",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.8.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.9.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.10.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.0.x"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.0.x"
+                ),
             ),
             (
                 "v1.11.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.12.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.13.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.14.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.15.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.16.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.17.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.11.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.11.1"
+                ),
             ),
             (
                 "v1.18.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.19.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.20.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.21.4",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.22.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.22.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.23.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.24.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.25.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.26.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.27.3",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.30.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.31.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.32.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.33.2",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.34.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.35.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.36.3",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.37.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.38.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.39.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.18.0"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.18.0"
+                ),
             ),
             (
                 "v1.41.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.41.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.41.1"
+                ),
             ),
             (
                 "v1.42.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.41.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.41.1"
+                ),
             ),
             (
                 "v1.43.2",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__v1.41.1"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__v1.41.1"
+                ),
             ),
             (
                 "v1.44.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.46.2",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.47.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.48.3",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.49.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.52.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.53.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.54.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.55.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.56.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.57.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.58.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.60.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.61.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.62.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.63.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.64.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.65.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.66.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.67.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.69.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.70.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.71.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.72.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.73.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.74.0",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             (
                 "v1.75.1",
-                ReleaseInfo(runtimes=["python"], testcases_file="python__master"),
+                ReleaseInfo(
+                    runtimes=["python"], testcases_file="python__master"
+                ),
             ),
             # Python images can't be anymore built without #40959 temporary fix,
             # or #40833 proper pyproject migration.


### PR DESCRIPTION
Add go version v1.79.1 to the client_matrix
Test : https://fusion2.corp.google.com/ci/kokoro/prod:grpc%2Fcore%2Fexperimental%2Flinux%2Fgrpc_interop_matrix_adhoc/activity/e8146c9d-44b9-4111-9ee6-a2330ae41185/summary

