### PR TITLE
[Backport][v1.78.x][Python] Resolve absl::InitializeLog warning

### DIFF
--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -198,6 +198,7 @@ python_dependencies:
   - boringssl
   - re2
   - z
+  - abseil-cpp
 ruby_gem:
   deps:
   - grpc

--- a/setup.py
+++ b/setup.py
@@ -515,6 +515,7 @@ def cython_extensions_and_necessity():
                 + list(CYTHON_HELPER_C_FILES)
                 + core_c_files
                 + asm_files
+                + ["third_party/abseil-cpp/absl/log/initialize.cc"]
             ),
             include_dirs=list(EXTENSION_INCLUDE_DIRECTORIES),
             libraries=list(EXTENSION_LIBRARIES),

--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -35,5 +35,6 @@ pyx_library(
     defines = ["GRPC_PYTHON_BUILD=1"],
     deps = [
         "//:grpc",
+        "@com_google_absl//absl/log:initialize",
     ],
 )

--- a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/absl.pxd.pxi
@@ -1,0 +1,18 @@
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# absl Utilities
+
+cdef extern from "absl/log/initialize.h" namespace "absl":
+  void InitializeLog() nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/absl.pyx.pxi
@@ -1,0 +1,25 @@
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cdef bint _disable_absl_init_log = os.environ.get("GRPC_PYTHON_DISABLE_ABSL_INIT_LOG", "") in {"1", "t", "true", "y", "yes"}
+
+#
+# initialize absl
+#
+cdef _initialize_absl():
+  if not _disable_absl_init_log:
+    InitializeLog()
+
+_initialize_absl()

--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
@@ -17,6 +17,8 @@ cimport cpython
 
 include "_cygrpc/grpc.pxi"
 
+include "_cygrpc/absl.pxd.pxi"
+
 include "_cygrpc/arguments.pxd.pxi"
 include "_cygrpc/call.pxd.pxi"
 include "_cygrpc/channel.pxd.pxi"

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -37,6 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 # TODO(atash): figure out why the coverage tool gets confused about the Cython
 # coverage plugin when the following files don't have a '.pxi' suffix.
 include "_cygrpc/grpc_string.pyx.pxi"
+include "_cygrpc/absl.pyx.pxi"
 include "_cygrpc/arguments.pyx.pxi"
 include "_cygrpc/call.pyx.pxi"
 include "_cygrpc/channel.pyx.pxi"
@@ -75,7 +76,6 @@ include "_cygrpc/aio/grpc_aio.pyx.pxi"
 include "_cygrpc/aio/call.pyx.pxi"
 include "_cygrpc/aio/channel.pyx.pxi"
 include "_cygrpc/aio/server.pyx.pxi"
-
 
 #
 # initialize gRPC


### PR DESCRIPTION
Backport of #39779 to v1.78.x.
---
Fixes #38703 

After Core recently changed its logging system to use absl logging, gRPC python users started seeing the warning log
`WARNING: All log messages before absl::InitializeLog() is called are written to STDERR.`

This issue especially affects users who are indirect users of the gRPC Python  library too, such as Gemini API users.

`absl::InitializeLog()` is a C++ library that cannot directly be called in the Python layer. It is hence added in the Cython layer at the time of initializing.
The Python layer so far did not have a dependency on the absl library, hence this PR also adds an external dependency on `absl/log:initialize`

Design gRFC for this: grpc/proposal#505

However, abseil-cpp currently [doesn't allow `absl::InitializeLog()` to be called more than once](https://github.com/abseil/abseil-cpp/issues/1656), and will result in an error like:
```
[globals.cc : 104] RAW: absl::log_internal::SetTimeZone() has already been called
```
The changes in this PR may hence cause problems to a small percentage of users with a custom build that's linking directly against gRPC Cython code, and then call absl::InitializeLog() (directly or transitively).

To solve this problem, this PR also introduces a new environment variable `GRPC_PYTHON_DISABLE_ABSL_INIT_LOG` that will allow users to opt-out of this automatic abseil log initialization when set.