### PR TITLE
Disable blzmod in tools/remote_build/mac.bazelrc

### DIFF
--- a/tools/remote_build/mac.bazelrc
+++ b/tools/remote_build/mac.bazelrc
@@ -21,5 +21,5 @@ build --build_tag_filters=-no_mac
 build --dynamic_mode=off
 
 import %workspace%/tools/remote_build/include/test_config_common.bazelrc
-
+# TODO(weizheyuan): Fix test failures. See https://github.com/grpc/grpc/issues/41487
 import %workspace%/tools/remote_build/include/disable_bzlmod.bazelrc


### PR DESCRIPTION
### Description

Bring back `disable_bzlmod.bazelrc` which was removed in https://github.com/grpc/grpc/commit/e42a876bb5298e72a959307a7c1a6be918e8acc2#diff-80339945fab2e0aa176f72b7cd811c1d8da0f678f0a3f4f18414c384126fc4dbL24-L25

This change fixes the MacOSx Bazel Python Tests.