### PR TITLE
[CI] Improve system info block in macOS CI jobs

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -15,13 +15,21 @@
 # Source this rc script to prepare the environment for macos builds
 
 # Print basic info about the mac worker
-echo "kokoro pool: \"$KOKORO_JOB_POOL\""
-echo "OS: $(sw_vers -productName) $(sw_vers -productVersion) $(sw_vers -buildVersion)"
-echo "CPU type: $(sysctl -n machdep.cpu.brand_string)"
+{ set +x; } 2>/dev/null
+echo "-- Kokoro worker info --"
+echo "Kokoro pool: ${KOKORO_JOB_POOL:-undefined}"
+if [[ -f /VERSION ]]; then
+  echo "Kokoro VM image: $(cat /VERSION)"
+fi
+echo "-- System --"
+echo "System: $(uname -a)"
+echo "Python: $(python3 -VV)"
+echo -e "-- OS --\n$(sw_vers -productName) $(sw_vers -productVersion) $(sw_vers -buildVersion)"
+echo "-- CPU --"
 echo "CPU: $(sysctl -n machdep.cpu.vendor) $(uname -m) Family $(sysctl -n machdep.cpu.family) Model $(sysctl -n machdep.cpu.brand_string)"
 echo "CPU Cores: $(sysctl -n hw.ncpu)"
-echo "Memory: $(sysctl -n hw.memsize)"
-echo "Kokoro image version: $(cat /VERSION)"
+echo -e "-- Memory --\n$(sysctl -n hw.memsize)"
+set -x
 
 # Info on disk usage and mounted volumes
 mount


### PR DESCRIPTION
Makes the output similar to [`prepare_build_linux_rc`](https://github.com/grpc/grpc/blob/d7a7277160b3b236a27e1f37a83b05a6a7a12fbe/tools/internal_ci/helper_scripts/prepare_build_linux_rc#L18-L31).

Output example:

```
-- Kokoro worker info --
Kokoro pool: macsvc-grpc
Kokoro VM image: 20221213-1155monterey-MacService
-- System --
System: Darwin 55c60a99-052a-4d44-b5d8-e20fecdde0e0.kokoro.c5.macservice.goog 21.6.0 Darwin Kernel Version 21.6.0: Sat Jun 18 17:07:25 PDT 2022; root:xnu-8020.140.41~1/RELEASE_X86_64 x86_64
Python: Python 3.10.3 (main, Dec  8 2022, 12:20:23) [Clang 14.0.0 (clang-1400.0.29.202)]
-- OS --
macOS 12.5 21G72
-- CPU --
CPU: GenuineIntel x86_64 Family 6 Model Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
CPU Cores: 4
-- Memory --
17179869184
```