### PR TITLE
[Python] Observability: Strip C++ flags when compiling C files

### DIFF
--- a/src/python/grpcio_observability/setup.py
+++ b/src/python/grpcio_observability/setup.py
@@ -215,9 +215,12 @@ EXTRA_LINK_ARGS = shlex.split(EXTRA_ENV_LINK_ARGS)
 if BUILD_WITH_STATIC_LIBSTDCXX:
     EXTRA_LINK_ARGS.append("-static-libstdc++")
 
-CC_FILES = [os.path.normpath(cc_file) for cc_file in observability_lib_deps.CC_FILES]
+CC_FILES = [
+    os.path.normpath(cc_file) for cc_file in observability_lib_deps.CC_FILES
+]
 CC_INCLUDES = [
-    os.path.normpath(include_dir) for include_dir in observability_lib_deps.CC_INCLUDES
+    os.path.normpath(include_dir)
+    for include_dir in observability_lib_deps.CC_INCLUDES
 ]
 
 DEFINE_MACROS = (("_WIN32_WINNT", 0x600),)
@@ -275,7 +278,9 @@ def extension_modules():
 
     plugin_sources = CC_FILES
 
-    O11Y_CC_PATHS = (os.path.join("grpc_observability", f) for f in O11Y_CC_SRCS)
+    O11Y_CC_PATHS = (
+        os.path.join("grpc_observability", f) for f in O11Y_CC_SRCS
+    )
     plugin_sources += O11Y_CC_PATHS
 
     plugin_sources += cython_module_files
@@ -293,7 +298,9 @@ def extension_modules():
     if BUILD_WITH_CYTHON:
         from Cython import Build
 
-        return Build.cythonize(extensions, compiler_directives={"language_level": "3"})
+        return Build.cythonize(
+            extensions, compiler_directives={"language_level": "3"}
+        )
     else:
         return extensions
 


### PR DESCRIPTION
Fixes #41611

Building `grpcio-observability` on macOS with Apple clang from source failed with `error: invalid argument '-std=c++17' not allowed with 'C'`.

Fix by overriding `BuildExt.build_extensions()` to strip C++-only flags (`-std=c++17`, `-stdlib=libc++`) when compiling `.c` files, mirroring the same pattern already used in [`src/python/grpcio/commands.py`](https://github.com/grpc/grpc/blob/v1.78.0/src/python/grpcio/commands.py#L292-L353).

**Testing**

```
cd src/python/grpcio_observability/
rm -rf build/ # Remove existing builds
GRPC_PYTHON_BUILD_WITH_CYTHON=1 python setup.py build_ext
```

Verify:
- No errors in output.
- `build/lib.macosx-*/grpc_observability/_cyobservability.cpython-*-darwin.so` is created.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

