### PR TITLE
[interop] Add v1.78.0 core release to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -898,6 +898,15 @@ LANG_RELEASE_MATRIX = {
                     runtimes=["python"], testcases_file="python__master"
                 ),
             ),
+            # Python images can't be anymore built without #40959 temporary fix,
+            # or #40833 proper pyproject migration.
+            # TODO(sreenithi): update this once v1.76.1 is out.
+            # (
+            #     "v1.76.0",
+            #     ReleaseInfo(
+            #         runtimes=["python"], testcases_file="python__master"
+            #     ),
+            # ),
             (
                 "v1.78.0",
                 ReleaseInfo(


### PR DESCRIPTION
Test: https://fusion2.corp.google.com/ci/kokoro/prod:grpc%2Fcore%2Fexperimental%2Flinux%2Fgrpc_interop_matrix_adhoc/activity/19ea2a9a-e440-470e-8404-06fc295facbc/summary
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

