### PR TITLE
[Bzlmod] Downgrade re2 to match WORKSPACE.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -125,9 +125,19 @@ http_archive(
 )
 
 # TODO(weizheyuan): Upgrade to a version available in a BCR
-# once we figure out how to properly build it with cmake.
-http_archive(
-    name = "com_googlesource_code_re2",
+# once we figure out how to properly use it in cmake setup.
+#
+# Trick bazel by declaring re2 as 2024-07-02.bcr.1 but internally using 2022-04-01,
+# which is the version we use for cmake builds.
+# This override has no effect when grpc is used as a dependency module.
+# See also https://bazel.build/rules/lib/globals/module#archive_override.
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")  # mismatched 2022-04-01
+archive_override(
+    module_name = "re2",
+    patch_strip = 1,
+    patches = [
+        "//bazel:re2.patch",
+    ],
     sha256 = "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9",
     strip_prefix = "re2-2022-04-01",
     urls = [

--- a/bazel/re2.patch
+++ b/bazel/re2.patch
@@ -1,0 +1,11 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 0000000..3c9e88f
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,5 @@
++module(name = "re2")
++
++# Match grpc main repo.
++bazel_dep(name = "platforms", version = "0.0.11")
++bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/templates/MODULE.bazel.inja
+++ b/templates/MODULE.bazel.inja
@@ -125,9 +125,19 @@ http_archive(
 )
 
 # TODO(weizheyuan): Upgrade to a version available in a BCR
-# once we figure out how to properly build it with cmake.
-http_archive(
-    name = "com_googlesource_code_re2",
+# once we figure out how to properly use it in cmake setup.
+#
+# Trick bazel by declaring re2 as 2024-07-02.bcr.1 but internally using 2022-04-01,
+# which is the version we use for cmake builds.
+# This override has no effect when grpc is used as a dependency module.
+# See also https://bazel.build/rules/lib/globals/module#archive_override.
+bazel_dep(name = "re2", version = "2024-07-02.bcr.1", repo_name = "com_googlesource_code_re2")  # mismatched 2022-04-01
+archive_override(
+    module_name = "re2",
+    patch_strip = 1,
+    patches = [
+        "//bazel:re2.patch",
+    ],
     sha256 = "1ae8ccfdb1066a731bba6ee0881baad5efd2cd661acd9569b689f2586e1a50e9",
     strip_prefix = "re2-2022-04-01",
     urls = [


### PR DESCRIPTION
Bzlmod migration mega-thread: https://github.com/grpc/grpc/issues/41487
non-bazel build issues:https://github.com/grpc/grpc/pull/41700

Our current module declares dependence on `re2@2024-07-02.bcr.1`, which is fine in bazel builds and CI tests, but breaks `generate_projects.sh` when bzlmod is enabled (likely because it now depends on absl and I don't know how to properly pull in the dependencies in cmake, See https://github.com/grpc/grpc/pull/41625)

Once we gained cmake knowledge we should be able up upgrade it back to 2024-07-02.bcr.1.

This change doesn't affect grpc-as-dependency-module builds because `archive_override` only takes effect in root module.
<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

