### PR TITLE
Preserve CMAKE_EXE_LINKER_FLAGS on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,7 +329,7 @@ if(MSVC)
   # Inconsistent object sizes can cause stack corruption and should be treated as an error
   set(_gRPC_C_CXX_FLAGS "${_gRPC_C_CXX_FLAGS} /we4789")
   # To decrease the size of PDB files
-  set(CMAKE_EXE_LINKER_FLAGS "/opt:ref /opt:icf /pdbcompress")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /opt:ref /opt:icf /pdbcompress")
 endif()
 if (MINGW)
   add_definitions(-D_WIN32_WINNT=0x600)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -428,7 +428,7 @@
     # Inconsistent object sizes can cause stack corruption and should be treated as an error
     set(_gRPC_C_CXX_FLAGS "<%text>${_gRPC_C_CXX_FLAGS}</%text> /we4789")
     # To decrease the size of PDB files
-    set(CMAKE_EXE_LINKER_FLAGS "/opt:ref /opt:icf /pdbcompress")
+    set(CMAKE_EXE_LINKER_FLAGS "<%text>${CMAKE_EXE_LINKER_FLAGS}</%text> /opt:ref /opt:icf /pdbcompress")
   endif()
   if (MINGW)
     add_definitions(-D_WIN32_WINNT=0x600)


### PR DESCRIPTION
For cross-compilation one needs to set `CMAKE_EXE_LINKER_FLAGS` to specify the paths of the Windows SDK library directories.  
The grpc `CMakeLists.txt` sets `CMAKE_EXE_LINKER_FLAGS` instead of appending to it, making it cumbersome to specify additional linker flags.

With this patch the original content of `CMAKE_EXE_LINKER_FLAGS` is preserved and grpc only appends its flags.