### PR TITLE
[Python] Don't close channels in fork child

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -2042,7 +2042,6 @@ class Channel(grpc.Channel):
         self._target = target
         self._call_state = _ChannelCallState(self._channel)
         self._connectivity_state = _ChannelConnectivityState(self._channel)
-        cygrpc.fork_register_channel(self)
         if cygrpc.g_gevent_activated:
             cygrpc.gevent_increment_channel_count()
 
@@ -2191,7 +2190,6 @@ class Channel(grpc.Channel):
     def _close(self) -> None:
         self._unsubscribe_all()
         self._channel.close(cygrpc.StatusCode.cancelled, "Channel closed!")
-        cygrpc.fork_unregister_channel(self)
         if cygrpc.g_gevent_activated:
             cygrpc.gevent_decrement_channel_count()
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork.pyx.pxi
@@ -85,8 +85,6 @@ cdef void __postfork_child() noexcept nogil:
                 state_to_reset.reset_postfork_child()
             _fork_state.postfork_states_to_reset = []
             _fork_state.fork_epoch += 1
-            for channel in _fork_state.channels:
-                channel._close_on_fork()
             with _fork_state.fork_in_progress_condition:
                 _fork_state.fork_in_progress = False
         except:
@@ -173,16 +171,6 @@ def is_fork_support_enabled():
     return _GRPC_ENABLE_FORK_SUPPORT
 
 
-def fork_register_channel(channel):
-    if _GRPC_ENABLE_FORK_SUPPORT:
-        _fork_state.channels.add(channel)
-
-
-def fork_unregister_channel(channel):
-    if _GRPC_ENABLE_FORK_SUPPORT:
-        _fork_state.channels.discard(channel)
-
-
 class _ActiveThreadCount(object):
     def __init__(self):
         self._num_active_threads = 0
@@ -224,7 +212,6 @@ class _ForkState(object):
         self.fork_handler_registered = False
         self.active_thread_count = _ActiveThreadCount()
         self.fork_epoch = 0
-        self.channels = set()
 
 
 _fork_state = _ForkState()


### PR DESCRIPTION
The commit message of [the original commit that implemented fork support in Python](https://github.com/grpc/grpc/commit/f8cf7ee56d4150ae870f44298a406f7b2ca038c0) says

> **A process may fork after invoking `grpc_init()` and use gRPC in the child if and only if the child process first destroys all gRPC resources inherited from the parent process and invokes `grpc_shutdown()`.** Subsequent to this, the child will be able to re-initialize and use gRPC. After fork, the parent process will be able to continue to use existing gRPC resources such as channels and calls without interference from the child process.
>
> **To facilitate gRPC Python applications meeting the above constraints, gRPC Python will automatically destroy and shutdown all gRPC Core resources in the child's post-fork handler, including cancelling in-flight calls (see detailed design below).** From the client's perspective, the child process is now free to create new channels and use gRPC.

This original intent of Python's fork support to automatically shut down channels in the child process is still how the functionality works. However, since 1.74 Python's build was unintentionally configured so that fork support behavior would be enabled by default in the core, but disabled by default at the Python level. As a result, users have been able to create channels in parent processes and then continue using them in child processes. This is not possible to do by either fully enabling or fully disabling the functionality, but unfortunately this intermediate state also causes problems, documented in #37710.

Fortunately, the unintended usage suggests the solution: users have been able to continue using channels in the child process because improvements have been made to the core's fork support to allow enable that usage in the time since Python's fork support was initially implemented. As a result, we can safely stop closing channels in child processes, and allow users to continue using them as they have been doing. This should allow us to fully enable fork support by default without breaking anyone.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

