### PR TITLE
Fix fd 0 incorrectly treated as invalid across POSIX socket code

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -834,7 +834,7 @@ absl::StatusOr<std::unique_ptr<EventEngine::Endpoint>>
 PosixEventEngine::CreatePosixEndpointFromFd(int fd,
                                             const EndpointConfig& config,
                                             MemoryAllocator memory_allocator) {
-  GRPC_DCHECK_GT(fd, 0);
+  GRPC_DCHECK_GE(fd, 0);
   if (poller_ == nullptr) {
     return absl::FailedPreconditionError("polling is not enabled");
   }

--- a/src/core/lib/event_engine/posix_engine/posix_interface_posix.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_interface_posix.cc
@@ -393,7 +393,7 @@ absl::StatusOr<int> InternalCreateDualStackSocket(
       errno = EAFNOSUPPORT;
     }
     // Check if we've got a valid dualstack socket.
-    if (newfd > 0 && SetSocketDualStack(newfd)) {
+    if (newfd >= 0 && SetSocketDualStack(newfd)) {
       dsmode = EventEnginePosixInterface::DSMode::DSMODE_DUALSTACK;
       return newfd;
     }
@@ -473,7 +473,7 @@ void EventEnginePosixInterface::AdvanceGeneration() {
         "Fork support is disabled but AdvanceGeneration was called");
   }
   for (int fd : descriptors_.ClearAndReturnRawDescriptors()) {
-    if (fd > 0) {
+    if (fd >= 0) {
       close(fd);
     }
   }
@@ -995,7 +995,7 @@ absl::Status EventEnginePosixInterface::PrepareTcpClientSocket(
     const PosixTcpOptions& options) {
   bool close_fd = true;
   auto sock_cleanup = absl::MakeCleanup([&close_fd, &fd]() -> void {
-    if (close_fd && fd > 0) {
+    if (close_fd && fd >= 0) {
       close(fd);
     }
   });

--- a/src/core/lib/iomgr/event_engine_shims/endpoint.cc
+++ b/src/core/lib/iomgr/event_engine_shims/endpoint.cc
@@ -212,7 +212,7 @@ class EventEngineEndpointWrapper {
         kShutdownBit + 1) {
       auto* supports_fd =
           QueryExtension<EndpointSupportsFdExtension>(endpoint_.get());
-      if (supports_fd != nullptr && fd_ > 0 && on_release_fd_) {
+      if (supports_fd != nullptr && fd_ >= 0 && on_release_fd_) {
         supports_fd->Shutdown(std::move(on_release_fd_));
       }
       OnShutdownInternal();
@@ -241,7 +241,7 @@ class EventEngineEndpointWrapper {
         Ref();
         if (shutdown_ref_.fetch_sub(1, std::memory_order_acq_rel) ==
             kShutdownBit + 1) {
-          if (supports_fd != nullptr && fd_ > 0 && on_release_fd_) {
+          if (supports_fd != nullptr && fd_ >= 0 && on_release_fd_) {
             supports_fd->Shutdown(std::move(on_release_fd_));
           }
           OnShutdownInternal();

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -332,7 +332,7 @@ static void deactivated_all_ports(grpc_tcp_server* s) {
     grpc_tcp_listener* sp;
     for (sp = s->head; sp; sp = sp->next) {
       // Do not unlink if there is a pre-allocated FD
-      if (grpc_tcp_server_pre_allocated_fd(s) <= 0) {
+      if (grpc_tcp_server_pre_allocated_fd(s) < 0) {
         grpc_unlink_if_unix_domain_socket(&sp->addr);
       }
       GRPC_CLOSURE_INIT(&sp->destroyed_closure, destroyed_port, s,
@@ -643,7 +643,7 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
             if (!listen_fd.ok()) {
               return;
             }
-            GRPC_DCHECK_GT(*listen_fd, 0);
+            GRPC_DCHECK_GE(*listen_fd, 0);
             s->listen_fd_to_index_map.insert_or_assign(
                 *listen_fd, std::tuple(s->n_bind_ports, fd_index++));
           });
@@ -698,7 +698,7 @@ static grpc_error_handle tcp_server_add_port(grpc_tcp_server* s,
 
   /* Do not unlink if there are pre-allocated FDs, or it will stop
      working after the first client connects */
-  if (grpc_tcp_server_pre_allocated_fd(s) <= 0) {
+  if (grpc_tcp_server_pre_allocated_fd(s) < 0) {
     grpc_unlink_if_unix_domain_socket(addr);
   }
 

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -161,7 +161,7 @@ grpc_error_handle grpc_tcp_server_add_addr(grpc_tcp_server* s,
   fd = grpc_tcp_server_pre_allocated_fd(s);
 
   // Check if FD has been pre-allocated
-  if (fd > 0) {
+  if (fd >= 0) {
     int family = grpc_sockaddr_get_family(addr);
     // Set dsmode value
     if (family == AF_INET6) {

--- a/test/core/event_engine/posix/dns_server.cc
+++ b/test/core/event_engine/posix/dns_server.cc
@@ -309,7 +309,7 @@ void DnsServer::ServerLoop(int sockfd) {
 absl::StatusOr<DnsServer> DnsServer::Start(int port) {
   bool success = false;
   int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-  if (sockfd > 0) {
+  if (sockfd >= 0) {
     int flags = fcntl(sockfd, F_GETFL, 0);
     if (flags >= 0) {
       success = fcntl(sockfd, F_SETFL, flags | O_NONBLOCK) == 0;

--- a/test/core/event_engine/posix/file_descriptor_collection_test.cc
+++ b/test/core/event_engine/posix/file_descriptor_collection_test.cc
@@ -56,6 +56,41 @@ TEST(FileDescriptorCollectionTest, RemoveHonorsGeneration) {
   EXPECT_EQ(collection.Remove(FileDescriptor(7, 2)), !ForkEnabled());
 }
 
+// Regression test for https://github.com/grpc/grpc/issues/40371
+// fd 0 is a valid file descriptor (e.g. when stdin is closed before forking)
+// and must not be treated as invalid.
+TEST(FileDescriptorTest, ZeroFdIsValid) {
+  FileDescriptor fd_zero(0, 1);
+  EXPECT_TRUE(fd_zero.ready());
+  EXPECT_EQ(fd_zero.fd(), 0);
+}
+
+TEST(FileDescriptorTest, NegativeFdIsInvalid) {
+  FileDescriptor fd_neg(-1, 1);
+  EXPECT_FALSE(fd_neg.ready());
+  EXPECT_EQ(fd_neg.fd(), -1);
+}
+
+TEST(FileDescriptorTest, DefaultConstructedIsInvalid) {
+  FileDescriptor fd_default;
+  EXPECT_FALSE(fd_default.ready());
+}
+
+TEST(FileDescriptorCollectionTest, AddZeroFd) {
+  FileDescriptorCollection collection(1);
+  FileDescriptor fd = collection.Add(0);
+  EXPECT_TRUE(fd.ready());
+  EXPECT_EQ(fd.fd(), 0);
+  EXPECT_EQ(fd.generation(), ForkEnabled() ? 1 : 0);
+  if (ForkEnabled()) {
+    EXPECT_THAT(collection.ClearAndReturnRawDescriptors(),
+                ::testing::UnorderedElementsAre(0));
+  } else {
+    EXPECT_THAT(collection.ClearAndReturnRawDescriptors(),
+                ::testing::IsEmpty());
+  }
+}
+
 }  // namespace grpc_event_engine::experimental
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
File descriptor 0 is a valid fd (e.g. when stdin is closed before forking, accept() can return fd 0). Multiple places in the codebase incorrectly used CHECK_GT(fd, 0) or 'if (fd > 0)' to validate file descriptors, which would crash or silently skip logic for fd 0.

This commit fixes all such checks:
- GRPC_DCHECK_GT(fd, 0) -> GRPC_DCHECK_GE(fd, 0) in posix_engine.cc and tcp_server_posix.cc
- 'fd > 0' -> 'fd >= 0' in posix_interface_posix.cc (dualstack socket creation, AdvanceGeneration cleanup, and client socket cleanup)
- 'fd_ > 0' -> 'fd_ >= 0' in endpoint.cc (shutdown path)
- 'fd > 0' -> 'fd >= 0' in tcp_server_utils_posix_common.cc (pre-allocated fd check, sentinel is -1)
- 'pre_allocated_fd <= 0' -> '< 0' in tcp_server_posix.cc (sentinel is -1, so fd 0 is a valid pre-allocated fd)
- 'sockfd > 0' -> 'sockfd >= 0' in test dns_server.cc

Also adds regression tests for FileDescriptor with fd=0.

Fixes #40371





