### PR TITLE
grpc_cli: support building with Protobuf 34

### DIFF
--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -61,7 +61,7 @@ ProtoReflectionDescriptorDatabase::~ProtoReflectionDescriptorDatabase() {
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileByName(
-    const string& filename, protobuf::FileDescriptorProto* output) {
+    StringViewArg filename, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileByName(filename, output)) {
     return true;
   }
@@ -104,7 +104,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileByName(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
-    const string& symbol_name, protobuf::FileDescriptorProto* output) {
+    StringViewArg symbol_name, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingSymbol(symbol_name, output)) {
     return true;
   }
@@ -147,7 +147,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
-    const string& containing_type, int field_number,
+    StringViewArg containing_type, int field_number,
     protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingExtension(containing_type, field_number,
                                              output)) {
@@ -205,7 +205,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbers(
-    const string& extendee_type, std::vector<int>* output) {
+    StringViewArg extendee_type, std::vector<int>* output) {
   if (cached_extension_numbers_.find(extendee_type) !=
       cached_extension_numbers_.end()) {
     *output = cached_extension_numbers_[extendee_type];

--- a/test/cpp/util/proto_reflection_descriptor_database.h
+++ b/test/cpp/util/proto_reflection_descriptor_database.h
@@ -34,6 +34,13 @@ namespace grpc {
 // provides the methods defined by DescriptorDatabase interfaces. It can be used
 // to feed a DescriptorPool instance.
 class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
+ protected:
+#if GOOGLE_PROTOBUF_VERSION >= 7034000
+  using StringViewArg = absl::string_view;
+#else
+  using StringViewArg = const std::string&;
+#endif
+
  public:
   explicit ProtoReflectionDescriptorDatabase(
       std::unique_ptr<reflection::v1alpha::ServerReflection::Stub> stub);
@@ -47,13 +54,13 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   //
   // Find a file by file name.  Fills in *output and returns true if found.
   // Otherwise, returns false, leaving the contents of *output undefined.
-  bool FindFileByName(const string& filename,
+  bool FindFileByName(StringViewArg filename,
                       protobuf::FileDescriptorProto* output) override;
 
   // Find the file that declares the given fully-qualified symbol name.
   // If found, fills in *output and returns true, otherwise returns false
   // and leaves *output undefined.
-  bool FindFileContainingSymbol(const string& symbol_name,
+  bool FindFileContainingSymbol(StringViewArg symbol_name,
                                 protobuf::FileDescriptorProto* output) override;
 
   // Find the file which defines an extension extending the given message type
@@ -61,7 +68,7 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   // otherwise returns false and leaves *output undefined.  containing_type
   // must be a fully-qualified type name.
   bool FindFileContainingExtension(
-      const string& containing_type, int field_number,
+      StringViewArg containing_type, int field_number,
       protobuf::FileDescriptorProto* output) override;
 
   // Finds the tag numbers used by all known extensions of
@@ -71,7 +78,7 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   // FindFileContainingExtension will return true on all of the found
   // numbers. Returns true if the search was successful, otherwise
   // returns false and leaves output unchanged.
-  bool FindAllExtensionNumbers(const string& extendee_type,
+  bool FindAllExtensionNumbers(StringViewArg extendee_type,
                                std::vector<int>* output) override;
 
   // Provide a list of full names of registered services


### PR DESCRIPTION
Change is based on a temporarily added compile-time switch in protobuf: https://github.com/protocolbuffers/protobuf/commit/acf5350bce9764163c6444458bf26f270c011b63 replacing `#ifdef PROTOBUF_FUTURE_STRING_VIEW_DESCRIPTOR_DATABASE` with `#if GOOGLE_PROTOBUF_VERSION >= 7034000`

PR only adds support in code paths needed to build `grpc_cli` target and my local build attempt was done with external packages (working on this for Homebrew).

Based on library build, most of installed targets already seem to support Protobuf 34.0 (C++ 7.34.0) but there may be other test/tool code that will need to be updated.