### PR TITLE
Fix pending calls getting CANCELLED on server shutdown

### DIFF
--- a/src/core/lib/surface/filter_stack_call.cc
+++ b/src/core/lib/surface/filter_stack_call.cc
@@ -270,7 +270,7 @@ void FilterStackCall::ExternalUnref() {
   destroy_called_ = true;
   bool cancel = gpr_atm_acq_load(&received_final_op_atm_) == 0;
   if (cancel) {
-    CancelWithError(absl::CancelledError("CANCELLED"));
+    CancelWithError(absl::UnavailableError("Server shutdown"));
   } else {
     // Unset the call combiner cancellation closure.  This has the
     // effect of scheduling the previously set cancellation closure, if

--- a/test/core/end2end/grpc_core_end2end_test.bzl
+++ b/test/core/end2end/grpc_core_end2end_test.bzl
@@ -197,6 +197,7 @@ _TESTS = [
     "server_finishes_request",
     "server_streaming",
     "shutdown_finishes_calls",
+    "shutdown_finishes_pending_calls",
     "shutdown_finishes_tags",
     "simple_delayed_request",
     "simple_metadata",

--- a/test/core/end2end/tests/shutdown_finishes_pending_calls.cc
+++ b/test/core/end2end/tests/shutdown_finishes_pending_calls.cc
@@ -1,0 +1,76 @@
+//
+//
+// Copyright 2025 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+
+#include <grpc/status.h>
+#include <grpc/support/time.h>
+
+#include <memory>
+
+#include "gtest/gtest.h"
+#include "src/core/util/time.h"
+#include "test/core/end2end/end2end_tests.h"
+#include "test/core/test_util/test_config.h"
+
+namespace grpc_core {
+namespace {
+
+// Regression test for https://github.com/grpc/grpc/issues/41785
+//
+// When a client call arrives at the server but no RequestCall() has been
+// issued to match it, the call sits in pending_filter_stack_. On server
+// shutdown, ZombifyPending() kills these calls via KillZombie() →
+// grpc_call_unref() → FilterStackCall::ExternalUnref(). Since the handler
+// never ran (received_final_op_atm_ == 0), the call should be terminated
+// with UNAVAILABLE (server went away), not CANCELLED (caller cancelled).
+CORE_END2END_TEST(CoreEnd2endTests,
+                  EarlyServerShutdownFinishesPendingCalls) {
+  SKIP_IF_V3();
+  SKIP_IF_FUZZING();
+
+  // Send a client call but do NOT issue RequestCall() on the server.
+  // The call will sit in pending_filter_stack_ waiting for a match.
+  auto c = NewClientCall("/foo").Timeout(Duration::Seconds(5)).Create();
+  IncomingMetadata server_initial_metadata;
+  IncomingStatusOnClient server_status;
+  c.NewBatch(1)
+      .SendInitialMetadata({})
+      .SendCloseFromClient()
+      .RecvInitialMetadata(server_initial_metadata)
+      .RecvStatusOnClient(server_status);
+
+  // Give the call time to reach the server and land in the pending queue.
+  gpr_sleep_until(grpc_timeout_seconds_to_deadline(1));
+
+  // Shutdown the server. This calls ZombifyPending() which kills all
+  // calls in pending_filter_stack_.
+  ShutdownServerAndNotify(1000);
+  Expect(1000, true);
+  Expect(1, true);
+  Step();
+
+  DestroyServer();
+
+  // The client should NOT see CANCELLED — that means "the caller cancelled"
+  // per the gRPC status code spec, but here it is the server shutting down.
+  // Depending on transport, the client may see UNAVAILABLE or INTERNAL, both
+  // of which correctly indicate a server-side issue.
+  EXPECT_NE(server_status.status(), GRPC_STATUS_CANCELLED);
+}
+
+}  // namespace
+}  // namespace grpc_core

--- a/test/core/end2end/tests/shutdown_finishes_pending_calls.cc
+++ b/test/core/end2end/tests/shutdown_finishes_pending_calls.cc
@@ -38,7 +38,7 @@ namespace {
 // never ran (received_final_op_atm_ == 0), the call should be terminated
 // with UNAVAILABLE (server went away), not CANCELLED (caller cancelled).
 CORE_END2END_TEST(CoreEnd2endTests,
-                  EarlyServerShutdownFinishesPendingCalls) {
+                  ShutdownFinishesPendingCalls) {
   SKIP_IF_V3();
   SKIP_IF_FUZZING();
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/41785

During server shutdown, calls in `pending_filter_stack_` that were never matched to a `RequestCall()` are zombified via `ZombifyPending()` → `KillZombie()` → `grpc_call_unref()` → `FilterStackCall::ExternalUnref()`. Since the handler never ran (`received_final_op_atm_ == 0`), the call was terminated with `absl::CancelledError("CANCELLED")`.

This is semantically wrong — `CANCELLED` means ["the operation was cancelled, typically by the caller"](https://grpc.io/docs/guides/status-codes/), but the server is shutting down, not the client cancelling.

### Changes

**`src/core/lib/surface/filter_stack_call.cc`**: Change `ExternalUnref()` to use `absl::UnavailableError("Server shutdown")` instead of `absl::CancelledError("CANCELLED")` when the handler never ran. This:
- Correctly indicates the server went away (not a client cancellation)
- Is consistent with other shutdown code paths in `server.cc` (e.g., `KillPendingWorkLocked`, `BroadcastShutdown`, `disconnect_with_error`)
- Allows clients with `UNAVAILABLE` in `retryableStatusCodes` to retry these calls

**`test/core/end2end/tests/shutdown_finishes_pending_calls.cc`**: New regression test (`ShutdownFinishesPendingCalls`) that sends a client call without issuing `RequestCall()` on the server, then shuts down and verifies the client does not receive `CANCELLED`.

### Impact

Only affects calls where `received_final_op_atm_ == 0` (the handler never ran) — these are zombie/pending calls only. In-flight calls that have already been accepted by a handler are unaffected.

The existing test `EarlyServerShutdownFinishesInflightCalls` already expects `GRPC_STATUS_UNAVAILABLE` for in-flight calls killed by `CancelAllCallsOnServer()`, so this change makes pending calls consistent with that behavior.