### PR TITLE
[Bazel][Python] Support generated Protobuf source files

### DIFF
--- a/bazel/grpc_util.bzl
+++ b/bazel/grpc_util.bzl
@@ -19,8 +19,8 @@ Contains generic helper utilities.
 
 _upper_segments_list = ["url", "http", "https"]
 
-def strip_extension(str):
-    return str.rpartition(".")[0]
+def strip_extension(str, sep = "."):
+    return str.rpartition(sep)[0]
 
 def capitalize(word):
     if word in _upper_segments_list:

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -196,7 +196,7 @@ def get_staged_proto_file(label, context, source_file):
     Returns:
       The original proto file OR a new file in the staged location.
     """
-    if source_file.dirname == label.package or \
+    if source_file.short_path.rpartition("/")[0] == label.package or \
        is_in_virtual_imports(source_file):
         # Current target and source_file are in same package
         return source_file

--- a/bazel/protobuf.bzl
+++ b/bazel/protobuf.bzl
@@ -14,6 +14,7 @@
 """Utility functions for generating protobuf code."""
 
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+load(":grpc_util.bzl", "strip_extension")
 
 _PROTO_EXTENSION = ".proto"
 _VIRTUAL_IMPORTS = "/_virtual_imports/"
@@ -196,8 +197,8 @@ def get_staged_proto_file(label, context, source_file):
     Returns:
       The original proto file OR a new file in the staged location.
     """
-    if source_file.short_path.rpartition("/")[0] == label.package or \
-       is_in_virtual_imports(source_file):
+    source_package = strip_extension(source_file.short_path, sep = "/")
+    if source_package == label.package or is_in_virtual_imports(source_file):
         # Current target and source_file are in same package
         return source_file
     else:

--- a/test/distrib/bazel/python/BUILD
+++ b/test/distrib/bazel/python/BUILD
@@ -196,3 +196,39 @@ py_test(
         ":helloworld_py_pb2_grpc_library_changed",
     ],
 )
+
+# Test that we can compile a Protobuf file that was generated dynamically via `genrule`.
+
+genrule(
+    name = "gen_echo_proto",
+    srcs = ["echo.proto"],
+    outs = ["gen_echo.proto"],
+    cmd = "cp $(location echo.proto) $(location gen_echo.proto)",
+)
+
+proto_library(
+    name = "gen_echo_proto_lib",
+    srcs = [":gen_echo_proto"],
+)
+
+py_proto_library(
+    name = "gen_echo_py_pb2",
+    deps = [":gen_echo_proto_lib"],
+)
+
+py_grpc_library(
+    name = "gen_echo_py_pb2_grpc",
+    srcs = [":gen_echo_proto_lib"],
+    deps = [":gen_echo_py_pb2"],
+)
+
+py_test(
+    name = "import_generated_proto_test",
+    srcs = ["import_generated_proto.py"],
+    main = "import_generated_proto.py",
+    python_version = "PY3",
+    deps = [
+        ":gen_echo_py_pb2",
+        ":gen_echo_py_pb2_grpc",
+    ],
+)

--- a/test/distrib/bazel/python/echo.proto
+++ b/test/distrib/bazel/python/echo.proto
@@ -1,0 +1,29 @@
+// Copyright 2026 The gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Minimal self-contained Proto service definition.
+
+syntax = "proto3";
+
+service EchoService {
+  rpc Echo(EchoRequest) returns (EchoResponse) {}
+}
+
+message EchoRequest {
+  string message = 1;
+}
+
+message EchoResponse {
+  string message = 1;
+}

--- a/test/distrib/bazel/python/import_generated_proto.py
+++ b/test/distrib/bazel/python/import_generated_proto.py
@@ -25,11 +25,9 @@ import gen_echo_pb2_grpc
 
 class GeneratedProtoImportTest(unittest.TestCase):
     def test_stubs_are_importable(self):
-        from gen_echo_pb2_grpc import (
-            EchoServiceServicer,
-            EchoServiceStub,
-            add_EchoServiceServicer_to_server,
-        )
+        from gen_echo_pb2_grpc import EchoServiceServicer
+        from gen_echo_pb2_grpc import EchoServiceStub
+        from gen_echo_pb2_grpc import add_EchoServiceServicer_to_server
 
     def test_proto_message_is_importable(self):
         from gen_echo_pb2 import EchoRequest

--- a/test/distrib/bazel/python/import_generated_proto.py
+++ b/test/distrib/bazel/python/import_generated_proto.py
@@ -1,0 +1,39 @@
+# Copyright 2026 the gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test: py_grpc_library must work when the proto_library source is
+a generated file (not a checked-in source file).
+
+See https://github.com/grpc/grpc/issues/41792.
+"""
+
+import unittest
+
+import gen_echo_pb2
+import gen_echo_pb2_grpc
+
+
+class GeneratedProtoImportTest(unittest.TestCase):
+    def test_stubs_are_importable(self):
+        from gen_echo_pb2_grpc import (
+            EchoServiceServicer,
+            EchoServiceStub,
+            add_EchoServiceServicer_to_server,
+        )
+
+    def test_proto_message_is_importable(self):
+        from gen_echo_pb2 import EchoRequest
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #41792.

The test fails in the first commit. It passes after the second commit.

`dirname` is based on `path`, which in this case is `bazel-out/k8-fastbuild/bin/echo.proto`. On the other hand, `short_path` always strips the `bazel-out/...` prefix; in this case it's just `echo.proto`. Since that does not contain a slash, `short_path.rpartition("/")[0]` is the empty string (which makes sense; it's in the root package).