### PR TITLE
[CI][Python] Fix gcf test error status propagation

### DIFF
--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -42,7 +42,7 @@ function cleanup() {
 
   # TODO: improve log error detection per https://github.com/grpc/grpc/pull/41749#discussion_r2876215927
   gcloud functions logs read "${FUNCTION_NAME}" --region="${REGION}" || true
-  (yes || true) | gcloud functions delete "${FUNCTION_NAME}" --region="${REGION}"
+  gcloud -q functions delete "${FUNCTION_NAME}" --region="${REGION}"
 }
 
 trap cleanup SIGINT SIGTERM EXIT


### PR DESCRIPTION
This PR:

- Fixes the issue with GCF tests not propagating error status, which resulted in a failure to detect #41725.
- Migrates the cloud functions to the internal ingress mode.
- Minor: specifies `--gen2` flag explicitly to remove the warning, and the region (needed for gen2)

