### PR TITLE
[Core] Remove hardcoded P-256 curve for OpenSSL 3.0+

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -474,9 +474,6 @@ const SSL_PRIVATE_KEY_METHOD TlsOffloadPrivateKeyMethod = {
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_NO_ENGINE)
 static const char kSslEnginePrefix[] = "engine:";
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x30000000
-static const int kSslEcCurveNames[] = {NID_X9_62_prime256v1};
-#endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000
 static gpr_mu* g_openssl_mutexes = nullptr;
@@ -1187,12 +1184,6 @@ static tsi_result populate_ssl_context(
     }
     SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
     EC_KEY_free(ecdh);
-#else
-    if (!SSL_CTX_set1_groups(context, kSslEcCurveNames, 1)) {
-      LOG(ERROR) << "Could not set ephemeral ECDH key.";
-      return TSI_INTERNAL_ERROR;
-    }
-    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
 #endif
   }
   return TSI_OK;


### PR DESCRIPTION
Resolves https://github.com/grpc/grpc/issues/41805

This PR removes the hardcoded `NID_X9_62_prime256v1` ECC curve for OpenSSL 3.0+, allowing the library to select the key exchange algorithms.
This is useful e.g. for supporting post-quantum computing algorithms like ML-KEM that are available in OpenSSL 3.5.

The `SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);` line is a no-op in OpenSSL 3 and was removed as well.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

