### PR TITLE
Fix call credentials callback proc swept prematurely

### DIFF
--- a/src/ruby/ext/grpc/rb_event_thread.c
+++ b/src/ruby/ext/grpc/rb_event_thread.c
@@ -34,13 +34,15 @@ typedef struct grpc_rb_event {
   // callback will be called with argument while holding the GVL
   void (*callback)(void*);
   void* argument;
-
   struct grpc_rb_event* next;
+  // Store the proc to be marked
+  VALUE proc;
 } grpc_rb_event;
 
 typedef struct grpc_rb_event_queue {
   grpc_rb_event* head;
   grpc_rb_event* tail;
+  VALUE last_dequeued_proc; // We also mark this
 
   gpr_mu mu;
   gpr_cv cv;
@@ -49,68 +51,162 @@ typedef struct grpc_rb_event_queue {
   bool abort;
 } grpc_rb_event_queue;
 
-static grpc_rb_event_queue event_queue;
+/* grpc_rb_cEventQueue is the ruby class that wraps the event queue. */
+static VALUE grpc_rb_cEventQueue = Qnil;
+
+/* g_event_queue is the global instance of the event queue */
+static VALUE g_event_queue = Qnil;
+
 static VALUE g_event_thread = Qnil;
 static bool g_one_time_init_done = false;
 
+/* Free function for the event queue */
+static void grpc_rb_event_queue_free(void* p) {
+  grpc_rb_event_queue* queue = (grpc_rb_event_queue*)p;
+  if (queue == NULL) return;
+
+  /* Clean up remaining events */
+  grpc_rb_event* event = queue->head;
+  while (event != NULL) {
+    grpc_rb_event* next = event->next;
+    gpr_free(event);
+    event = next;
+  }
+
+  gpr_mu_destroy(&queue->mu);
+  gpr_cv_destroy(&queue->cv);
+
+  xfree(queue);
+}
+
+/* Mark function for the event queue - marks all procs in the queue */
+static void grpc_rb_event_queue_mark(void* p) {
+  grpc_rb_event_queue* queue = (grpc_rb_event_queue*)p;
+  if (queue == NULL) return;
+
+  gpr_mu_lock(&queue->mu);
+  grpc_rb_event* event = queue->head;
+  while (event != NULL) {
+    if (event->proc != Qnil) {
+      rb_gc_mark(event->proc);
+    }
+    event = event->next;
+  }
+  if (queue->last_dequeued_proc && queue->last_dequeued_proc != Qnil) {
+    rb_gc_mark(queue->last_dequeued_proc);
+  }
+  gpr_mu_unlock(&queue->mu);
+}
+
+/* Ruby data type for the event queue */
+static const rb_data_type_t grpc_rb_event_queue_data_type = {
+    "grpc_event_queue",
+    {grpc_rb_event_queue_mark,
+     grpc_rb_event_queue_free,
+     GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
+    NULL,
+    NULL,
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+    RUBY_TYPED_FREE_IMMEDIATELY
+#endif
+};
+
+/* Allocate a new event queue instance */
+static VALUE grpc_rb_event_queue_alloc(VALUE cls) {
+  grpc_rb_event_queue* queue = ALLOC(grpc_rb_event_queue);
+
+  queue->head = NULL;
+  queue->tail = NULL;
+  queue->abort = false;
+  queue->last_dequeued_proc = Qnil;
+  gpr_mu_init(&queue->mu);
+  gpr_cv_init(&queue->cv);
+
+  return TypedData_Wrap_Struct(cls, &grpc_rb_event_queue_data_type, queue);
+}
+
 void grpc_rb_event_queue_enqueue(void (*callback)(void*), void* argument) {
+  grpc_rb_event_queue* queue;
+
+  if (!RTEST(g_event_queue)) {
+    rb_raise(rb_eRuntimeError, "Event queue not initialized");
+    return;
+  }
+
+  TypedData_Get_Struct(g_event_queue, grpc_rb_event_queue,
+                       &grpc_rb_event_queue_data_type, queue);
+
   grpc_rb_event* event = gpr_malloc(sizeof(grpc_rb_event));
   event->callback = callback;
   event->argument = argument;
   event->next = NULL;
-  gpr_mu_lock(&event_queue.mu);
-  if (event_queue.tail == NULL) {
-    event_queue.head = event_queue.tail = event;
+
+  /* For credential callbacks, the argument is a callback_params struct
+   * where the first field is the Ruby proc (VALUE get_metadata).
+   * We can safely extract it as the first VALUE in the struct. */
+  if (argument != NULL) {
+    VALUE* first_value = (VALUE*)argument;
+    event->proc = *first_value;
   } else {
-    event_queue.tail->next = event;
-    event_queue.tail = event;
+    event->proc = Qnil;
   }
-  gpr_cv_signal(&event_queue.cv);
-  gpr_mu_unlock(&event_queue.mu);
+
+  gpr_mu_lock(&queue->mu);
+  if (queue->tail == NULL) {
+    queue->head = queue->tail = event;
+  } else {
+    queue->tail->next = event;
+    queue->tail = event;
+  }
+  gpr_cv_signal(&queue->cv);
+  gpr_mu_unlock(&queue->mu);
 }
 
-static grpc_rb_event* grpc_rb_event_queue_dequeue() {
+static grpc_rb_event* grpc_rb_event_queue_dequeue(grpc_rb_event_queue* queue) {
   grpc_rb_event* event;
-  if (event_queue.head == NULL) {
+  if (queue->head == NULL) {
     event = NULL;
   } else {
-    event = event_queue.head;
-    if (event_queue.head->next == NULL) {
-      event_queue.head = event_queue.tail = NULL;
+    event = queue->head;
+    if (queue->head->next == NULL) {
+      queue->head = queue->tail = NULL;
     } else {
-      event_queue.head = event_queue.head->next;
+      queue->head = queue->head->next;
     }
+  }
+  if (event) {
+    queue->last_dequeued_proc = event->proc;
+  } else {
+    queue->last_dequeued_proc = Qnil;
   }
   return event;
 }
 
-static void grpc_rb_event_queue_destroy() {
-  gpr_mu_destroy(&event_queue.mu);
-  gpr_cv_destroy(&event_queue.cv);
-}
-
 static void* grpc_rb_wait_for_event_no_gil(void* param) {
+  grpc_rb_event_queue* queue = (grpc_rb_event_queue*)param;
   grpc_rb_event* event = NULL;
-  (void)param;
-  gpr_mu_lock(&event_queue.mu);
-  while (!event_queue.abort) {
-    if ((event = grpc_rb_event_queue_dequeue()) != NULL) {
-      gpr_mu_unlock(&event_queue.mu);
+
+  gpr_mu_lock(&queue->mu);
+  while (!queue->abort) {
+    if ((event = grpc_rb_event_queue_dequeue(queue)) != NULL) {
+      gpr_mu_unlock(&queue->mu);
       return event;
     }
-    gpr_cv_wait(&event_queue.cv, &event_queue.mu,
+    gpr_cv_wait(&queue->cv, &queue->mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
   }
-  gpr_mu_unlock(&event_queue.mu);
+  gpr_mu_unlock(&queue->mu);
   return NULL;
 }
 
 static void* grpc_rb_event_unblocking_func_wrapper(void* arg) {
-  (void)arg;
-  gpr_mu_lock(&event_queue.mu);
-  event_queue.abort = true;
-  gpr_cv_signal(&event_queue.cv);
-  gpr_mu_unlock(&event_queue.mu);
+  grpc_rb_event_queue* queue = (grpc_rb_event_queue*)arg;
+
+  gpr_mu_lock(&queue->mu);
+  queue->abort = true;
+  gpr_cv_signal(&queue->cv);
+  gpr_mu_unlock(&queue->mu);
   return NULL;
 }
 
@@ -121,12 +217,17 @@ static void grpc_rb_event_unblocking_func(void* arg) {
 /* This is the implementation of the thread that handles auth metadata plugin
  * events */
 static VALUE grpc_rb_event_thread(void* arg) {
+  grpc_rb_event_queue* queue;
   grpc_rb_event* event;
   (void)arg;
+
+  TypedData_Get_Struct(g_event_queue, grpc_rb_event_queue,
+                       &grpc_rb_event_queue_data_type, queue);
+
   while (true) {
     event = (grpc_rb_event*)rb_thread_call_without_gvl(
-        grpc_rb_wait_for_event_no_gil, NULL, grpc_rb_event_unblocking_func,
-        NULL);
+        grpc_rb_wait_for_event_no_gil, queue, grpc_rb_event_unblocking_func,
+        queue);
     if (event == NULL) {
       // Indicates that the thread needs to shut down
       break;
@@ -135,24 +236,37 @@ static VALUE grpc_rb_event_thread(void* arg) {
       gpr_free(event);
     }
   }
-  grpc_rb_event_queue_destroy();
   return Qnil;
 }
 
+void Init_grpc_event_queue() {
+  grpc_rb_cEventQueue = rb_define_class_under(grpc_rb_mGrpcCore, "EventQueue",
+                                             rb_cObject);
+  rb_define_alloc_func(grpc_rb_cEventQueue, grpc_rb_event_queue_alloc);
+}
+
 void grpc_rb_event_queue_thread_start() {
+  grpc_rb_event_queue* queue;
+
   if (!g_one_time_init_done) {
     g_one_time_init_done = true;
-    gpr_mu_init(&event_queue.mu);
-    gpr_cv_init(&event_queue.cv);
+    Init_grpc_event_queue();
+
+    g_event_queue = grpc_rb_event_queue_alloc(grpc_rb_cEventQueue);
+    rb_global_variable(&g_event_queue);
     rb_global_variable(&g_event_thread);
-    event_queue.head = event_queue.tail = NULL;
   }
-  event_queue.abort = false;
+
+  TypedData_Get_Struct(g_event_queue, grpc_rb_event_queue,
+                       &grpc_rb_event_queue_data_type, queue);
+
   GRPC_RUBY_ASSERT(!RTEST(g_event_thread));
   g_event_thread = rb_thread_create(grpc_rb_event_thread, NULL);
 }
 
 void grpc_rb_event_queue_thread_stop() {
+  grpc_rb_event_queue* queue;
+
   GRPC_RUBY_ASSERT(g_one_time_init_done);
   if (!RTEST(g_event_thread)) {
     grpc_absl_log(
@@ -160,8 +274,13 @@ void grpc_rb_event_queue_thread_stop() {
         "GRPC_RUBY: call credentials thread stop: thread not running");
     return;
   }
-  rb_thread_call_without_gvl(grpc_rb_event_unblocking_func_wrapper, NULL, NULL,
-                             NULL);
+
+  TypedData_Get_Struct(g_event_queue, grpc_rb_event_queue,
+                       &grpc_rb_event_queue_data_type, queue);
+
+  rb_thread_call_without_gvl(grpc_rb_event_unblocking_func_wrapper, queue,
+                             NULL, NULL);
   rb_funcall(g_event_thread, rb_intern("join"), 0);
   g_event_thread = Qnil;
+  g_event_queue = Qnil;
 }


### PR DESCRIPTION
This fixes a bug we were having in production where a CallCredentials proc is swept prematurely, before the event thread can run the callback. Now, the event thread marks all the event procs in the event list.

Reproduction of the crash:

```ruby
#!/usr/bin/env ruby

# Test case to reproduce segfault with active RPCs

require 'grpc'

# Create simple message types
class TestMessage
  attr_accessor :data

  def initialize(data = '')
    @data = data
  end

  def self.encode(msg)
    msg.data
  end

  def self.decode(str)
    TestMessage.new(str)
  end

  def to_s
    @data
  end
end

module Test
  class MyService
    include GRPC::GenericService
    self.marshal_class_method = :encode
    self.unmarshal_class_method = :decode
    self.service_name = 'test.SlowService'
    rpc :slow_call, TestMessage, TestMessage

    def slow_call(request, _call)
      sleep 2
      TestMessage.new("Response: #{request}")
    end
  end

  MyServiceStub = MyService.rpc_stub_class
end

def test_server_certs
  # These are test certificates from GRPC test suite (Shopify/grpc)
  test_root = File.join(File.dirname(__FILE__), 'src', 'ruby', 'spec', 'testdata')
  files = ['ca.pem', 'server1.key', 'server1.pem']

  if files.all? { |f| File.exist?(File.join(test_root, f)) }
    puts "Using test certificates from #{test_root}"
    [File.read(File.join(test_root, files[0])),
     [{private_key: File.read(File.join(test_root, files[1])),
       cert_chain: File.read(File.join(test_root, files[2]))}],
     true]
  else
    puts "Test certificates not found, using insecure connection"
    nil
  end
end

# Start server in background
$server_port = nil
def start_server_thread
  $server_creds = test_server_certs()
  Thread.new do
    @server = GRPC::RpcServer.new
    service = Test::MyService.new

    if $server_creds
      $server_port = @server.add_http2_port('0.0.0.0:0',
        GRPC::Core::ServerCredentials.new(*$server_creds))
      $server_creds = nil
    else
      $server_port = @server.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
    end

    @server.handle(service)
    @server.run_till_terminated
  end
end

$server_thread = start_server_thread()
# Wait for server to start
sleep 0.5

puts "Server running on port #{$server_port}"

$callback_count = 0
def create_call_creds
  # Create closure variables that should be kept alive
  secret = "secret-token-#{rand(1000)}"
  user_data = { id: 123, name: "test_user" }

  # Create call credentials with a Ruby proc
  GRPC::Core::CallCredentials.new(proc do |context|
    $callback_count += 1
    puts "[CALLBACK #{$callback_count}] Credential callback called!"
    puts "[CALLBACK] Context: #{context.inspect}"
    puts "[CALLBACK] Secret from closure: #{secret}"
    sleep rand(3)
    { 'authorization' => "Bearer #{secret}", 'x-user' => user_data.to_s }
  end)
end

def trigger_gc_crash(use_creds = true)
  puts "Creating channel and starting RPCs..."

  if use_creds
    channel_creds = GRPC::Core::ChannelCredentials.new(
      File.read(File.join(File.dirname(__FILE__), 'src', 'ruby', 'spec', 'testdata', 'ca.pem')),
      File.read(File.join(File.dirname(__FILE__), 'src', 'ruby', 'spec', 'testdata', 'client.key')),
      File.read(File.join(File.dirname(__FILE__), 'src', 'ruby', 'spec', 'testdata', 'client.pem'))
    )
    # Compose with call credentials
    call_creds = create_call_creds()
    composite_creds = channel_creds.compose(call_creds)
    stub = Test::MyServiceStub.new("localhost:#{$server_port}", composite_creds,
      channel_args: { GRPC::Core::Channel::SSL_TARGET => 'foo.test.google.fr' }
    )
  else
    stub = Test::MyServiceStub.new("localhost:#{$server_port}", :this_channel_is_insecure)
  end

  threads = []
  10.times do |i|
    threads << Thread.new do
      Thread.abort_on_exception = true
      begin
        if stub
          response = stub.slow_call(TestMessage.new("Request #{i}"), deadline: Time.now + 1)
          puts "AFTER slow_call: #{response}"
        end
      rescue => e
        puts "Call #{i} error: #{e.message}"
      end
    end
  end

  threads.each(&:join)

  puts "If you see this, the crash didn't happen yet..."
end

# Try to trigger the crash
begin
  trigger_gc_crash

  ## Try again with more aggressive GC
  10.times do
    puts "Retrying with GC.stress"
    GC.stress = true
    trigger_gc_crash
    GC.stress = false
  end

rescue => e
  puts "Error: #{e.message}"
  puts e.backtrace
end

puts "Test completed without segfault - issue might not be reproducible this way"
puts "Total credential callbacks invoked: #{$callback_count}"
@server&.stop
$server_thread.join
```

This must be saved as a file and run in the `grpc` root directory.