### PR TITLE
Remove debug log messages

### DIFF
--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -165,10 +165,8 @@ int plugin_get_metadata(
 
   PHP_GRPC_DELREF(arg);
 
-  grpc_absl_log(GPR_INFO, "GRPC_PHP: call credentials plugin function - begin");
   /* call the user callback function */
   PHP_GRPC_CALL_FUNCTION(state->fci, state->fci_cache);
-  grpc_absl_log(GPR_INFO, "GRPC_PHP: call credentials plugin function - end");
 
   *num_creds_md = 0;
   *status = GRPC_STATUS_OK;


### PR DESCRIPTION
This will remove the log messages added in https://github.com/grpc/grpc/pull/14659. 

Removing them will fix part of https://github.com/grpc/grpc/issues/38336 and fix https://github.com/grpc/grpc/issues/41525.

Sure there are many better ways to do this. One would be to make sure the log method respect verbosity settings. I decided to be pragmatic. These log messages was added 8 years ago and seams to not provide any value other than for debug purposes. 