### PR TITLE
[Bzlmod] Re-enable bzlmod for arm64 C/C++ tests

### DIFF
--- a/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp_in_docker.sh
+++ b/tools/internal_ci/linux/arm64/grpc_bazel_test_c_cpp_in_docker.sh
@@ -21,7 +21,7 @@ python3 tools/run_tests/start_port_server.py
 # test gRPC C/C++ with bazel
 python3 tools/run_tests/python_utils/bazel_report_helper.py --report_path bazel_test_c_cpp
 bazel_test_c_cpp/bazel_wrapper \
-  --bazelrc=tools/remote_build/include/test_locally_with_resultstore_results.bazelrc \
+  --bazelrc=tools/remote_build/include/test_arm64_locally_with_resultstore_results.bazelrc \
   test --config=opt \
   --test_tag_filters=-no_linux,-no_arm64 \
   --build_tag_filters=-no_linux,-no_arm64 \

--- a/tools/remote_build/include/test_arm64_locally_with_resultstore_results.bazelrc
+++ b/tools/remote_build/include/test_arm64_locally_with_resultstore_results.bazelrc
@@ -1,0 +1,18 @@
+# Run tests locally, but configure bazel to upload
+# the results to resultstore UI.
+# Also easily extended to use remote cache for
+# locally run builds and tests (but not on by default for safety)
+
+import %workspace%/tools/remote_build/include/rbe_base_config.bazelrc
+
+# Disable uploading to build cache by default. This is to prevent
+# polluting the build cache with local build and test results.
+# When running on CI, we will override this setting along
+# with cache silo keys that prevent the build from being broken
+# by unintentional cache hits.
+build --remote_upload_local_results=false
+
+import %workspace%/tools/remote_build/include/test_config_common.bazelrc
+
+# TODO(weizheyuan): Delete this file and converge to
+# test_locally_with_resultstore_results.bazelrc after bzlmod migration.


### PR DESCRIPTION
Bzlmod was once enabled for this test but later disabled via `test_locally_with_resultstore_results.bazelrc` due to an unrelated python issue.

This PR forks the bazelrc file to re-enable bzlmod for arm64 only.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

