### PR TITLE
[Backport][v1.78.x] Revert "[Python] Align GRPC_ENABLE_FORK_SUPPORT env defaults in core and python (#41455)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -452,17 +452,6 @@ else:
     DEFINE_MACROS += (
         ("HAVE_CONFIG_H", 1),
         ("GRPC_ENABLE_FORK_SUPPORT", 1),
-        # Set runtime GRPC_ENABLE_FORK_SUPPORT setting in core to "off".
-        #
-        # By default, gRPC core GRPC_ENABLE_FORK_SUPPORT runtime config_var
-        # is "on" when it's compiled with GRPC_ENABLE_FORK_SUPPORT macro.
-        # However, in python GRPC_ENABLE_FORK_SUPPORT by default is "off".
-        # Compare config_vars.cc and fork_posix.pyx.pxi.
-        # This leads to an inconsistent and broken behavior.
-        #
-        # Important! This must by in sync with the default value for the
-        # GRPC_ENABLE_FORK_SUPPORT env var parsed in fork_posix.pyx.pxi
-        ("GRPC_ENABLE_FORK_SUPPORT_DEFAULT", "false"),
     )
 
 # Fix for multiprocessing support on Apple devices.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -29,10 +29,6 @@ _TRUE_VALUES = ['yes',  'Yes',  'YES', 'true', 'True', 'TRUE', '1']
 #
 # This flag is not supported on Windows.
 # This flag is also not supported for non-native IO manager.
-#
-# Important: when changing the default, GRPC_ENABLE_FORK_SUPPORT_DEFAULT
-# macro in the setup.py needs to be updated to the same value.
-# TODO(sergiitk): reconsider enabling this by default.
 _GRPC_ENABLE_FORK_SUPPORT = (
     os.environ.get('GRPC_ENABLE_FORK_SUPPORT', '0')
         .lower() in _TRUE_VALUES)


### PR DESCRIPTION
Backport of #41769 to v1.78.x.
---

This reverts #41588, the backport of #41455 to v1.78.x.
Note that v1.78.1 has been yanked, so this PR is one of two changes needed to restore v1.78.x branch to the state prior to v1.78.1. 

---
- This reverts commit ee658b2355ab236b377be67b0c3d068df34a4ddb.
- This changed caused #41725 in v1.78.1, which was yanked as the result (ref b/487190834).
- Tracking ticket for the follow-up investigation and the fix implementation: #41768.
- Reopens #37710.

