### PR TITLE
[Backport][v1.78.x][CI][Python] Fix gcf test error status propagation

### DIFF
--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -37,12 +37,23 @@ echo "${ARTIFACT_URL}" >>requirements.txt
 FUNCTION_NAME="${FUNCTION_PREFIX}-$(uuidgen)"
 
 function cleanup() {
+  # Capture exit status of the main script.
+  local exit_status="$?"
+
+  # Print without repeating due to -x.
+  { set +x; } 2>/dev/null
+  echo -e "\nInitiating cleanup for ${FUNCTION_NAME}. Waiting for logs to quiesce: ${LOG_QUIESCE_SECONDS} sec."
+  set -x
+
   # Wait for logs to quiesce.
   sleep "${LOG_QUIESCE_SECONDS}"
 
   # TODO: improve log error detection per https://github.com/grpc/grpc/pull/41749#discussion_r2876215927
   gcloud functions logs read "${FUNCTION_NAME}" --region="${REGION}" || true
-  gcloud -q functions delete "${FUNCTION_NAME}" --region="${REGION}"
+  gcloud -q functions delete "${FUNCTION_NAME}" --region="${REGION}" || true
+
+  # Propagate exit status.
+  exit "$exit_status"
 }
 
 trap cleanup SIGINT SIGTERM EXIT
@@ -63,5 +74,8 @@ HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 for _ in $(seq 1 "${REQUEST_COUNT}"); do
   # TODO(sergiitk): switch to --fail-with-body once the base image contains
   #   curl >= v7.76.0; as of 2026-03-04 it's v7.68.0.
-  curl -L --fail --no-progress-meter "${HTTP_URL}" && echo
+  curl -L --fail --no-progress-meter "${HTTP_URL}"
+
+  # Print a newline to make logs readable: the "ok" response end with \n.
+  { set +x; } 2>/dev/null; echo; set -x
 done


### PR DESCRIPTION
Backport of #41800 and #41833 to v1.78.x.
---

## #41800

This PR:

- Fixes the issue with GCF tests not propagating error status, which resulted in a failure to detect #41725.
- Migrates the cloud functions to the internal ingress mode.
- Minor: specifies `--gen2` flag explicitly to remove the warning, and the region (needed for gen2)

## #41833

#41800 wasn't enough to fix the issue with GCF tests error status propagation. 

This PR fixes remaining two issues:

First, the cleanup function that runs on exit overriding the return status. This PR fixes this issue by capturing and propagating the error status.

Second, `curl ... && echo` prevented bash immediate exit (set with `-e` option) after `curl` failed. While counterintuitive, the immediate exit option specifically exempts the commands followed by `&&`. For example, in `false && my_cmd`, bash with `set -e` won't exit on `false`, despite the fact that `&& my_cmd` will never be executed:

> `-e` \
> [...] The shell does not exit if the command that fails is [...] part of any command executed in a `&&` or `||` list except the command following the final `&&` or `||`.\
> — https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

