### PR TITLE
[CI][Python] Fix gcf test error status propagation part 2

### DIFF
--- a/test/distrib/gcf/python/run_single.sh
+++ b/test/distrib/gcf/python/run_single.sh
@@ -40,6 +40,11 @@ function cleanup() {
   # Capture exit status of the main script.
   local exit_status="$?"
 
+  # Print without repeating due to -x.
+  { set +x; } 2>/dev/null
+  echo -e "\nInitiating cleanup for ${FUNCTION_NAME}. Waiting for logs to quiesce: ${LOG_QUIESCE_SECONDS} sec."
+  set -x
+
   # Wait for logs to quiesce.
   sleep "${LOG_QUIESCE_SECONDS}"
 
@@ -69,5 +74,8 @@ HTTP_URL=$(echo "${DEPLOY_OUTPUT}" | grep "url: " | awk '{print $2;}')
 for _ in $(seq 1 "${REQUEST_COUNT}"); do
   # TODO(sergiitk): switch to --fail-with-body once the base image contains
   #   curl >= v7.76.0; as of 2026-03-04 it's v7.68.0.
-  curl -L --fail --no-progress-meter "${HTTP_URL}" && echo
+  curl -L --fail --no-progress-meter "${HTTP_URL}"
+
+  # Print a newline to make logs readable: the "ok" response end with \n.
+  { set +x; } 2>/dev/null; echo; set -x
 done


### PR DESCRIPTION
#41800 wasn't enough to fix the issue with GCF tests error status propagation. 

This PR fixes remaining two issues:

First, the cleanup function that runs on exit overriding the return status. This PR fixes this issue by capturing and propagating the error status.

Second, `curl ... && echo` prevented bash immediate exit (set with `-e` option) after `curl` failed. While counterintuitive, the immediate exit option specifically exempts the commands followed by `&&`. For example, in `false && my_cmd`, bash with `set -e` won't exit on `false`, despite the fact that `&& my_cmd` will never be executed:

> `-e` \
> [...] The shell does not exit if the command that fails is [...] part of any command executed in a `&&` or `||` list except the command following the final `&&` or `||`.\
> — https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

