### PR TITLE
[subchannel] fix crash in connection scaling code

### DIFF
--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -2357,6 +2357,7 @@ NewSubchannel::ChooseConnectionLocked() {
 
 void NewSubchannel::RetryQueuedRpcs() {
   MutexLock lock(&mu_);
+  if (shutdown_) return;
   RetryQueuedRpcsLocked();
 }
 


### PR DESCRIPTION
The crash occured in the following specific sequence of events:
1. There is at least one call in flight on a connection and at least one call queued waiting for a connection.
2. The subchannel shuts down.  This resets the subchannel connector and shuts down all connections.
3. The in-flight call finishes before the subchannel sees the last connection shut down.  This triggers the subchannel to retry the queued calls, possibly attempting to create a new connection, which crashes because the connector is now null.  Note that if the subchannel sees the last connection shut down before the in-flight call finishes, then the crash would not happen, because seeing the last connection shut down would cause the subchannel to fail all queued RPCs.

Example failure: https://btx.cloud.google.com/invocations/8f91fb87-990d-4717-a80c-eeeaafaaa80b/targets/%2F%2Ftest%2Fcpp%2Fend2end:client_lb_end2end_test@experiment%3Dsubchannel_connection_scaling;config=71d110ec9fea5b999eb1f2c4e7a7a6c367de78f905161866a54a769ac98fc7fc/log

This PR fixes the bug by avoiding retrying the queued calls if the subchannel is being shut down.