### PR TITLE
[Python] Trim Python2 backward compatibility syntax - remove "__future__"

### DIFF
--- a/examples/python/multiplex/multiplex_client.py
+++ b/examples/python/multiplex/multiplex_client.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """A client that makes both Greeter and RouteGuide RPCs."""
 
-from __future__ import print_function
-
 import logging
 import random
 import time

--- a/examples/python/multiprocessing/client.py
+++ b/examples/python/multiprocessing/client.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 """An example of multiprocessing concurrency with gRPC."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import argparse
 import atexit
 import logging

--- a/examples/python/multiprocessing/server.py
+++ b/examples/python/multiprocessing/server.py
@@ -13,10 +13,6 @@
 # limitations under the License.
 """An example of multiprocess concurrency with gRPC."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 from concurrent import futures
 import contextlib
 import datetime

--- a/examples/python/route_guide/route_guide_client.py
+++ b/examples/python/route_guide/route_guide_client.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """The Python implementation of the gRPC route guide client."""
 
-from __future__ import print_function
-
 import logging
 import random
 

--- a/examples/python/uds/greeter_client.py
+++ b/examples/python/uds/greeter_client.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """The gRPC Python client for the UDS example."""
 
-from __future__ import print_function
-
 import logging
 
 import grpc

--- a/src/python/grpcio_tests/tests/__init__.py
+++ b/src/python/grpcio_tests/tests/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 from tests import _loader
 from tests import _runner
 

--- a/src/python/grpcio_tests/tests/_loader.py
+++ b/src/python/grpcio_tests/tests/_loader.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import importlib
 import logging
 import os

--- a/src/python/grpcio_tests/tests/_result.py
+++ b/src/python/grpcio_tests/tests/_result.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import collections
 import datetime
 import io

--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import collections
 import io
 import os

--- a/src/python/grpcio_tests/tests/unit/_server_wait_for_termination_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_wait_for_termination_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
-
 from concurrent import futures
 import datetime
 import threading

--- a/src/python/grpcio_tests/tests/unit/_signal_client.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_client.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Client for testing responsiveness to signals."""
 
-from __future__ import print_function
-
 import argparse
 import functools
 import logging

--- a/src/python/grpcio_tests/tests/unit/_tcp_proxy.py
+++ b/src/python/grpcio_tests/tests/unit/_tcp_proxy.py
@@ -18,10 +18,6 @@ which a test needs to spy on the bytes put on the wire between a server and
 a client.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import datetime
 import select
 import socket

--- a/src/python/grpcio_tests/tests_aio/__init__.py
+++ b/src/python/grpcio_tests/tests_aio/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 from tests import _loader
 from tests import _runner
 

--- a/src/python/grpcio_tests/tests_py3_only/__init__.py
+++ b/src/python/grpcio_tests/tests_py3_only/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 from tests import _loader
 from tests import _runner
 

--- a/test/cpp/qps/scenario_generator_helper.py
+++ b/test/cpp/qps/scenario_generator_helper.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import json
 import os
 import sys

--- a/tools/codegen/core/experiments_compiler.py
+++ b/tools/codegen/core/experiments_compiler.py
@@ -17,8 +17,6 @@
 A module to assist in generating experiment related code and artifacts.
 """
 
-from __future__ import print_function
-
 import collections
 from copy import deepcopy
 import ctypes

--- a/tools/codegen/core/gen_config_vars.py
+++ b/tools/codegen/core/gen_config_vars.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import binascii
 import collections
 import ctypes

--- a/tools/codegen/core/gen_experiments.py
+++ b/tools/codegen/core/gen_experiments.py
@@ -20,8 +20,6 @@ Invoke as: tools/codegen/core/gen_experiments.py
 Experiment definitions are in src/core/lib/experiments/experiments.yaml
 """
 
-from __future__ import print_function
-
 import argparse
 import os
 import sys

--- a/tools/codegen/core/gen_grpc_tls_credentials_options.py
+++ b/tools/codegen/core/gen_grpc_tls_credentials_options.py
@@ -17,8 +17,6 @@
 # Generator script for src/core/credentials/transport/tls/grpc_tls_credentials_options.h and test/core/credentials/transport/tls/grpc_tls_credentials_options_comparator_test.cc
 # Should be executed from grpc's root directory.
 
-from __future__ import print_function
-
 import collections
 from dataclasses import dataclass
 import difflib

--- a/tools/distrib/python/docgen.py
+++ b/tools/distrib/python/docgen.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
 import os
 import os.path

--- a/tools/distrib/python/make_grpcio_tools.py
+++ b/tools/distrib/python/make_grpcio_tools.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
 import errno
 import filecmp

--- a/tools/gcp/utils/big_query_utils.py
+++ b/tools/gcp/utils/big_query_utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import argparse
 import json
 import uuid

--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Build and upload docker images to Google Container Registry per matrix."""
 
-from __future__ import print_function
-
 import argparse
 import atexit
 import multiprocessing

--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Run tests using docker images in Google Container Registry per matrix."""
 
-from __future__ import print_function
-
 import argparse
 import atexit
 import json

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import datetime
 import json
 import os

--- a/tools/run_tests/python_utils/dockerjob.py
+++ b/tools/run_tests/python_utils/dockerjob.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Helpers to run docker instances as jobs."""
 
-from __future__ import print_function
-
 import json
 import os
 import subprocess

--- a/tools/run_tests/python_utils/download_and_unzip.py
+++ b/tools/run_tests/python_utils/download_and_unzip.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Download and unzip the target file to the destination."""
 
-from __future__ import print_function
-
 import os
 import sys
 import tempfile

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Run test matrix."""
 
-from __future__ import print_function
-
 import argparse
 import datetime
 import multiprocessing

--- a/tools/run_tests/task_runner.py
+++ b/tools/run_tests/task_runner.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Runs selected gRPC test/build tasks."""
 
-from __future__ import print_function
-
 import argparse
 import multiprocessing
 import sys


### PR DESCRIPTION
The "from __future__ import annotations" are Python 3 specific and are kept.

```
$ git diff | grep ^- | grep __future__ | sort -u
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
```