### PR TITLE
[TSI] Strip trailing dot from SNI hostname per RFC 6066

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2563,7 +2563,15 @@ static tsi_result create_tsi_ssl_handshaker(
     // allowed as host names.
     if (server_name_indication != nullptr &&
         !looks_like_ip_address(server_name_indication)) {
-      if (!SSL_set_tlsext_host_name(ssl, server_name_indication)) {
+      // Per RFC 6066 Section 3, the SNI hostname must not include a trailing
+      // dot. A trailing dot denotes a fully qualified domain name (FQDN) and
+      // is valid in DNS contexts, but is explicitly prohibited in the SNI
+      // extension. Strip it before setting the hostname.
+      std::string sni_hostname(server_name_indication);
+      if (!sni_hostname.empty() && sni_hostname.back() == '.') {
+        sni_hostname.pop_back();
+      }
+      if (!SSL_set_tlsext_host_name(ssl, sni_hostname.c_str())) {
         LOG(ERROR) << "Invalid server name indication "
                    << server_name_indication;
         SSL_free(ssl);

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -879,6 +879,34 @@ TEST_P(SslTransportSecurityTest,
   DoHandshake();
 }
 
+TEST_P(SslTransportSecurityTest,
+       DoHandshakeWithTrailingDotServerNameIndicationExactDomain) {
+  LOG(INFO) << "ssl_tsi_test_do_handshake_with_trailing_dot_server_name_"
+               "indication_exact_domain";
+  SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  // Per RFC 6066, SNI must not contain a trailing dot. The trailing dot (FQDN
+  // notation) should be stripped before setting the SNI extension. server1 cert
+  // contains "waterzooi.test.google.be" in SAN, so this should match after
+  // stripping the trailing dot.
+  ssl_fixture_->SetServerNameIndication(
+      const_cast<char*>("waterzooi.test.google.be."));
+  DoHandshake();
+}
+
+TEST_P(SslTransportSecurityTest,
+       DoHandshakeWithTrailingDotServerNameIndicationWildStarDomain) {
+  LOG(INFO) << "ssl_tsi_test_do_handshake_with_trailing_dot_server_name_"
+               "indication_wild_star_domain";
+  SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  // server1 cert contains "*.test.google.fr" in SAN. A trailing dot on the
+  // SNI hostname should be stripped per RFC 6066 before the handshake.
+  ssl_fixture_->SetServerNameIndication(
+      const_cast<char*>("juju.test.google.fr."));
+  DoHandshake();
+}
+
 TEST_P(SslTransportSecurityTest, DoHandshakeWithBadServerCert) {
   SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1001,6 +1029,41 @@ TEST_P(SslTransportSecurityTest, DoHandshakeSessionCache) {
   memset(session_ticket_key, 'c', sizeof(session_ticket_key));
   do_handshake(false);
   do_handshake(true);
+  tsi_ssl_session_cache_unref(session_cache);
+}
+
+TEST_P(SslTransportSecurityTest,
+       DoHandshakeSessionCacheTrailingDotSniIsStripped) {
+  LOG(INFO)
+      << "ssl_tsi_test_do_handshake_session_cache_trailing_dot_sni_is_stripped";
+  // Validates that trailing dots are stripped from SNI hostnames per RFC 6066
+  // before being stored in the SSL object. The session cache is keyed by the
+  // hostname returned from SSL_get_servername(), which reflects whatever was
+  // passed to SSL_set_tlsext_host_name(). If the trailing dot is not stripped,
+  // the second handshake looks up "waterzooi.test.google.be." in the cache
+  // instead of "waterzooi.test.google.be", misses the cached session, and the
+  // session_reused assertion fails.
+  tsi_ssl_session_cache* session_cache = tsi_ssl_session_cache_create_lru(16);
+  char session_ticket_key[kSessionTicketEncryptionKeySize];
+  auto do_handshake = [this, &session_ticket_key,
+                       &session_cache](const char* sni, bool session_reused) {
+    SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
+                    /*send_client_ca_list=*/std::get<1>(GetParam()));
+    ssl_fixture_->SetServerNameIndication(const_cast<char*>(sni));
+    ssl_fixture_->SetSessionTicketKey(session_ticket_key,
+                                      sizeof(session_ticket_key));
+    tsi_ssl_session_cache_ref(session_cache);
+    ssl_fixture_->SetSessionCache(session_cache);
+    ssl_fixture_->SetSessionReused(session_reused);
+    DoRoundTrip();
+    DestroyFixture();
+  };
+  memset(session_ticket_key, 'a', sizeof(session_ticket_key));
+  // Prime the session cache under key "waterzooi.test.google.be".
+  do_handshake("waterzooi.test.google.be", /*session_reused=*/false);
+  // The trailing dot must be stripped so the cache lookup finds the session
+  // cached above rather than looking for "waterzooi.test.google.be.".
+  do_handshake("waterzooi.test.google.be.", /*session_reused=*/true);
   tsi_ssl_session_cache_unref(session_cache);
 }
 #endif  // OPENSSL_IS_BORINGSSL


### PR DESCRIPTION
## Problem

When a gRPC channel target URI contains a trailing dot (e.g. `grpc-server.example.com.:443`), gRPC C-core passes the raw hostname including the dot to `SSL_set_tlsext_host_name`. This results in the trailing dot being sent in the SNI extension of the TLS ClientHello.

RFC 6066 §3 explicitly prohibits trailing dots in SNI hostnames:

> The hostname is represented as a byte string using ASCII encoding without a trailing dot.

Servers that strictly enforce RFC 6066 reject such ClientHellos. In particular, Go's `crypto/tls` — used by several gRPC control plane implementations — returns a `decode_error` alert and closes the connection, making the channel permanently unusable.

## Fix

Strip the trailing dot from the SNI hostname in `create_tsi_ssl_handshaker` before calling `SSL_set_tlsext_host_name`. 
This avoids stripping the the dot in other places that might still need it (e.g. `:authority` header).

## Tests

The following tests are added to `ssl_transport_security_test.cc`:

- Handshake succeeds when SNI hostname has a trailing dot matching an exact SAN entry.
- Handshake succeeds when SNI hostname has a trailing dot matching a wildcard SAN entry.
- Session cache keys are consistent: connections using the dotted and non-dotted forms of the same hostname share a cached session.