### PR TITLE
[bzlmod] upgrade rules_swift to avoid BCR CI breakage on Windows with bazel 7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,6 +22,10 @@ module(
 # Regular dependencies
 # ====================
 
+# Upgrade version of rules_swift to avoid an error in BCR CI of not
+# finding switfc.exe on Windows with bazel 7.
+bazel_dep(name = "rules_swift", version = "2.5.0")
+
 # -- Abseil library.
 # Pinning version to be consistent with third_party/abseil-cpp
 bazel_dep(name = "abseil-cpp", version = "20250512.1", repo_name = "com_google_absl")

--- a/templates/MODULE.bazel.inja
+++ b/templates/MODULE.bazel.inja
@@ -22,6 +22,10 @@ module(
 # Regular dependencies
 # ====================
 
+# Upgrade version of rules_swift to avoid an error in BCR CI of not
+# finding switfc.exe on Windows with bazel 7.
+bazel_dep(name = "rules_swift", version = "2.5.0")
+
 # -- Abseil library.
 # Pinning version to be consistent with third_party/abseil-cpp
 bazel_dep(name = "abseil-cpp", version = "20250512.1", repo_name = "com_google_absl")


### PR DESCRIPTION
Back-port of #41867 to 1.80.