### PR TITLE
[Backport][v1.80.x][Python] New `_create` method for aio.Metadata

### DIFF
--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -182,7 +182,7 @@ def _create_rpc_error(
 ) -> AioRpcError:
     return AioRpcError(
         _common.CYGRPC_STATUS_CODE_TO_STATUS_CODE[status.code()],
-        Metadata.from_tuple(initial_metadata),
+        Metadata._create(initial_metadata),
         Metadata.from_tuple(status.trailing_metadata()),
         details=status.details(),
         debug_error_string=status.debug_error_string(),

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -12,17 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Implementation of the metadata abstraction for gRPC Asyncio Python."""
+from __future__ import annotations
+
 from collections import OrderedDict
-from collections import abc
-from typing import Any, Iterator, List, Optional, Tuple, Union
+from collections.abc import Collection
+from collections.abc import ItemsView
+from collections.abc import Iterable
+from collections.abc import Iterator
+from collections.abc import KeysView
+from collections.abc import Sequence
+from collections.abc import ValuesView
+from typing import Any, List, Optional, Tuple, Union
 
 from typing_extensions import Self
 
 MetadataKey = str
 MetadataValue = Union[str, bytes]
+MetadatumType = Tuple[MetadataKey, MetadataValue]
+MetadataType = Union["Metadata", Sequence[MetadatumType]]
 
 
-class Metadata(abc.Collection):  # noqa: PLW1641
+class Metadata(Collection):  # noqa: PLW1641
     """Metadata abstraction for the asynchronous calls and interceptors.
 
     The metadata is a mapping from str -> List[str]
@@ -35,13 +45,28 @@ class Metadata(abc.Collection):  # noqa: PLW1641
         * Allows partial mutation on the data without recreating the new object from scratch.
     """
 
-    def __init__(self, *args: Tuple[MetadataKey, MetadataValue]) -> None:
+    def __init__(self, *args: MetadatumType) -> None:
         self._metadata = OrderedDict()
         for md_key, md_value in args:
             self.add(md_key, md_value)
 
     @classmethod
-    def from_tuple(cls, raw_metadata: Union[tuple, Self]):
+    def from_tuple(cls, raw_metadata: tuple):
+        # Note: We unintentionally support non-tuple arguments here. We plan
+        # to emit a DeprecationWarning when a non-tuple type is used.
+        if raw_metadata:
+            return cls(*raw_metadata)
+        return cls()
+
+    @classmethod
+    def _create(
+        cls,
+        raw_metadata: Union[None, Self, Iterable[MetadatumType]],
+    ) -> Self:
+        # TODO(asheshvidyut): Make this method public and encourage people to use it instead
+        # of `from_tuple` to create metadata from non-tuple types.
+        if raw_metadata is None:
+            return Metadata()
         if isinstance(raw_metadata, cls):
             return raw_metadata
         if raw_metadata:
@@ -94,14 +119,14 @@ class Metadata(abc.Collection):  # noqa: PLW1641
             for value in values:
                 yield (key, value)
 
-    def keys(self) -> abc.KeysView:
-        return abc.KeysView(self._metadata)
+    def keys(self) -> KeysView:
+        return KeysView(self._metadata)
 
-    def values(self) -> abc.ValuesView:
-        return abc.ValuesView(self._metadata)
+    def values(self) -> ValuesView:
+        return ValuesView(self._metadata)
 
-    def items(self) -> abc.ItemsView:
-        return abc.ItemsView(self._metadata)
+    def items(self) -> ItemsView:
+        return ItemsView(self._metadata)
 
     def get(
         self, key: MetadataKey, default: Optional[MetadataValue] = None

--- a/src/python/grpcio/grpc/aio/_typing.py
+++ b/src/python/grpcio/grpc/aio/_typing.py
@@ -26,16 +26,19 @@ from typing import (
 
 from grpc._cython.cygrpc import EOF
 
+# pylint: disable=unused-import
 from ._metadata import Metadata
 from ._metadata import MetadataKey
+from ._metadata import MetadataType
 from ._metadata import MetadataValue
+from ._metadata import MetadatumType
+
+# pylint: enable=unused-import
 
 RequestType = TypeVar("RequestType")
 ResponseType = TypeVar("ResponseType")
 SerializingFunction = Callable[[Any], bytes]
 DeserializingFunction = Callable[[bytes], Any]
-MetadatumType = Tuple[MetadataKey, MetadataValue]
-MetadataType = Union[Metadata, Sequence[MetadatumType]]
 ChannelArgumentType = Sequence[Tuple[str, Any]]
 EOFType = type(EOF)
 DoneCallbackType = Callable[[Any], None]

--- a/src/python/grpcio_tests/tests_aio/unit/_common.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_common.py
@@ -20,7 +20,6 @@ import grpc
 from grpc.aio._metadata import Metadata
 from grpc.aio._typing import MetadataKey
 from grpc.aio._typing import MetadataValue
-from grpc.aio._typing import MetadatumType
 from grpc.experimental import aio
 
 from tests.unit.framework.common import test_constants

--- a/src/python/grpcio_tests/tests_aio/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/_metadata_test.py
@@ -18,6 +18,7 @@ import unittest
 import grpc
 from grpc.experimental import aio
 from grpc.experimental.aio import Metadata
+import typeguard
 
 from tests_aio.unit import _common
 from tests_aio.unit._test_base import AioTestBase
@@ -196,14 +197,61 @@ class TestTypeMetadata(unittest.TestCase):
 
     def test_metadata_from_tuple(self):
         scenarios = (
-            (Metadata(), Metadata()),
             (self._DEFAULT_DATA, Metadata(*self._DEFAULT_DATA)),
             (self._MULTI_ENTRY_DATA, Metadata(*self._MULTI_ENTRY_DATA)),
-            (Metadata(*self._DEFAULT_DATA), Metadata(*self._DEFAULT_DATA)),
         )
         for source, expected in scenarios:
             with self.subTest(raw_metadata=source, expected=expected):
                 self.assertEqual(expected, Metadata.from_tuple(source))
+
+    @typeguard.suppress_type_checks
+    def test_metadata_from_tuple_non_tuple(self):
+        scenarios = (
+            (None, Metadata()),
+            (Metadata(), Metadata()),
+            (Metadata(*self._DEFAULT_DATA), Metadata(*self._DEFAULT_DATA)),
+        )
+        for source, expected in scenarios:
+            with self.subTest(raw_metadata=source, expected=expected):
+                self.assertEqual(expected, Metadata.from_tuple(source))  # type: ignore
+
+    @typeguard.suppress_type_checks
+    def test_create_invalid_type(self):
+
+        # 2. raw_metadata is string
+        l = "key, value"
+        with self.assertRaises(ValueError) as container:
+            Metadata._create(l)  # type: ignore
+        self.assertEqual(
+            str(container.exception),
+            "not enough values to unpack (expected 2, got 1)",
+        )
+
+    def test_create(self):
+        # 1. raw_metadata is None
+        self.assertEqual(Metadata._create(None), Metadata())
+
+        # 2. raw_metadata is Metadata
+        m = Metadata(("key", "value"))
+        self.assertIs(Metadata._create(m), m)
+
+        # 3. raw_metadata is tuple
+        t = (("key", "value"),)
+        self.assertEqual(Metadata._create(t), Metadata(("key", "value")))
+
+        # 4. raw_metadata is list
+        l = [("key", "value")]
+        self.assertEqual(Metadata._create(l), Metadata(("key", "value")))
+
+        # 5. raw_metadata is set
+        s = {("key", "value")}
+        self.assertEqual(Metadata._create(s), Metadata(("key", "value")))
+
+        # 5. raw_metadata is empty list
+        self.assertEqual(Metadata._create([]), Metadata())
+
+        # 6. raw_metadata is empty tuple
+        self.assertEqual(Metadata._create(()), Metadata())
 
     def test_keys_values_items(self):
         metadata = Metadata(*self._MULTI_ENTRY_DATA)


### PR DESCRIPTION
Backport of #41678 to v1.80.x.
---
This PR adds new create method for `aio.Metadata`, as described in the comment here  - https://github.com/grpc/grpc/pull/40226#discussion_r2823705654

Reason being `from_tuple` as the name says should actually create only from `tuple` whereas the method actually takes other arguments as well.

Hence we introduce the new `_create` method, which is internal as of now. 