### PR TITLE
[Python] Fixes leaking AIO tasks on channel.close()

### DIFF
--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -15,8 +15,8 @@
 
 import asyncio
 import sys
-import weakref
 from typing import Any, Iterable, List, Optional, Sequence
+import weakref
 
 import grpc
 from grpc import _common
@@ -388,7 +388,9 @@ class Channel(_base_channel.Channel):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._close(None)
 
-    async def _close(self, grace: Optional[float]):  # pylint: disable=too-many-branches
+    async def _close(
+        self, grace: Optional[float]
+    ):  # pylint: disable=too-many-branches
         if self._channel.closed():
             return
 

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -402,11 +402,9 @@ class Channel(_base_channel.Channel):
         if grace is not None and grace > 0:
             tasks_to_wait = []
             for call in calls:
-                # Unary response calls (UnaryUnary, StreamUnary) use _call_response
-                if hasattr(call, "_call_response"):
+                if isinstance(call, _base_call._UnaryResponseCall):
                     tasks_to_wait.append(call._call_response)
-                # Stream response calls (UnaryStream, StreamStream) use _preparation
-                elif hasattr(call, "_preparation"):
+                elif isinstance(call, _base_call._StreamResponseCall):
                     tasks_to_wait.append(call._preparation)
 
             if tasks_to_wait:

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import sys
+import weakref
 from typing import Any, Iterable, List, Optional, Sequence
 
 import grpc
@@ -88,6 +89,7 @@ class _BaseMultiCallable:
 
     _loop: asyncio.AbstractEventLoop
     _channel: cygrpc.AioChannel
+    _channel_py: "Channel"
     _method: bytes
     _request_serializer: Optional[SerializingFunction]
     _response_deserializer: Optional[DeserializingFunction]
@@ -113,6 +115,7 @@ class _BaseMultiCallable:
         self._response_deserializer = response_deserializer
         self._interceptors = interceptors
         self._references = references
+        self._channel_py = references[0]
 
     @staticmethod
     def _init_metadata(
@@ -176,6 +179,7 @@ class UnaryUnaryMultiCallable(
                 self._loop,
             )
 
+        self._channel_py._active_calls.add(call)
         return call
 
 
@@ -222,6 +226,7 @@ class UnaryStreamMultiCallable(
                 self._loop,
             )
 
+        self._channel_py._active_calls.add(call)
         return call
 
 
@@ -267,6 +272,7 @@ class StreamUnaryMultiCallable(
                 self._loop,
             )
 
+        self._channel_py._active_calls.add(call)
         return call
 
 
@@ -312,6 +318,7 @@ class StreamStreamMultiCallable(
                 self._loop,
             )
 
+        self._channel_py._active_calls.add(call)
         return call
 
 
@@ -367,6 +374,7 @@ class Channel(_base_channel.Channel):
                     )
 
         self._loop = cygrpc.get_working_loop()
+        self._active_calls = weakref.WeakSet()
         self._channel = cygrpc.AioChannel(
             _common.encode(target),
             _augment_channel_arguments(options, compression),
@@ -387,65 +395,7 @@ class Channel(_base_channel.Channel):
         # No new calls will be accepted by the Cython channel.
         self._channel.closing()
 
-        # Iterate through running tasks
-        tasks = _all_tasks()
-        calls = []
-        call_tasks = []
-        for task in tasks:
-            try:
-                stack = task.get_stack(limit=1)
-            except AttributeError as attribute_error:
-                # NOTE(lidiz) tl;dr: If the Task is created with a CPython
-                # object, it will trigger AttributeError.
-                #
-                # In the global finalizer, the event loop schedules
-                # a CPython PyAsyncGenAThrow object.
-                # https://github.com/python/cpython/blob/00e45877e33d32bb61aa13a2033e3bba370bda4d/Lib/asyncio/base_events.py#L484
-                #
-                # However, the PyAsyncGenAThrow object is written in C and
-                # failed to include the normal Python frame objects. Hence,
-                # this exception is a false negative, and it is safe to ignore
-                # the failure. It is fixed by https://github.com/python/cpython/pull/18669,
-                # but not available until 3.9 or 3.8.3. So, we have to keep it
-                # for a while.
-                # TODO(lidiz): drop this hack after 3.8 deprecation
-                if "frame" in str(attribute_error):
-                    continue
-                raise
-
-            # If the Task is created by a C-extension, the stack will be empty.
-            if not stack:
-                continue
-
-            # Locate ones created by `aio.Call`.
-            frame = stack[0]
-            candidate = frame.f_locals.get("self")
-            # Explicitly check for a non-null candidate instead of the more pythonic 'if candidate:'
-            # because doing 'if candidate:' assumes that the coroutine implements '__bool__' which
-            # might not always be the case.
-            if candidate is not None and isinstance(candidate, _base_call.Call):
-                if hasattr(candidate, "_channel"):
-                    # For intercepted Call object
-                    if candidate._channel is not self._channel:
-                        continue
-                elif hasattr(candidate, "_cython_call"):
-                    # For normal Call object
-                    if candidate._cython_call._channel is not self._channel:
-                        continue
-                else:
-                    # Unidentified Call object
-                    error_msg = f"Unrecognized call object: {candidate}"
-                    raise cygrpc.InternalError(error_msg)
-
-                calls.append(candidate)
-                call_tasks.append(task)
-
-        # If needed, try to wait for them to finish.
-        # Call objects are not always awaitables.
-        if grace and call_tasks:
-            await asyncio.wait(call_tasks, timeout=grace)
-
-        # Time to cancel existing calls.
+        calls = list(self._active_calls)
         for call in calls:
             call.cancel()
 

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -388,7 +388,7 @@ class Channel(_base_channel.Channel):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self._close(None)
 
-    async def _close(self, grace):  # pylint: disable=too-many-branches
+    async def _close(self, grace: Optional[float]):  # pylint: disable=too-many-branches
         if self._channel.closed():
             return
 
@@ -396,6 +396,16 @@ class Channel(_base_channel.Channel):
         self._channel.closing()
 
         calls = list(self._active_calls)
+
+        if grace is not None and grace > 0:
+            tasks_to_wait = []
+            for call in calls:
+                if hasattr(call, "_call_response"):
+                    tasks_to_wait.append(call._call_response)
+
+            if tasks_to_wait:
+                await asyncio.wait(tasks_to_wait, timeout=grace)
+
         for call in calls:
             call.cancel()
 

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -402,9 +402,11 @@ class Channel(_base_channel.Channel):
         if grace is not None and grace > 0:
             tasks_to_wait = []
             for call in calls:
-                if isinstance(call, _base_call._UnaryResponseCall):
+                # Unary response calls (UnaryUnary, StreamUnary) use _call_response
+                if hasattr(call, "_call_response"):
                     tasks_to_wait.append(call._call_response)
-                elif isinstance(call, _base_call._StreamResponseCall):
+                # Stream response calls (UnaryStream, StreamStream) use _preparation
+                elif hasattr(call, "_preparation"):
                     tasks_to_wait.append(call._preparation)
 
             if tasks_to_wait:

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -400,8 +400,10 @@ class Channel(_base_channel.Channel):
         if grace is not None and grace > 0:
             tasks_to_wait = []
             for call in calls:
+                # Unary response calls (UnaryUnary, StreamUnary) use _call_response
                 if hasattr(call, "_call_response"):
                     tasks_to_wait.append(call._call_response)
+                # Stream response calls (UnaryStream, StreamStream) use _preparation
                 elif hasattr(call, "_preparation"):
                     tasks_to_wait.append(call._preparation)
 

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -408,6 +408,7 @@ class Channel(_base_channel.Channel):
             if tasks_to_wait:
                 await asyncio.wait(tasks_to_wait, timeout=grace)
 
+        # Time to cancel existing calls.
         for call in calls:
             call.cancel()
 

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -402,6 +402,8 @@ class Channel(_base_channel.Channel):
             for call in calls:
                 if hasattr(call, "_call_response"):
                     tasks_to_wait.append(call._call_response)
+                elif hasattr(call, "_preparation"):
+                    tasks_to_wait.append(call._preparation)
 
             if tasks_to_wait:
                 await asyncio.wait(tasks_to_wait, timeout=grace)

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -408,6 +408,8 @@ class Channel(_base_channel.Channel):
                 # Stream response calls (UnaryStream, StreamStream) use _preparation
                 elif hasattr(call, "_preparation"):
                     tasks_to_wait.append(call._preparation)
+                elif hasattr(call, "_interceptors_task"):
+                    tasks_to_wait.append(call._interceptors_task)
 
             if tasks_to_wait:
                 await asyncio.wait(tasks_to_wait, timeout=grace)

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -397,7 +397,7 @@ class Channel(_base_channel.Channel):
         # No new calls will be accepted by the Cython channel.
         self._channel.closing()
 
-        calls = list(self._active_calls)
+        calls = [call for call in self._active_calls if not call.done()]
 
         if grace is not None and grace > 0:
             tasks_to_wait = []

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -386,7 +386,10 @@ class InterceptedCall:
             return True
 
         if exc is not None:
-            if isinstance(exc, AioRpcError) and exc.code() == grpc.StatusCode.CANCELLED:
+            if (
+                isinstance(exc, AioRpcError)
+                and exc.code() == grpc.StatusCode.CANCELLED
+            ):
                 return True
             return False
 

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -393,8 +393,6 @@ class InterceptedCall:
         call = self._interceptors_task.result()
         return call.cancelled()
 
-        return call.cancelled()
-
     def done(self) -> bool:
         if not self._interceptors_task.done():
             return False
@@ -408,8 +406,6 @@ class InterceptedCall:
             return True
 
         call = self._interceptors_task.result()
-        return call.done()
-
         return call.done()
 
     def add_done_callback(self, callback: DoneCallbackType) -> None:

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -330,11 +330,16 @@ class InterceptedCall:
         call_completed = False
 
         try:
-            call = interceptors_task.result()
-            if call.done():
-                call_completed = True
-        except (AioRpcError, asyncio.CancelledError):
+            exc = interceptors_task.exception()
+        except asyncio.CancelledError:
             call_completed = True
+        else:
+            if exc is not None:
+                call_completed = True
+            else:
+                call = interceptors_task.result()
+                if call.done():
+                    call_completed = True
 
         if call_completed:
             for callback in self._pending_add_done_callbacks:
@@ -361,12 +366,14 @@ class InterceptedCall:
             return self._interceptors_task.cancel()
 
         try:
-            call = self._interceptors_task.result()
-        except AioRpcError:
-            return False
+            exc = self._interceptors_task.exception()
         except asyncio.CancelledError:
             return False
 
+        if exc is not None:
+            return False
+
+        call = self._interceptors_task.result()
         return call.cancel()
 
     def cancelled(self) -> bool:
@@ -374,11 +381,17 @@ class InterceptedCall:
             return False
 
         try:
-            call = self._interceptors_task.result()
-        except AioRpcError as err:
-            return err.code() == grpc.StatusCode.CANCELLED
+            exc = self._interceptors_task.exception()
         except asyncio.CancelledError:
             return True
+
+        if exc is not None:
+            if isinstance(exc, AioRpcError) and exc.code() == grpc.StatusCode.CANCELLED:
+                return True
+            return False
+
+        call = self._interceptors_task.result()
+        return call.cancelled()
 
         return call.cancelled()
 
@@ -387,9 +400,15 @@ class InterceptedCall:
             return False
 
         try:
-            call = self._interceptors_task.result()
-        except (AioRpcError, asyncio.CancelledError):
+            exc = self._interceptors_task.exception()
+        except asyncio.CancelledError:
             return True
+
+        if exc is not None:
+            return True
+
+        call = self._interceptors_task.result()
+        return call.done()
 
         return call.done()
 
@@ -399,10 +418,16 @@ class InterceptedCall:
             return
 
         try:
-            call = self._interceptors_task.result()
-        except (AioRpcError, asyncio.CancelledError):
+            exc = self._interceptors_task.exception()
+        except asyncio.CancelledError:
             callback(self)
             return
+
+        if exc is not None:
+            callback(self)
+            return
+
+        call = self._interceptors_task.result()
 
         if call.done():
             callback(self)

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -386,12 +386,10 @@ class InterceptedCall:
             return True
 
         if exc is not None:
-            if (
+            return (
                 isinstance(exc, AioRpcError)
                 and exc.code() == grpc.StatusCode.CANCELLED
-            ):
-                return True
-            return False
+            )
 
         call = self._interceptors_task.result()
         return call.cancelled()

--- a/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
@@ -180,9 +180,11 @@ class TestCloseChannel(AioTestBase):
                 continue
             pending.append(t)
 
-        self.assertEqual(len(pending), 0, f"Leaked tasks: {[getattr(t.get_coro(), '__qualname__', str(t)) for t in pending]}")
-
-
+        self.assertEqual(
+            len(pending),
+            0,
+            f"Leaked tasks: {[getattr(t.get_coro(), '__qualname__', str(t)) for t in pending]}",
+        )
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
@@ -132,6 +132,61 @@ class TestCloseChannel(AioTestBase):
             self.assertFalse(call1.cancelled())
             self.assertTrue(call2.cancelled())
 
+    async def test_close_channel_with_delayed_handler(self):
+        class _DelayedHandlerServicer(test_pb2_grpc.TestServiceServicer):
+            def __init__(self):
+                self.messages_received = 0
+                self.handler_exited = asyncio.Event()
+
+            async def FullDuplexCall(self, request_async_iterator, context):
+                async for request in request_async_iterator:
+                    self.messages_received += 1
+                    yield messages_pb2.StreamingOutputCallResponse()
+                try:
+                    await asyncio.sleep(2)
+                finally:
+                    self.handler_exited.set()
+
+        server = aio.server()
+        servicer = _DelayedHandlerServicer()
+        test_pb2_grpc.add_TestServiceServicer_to_server(servicer, server)
+        port = server.add_insecure_port("[::]:0")
+        await server.start()
+        server_target = f"localhost:{port}"
+
+        try:
+            channel = aio.insecure_channel(server_target)
+
+
+            stub = test_pb2_grpc.TestServiceStub(channel)
+
+            call = stub.FullDuplexCall()
+
+            await call.write(messages_pb2.StreamingOutputCallRequest())
+            await call.read()
+
+            await call.done_writing()
+
+            await channel.close(grace=0.5)
+
+        finally:
+            await server.stop(None)
+
+        await asyncio.sleep(0.1)
+        current = asyncio.current_task()
+        pending = []
+        for t in asyncio.all_tasks():
+            if t.done() or t is current:
+                continue
+            name = getattr(t.get_coro(), "__qualname__", "")
+            if "_server_main_loop" in name:
+                continue
+            pending.append(t)
+
+        self.assertEqual(len(pending), 0, f"Leaked tasks: {[getattr(t.get_coro(), '__qualname__', str(t)) for t in pending]}")
+
+
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/close_channel_test.py
@@ -156,19 +156,16 @@ class TestCloseChannel(AioTestBase):
 
         try:
             channel = aio.insecure_channel(server_target)
-
-
             stub = test_pb2_grpc.TestServiceStub(channel)
-
             call = stub.FullDuplexCall()
 
             await call.write(messages_pb2.StreamingOutputCallRequest())
+
             await call.read()
 
             await call.done_writing()
 
             await channel.close(grace=0.5)
-
         finally:
             await server.stop(None)
 


### PR DESCRIPTION
### Description

Fixes issue https://github.com/grpc/grpc/issues/41875

* Storing active calls in `weakref.WeakSet()`
* Using the active calls in `channel.close()` to `cancel` 
* Reversed the logic in `channel.close()`, getting task from call instead of getting call from task (previous implementation). 
* Update `InterceptedCall` to properly check for exception and bubble up accordingly
