### PR TITLE
[experiments] Extend event_engine_poller_for_python to EOQ2

### DIFF
--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -142,7 +142,7 @@
   allow_in_fuzzing_config: false
 - name: event_engine_poller_for_python
   description: "Enable event engine poller in gRPC Python"
-  expiry: 2026/03/16
+  expiry: 2026/06/30
   owner: mlumish@google.com
   test_tags: []
   uses_polling: true


### PR DESCRIPTION
The experiment was activated by default in the 1.80 release. We want to see two releases without reported problems before removing the experiment, which puts the target date for removing the experiment around the end of Q2.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

