### PR TITLE
Fix grpc Bazel build for newer protobuf versions

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -31,7 +31,8 @@ load("@build_bazel_apple_support//rules:universal_binary.bzl", "universal_binary
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_apple//apple/testing/default_runner:ios_test_runner.bzl", "ios_test_runner")
 load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
-load("@com_google_protobuf//bazel:upb_proto_library.bzl", "upb_proto_library", "upb_proto_reflection_library")
+load("@com_google_protobuf//bazel:upb_c_proto_library.bzl", "upb_c_proto_library")
+load("@com_google_protobuf//bazel:upb_proto_reflection_library.bzl", "upb_proto_reflection_library")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
@@ -821,7 +822,7 @@ def grpc_objc_library(
     )
 
 def grpc_upb_proto_library(name, deps):
-    upb_proto_library(name = name, deps = deps)
+    upb_c_proto_library(name = name, deps = deps)
 
 def grpc_upb_proto_reflection_library(name, deps):
     upb_proto_reflection_library(name = name, deps = deps)


### PR DESCRIPTION
Newer versions of protobuf removed `@com_google_protobuf//bazel:upb_proto_library.bzl`, `@com_google_protobuf//bazel:upb_c_proto_library.bzl`, and `@com_google_protobuf//bazel:upb_proto_reflection_library.bzl`. We then restored the second two for compatibility but not the first one, as that is super deprecated. This fixes gRPC to build with newer protobuf versions.