### PR TITLE
[subchannel connection scaling] fix when we reset backoff

### DIFF
--- a/src/core/client_channel/subchannel.cc
+++ b/src/core/client_channel/subchannel.cc
@@ -1750,8 +1750,6 @@ class NewSubchannel::ConnectionStateWatcher final
       // connection attempt.
       subchannel->RetryQueuedRpcsLocked();
     }
-    // Reset backoff.
-    subchannel->backoff_.Reset();
   }
 
   void OnPeerMaxConcurrentStreamsUpdate(
@@ -2264,6 +2262,8 @@ bool NewSubchannel::PublishTransportLocked() {
         connecting_result_.max_concurrent_streams);
   }
   connecting_result_.Reset();
+  // Reset backoff.
+  backoff_.Reset();
   // Publish.
   GRPC_TRACE_LOG(subchannel, INFO)
       << "subchannel " << this << " " << key_.ToString()


### PR DESCRIPTION
In the original subchannel code, we reset backoff when a successful connection fails, which is fine, because we can't possibly be using the backoff state until we try to start the next connection attempt, and we aren't going to do that while we still have a working connection.

When I forked the subchannel code to implement connection scaling, I kept the backoff reset in the same place, but that is no longer the right place to do it: we can now start a new connection attempt before the working connection fails.  So this PR fixes the new subchannel implementation to instead reset the backoff when the connection attempt succeeds.