### PR TITLE
[ObjC] Fix cancel for streaming call in objectiveC

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -219,7 +219,6 @@
   GRPCCall2 *copiedCall;
   @synchronized(self) {
     copiedCall = _call;
-    _call = nil;
   }
   [copiedCall finish];
 }


### PR DESCRIPTION
RootCause : We were removing reference to the call on half-close (when we done sending data). Doing this client cannot cancel the stream if needed before trailing headers.

Fix:
Remove call_ = nil from finish. This will not cause any leak as we already handle call nil on complete of RPC

When the user explicitly invokes cancellation: ProtoRPC.m : 181
When a severe parsing error occurs: ProtoRPC.m:279
When the server naturally finishes the stream: ProtoRPC.m:296


