### PR TITLE
Fix incorrect hostname suffix matching in no_proxy handling (prevents proxy bypass)

### DIFF
--- a/doc/core/default_http_proxy_mapper.md
+++ b/doc/core/default_http_proxy_mapper.md
@@ -48,13 +48,24 @@ again stopping at the first one that is set:
 
 If none of the above are set, then the previously found HTTP proxy is used.
 
-The format takes a comma-separated list of names, and if any of these names
-matches as a suffix of the server host (provided in the channel target), then
-the proxy will not be used for that target. For example, with a `grpc_proxy`
-setting of `proxy.google.com` and a `no_grpc_proxy` setting of `example.com,
-google.com`, channel targets such as `dns:///foo.google.com:50051` and
-`bar.example.com:1234` will not use the proxy, but `baz.googleapis.com:443`
-would still use the configured proxy `proxy.google.com`.
+As of [PR#41915](https://github.com/grpc/grpc/pull/41915), the matching
+  behavior was changed from naive suffix matching to boundary-aware domain
+  validation. Entries without a leading dot now require an exact match, and
+  entries with a leading dot match the domain and its subdomains.
+
+  -   If the entry starts with a dot (e.g., `.example.com`), it matches the
+      domain itself (`example.com`) and all of its subdomains
+      (`foo.example.com`, `bar.baz.example.com`).
+  -   If the entry does not start with a dot (e.g., `example.com`), it matches
+      only that exact hostname.
+
+  For example, with a `grpc_proxy` setting of `proxy.google.com` and a
+  `no_grpc_proxy` setting of `.google.com, example.com`:
+  
+  -   `dns:///foo.google.com:50051` — no proxy (subdomain of `.google.com`)
+  -   `example.com:1234` — no proxy (exact match)
+  -   `bar.example.com:443` — uses proxy (not an exact match for `example.com`)
+  -   `baz.googleapis.com:443` — uses proxy (not under `.google.com`)
 
 As of [PR#31119](https://github.com/grpc/grpc/pull/31119), CIDR blocks are also
 supported in the list of names. For example, a `no_proxy` setting of

--- a/doc/core/default_http_proxy_mapper.md
+++ b/doc/core/default_http_proxy_mapper.md
@@ -44,7 +44,7 @@ traffic destined to listed hosts from going through the proxy determined above,
 again stopping at the first one that is set:
 
 1.  `no_grpc_proxy` environment variable
-2.  `no_proxy`environment variable
+2.  `no_proxy` environment variable
 
 If none of the above are set, then the previously found HTTP proxy is used.
 

--- a/doc/core/default_http_proxy_mapper.md
+++ b/doc/core/default_http_proxy_mapper.md
@@ -97,3 +97,4 @@ accessed through the proxy. This can be specified using
 the `GRPC_ARG_ADDRESS_HTTP_PROXY_ENABLED_ADDRESSES` channel argument
 or `GRPC_ADDRESS_HTTP_PROXY_ENABLED_ADDRESSES` environment variable. Value of
 the channel argument is preferred if both values are specified.
+

--- a/doc/core/default_http_proxy_mapper.md
+++ b/doc/core/default_http_proxy_mapper.md
@@ -28,7 +28,7 @@ at the first one that is set:
 If none of the above are set, then no HTTP proxy will be used.
 
 The allowed format is an [RFC3986](https://www.rfc-editor.org/rfc/rfc3986) URI
-string where the scheme is expected to be "http" and the authority portion is
+string where the scheme is expected to be `http` and the authority portion is
 used to determine the proxy to be used. For example, for an HTTP proxy setting
 of `http://username:password@proxy.google.com:443`, `username:password` would be
 used as user credentials for proxy authentication as per
@@ -49,23 +49,23 @@ again stopping at the first one that is set:
 If none of the above are set, then the previously found HTTP proxy is used.
 
 As of [PR#41915](https://github.com/grpc/grpc/pull/41915), the matching
-  behavior was changed from naive suffix matching to boundary-aware domain
-  validation. Entries without a leading dot now require an exact match, and
-  entries with a leading dot match the domain and its subdomains.
+behavior was changed from naive suffix matching to boundary-aware domain
+validation. An entry matches if the host is an exact match OR a proper
+subdomain (separated by a dot boundary). A leading dot on an entry is
+optional and treated identically to the same entry without a dot.
 
-  -   If the entry starts with a dot (e.g., `.example.com`), it matches the
-      domain itself (`example.com`) and all of its subdomains
-      (`foo.example.com`, `bar.baz.example.com`).
-  -   If the entry does not start with a dot (e.g., `example.com`), it matches
-      only that exact hostname.
+- `example.com` and `.example.com` both match `example.com` (exact) and
+  `foo.example.com`, `bar.baz.example.com` (subdomains).
+- `notexample.com` does **not** match `example.com` because there is no
+  dot boundary before the suffix.
 
-  For example, with a `grpc_proxy` setting of `proxy.google.com` and a
-  `no_grpc_proxy` setting of `.google.com, example.com`:
-  
-  -   `dns:///foo.google.com:50051` — no proxy (subdomain of `.google.com`)
-  -   `example.com:1234` — no proxy (exact match)
-  -   `bar.example.com:443` — uses proxy (not an exact match for `example.com`)
-  -   `baz.googleapis.com:443` — uses proxy (not under `.google.com`)
+For example, with a `grpc_proxy` setting of `proxy.google.com` and a
+`no_grpc_proxy` setting of `google.com`:
+
+- `dns:///foo.google.com:50051` - no proxy (subdomain of `google.com`)
+- `google.com:1234` - no proxy (exact match)
+- `notgoogle.com:443` - uses proxy (no dot boundary before `google.com`)
+- `baz.googleapis.com:443` - uses proxy (not under `google.com`)
 
 As of [PR#31119](https://github.com/grpc/grpc/pull/31119), CIDR blocks are also
 supported in the list of names. For example, a `no_proxy` setting of
@@ -97,4 +97,3 @@ accessed through the proxy. This can be specified using
 the `GRPC_ARG_ADDRESS_HTTP_PROXY_ENABLED_ADDRESSES` channel argument
 or `GRPC_ADDRESS_HTTP_PROXY_ENABLED_ADDRESSES` environment variable. Value of
 the channel argument is preferred if both values are specified.
-

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -77,10 +77,10 @@ bool ServerInCIDRRange(const grpc_resolved_address& server_address,
 
 bool ExactMatchOrSubdomain(absl::string_view host_name,
                            absl::string_view no_proxy_entry) {
-  //remove surrounding whitespace
+  // remove surrounding whitespace
   no_proxy_entry = absl::StripAsciiWhitespace(no_proxy_entry);
 
-  //match domain + subdomains
+  // match domain + subdomains
   if (!no_proxy_entry.empty() && no_proxy_entry[0] == '.') {
     absl::string_view domain = no_proxy_entry.substr(1);
 

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -76,8 +76,29 @@ bool ServerInCIDRRange(const grpc_resolved_address& server_address,
 }
 
 bool ExactMatchOrSubdomain(absl::string_view host_name,
-                           absl::string_view host_name_or_domain) {
-  return absl::EndsWithIgnoreCase(host_name, host_name_or_domain);
+                           absl::string_view no_proxy_entry) {
+  //remove surrounding whitespace
+  no_proxy_entry = absl::StripAsciiWhitespace(no_proxy_entry);
+
+  //match domain + subdomains
+  if (!no_proxy_entry.empty() && no_proxy_entry[0] == '.') {
+    absl::string_view domain = no_proxy_entry.substr(1);
+
+    // Exact match
+    if (absl::EqualsIgnoreCase(host_name, domain)) {
+      return true;
+    }
+    if (host_name.size() > domain.size() &&
+        absl::EndsWithIgnoreCase(host_name, domain) &&
+        host_name[host_name.size() - domain.size() - 1] == '.') {
+      return true;
+    }
+
+    return false;
+  }
+
+  // Non-dot entry: exact match only
+  return absl::EqualsIgnoreCase(host_name, no_proxy_entry);
 }
 
 // Parses the list of host names, addresses or subnet masks and returns true if

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -77,21 +77,27 @@ bool ServerInCIDRRange(const grpc_resolved_address& server_address,
 
 bool ExactMatchOrSubdomain(absl::string_view host_name,
                            absl::string_view no_proxy_entry) {
-  // Remove surrounding whitespace
+  // Remove surrounding whitespace.
   no_proxy_entry = absl::StripAsciiWhitespace(no_proxy_entry);
-
-  // Exact match
+  // Strip a leading dot if present (e.g. ".example.com" -> "example.com").
+  // A leading dot is optional notation; both "example.com" and
+  // ".example.com" match the domain itself and all of its subdomains.
+  if (!no_proxy_entry.empty() && no_proxy_entry[0] == '.') {
+    no_proxy_entry = no_proxy_entry.substr(1);
+  }
+  if (no_proxy_entry.empty()) return false;
+  // Exact match (case-insensitive).
   if (absl::EqualsIgnoreCase(host_name, no_proxy_entry)) {
     return true;
   }
-
-  // Proper subdomain match only
+  // Boundary-aware subdomain match: host_name must end with
+  // ".<no_proxy_entry>". Prevents "notexample.com" from matching
+  // "example.com", while "test.example.com" still matches.
   if (host_name.size() > no_proxy_entry.size() &&
       absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
       host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
     return true;
   }
-
   return false;
 }
 

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -97,9 +97,9 @@ bool ExactMatchOrSubdomain(absl::string_view host_name,
   // Boundary-aware subdomain match: host_name must end with
   // ".<no_proxy_entry>". Prevents "notexample.com" from matching
   // "example.com", while "test.example.com" still matches.
-  if (host_name.size() > no_proxy_entry.size() &&
-      absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
-      host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
+  if (host_name.size() > no_proxy_entry.size() + 1 &&
+     absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
+     host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
     return true;
   }
 

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -98,8 +98,8 @@ bool ExactMatchOrSubdomain(absl::string_view host_name,
   // ".<no_proxy_entry>". Prevents "notexample.com" from matching
   // "example.com", while "test.example.com" still matches.
   if (host_name.size() > no_proxy_entry.size() + 1 &&
-     absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
-     host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
+      absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
+      host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
     return true;
   }
 

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -97,7 +97,7 @@ bool ExactMatchOrSubdomain(absl::string_view host_name,
   // Boundary-aware subdomain match: host_name must end with
   // ".<no_proxy_entry>". Prevents "notexample.com" from matching
   // "example.com", while "test.example.com" still matches.
-  if (host_name.size() > no_proxy_entry.size() + 1 &&
+  if (host_name.size() > no_proxy_entry.size() &&
       absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
       host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
     return true;

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -77,28 +77,22 @@ bool ServerInCIDRRange(const grpc_resolved_address& server_address,
 
 bool ExactMatchOrSubdomain(absl::string_view host_name,
                            absl::string_view no_proxy_entry) {
-  // remove surrounding whitespace
+  // Remove surrounding whitespace
   no_proxy_entry = absl::StripAsciiWhitespace(no_proxy_entry);
 
-  // match domain + subdomains
-  if (!no_proxy_entry.empty() && no_proxy_entry[0] == '.') {
-    absl::string_view domain = no_proxy_entry.substr(1);
-
-    // Exact match
-    if (absl::EqualsIgnoreCase(host_name, domain)) {
-      return true;
-    }
-    if (host_name.size() > domain.size() &&
-        absl::EndsWithIgnoreCase(host_name, domain) &&
-        host_name[host_name.size() - domain.size() - 1] == '.') {
-      return true;
-    }
-
-    return false;
+  // Exact match
+  if (absl::EqualsIgnoreCase(host_name, no_proxy_entry)) {
+    return true;
   }
 
-  // Non-dot entry: exact match only
-  return absl::EqualsIgnoreCase(host_name, no_proxy_entry);
+  // Proper subdomain match only
+  if (host_name.size() > no_proxy_entry.size() &&
+      absl::EndsWithIgnoreCase(host_name, no_proxy_entry) &&
+      host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
+    return true;
+  }
+
+  return false;
 }
 
 // Parses the list of host names, addresses or subnet masks and returns true if

--- a/src/core/handshaker/http_connect/http_proxy_mapper.cc
+++ b/src/core/handshaker/http_connect/http_proxy_mapper.cc
@@ -79,17 +79,21 @@ bool ExactMatchOrSubdomain(absl::string_view host_name,
                            absl::string_view no_proxy_entry) {
   // Remove surrounding whitespace.
   no_proxy_entry = absl::StripAsciiWhitespace(no_proxy_entry);
+
   // Strip a leading dot if present (e.g. ".example.com" -> "example.com").
   // A leading dot is optional notation; both "example.com" and
   // ".example.com" match the domain itself and all of its subdomains.
   if (!no_proxy_entry.empty() && no_proxy_entry[0] == '.') {
     no_proxy_entry = no_proxy_entry.substr(1);
   }
+
   if (no_proxy_entry.empty()) return false;
+
   // Exact match (case-insensitive).
   if (absl::EqualsIgnoreCase(host_name, no_proxy_entry)) {
     return true;
   }
+
   // Boundary-aware subdomain match: host_name must end with
   // ".<no_proxy_entry>". Prevents "notexample.com" from matching
   // "example.com", while "test.example.com" still matches.
@@ -98,6 +102,7 @@ bool ExactMatchOrSubdomain(absl::string_view host_name,
       host_name[host_name.size() - no_proxy_entry.size() - 1] == '.') {
     return true;
   }
+
   return false;
 }
 


### PR DESCRIPTION
The current implementation of hostname matching in `no_proxy` logic uses a naive suffix check:

   ` absl::EndsWithIgnoreCase(host_name, host_name_or_domain)`

This can incorrectly match unrelated domains:
- `evilcorp.example.com` matches `corp.example.com`
- `notexample.com` matches `example.com`

This behavior deviates from standard `no_proxy` implementations and can lead to proxy bypass or policy evasion.

## Fix
This patch replaces suffix matching with boundary-aware domain validation:
- Exact match for normal entries
- Proper subdomain matching only for dot-prefixed entries

## Security Impact
Prevents:
- Proxy bypass
- Security control evasion

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

