### PR TITLE
[Fix][CI] Fix Bloat Diff Kokoro job JWT generation

### DIFF
--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -59,7 +59,7 @@ def _jwt_token():
         {
             "iat": int(time.time()),
             "exp": int(time.time() + 60 * 10),  # expire in 10 minutes
-            "iss": _GITHUB_APP_ID,
+            "iss": f"{_GITHUB_APP_ID}",
         },
         github_app_key,
         algorithm="RS256",


### PR DESCRIPTION
Fixes `TypeError: Issuer (iss) must be a string.`

The issue was introduced in #41856.
Root cause: pyjwt [2.11.0](https://github.com/jpadilla/pyjwt/releases/tag/2.11.0) added type validation to the issuer (`iss`), see [jpadilla/pyjwt#1040](https://redirect.github.com/jpadilla/pyjwt/pull/1040).