### PR TITLE
[error_flatten] set status details to empty slice for OK status in v3 stack

### DIFF
--- a/src/core/call/client_call.cc
+++ b/src/core/call/client_call.cc
@@ -442,14 +442,14 @@ void ClientCall::OnReceivedStatus(ServerMetadataHandle server_trailing_metadata,
   const auto status = server_trailing_metadata->get(GrpcStatusMetadata())
                           .value_or(GRPC_STATUS_UNKNOWN);
   *out_status = status;
+  Slice message_slice;
   if (!IsErrorFlattenEnabled() || status != GRPC_STATUS_OK) {
-    Slice message_slice;
     if (Slice* message =
             server_trailing_metadata->get_pointer(GrpcMessageMetadata())) {
       message_slice = message->Ref();
     }
-    *out_status_details = message_slice.TakeCSlice();
   }
+  *out_status_details = message_slice.TakeCSlice();
   if (out_error_string != nullptr) {
     if (status != GRPC_STATUS_OK) {
       *out_error_string =


### PR DESCRIPTION
It looks like this bug was introduced back in #38874 when I originally implemented the error_flatten changes.  I'm honestly surprised that nothing has caught this until now.

See #41930 for context.