### PR TITLE
[CI] (minor) Fix PR filter script SyntaxWarning: invalid escape sequence

### DIFF
--- a/tools/run_tests/python_utils/filter_pull_request_tests.py
+++ b/tools/run_tests/python_utils/filter_pull_request_tests.py
@@ -117,7 +117,7 @@ _ALLOWLIST_DICT = {
 }
 
 # Regex that combines all keys in _ALLOWLIST_DICT
-_ALL_TRIGGERS = re.compile(f"({")|(".join(_ALLOWLIST_DICT)})")
+_ALL_TRIGGERS = re.compile(f"({')|('.join(_ALLOWLIST_DICT)})")
 
 # Add all triggers to their respective test suites
 for trigger, test_suites in _ALLOWLIST_DICT.items():


### PR DESCRIPTION
Minor fix and improvement. 

1. Fixes `SyntaxWarning: invalid escape sequence` for '\+' and '\.'
2. Removes unnecessary `\-` escapes
3. Optimization: pre-compile regex