### PR TITLE
[CI][Python] Fix `setuptools.command.test` deprecation warning

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -172,7 +172,7 @@ class TestAio(setuptools.Command):
             sys.exit("Test failure")
 
 
-class RunInterop(test.test):
+class RunInterop(setuptools.Command):
     description = "run interop test client/server"
     user_options = [
         ("args=", None, "pass-thru arguments for the client/server"),
@@ -225,7 +225,7 @@ class RunInterop(test.test):
         client.test_interoperability(client.parse_interop_client_args(sys.argv))
 
 
-class RunFork(test.test):
+class RunFork(setuptools.Command):
     description = "run fork test client"
     user_options = [("args=", "a", "pass-thru arguments for the client")]
 


### PR DESCRIPTION
Fixes below warnings:
```
/usr/local/google/home/ssreenithi/my_forks/grpc/src/python/grpcio_tests/commands.py:175: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
!!

        ********************************************************************************
        Please remove any references to `setuptools.command.test` in all supported versions of the affected package.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
  class RunInterop(test.test):
/usr/local/google/home/ssreenithi/my_forks/grpc/src/python/grpcio_tests/commands.py:231: SetuptoolsDeprecationWarning: The test command is disabled and references to it are deprecated.
!!

        ********************************************************************************
        Please remove any references to `setuptools.command.test` in all supported versions of the affected package.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
  class RunFork(test.test):
```