### PR TITLE
[interop] Add 1.79.3, 1.80.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -329,7 +329,8 @@ LANG_RELEASE_MATRIX = {
             ("v1.76.0", ReleaseInfo()),
             ("v1.77.0", ReleaseInfo()),
             ("v1.78.0", ReleaseInfo()),
-            ("v1.79.1", ReleaseInfo()),
+            ("v1.79.3", ReleaseInfo()),
+            ("v1.80.0", ReleaseInfo()),
         ]
     ),
     "java": OrderedDict(


### PR DESCRIPTION


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

Ad-hoc run: https://source.cloud.google.com/results/invocations/ddceab64-2559-4f3a-af6c-f4bd881d5980
