### PR TITLE
[C# Tools] Fix regression gRPC Tools stops working on ARM64

### DIFF
--- a/tools/bazelify_tests/test/build_artifact_protoc_linux_aarch64.sh
+++ b/tools/bazelify_tests/test/build_artifact_protoc_linux_aarch64.sh
@@ -16,7 +16,10 @@
 set -ex
 
 # compile/link options extracted from ProtocArtifact in tools/run_tests/artifacts/artifact_targets.py
-export LDFLAGS="${LDFLAGS} -static-libgcc -static-libstdc++ -s"
+# NOTE: -Wl,-z,max-page-size=65536 is required because ARM64 Linux kernels may
+# use page sizes up to 64KB. Without this flag the protoc binary may segfault
+# (exit code 139) on such systems. See https://github.com/grpc/grpc/issues/38538.
+export LDFLAGS="${LDFLAGS} -static-libgcc -static-libstdc++ -Wl,-z,max-page-size=65536 -s"
 # set build parallelism to fit the machine configuration of bazelified tests RBE pool.
 export GRPC_PROTOC_BUILD_COMPILER_JOBS=8
 

--- a/tools/bazelify_tests/test/build_artifact_protoc_linux_aarch64.sh
+++ b/tools/bazelify_tests/test/build_artifact_protoc_linux_aarch64.sh
@@ -16,9 +16,12 @@
 set -ex
 
 # compile/link options extracted from ProtocArtifact in tools/run_tests/artifacts/artifact_targets.py
-# NOTE: -Wl,-z,max-page-size=65536 is required because ARM64 Linux kernels may
-# use page sizes up to 64KB. Without this flag the protoc binary may segfault
-# (exit code 139) on such systems. See https://github.com/grpc/grpc/issues/38538.
+# NOTE: -Wl,-z,max-page-size=65536 is required because the manylinux2014
+# cross-compilation toolchain may produce binaries with 4KB page alignment,
+# but ARM64 Linux kernels (e.g. RHEL) can use 64KB pages. Without this flag
+# the protoc binary will segfault (exit code 139) on such systems.
+# See https://github.com/grpc/grpc/issues/38538
+# and https://github.com/pypa/manylinux/issues/735.
 export LDFLAGS="${LDFLAGS} -static-libgcc -static-libstdc++ -Wl,-z,max-page-size=65536 -s"
 # set build parallelism to fit the machine configuration of bazelified tests RBE pool.
 export GRPC_PROTOC_BUILD_COMPILER_JOBS=8

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -365,6 +365,11 @@ class ProtocArtifact:
                     dockerfile_dir = (
                         "tools/dockerfile/grpc_artifact_manylinux2014_aarch64"
                     )
+                    # ARM64 Linux kernels may use page sizes of 4KB, 16KB, or 64KB.
+                    # Without explicitly setting max-page-size=65536, the protoc
+                    # binary may segfault (exit code 139) on kernels with larger
+                    # page sizes. See https://github.com/grpc/grpc/issues/38538.
+                    environ["LDFLAGS"] += " -Wl,-z,max-page-size=65536"
                 environ["LDFLAGS"] += " -static-libgcc -static-libstdc++ -s"
                 return create_docker_jobspec(
                     self.name,

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -365,10 +365,12 @@ class ProtocArtifact:
                     dockerfile_dir = (
                         "tools/dockerfile/grpc_artifact_manylinux2014_aarch64"
                     )
-                    # ARM64 Linux kernels may use page sizes of 4KB, 16KB, or 64KB.
-                    # Without explicitly setting max-page-size=65536, the protoc
-                    # binary may segfault (exit code 139) on kernels with larger
-                    # page sizes. See https://github.com/grpc/grpc/issues/38538.
+                    # The manylinux2014 cross-compilation toolchain may produce
+                    # binaries with 4KB page alignment, but ARM64 Linux kernels
+                    # (e.g. RHEL) can use 64KB pages. Without this flag the
+                    # protoc binary will segfault (exit code 139) on such systems.
+                    # See https://github.com/grpc/grpc/issues/38538
+                    # and https://github.com/pypa/manylinux/issues/735.
                     environ["LDFLAGS"] += " -Wl,-z,max-page-size=65536"
                 environ["LDFLAGS"] += " -static-libgcc -static-libstdc++ -s"
                 return create_docker_jobspec(


### PR DESCRIPTION
### Description

Fixes - https://github.com/grpc/grpc/issues/38538

#### Root Cause

PR #38084 switched the protoc aarch64 artifact build from `dockcross/linux-arm64` to `dockcross/manylinux2014-aarch64`. 

The `manylinux2014` container's cross-compilation toolchain can produce ELF binaries with 4KB page alignment for aarch64 targets. 

This is incompatible with ARM64 Linux kernels configured with 64KB page sizes (e.g., RHEL ARM64), causing SIGSEGV (exit code 139) when the kernel attempts to map misaligned ELF load segments.

This is a well-known issue with manylinux aarch64 build environments:

https://github.com/pypa/manylinux/issues/735
https://github.com/numpy/numpy/issues/16677

#### Fix
Adds `-Wl,-z,max-page-size=65536` to the linker flags for the aarch64 protoc build. This forces ELF LOAD segment alignment to 64KB, making the binary compatible with all ARM64 page size configurations (4KB, 16KB, and 64KB).

The flag is added in two places:

tools/run_tests/artifacts/artifact_targets.py - the Python build configuration
tools/bazelify_tests/test/build_artifact_protoc_linux_aarch64.sh - the bazelified test build script

### Testing

Verified by @ganesh-tn on RHEL 10.1 ARM64 (kernel 6.12.0, aarch64) - dotnet build succeeded with the fix applied.