### PR TITLE
Enforce max receive size after decompression and fix related tests

### DIFF
--- a/src/core/ext/filters/http/message_compress/compression_filter.cc
+++ b/src/core/ext/filters/http/message_compress/compression_filter.cc
@@ -256,8 +256,22 @@ ClientCompressionFilter::Call::OnServerToClientMessage(
     MessageHandle message, ClientCompressionFilter* filter) {
   GRPC_LATENT_SEE_SCOPE(
       "ClientCompressionFilter::Call::OnServerToClientMessage");
-  return filter->compression_engine_.DecompressMessage(
-      /*is_client=*/true, std::move(message), decompress_args_, call_tracer_);
+  auto decompressed = filter->compression_engine_.DecompressMessage(
+    /*is_client=*/true, std::move(message), decompress_args_, call_tracer_);
+  if (!decompressed.ok()) {
+    return decompressed.status();
+  }
+  const bool is_client = true;
+  if (decompress_args_.max_recv_message_length.has_value() &&
+    (*decompressed)->payload()->Length() >
+      static_cast<size_t>(*decompress_args_.max_recv_message_length)) {
+    return absl::ResourceExhaustedError(
+        absl::StrFormat("%s: Received message larger than max (%u vs. %d)",
+                        is_client ? "CLIENT" : "SERVER",
+                        (*decompressed)->payload()->Length(),
+                        *decompress_args_.max_recv_message_length));
+  }
+  return std::move(*decompressed);
 }
 
 void ServerCompressionFilter::Call::OnClientInitialMetadata(
@@ -272,9 +286,23 @@ ServerCompressionFilter::Call::OnClientToServerMessage(
     MessageHandle message, ServerCompressionFilter* filter) {
   GRPC_LATENT_SEE_SCOPE(
       "ServerCompressionFilter::Call::OnClientToServerMessage");
-  return filter->compression_engine_.DecompressMessage(
-      /*is_client=*/false, std::move(message), decompress_args_,
-      MaybeGetContext<CallTracer>());
+  auto decompressed = filter->compression_engine_.DecompressMessage(
+    /*is_client=*/false, std::move(message), decompress_args_,
+    MaybeGetContext<CallTracer>());
+  if (!decompressed.ok()) {
+    return decompressed.status();
+  }
+  const bool is_client = false;
+  if (decompress_args_.max_recv_message_length.has_value() &&
+    (*decompressed)->payload()->Length() >
+      static_cast<size_t>(*decompress_args_.max_recv_message_length)) {
+    return absl::ResourceExhaustedError(
+        absl::StrFormat("%s: Received message larger than max (%u vs. %d)",
+                        is_client ? "CLIENT" : "SERVER",
+                        (*decompressed)->payload()->Length(),
+                        *decompress_args_.max_recv_message_length));
+  }
+  return std::move(*decompressed);
 }
 
 void ServerCompressionFilter::Call::OnServerInitialMetadata(

--- a/test/core/end2end/tests/max_message_length.cc
+++ b/test/core/end2end/tests/max_message_length.cc
@@ -306,5 +306,90 @@ CORE_END2END_TEST(Http2Tests,
               StartsWith("CLIENT: Received message larger than max"));
 }
 
+CORE_END2END_TEST(Http2Tests,
+                  MaxMessageLengthOnServerOnRequestAfterDecompression) {
+  SKIP_IF_MINSTACK();
+  constexpr int kLimit = 1024;
+  constexpr size_t kPayloadSize = 64 * 1024;
+  const std::string payload(kPayloadSize, 'a');
+
+  InitServer(DefaultServerArgs()
+                 .Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, kLimit)
+                 .Set(GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION, true));
+  InitClient(ChannelArgs().Set(GRPC_ARG_ENABLE_PER_MESSAGE_COMPRESSION, true));
+
+  auto c = NewClientCall("/service/method").Create();
+  IncomingStatusOnClient status;
+  IncomingMetadata server_initial_metadata;
+  c.NewBatch(1)
+      .SendInitialMetadata({{"grpc-internal-encoding-request", "gzip"}})
+      .SendMessage(payload)
+      .SendCloseFromClient()
+      .RecvInitialMetadata(server_initial_metadata)
+      .RecvStatusOnClient(status);
+
+  auto s = RequestCall(101);
+  Expect(101, true);
+  Step();
+
+  IncomingMessage client_message;
+  IncomingCloseOnServer client_close;
+  s.NewBatch(102).RecvMessage(client_message);
+  s.NewBatch(103).RecvCloseOnServer(client_close);
+  // Validate the failing recv path explicitly to avoid deadlocks in this flow.
+  Expect(102, false);
+  Expect(103, true);
+  Expect(1, true);
+  Step();
+
+  EXPECT_TRUE(client_close.was_cancelled());
+  EXPECT_EQ(status.status(), GRPC_STATUS_RESOURCE_EXHAUSTED);
+  EXPECT_THAT(status.message(),
+              StartsWith("SERVER: Received message larger than max"));
+}
+
+CORE_END2END_TEST(Http2Tests,
+                  MaxMessageLengthOnClientOnResponseAfterDecompression) {
+  SKIP_IF_MINSTACK();
+  constexpr int kLimit = 1024;
+  constexpr size_t kPayloadSize = 64 * 1024;
+  const std::string payload(kPayloadSize, 'a');
+
+  InitServer(
+      DefaultServerArgs().Set(GRPC_ARG_ENABLE_PER_MESSAGE_COMPRESSION, true));
+  InitClient(ChannelArgs()
+                 .Set(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, kLimit)
+                 .Set(GRPC_ARG_ENABLE_PER_MESSAGE_DECOMPRESSION, true));
+
+  auto c = NewClientCall("/service/method").Create();
+  IncomingStatusOnClient status;
+  IncomingMetadata server_initial_metadata;
+  IncomingMessage server_message;
+  c.NewBatch(1)
+      .SendInitialMetadata({})
+      .SendCloseFromClient()
+      .RecvInitialMetadata(server_initial_metadata)
+      .RecvMessage(server_message)
+      .RecvStatusOnClient(status);
+
+  auto s = RequestCall(101);
+  Expect(101, true);
+  Step();
+
+  IncomingCloseOnServer client_close;
+  s.NewBatch(102)
+      .SendInitialMetadata({{"grpc-internal-encoding-request", "gzip"}})
+      .RecvCloseOnServer(client_close)
+      .SendMessage(payload)
+      .SendStatusFromServer(GRPC_STATUS_OK, "xyz", {});
+  Expect(102, true);
+  Expect(1, true);
+  Step();
+
+  EXPECT_EQ(status.status(), GRPC_STATUS_RESOURCE_EXHAUSTED);
+  EXPECT_THAT(status.message(),
+              StartsWith("CLIENT: Received message larger than max"));
+}
+
 }  // namespace
 }  // namespace grpc_core


### PR DESCRIPTION
### Problem

Compressed messages are validated against the maximum receive size **before decompression**, but not after decompression.  
This allows highly compressible payloads to expand beyond the configured limit.

In addition, existing tests did not fully exercise the receive/cancellation lifecycle, which could lead to misleading behavior (e.g., incomplete failure propagation).

---

### Fix

- Add a **post-decompression size check** in the compression filter for both client and server receive paths.
- If the decompressed payload exceeds the configured limit, return `RESOURCE_EXHAUSTED`.
- Preserve existing interfaces and rely on the current `StatusOr` error propagation (no framework changes).

---

### Tests

- Update end-to-end tests to:
  - use proper gzip negotiation
  - exercise the full recv + cancellation flow
  - verify deterministic `RESOURCE_EXHAUSTED` behavior

---

### Why this is safe

- No API or interface changes  
- Minimal, localized modification  
- Consistent with existing `message_size_filter` behavior  
- Verified with end-to-end tests (no hangs or regressions)