### PR TITLE
[ssl] Server side handshaker factory stores a map of key signers

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -25,7 +25,6 @@
 
 #include <cstddef>
 #include <cstdlib>
-#include <map>
 #include <utility>
 
 // TODO(jboeuf): refactor inet_ntop into a portability header.
@@ -141,6 +140,10 @@ struct tsi_ssl_client_handshaker_factory {
 #endif
 };
 
+// Wrapper of the SSL_CTX for use on the server side. In addition to the
+// SSL_CTX, it carries extra state that is needed for the server side SSL
+// handshake, e.g. the server name for checking whether this SSL_CTX
+// corresponds to a particular SNI.
 struct SslContext {
   SSL_CTX* ssl_ctx;
   tsi_peer x509_subject_name;
@@ -2719,8 +2722,7 @@ static void tsi_ssl_server_handshaker_factory_destroy(
   if (factory == nullptr) return;
   tsi_ssl_server_handshaker_factory* self =
       reinterpret_cast<tsi_ssl_server_handshaker_factory*>(factory);
-  size_t i;
-  for (i = 0; i < self->ssl_contexts.size(); i++) {
+  for (size_t i = 0; i < self->ssl_contexts.size(); i++) {
     if (self->ssl_contexts[i].ssl_ctx != nullptr) {
       SSL_CTX_free(self->ssl_contexts[i].ssl_ctx);
       tsi_peer_destruct(&self->ssl_contexts[i].x509_subject_name);
@@ -2775,13 +2777,12 @@ static int ssl_server_handshaker_factory_servername_callback(SSL* ssl,
                                                              void* arg) {
   tsi_ssl_server_handshaker_factory* impl =
       static_cast<tsi_ssl_server_handshaker_factory*>(arg);
-  size_t i = 0;
   const char* servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (servername == nullptr || strlen(servername) == 0) {
     return SSL_TLSEXT_ERR_NOACK;
   }
 
-  for (i = 0; i < impl->ssl_contexts.size(); i++) {
+  for (size_t i = 0; i < impl->ssl_contexts.size(); i++) {
     if (tsi_ssl_peer_matches_name(&impl->ssl_contexts[i].x509_subject_name,
                                   servername)) {
       SSL_set_SSL_CTX(ssl, impl->ssl_contexts[i].ssl_ctx);
@@ -3123,174 +3124,170 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
   }
 
   for (i = 0; i < options->pem_key_cert_pairs.size(); i++) {
-    do {
-      SslContext ssl_context;
+    SslContext ssl_context;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
-      ssl_context.ssl_ctx = SSL_CTX_new(TLS_method());
+    ssl_context.ssl_ctx = SSL_CTX_new(TLS_method());
 #else
-      ssl_context.ssl_ctx = SSL_CTX_new(TLSv1_2_method());
+    ssl_context.ssl_ctx = SSL_CTX_new(TLSv1_2_method());
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
-      SSL_CTX_set_options(ssl_context.ssl_ctx, SSL_OP_NO_RENEGOTIATION);
+    SSL_CTX_set_options(ssl_context.ssl_ctx, SSL_OP_NO_RENEGOTIATION);
 #endif
-      if (ssl_context.ssl_ctx == nullptr) {
-        tsi::LogSslErrorStack();
-        LOG(ERROR) << "Could not create ssl context.";
-        result = TSI_OUT_OF_RESOURCES;
-        break;
-      }
+    if (ssl_context.ssl_ctx == nullptr) {
+      tsi::LogSslErrorStack();
+      LOG(ERROR) << "Could not create ssl context.";
+      result = TSI_OUT_OF_RESOURCES;
+      break;
+    }
 
-      result = tsi_set_min_and_max_tls_versions(ssl_context.ssl_ctx,
-                                                options->min_tls_version,
-                                                options->max_tls_version);
-      if (result != TSI_OK) return result;
+    result = tsi_set_min_and_max_tls_versions(ssl_context.ssl_ctx,
+                                              options->min_tls_version,
+                                              options->max_tls_version);
+    if (result != TSI_OK) return result;
 
-      result = populate_ssl_context(
-          ssl_context.ssl_ctx, &options->pem_key_cert_pairs[i],
-          options->cipher_suites, options->key_exchange_groups);
-      if (result != TSI_OK) break;
+    result = populate_ssl_context(
+        ssl_context.ssl_ctx, &options->pem_key_cert_pairs[i],
+        options->cipher_suites, options->key_exchange_groups);
+    if (result != TSI_OK) break;
 
 #if defined(OPENSSL_IS_BORINGSSL)
-      grpc_core::Match(
-          options->pem_key_cert_pairs[i].private_key, [](const std::string&) {},
-          [&](const std::shared_ptr<grpc_core::PrivateKeySigner>& key_signer) {
-            ssl_context.key_signer = key_signer;
-          });
+    grpc_core::Match(
+        options->pem_key_cert_pairs[i].private_key, [](const std::string&) {},
+        [&](const std::shared_ptr<grpc_core::PrivateKeySigner>& key_signer) {
+          ssl_context.key_signer = key_signer;
+        });
 #endif
 
-      // TODO(elessar): Provide ability to disable session ticket keys.
+    // TODO(elessar): Provide ability to disable session ticket keys.
 
-      // Allow client cache sessions (it's needed for OpenSSL only).
-      int set_sid_ctx_result = SSL_CTX_set_session_id_context(
-          ssl_context.ssl_ctx, kSslSessionIdContext,
-          GPR_ARRAY_SIZE(kSslSessionIdContext));
-      if (set_sid_ctx_result == 0) {
-        LOG(ERROR) << "Failed to set session id context.";
-        result = TSI_INTERNAL_ERROR;
+    // Allow client cache sessions (it's needed for OpenSSL only).
+    int set_sid_ctx_result = SSL_CTX_set_session_id_context(
+        ssl_context.ssl_ctx, kSslSessionIdContext,
+        GPR_ARRAY_SIZE(kSslSessionIdContext));
+    if (set_sid_ctx_result == 0) {
+      LOG(ERROR) << "Failed to set session id context.";
+      result = TSI_INTERNAL_ERROR;
+      break;
+    }
+
+    if (options->session_ticket_key != nullptr) {
+      if (SSL_CTX_set_tlsext_ticket_keys(
+              ssl_context.ssl_ctx,
+              const_cast<char*>(options->session_ticket_key),
+              options->session_ticket_key_size) == 0) {
+        LOG(ERROR) << "Invalid STEK size.";
+        result = TSI_INVALID_ARGUMENT;
         break;
       }
-
-      if (options->session_ticket_key != nullptr) {
-        if (SSL_CTX_set_tlsext_ticket_keys(
-                ssl_context.ssl_ctx,
-                const_cast<char*>(options->session_ticket_key),
-                options->session_ticket_key_size) == 0) {
-          LOG(ERROR) << "Invalid STEK size.";
-          result = TSI_INVALID_ARGUMENT;
-          break;
-        }
+    }
+    if (options->root_cert_info != nullptr) {
+      Match(
+          *options->root_cert_info,
+          [&](const std::string& pem_root_certs) {
+            STACK_OF(X509_NAME)* root_names = nullptr;
+            result = ssl_ctx_load_verification_certs(
+                ssl_context.ssl_ctx, pem_root_certs.c_str(),
+                pem_root_certs.size(), nullptr);
+            if (result != TSI_OK) {
+              LOG(ERROR) << "Invalid verification certs.";
+            }
+            if (options->send_client_ca_list) {
+              SSL_CTX_set_client_CA_list(ssl_context.ssl_ctx, root_names);
+            }
+          },
+          [&](const grpc_core::SpiffeBundleMap& spiffe_bundle_map) {
+            X509_STORE* cert_store =
+                SSL_CTX_get_cert_store(ssl_context.ssl_ctx);
+            X509_STORE_set_flags(cert_store, X509_V_FLAG_PARTIAL_CHAIN |
+                                                 X509_V_FLAG_TRUSTED_FIRST);
+            const void* p = &spiffe_bundle_map;
+            void* map = const_cast<void*>(p);
+            SSL_CTX_set_ex_data(ssl_context.ssl_ctx,
+                                g_ssl_ctx_ex_spiffe_bundle_map_index, map);
+          });
+      if (result != TSI_OK) {
+        break;
       }
-      if (options->root_cert_info != nullptr) {
-        Match(
-            *options->root_cert_info,
-            [&](const std::string& pem_root_certs) {
-              STACK_OF(X509_NAME)* root_names = nullptr;
-              result = ssl_ctx_load_verification_certs(
-                  ssl_context.ssl_ctx, pem_root_certs.c_str(),
-                  pem_root_certs.size(), nullptr);
-              if (result != TSI_OK) {
-                LOG(ERROR) << "Invalid verification certs.";
-              }
-              if (options->send_client_ca_list) {
-                SSL_CTX_set_client_CA_list(ssl_context.ssl_ctx, root_names);
-              }
-            },
-            [&](const grpc_core::SpiffeBundleMap& spiffe_bundle_map) {
-              X509_STORE* cert_store =
-                  SSL_CTX_get_cert_store(ssl_context.ssl_ctx);
-              X509_STORE_set_flags(cert_store, X509_V_FLAG_PARTIAL_CHAIN |
-                                                   X509_V_FLAG_TRUSTED_FIRST);
-              const void* p = &spiffe_bundle_map;
-              void* map = const_cast<void*>(p);
-              SSL_CTX_set_ex_data(ssl_context.ssl_ctx,
-                                  g_ssl_ctx_ex_spiffe_bundle_map_index, map);
-            });
-        if (result != TSI_OK) {
-          break;
-        }
-      }
-      switch (options->client_certificate_request) {
-        case TSI_DONT_REQUEST_CLIENT_CERTIFICATE:
-          SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_NONE, nullptr);
-          break;
-        case TSI_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
-          SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_PEER, nullptr);
-          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
-                                           NullVerifyCallback, nullptr);
-          break;
-        case TSI_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY:
-          SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_PEER, nullptr);
-          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
-                                           CustomVerificationFunction, nullptr);
-          break;
-        case TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
-          SSL_CTX_set_verify(ssl_context.ssl_ctx,
-                             SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
-                             nullptr);
-          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
-                                           NullVerifyCallback, nullptr);
-          break;
-        case TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY:
-          SSL_CTX_set_verify(ssl_context.ssl_ctx,
-                             SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
-                             nullptr);
-          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
-                                           CustomVerificationFunction, nullptr);
-          break;
-      }
+    }
+    switch (options->client_certificate_request) {
+      case TSI_DONT_REQUEST_CLIENT_CERTIFICATE:
+        SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_NONE, nullptr);
+        break;
+      case TSI_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
+        SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_PEER, nullptr);
+        SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
+                                         NullVerifyCallback, nullptr);
+        break;
+      case TSI_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY:
+        SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_PEER, nullptr);
+        SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
+                                         CustomVerificationFunction, nullptr);
+        break;
+      case TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
+        SSL_CTX_set_verify(ssl_context.ssl_ctx,
+                           SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           nullptr);
+        SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
+                                         NullVerifyCallback, nullptr);
+        break;
+      case TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY:
+        SSL_CTX_set_verify(ssl_context.ssl_ctx,
+                           SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           nullptr);
+        SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
+                                         CustomVerificationFunction, nullptr);
+        break;
+    }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
-      if (options->crl_provider != nullptr) {
-        SSL_CTX_set_ex_data(ssl_context.ssl_ctx,
-                            g_ssl_ctx_ex_crl_provider_index,
-                            options->crl_provider.get());
-      } else if (options->crl_directory != nullptr &&
-                 strcmp(options->crl_directory, "") != 0) {
-        X509_STORE* cert_store = SSL_CTX_get_cert_store(ssl_context.ssl_ctx);
-        X509_STORE_set_verify_cb(cert_store, verify_cb);
-        if (!X509_STORE_load_locations(cert_store, nullptr,
-                                       options->crl_directory)) {
-          LOG(ERROR) << "Failed to load CRL File from directory.";
-        } else {
-          X509_VERIFY_PARAM* param = X509_STORE_get0_param(cert_store);
-          X509_VERIFY_PARAM_set_flags(
-              param, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
-        }
+    if (options->crl_provider != nullptr) {
+      SSL_CTX_set_ex_data(ssl_context.ssl_ctx, g_ssl_ctx_ex_crl_provider_index,
+                          options->crl_provider.get());
+    } else if (options->crl_directory != nullptr &&
+               strcmp(options->crl_directory, "") != 0) {
+      X509_STORE* cert_store = SSL_CTX_get_cert_store(ssl_context.ssl_ctx);
+      X509_STORE_set_verify_cb(cert_store, verify_cb);
+      if (!X509_STORE_load_locations(cert_store, nullptr,
+                                     options->crl_directory)) {
+        LOG(ERROR) << "Failed to load CRL File from directory.";
+      } else {
+        X509_VERIFY_PARAM* param = X509_STORE_get0_param(cert_store);
+        X509_VERIFY_PARAM_set_flags(
+            param, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
       }
+    }
 #endif
 
-      result = tsi_ssl_extract_x509_subject_names_from_pem_cert(
-          options->pem_key_cert_pairs[i].cert_chain.c_str(),
-          &ssl_context.x509_subject_name);
-      if (result != TSI_OK) break;
+    result = tsi_ssl_extract_x509_subject_names_from_pem_cert(
+        options->pem_key_cert_pairs[i].cert_chain.c_str(),
+        &ssl_context.x509_subject_name);
+    if (result != TSI_OK) break;
 
-      SSL_CTX_set_tlsext_servername_callback(
-          ssl_context.ssl_ctx,
-          ssl_server_handshaker_factory_servername_callback);
-      SSL_CTX_set_tlsext_servername_arg(ssl_context.ssl_ctx, impl);
+    SSL_CTX_set_tlsext_servername_callback(
+        ssl_context.ssl_ctx, ssl_server_handshaker_factory_servername_callback);
+    SSL_CTX_set_tlsext_servername_arg(ssl_context.ssl_ctx, impl);
 #if TSI_OPENSSL_ALPN_SUPPORT
-      SSL_CTX_set_alpn_select_cb(ssl_context.ssl_ctx,
-                                 ServerHandshakerFactoryAlpnCallback, impl);
+    SSL_CTX_set_alpn_select_cb(ssl_context.ssl_ctx,
+                               ServerHandshakerFactoryAlpnCallback, impl);
 #endif  // TSI_OPENSSL_ALPN_SUPPORT
-      SSL_CTX_set_next_protos_advertised_cb(
-          ssl_context.ssl_ctx,
-          server_handshaker_factory_npn_advertised_callback, impl);
+    SSL_CTX_set_next_protos_advertised_cb(
+        ssl_context.ssl_ctx, server_handshaker_factory_npn_advertised_callback,
+        impl);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
-      // Register factory at index
-      if (options->key_logger != nullptr) {
-        // Need to set factory at g_ssl_ctx_ex_factory_index
-        SSL_CTX_set_ex_data(ssl_context.ssl_ctx, g_ssl_ctx_ex_factory_index,
-                            impl);
-        // SSL_CTX_set_keylog_callback is set here to register callback
-        // when ssl/tls handshakes complete.
-        SSL_CTX_set_keylog_callback(
-            ssl_context.ssl_ctx,
-            ssl_keylogging_callback<tsi_ssl_server_handshaker_factory>);
-      }
+    // Register factory at index
+    if (options->key_logger != nullptr) {
+      // Need to set factory at g_ssl_ctx_ex_factory_index
+      SSL_CTX_set_ex_data(ssl_context.ssl_ctx, g_ssl_ctx_ex_factory_index,
+                          impl);
+      // SSL_CTX_set_keylog_callback is set here to register callback
+      // when ssl/tls handshakes complete.
+      SSL_CTX_set_keylog_callback(
+          ssl_context.ssl_ctx,
+          ssl_keylogging_callback<tsi_ssl_server_handshaker_factory>);
+    }
 #endif
-      impl->ssl_contexts.push_back(std::move(ssl_context));
-    } while (false);
+    impl->ssl_contexts.push_back(std::move(ssl_context));
 
     if (result != TSI_OK) {
       tsi_ssl_handshaker_factory_unref(&impl->base);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -154,6 +154,7 @@ struct tsi_ssl_server_handshaker_factory {
   grpc_core::RefCountedPtr<TlsSessionKeyLogger> key_logger;
   std::shared_ptr<tsi::RootCertInfo> root_cert_info;
 #if defined(OPENSSL_IS_BORINGSSL)
+  // The key is the index of SSL_CONTEXT in `sll_contexts`.
   std::map<int, std::shared_ptr<grpc_core::PrivateKeySigner>> key_signers;
 #endif
 };
@@ -448,14 +449,13 @@ enum ssl_private_key_result_t TlsPrivateKeySignWrapper(
     handshaker->MaybeSetError(algorithm.status().ToString());
     return ssl_private_key_failure;
   }
-  grpc_core::PrivateKeySigner* signer = handshaker->key_signer.get();
-  if (signer == nullptr) {
+  if (handshaker->key_signer == nullptr) {
     handshaker->MaybeSetError("PrivateKeySigner is null");
     return ssl_private_key_failure;
   }
-  auto result =
-      signer->Sign(absl::string_view(reinterpret_cast<const char*>(in), in_len),
-                   *algorithm, done_callback);
+  auto result = handshaker->key_signer->Sign(
+      absl::string_view(reinterpret_cast<const char*>(in), in_len), *algorithm,
+      done_callback);
   // Handle synchronous return.
   return grpc_core::MatchMutable(
       &result,

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -145,11 +145,18 @@ struct tsi_ssl_client_handshaker_factory {
 // handshake, e.g. the server name for checking whether this SSL_CTX
 // corresponds to a particular SNI.
 struct SslContext {
-  SSL_CTX* ssl_ctx;
+  SSL_CTX* ssl_ctx = nullptr;
   tsi_peer x509_subject_name;
 #if defined(OPENSSL_IS_BORINGSSL)
   std::shared_ptr<grpc_core::PrivateKeySigner> key_signer;
 #endif
+
+  ~SslContext() {
+    if (ssl_ctx != nullptr) {
+      SSL_CTX_free(ssl_ctx);
+      tsi_peer_destruct(&x509_subject_name);
+    }
+  }
 };
 
 struct tsi_ssl_server_handshaker_factory {
@@ -2488,6 +2495,7 @@ static tsi_result create_tsi_ssl_handshaker(
     SSL_CTX* ctx, int is_client, const char* server_name_indication,
     size_t network_bio_buf_size, size_t ssl_bio_buf_size,
     std::optional<std::string> alpn_preferred_protocol_raw_list,
+    std::shared_ptr<grpc_core::PrivateKeySigner> key_signer,
     tsi_ssl_handshaker_factory* factory, tsi_handshaker** handshaker) {
   SSL* ssl = SSL_new(ctx);
   BIO* network_io = nullptr;
@@ -2592,25 +2600,7 @@ static tsi_result create_tsi_ssl_handshaker(
       static_cast<unsigned char*>(gpr_zalloc(impl->outgoing_bytes_buffer_size));
   impl->vtable = &handshaker_vtable;
   impl->factory_ref = tsi_ssl_handshaker_factory_ref(factory);
-#if defined(OPENSSL_IS_BORINGSSL)
-  if (is_client) {
-    tsi_ssl_client_handshaker_factory* client_factory =
-        reinterpret_cast<tsi_ssl_client_handshaker_factory*>(factory);
-    impl->key_signer = client_factory->key_signer;
-  } else {
-    tsi_ssl_server_handshaker_factory* server_factory =
-        reinterpret_cast<tsi_ssl_server_handshaker_factory*>(factory);
-    // If the client sends an SNI in the ClientHello message, the key_signer
-    // will be dynamically selected by
-    // `ssl_server_handshaker_factory_servername_callback`. In the event that
-    // the client does not send an SNI in the ClientHello or the SNI does not
-    // match any of the certificate, we use the default certificate and the
-    // signer that may come with it.
-    if (server_factory->ssl_contexts[0].key_signer != nullptr) {
-      impl->key_signer = server_factory->ssl_contexts[0].key_signer;
-    }
-  }
-#endif
+  impl->key_signer = std::move(key_signer);
 
   *handshaker = impl;
 
@@ -2661,8 +2651,8 @@ tsi_result tsi_ssl_client_handshaker_factory_create_handshaker(
       << "Creating SSL handshaker with SNI " << server_name_indication;
   return create_tsi_ssl_handshaker(
       factory->ssl_context, 1, server_name_indication, network_bio_buf_size,
-      ssl_bio_buf_size, alpn_preferred_protocol_list, &factory->base,
-      handshaker);
+      ssl_bio_buf_size, alpn_preferred_protocol_list, factory->key_signer,
+      &factory->base, handshaker);
 }
 
 void tsi_ssl_client_handshaker_factory_unref(
@@ -2706,9 +2696,12 @@ tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
   if (factory->ssl_contexts.empty()) return TSI_INVALID_ARGUMENT;
   // Create the handshaker with the first context. We will switch if needed
   // because of SNI in ssl_server_handshaker_factory_servername_callback.
-  return create_tsi_ssl_handshaker(factory->ssl_contexts[0].ssl_ctx, 0, nullptr,
-                                   network_bio_buf_size, ssl_bio_buf_size,
-                                   std::nullopt, &factory->base, handshaker);
+  // Likewise, we pass the private key signer corresponding to the first
+  // context.
+  return create_tsi_ssl_handshaker(
+      factory->ssl_contexts[0].ssl_ctx, 0, nullptr, network_bio_buf_size,
+      ssl_bio_buf_size, std::nullopt, factory->ssl_contexts[0].key_signer,
+      &factory->base, handshaker);
 }
 
 void tsi_ssl_server_handshaker_factory_unref(
@@ -2722,12 +2715,6 @@ static void tsi_ssl_server_handshaker_factory_destroy(
   if (factory == nullptr) return;
   tsi_ssl_server_handshaker_factory* self =
       reinterpret_cast<tsi_ssl_server_handshaker_factory*>(factory);
-  for (size_t i = 0; i < self->ssl_contexts.size(); i++) {
-    if (self->ssl_contexts[i].ssl_ctx != nullptr) {
-      SSL_CTX_free(self->ssl_contexts[i].ssl_ctx);
-      tsi_peer_destruct(&self->ssl_contexts[i].x509_subject_name);
-    }
-  }
   if (self->alpn_protocol_list != nullptr) gpr_free(self->alpn_protocol_list);
   delete self;
 }
@@ -2782,13 +2769,12 @@ static int ssl_server_handshaker_factory_servername_callback(SSL* ssl,
     return SSL_TLSEXT_ERR_NOACK;
   }
 
-  for (size_t i = 0; i < impl->ssl_contexts.size(); i++) {
-    if (tsi_ssl_peer_matches_name(&impl->ssl_contexts[i].x509_subject_name,
-                                  servername)) {
-      SSL_set_SSL_CTX(ssl, impl->ssl_contexts[i].ssl_ctx);
+  for (const auto& ssl_context : impl->ssl_contexts) {
+    if (tsi_ssl_peer_matches_name(&ssl_context.x509_subject_name, servername)) {
+      SSL_set_SSL_CTX(ssl, ssl_context.ssl_ctx);
 #if defined(OPENSSL_IS_BORINGSSL)
-      if (impl->ssl_contexts[i].key_signer != nullptr) {
-        GetHandshaker(ssl)->key_signer = impl->ssl_contexts[i].key_signer;
+      if (ssl_context.key_signer != nullptr) {
+        GetHandshaker(ssl)->key_signer = ssl_context.key_signer;
       }
 #endif
       return SSL_TLSEXT_ERR_OK;
@@ -3104,7 +3090,6 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
   tsi_ssl_handshaker_factory_init(&impl->base);
   impl->base.vtable = &server_handshaker_factory_vtable;
 
-  impl->ssl_contexts.reserve(options->pem_key_cert_pairs.size());
   if (options->root_cert_info != nullptr) {
     impl->root_cert_info = options->root_cert_info;
   }
@@ -3123,8 +3108,10 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
     impl->key_logger = options->key_logger->Ref();
   }
 
+  impl->ssl_contexts.reserve(options->pem_key_cert_pairs.size());
   for (i = 0; i < options->pem_key_cert_pairs.size(); i++) {
-    SslContext ssl_context;
+    SslContext& ssl_context = impl->ssl_contexts.emplace_back();
+    ;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
     ssl_context.ssl_ctx = SSL_CTX_new(TLS_method());
 #else
@@ -3287,7 +3274,6 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
           ssl_keylogging_callback<tsi_ssl_server_handshaker_factory>);
     }
 #endif
-    impl->ssl_contexts.push_back(std::move(ssl_context));
 
     if (result != TSI_OK) {
       tsi_ssl_handshaker_factory_unref(&impl->base);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <map>
 #include <utility>
 
 // TODO(jboeuf): refactor inet_ntop into a portability header.
@@ -122,9 +123,6 @@ struct tsi_ssl_root_certs_store {
 struct tsi_ssl_handshaker_factory {
   const tsi_ssl_handshaker_factory_vtable* vtable;
   gpr_refcount refcount;
-#if defined(OPENSSL_IS_BORINGSSL)
-  std::shared_ptr<grpc_core::PrivateKeySigner> key_signer;
-#endif
 };
 
 static void tsi_ssl_handshaker_factory_unref(
@@ -138,6 +136,9 @@ struct tsi_ssl_client_handshaker_factory {
   grpc_core::RefCountedPtr<tsi::SslSessionLRUCache> session_cache;
   grpc_core::RefCountedPtr<TlsSessionKeyLogger> key_logger;
   std::shared_ptr<tsi::RootCertInfo> root_cert_info;
+#if defined(OPENSSL_IS_BORINGSSL)
+  std::shared_ptr<grpc_core::PrivateKeySigner> key_signer;
+#endif
 };
 
 struct tsi_ssl_server_handshaker_factory {
@@ -152,6 +153,9 @@ struct tsi_ssl_server_handshaker_factory {
   size_t alpn_protocol_list_length;
   grpc_core::RefCountedPtr<TlsSessionKeyLogger> key_logger;
   std::shared_ptr<tsi::RootCertInfo> root_cert_info;
+#if defined(OPENSSL_IS_BORINGSSL)
+  std::map<int, std::shared_ptr<grpc_core::PrivateKeySigner>> key_signers;
+#endif
 };
 
 // Tracks the arguments for a pending call to tsi_handshaker_next().
@@ -198,6 +202,7 @@ struct tsi_ssl_handshaker : public tsi_handshaker,
     *handshaker_next_args->error_ptr = std::move(error);
   }
 #if defined(OPENSSL_IS_BORINGSSL)
+  std::shared_ptr<grpc_core::PrivateKeySigner> key_signer;
   // The signed_bytes are populated when the signature process is completed if
   // the Private Key offload was successful. If there was an error during the
   // signature, the status will be returned.
@@ -443,8 +448,7 @@ enum ssl_private_key_result_t TlsPrivateKeySignWrapper(
     handshaker->MaybeSetError(algorithm.status().ToString());
     return ssl_private_key_failure;
   }
-  grpc_core::PrivateKeySigner* signer =
-      handshaker->factory_ref->key_signer.get();
+  grpc_core::PrivateKeySigner* signer = handshaker->key_signer.get();
   if (signer == nullptr) {
     handshaker->MaybeSetError("PrivateKeySigner is null");
     return ssl_private_key_failure;
@@ -2290,7 +2294,7 @@ static tsi_result ssl_handshaker_next_impl(tsi_ssl_handshaker* self)
       self->handshaker_next_args->received_bytes.clear();
     }
 #if defined(OPENSSL_IS_BORINGSSL)
-  } else if (self->factory_ref->key_signer != nullptr) {
+  } else if (self->key_signer != nullptr) {
     // During the PrivateKeyOffload signature, an empty call to
     // ssl_handshaker_do_handshake needs to be forced  after the async offload
     // has completed.
@@ -2416,24 +2420,18 @@ static tsi_result ssl_handshaker_next(
 static void ssl_handshaker_shutdown(tsi_handshaker* self) {
 #if defined(OPENSSL_IS_BORINGSSL)
   tsi_ssl_handshaker* impl = static_cast<tsi_ssl_handshaker*>(self);
-  std::shared_ptr<grpc_core::PrivateKeySigner::AsyncSigningHandle>
-      signing_handle;
   std::optional<HandshakerNextArgs> next_args;
   {
     grpc_core::MutexLock lock(&impl->mu);
     if (impl->ssl == nullptr) return;
     impl->is_shutdown = true;
-    if (impl->factory_ref->key_signer != nullptr &&
-        impl->signing_handle != nullptr) {
-      signing_handle = std::move(impl->signing_handle);
+    if (impl->key_signer != nullptr && impl->signing_handle != nullptr) {
+      impl->key_signer->Cancel(impl->signing_handle);
     }
     if (impl->handshaker_next_args.has_value()) {
       next_args = std::move(*impl->handshaker_next_args);
       impl->handshaker_next_args.reset();
     }
-  }
-  if (signing_handle != nullptr) {
-    impl->factory_ref->key_signer->Cancel(signing_handle);
   }
   if (next_args.has_value()) {
     grpc_event_engine::experimental::GetDefaultEventEngine()->Run(
@@ -2584,6 +2582,22 @@ static tsi_result create_tsi_ssl_handshaker(
       static_cast<unsigned char*>(gpr_zalloc(impl->outgoing_bytes_buffer_size));
   impl->vtable = &handshaker_vtable;
   impl->factory_ref = tsi_ssl_handshaker_factory_ref(factory);
+  if (is_client) {
+    tsi_ssl_client_handshaker_factory* client_factory =
+        reinterpret_cast<tsi_ssl_client_handshaker_factory*>(factory);
+    impl->key_signer = client_factory->key_signer;
+  } else {
+    tsi_ssl_server_handshaker_factory* server_factory =
+        reinterpret_cast<tsi_ssl_server_handshaker_factory*>(factory);
+    // By default we use the first SSL_CTX if there is no SNI in the ClientHello
+    // or there is no match. So we initialize the key signer of the handshaker
+    // to the first one if present.
+    if (server_factory->key_signers.find(0) !=
+        server_factory->key_signers.end()) {
+      impl->key_signer = server_factory->key_signers[0];
+    }
+  }
+
   *handshaker = impl;
 
   if (!SSL_set_ex_data(ssl, g_ssl_ex_handshaker_index, impl)) {
@@ -2764,6 +2778,9 @@ static int ssl_server_handshaker_factory_servername_callback(SSL* ssl,
     if (tsi_ssl_peer_matches_name(&impl->ssl_context_x509_subject_names[i],
                                   servername)) {
       SSL_set_SSL_CTX(ssl, impl->ssl_contexts[i]);
+      if (impl->key_signers.find(i) != impl->key_signers.end()) {
+        GetHandshaker(ssl)->key_signer = impl->key_signers[i];
+      }
       return SSL_TLSEXT_ERR_OK;
     }
   }
@@ -2920,7 +2937,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory_with_options(
           [&](const std::shared_ptr<grpc_core::PrivateKeySigner>& key_signer) {
             // The Handshaker Factory will own a shared copy of the reference
             // passed through the options.
-            impl->base.key_signer = key_signer;
+            impl->key_signer = key_signer;
           });
     }
 #endif
@@ -3133,13 +3150,11 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
       if (result != TSI_OK) break;
 
 #if defined(OPENSSL_IS_BORINGSSL)
-      if (impl->base.key_signer == nullptr) {
-        grpc_core::Match(
-            options->pem_key_cert_pairs[i].private_key,
-            [](const std::string&) {},
-            [&](const std::shared_ptr<grpc_core::PrivateKeySigner>&
-                    key_signer) { impl->base.key_signer = key_signer; });
-      }
+      grpc_core::Match(
+          options->pem_key_cert_pairs[i].private_key, [](const std::string&) {},
+          [&](const std::shared_ptr<grpc_core::PrivateKeySigner>& key_signer) {
+            impl->key_signers[i] = key_signer;
+          });
 #endif
 
       // TODO(elessar): Provide ability to disable session ticket keys.

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -3113,7 +3113,6 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
   impl->ssl_contexts.reserve(options->pem_key_cert_pairs.size());
   for (i = 0; i < options->pem_key_cert_pairs.size(); i++) {
     SslContext& ssl_context = impl->ssl_contexts.emplace_back();
-    ;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
     ssl_context.ssl_ctx = SSL_CTX_new(TLS_method());
 #else

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -141,22 +141,24 @@ struct tsi_ssl_client_handshaker_factory {
 #endif
 };
 
+struct SslContext {
+  SSL_CTX* ssl_ctx;
+  tsi_peer x509_subject_name;
+#if defined(OPENSSL_IS_BORINGSSL)
+  std::shared_ptr<grpc_core::PrivateKeySigner> key_signer;
+#endif
+};
+
 struct tsi_ssl_server_handshaker_factory {
   // Several contexts to support SNI.
   // The tsi_peer array contains the subject names of the server certificates
   // associated with the contexts at the same index.
   tsi_ssl_handshaker_factory base;
-  SSL_CTX** ssl_contexts;
-  tsi_peer* ssl_context_x509_subject_names;
-  size_t ssl_context_count;
+  std::vector<SslContext> ssl_contexts;
   unsigned char* alpn_protocol_list;
   size_t alpn_protocol_list_length;
   grpc_core::RefCountedPtr<TlsSessionKeyLogger> key_logger;
   std::shared_ptr<tsi::RootCertInfo> root_cert_info;
-#if defined(OPENSSL_IS_BORINGSSL)
-  // The key is the index of SSL_CONTEXT in `sll_contexts`.
-  std::map<int, std::shared_ptr<grpc_core::PrivateKeySigner>> key_signers;
-#endif
 };
 
 // Tracks the arguments for a pending call to tsi_handshaker_next().
@@ -2420,18 +2422,23 @@ static tsi_result ssl_handshaker_next(
 static void ssl_handshaker_shutdown(tsi_handshaker* self) {
 #if defined(OPENSSL_IS_BORINGSSL)
   tsi_ssl_handshaker* impl = static_cast<tsi_ssl_handshaker*>(self);
+  std::shared_ptr<grpc_core::PrivateKeySigner::AsyncSigningHandle>
+      signing_handle;
   std::optional<HandshakerNextArgs> next_args;
   {
     grpc_core::MutexLock lock(&impl->mu);
     if (impl->ssl == nullptr) return;
     impl->is_shutdown = true;
     if (impl->key_signer != nullptr && impl->signing_handle != nullptr) {
-      impl->key_signer->Cancel(impl->signing_handle);
+      signing_handle = std::move(impl->signing_handle);
     }
     if (impl->handshaker_next_args.has_value()) {
       next_args = std::move(*impl->handshaker_next_args);
       impl->handshaker_next_args.reset();
     }
+  }
+  if (signing_handle != nullptr) {
+    impl->key_signer->Cancel(signing_handle);
   }
   if (next_args.has_value()) {
     grpc_event_engine::experimental::GetDefaultEventEngine()->Run(
@@ -2582,6 +2589,7 @@ static tsi_result create_tsi_ssl_handshaker(
       static_cast<unsigned char*>(gpr_zalloc(impl->outgoing_bytes_buffer_size));
   impl->vtable = &handshaker_vtable;
   impl->factory_ref = tsi_ssl_handshaker_factory_ref(factory);
+#if defined(OPENSSL_IS_BORINGSSL)
   if (is_client) {
     tsi_ssl_client_handshaker_factory* client_factory =
         reinterpret_cast<tsi_ssl_client_handshaker_factory*>(factory);
@@ -2589,14 +2597,17 @@ static tsi_result create_tsi_ssl_handshaker(
   } else {
     tsi_ssl_server_handshaker_factory* server_factory =
         reinterpret_cast<tsi_ssl_server_handshaker_factory*>(factory);
-    // By default we use the first SSL_CTX if there is no SNI in the ClientHello
-    // or there is no match. So we initialize the key signer of the handshaker
-    // to the first one if present.
-    if (server_factory->key_signers.find(0) !=
-        server_factory->key_signers.end()) {
-      impl->key_signer = server_factory->key_signers[0];
+    // If the client sends an SNI in the ClientHello message, the key_signer
+    // will be dynamically selected by
+    // `ssl_server_handshaker_factory_servername_callback`. In the event that
+    // the client does not send an SNI in the ClientHello or the SNI does not
+    // match any of the certificate, we use the default certificate and the
+    // signer that may come with it.
+    if (server_factory->ssl_contexts[0].key_signer != nullptr) {
+      impl->key_signer = server_factory->ssl_contexts[0].key_signer;
     }
   }
+#endif
 
   *handshaker = impl;
 
@@ -2689,10 +2700,10 @@ static int client_handshaker_factory_npn_callback(
 tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
     tsi_ssl_server_handshaker_factory* factory, size_t network_bio_buf_size,
     size_t ssl_bio_buf_size, tsi_handshaker** handshaker) {
-  if (factory->ssl_context_count == 0) return TSI_INVALID_ARGUMENT;
+  if (factory->ssl_contexts.empty()) return TSI_INVALID_ARGUMENT;
   // Create the handshaker with the first context. We will switch if needed
   // because of SNI in ssl_server_handshaker_factory_servername_callback.
-  return create_tsi_ssl_handshaker(factory->ssl_contexts[0], 0, nullptr,
+  return create_tsi_ssl_handshaker(factory->ssl_contexts[0].ssl_ctx, 0, nullptr,
                                    network_bio_buf_size, ssl_bio_buf_size,
                                    std::nullopt, &factory->base, handshaker);
 }
@@ -2709,15 +2720,11 @@ static void tsi_ssl_server_handshaker_factory_destroy(
   tsi_ssl_server_handshaker_factory* self =
       reinterpret_cast<tsi_ssl_server_handshaker_factory*>(factory);
   size_t i;
-  for (i = 0; i < self->ssl_context_count; i++) {
-    if (self->ssl_contexts[i] != nullptr) {
-      SSL_CTX_free(self->ssl_contexts[i]);
-      tsi_peer_destruct(&self->ssl_context_x509_subject_names[i]);
+  for (i = 0; i < self->ssl_contexts.size(); i++) {
+    if (self->ssl_contexts[i].ssl_ctx != nullptr) {
+      SSL_CTX_free(self->ssl_contexts[i].ssl_ctx);
+      tsi_peer_destruct(&self->ssl_contexts[i].x509_subject_name);
     }
-  }
-  if (self->ssl_contexts != nullptr) gpr_free(self->ssl_contexts);
-  if (self->ssl_context_x509_subject_names != nullptr) {
-    gpr_free(self->ssl_context_x509_subject_names);
   }
   if (self->alpn_protocol_list != nullptr) gpr_free(self->alpn_protocol_list);
   delete self;
@@ -2774,13 +2781,15 @@ static int ssl_server_handshaker_factory_servername_callback(SSL* ssl,
     return SSL_TLSEXT_ERR_NOACK;
   }
 
-  for (i = 0; i < impl->ssl_context_count; i++) {
-    if (tsi_ssl_peer_matches_name(&impl->ssl_context_x509_subject_names[i],
+  for (i = 0; i < impl->ssl_contexts.size(); i++) {
+    if (tsi_ssl_peer_matches_name(&impl->ssl_contexts[i].x509_subject_name,
                                   servername)) {
-      SSL_set_SSL_CTX(ssl, impl->ssl_contexts[i]);
-      if (impl->key_signers.find(i) != impl->key_signers.end()) {
-        GetHandshaker(ssl)->key_signer = impl->key_signers[i];
+      SSL_set_SSL_CTX(ssl, impl->ssl_contexts[i].ssl_ctx);
+#if defined(OPENSSL_IS_BORINGSSL)
+      if (impl->ssl_contexts[i].key_signer != nullptr) {
+        GetHandshaker(ssl)->key_signer = impl->ssl_contexts[i].key_signer;
       }
+#endif
       return SSL_TLSEXT_ERR_OK;
     }
   }
@@ -3062,7 +3071,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_ex(
     const char* cipher_suites, const char** alpn_protocols,
     uint16_t num_alpn_protocols, tsi_ssl_server_handshaker_factory** factory) {
   tsi_ssl_server_handshaker_options options;
-  options.pem_key_cert_pairs = pem_key_cert_pairs;
+  options.pem_key_cert_pairs = std::move(pem_key_cert_pairs);
   if (pem_client_root_certs != nullptr) {
     options.root_cert_info =
         std::make_shared<tsi::RootCertInfo>(pem_client_root_certs);
@@ -3094,16 +3103,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
   tsi_ssl_handshaker_factory_init(&impl->base);
   impl->base.vtable = &server_handshaker_factory_vtable;
 
-  impl->ssl_contexts = static_cast<SSL_CTX**>(
-      gpr_zalloc(options->pem_key_cert_pairs.size() * sizeof(SSL_CTX*)));
-  impl->ssl_context_x509_subject_names = static_cast<tsi_peer*>(
-      gpr_zalloc(options->pem_key_cert_pairs.size() * sizeof(tsi_peer)));
-  if (impl->ssl_contexts == nullptr ||
-      impl->ssl_context_x509_subject_names == nullptr) {
-    tsi_ssl_handshaker_factory_unref(&impl->base);
-    return TSI_OUT_OF_RESOURCES;
-  }
-  impl->ssl_context_count = options->pem_key_cert_pairs.size();
+  impl->ssl_contexts.reserve(options->pem_key_cert_pairs.size());
   if (options->root_cert_info != nullptr) {
     impl->root_cert_info = options->root_cert_info;
   }
@@ -3124,28 +3124,29 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 
   for (i = 0; i < options->pem_key_cert_pairs.size(); i++) {
     do {
+      SslContext ssl_context;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
-      impl->ssl_contexts[i] = SSL_CTX_new(TLS_method());
+      ssl_context.ssl_ctx = SSL_CTX_new(TLS_method());
 #else
-      impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
+      ssl_context.ssl_ctx = SSL_CTX_new(TLSv1_2_method());
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
-      SSL_CTX_set_options(impl->ssl_contexts[i], SSL_OP_NO_RENEGOTIATION);
+      SSL_CTX_set_options(ssl_context.ssl_ctx, SSL_OP_NO_RENEGOTIATION);
 #endif
-      if (impl->ssl_contexts[i] == nullptr) {
+      if (ssl_context.ssl_ctx == nullptr) {
         tsi::LogSslErrorStack();
         LOG(ERROR) << "Could not create ssl context.";
         result = TSI_OUT_OF_RESOURCES;
         break;
       }
 
-      result = tsi_set_min_and_max_tls_versions(impl->ssl_contexts[i],
+      result = tsi_set_min_and_max_tls_versions(ssl_context.ssl_ctx,
                                                 options->min_tls_version,
                                                 options->max_tls_version);
       if (result != TSI_OK) return result;
 
       result = populate_ssl_context(
-          impl->ssl_contexts[i], &options->pem_key_cert_pairs[i],
+          ssl_context.ssl_ctx, &options->pem_key_cert_pairs[i],
           options->cipher_suites, options->key_exchange_groups);
       if (result != TSI_OK) break;
 
@@ -3153,7 +3154,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
       grpc_core::Match(
           options->pem_key_cert_pairs[i].private_key, [](const std::string&) {},
           [&](const std::shared_ptr<grpc_core::PrivateKeySigner>& key_signer) {
-            impl->key_signers[i] = key_signer;
+            ssl_context.key_signer = key_signer;
           });
 #endif
 
@@ -3161,7 +3162,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 
       // Allow client cache sessions (it's needed for OpenSSL only).
       int set_sid_ctx_result = SSL_CTX_set_session_id_context(
-          impl->ssl_contexts[i], kSslSessionIdContext,
+          ssl_context.ssl_ctx, kSslSessionIdContext,
           GPR_ARRAY_SIZE(kSslSessionIdContext));
       if (set_sid_ctx_result == 0) {
         LOG(ERROR) << "Failed to set session id context.";
@@ -3171,7 +3172,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 
       if (options->session_ticket_key != nullptr) {
         if (SSL_CTX_set_tlsext_ticket_keys(
-                impl->ssl_contexts[i],
+                ssl_context.ssl_ctx,
                 const_cast<char*>(options->session_ticket_key),
                 options->session_ticket_key_size) == 0) {
           LOG(ERROR) << "Invalid STEK size.";
@@ -3185,23 +3186,23 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
             [&](const std::string& pem_root_certs) {
               STACK_OF(X509_NAME)* root_names = nullptr;
               result = ssl_ctx_load_verification_certs(
-                  impl->ssl_contexts[i], pem_root_certs.c_str(),
+                  ssl_context.ssl_ctx, pem_root_certs.c_str(),
                   pem_root_certs.size(), nullptr);
               if (result != TSI_OK) {
                 LOG(ERROR) << "Invalid verification certs.";
               }
               if (options->send_client_ca_list) {
-                SSL_CTX_set_client_CA_list(impl->ssl_contexts[i], root_names);
+                SSL_CTX_set_client_CA_list(ssl_context.ssl_ctx, root_names);
               }
             },
             [&](const grpc_core::SpiffeBundleMap& spiffe_bundle_map) {
               X509_STORE* cert_store =
-                  SSL_CTX_get_cert_store(impl->ssl_contexts[i]);
+                  SSL_CTX_get_cert_store(ssl_context.ssl_ctx);
               X509_STORE_set_flags(cert_store, X509_V_FLAG_PARTIAL_CHAIN |
                                                    X509_V_FLAG_TRUSTED_FIRST);
               const void* p = &spiffe_bundle_map;
               void* map = const_cast<void*>(p);
-              SSL_CTX_set_ex_data(impl->ssl_contexts[i],
+              SSL_CTX_set_ex_data(ssl_context.ssl_ctx,
                                   g_ssl_ctx_ex_spiffe_bundle_map_index, map);
             });
         if (result != TSI_OK) {
@@ -3210,42 +3211,42 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
       }
       switch (options->client_certificate_request) {
         case TSI_DONT_REQUEST_CLIENT_CERTIFICATE:
-          SSL_CTX_set_verify(impl->ssl_contexts[i], SSL_VERIFY_NONE, nullptr);
+          SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_NONE, nullptr);
           break;
         case TSI_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
-          SSL_CTX_set_verify(impl->ssl_contexts[i], SSL_VERIFY_PEER, nullptr);
-          SSL_CTX_set_cert_verify_callback(impl->ssl_contexts[i],
+          SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_PEER, nullptr);
+          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
                                            NullVerifyCallback, nullptr);
           break;
         case TSI_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY:
-          SSL_CTX_set_verify(impl->ssl_contexts[i], SSL_VERIFY_PEER, nullptr);
-          SSL_CTX_set_cert_verify_callback(impl->ssl_contexts[i],
+          SSL_CTX_set_verify(ssl_context.ssl_ctx, SSL_VERIFY_PEER, nullptr);
+          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
                                            CustomVerificationFunction, nullptr);
           break;
         case TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY:
-          SSL_CTX_set_verify(impl->ssl_contexts[i],
+          SSL_CTX_set_verify(ssl_context.ssl_ctx,
                              SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                              nullptr);
-          SSL_CTX_set_cert_verify_callback(impl->ssl_contexts[i],
+          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
                                            NullVerifyCallback, nullptr);
           break;
         case TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY:
-          SSL_CTX_set_verify(impl->ssl_contexts[i],
+          SSL_CTX_set_verify(ssl_context.ssl_ctx,
                              SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
                              nullptr);
-          SSL_CTX_set_cert_verify_callback(impl->ssl_contexts[i],
+          SSL_CTX_set_cert_verify_callback(ssl_context.ssl_ctx,
                                            CustomVerificationFunction, nullptr);
           break;
       }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000 && !defined(LIBRESSL_VERSION_NUMBER)
       if (options->crl_provider != nullptr) {
-        SSL_CTX_set_ex_data(impl->ssl_contexts[i],
+        SSL_CTX_set_ex_data(ssl_context.ssl_ctx,
                             g_ssl_ctx_ex_crl_provider_index,
                             options->crl_provider.get());
       } else if (options->crl_directory != nullptr &&
                  strcmp(options->crl_directory, "") != 0) {
-        X509_STORE* cert_store = SSL_CTX_get_cert_store(impl->ssl_contexts[i]);
+        X509_STORE* cert_store = SSL_CTX_get_cert_store(ssl_context.ssl_ctx);
         X509_STORE_set_verify_cb(cert_store, verify_cb);
         if (!X509_STORE_load_locations(cert_store, nullptr,
                                        options->crl_directory)) {
@@ -3260,34 +3261,35 @@ tsi_result tsi_create_ssl_server_handshaker_factory_with_options(
 
       result = tsi_ssl_extract_x509_subject_names_from_pem_cert(
           options->pem_key_cert_pairs[i].cert_chain.c_str(),
-          &impl->ssl_context_x509_subject_names[i]);
+          &ssl_context.x509_subject_name);
       if (result != TSI_OK) break;
 
       SSL_CTX_set_tlsext_servername_callback(
-          impl->ssl_contexts[i],
+          ssl_context.ssl_ctx,
           ssl_server_handshaker_factory_servername_callback);
-      SSL_CTX_set_tlsext_servername_arg(impl->ssl_contexts[i], impl);
+      SSL_CTX_set_tlsext_servername_arg(ssl_context.ssl_ctx, impl);
 #if TSI_OPENSSL_ALPN_SUPPORT
-      SSL_CTX_set_alpn_select_cb(impl->ssl_contexts[i],
+      SSL_CTX_set_alpn_select_cb(ssl_context.ssl_ctx,
                                  ServerHandshakerFactoryAlpnCallback, impl);
 #endif  // TSI_OPENSSL_ALPN_SUPPORT
       SSL_CTX_set_next_protos_advertised_cb(
-          impl->ssl_contexts[i],
+          ssl_context.ssl_ctx,
           server_handshaker_factory_npn_advertised_callback, impl);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000 && !defined(LIBRESSL_VERSION_NUMBER)
       // Register factory at index
       if (options->key_logger != nullptr) {
         // Need to set factory at g_ssl_ctx_ex_factory_index
-        SSL_CTX_set_ex_data(impl->ssl_contexts[i], g_ssl_ctx_ex_factory_index,
+        SSL_CTX_set_ex_data(ssl_context.ssl_ctx, g_ssl_ctx_ex_factory_index,
                             impl);
         // SSL_CTX_set_keylog_callback is set here to register callback
         // when ssl/tls handshakes complete.
         SSL_CTX_set_keylog_callback(
-            impl->ssl_contexts[i],
+            ssl_context.ssl_ctx,
             ssl_keylogging_callback<tsi_ssl_server_handshaker_factory>);
       }
 #endif
+      impl->ssl_contexts.push_back(std::move(ssl_context));
     } while (false);
 
     if (result != TSI_OK) {

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2600,7 +2600,9 @@ static tsi_result create_tsi_ssl_handshaker(
       static_cast<unsigned char*>(gpr_zalloc(impl->outgoing_bytes_buffer_size));
   impl->vtable = &handshaker_vtable;
   impl->factory_ref = tsi_ssl_handshaker_factory_ref(factory);
+#if defined(OPENSSL_IS_BORINGSSL)
   impl->key_signer = std::move(key_signer);
+#endif
 
   *handshaker = impl;
 

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2651,10 +2651,17 @@ tsi_result tsi_ssl_client_handshaker_factory_create_handshaker(
     tsi_handshaker** handshaker) {
   GRPC_TRACE_LOG(tsi, INFO)
       << "Creating SSL handshaker with SNI " << server_name_indication;
+#if defined(OPENSSL_IS_BORINGSSL)
   return create_tsi_ssl_handshaker(
       factory->ssl_context, 1, server_name_indication, network_bio_buf_size,
       ssl_bio_buf_size, alpn_preferred_protocol_list, factory->key_signer,
       &factory->base, handshaker);
+#else
+  return create_tsi_ssl_handshaker(
+      factory->ssl_context, 1, server_name_indication, network_bio_buf_size,
+      ssl_bio_buf_size, alpn_preferred_protocol_list, /*key_signer=*/nullptr,
+      &factory->base, handshaker);
+#endif
 }
 
 void tsi_ssl_client_handshaker_factory_unref(
@@ -2696,6 +2703,7 @@ tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
     tsi_ssl_server_handshaker_factory* factory, size_t network_bio_buf_size,
     size_t ssl_bio_buf_size, tsi_handshaker** handshaker) {
   if (factory->ssl_contexts.empty()) return TSI_INVALID_ARGUMENT;
+#if defined(OPENSSL_IS_BORINGSSL)
   // Create the handshaker with the first context. We will switch if needed
   // because of SNI in ssl_server_handshaker_factory_servername_callback.
   // Likewise, we pass the private key signer corresponding to the first
@@ -2704,6 +2712,12 @@ tsi_result tsi_ssl_server_handshaker_factory_create_handshaker(
       factory->ssl_contexts[0].ssl_ctx, 0, nullptr, network_bio_buf_size,
       ssl_bio_buf_size, std::nullopt, factory->ssl_contexts[0].key_signer,
       &factory->base, handshaker);
+#else
+  return create_tsi_ssl_handshaker(factory->ssl_contexts[0].ssl_ctx, 0, nullptr,
+                                   network_bio_buf_size, ssl_bio_buf_size,
+                                   std::nullopt, /*key_signer=*/nullptr,
+                                   &factory->base, handshaker);
+#endif
 }
 
 void tsi_ssl_server_handshaker_factory_unref(

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -280,6 +280,7 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:client.pem",
         "//src/core/tsi/test_creds:client1.key",
         "//src/core/tsi/test_creds:server0.key",
+        "//src/core/tsi/test_creds:server0.pem",
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],

--- a/test/core/tsi/private_key_offload_test.cc
+++ b/test/core/tsi/private_key_offload_test.cc
@@ -25,6 +25,7 @@
 
 #include "src/core/lib/iomgr/timer_manager.h"
 #include "src/core/tsi/ssl_transport_security.h"
+#include "src/core/tsi/transport_security.h"
 #include "src/core/util/wait_for_single_owner.h"
 #include "test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.h"
 #include "test/core/test_util/test_config.h"
@@ -204,7 +205,6 @@ class AsyncTestPrivateKeySigner final
 enum class OffloadParty {
   kClient,
   kServer,
-  kNone,
 };
 
 class SslOffloadTsiTestFixture {
@@ -334,6 +334,9 @@ class SslOffloadTsiTestFixture {
       tsi_peer peer;
       EXPECT_EQ(tsi_handshaker_result_extract_peer(base_.client_result, &peer),
                 TSI_OK);
+      if (!sni_.empty()) {
+        EXPECT_EQ(tsi_ssl_peer_matches_name(&peer, sni_), 1);
+      }
       tsi_peer_destruct(&peer);
       EXPECT_EQ(tsi_handshaker_result_extract_peer(base_.server_result, &peer),
                 TSI_OK);

--- a/test/core/tsi/private_key_offload_test.cc
+++ b/test/core/tsi/private_key_offload_test.cc
@@ -212,11 +212,11 @@ class SslOffloadTsiTestFixture {
   SslOffloadTsiTestFixture(OffloadParty offload_party,
                            std::shared_ptr<PrivateKeySigner> signer,
                            tsi_tls_version tls_version,
-                           std::string sni_name = "")
+                           std::string sni = "")
       : offload_party_(offload_party),
         signer_(std::move(signer)),
         tls_version_(tls_version),
-        sni_name_(std::move(sni_name)) {
+        sni_(std::move(sni)) {
     tsi_test_fixture_init(&base_);
     base_.test_unused_bytes = true;
     base_.vtable = &kVtable;
@@ -315,7 +315,7 @@ class SslOffloadTsiTestFixture {
     tsi_handshaker* server_hs;
     ASSERT_EQ(tsi_ssl_client_handshaker_factory_create_handshaker(
                   client_handshaker_factory_,
-                  sni_name_.empty() ? nullptr : sni_name_.c_str(), 0, 0,
+                  sni_.empty() ? nullptr : sni_.c_str(), 0, 0,
                   std::nullopt, &client_hs),
               TSI_OK);
     ASSERT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
@@ -366,7 +366,7 @@ class SslOffloadTsiTestFixture {
   OffloadParty offload_party_;
   std::shared_ptr<PrivateKeySigner> signer_;
   tsi_tls_version tls_version_;
-  std::string sni_name_;
+  std::string sni_;
   bool expect_success_ = false;
   bool expect_success_on_client_ = false;
 };

--- a/test/core/tsi/private_key_offload_test.cc
+++ b/test/core/tsi/private_key_offload_test.cc
@@ -211,8 +211,7 @@ class SslOffloadTsiTestFixture {
  public:
   SslOffloadTsiTestFixture(OffloadParty offload_party,
                            std::shared_ptr<PrivateKeySigner> signer,
-                           tsi_tls_version tls_version,
-                           std::string sni = "")
+                           tsi_tls_version tls_version, std::string sni = "")
       : offload_party_(offload_party),
         signer_(std::move(signer)),
         tls_version_(tls_version),
@@ -313,11 +312,11 @@ class SslOffloadTsiTestFixture {
     // Create handshakers.
     tsi_handshaker* client_hs;
     tsi_handshaker* server_hs;
-    ASSERT_EQ(tsi_ssl_client_handshaker_factory_create_handshaker(
-                  client_handshaker_factory_,
-                  sni_.empty() ? nullptr : sni_.c_str(), 0, 0,
-                  std::nullopt, &client_hs),
-              TSI_OK);
+    ASSERT_EQ(
+        tsi_ssl_client_handshaker_factory_create_handshaker(
+            client_handshaker_factory_, sni_.empty() ? nullptr : sni_.c_str(),
+            0, 0, std::nullopt, &client_hs),
+        TSI_OK);
     ASSERT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
                   server_handshaker_factory_, 0, 0, &server_hs),
               TSI_OK);

--- a/test/core/tsi/private_key_offload_test.cc
+++ b/test/core/tsi/private_key_offload_test.cc
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "src/core/lib/iomgr/timer_manager.h"
 #include "src/core/tsi/ssl_transport_security.h"
@@ -210,17 +211,23 @@ class SslOffloadTsiTestFixture {
  public:
   SslOffloadTsiTestFixture(OffloadParty offload_party,
                            std::shared_ptr<PrivateKeySigner> signer,
-                           tsi_tls_version tls_version)
+                           tsi_tls_version tls_version,
+                           std::string sni_name = "")
       : offload_party_(offload_party),
         signer_(std::move(signer)),
-        tls_version_(tls_version) {
+        tls_version_(tls_version),
+        sni_name_(std::move(sni_name)) {
     tsi_test_fixture_init(&base_);
     base_.test_unused_bytes = true;
     base_.vtable = &kVtable;
     ca_cert_ = GetFileContents(absl::StrCat(kTestCredsRelativePath, "ca.pem"));
-    server_key_ =
+    server0_key_ =
+        GetFileContents(absl::StrCat(kTestCredsRelativePath, "server0.key"));
+    server0_cert_ =
+        GetFileContents(absl::StrCat(kTestCredsRelativePath, "server0.pem"));
+    server1_key_ =
         GetFileContents(absl::StrCat(kTestCredsRelativePath, "server1.key"));
-    server_cert_ =
+    server1_cert_ =
         GetFileContents(absl::StrCat(kTestCredsRelativePath, "server1.pem"));
     client_key_ =
         GetFileContents(absl::StrCat(kTestCredsRelativePath, "client.key"));
@@ -230,13 +237,23 @@ class SslOffloadTsiTestFixture {
       if (offload_party_ == OffloadParty::kClient) {
         signer_ = std::make_shared<SyncTestPrivateKeySigner>(client_key_);
       } else if (offload_party_ == OffloadParty::kServer) {
-        signer_ = std::make_shared<SyncTestPrivateKeySigner>(server_key_);
+        signer_ = std::make_shared<SyncTestPrivateKeySigner>(server0_key_);
       }
     }
-    server_pem_key_cert_pairs_.emplace_back(server_key_, server_cert_);
-    client_pem_key_cert_pairs_.emplace_back(client_key_, client_cert_);
-    server_pem_key_cert_pairs_with_signer_.emplace_back(signer_, server_cert_);
-    client_pem_key_cert_pairs_with_signer_.emplace_back(signer_, client_cert_);
+    if (offload_party_ == OffloadParty::kServer) {
+      // Use the given signer for the default server certificate.
+      server_pem_key_cert_pairs_.emplace_back(signer_, server0_cert_);
+      server_pem_key_cert_pairs_.emplace_back(
+          std::make_shared<SyncTestPrivateKeySigner>(server1_key_),
+          server1_cert_);
+      client_pem_key_cert_pair_ =
+          tsi_ssl_pem_key_cert_pair(client_key_, client_cert_);
+    } else {
+      server_pem_key_cert_pairs_.emplace_back(server0_key_, server0_cert_);
+      server_pem_key_cert_pairs_.emplace_back(server1_key_, server1_cert_);
+      client_pem_key_cert_pair_ =
+          tsi_ssl_pem_key_cert_pair(signer_, client_cert_);
+    }
   }
 
   void Run(bool expect_success, bool expect_success_on_client,
@@ -275,12 +292,7 @@ class SslOffloadTsiTestFixture {
         std::make_shared<tsi::RootCertInfo>(ca_cert_);
     client_options.min_tls_version = tls_version_;
     client_options.max_tls_version = tls_version_;
-    if (offload_party_ == OffloadParty::kClient) {
-      client_options.pem_key_cert_pair =
-          &client_pem_key_cert_pairs_with_signer_[0];
-    } else {
-      client_options.pem_key_cert_pair = &client_pem_key_cert_pairs_[0];
-    }
+    client_options.pem_key_cert_pair = &client_pem_key_cert_pair_;
     ASSERT_EQ(tsi_create_ssl_client_handshaker_factory_with_options(
                   &client_options, &client_handshaker_factory_),
               TSI_OK);
@@ -293,12 +305,7 @@ class SslOffloadTsiTestFixture {
         TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
     server_options.min_tls_version = tls_version_;
     server_options.max_tls_version = tls_version_;
-    if (offload_party_ == OffloadParty::kServer) {
-      server_options.pem_key_cert_pairs =
-          server_pem_key_cert_pairs_with_signer_;
-    } else {
-      server_options.pem_key_cert_pairs = server_pem_key_cert_pairs_;
-    }
+    server_options.pem_key_cert_pairs = server_pem_key_cert_pairs_;
     ASSERT_EQ(tsi_create_ssl_server_handshaker_factory_with_options(
                   &server_options, &server_handshaker_factory_),
               TSI_OK);
@@ -307,8 +314,9 @@ class SslOffloadTsiTestFixture {
     tsi_handshaker* client_hs;
     tsi_handshaker* server_hs;
     ASSERT_EQ(tsi_ssl_client_handshaker_factory_create_handshaker(
-                  client_handshaker_factory_, nullptr, 0, 0, std::nullopt,
-                  &client_hs),
+                  client_handshaker_factory_,
+                  sni_name_.empty() ? nullptr : sni_name_.c_str(), 0, 0,
+                  std::nullopt, &client_hs),
               TSI_OK);
     ASSERT_EQ(tsi_ssl_server_handshaker_factory_create_handshaker(
                   server_handshaker_factory_, 0, 0, &server_hs),
@@ -347,17 +355,18 @@ class SslOffloadTsiTestFixture {
   tsi_ssl_server_handshaker_factory* server_handshaker_factory_ = nullptr;
   tsi_ssl_client_handshaker_factory* client_handshaker_factory_ = nullptr;
   std::string ca_cert_;
-  std::string server_key_;
-  std::string server_cert_;
+  std::string server0_key_;
+  std::string server0_cert_;
+  std::string server1_key_;
+  std::string server1_cert_;
   std::string client_key_;
   std::string client_cert_;
   std::vector<tsi_ssl_pem_key_cert_pair> server_pem_key_cert_pairs_;
-  std::vector<tsi_ssl_pem_key_cert_pair> client_pem_key_cert_pairs_;
-  std::vector<tsi_ssl_pem_key_cert_pair> server_pem_key_cert_pairs_with_signer_;
-  std::vector<tsi_ssl_pem_key_cert_pair> client_pem_key_cert_pairs_with_signer_;
+  tsi_ssl_pem_key_cert_pair client_pem_key_cert_pair_;
   OffloadParty offload_party_;
   std::shared_ptr<PrivateKeySigner> signer_;
   tsi_tls_version tls_version_;
+  std::string sni_name_;
   bool expect_success_ = false;
   bool expect_success_on_client_ = false;
 };
@@ -393,10 +402,22 @@ class PrivateKeyOffloadTest : public ::testing::TestWithParam<tsi_tls_version> {
       event_engine_;
 };
 
-// Verifies that server-side signing offload succeeds.
-TEST_P(PrivateKeyOffloadTest, OffloadOnServerSucceeds) {
+// Verifies that server-side signing offload succeeds without SNI.
+TEST_P(PrivateKeyOffloadTest, OffloadOnServerSucceedsWithoutSNI) {
   auto fixture = std::make_shared<SslOffloadTsiTestFixture>(
       OffloadParty::kServer, nullptr, GetParam());
+  fixture->Run(/*expect_success=*/true, /*expect_success_on_client*/ true,
+               event_engine_.get());
+}
+
+// Verifies that server-side signing offload succeeds with SNI match.
+TEST_P(PrivateKeyOffloadTest, OffloadOnServerSucceedsWithSNI) {
+  // This signer should not be invoked because SNI should match server1.key.
+  auto signer = std::make_shared<SyncTestPrivateKeySigner>(
+      GetFileContents(absl::StrCat(kTestCredsRelativePath, "server0.key")),
+      SyncTestPrivateKeySigner::Mode::kInvalidSignature);
+  auto fixture = std::make_shared<SslOffloadTsiTestFixture>(
+      OffloadParty::kServer, signer, GetParam(), "bar.test.google.fr");
   fixture->Run(/*expect_success=*/true, /*expect_success_on_client*/ true,
                event_engine_.get());
 }
@@ -487,7 +508,7 @@ TEST_P(PrivateKeyOffloadTest, OffloadFailsWithAsyncSignerErrorOnClient) {
 // server fails the handshake.
 TEST_P(PrivateKeyOffloadTest, OffloadFailsWithInvalidSignatureOnServer) {
   std::string server_key =
-      GetFileContents(absl::StrCat(kTestCredsRelativePath, "server0.key"));
+      GetFileContents(absl::StrCat(kTestCredsRelativePath, "server1.key"));
   auto fixture = std::make_shared<SslOffloadTsiTestFixture>(
       OffloadParty::kServer,
       std::make_shared<SyncTestPrivateKeySigner>(server_key), GetParam());
@@ -513,7 +534,7 @@ TEST_P(PrivateKeyOffloadTest, OffloadFailsWithInvalidSignatureOnClient) {
 // server fails the handshake.
 TEST_P(PrivateKeyOffloadTest, OffloadFailsWithAsyncInvalidSignatureOnServer) {
   std::string server_key =
-      GetFileContents(absl::StrCat(kTestCredsRelativePath, "server0.key"));
+      GetFileContents(absl::StrCat(kTestCredsRelativePath, "server1.key"));
   auto fixture = std::make_shared<SslOffloadTsiTestFixture>(
       OffloadParty::kServer,
       std::make_shared<AsyncTestPrivateKeySigner>(server_key, event_engine_),

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -1717,6 +1717,8 @@ grpc_cc_test(
         "//src/core/tsi/test_creds:ca.pem",
         "//src/core/tsi/test_creds:client.key",
         "//src/core/tsi/test_creds:client.pem",
+        "//src/core/tsi/test_creds:server0.key",
+        "//src/core/tsi/test_creds:server0.pem",
         "//src/core/tsi/test_creds:server1.key",
         "//src/core/tsi/test_creds:server1.pem",
     ],

--- a/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
+++ b/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
@@ -24,6 +24,7 @@
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/security/tls_certificate_provider.h>
+#include <grpcpp/security/tls_certificate_verifier.h>
 #include <grpcpp/security/tls_credentials_options.h>
 #include <grpcpp/security/tls_private_key_signer.h>
 #include <grpcpp/server.h>
@@ -65,7 +66,12 @@ namespace testing {
 namespace {
 
 constexpr absl::string_view kMessage = "Hello";
-constexpr absl::string_view kCaPemPath = "src/core/tsi/test_creds/ca.pem";
+constexpr absl::string_view kCaPemPath =
+    "src/core/tsi/test_creds/ca.pem";
+constexpr absl::string_view kServerKey0Path =
+    "src/core/tsi/test_creds/server0.key";
+constexpr absl::string_view kServerCert0Path =
+    "src/core/tsi/test_creds/server0.pem";
 constexpr absl::string_view kServerKeyPath =
     "src/core/tsi/test_creds/server1.key";
 constexpr absl::string_view kServerCertPath =
@@ -387,8 +393,12 @@ class AsyncTestPrivateKeySigner final
 
 // Verifies that the server can successfully offload signing to an asynchronous
 // custom signer.
-TEST_F(TlsPrivateKeyOffloadTest, OffloadWithCustomKeySignerAsync) {
+TEST_F(TlsPrivateKeyOffloadTest, OffloadWithCustomKeySignerAsyncWithSniMatch) {
   server_addr_ = absl::StrCat("localhost:", grpc_pick_unused_port_or_die());
+  std::string server_key_0 =
+      grpc_core::testing::GetFileContents(std::string(kServerKey0Path));
+  std::string server_cert_0 =
+      grpc_core::testing::GetFileContents(std::string(kServerCert0Path));
   std::string server_key =
       grpc_core::testing::GetFileContents(std::string(kServerKeyPath));
   std::string server_cert =
@@ -399,6 +409,13 @@ TEST_F(TlsPrivateKeyOffloadTest, OffloadWithCustomKeySignerAsync) {
   std::vector<experimental::IdentityKeyOrSignerCertPair>
       server_identity_key_cert_pairs;
   signer_ = std::make_shared<AsyncTestPrivateKeySigner>(server_key);
+  // The bad signer should not be used with correct SNI matching.
+  std::shared_ptr<experimental::PrivateKeySigner> bad_signer =
+      std::make_shared<AsyncTestPrivateKeySigner>(
+          server_key_0, AsyncTestPrivateKeySigner::Mode::kError);
+  server_identity_key_cert_pairs.emplace_back(
+      grpc::experimental::IdentityKeyOrSignerCertPair{bad_signer,
+                                                      server_cert_0});
   server_identity_key_cert_pairs.emplace_back(
       grpc::experimental::IdentityKeyOrSignerCertPair{signer_, server_cert});
   auto server_certificate_provider =
@@ -431,6 +448,60 @@ TEST_F(TlsPrivateKeyOffloadTest, OffloadWithCustomKeySignerAsync) {
   options.watch_identity_key_cert_pairs();
   options.set_identity_cert_name("identity");
   options.set_check_call_host(false);
+
+  DoRpc(server_addr_, options);
+}
+
+// Verifies that the server can successfully offload signing to an asynchronous
+// custom signer.
+TEST_F(TlsPrivateKeyOffloadTest,
+       OffloadWithCustomKeySignerAsyncWithoutSniMatch) {
+  server_addr_ = absl::StrCat("localhost:", grpc_pick_unused_port_or_die());
+  std::string server_key_0 =
+      grpc_core::testing::GetFileContents(std::string(kServerKey0Path));
+  std::string server_cert_0 =
+      grpc_core::testing::GetFileContents(std::string(kServerCert0Path));
+  std::string ca_cert =
+      grpc_core::testing::GetFileContents(std::string(kCaPemPath));
+
+  // SNI doesn't match so the default certificate will be used.
+  std::vector<experimental::IdentityKeyOrSignerCertPair>
+      server_identity_key_cert_pairs;
+  signer_ = std::make_shared<AsyncTestPrivateKeySigner>(server_key_0);
+  server_identity_key_cert_pairs.emplace_back(
+      grpc::experimental::IdentityKeyOrSignerCertPair{signer_, server_cert_0});
+  auto server_certificate_provider =
+      std::make_shared<experimental::InMemoryCertificateProvider>();
+  ASSERT_TRUE(server_certificate_provider
+                  ->UpdateIdentityKeyCertPair(server_identity_key_cert_pairs)
+                  .ok());
+  ASSERT_TRUE(server_certificate_provider->UpdateRoot(ca_cert).ok());
+
+  StartServer(server_certificate_provider);
+
+  std::string client_key =
+      grpc_core::testing::GetFileContents(std::string(kClientKeyPath));
+  std::string client_cert =
+      grpc_core::testing::GetFileContents(std::string(kClientCertPath));
+  auto client_certificate_provider =
+      std::make_shared<experimental::InMemoryCertificateProvider>();
+  std::vector<experimental::IdentityKeyCertPair> identity_key_cert_pairs;
+  identity_key_cert_pairs.emplace_back(
+      experimental::IdentityKeyCertPair{client_key, client_cert});
+  ASSERT_TRUE(client_certificate_provider
+                  ->UpdateIdentityKeyCertPair(identity_key_cert_pairs)
+                  .ok());
+  ASSERT_TRUE(client_certificate_provider->UpdateRoot(ca_cert).ok());
+
+  grpc::experimental::TlsChannelCredentialsOptions options;
+  options.set_certificate_provider(client_certificate_provider);
+  options.watch_root_certs();
+  options.set_root_cert_name("root");
+  options.watch_identity_key_cert_pairs();
+  options.set_identity_cert_name("identity");
+  // Skip the host name check intentionally so make sure the handshake succeeds.
+  options.set_certificate_verifier(
+      std::make_shared<experimental::NoOpCertificateVerifier>());
 
   DoRpc(server_addr_, options);
 }

--- a/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
+++ b/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
@@ -184,7 +184,8 @@ class TlsPrivateKeyOffloadTest : public ::testing::Test {
 };
 
 void DoRpc(const std::string& server_addr,
-           const experimental::TlsChannelCredentialsOptions& tls_options) {
+           const experimental::TlsChannelCredentialsOptions& tls_options,
+           bool expect_sni_match = false) {
   ChannelArguments channel_args;
   channel_args.SetSslTargetNameOverride("foo.test.google.fr");
   std::shared_ptr<Channel> channel = grpc::CreateCustomChannel(
@@ -198,6 +199,18 @@ void DoRpc(const std::string& server_addr,
   ClientContext context;
   context.set_deadline(grpc_timeout_seconds_to_deadline(/*time_s=*/5));
   grpc::Status result = stub->Echo(&context, request, &response);
+  if (expect_sni_match) {
+    std::vector<grpc::string_ref> san_names =
+        context.auth_context()->FindPropertyValues(GRPC_X509_SAN_PROPERTY_NAME);
+    bool sni_match = false;
+    for (const auto& san : san_names) {
+      if (san.ends_with("test.google.fr")) {
+        sni_match = true;
+        break;
+      }
+    }
+    EXPECT_TRUE(sni_match);
+  }
   EXPECT_TRUE(result.ok()) << result.error_message().c_str() << ", "
                            << result.error_details().c_str();
   EXPECT_EQ(response.message(), kMessage);

--- a/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
+++ b/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
@@ -66,8 +66,7 @@ namespace testing {
 namespace {
 
 constexpr absl::string_view kMessage = "Hello";
-constexpr absl::string_view kCaPemPath =
-    "src/core/tsi/test_creds/ca.pem";
+constexpr absl::string_view kCaPemPath = "src/core/tsi/test_creds/ca.pem";
 constexpr absl::string_view kServerKey0Path =
     "src/core/tsi/test_creds/server0.key";
 constexpr absl::string_view kServerCert0Path =

--- a/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
+++ b/test/cpp/end2end/tls_private_key_signer_end2end_test.cc
@@ -499,7 +499,7 @@ TEST_F(TlsPrivateKeyOffloadTest,
   options.set_root_cert_name("root");
   options.watch_identity_key_cert_pairs();
   options.set_identity_cert_name("identity");
-  // Skip the host name check intentionally so make sure the handshake succeeds.
+  // Skip the host name check so that the handshake can succeed.
   options.set_certificate_verifier(
       std::make_shared<experimental::NoOpCertificateVerifier>());
 


### PR DESCRIPTION
The server takes a vector of key/cert pairs for SNI. So it could have the same number of private key signers. Right now it keeps only one, which is incorrect.

This is a bug fix so it could be worth a patch release as suggested by @gtcooke94.

One open question is whether we should store the `key_signer` in the handshaker. As of now , I still find the code to be easier to read and manage by doing that, especially when we introduce the `key_signer` from the certificate selector later on. But I acknowledge in this case, key signers are 1-1 mapped to SSL_CTXs and there is some overhead by copying it to each handshaker and the ownership also gets less clear.
