### PR TITLE
Harden port parsing by rejecting malformed and out-of-range inputs

### DIFF
--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -55,6 +55,25 @@
 
 // IWYU pragma: no_include <arpa/inet.h>
 
+namespace {
+
+constexpr uint32_t kMaxPort = 65535;
+
+bool ParseNumericPort(absl::string_view port, uint16_t* out) {
+  if (port.empty()) return false;
+  uint32_t value = 0;
+  for (char c : port) {
+    if (c < '0' || c > '9') return false;
+    const uint32_t digit = static_cast<uint32_t>(c - '0');
+    if (value > (kMaxPort - digit) / 10) return false;
+    value = value * 10 + digit;
+  }
+  *out = static_cast<uint16_t>(value);
+  return true;
+}
+
+}  // namespace
+
 #ifdef GRPC_HAVE_UNIX_SOCKET
 
 bool grpc_parse_unix(const grpc_core::URI& uri,
@@ -235,13 +254,12 @@ bool grpc_parse_ipv4_hostport(absl::string_view hostport,
     if (log_errors) LOG(ERROR) << "no port given for ipv4 scheme";
     goto done;
   }
-  int port_num;
-  if (sscanf(port.c_str(), "%d", &port_num) != 1 || port_num < 0 ||
-      port_num > 65535) {
+  uint16_t port_num;
+  if (!ParseNumericPort(port, &port_num)) {
     if (log_errors) LOG(ERROR) << "invalid ipv4 port: '" << port << "'";
     goto done;
   }
-  in->sin_port = grpc_htons(static_cast<uint16_t>(port_num));
+  in->sin_port = grpc_htons(port_num);
   success = true;
 done:
   return success;
@@ -324,13 +342,12 @@ bool grpc_parse_ipv6_hostport(absl::string_view hostport,
     if (log_errors) LOG(ERROR) << "no port given for ipv6 scheme";
     goto done;
   }
-  int port_num;
-  if (sscanf(port.c_str(), "%d", &port_num) != 1 || port_num < 0 ||
-      port_num > 65535) {
+  uint16_t port_num;
+  if (!ParseNumericPort(port, &port_num)) {
     if (log_errors) LOG(ERROR) << "invalid ipv6 port: '" << port << "'";
     goto done;
   }
-  in6->sin6_port = grpc_htons(static_cast<uint16_t>(port_num));
+  in6->sin6_port = grpc_htons(port_num);
   success = true;
 done:
   return success;
@@ -368,12 +385,19 @@ bool grpc_parse_uri(const grpc_core::URI& uri,
 }
 
 uint16_t grpc_strhtons(const char* port) {
+  if (port == nullptr) {
+    return htons(0);
+  }
   if (strcmp(port, "http") == 0) {
     return htons(80);
   } else if (strcmp(port, "https") == 0) {
     return htons(443);
   }
-  return htons(static_cast<unsigned short>(atoi(port)));
+  uint16_t port_num;
+  if (!ParseNumericPort(port, &port_num)) {
+    return htons(0);
+  }
+  return htons(port_num);
 }
 
 namespace grpc_core {

--- a/test/core/address_utils/parse_address_test.cc
+++ b/test/core/address_utils/parse_address_test.cc
@@ -156,6 +156,18 @@ static void test_grpc_parse_ipv6(const char* uri_text, const char* host,
   ASSERT_EQ(addr_in6->sin6_scope_id, scope_id);
 }
 
+// Test parsing invalid ipv4 addresses (valid uri_text but invalid ipv4 addr)
+static void test_grpc_parse_ipv4_invalid(const char* uri_text) {
+  grpc_core::ExecCtx exec_ctx;
+  absl::StatusOr<grpc_core::URI> uri = grpc_core::URI::Parse(uri_text);
+  if (!uri.ok()) {
+    LOG(ERROR) << uri.status();
+    ASSERT_TRUE(uri.ok());
+  }
+  grpc_resolved_address addr;
+  ASSERT_FALSE(grpc_parse_ipv4(*uri, &addr));
+}
+
 // Test parsing invalid ipv6 addresses (valid uri_text but invalid ipv6 addr)
 static void test_grpc_parse_ipv6_invalid(const char* uri_text) {
   grpc_core::ExecCtx exec_ctx;
@@ -183,7 +195,26 @@ TEST(ParseAddressTest, MainTest) {
       "ipv6:WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW45%"
       "25v6:45%25x$1*");
 
+  // Ports must be decimal-only and bounded.
+  test_grpc_parse_ipv4_invalid("ipv4:192.0.2.1:12345junk");
+  test_grpc_parse_ipv4_invalid("ipv4:192.0.2.1:+12345");
+  test_grpc_parse_ipv4_invalid("ipv4:192.0.2.1:-1");
+  test_grpc_parse_ipv6_invalid("ipv6:[2001:db8::1]:12345junk");
+  test_grpc_parse_ipv6_invalid("ipv6:[2001:db8::1]:+12345");
+  test_grpc_parse_ipv6_invalid("ipv6:[2001:db8::1]:-1");
+
   grpc_shutdown();
+}
+
+TEST(ParseAddressTest, GrpcStrhtonsRejectsMalformedPorts) {
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons("http")), 80);
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons("https")), 443);
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons("65535")), 65535);
+
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons("65536")), 0);
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons("-1")), 0);
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons("80xyz")), 0);
+  ASSERT_EQ(grpc_ntohs(grpc_strhtons(nullptr)), 0);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION

## Summary

This change makes port parsing strict and consistent by rejecting malformed and out-of-range inputs.

Previously, parsing relied on `sscanf("%d")` and `atoi`, which allowed partial values like `"123abc"`, accepted signed inputs such as `"+123"` and `"-1"`, and could silently truncate large values (e.g. `"70000"`).

This patch introduces a small helper that parses ports as digits-only within `[0, 65535]`, and applies it across IPv4, IPv6, and `grpc_strhtons`. Invalid inputs are now consistently rejected, while valid inputs continue to behave the same.

Tests are added to cover malformed, out-of-range, and valid cases.