### PR TITLE
Harden port parsing and remove permissive atoi/sscanf

### DIFF
--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -50,10 +50,29 @@
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/strip.h"
 
 // IWYU pragma: no_include <arpa/inet.h>
+
+namespace {
+
+bool ParseNumericPort(absl::string_view port, uint16_t* out) {
+  if (port.empty()) return false;
+  for (char c : port) {
+    if (!absl::ascii_isdigit(c)) return false;
+  }
+  uint32_t parsed_port = 0;
+  if (!absl::SimpleAtoi(port, &parsed_port) || parsed_port > 65535) {
+    return false;
+  }
+  *out = static_cast<uint16_t>(parsed_port);
+  return true;
+}
+
+}  // namespace
 
 #ifdef GRPC_HAVE_UNIX_SOCKET
 
@@ -180,7 +199,9 @@ grpc_error_handle VSockaddrPopulate(absl::string_view path,
       reinterpret_cast<struct sockaddr_vm*>(resolved_addr->addr);
   vm->svm_family = AF_VSOCK;
   std::string s = std::string(path);
-  if (sscanf(s.c_str(), "%u:%u", &vm->svm_cid, &vm->svm_port) != 2) {
+  char trailing = '\0';
+  if (sscanf(s.c_str(), "%u:%u%c", &vm->svm_cid, &vm->svm_port,
+             &trailing) != 2) {
     return GRPC_ERROR_CREATE(
         absl::StrCat("Failed to parse vsock cid/port: ", s));
   }
@@ -235,13 +256,12 @@ bool grpc_parse_ipv4_hostport(absl::string_view hostport,
     if (log_errors) LOG(ERROR) << "no port given for ipv4 scheme";
     goto done;
   }
-  int port_num;
-  if (sscanf(port.c_str(), "%d", &port_num) != 1 || port_num < 0 ||
-      port_num > 65535) {
+  uint16_t port_num;
+  if (!ParseNumericPort(port, &port_num)) {
     if (log_errors) LOG(ERROR) << "invalid ipv4 port: '" << port << "'";
     goto done;
   }
-  in->sin_port = grpc_htons(static_cast<uint16_t>(port_num));
+  in->sin_port = grpc_htons(port_num);
   success = true;
 done:
   return success;
@@ -324,13 +344,12 @@ bool grpc_parse_ipv6_hostport(absl::string_view hostport,
     if (log_errors) LOG(ERROR) << "no port given for ipv6 scheme";
     goto done;
   }
-  int port_num;
-  if (sscanf(port.c_str(), "%d", &port_num) != 1 || port_num < 0 ||
-      port_num > 65535) {
+  uint16_t port_num;
+  if (!ParseNumericPort(port, &port_num)) {
     if (log_errors) LOG(ERROR) << "invalid ipv6 port: '" << port << "'";
     goto done;
   }
-  in6->sin6_port = grpc_htons(static_cast<uint16_t>(port_num));
+  in6->sin6_port = grpc_htons(port_num);
   success = true;
 done:
   return success;
@@ -368,12 +387,19 @@ bool grpc_parse_uri(const grpc_core::URI& uri,
 }
 
 uint16_t grpc_strhtons(const char* port) {
+  if (port == nullptr) {
+    return htons(0);
+  }
   if (strcmp(port, "http") == 0) {
     return htons(80);
   } else if (strcmp(port, "https") == 0) {
     return htons(443);
   }
-  return htons(static_cast<unsigned short>(atoi(port)));
+  uint16_t numeric_port;
+  if (!ParseNumericPort(port, &numeric_port)) {
+    return htons(0);
+  }
+  return htons(numeric_port);
 }
 
 namespace grpc_core {

--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -65,6 +65,8 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -944,7 +946,21 @@ static bool inner_resolve_as_ip_literal_locked(
     *port = default_port;
   }
   grpc_resolved_address addr;
-  *hostport = grpc_core::JoinHostPort(*host, atoi(port->c_str()));
+  for (char c : *port) {
+    if (!absl::ascii_isdigit(c)) {
+      LOG(ERROR) << "Port is not a valid decimal number in " << name
+                 << " while attempting to resolve as ip literal.";
+      return false;
+    }
+  }
+  int parsed_port = 0;
+  if (!absl::SimpleAtoi(*port, &parsed_port) || parsed_port < 0 ||
+      parsed_port > 65535) {
+    LOG(ERROR) << "Port is out of range in " << name
+               << " while attempting to resolve as ip literal.";
+    return false;
+  }
+  *hostport = grpc_core::JoinHostPort(*host, parsed_port);
   if (grpc_parse_ipv4_hostport(hostport->c_str(), &addr,
                                false /* log errors */) ||
       grpc_parse_ipv6_hostport(hostport->c_str(), &addr,

--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -946,25 +946,9 @@ static bool inner_resolve_as_ip_literal_locked(
     *port = default_port;
   }
   grpc_resolved_address addr;
-  for (char c : *port) {
-    if (!absl::ascii_isdigit(c)) {
-      LOG(ERROR) << "Port is not a valid decimal number in " << name
-                 << " while attempting to resolve as ip literal.";
-      return false;
-    }
-  }
-  int parsed_port = 0;
-  if (!absl::SimpleAtoi(*port, &parsed_port) || parsed_port < 0 ||
-      parsed_port > 65535) {
-    LOG(ERROR) << "Port is out of range in " << name
-               << " while attempting to resolve as ip literal.";
-    return false;
-  }
-  *hostport = grpc_core::JoinHostPort(*host, parsed_port);
-  if (grpc_parse_ipv4_hostport(hostport->c_str(), &addr,
-                               false /* log errors */) ||
-      grpc_parse_ipv6_hostport(hostport->c_str(), &addr,
-                               false /* log errors */)) {
+  *hostport = grpc_core::JoinHostPort(*host, *port);
+  if (grpc_parse_ipv4_hostport(*hostport, &addr, false /* log errors */) ||
+      grpc_parse_ipv6_hostport(*hostport, &addr, false /* log errors */)) {
     GRPC_CHECK(*addrs == nullptr);
     *addrs = std::make_unique<EndpointAddressesList>();
     (*addrs)->emplace_back(addr, grpc_core::ChannelArgs());

--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -65,8 +65,6 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "absl/strings/ascii.h"
-#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 
@@ -946,21 +944,11 @@ static bool inner_resolve_as_ip_literal_locked(
     *port = default_port;
   }
   grpc_resolved_address addr;
-  for (char c : *port) {
-    if (!absl::ascii_isdigit(c)) {
-      LOG(ERROR) << "Port is not a valid decimal number in " << name
-                 << " while attempting to resolve as ip literal.";
-      return false;
-    }
-  }
-  int parsed_port = 0;
-  if (!absl::SimpleAtoi(*port, &parsed_port) || parsed_port < 0 ||
-      parsed_port > 65535) {
-    LOG(ERROR) << "Port is out of range in " << name
-               << " while attempting to resolve as ip literal.";
-    return false;
-  }
-  *hostport = grpc_core::JoinHostPort(*host, parsed_port);
+  // Keep the port as a string and let grpc_parse_ipv4_hostport /
+  // grpc_parse_ipv6_hostport validate it, rather than re-implementing the
+  // numeric checks here. Using atoi() previously accepted malformed ports such
+  // as "1234x" by silently truncating them.
+  *hostport = grpc_core::JoinHostPort(*host, *port);
   if (grpc_parse_ipv4_hostport(*hostport, &addr, false /* log errors */) ||
       grpc_parse_ipv6_hostport(*hostport, &addr, false /* log errors */)) {
     GRPC_CHECK(*addrs == nullptr);

--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -946,7 +946,21 @@ static bool inner_resolve_as_ip_literal_locked(
     *port = default_port;
   }
   grpc_resolved_address addr;
-  *hostport = grpc_core::JoinHostPort(*host, *port);
+  for (char c : *port) {
+    if (!absl::ascii_isdigit(c)) {
+      LOG(ERROR) << "Port is not a valid decimal number in " << name
+                 << " while attempting to resolve as ip literal.";
+      return false;
+    }
+  }
+  int parsed_port = 0;
+  if (!absl::SimpleAtoi(*port, &parsed_port) || parsed_port < 0 ||
+      parsed_port > 65535) {
+    LOG(ERROR) << "Port is out of range in " << name
+               << " while attempting to resolve as ip literal.";
+    return false;
+  }
+  *hostport = grpc_core::JoinHostPort(*host, parsed_port);
   if (grpc_parse_ipv4_hostport(*hostport, &addr, false /* log errors */) ||
       grpc_parse_ipv6_hostport(*hostport, &addr, false /* log errors */)) {
     GRPC_CHECK(*addrs == nullptr);

--- a/src/core/util/host_port.cc
+++ b/src/core/util/host_port.cc
@@ -36,6 +36,15 @@ std::string JoinHostPort(absl::string_view host, int port) {
   return absl::StrFormat("%s:%d", host, port);
 }
 
+std::string JoinHostPort(absl::string_view host, absl::string_view port) {
+  if (!host.empty() && host[0] != '[' && host.rfind(':') != host.npos) {
+    // IPv6 literals must be enclosed in brackets.
+    return absl::StrFormat("[%s]:%s", host, port);
+  }
+  // Ordinary non-bracketed host:port.
+  return absl::StrFormat("%s:%s", host, port);
+}
+
 namespace {
 bool DoSplitHostPort(absl::string_view name, absl::string_view* host,
                      absl::string_view* port, bool* has_port) {

--- a/src/core/util/host_port.h
+++ b/src/core/util/host_port.h
@@ -33,6 +33,12 @@ namespace grpc_core {
 // brackets will not be added.
 std::string JoinHostPort(absl::string_view host, int port);
 
+// Overload that keeps the port as a string rather than an int. Useful when the
+// caller wants the original (possibly invalid) port text preserved so that a
+// downstream parser can validate it, instead of being silently normalised by an
+// integer conversion.
+std::string JoinHostPort(absl::string_view host, absl::string_view port);
+
 /// Given a name in the form "host:port" or "[ho:st]:port", split into hostname
 /// and port number.
 

--- a/test/core/address_utils/parse_address_test.cc
+++ b/test/core/address_utils/parse_address_test.cc
@@ -183,6 +183,19 @@ TEST(ParseAddressTest, MainTest) {
       "ipv6:WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW45%"
       "25v6:45%25x$1*");
 
+  grpc_resolved_address addr;
+  EXPECT_FALSE(grpc_parse_ipv4_hostport("192.0.2.1:12345x", &addr, false));
+  EXPECT_FALSE(grpc_parse_ipv4_hostport("192.0.2.1:+12345", &addr, false));
+  EXPECT_FALSE(
+      grpc_parse_ipv6_hostport("[2001:db8::1]:12345x", &addr, false));
+  EXPECT_FALSE(
+      grpc_parse_ipv6_hostport("[2001:db8::1]:+12345", &addr, false));
+  EXPECT_EQ(grpc_ntohs(grpc_strhtons("http")), 80);
+  EXPECT_EQ(grpc_ntohs(grpc_strhtons("https")), 443);
+  EXPECT_EQ(grpc_ntohs(grpc_strhtons("12345")), 12345);
+  EXPECT_EQ(grpc_ntohs(grpc_strhtons("70000")), 0);
+  EXPECT_EQ(grpc_ntohs(grpc_strhtons("12345x")), 0);
+
   grpc_shutdown();
 }
 


### PR DESCRIPTION
This change hardens port parsing across core address utilities and resolver paths by replacing permissive and unsafe parsing patterns with strict range-checked validation.

Introduces a centralized `ParseNumericPort()` helper that:
  - Accepts only decimal digits
  - Uses `absl::SimpleAtoi` for checked conversion
  
Replaces permissive parsing in:
  - IPv4 host/port parsing
  - IPv6 host/port parsing
  - `grpc_strhtons`
  - DNS resolver literal handling path
  
Tightens vsock parsing by requiring full input consumption

Eliminates all uses of `atoi()` in affected paths