### PR TITLE
[Fixit2026] Remove stale experiment event_engine_dns_non_client_channel

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -26,11 +26,10 @@ EXPERIMENT_ENABLES = {
     "error_flatten": "error_flatten",
     "event_engine_client": "event_engine_client",
     "event_engine_dns": "event_engine_dns",
-    "event_engine_dns_non_client_channel": "event_engine_dns_non_client_channel",
     "event_engine_fork": "event_engine_fork",
     "event_engine_listener": "event_engine_listener",
     "event_engine_callback_cq": "event_engine_callback_cq,event_engine_client,event_engine_listener",
-    "event_engine_for_all_other_endpoints": "event_engine_client,event_engine_dns,event_engine_dns_non_client_channel,event_engine_for_all_other_endpoints,event_engine_listener",
+    "event_engine_for_all_other_endpoints": "event_engine_client,event_engine_dns,event_engine_for_all_other_endpoints,event_engine_listener",
     "event_engine_poller_for_python": "event_engine_poller_for_python",
     "fail_recv_metadata_on_deadline_exceeded": "fail_recv_metadata_on_deadline_exceeded",
     "free_large_allocator": "free_large_allocator",
@@ -74,7 +73,6 @@ EXPERIMENT_ENABLES = {
 EXPERIMENT_POLLERS = [
     "event_engine_client",
     "event_engine_dns",
-    "event_engine_dns_non_client_channel",
     "event_engine_fork",
     "event_engine_listener",
     "event_engine_for_all_other_endpoints",
@@ -98,7 +96,6 @@ EXPERIMENTS = {
             ],
             "core_end2end_test": [
                 "event_engine_client",
-                "event_engine_dns_non_client_channel",
                 "event_engine_for_all_other_endpoints",
                 "event_engine_fork",
                 "event_engine_listener",
@@ -132,7 +129,6 @@ EXPERIMENTS = {
             ],
             "core_end2end_test": [
                 "event_engine_client",
-                "event_engine_dns_non_client_channel",
                 "event_engine_for_all_other_endpoints",
                 "event_engine_fork",
                 "event_engine_listener",
@@ -211,7 +207,6 @@ EXPERIMENTS = {
             "core_end2end_test": [
                 "error_flatten",
                 "event_engine_client",
-                "event_engine_dns_non_client_channel",
                 "event_engine_for_all_other_endpoints",
                 "event_engine_fork",
                 "event_engine_listener",

--- a/src/core/ext/transport/chaotic_good/server/chaotic_good_server.cc
+++ b/src/core/ext/transport/chaotic_good/server/chaotic_good_server.cc
@@ -696,8 +696,7 @@ absl::StatusOr<int> AddChaoticGoodPort(Server* server, std::string addr,
   const std::string parsed_addr = URI::PercentDecode(addr);
   absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> results =
       std::vector<EventEngine::ResolvedAddress>();
-  if (IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
+  if (!grpc_event_engine::experimental::
           EventEngineExperimentDisabledForPython()) {
     absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver =
         args.GetObjectRef<EventEngine>()->GetDNSResolver(

--- a/src/core/ext/transport/chaotic_good_legacy/server/chaotic_good_server.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/server/chaotic_good_server.cc
@@ -489,8 +489,7 @@ absl::StatusOr<int> AddLegacyChaoticGoodPort(Server* server, std::string addr,
   const std::string parsed_addr = URI::PercentDecode(addr);
   absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> results =
       std::vector<EventEngine::ResolvedAddress>();
-  if (IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
+  if (!grpc_event_engine::experimental::
           EventEngineExperimentDisabledForPython()) {
     absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver =
         args.GetObjectRef<EventEngine>()->GetDNSResolver(

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -646,8 +646,7 @@ absl::StatusOr<int> Chttp2ServerAddPort(Server* server, const char* addr,
       resolved = grpc_resolve_vsock_address(parsed_addr_unprefixed);
       GRPC_RETURN_IF_ERROR(resolved.status());
     } else {
-      if (IsEventEngineDnsNonClientChannelEnabled() &&
-          !grpc_event_engine::experimental::
+      if (!grpc_event_engine::experimental::
               EventEngineExperimentDisabledForPython()) {
         absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver =
             args.GetObjectRef<EventEngine>()->GetDNSResolver(

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -57,11 +57,6 @@ const char* const additional_constraints_event_engine_client = "{}";
 const char* const description_event_engine_dns =
     "If set, use EventEngine DNSResolver for client channel resolution";
 const char* const additional_constraints_event_engine_dns = "{}";
-const char* const description_event_engine_dns_non_client_channel =
-    "If set, use EventEngine DNSResolver in other places besides client "
-    "channel.";
-const char* const additional_constraints_event_engine_dns_non_client_channel =
-    "{}";
 const char* const description_event_engine_fork =
     "Enables event engine fork handling, including onfork events and file "
     "descriptor generations";
@@ -83,8 +78,6 @@ const char* const additional_constraints_event_engine_for_all_other_endpoints =
 const uint8_t required_experiments_event_engine_for_all_other_endpoints[] = {
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineClient),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineDns),
-    static_cast<uint8_t>(
-        grpc_core::kExperimentIdEventEngineDnsNonClientChannel),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineListener)};
 const char* const description_event_engine_poller_for_python =
     "Enable event engine poller in gRPC Python";
@@ -269,10 +262,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_event_engine_client, nullptr, 0, true, false},
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, nullptr, 0, true, false},
-    {"event_engine_dns_non_client_channel",
-     description_event_engine_dns_non_client_channel,
-     additional_constraints_event_engine_dns_non_client_channel, nullptr, 0,
-     true, false},
     {"event_engine_fork", description_event_engine_fork,
      additional_constraints_event_engine_fork, nullptr, 0, true, false},
     {"event_engine_listener", description_event_engine_listener,
@@ -283,7 +272,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_for_all_other_endpoints",
      description_event_engine_for_all_other_endpoints,
      additional_constraints_event_engine_for_all_other_endpoints,
-     required_experiments_event_engine_for_all_other_endpoints, 4, true, false},
+     required_experiments_event_engine_for_all_other_endpoints, 3, true, false},
     {"event_engine_poller_for_python",
      description_event_engine_poller_for_python,
      additional_constraints_event_engine_poller_for_python, nullptr, 0, true,
@@ -448,11 +437,6 @@ const char* const additional_constraints_event_engine_client = "{}";
 const char* const description_event_engine_dns =
     "If set, use EventEngine DNSResolver for client channel resolution";
 const char* const additional_constraints_event_engine_dns = "{}";
-const char* const description_event_engine_dns_non_client_channel =
-    "If set, use EventEngine DNSResolver in other places besides client "
-    "channel.";
-const char* const additional_constraints_event_engine_dns_non_client_channel =
-    "{}";
 const char* const description_event_engine_fork =
     "Enables event engine fork handling, including onfork events and file "
     "descriptor generations";
@@ -474,8 +458,6 @@ const char* const additional_constraints_event_engine_for_all_other_endpoints =
 const uint8_t required_experiments_event_engine_for_all_other_endpoints[] = {
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineClient),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineDns),
-    static_cast<uint8_t>(
-        grpc_core::kExperimentIdEventEngineDnsNonClientChannel),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineListener)};
 const char* const description_event_engine_poller_for_python =
     "Enable event engine poller in gRPC Python";
@@ -660,10 +642,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_event_engine_client, nullptr, 0, true, false},
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, nullptr, 0, true, false},
-    {"event_engine_dns_non_client_channel",
-     description_event_engine_dns_non_client_channel,
-     additional_constraints_event_engine_dns_non_client_channel, nullptr, 0,
-     true, false},
     {"event_engine_fork", description_event_engine_fork,
      additional_constraints_event_engine_fork, nullptr, 0, true, false},
     {"event_engine_listener", description_event_engine_listener,
@@ -674,7 +652,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_for_all_other_endpoints",
      description_event_engine_for_all_other_endpoints,
      additional_constraints_event_engine_for_all_other_endpoints,
-     required_experiments_event_engine_for_all_other_endpoints, 4, true, false},
+     required_experiments_event_engine_for_all_other_endpoints, 3, true, false},
     {"event_engine_poller_for_python",
      description_event_engine_poller_for_python,
      additional_constraints_event_engine_poller_for_python, nullptr, 0, true,
@@ -839,11 +817,6 @@ const char* const additional_constraints_event_engine_client = "{}";
 const char* const description_event_engine_dns =
     "If set, use EventEngine DNSResolver for client channel resolution";
 const char* const additional_constraints_event_engine_dns = "{}";
-const char* const description_event_engine_dns_non_client_channel =
-    "If set, use EventEngine DNSResolver in other places besides client "
-    "channel.";
-const char* const additional_constraints_event_engine_dns_non_client_channel =
-    "{}";
 const char* const description_event_engine_fork =
     "Enables event engine fork handling, including onfork events and file "
     "descriptor generations";
@@ -865,8 +838,6 @@ const char* const additional_constraints_event_engine_for_all_other_endpoints =
 const uint8_t required_experiments_event_engine_for_all_other_endpoints[] = {
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineClient),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineDns),
-    static_cast<uint8_t>(
-        grpc_core::kExperimentIdEventEngineDnsNonClientChannel),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineListener)};
 const char* const description_event_engine_poller_for_python =
     "Enable event engine poller in gRPC Python";
@@ -1051,10 +1022,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      additional_constraints_event_engine_client, nullptr, 0, true, false},
     {"event_engine_dns", description_event_engine_dns,
      additional_constraints_event_engine_dns, nullptr, 0, true, false},
-    {"event_engine_dns_non_client_channel",
-     description_event_engine_dns_non_client_channel,
-     additional_constraints_event_engine_dns_non_client_channel, nullptr, 0,
-     true, false},
     {"event_engine_fork", description_event_engine_fork,
      additional_constraints_event_engine_fork, nullptr, 0, true, false},
     {"event_engine_listener", description_event_engine_listener,
@@ -1065,7 +1032,7 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"event_engine_for_all_other_endpoints",
      description_event_engine_for_all_other_endpoints,
      additional_constraints_event_engine_for_all_other_endpoints,
-     required_experiments_event_engine_for_all_other_endpoints, 4, true, false},
+     required_experiments_event_engine_for_all_other_endpoints, 3, true, false},
     {"event_engine_poller_for_python",
      description_event_engine_poller_for_python,
      additional_constraints_event_engine_poller_for_python, nullptr, 0, true,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -76,8 +76,6 @@ inline bool IsErrorFlattenEnabled() { return true; }
 inline bool IsEventEngineClientEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
 inline bool IsEventEngineDnsEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS_NON_CLIENT_CHANNEL
-inline bool IsEventEngineDnsNonClientChannelEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FORK
 inline bool IsEventEngineForkEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
@@ -151,8 +149,6 @@ inline bool IsErrorFlattenEnabled() { return true; }
 inline bool IsEventEngineClientEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
 inline bool IsEventEngineDnsEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS_NON_CLIENT_CHANNEL
-inline bool IsEventEngineDnsNonClientChannelEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FORK
 inline bool IsEventEngineForkEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
@@ -226,8 +222,6 @@ inline bool IsErrorFlattenEnabled() { return true; }
 inline bool IsEventEngineClientEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
 inline bool IsEventEngineDnsEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS_NON_CLIENT_CHANNEL
-inline bool IsEventEngineDnsNonClientChannelEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FORK
 inline bool IsEventEngineForkEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_LISTENER
@@ -293,7 +287,6 @@ enum ExperimentIds {
   kExperimentIdErrorFlatten,
   kExperimentIdEventEngineClient,
   kExperimentIdEventEngineDns,
-  kExperimentIdEventEngineDnsNonClientChannel,
   kExperimentIdEventEngineFork,
   kExperimentIdEventEngineListener,
   kExperimentIdEventEngineCallbackCq,
@@ -375,10 +368,6 @@ inline bool IsEventEngineClientEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS
 inline bool IsEventEngineDnsEnabled() {
   return IsExperimentEnabled<kExperimentIdEventEngineDns>();
-}
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_DNS_NON_CLIENT_CHANNEL
-inline bool IsEventEngineDnsNonClientChannelEnabled() {
-  return IsExperimentEnabled<kExperimentIdEventEngineDnsNonClientChannel>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FORK
 inline bool IsEventEngineForkEnabled() {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -107,14 +107,6 @@
   allow_in_fuzzing_config: false
   uses_polling: true
   platforms: ["all"]
-- name: event_engine_dns_non_client_channel
-  description: If set, use EventEngine DNSResolver in other places besides client channel.
-  expiry: 2026/04/23
-  owner: mlumish@google.com
-  test_tags: ["core_end2end_test"]
-  allow_in_fuzzing_config: false
-  uses_polling: true
-  platforms: ["all"]
 - name: event_engine_for_all_other_endpoints
   description: Use EventEngine endpoints for all call sites, including direct uses of grpc_tcp_create.
   expiry: 2026/04/23

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -119,7 +119,6 @@
       "event_engine_client",
       "event_engine_listener",
       "event_engine_dns",
-      "event_engine_dns_non_client_channel",
     ]
   platforms: ["all"]
 - name: event_engine_fork

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -54,8 +54,6 @@
   default: true
 - name: event_engine_dns
   default: true
-- name: event_engine_dns_non_client_channel
-  default: true
 - name: event_engine_for_all_other_endpoints
   default: true
 - name: event_engine_fork

--- a/src/core/util/http_client/httpcli.cc
+++ b/src/core/util/http_client/httpcli.cc
@@ -177,7 +177,6 @@ HttpRequest::HttpRequest(
       pollset_set_(grpc_pollset_set_create()),
       test_only_generate_response_(std::move(test_only_generate_response)),
       use_event_engine_dns_resolver_(
-          IsEventEngineDnsNonClientChannelEnabled() &&
           !grpc_event_engine::experimental::
               EventEngineExperimentDisabledForPython()),
       resolver_(!use_event_engine_dns_resolver_ ? GetDNSResolver() : nullptr),

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -909,8 +909,7 @@ inline bool IsTestSampledInPr(const CoreTestConfiguration* config) {
     }                                                                          \
     SKIP_IF_DISABLED_IN_CONFIG(config, #suite, #name);                         \
     SKIP_IF_NOT_SAMPLED_IN_PR(config);                                         \
-    if (IsEventEngineDnsNonClientChannelEnabled() &&                           \
-        !grpc_event_engine::experimental::                                     \
+    if (!grpc_event_engine::experimental::                                     \
             EventEngineExperimentDisabledForPython()) {                        \
       GTEST_SKIP() << "event_engine_dns_non_client_channel experiment breaks " \
                       "fuzzing currently";                                     \

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -592,8 +592,7 @@ static void on_read_request_done_locked(void* arg, grpc_error_handle error) {
   // Resolve address.
   grpc_resolved_address first_address;
   VLOG(2) << "proxy connecting to backend: " << conn->http_request.path;
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
+  if (!grpc_event_engine::experimental::
           EventEngineExperimentDisabledForPython()) {
     auto resolver = conn->proxy->combiner->event_engine->GetDNSResolver(
         grpc_event_engine::experimental::EventEngine::DNSResolver::

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -254,7 +254,6 @@ bool IsSaneTimerEnvironment() {
   return grpc_core::IsEventEngineClientEnabled() &&
          grpc_core::IsEventEngineListenerEnabled() &&
          grpc_core::IsEventEngineDnsEnabled() &&
-         grpc_core::IsEventEngineDnsNonClientChannelEnabled() &&
          !grpc_event_engine::experimental::
              EventEngineExperimentDisabledForPython();
 }

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -794,8 +794,7 @@ class FuzzerDNSResolver : public ExtendedType<EventEngine::DNSResolver,
 absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>>
 FuzzingEventEngine::GetDNSResolver(const DNSResolver::ResolverOptions&) {
 #if defined(GRPC_POSIX_SOCKET_TCP)
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
+  if (!grpc_event_engine::experimental::
           EventEngineExperimentDisabledForPython()) {
     return std::make_unique<FuzzerDNSResolver>(shared_from_this());
   }

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -177,13 +177,8 @@ static void test_named_and_numeric_scope_ids(void) {
 ABSL_FLAG(std::string, resolver, "", "Resolver type (ares or native)");
 
 TEST(ResolveAddressUsingAresResolverPosixTest, MainTest) {
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() ||
-      grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
-    GTEST_SKIP()
-        << "The event_engine_dns_non_client_channel experiment is "
-           "enabled, so the legacy resolver is not used in this binary.";
-  }
+  GTEST_SKIP() << "The event_engine_dns_non_client_channel experiment is "
+                  "enabled, so the legacy resolver is not used in this binary.";
   // First set the resolver type based off of --resolver
   std::string resolver_type = absl::GetFlag(FLAGS_resolver);
   // In case that there are more than one argument on the command line,

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -135,20 +135,14 @@ void test_bind_server_to_addr(const char* host, bool secure) {
 }
 
 static bool external_dns_works(const char* host) {
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() ||
-      grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
-    auto resolver =
-        grpc_event_engine::experimental::GetDefaultEventEngine()
-            ->GetDNSResolver(grpc_event_engine::experimental::EventEngine::
-                                 DNSResolver::ResolverOptions());
-    if (!resolver.ok()) return false;
-    return grpc_event_engine::experimental::LookupHostnameBlocking(
-               resolver->get(), host, "80")
-        .ok();
-  } else {
-    return grpc_core::GetDNSResolver()->LookupHostnameBlocking(host, "80").ok();
-  }
+  auto resolver =
+      grpc_event_engine::experimental::GetDefaultEventEngine()->GetDNSResolver(
+          grpc_event_engine::experimental::EventEngine::DNSResolver::
+              ResolverOptions());
+  if (!resolver.ok()) return false;
+  return grpc_event_engine::experimental::LookupHostnameBlocking(
+             resolver->get(), host, "80")
+      .ok();
 }
 
 static void test_bind_server_to_addrs(const char** addrs, size_t n) {

--- a/test/core/test_util/resolve_localhost_ip46.cc
+++ b/test/core/test_util/resolve_localhost_ip46.cc
@@ -41,8 +41,7 @@ bool localhost_to_ipv6 = false;
 gpr_once g_resolve_localhost_ipv46 = GPR_ONCE_INIT;
 
 void InitResolveLocalhost() {
-  if (IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
+  if (!grpc_event_engine::experimental::
           EventEngineExperimentDisabledForPython()) {
     auto resolver =
         grpc_event_engine::experimental::GetDefaultEventEngine()

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -134,8 +134,7 @@ class Client {
   void Connect() {
     ExecCtx exec_ctx;
     grpc_resolved_address addr;
-    if (IsEventEngineDnsNonClientChannelEnabled() &&
-        !grpc_event_engine::experimental::
+    if (!grpc_event_engine::experimental::
             EventEngineExperimentDisabledForPython()) {
       auto resolver =
           grpc_event_engine::experimental::GetDefaultEventEngine()


### PR DESCRIPTION
[Fixit2026] Remove stale experiment event_engine_dns_non_client_channel

1. Reference : https://github.com/grpc/grpc/blame/8a06f006d0f81f8613dddd7edc6e0f9614c67e87/src/core/lib/experiments/rollouts.yaml#L57 . Experiment `event_engine_dns_non_client_channel` was enabled 11 months ago. 
2. It runs the `core_end2end_test` on `all` platforms which is expensive.
3. It is enabled internally too. 
4. It appears that this experiment is safe to delete

However, the owner of the experiment is the best judge of whether there was pending work for this experiment or is it safe to delete.