### PR TITLE
[Ruby] Fix interceptor metadata not applied to streaming calls with return_op: true

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -43,6 +43,10 @@ module GRPC
     include Core::TimeConsts
     include Core::CallOps
     extend Forwardable
+    # metadata_to_send is the live hash of client metadata that will be sent
+    # on the next call. Client interceptors may mutate it in place (add or
+    # delete keys) before the underlying RPC method is invoked; mutations after
+    # metadata has been sent (i.e. once metadata_sent is true) have no effect.
     attr_reader :deadline, :metadata_sent, :metadata_to_send, :peer, :peer_cert
     def_delegators :@call, :cancel, :cancel_with_status, :metadata,
                    :write_flag, :write_flag=, :trailing_metadata, :status

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -170,6 +170,9 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          # Sync back the fully merged metadata (including anything added by
+          # merge_metadata_to_send) so that interceptors see the complete
+          # metadata context when the operation is executed lazily.
           updated_metadata = c.metadata_to_send.dup
           intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:request_response, intercept_args) do
@@ -249,6 +252,9 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          # Sync back the fully merged metadata (including anything added by
+          # merge_metadata_to_send) so that interceptors see the complete
+          # metadata context when the operation is executed lazily.
           updated_metadata = c.metadata_to_send.dup
           intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:client_streamer, intercept_args) do
@@ -343,6 +349,9 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          # Sync back the fully merged metadata (including anything added by
+          # merge_metadata_to_send) so that interceptors see the complete
+          # metadata context when the operation is executed lazily.
           updated_metadata = c.metadata_to_send.dup
           intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:server_streamer, intercept_args) do
@@ -467,6 +476,9 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          # Sync back the fully merged metadata (including anything added by
+          # merge_metadata_to_send) so that interceptors see the complete
+          # metadata context when the operation is executed lazily.
           updated_metadata = c.metadata_to_send.dup
           intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:bidi_streamer, intercept_args) do

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -170,8 +170,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:request_response, intercept_args) do
-            c.request_response(req, metadata: metadata)
+            c.request_response(req, metadata: updated_metadata)
           end
         end
         op
@@ -247,8 +249,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:client_streamer, intercept_args) do
-            c.client_streamer(requests)
+            c.client_streamer(requests, metadata: updated_metadata)
           end
         end
         op
@@ -339,8 +343,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:server_streamer, intercept_args) do
-            c.server_streamer(req, &blk)
+            c.server_streamer(req, metadata: updated_metadata, &blk)
           end
         end
         op
@@ -461,8 +467,10 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
+          updated_metadata = c.metadata_to_send.dup
+          intercept_args[:metadata] = updated_metadata
           interception_context.intercept!(:bidi_streamer, intercept_args) do
-            c.bidi_streamer(requests, &blk)
+            c.bidi_streamer(requests, metadata: updated_metadata, &blk)
           end
         end
         op

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -419,19 +419,19 @@ module GRPC
 
     private
 
-    # Merges caller metadata into c.metadata_to_send and exposes that live
-    # hash to interceptors via intercept_args[:metadata], so interceptors
-    # can add or remove keys in place and the mutations propagate to the
-    # wire without a redundant merge. Wraps the call in the interception
-    # chain; when return_op is true, the chain is deferred into the op's
-    # execute singleton method. The block is the underlying ActiveCall
-    # invocation and is invoked inside intercept!.
-    def intercept_and_invoke(c, type, intercept_args, return_op, &block)
-      c.merge_metadata_to_send(intercept_args[:metadata])
-      intercept_args[:metadata] = c.metadata_to_send
+    # Merges caller metadata into active_call.metadata_to_send and exposes
+    # that live hash to interceptors via intercept_args[:metadata], so
+    # interceptors can add or remove keys in place and the mutations
+    # propagate to the wire without a redundant merge. Wraps the call in
+    # the interception chain; when return_op is true, the chain is
+    # deferred into the op's execute singleton method. The block is the
+    # underlying ActiveCall invocation and is invoked inside intercept!.
+    def intercept_and_invoke(active_call, type, intercept_args, return_op, &block)
+      active_call.merge_metadata_to_send(intercept_args[:metadata])
+      intercept_args[:metadata] = active_call.metadata_to_send
       interception_context = @interceptors.build_context
       if return_op
-        op = c.operation
+        op = active_call.operation
         op.define_singleton_method(:execute) do
           interception_context.intercept!(type, intercept_args, &block)
         end

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -157,32 +157,14 @@ module GRPC
                           deadline: deadline,
                           parent: parent,
                           credentials: credentials)
-      interception_context = @interceptors.build_context
       intercept_args = {
         method: method,
         request: req,
         call: c.interceptable,
         metadata: metadata
       }
-      if return_op
-        # return the operation view of the active_call; define #execute as a
-        # new method for this instance that invokes #request_response.
-        c.merge_metadata_to_send(metadata)
-        op = c.operation
-        op.define_singleton_method(:execute) do
-          # Expose the live metadata_to_send hash so interceptors see the
-          # fully merged metadata and can add or remove keys in place before
-          # the request is sent.
-          intercept_args[:metadata] = c.metadata_to_send
-          interception_context.intercept!(:request_response, intercept_args) do
-            c.request_response(req)
-          end
-        end
-        op
-      else
-        interception_context.intercept!(:request_response, intercept_args) do
-          c.request_response(req, metadata: metadata)
-        end
+      intercept_and_invoke(c, :request_response, intercept_args, return_op) do
+        c.request_response(req)
       end
     end
 
@@ -238,32 +220,14 @@ module GRPC
                           deadline: deadline,
                           parent: parent,
                           credentials: credentials)
-      interception_context = @interceptors.build_context
       intercept_args = {
         method: method,
         requests: requests,
         call: c.interceptable,
         metadata: metadata
       }
-      if return_op
-        # return the operation view of the active_call; define #execute as a
-        # new method for this instance that invokes #client_streamer.
-        c.merge_metadata_to_send(metadata)
-        op = c.operation
-        op.define_singleton_method(:execute) do
-          # Expose the live metadata_to_send hash so interceptors see the
-          # fully merged metadata and can add or remove keys in place before
-          # the request is sent.
-          intercept_args[:metadata] = c.metadata_to_send
-          interception_context.intercept!(:client_streamer, intercept_args) do
-            c.client_streamer(requests)
-          end
-        end
-        op
-      else
-        interception_context.intercept!(:client_streamer, intercept_args) do
-          c.client_streamer(requests, metadata: metadata)
-        end
+      intercept_and_invoke(c, :client_streamer, intercept_args, return_op) do
+        c.client_streamer(requests)
       end
     end
 
@@ -334,32 +298,14 @@ module GRPC
                           deadline: deadline,
                           parent: parent,
                           credentials: credentials)
-      interception_context = @interceptors.build_context
       intercept_args = {
         method: method,
         request: req,
         call: c.interceptable,
         metadata: metadata
       }
-      if return_op
-        # return the operation view of the active_call; define #execute
-        # as a new method for this instance that invokes #server_streamer
-        c.merge_metadata_to_send(metadata)
-        op = c.operation
-        op.define_singleton_method(:execute) do
-          # Expose the live metadata_to_send hash so interceptors see the
-          # fully merged metadata and can add or remove keys in place before
-          # the request is sent.
-          intercept_args[:metadata] = c.metadata_to_send
-          interception_context.intercept!(:server_streamer, intercept_args) do
-            c.server_streamer(req, &blk)
-          end
-        end
-        op
-      else
-        interception_context.intercept!(:server_streamer, intercept_args) do
-          c.server_streamer(req, metadata: metadata, &blk)
-        end
+      intercept_and_invoke(c, :server_streamer, intercept_args, return_op) do
+        c.server_streamer(req, &blk)
       end
     end
 
@@ -460,36 +406,40 @@ module GRPC
                           deadline: deadline,
                           parent: parent,
                           credentials: credentials)
-      interception_context = @interceptors.build_context
       intercept_args = {
         method: method,
         requests: requests,
         call: c.interceptable,
         metadata: metadata
       }
-      if return_op
-        # return the operation view of the active_call; define #execute
-        # as a new method for this instance that invokes #bidi_streamer
-        c.merge_metadata_to_send(metadata)
-        op = c.operation
-        op.define_singleton_method(:execute) do
-          # Expose the live metadata_to_send hash so interceptors see the
-          # fully merged metadata and can add or remove keys in place before
-          # the request is sent.
-          intercept_args[:metadata] = c.metadata_to_send
-          interception_context.intercept!(:bidi_streamer, intercept_args) do
-            c.bidi_streamer(requests, &blk)
-          end
-        end
-        op
-      else
-        interception_context.intercept!(:bidi_streamer, intercept_args) do
-          c.bidi_streamer(requests, metadata: metadata, &blk)
-        end
+      intercept_and_invoke(c, :bidi_streamer, intercept_args, return_op) do
+        c.bidi_streamer(requests, &blk)
       end
     end
 
     private
+
+    # Merges caller metadata into c.metadata_to_send and exposes that live
+    # hash to interceptors via intercept_args[:metadata], so interceptors
+    # can add or remove keys in place and the mutations propagate to the
+    # wire without a redundant merge. Wraps the call in the interception
+    # chain; when return_op is true, the chain is deferred into the op's
+    # execute singleton method. The block is the underlying ActiveCall
+    # invocation and is invoked inside intercept!.
+    def intercept_and_invoke(c, type, intercept_args, return_op, &block)
+      c.merge_metadata_to_send(intercept_args[:metadata])
+      intercept_args[:metadata] = c.metadata_to_send
+      interception_context = @interceptors.build_context
+      if return_op
+        op = c.operation
+        op.define_singleton_method(:execute) do
+          interception_context.intercept!(type, intercept_args, &block)
+        end
+        op
+      else
+        interception_context.intercept!(type, intercept_args, &block)
+      end
+    end
 
     # Creates a new active stub
     #

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -170,13 +170,12 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          # Sync back the fully merged metadata (including anything added by
-          # merge_metadata_to_send) so that interceptors see the complete
-          # metadata context when the operation is executed lazily.
-          updated_metadata = c.metadata_to_send.dup
-          intercept_args[:metadata] = updated_metadata
+          # Expose the live metadata_to_send hash so interceptors see the
+          # fully merged metadata and can add or remove keys in place before
+          # the request is sent.
+          intercept_args[:metadata] = c.metadata_to_send
           interception_context.intercept!(:request_response, intercept_args) do
-            c.request_response(req, metadata: updated_metadata)
+            c.request_response(req)
           end
         end
         op
@@ -252,13 +251,12 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          # Sync back the fully merged metadata (including anything added by
-          # merge_metadata_to_send) so that interceptors see the complete
-          # metadata context when the operation is executed lazily.
-          updated_metadata = c.metadata_to_send.dup
-          intercept_args[:metadata] = updated_metadata
+          # Expose the live metadata_to_send hash so interceptors see the
+          # fully merged metadata and can add or remove keys in place before
+          # the request is sent.
+          intercept_args[:metadata] = c.metadata_to_send
           interception_context.intercept!(:client_streamer, intercept_args) do
-            c.client_streamer(requests, metadata: updated_metadata)
+            c.client_streamer(requests)
           end
         end
         op
@@ -349,13 +347,12 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          # Sync back the fully merged metadata (including anything added by
-          # merge_metadata_to_send) so that interceptors see the complete
-          # metadata context when the operation is executed lazily.
-          updated_metadata = c.metadata_to_send.dup
-          intercept_args[:metadata] = updated_metadata
+          # Expose the live metadata_to_send hash so interceptors see the
+          # fully merged metadata and can add or remove keys in place before
+          # the request is sent.
+          intercept_args[:metadata] = c.metadata_to_send
           interception_context.intercept!(:server_streamer, intercept_args) do
-            c.server_streamer(req, metadata: updated_metadata, &blk)
+            c.server_streamer(req, &blk)
           end
         end
         op
@@ -476,13 +473,12 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          # Sync back the fully merged metadata (including anything added by
-          # merge_metadata_to_send) so that interceptors see the complete
-          # metadata context when the operation is executed lazily.
-          updated_metadata = c.metadata_to_send.dup
-          intercept_args[:metadata] = updated_metadata
+          # Expose the live metadata_to_send hash so interceptors see the
+          # fully merged metadata and can add or remove keys in place before
+          # the request is sent.
+          intercept_args[:metadata] = c.metadata_to_send
           interception_context.intercept!(:bidi_streamer, intercept_args) do
-            c.bidi_streamer(requests, metadata: updated_metadata, &blk)
+            c.bidi_streamer(requests, &blk)
           end
         end
         op

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -304,8 +304,8 @@ module GRPC
         call: c.interceptable,
         metadata: metadata
       }
-      intercept_and_invoke(c, :server_streamer, intercept_args, return_op) do
-        c.server_streamer(req, &blk)
+      intercept_and_invoke(c, :server_streamer, intercept_args, return_op) do |&runtime_blk|
+        c.server_streamer(req, &runtime_blk || blk)
       end
     end
 
@@ -412,8 +412,8 @@ module GRPC
         call: c.interceptable,
         metadata: metadata
       }
-      intercept_and_invoke(c, :bidi_streamer, intercept_args, return_op) do
-        c.bidi_streamer(requests, &blk)
+      intercept_and_invoke(c, :bidi_streamer, intercept_args, return_op) do |&runtime_blk|
+        c.bidi_streamer(requests, &runtime_blk || blk)
       end
     end
 
@@ -432,8 +432,13 @@ module GRPC
       interception_context = @interceptors.build_context
       if return_op
         op = active_call.operation
-        op.define_singleton_method(:execute) do
-          interception_context.intercept!(type, intercept_args, &block)
+        # Forward any block passed to op.execute through to the underlying
+        # streaming call; server_streamer / bidi_streamer use it to yield
+        # responses. Unary calls ignore the forwarded block.
+        op.define_singleton_method(:execute) do |&exec_blk|
+          interception_context.intercept!(type, intercept_args) do
+            block.call(&exec_blk)
+          end
         end
         op
       else

--- a/src/ruby/spec/generic/client_interceptors_spec.rb
+++ b/src/ruby/spec/generic/client_interceptors_spec.rb
@@ -49,6 +49,21 @@ describe 'Client Interceptors' do
           expect(stub.an_rpc(request)).to be_a(EchoMsg)
         end
       end
+
+      it 'can modify outgoing metadata with return_op', server: true do
+        expect(interceptor).to receive(:request_response)
+          .once.and_call_original
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
+          expect_any_instance_of(GRPC::ActiveCall).to receive(:request_response)
+            .with(request, metadata: { 'foo' => 'bar_from_request_response' })
+            .once.and_call_original
+          op = stub.an_rpc(request, return_op: true)
+          result = op.execute
+          expect(result).to be_a(EchoMsg)
+        end
+      end
     end
 
     context 'with a client streaming call' do
@@ -76,6 +91,22 @@ describe 'Client Interceptors' do
             .with(requests, metadata: { 'foo' => 'bar_from_client_streamer' })
             .once.and_call_original
           expect(stub.a_client_streaming_rpc(requests)).to be_a(EchoMsg)
+        end
+      end
+
+      it 'can modify outgoing metadata with return_op', server: true do
+        expect(interceptor).to receive(:client_streamer)
+          .once.and_call_original
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
+          requests = [EchoMsg.new, EchoMsg.new]
+          expect_any_instance_of(GRPC::ActiveCall).to receive(:client_streamer)
+            .with(requests, metadata: { 'foo' => 'bar_from_client_streamer' })
+            .once.and_call_original
+          op = stub.a_client_streaming_rpc(requests, return_op: true)
+          result = op.execute
+          expect(result).to be_a(EchoMsg)
         end
       end
     end
@@ -113,6 +144,24 @@ describe 'Client Interceptors' do
           end
         end
       end
+
+      it 'can modify outgoing metadata with return_op', server: true do
+        expect(interceptor).to receive(:server_streamer)
+          .once.and_call_original
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
+          request = EchoMsg.new
+          expect_any_instance_of(GRPC::ActiveCall).to receive(:server_streamer)
+            .with(request, metadata: { 'foo' => 'bar_from_server_streamer' })
+            .once.and_call_original
+          op = stub.a_server_streaming_rpc(request, return_op: true)
+          responses = op.execute
+          responses.each do |r|
+            expect(r).to be_a(EchoMsg)
+          end
+        end
+      end
     end
 
     context 'with a bidi call' do
@@ -143,6 +192,24 @@ describe 'Client Interceptors' do
             .with(requests, metadata: { 'foo' => 'bar_from_bidi_streamer' })
             .once.and_call_original
           responses = stub.a_bidi_rpc(requests)
+          responses.each do |r|
+            expect(r).to be_a(EchoMsg)
+          end
+        end
+      end
+
+      it 'can modify outgoing metadata with return_op', server: true do
+        expect(interceptor).to receive(:bidi_streamer)
+          .once.and_call_original
+
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
+          requests = [EchoMsg.new, EchoMsg.new]
+          expect_any_instance_of(GRPC::ActiveCall).to receive(:bidi_streamer)
+            .with(requests, metadata: { 'foo' => 'bar_from_bidi_streamer' })
+            .once.and_call_original
+          op = stub.a_bidi_rpc(requests, return_op: true)
+          responses = op.execute
           responses.each do |r|
             expect(r).to be_a(EchoMsg)
           end

--- a/src/ruby/spec/generic/client_interceptors_spec.rb
+++ b/src/ruby/spec/generic/client_interceptors_spec.rb
@@ -41,12 +41,12 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:request_response)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:request_response)
-            .with(request, metadata: { 'foo' => 'bar_from_request_response' })
-            .once.and_call_original
           expect(stub.an_rpc(request)).to be_a(EchoMsg)
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_request_response')
         end
       end
 
@@ -105,13 +105,13 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:client_streamer)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
           requests = [EchoMsg.new, EchoMsg.new]
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:client_streamer)
-            .with(requests, metadata: { 'foo' => 'bar_from_client_streamer' })
-            .once.and_call_original
           expect(stub.a_client_streaming_rpc(requests)).to be_a(EchoMsg)
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_client_streamer')
         end
       end
 
@@ -153,16 +153,16 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:server_streamer)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
           request = EchoMsg.new
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:server_streamer)
-            .with(request, metadata: { 'foo' => 'bar_from_server_streamer' })
-            .once.and_call_original
           responses = stub.a_server_streaming_rpc(request)
           responses.each do |r|
             expect(r).to be_a(EchoMsg)
           end
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_server_streamer')
         end
       end
 
@@ -206,16 +206,16 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:bidi_streamer)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
           requests = [EchoMsg.new, EchoMsg.new]
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:bidi_streamer)
-            .with(requests, metadata: { 'foo' => 'bar_from_bidi_streamer' })
-            .once.and_call_original
           responses = stub.a_bidi_rpc(requests)
           responses.each do |r|
             expect(r).to be_a(EchoMsg)
           end
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_bidi_streamer')
         end
       end
 

--- a/src/ruby/spec/generic/client_interceptors_spec.rb
+++ b/src/ruby/spec/generic/client_interceptors_spec.rb
@@ -183,6 +183,18 @@ describe 'Client Interceptors' do
             .to eq('bar_from_server_streamer')
         end
       end
+
+      it 'forwards a block passed to op.execute', server: true do
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub)
+          request = EchoMsg.new
+          received = []
+          op = stub.a_server_streaming_rpc(request, return_op: true)
+          op.execute { |r| received << r }
+          expect(received.length).to eq(2)
+          received.each { |r| expect(r).to be_a(EchoMsg) }
+        end
+      end
     end
 
     context 'with a bidi call' do
@@ -256,6 +268,18 @@ describe 'Client Interceptors' do
           op.execute.each { |r| expect(r).to be_a(EchoMsg) }
           expect(echo_service.received_md[0]).not_to have_key('to-delete')
           expect(echo_service.received_md[0]['to-keep']).to eq('y')
+        end
+      end
+
+      it 'forwards a block passed to op.execute', server: true do
+        run_services_on_server(@server, services: [service]) do
+          stub = build_insecure_stub(EchoStub)
+          requests = [EchoMsg.new, EchoMsg.new]
+          received = []
+          op = stub.a_bidi_rpc(requests, return_op: true)
+          op.execute { |r| received << r }
+          expect(received.length).to eq(2)
+          received.each { |r| expect(r).to be_a(EchoMsg) }
         end
       end
     end

--- a/src/ruby/spec/generic/client_interceptors_spec.rb
+++ b/src/ruby/spec/generic/client_interceptors_spec.rb
@@ -54,14 +54,35 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:request_response)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:request_response)
-            .with(request, metadata: { 'foo' => 'bar_from_request_response' })
-            .once.and_call_original
           op = stub.an_rpc(request, return_op: true)
           result = op.execute
           expect(result).to be_a(EchoMsg)
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_request_response')
+        end
+      end
+
+      it 'can remove outgoing metadata with return_op', server: true do
+        deleting_interceptor = Class.new(GRPC::ClientInterceptor) do
+          def request_response(request:, call:, method:, metadata: {})
+            metadata.delete('to-delete')
+            yield
+          end
+        end.new
+        opts = { interceptors: [deleting_interceptor] }
+
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
+          stub = build_insecure_stub(EchoStub, opts: opts)
+          op = stub.an_rpc(request,
+                           metadata: { 'to-delete' => 'x', 'to-keep' => 'y' },
+                           return_op: true)
+          expect(op.execute).to be_a(EchoMsg)
+          expect(echo_service.received_md[0]).not_to have_key('to-delete')
+          expect(echo_service.received_md[0]['to-keep']).to eq('y')
         end
       end
     end
@@ -98,15 +119,15 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:client_streamer)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
           requests = [EchoMsg.new, EchoMsg.new]
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:client_streamer)
-            .with(requests, metadata: { 'foo' => 'bar_from_client_streamer' })
-            .once.and_call_original
           op = stub.a_client_streaming_rpc(requests, return_op: true)
           result = op.execute
           expect(result).to be_a(EchoMsg)
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_client_streamer')
         end
       end
     end
@@ -149,17 +170,17 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:server_streamer)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
           request = EchoMsg.new
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:server_streamer)
-            .with(request, metadata: { 'foo' => 'bar_from_server_streamer' })
-            .once.and_call_original
           op = stub.a_server_streaming_rpc(request, return_op: true)
           responses = op.execute
           responses.each do |r|
             expect(r).to be_a(EchoMsg)
           end
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_server_streamer')
         end
       end
     end
@@ -202,17 +223,39 @@ describe 'Client Interceptors' do
         expect(interceptor).to receive(:bidi_streamer)
           .once.and_call_original
 
-        run_services_on_server(@server, services: [service]) do
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
           stub = build_insecure_stub(EchoStub, opts: interceptors_opts)
           requests = [EchoMsg.new, EchoMsg.new]
-          expect_any_instance_of(GRPC::ActiveCall).to receive(:bidi_streamer)
-            .with(requests, metadata: { 'foo' => 'bar_from_bidi_streamer' })
-            .once.and_call_original
           op = stub.a_bidi_rpc(requests, return_op: true)
           responses = op.execute
           responses.each do |r|
             expect(r).to be_a(EchoMsg)
           end
+          expect(echo_service.received_md[0]['foo'])
+            .to eq('bar_from_bidi_streamer')
+        end
+      end
+
+      it 'can remove outgoing metadata with return_op', server: true do
+        deleting_interceptor = Class.new(GRPC::ClientInterceptor) do
+          def bidi_streamer(requests:, call:, method:, metadata: {})
+            metadata.delete('to-delete')
+            yield
+          end
+        end.new
+        opts = { interceptors: [deleting_interceptor] }
+
+        echo_service = EchoService.new
+        run_services_on_server(@server, services: [echo_service]) do
+          stub = build_insecure_stub(EchoStub, opts: opts)
+          requests = [EchoMsg.new, EchoMsg.new]
+          op = stub.a_bidi_rpc(requests,
+                               metadata: { 'to-delete' => 'x', 'to-keep' => 'y' },
+                               return_op: true)
+          op.execute.each { |r| expect(r).to be_a(EchoMsg) }
+          expect(echo_service.received_md[0]).not_to have_key('to-delete')
+          expect(echo_service.received_md[0]['to-keep']).to eq('y')
         end
       end
     end

--- a/src/ruby/spec/generic/client_interceptors_spec.rb
+++ b/src/ruby/spec/generic/client_interceptors_spec.rb
@@ -67,7 +67,7 @@ describe 'Client Interceptors' do
 
       it 'can remove outgoing metadata with return_op', server: true do
         deleting_interceptor = Class.new(GRPC::ClientInterceptor) do
-          def request_response(request:, call:, method:, metadata: {})
+          def request_response(metadata: {}, **)
             metadata.delete('to-delete')
             yield
           end
@@ -239,7 +239,7 @@ describe 'Client Interceptors' do
 
       it 'can remove outgoing metadata with return_op', server: true do
         deleting_interceptor = Class.new(GRPC::ClientInterceptor) do
-          def bidi_streamer(requests:, call:, method:, metadata: {})
+          def bidi_streamer(metadata: {}, **)
             metadata.delete('to-delete')
             yield
           end

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -49,7 +49,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:request_response).with(request, metadata: client_metadata)
+            receive(:request_response).with(request)
               .once.and_call_original
           )
           op = stub.an_rpc(request, client_call_opts)
@@ -84,7 +84,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:client_streamer).with(requests, metadata: client_metadata)
+            receive(:client_streamer).with(requests)
               .once.and_call_original
           )
           op = stub.a_client_streaming_rpc(requests, client_call_opts)
@@ -122,7 +122,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:server_streamer).with(request, metadata: client_metadata)
+            receive(:server_streamer).with(request)
               .once.and_call_original
           )
           op = stub.a_server_streaming_rpc(request, client_call_opts)
@@ -162,7 +162,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:bidi_streamer).with(requests, metadata: client_metadata)
+            receive(:bidi_streamer).with(requests)
               .once.and_call_original
           )
           op = stub.a_bidi_rpc(requests, client_call_opts)

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -84,7 +84,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:client_streamer).with(requests)
+            receive(:client_streamer).with(requests, metadata: client_metadata)
               .once.and_call_original
           )
           op = stub.a_client_streaming_rpc(requests, client_call_opts)
@@ -122,7 +122,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:server_streamer).with(request)
+            receive(:server_streamer).with(request, metadata: client_metadata)
               .once.and_call_original
           )
           op = stub.a_server_streaming_rpc(request, client_call_opts)
@@ -162,7 +162,7 @@ describe 'Server Interceptors' do
         run_services_on_server(@server, services: [service]) do
           stub = build_insecure_stub(EchoStub)
           expect_any_instance_of(GRPC::ActiveCall).to(
-            receive(:bidi_streamer).with(requests)
+            receive(:bidi_streamer).with(requests, metadata: client_metadata)
               .once.and_call_original
           )
           op = stub.a_bidi_rpc(requests, client_call_opts)

--- a/src/ruby/spec/support/services.rb
+++ b/src/ruby/spec/support/services.rb
@@ -60,6 +60,7 @@ class EchoService
   def a_client_streaming_rpc(call)
     # iterate through requests so call can complete
     call.output_metadata.update(@trailing_metadata)
+    @received_md << call.metadata unless call.metadata.nil?
     call.each_remote_read.each do |r|
       GRPC.logger.info(r)
     end
@@ -68,11 +69,13 @@ class EchoService
 
   def a_server_streaming_rpc(_req, call)
     call.output_metadata.update(@trailing_metadata)
+    @received_md << call.metadata unless call.metadata.nil?
     [EchoMsg.new, EchoMsg.new]
   end
 
   def a_bidi_rpc(requests, call)
     call.output_metadata.update(@trailing_metadata)
+    @received_md << call.metadata unless call.metadata.nil?
     requests.each do |r|
       GRPC.logger.info(r)
     end


### PR DESCRIPTION
## Description

When using client interceptors that modify metadata (e.g., adding authorization headers), the metadata changes are silently dropped for all three streaming call types (`client_streamer`, `server_streamer`, `bidi_streamer`) when `return_op: true` is used.

This is a 6-year-old bug originally reported in #22448, which was closed as stale without a fix. A previous fix was authored by @apolcyn in #25072, but it too was closed by the stale bot before it was reviewed successfully. This PR revives that work and adopts the same approach.

### Root cause

In `ClientStub`, the `execute` block defined on the `Operation` for each streaming method omits the `metadata:` keyword argument when calling the underlying `ActiveCall` method. Compare with `request_response`, which correctly passes metadata in both the `return_op: true` and `return_op: false` paths.

For example, in `server_streamer`:

```ruby
# return_op: true path (BROKEN - metadata lost)
op.define_singleton_method(:execute) do
  interception_context.intercept!(:server_streamer, intercept_args) do
    c.server_streamer(req, &blk)  # <-- missing metadata
  end
end

# return_op: false path (correct)
interception_context.intercept!(:server_streamer, intercept_args) do
  c.server_streamer(req, metadata: metadata, &blk)  # <-- metadata passed
end
```

### Impact

Any framework or application that uses `return_op: true` for streaming calls — including [Gruf](https://github.com/bigcommerce/gruf), which always sets `return_op: true` internally — will silently lose all interceptor-modified metadata (e.g., authorization tokens) on streaming RPCs. The call proceeds without the metadata, leading to authentication failures on the server side that are difficult to diagnose because the client-side interceptor appears to execute correctly.

### Fix

Adopting the approach from @apolcyn's #25072: in each `return_op: true` path, read back the fully merged metadata via `c.metadata_to_send.dup` and update `intercept_args[:metadata]` so interceptors see the complete metadata context. This is more thorough than simply passing the original `metadata` variable, because `metadata_to_send` reflects any metadata merged into the `ActiveCall` through `merge_metadata_to_send`. The fix is applied consistently across all four call types (`request_response`, `client_streamer`, `server_streamer`, `bidi_streamer`).

### Testing

Added `'can modify outgoing metadata with return_op'` tests for all four call types in `client_interceptors_spec.rb`. These tests:

- **FAIL** without the fix (confirming the 3 streaming methods drop metadata)
- **PASS** with the fix
- The existing `request_response` test for `return_op` also passes, confirming it was already correct

All 81 tests pass (12 interceptor + 69 client_stub) with no regressions.

### Prior art

- #22448 — original bug report (closed as stale)
- #25072 — previous fix by @apolcyn (closed as stale!)

Fixes #22448

> Built with [Cursor](https://cursor.com)