### PR TITLE
[xDS] fix race condition in GrpcXdsClient::GetOrCreate()

### DIFF
--- a/src/core/xds/grpc/xds_client_grpc.cc
+++ b/src/core/xds/grpc/xds_client_grpc.cc
@@ -313,7 +313,7 @@ absl::StatusOr<RefCountedPtr<GrpcXdsClient>> GrpcXdsClient::GetOrCreate(
                                               certificate_provider_store),
       certificate_provider_store,
       GetStatsPluginGroupForKeyAndChannelArgs(key, args));
-  g_xds_client_map->emplace(xds_client->key(), xds_client.get());
+  g_xds_client_map->insert_or_assign(xds_client->key(), xds_client.get());
   GRPC_TRACE_LOG(xds_client, INFO) << "[xds_client " << xds_client.get()
                                    << "] Created xDS client for key " << key;
   return xds_client;


### PR DESCRIPTION
If the global XdsClient map already contains an entry with the specified key, but the XdsClient object has a ref-count of 0, we will create a new one.  However, we were using `emplace()` to insert it in the map, which in this case is a no-op, because the map entry already exists.  This causes unnecessary churn in XdsClient creation, which can cause bugs with the c2p resolver when rapidly creating and destroying channels in multiple threads at the same time.

This PR fixes the bug by switching from `emplace()` to `insert_or_assign()`, which will always set the value, even if the entry is already present in the map.

b/486455330