### PR TITLE
[Fixit] [CI] Speed up C++ distribtests on RBE using all available cores

### DIFF
--- a/tools/bazelify_tests/grpc_run_cpp_distribtest_test.sh
+++ b/tools/bazelify_tests/grpc_run_cpp_distribtest_test.sh
@@ -28,7 +28,8 @@ REPORT_SUITE_NAME="$(echo ${TEST_TARGET} | sed 's|^.*[:/]||')"
 tar -xopf ${ARCHIVE_WITH_SUBMODULES}
 cd grpc
 
-# TODO(jtattermusch): adjust GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS for faster build.
+# Use all available cores to speed up the build
+export GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS="$(nproc)"
 
 # Run distribtest script passed as args
 "$@"


### PR DESCRIPTION
This addresses timeouts in the cpp_distribtests_linux test suite by exporting GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=$(nproc). This allows the build scripts to use all CPUs available in the RBE docker container instead of defaulting to 4, significantly decreasing the build time.


