### PR TITLE
[Fixit] [CI] Optimize Bazel distribtest by building :all instead of //...

### DIFF
--- a/test/distrib/bazel/test_single_bazel_version.sh
+++ b/test/distrib/bazel/test_single_bazel_version.sh
@@ -91,7 +91,7 @@ do
   SHARD_RAN=""
   if [ "${TEST_SHARD}" == "buildtest" ] ; then
     tools/bazel version | grep "$VERSION" || { echo "Detected bazel version did not match expected value of $VERSION" >/dev/stderr; exit 1; }
-    tools/bazel build "${ACTION_ENV_FLAG}" --build_tag_filters='-experiment_variation' -- //... "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}buildtest "
+    tools/bazel build "${ACTION_ENV_FLAG}" --build_tag_filters='-experiment_variation' -- :all "${EXCLUDED_TARGETS[@]}" || FAILED_TESTS="${FAILED_TESTS}buildtest "
     SHARD_RAN="true"
   fi
 


### PR DESCRIPTION
This changes the inner Bazel build in the distribtests to build only the targets in the root package (:all) rather than the entire repository (//...). This significantly reduces the scope of the build simulation while still verifying the core functionality, leading to faster CI runs.




