### PR TITLE
Fix oversized chttp2 frame validation before parser init

### DIFF
--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -346,6 +346,12 @@ std::variant<size_t, absl::Status> grpc_chttp2_perform_read(
           << " len:" << t->incoming_frame_size
           << absl::StrFormat(" id:0x%08x", t->incoming_stream_id);
       t->deframe_state = GRPC_DTS_FRAME;
+      if (t->incoming_frame_size != 0 &&
+          t->incoming_frame_size > t->settings.acked().max_frame_size()) {
+        return GRPC_ERROR_CREATE(absl::StrFormat(
+            "Frame size %d is larger than max frame size %d",
+            t->incoming_frame_size, t->settings.acked().max_frame_size()));
+      }
       err = init_frame_parser(t, requests_started);
       if (!err.ok()) {
         return err;
@@ -361,11 +367,6 @@ std::variant<size_t, absl::Status> grpc_chttp2_perform_read(
           return absl::OkStatus();
         }
         goto dts_fh_0;  // loop
-      } else if (t->incoming_frame_size >
-                 t->settings.acked().max_frame_size()) {
-        return GRPC_ERROR_CREATE(absl::StrFormat(
-            "Frame size %d is larger than max frame size %d",
-            t->incoming_frame_size, t->settings.acked().max_frame_size()));
       }
       if (++cur == end) {
         return absl::OkStatus();


### PR DESCRIPTION
  ## Summary

  Reject oversized incoming HTTP/2 frames before running frame-specific parser initialization.

  This prevents GOAWAY parser initialization from performing a size-based allocation from the declared frame length before the transport enforces the local max frame size.

  ## Details

  In `grpc_chttp2_perform_read()`, the oversized frame check now runs immediately after the frame header is parsed and before `init_frame_parser()` is called.

  That keeps frame-specific parser setup from observing attacker-controlled oversized lengths that should already have been rejected.

  ## Testing

  - `git diff --check`

