### PR TITLE
[Security] Fix variable name in SSL transport security.

### DIFF
--- a/src/core/tsi/ssl_transport_security_utils.cc
+++ b/src/core/tsi/ssl_transport_security_utils.cc
@@ -282,7 +282,7 @@ bool VerifyCrlCertIssuerNamesMatch(X509_CRL* crl, X509* cert) {
     return false;
   }
   X509_NAME* cert_issuer_name = X509_get_issuer_name(cert);
-  if (cert == nullptr) {
+  if (cert_issuer_name == nullptr) {
     return false;
   }
   X509_NAME* crl_issuer_name = X509_CRL_get_issuer(crl);


### PR DESCRIPTION
Slight bug in not checking the right var name