### PR TITLE
PR Ruby distribtest: Build only for earliest and latest supported Ruby versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,7 +144,7 @@ task 'gem:native', [:plat, :build_type] do |t, args|
 
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   target_ruby_minor_versions = ['4.0', '3.4', '3.3', '3.2', '3.1']
-  if args[:build_type] == 'presubmit' do
+  if args[:build_type] == 'presubmit'
     # For presubmits, only build the earliest and latest versions
     target_ruby_minor_versions = [target_ruby_minor_versions[0], target_ruby_minor_versions[-1]]
   end

--- a/Rakefile
+++ b/Rakefile
@@ -144,10 +144,8 @@ task 'gem:native', [:plat, :build_type] do |t, args|
 
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   target_ruby_minor_versions = ['4.0', '3.4', '3.3', '3.2', '3.1']
-  if args[:build_type] == 'presubmit'
-    # For presubmits, only build the earliest and latest versions
-    target_ruby_minor_versions = [target_ruby_minor_versions[0], target_ruby_minor_versions[-1]]
-  end
+  # For presubmits, only build the earliest and latest versions
+  target_ruby_minor_versions = [target_ruby_minor_versions.first, target_ruby_minor_versions.last] if args[:build_type] == 'presubmit'
   selected_plat = "#{args[:plat]}"
 
   # use env variable to set artifact build paralellism

--- a/Rakefile
+++ b/Rakefile
@@ -139,11 +139,15 @@ task 'dlls', [:plat] do |t, args|
 end
 
 desc 'Build the native gem file under rake_compiler_dock. Optionally one can pass argument to build only native gem for a chosen platform.'
-task 'gem:native', [:plat] do |t, args|
+task 'gem:native', [:plat, :build_type] do |t, args|
   verbose = ENV['V'] || '0'
 
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   target_ruby_minor_versions = ['4.0', '3.4', '3.3', '3.2', '3.1']
+  if args[:build_type] == 'presubmit' do
+    # For presubmits, only build the earliest and latest versions
+    target_ruby_minor_versions = [target_ruby_minor_versions[0], target_ruby_minor_versions[-1]]
+  end
   selected_plat = "#{args[:plat]}"
 
   # use env variable to set artifact build paralellism

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -268,6 +268,9 @@ class RubyArtifact:
         self.labels = ["artifact", "ruby", platform, gem_platform]
         if presubmit:
             self.labels.append("presubmit")
+            self.build_type = "presubmit"
+        else:
+            self.build_type = "continuous"
 
     def pre_build_jobspecs(self):
         return []
@@ -284,6 +287,7 @@ class RubyArtifact:
             [
                 "tools/run_tests/artifacts/build_artifact_ruby.sh",
                 self.gem_platform,
+                self.build_type
             ],
             use_workspace=True,
             timeout_seconds=240 * 60,

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -287,7 +287,7 @@ class RubyArtifact:
             [
                 "tools/run_tests/artifacts/build_artifact_ruby.sh",
                 self.gem_platform,
-                self.build_type
+                self.build_type,
             ],
             use_workspace=True,
             timeout_seconds=240 * 60,

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -17,6 +17,8 @@ set -ex
 
 # the platform for which we wanna build the native gem
 GEM_PLATFORM="$1"
+# the type of build job this is running in ("presubmit" or "continuous")
+BUILD_TYPE="$2"
 
 SYSTEM=$(uname | cut -f 1 -d_)
 
@@ -48,7 +50,7 @@ gem list || true
 export BUNDLE_PATH=bundle_local_gems
 tools/run_tests/helper_scripts/bundle_install_wrapper.sh
 
-bundle exec rake "gem:native[${GEM_PLATFORM}]"
+bundle exec rake "gem:native[${GEM_PLATFORM},${BUILD_TYPE}]"
 
 if [ "$SYSTEM" == "Darwin" ] ; then
   # TODO: consider rewriting this to pass shellcheck

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -513,7 +513,6 @@ def targets():
             "debian11",
             ruby_version="ruby_3_2",
             source=True,
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-gnu",
@@ -527,14 +526,12 @@ def targets():
             "x64",
             "debian11",
             ruby_version="ruby_3_2",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-gnu",
             "x64",
             "debian11",
             ruby_version="ruby_3_3",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-gnu",
@@ -542,14 +539,12 @@ def targets():
             "debian11",
             ruby_version="ruby_3_3",
             protobuf_version="3.25",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-gnu",
             "x64",
             "debian11",
             ruby_version="ruby_3_4",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-gnu",
@@ -572,21 +567,18 @@ def targets():
             "x64",
             "alpine",
             ruby_version="ruby_3_2",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-musl",
             "x64",
             "alpine",
             ruby_version="ruby_3_3",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-musl",
             "x64",
             "alpine",
             ruby_version="ruby_3_4",
-            presubmit=True,
         ),
         RubyDistribTest(
             "linux-musl",


### PR DESCRIPTION
Currently the distribtests build the library for all supported Ruby versions in both PR jobs and master jobs. To reduce PR job time, with this change it will instead only build for the earliest and latest supported version in the PR job, similar to what we already do for Python. This will have no impact on the master build.

Similar to #42049, this reduces another dimension of the PR Ruby distribtest build matrix.



<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

