### PR TITLE
[CI] Coerce jobset log files to be open()ed in byte mode.

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -310,7 +310,7 @@ class Job:
             if not os.path.exists(logfile_dir):
                 os.makedirs(logfile_dir)
             message("LOG", f"Logging output to {self._spec.logfilename}")
-            self._logfile = open(self._spec.logfilename, "w+")
+            self._logfile = open(self._spec.logfilename, "w+b")
         else:
             # macOS: a series of quick os.unlink invocation might cause OS
             # error during the creation of temporary file. By using
@@ -404,10 +404,15 @@ class Job:
             else:
                 self._state = _SUCCESS
                 measurement = ""
+                stdout_maybe_bytes = stdout()
+                if isinstance(stdout_maybe_bytes, bytes):
+                    stdout_str = stdout_maybe_bytes.decode("utf8", errors="replace")
+                else:
+                    stdout_str = stdout_maybe_bytes
                 if measure_cpu_costs:
                     m = re.search(
                         r"real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)",
-                        (stdout()).decode("utf8", errors="replace"),
+                        stdout_str,
                     )
                     real = float(m.group(1))
                     user = float(m.group(2))

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -404,15 +404,10 @@ class Job:
             else:
                 self._state = _SUCCESS
                 measurement = ""
-                stdout_maybe_bytes = stdout()
-                if isinstance(stdout_maybe_bytes, bytes):
-                    stdout_str = stdout_maybe_bytes.decode("utf8", errors="replace")
-                else:
-                    stdout_str = stdout_maybe_bytes
                 if measure_cpu_costs:
                     m = re.search(
                         r"real\s+([0-9.]+)\nuser\s+([0-9.]+)\nsys\s+([0-9.]+)",
-                        stdout_str,
+                        (stdout()).decode("utf8", errors="replace"),
                     )
                     real = float(m.group(1))
                     user = float(m.group(2))

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -46,6 +46,8 @@ gcp_utils_dir = os.path.abspath(
 )
 sys.path.append(gcp_utils_dir)
 
+REPORT_BASE_PATH = os.getenv("GRPC_TEST_REPORT_BASE_DIR", os.path.abspath("."))
+
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "../.."))
 os.chdir(_ROOT)
 
@@ -151,6 +153,9 @@ class Config:
                 self.timeout_multiplier * timeout_seconds
                 if timeout_seconds
                 else None
+            ),
+            logfilename=os.path.abspath(
+                f"{REPORT_BASE_PATH}/reports/{self.build_config}/sponge_log.log"
             ),
             flake_retries=4 if flaky or args.allow_flakes else 0,
             timeout_retries=1 if flaky or args.allow_flakes else 0,
@@ -1329,6 +1334,9 @@ _LANGUAGES = {
     "clang-tidy": Sanity("clang_tidy_tests.yaml"),
 }
 
+# Inverse map from test suite object to language name.
+_LANGUAGE_NAMES = {name: language for language, name in _LANGUAGES.items()}
+
 _MSBUILD_CONFIG = {
     "dbg": "Debug",
     "opt": "Release",
@@ -1921,6 +1929,19 @@ if args.use_docker:
 
 _check_arch_option(args.arch)
 
+
+# Generate log files under /reports subfolder so it can be stored
+# into GCS by kokoro.
+def _gen_logfile_name(stage, language_name, cmdline):
+    script = os.path.basename(cmdline[0])
+    # TODO(weizheyuan): Understand what else needs to be done
+    # (other than setting file name to sponge_log.log)
+    # for these logs to show up in sponge UI.
+    return os.path.abspath(
+        f"{REPORT_BASE_PATH}/reports/{language_name}_{platform_string()}_{build_config}/{stage}/{script}/sponge_log.log"
+    )
+
+
 # collect pre-build steps (which get retried if they fail, e.g. to avoid
 # flakes on downloading dependencies etc.)
 build_steps = list(
@@ -1928,13 +1949,18 @@ build_steps = list(
         jobset.JobSpec(
             cmdline,
             environ=_build_step_environ(
-                build_config, extra_env=l.build_steps_environ()
+                build_config, extra_env=language.build_steps_environ()
             ),
             timeout_seconds=_PRE_BUILD_STEP_TIMEOUT_SECONDS,
+            logfilename=_gen_logfile_name(
+                stage="pre_build_steps",
+                language_name=_LANGUAGE_NAMES[language],
+                cmdline=cmdline,
+            ),
             flake_retries=2,
         )
-        for l in languages
-        for cmdline in l.pre_build_steps()
+        for language in languages
+        for cmdline in language.pre_build_steps()
     )
 )
 
@@ -1944,12 +1970,17 @@ build_steps.extend(
         jobset.JobSpec(
             cmdline,
             environ=_build_step_environ(
-                build_config, extra_env=l.build_steps_environ()
+                build_config, extra_env=language.build_steps_environ()
+            ),
+            logfilename=_gen_logfile_name(
+                stage="build_steps",
+                language_name=_LANGUAGE_NAMES[language],
+                cmdline=cmdline,
             ),
             timeout_seconds=None,
         )
-        for l in languages
-        for cmdline in l.build_steps()
+        for language in languages
+        for cmdline in language.build_steps()
     )
 )
 
@@ -1959,11 +1990,16 @@ post_tests_steps = list(
         jobset.JobSpec(
             cmdline,
             environ=_build_step_environ(
-                build_config, extra_env=l.build_steps_environ()
+                build_config, extra_env=language.build_steps_environ()
+            ),
+            logfilename=_gen_logfile_name(
+                stage="post_build_steps",
+                language_name=_LANGUAGE_NAMES[language],
+                cmdline=cmdline,
             ),
         )
-        for l in languages
-        for cmdline in l.post_tests_steps()
+        for language in languages
+        for cmdline in language.post_tests_steps()
     )
 )
 runs_per_test = args.runs_per_test


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/42052 seems to cause some breakage in tests. Per documentation tempfile.TemporaryFile() creates file in "w+b" mode and our tooling seems to have implicit assumption on the stdout of log file being bytes.

See also https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile

Sample breakage: https://btx.cloud.google.com/invocations/9a2ae53b-6c8e-4d96-845f-2f2a46c78c27/log

log:

```
2026-04-14 20:48:44,405 START: tools/run_tests/helper_scripts/build_cxx.sh
2026-04-14 20:48:44,406 LOG: Logging output to /var/local/report_dir/reports/c++_linux_dbg/build_steps/build_cxx.sh/sponge_log.log
Traceback (most recent call last):
  File "/var/local/git/grpc/tools/run_tests/run_tests.py", line 2007, in 
    errors = _build_and_run(
  File "/var/local/git/grpc/tools/run_tests/run_tests.py", line 1508, in _build_and_run
    num_failures, resultset = jobset.run(
  File "/var/local/git/grpc/tools/run_tests/python_utils/jobset.py", line 706, in run
    js.finish()
  File "/var/local/git/grpc/tools/run_tests/python_utils/jobset.py", line 643, in finish
    self.reap()
  File "/var/local/git/grpc/tools/run_tests/python_utils/jobset.py", line 570, in reap
    st = eintr_be_gone(lambda: job.state())
  File "/var/local/git/grpc/tools/run_tests/python_utils/jobset.py", line 119, in eintr_be_gone
    return fn()
  File "/var/local/git/grpc/tools/run_tests/python_utils/jobset.py", line 570, in 
    st = eintr_be_gone(lambda: job.state())
  File "/var/local/git/grpc/tools/run_tests/python_utils/jobset.py", line 410, in state
    (stdout()).decode("utf8", errors="replace"),
```


<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

