### PR TITLE
chaotic_good: cap BeginMessage declared length against configurable max_receive_message_length

### DIFF
--- a/src/core/ext/transport/chaotic_good/message_reassembly.h
+++ b/src/core/ext/transport/chaotic_good/message_reassembly.h
@@ -36,6 +36,12 @@ class MessageReassembly {
         CancelledServerMetadataFromStatus(GRPC_STATUS_INTERNAL, msg));
   }
 
+  // Sets the maximum allowed incoming message size in bytes.
+  // Should reflect GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH for the channel.
+  void set_max_receive_message_length(size_t max) {
+    max_receive_message_length_ = max;
+  }
+
   template <typename Sink>
   auto PushFrameInto(MessageFrame frame, Sink& sink) {
     return If(
@@ -59,7 +65,7 @@ class MessageReassembly {
     } else if (frame.body.length() == 0) {
       FailCall(sink,
                "Received begin message for an empty message (not allowed)");
-    } else if (frame.body.length() > std::numeric_limits<size_t>::max() / 2) {
+    } else if (frame.body.length() > max_receive_message_length_) {
       FailCall(sink, "Received too large begin message");
     } else {
       GRPC_TRACE_LOG(chaotic_good, INFO)
@@ -105,6 +111,11 @@ class MessageReassembly {
   bool in_message_boundary() { return chunk_receiver_ == nullptr; }
 
  private:
+  // Maximum allowed incoming message size. Defaults to 4 GiB as a hard
+  // safety ceiling to prevent unbounded heap allocation; callers must lower
+  // this to GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH for the channel.
+  size_t max_receive_message_length_ = std::numeric_limits<uint32_t>::max();
+
   struct ChunkReceiver {
     size_t bytes_remaining;
     SliceBuffer incoming;

--- a/src/core/ext/transport/chaotic_good_legacy/message_reassembly.h
+++ b/src/core/ext/transport/chaotic_good_legacy/message_reassembly.h
@@ -36,6 +36,12 @@ class MessageReassembly {
         CancelledServerMetadataFromStatus(GRPC_STATUS_INTERNAL, msg));
   }
 
+  // Sets the maximum allowed incoming message size in bytes.
+  // Should reflect GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH for the channel.
+  void set_max_receive_message_length(size_t max) {
+    max_receive_message_length_ = max;
+  }
+
   template <typename Sink>
   auto PushFrameInto(MessageFrame frame, Sink& sink) {
     return If(
@@ -59,7 +65,7 @@ class MessageReassembly {
     } else if (frame.body.length() == 0) {
       FailCall(sink,
                "Received begin message for an empty message (not allowed)");
-    } else if (frame.body.length() > std::numeric_limits<size_t>::max() / 2) {
+    } else if (frame.body.length() > max_receive_message_length_) {
       FailCall(sink, "Received too large begin message");
     } else {
       GRPC_TRACE_LOG(chaotic_good, INFO)
@@ -105,6 +111,11 @@ class MessageReassembly {
   bool in_message_boundary() { return chunk_receiver_ == nullptr; }
 
  private:
+  // Maximum allowed incoming message size. Defaults to 4 GiB as a hard
+  // safety ceiling to prevent unbounded heap allocation; callers must lower
+  // this to GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH for the channel.
+  size_t max_receive_message_length_ = std::numeric_limits<uint32_t>::max();
+
   struct ChunkReceiver {
     size_t bytes_remaining;
     SliceBuffer incoming;


### PR DESCRIPTION
## Problem

The `BeginMessage` handler in `MessageReassembly` validates the declared message length with a single guard:

```cpp
} else if (frame.body.length() > std::numeric_limits<size_t>::max() / 2) {
    FailCall(sink, "Received too large begin message");
```

On a 64-bit system this threshold is ~8 exabytes, making the check effectively unreachable. An unauthenticated client can send a `BeginMessage` frame with a declared length just below the threshold. The server allocates a `ChunkReceiver` with `bytes_remaining` set to that value and buffers all subsequent `MessageChunk` frames without any size limit until the process is killed.

Additionally, `GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH` (enforced by `MessageSizeFilter`) is never applied in the `chaotic_good` and `chaotic_good_legacy` transports because `MessageSizeFilter` fires only after a complete message is reassembled — a condition that is never reached when `bytes_remaining` starts at a near-exabyte value.

## Fix

Add a `max_receive_message_length_` member to `MessageReassembly` (defaulting to `UINT32_MAX` as a hard safety ceiling) and a `set_max_receive_message_length()` setter so transport code can propagate `GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH` into the reassembly layer. Replace the exabyte guard with a check against this limit.

Applied identically to both `chaotic_good_legacy/message_reassembly.h` and `chaotic_good/message_reassembly.h`.

```cpp
// Before
} else if (frame.body.length() > std::numeric_limits<size_t>::max() / 2) {

// After
} else if (frame.body.length() > max_receive_message_length_) {
```

## Backward compatibility

The default value of `max_receive_message_length_` is `std::numeric_limits<uint32_t>::max()` (4 GiB), which is lower than the previous threshold but well above any realistic message size. Existing callers that do not call `set_max_receive_message_length()` retain functional behaviour.