### PR TITLE
[Security] Add support for SECP384R1 (P-384) to TLS key exchange groups

### DIFF
--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -155,6 +155,8 @@ typedef enum {
   GRPC_TLS_GROUP_X25519,
   /** X25519_MLKEM768 hybrid key exchange. Post-quantum cryptography. */
   GRPC_TLS_GROUP_X25519_MLKEM768,
+  /** secp384r1 ECDH key exchange. */
+  GRPC_TLS_GROUP_SECP384R1,
 } grpc_tls_key_exchange_group;
 
 #ifdef __cplusplus

--- a/src/core/tsi/ssl_transport_security_utils.cc
+++ b/src/core/tsi/ssl_transport_security_utils.cc
@@ -456,6 +456,8 @@ absl::StatusOr<absl::string_view> ConvertKeyExchangeGroupToString(
   switch (group) {
     case GRPC_TLS_GROUP_SECP256R1:
       return "P-256";
+    case GRPC_TLS_GROUP_SECP384R1:
+      return "P-384";
     case GRPC_TLS_GROUP_X25519:
       return "X25519";
     case GRPC_TLS_GROUP_X25519_MLKEM768:

--- a/test/core/credentials/transport/tls/grpc_tls_credentials_options_test.cc
+++ b/test/core/credentials/transport/tls/grpc_tls_credentials_options_test.cc
@@ -618,6 +618,7 @@ TEST_F(GrpcTlsCredentialsOptionsTest, SetKeyExchangeGroups) {
       grpc_tls_key_exchange_group::GRPC_TLS_GROUP_X25519_MLKEM768,
       grpc_tls_key_exchange_group::GRPC_TLS_GROUP_X25519,
       grpc_tls_key_exchange_group::GRPC_TLS_GROUP_SECP256R1,
+      grpc_tls_key_exchange_group::GRPC_TLS_GROUP_SECP384R1,
   };
   grpc_tls_credentials_options_set_key_exchange_groups(
       options.get(), groups.data(), groups.size());

--- a/test/core/tsi/ssl_transport_security_utils_test.cc
+++ b/test/core/tsi/ssl_transport_security_utils_test.cc
@@ -505,6 +505,8 @@ INSTANTIATE_TEST_SUITE_P(FrameProtectorUtil, FlowTest,
 TEST(ConvertKeyExchangeGroupToStringTest, ValidCases) {
   EXPECT_EQ(*tsi::ConvertKeyExchangeGroupToString(GRPC_TLS_GROUP_SECP256R1),
             "P-256");
+  EXPECT_EQ(*tsi::ConvertKeyExchangeGroupToString(GRPC_TLS_GROUP_SECP384R1),
+            "P-384");
   EXPECT_EQ(*tsi::ConvertKeyExchangeGroupToString(GRPC_TLS_GROUP_X25519),
             "X25519");
 #if defined(OPENSSL_IS_BORINGSSL)


### PR DESCRIPTION
I recently ran into a nasty issue where my gRPC client was failing to connect  server, throwing a TSI_PROTOCOL_FAILURE (Fatal Alert 40: Handshake Failure).

Dumping the raw TLS packets, I found the culprit: the server was strictly configured to require the secp384r1 (P-384) elliptic curve for some reasons. Currently only P-256 (and X25519) in the ClientHello Supported Groups extension is supported. Since there was no overlap, the server instantly dropped the connection.

I added GRPC_TLS_GROUP_SECP384R1 to the key exchange groups. This allows us to explicitly configure our TLS options to use the P-384 curve so the handshake can actually succeed with endpoints like this.