### PR TITLE
ci: increase timeout for macOS jobs to 180

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_ruby.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_basictests_ruby.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 90
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_ruby.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_ruby.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_basictests_ruby.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 120
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos ruby -j 1 --inner_jobs 4 --max_time=7200"
+  value: "-f basictests macos ruby -j 1 --inner_jobs 4 --max_time=10800"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_opt.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_bazel_c_cpp_opt.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh"
-timeout_mins: 105
+timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
MACO OS job runs on 4 core machine which take more time if cache is missed. this will avoid the timeout failure, we can check for P80 time for run time.
