### PR TITLE
[CI] Determine Ruby build_type at runtime to fix continuous distribtest failures

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -268,9 +268,6 @@ class RubyArtifact:
         self.labels = ["artifact", "ruby", platform, gem_platform]
         if presubmit:
             self.labels.append("presubmit")
-            self.build_type = "presubmit"
-        else:
-            self.build_type = "continuous"
 
     def pre_build_jobspecs(self):
         return []
@@ -280,6 +277,14 @@ class RubyArtifact:
         if inner_jobs is not None:
             # set number of parallel jobs when building native extension
             environ["GRPC_RUBY_BUILD_PROCS"] = str(inner_jobs)
+
+        # determine build_type at runtime.
+        # By default, build all supported ruby versions ("continuous").
+        # If explicitly running in presubmit, build only a subset of versions to save time.
+        build_type = "continuous"
+        if os.environ.get("KOKORO_JOB_TYPE") == "PRESUBMIT":
+            build_type = "presubmit"
+
         # Ruby build uses docker internally and docker cannot be nested.
         # We are using a custom workspace instead.
         return create_jobspec(
@@ -287,7 +292,7 @@ class RubyArtifact:
             [
                 "tools/run_tests/artifacts/build_artifact_ruby.sh",
                 self.gem_platform,
-                self.build_type,
+                build_type,
             ],
             use_workspace=True,
             timeout_seconds=240 * 60,


### PR DESCRIPTION

The recent optimization to build fewer Ruby versions in presubmit was incorrectly applied to any target eligible for presubmit, causing continuous/master builds to also build reduced gems and fail their distribution tests. This change determines the build_type at runtime based on the KOKORO_JOB_TYPE environment variable.

Relevant commit : https://github.com/grpc/grpc/commit/0faedb9e0bf0a4908d0f77e9ae4b12490c3c5154

