### PR TITLE
[Fixit][Core CI] Disable Bazel remote cache uploads for macOS PR runs

### DIFF
--- a/tools/internal_ci/macos/grpc_objc_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_objc_bazel_test.sh
@@ -34,9 +34,15 @@ tools/bazel version
 # for kokoro mac workers, exact image version is store in a well-known location on disk
 KOKORO_IMAGE_VERSION="$(cat /VERSION)"
 
+# only upload results to the remote cache for the master branch
+UPLOAD_LOCAL_RESULTS="true"
+if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+  UPLOAD_LOCAL_RESULTS="false"
+fi
+
 BAZEL_REMOTE_CACHE_ARGS=(
   # Enable uploading to remote cache. Requires the "roles/remotebuildexecution.actionCacheWriter" permission.
-  --remote_upload_local_results=true
+  --remote_upload_local_results="${UPLOAD_LOCAL_RESULTS}"
   # allow invalidating the old cache by setting to a new random key
   --remote_default_exec_properties="grpc_cache_silo_key1=83d8e488-1ca9-40fd-929e-d37d13529c99"
   # make sure we only get cache hits from binaries built on exact same macos image

--- a/tools/internal_ci/macos/grpc_python_bazel_test.sh
+++ b/tools/internal_ci/macos/grpc_python_bazel_test.sh
@@ -31,9 +31,15 @@ tools/bazel version
 # for kokoro mac workers, exact image version is store in a well-known location on disk
 KOKORO_IMAGE_VERSION="$(cat /VERSION)"
 
+# only upload results to the remote cache for the master branch
+UPLOAD_LOCAL_RESULTS="true"
+if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+  UPLOAD_LOCAL_RESULTS="false"
+fi
+
 BAZEL_REMOTE_CACHE_ARGS=(
   # Enable uploading to remote cache. Requires the "roles/remotebuildexecution.actionCacheWriter" permission.
-  --remote_upload_local_results=true
+  --remote_upload_local_results="${UPLOAD_LOCAL_RESULTS}"
   # allow invalidating the old cache by setting to a new random key
   --remote_default_exec_properties="grpc_cache_silo_key1=83d8e488-1ca9-40fd-929e-d37d13529c99"
   # make sure we only get cache hits from binaries built on exact same macos image

--- a/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_c_cpp_tests.sh
@@ -31,9 +31,15 @@ tools/bazel version
 # for kokoro mac workers, exact image version is store in a well-known location on disk
 KOKORO_IMAGE_VERSION="$(cat /VERSION)"
 
+# only upload results to the remote cache for the master branch
+UPLOAD_LOCAL_RESULTS="true"
+if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+  UPLOAD_LOCAL_RESULTS="false"
+fi
+
 BAZEL_REMOTE_CACHE_ARGS=(
   # Enable uploading to remote cache. Requires the "roles/remotebuildexecution.actionCacheWriter" permission.
-  --remote_upload_local_results=true
+  --remote_upload_local_results="${UPLOAD_LOCAL_RESULTS}"
   # allow invalidating the old cache by setting to a new random key
   --remote_default_exec_properties="grpc_cache_silo_key1=83d8e488-1ca9-40fd-929e-d37d13529c99"
   # make sure we only get cache hits from binaries built on exact same macos image

--- a/tools/internal_ci/macos/grpc_run_bazel_cpp_ios_tests.sh
+++ b/tools/internal_ci/macos/grpc_run_bazel_cpp_ios_tests.sh
@@ -29,9 +29,15 @@ tools/bazel version
 # for kokoro mac workers, exact image version is store in a well-known location on disk
 KOKORO_IMAGE_VERSION="$(cat /VERSION)"
 
+# only upload results to the remote cache for the master branch
+UPLOAD_LOCAL_RESULTS="true"
+if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+  UPLOAD_LOCAL_RESULTS="false"
+fi
+
 BAZEL_REMOTE_CACHE_ARGS=(
   # Enable uploading to remote cache. Requires the "roles/remotebuildexecution.actionCacheWriter" permission.
-  --remote_upload_local_results=true
+  --remote_upload_local_results="${UPLOAD_LOCAL_RESULTS}"
   # allow invalidating the old cache by setting to a new random key
   --remote_default_exec_properties="grpc_cache_silo_key1=83d8e488-1ca9-40fd-929e-d37d13529c99"
   # make sure we only get cache hits from binaries built on exact same macos image


### PR DESCRIPTION
This prevents PR runs from uploading to the remote cache, while still allowing the master branch to populate it.



