### PR TITLE
fix: a google service api key is hardcoded and commi... in...

### DIFF
--- a/examples/objective-c/auth_sample/Misc/GoogleService-Info.plist
+++ b/examples/objective-c/auth_sample/Misc/GoogleService-Info.plist
@@ -7,9 +7,9 @@
 	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
 	<string>redacted</string>
 	<key>CLIENT_ID</key>
-	<string>15087385131-lh9bpkiai9nls53uadju0if6k7un3uih.apps.googleusercontent.com</string>
+	<string>redacted</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.15087385131-lh9bpkiai9nls53uadju0if6k7un3uih</string>
+	<string>redacted</string>
 	<key>API_KEY</key>
 	<string>redacted</string>
 	<key>GCM_SENDER_ID</key>
@@ -33,7 +33,7 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true/>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:15087385131:ios:d547168abe3c362f</string>
+	<string>redacted</string>
 	<key>DATABASE_URL</key>
 	<string>https://grpc-authsample.firebaseio.com</string>
 </dict>


### PR DESCRIPTION
## Summary
Fix high severity security issue in `examples/objective-c/auth_sample/Misc/GoogleService-Info.plist`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `examples/objective-c/auth_sample/Misc/GoogleService-Info.plist:13` |

**Description**: A Google service API key is hardcoded and committed directly into the repository inside the GoogleService-Info.plist configuration file. This is a standard Google Firebase/Google Services configuration file that contains sensitive credentials including API keys, client IDs, and project identifiers. Any person with read access to the repository — including all public viewers if the repository is public — can extract and abuse this credential.

## Changes
- `examples/objective-c/auth_sample/Misc/GoogleService-Info.plist`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
