### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/pr-check-bzlmod-deps.yaml
+++ b/.github/workflows/pr-check-bzlmod-deps.yaml
@@ -10,6 +10,9 @@ on:
       - 'third_party/**'
       - 'tools/run_tests/sanity/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-bcr.yaml
+++ b/.github/workflows/publish-to-bcr.yaml
@@ -18,6 +18,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.1.0

--- a/.github/workflows/update-artifacts-branch.yaml
+++ b/.github/workflows/update-artifacts-branch.yaml
@@ -5,12 +5,13 @@ on:
     branches:
       - master
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #42177
