### PR TITLE
[Fixit][CI] Fix crash due to access statusOr in failure case

### DIFF
--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -185,10 +185,12 @@ TEST(CFEventEngineTest, TestResolveIPv6Remote) {
 
   dns_resolver.value()->LookupHostname(
       [&resolve_signal](auto result) {
-        EXPECT_TRUE(result.status().ok());
-        EXPECT_THAT(
-            ResolvedAddressesToStrings(result.value()),
-            testing::UnorderedElementsAre("[2607:f8b0:400a:801::1002]:80"));
+        EXPECT_TRUE(result.status().ok()) << result.status();
+        if (result.ok()) {
+          EXPECT_THAT(
+              ResolvedAddressesToStrings(result.value()),
+              testing::UnorderedElementsAre("[2607:f8b0:400a:801::1002]:80"));
+        }
 
         resolve_signal.Notify();
       },


### PR DESCRIPTION
- Improved error handling to avoid a BadStatusOrAccess crash when the DNS lookup fails due to transient network issues.
  
[ RUN      ] CFEventEngineTest.TestResolveIPv6Remote
    /Volumes/BuildData/tmpfs/altsrc/github/grpc/workspace_c++_macos_opt_native/test/core/event_engine/cf/cf_engine_tes
     t.cc:188: Failure
   Value of: result.status().ok()
      Actual: false
    Expected: true
   
    libc++abi: terminating due to uncaught exception of type absl::lts_20250512::BadStatusOrAccess: Bad StatusOr
     access: NOT_FOUND: address lookup failed for 2607-f8b0-400a-801--1002.sslip.io.: Domain name not found
    time: command terminated abnormally


[Not a fix for flakiness of the test, flakiness is due to network issue]


