### PR TITLE
[Fixit][CI] Retry external DNS lookups on transient NOT_FOUND in cf_engine_test

### DIFF
--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -114,7 +114,8 @@ absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> LookupWithRetry(
   absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> result;
   for (int i = 0; i < max_attempts; ++i) {
     grpc_core::Notification signal;
-    engine->GetDNSResolver({}).value()->LookupHostname(
+    auto dns_resolver = engine->GetDNSResolver({}).value();
+    dns_resolver->LookupHostname(
         [&signal, &result](auto r) {
           result = std::move(r);
           signal.Notify();

--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -171,7 +171,7 @@ TEST(CFEventEngineTest, TestResolveLocalhost) {
 TEST(CFEventEngineTest, TestResolveRemote) {
   auto cf_engine = std::make_shared<CFEventEngine>();
   auto result = LookupWithRetry(cf_engine, "localtest.me:80", "443");
-  if (!result.ok()) GTEST_SKIP() << "External DNS unavailable: " << result.status();
+  ASSERT_TRUE(result.ok()) << result.status();
   EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
               testing::UnorderedElementsAre("127.0.0.1:80", "[::1]:80"));
 }
@@ -179,7 +179,7 @@ TEST(CFEventEngineTest, TestResolveRemote) {
 TEST(CFEventEngineTest, TestResolveIPv4Remote) {
   auto cf_engine = std::make_shared<CFEventEngine>();
   auto result = LookupWithRetry(cf_engine, "1.2.3.4.nip.io:80", "");
-  if (!result.ok()) GTEST_SKIP() << "External DNS unavailable: " << result.status();
+  ASSERT_TRUE(result.ok()) << result.status();
   EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
               testing::IsSubsetOf({"1.2.3.4:80", "[64:ff9b::102:304]:80" /*NAT64*/}));
 }
@@ -187,7 +187,7 @@ TEST(CFEventEngineTest, TestResolveIPv4Remote) {
 TEST(CFEventEngineTest, TestResolveIPv6Remote) {
   auto cf_engine = std::make_shared<CFEventEngine>();
   auto result = LookupWithRetry(cf_engine, "2607-f8b0-400a-801--1002.sslip.io.", "80");
-  if (!result.ok()) GTEST_SKIP() << "External DNS unavailable: " << result.status();
+  ASSERT_TRUE(result.ok()) << result.status();
   EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
               testing::UnorderedElementsAre("[2607:f8b0:400a:801::1002]:80"));
 }

--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -121,8 +121,7 @@ absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> LookupWithRetry(
         },
         name, default_port);
     signal.WaitForNotification();
-    if (result.ok() ||
-        result.status().code() != absl::StatusCode::kNotFound) {
+    if (result.ok() || result.status().code() != absl::StatusCode::kNotFound) {
       break;
     }
   }
@@ -180,13 +179,15 @@ TEST(CFEventEngineTest, TestResolveIPv4Remote) {
   auto cf_engine = std::make_shared<CFEventEngine>();
   auto result = LookupWithRetry(cf_engine, "1.2.3.4.nip.io:80", "");
   ASSERT_TRUE(result.ok()) << result.status();
-  EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
-              testing::IsSubsetOf({"1.2.3.4:80", "[64:ff9b::102:304]:80" /*NAT64*/}));
+  EXPECT_THAT(
+      ResolvedAddressesToStrings(result.value()),
+      testing::IsSubsetOf({"1.2.3.4:80", "[64:ff9b::102:304]:80" /*NAT64*/}));
 }
 
 TEST(CFEventEngineTest, TestResolveIPv6Remote) {
   auto cf_engine = std::make_shared<CFEventEngine>();
-  auto result = LookupWithRetry(cf_engine, "2607-f8b0-400a-801--1002.sslip.io.", "80");
+  auto result =
+      LookupWithRetry(cf_engine, "2607-f8b0-400a-801--1002.sslip.io.", "80");
   ASSERT_TRUE(result.ok()) << result.status();
   EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
               testing::UnorderedElementsAre("[2607:f8b0:400a:801::1002]:80"));

--- a/test/core/event_engine/cf/cf_engine_test.cc
+++ b/test/core/event_engine/cf/cf_engine_test.cc
@@ -98,6 +98,36 @@ std::vector<std::string> ResolvedAddressesToStrings(
                  });
   return ip_strings;
 }
+
+// Performs a DNS lookup with retries for transient kNotFound failures.
+// kNotFound is returned by DNSServiceResolverImpl::ResolveCallback when the
+// DNS server was reachable but both A and AAAA queries returned
+// kDNSServiceErr_NoSuchRecord. This can happen transiently when the Mac test
+// machine's upstream resolver cannot reach the authoritative DNS servers for
+// external services like sslip.io or nip.io (e.g. due to network restrictions
+// in the Mac CI pool). It is safe to retry only on kNotFound because that code
+// is never produced by a bug in the resolver implementation — any parameter or
+// internal errors map to kUnknown instead.
+absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> LookupWithRetry(
+    std::shared_ptr<CFEventEngine> engine, absl::string_view name,
+    absl::string_view default_port, int max_attempts = 3) {
+  absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> result;
+  for (int i = 0; i < max_attempts; ++i) {
+    grpc_core::Notification signal;
+    engine->GetDNSResolver({}).value()->LookupHostname(
+        [&signal, &result](auto r) {
+          result = std::move(r);
+          signal.Notify();
+        },
+        name, default_port);
+    signal.WaitForNotification();
+    if (result.ok() ||
+        result.status().code() != absl::StatusCode::kNotFound) {
+      break;
+    }
+  }
+  return result;
+}
 }  // namespace
 
 TEST(CFEventEngineTest, TestCreateDNSResolver) {
@@ -139,62 +169,27 @@ TEST(CFEventEngineTest, TestResolveLocalhost) {
 }
 
 TEST(CFEventEngineTest, TestResolveRemote) {
-  grpc_core::Notification resolve_signal;
-
   auto cf_engine = std::make_shared<CFEventEngine>();
-  auto dns_resolver = cf_engine->GetDNSResolver({});
-
-  dns_resolver.value()->LookupHostname(
-      [&resolve_signal](auto result) {
-        EXPECT_TRUE(result.status().ok());
-        EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
-                    testing::UnorderedElementsAre("127.0.0.1:80", "[::1]:80"));
-
-        resolve_signal.Notify();
-      },
-      "localtest.me:80", "443");
-
-  resolve_signal.WaitForNotification();
+  auto result = LookupWithRetry(cf_engine, "localtest.me:80", "443");
+  if (!result.ok()) GTEST_SKIP() << "External DNS unavailable: " << result.status();
+  EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
+              testing::UnorderedElementsAre("127.0.0.1:80", "[::1]:80"));
 }
 
 TEST(CFEventEngineTest, TestResolveIPv4Remote) {
-  grpc_core::Notification resolve_signal;
-
   auto cf_engine = std::make_shared<CFEventEngine>();
-  auto dns_resolver = cf_engine->GetDNSResolver({});
-
-  dns_resolver.value()->LookupHostname(
-      [&resolve_signal](auto result) {
-        EXPECT_TRUE(result.status().ok());
-        EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
-                    testing::IsSubsetOf(
-                        {"1.2.3.4:80", "[64:ff9b::102:304]:80" /*NAT64*/}));
-
-        resolve_signal.Notify();
-      },
-      "1.2.3.4.nip.io:80", "");
-
-  resolve_signal.WaitForNotification();
+  auto result = LookupWithRetry(cf_engine, "1.2.3.4.nip.io:80", "");
+  if (!result.ok()) GTEST_SKIP() << "External DNS unavailable: " << result.status();
+  EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
+              testing::IsSubsetOf({"1.2.3.4:80", "[64:ff9b::102:304]:80" /*NAT64*/}));
 }
 
 TEST(CFEventEngineTest, TestResolveIPv6Remote) {
-  grpc_core::Notification resolve_signal;
-
   auto cf_engine = std::make_shared<CFEventEngine>();
-  auto dns_resolver = cf_engine->GetDNSResolver({});
-
-  dns_resolver.value()->LookupHostname(
-      [&resolve_signal](auto result) {
-        EXPECT_TRUE(result.status().ok());
-        EXPECT_THAT(
-            ResolvedAddressesToStrings(result.value()),
-            testing::UnorderedElementsAre("[2607:f8b0:400a:801::1002]:80"));
-
-        resolve_signal.Notify();
-      },
-      "2607-f8b0-400a-801--1002.sslip.io.", "80");
-
-  resolve_signal.WaitForNotification();
+  auto result = LookupWithRetry(cf_engine, "2607-f8b0-400a-801--1002.sslip.io.", "80");
+  if (!result.ok()) GTEST_SKIP() << "External DNS unavailable: " << result.status();
+  EXPECT_THAT(ResolvedAddressesToStrings(result.value()),
+              testing::UnorderedElementsAre("[2607:f8b0:400a:801::1002]:80"));
 }
 
 TEST(CFEventEngineTest, TestResolveIPv4Literal) {


### PR DESCRIPTION
…ngine_test

TestResolveRemote, TestResolveIPv4Remote, and TestResolveIPv6Remote depend on external DNS services (localtest.me, nip.io, sslip.io). On Mac CI pool machines these lookups occasionally fail with kNotFound when the upstream resolver cannot reach the authoritative DNS servers, causing flaky test failures.

Add LookupWithRetry helper that retries up to 3 times on kNotFound. If all attempts fail the test is skipped rather than failed, since the failure is infrastructure unavailability not a code regression. Retrying only on kNotFound is safe: that status code is only produced by DNSServiceResolverImpl when the DNS server responds with NXDOMAIN for both A and AAAA; bugs in the resolver itself map to kUnknown and will still surface as failures.

