### PR TITLE
[CI] Add retry to cmake install 

### DIFF
--- a/cmake/download_archive.cmake
+++ b/cmake/download_archive.cmake
@@ -21,11 +21,35 @@ file(MAKE_DIRECTORY ${_download_archive_TEMPORARY_DIR})
 function(download_archive destination url hash strip_prefix)
   # Fetch and validate
   set(_TEMPORARY_FILE ${_download_archive_TEMPORARY_DIR}/${strip_prefix}.tar.gz)
-  message(STATUS "Downloading from ${url}, if failed, please try configuring again")
-  file(DOWNLOAD ${url} ${_TEMPORARY_FILE}
-       TIMEOUT 60
-       EXPECTED_HASH SHA256=${hash}
-       TLS_VERIFY ON)
+  set(_download_SUCCESS FALSE)
+  set(_download_ATTEMPT 0)
+  set(_download_MAX_ATTEMPTS 3)
+  while(NOT _download_SUCCESS AND _download_ATTEMPT LESS _download_MAX_ATTEMPTS)
+    math(EXPR _download_ATTEMPT "${_download_ATTEMPT} + 1")
+    message(STATUS "Downloading from ${url} (Attempt ${_download_ATTEMPT} of ${_download_MAX_ATTEMPTS})")
+    file(DOWNLOAD ${url} ${_TEMPORARY_FILE}
+         TIMEOUT 60
+         EXPECTED_HASH SHA256=${hash}
+         TLS_VERIFY ON
+         STATUS _download_STATUS)
+    
+    list(GET _download_STATUS 0 _download_STATUS_CODE)
+    
+    if(_download_STATUS_CODE EQUAL 0)
+      set(_download_SUCCESS TRUE)
+    else()
+      list(GET _download_STATUS 1 _download_STATUS_MESSAGE)
+      message(WARNING "Download failed (Attempt ${_download_ATTEMPT}): ${_download_STATUS_MESSAGE}")
+      if(_download_ATTEMPT LESS _download_MAX_ATTEMPTS)
+        message(STATUS "Retrying in 5 seconds...")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 5)
+      endif()
+    endif()
+  endwhile()
+
+  if(NOT _download_SUCCESS)
+    message(FATAL_ERROR "Failed to download from ${url} after ${_download_MAX_ATTEMPTS} attempts.")
+  endif()
   # Extract
   execute_process(COMMAND
                   ${CMAKE_COMMAND} -E tar xvf ${_TEMPORARY_FILE}


### PR DESCRIPTION
### Description

Last 3 runs of tests flaking with following error

```
-- Downloading from https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.tar.gz, if failed, please try configuring again
CMake Error at cmake/download_archive.cmake:25 (file):
  file DOWNLOAD HASH mismatch

    for file: [/b/f/w/bazel-out/k8-fastbuild/bin/tools/bazelify_tests/test/cpp_distribtest_cmake_pkgconfig_linux.runfiles/_main/grpc/cmake/build/http_archives/protoc-gen-validate-1.2.1.tar.gz]
      expected hash: [e4718352754df1393b8792b631338aa8562f390e8160783e365454bc11d96328]
        actual hash: [e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]
             status: [22;"HTTP response code said error"]

Call Stack (most recent call first):
  CMakeLists.txt:442 (download_archive)
```

```
--   No package 'libsystemd' found
-- Downloading from https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz, if failed, please try configuring again
-- Downloading from https://github.com/envoyproxy/data-plane-api/archive/6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz, if failed, please try configuring again
CMake Error at cmake/download_archive.cmake:25 (file):
  file DOWNLOAD HASH mismatch

    for file: [/b/f/w/bazel-out/k8-fastbuild/bin/tools/bazelify_tests/test/cpp_distribtest_cmake_linux.runfiles/_main/grpc/cmake/build/http_archives/data-plane-api-6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz]
      expected hash: [ed5e6c319f8ebcdf24a9491f866a599bb9a3c193b859a94ad13bd31f85b46855]
        actual hash: [e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]
             status: [22;"HTTP response code said error"]

```

```
-- Downloading from https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz, if failed, please try configuring again
CMake Error at cmake/download_archive.cmake:25 (file):
  file DOWNLOAD HASH mismatch

    for file: [/b/f/w/bazel-out/k8-fastbuild/bin/tools/bazelify_tests/test/cpp_distribtest_cmake_pkgconfig_linux.runfiles/_main/grpc/cmake/build/http_archives/cel-spec-0.25.1.tar.gz]
      expected hash: [13583c5a312861648449845b709722676a3c9b43396b6b8e9cbe4538feb74ad2]
        actual hash: [e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855]
             status: [22;"HTTP response code said error"]

```

#### Note 

SHA256 of empty file is `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`

```bash
[20/04/26 6:09:23] ⚡️asheshvidyut@asheshvidyut-mac ~/grpc (pr-42171) » touch check                   130 ↵
[20/04/26 6:09:26] ⚡️asheshvidyut@asheshvidyut-mac ~/grpc (pr-42171 %) » sha256 check
SHA256 (check) = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
[20/04/26 6:09:27] ⚡️asheshvidyut@asheshvidyut-mac ~/grpc (pr-42171 %) »
```

Proposal is to retry the install attempt.