### PR TITLE
[CI] Improve ccache performance for Windows Python builds (ccache windows version bump)

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -57,7 +57,7 @@ nasm
 
 @rem Install ccache
 mkdir C:\ccache
-curl -sSL --fail -o C:\ccache\ccache.exe https://storage.googleapis.com/grpc-build-helper/ccache-4.8-windows-64/ccache.exe || goto :error
+curl -sSL --fail -o C:\ccache\ccache.exe https://storage.googleapis.com/grpc-build-helper/ccache-4.13.4-windows-x86_64/ccache.exe || goto :error
 set PATH=C:\ccache;%PATH%
 ccache --version
 


### PR DESCRIPTION
In the Python Windows builds, ccache currently has a low cache hit rate and fails to populate the direct mode cache. This is an attempt to fix that.

