### PR TITLE
reflection: expose default health service descriptors

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2870,6 +2870,7 @@ grpc_cc_library(
         "config_vars",
         "grpc++",
         "grpc++_config_proto",
+        "//src/proto/grpc/health/v1:health_cc_proto",
         "//src/proto/grpc/reflection/v1:reflection_proto",
         "//src/proto/grpc/reflection/v1alpha:reflection_proto",
     ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5408,6 +5408,8 @@ endif()
 
 if(gRPC_BUILD_CODEGEN)
 add_library(grpc++_reflection ${_gRPC_STATIC_WIN32}
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.pb.h
@@ -29060,6 +29062,8 @@ endif()
 if(gRPC_BUILD_TESTS)
 
 add_executable(proto_server_reflection_test
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.h
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/duplicate/echo_duplicate.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/duplicate/echo_duplicate.grpc.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/duplicate/echo_duplicate.pb.h

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -4304,6 +4304,7 @@ libs:
   headers:
   - src/cpp/ext/proto_server_reflection.h
   src:
+  - src/proto/grpc/health/v1/health.proto
   - src/proto/grpc/reflection/v1/reflection.proto
   - src/proto/grpc/reflection/v1alpha/reflection.proto
   - src/cpp/ext/proto_server_reflection.cc
@@ -21317,6 +21318,7 @@ targets:
   - test/cpp/end2end/test_service_impl.h
   - test/cpp/util/proto_reflection_descriptor_database.h
   src:
+  - src/proto/grpc/health/v1/health.proto
   - src/proto/grpc/testing/duplicate/echo_duplicate.proto
   - src/proto/grpc/testing/echo.proto
   - src/proto/grpc/testing/echo_messages.proto

--- a/src/cpp/ext/proto_server_reflection_plugin.cc
+++ b/src/cpp/ext/proto_server_reflection_plugin.cc
@@ -26,6 +26,7 @@
 
 #include "src/core/config/config_vars.h"
 #include "src/cpp/ext/proto_server_reflection.h"
+#include "src/proto/grpc/health/v1/health.pb.h"
 
 namespace grpc {
 namespace reflection {
@@ -35,7 +36,13 @@ ProtoServerReflectionPlugin::ProtoServerReflectionPlugin()
       reflection_service_v1alpha_(
           std::make_shared<ProtoServerReflection>(backend_)),
       reflection_service_v1_(
-          std::make_shared<ProtoServerReflectionV1>(backend_)) {}
+          std::make_shared<ProtoServerReflectionV1>(backend_)) {
+  // Force registration of the generated health proto file descriptors so the
+  // reflection plugin can describe grpc.health.v1.Health when it is enabled.
+  // Referencing any descriptor from health.pb.cc registers the entire file
+  // descriptor, including the Health service descriptors.
+  (void)grpc::health::v1::HealthCheckRequest::descriptor();
+}
 
 std::string ProtoServerReflectionPlugin::name() {
   return "proto_server_reflection";

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -1051,6 +1051,7 @@ grpc_cc_test(
         "//:grpc++_public_hdrs",
         "//:grpc++_reflection",
         "//:grpc_public_hdrs",
+        "//src/proto/grpc/health/v1:health_cc_proto",
         "//src/proto/grpc/reflection/v1:reflection_proto",
         "//src/proto/grpc/reflection/v1:reflection_proto_cc_proto",
         "//src/proto/grpc/reflection/v1alpha:reflection_proto",

--- a/test/cpp/end2end/proto_server_reflection_test.cc
+++ b/test/cpp/end2end/proto_server_reflection_test.cc
@@ -20,6 +20,7 @@
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
 #include <grpcpp/create_channel.h>
+#include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/security/server_credentials.h>
@@ -29,12 +30,14 @@
 #include <grpcpp/support/channel_arguments.h>
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include "src/proto/grpc/reflection/v1/reflection.grpc.pb.h"
 #include "src/proto/grpc/reflection/v1/reflection.pb.h"
 #include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
 #include "src/proto/grpc/reflection/v1alpha/reflection.pb.h"
+#include "src/proto/grpc/health/v1/health.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/test_util/port.h"
 #include "test/core/test_util/test_config.h"
@@ -45,6 +48,31 @@
 
 namespace grpc {
 namespace testing {
+namespace {
+
+class ScopedDefaultHealthCheckServiceEnable final {
+ public:
+  explicit ScopedDefaultHealthCheckServiceEnable(bool enable)
+      : lock_(GetMutex()),
+        previous_value_(grpc::DefaultHealthCheckServiceEnabled()) {
+    grpc::EnableDefaultHealthCheckService(enable);
+  }
+
+  ~ScopedDefaultHealthCheckServiceEnable() {
+    grpc::EnableDefaultHealthCheckService(previous_value_);
+  }
+
+ private:
+  static std::mutex& GetMutex() {
+    static auto* mu = new std::mutex();
+    return *mu;
+  }
+
+  std::lock_guard<std::mutex> lock_;
+  bool previous_value_;
+};
+
+}  // namespace
 
 class ProtoServerReflectionTest : public ::testing::Test {
  public:
@@ -54,6 +82,15 @@ class ProtoServerReflectionTest : public ::testing::Test {
     port_ = grpc_pick_unused_port_or_die();
     ref_desc_pool_ = protobuf::DescriptorPool::generated_pool();
 
+    StartServer();
+  }
+
+  void StartServer(bool enable_default_health_service = false) {
+    std::unique_ptr<ScopedDefaultHealthCheckServiceEnable> health_check_guard;
+    if (enable_default_health_service) {
+      health_check_guard =
+          std::make_unique<ScopedDefaultHealthCheckServiceEnable>(true);
+    }
     ServerBuilder builder;
     std::string server_address = "localhost:" + to_string(port_);
     builder.AddListeningPort(server_address, InsecureServerCredentials());
@@ -218,6 +255,43 @@ TEST_F(ProtoServerReflectionTest, V1ApiInstalled) {
   ASSERT_TRUE(reader_writer->Read(&response));
   EXPECT_EQ(response.file_descriptor_response().file_descriptor_proto_size(), 1)
       << response.DebugString();
+}
+
+TEST_F(ProtoServerReflectionTest, DefaultHealthServiceDescriptorAvailable) {
+  server_->Shutdown();
+  server_.reset();
+  port_ = grpc_pick_unused_port_or_die();
+  StartServer(true);
+  ResetStub();
+
+  using Service = reflection::v1alpha::ServerReflection;
+  using Request = reflection::v1alpha::ServerReflectionRequest;
+  using Response = reflection::v1alpha::ServerReflectionResponse;
+  Service::Stub stub(channel_);
+  ClientContext context;
+  auto reader_writer = stub.ServerReflectionInfo(&context);
+  Request request;
+  request.set_list_services("*");
+  ASSERT_TRUE(reader_writer->Write(request));
+  Response response;
+  ASSERT_TRUE(reader_writer->Read(&response));
+  EXPECT_THAT(ServicesFromResponse(response),
+              ::testing::Contains("grpc.health.v1.Health"));
+
+  request = Request::default_instance();
+  request.set_file_containing_symbol("grpc.health.v1.Health");
+  ASSERT_TRUE(reader_writer->WriteLast(request, WriteOptions()));
+  response = Response::default_instance();
+  ASSERT_TRUE(reader_writer->Read(&response));
+  ASSERT_EQ(response.file_descriptor_response().file_descriptor_proto_size(), 1)
+      << response.DebugString();
+  EXPECT_TRUE(reader_writer->Finish().ok());
+
+  protobuf::FileDescriptorProto file_desc_proto;
+  ASSERT_TRUE(file_desc_proto.ParseFromString(
+      response.file_descriptor_response().file_descriptor_proto(0)));
+  EXPECT_EQ(file_desc_proto.name(),
+            grpc::health::v1::HealthCheckRequest::descriptor()->file()->name());
 }
 
 }  // namespace testing


### PR DESCRIPTION
Fixes #36665.

## Summary
- force registration of the grpc.health.v1 descriptors in `grpc++_reflection` so the built-in health service is visible to server reflection
- add a regression test that enables the default health service and verifies `file_containing_symbol("grpc.health.v1.Health")` succeeds
- keep Bazel/CMake generated build metadata in sync with the new dependency

## Testing
- `git diff --check`
- attempted `./tools/bazel test //test/cpp/end2end:proto_server_reflection_test --test_output=errors`
