### PR TITLE
Fix flaky GetCpuStatsTest.Ascending on Windows

### DIFF
--- a/src/cpp/server/load_reporter/get_cpu_stats_windows.cc
+++ b/src/cpp/server/load_reporter/get_cpu_stats_windows.cc
@@ -45,8 +45,11 @@ std::pair<uint64_t, uint64_t> GetCpuStatsImpl() {
   uint64_t busy = 0, total = 0;
   FILETIME idle, kernel, user;
   if (GetSystemTimes(&idle, &kernel, &user) != 0) {
-    total = FiletimeToInt(kernel) + FiletimeToInt(user);
-    busy = total - FiletimeToInt(idle);
+    uint64_t idle_val = FiletimeToInt(idle);
+    uint64_t kernel_val = FiletimeToInt(kernel);
+    uint64_t user_val = FiletimeToInt(user);
+    total = kernel_val + user_val;
+    busy = (total > idle_val) ? (total - idle_val) : 0;
   }
   return std::pair(busy, total);
 }

--- a/test/cpp/server/load_reporter/get_cpu_stats_test.cc
+++ b/test/cpp/server/load_reporter/get_cpu_stats_test.cc
@@ -44,11 +44,8 @@ TEST(GetCpuStatsTest, Ascending) {
   const size_t kRuns = 100;
   auto prev = grpc::load_reporter::GetCpuStatsImpl();
   for (size_t i = 0; i < kRuns; ++i) {
-#ifdef GPR_WINDOWS
-    // Windows counters can be jittery or have low resolution in a tight loop.
     gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
                                  gpr_time_from_millis(1, GPR_TIMESPAN)));
-#endif
     auto cur = grpc::load_reporter::GetCpuStatsImpl();
     ASSERT_LE(prev.first, cur.first)
         << "Busy time decreased at run " << i << ": " << prev.first << " -> "

--- a/test/cpp/server/load_reporter/get_cpu_stats_test.cc
+++ b/test/cpp/server/load_reporter/get_cpu_stats_test.cc
@@ -20,6 +20,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/support/port_platform.h>
+#include <grpc/support/time.h>
 
 #include "test/core/test_util/port.h"
 #include "test/core/test_util/test_config.h"
@@ -35,16 +36,26 @@ TEST(GetCpuStatsTest, BusyNoLargerThanTotal) {
   auto p = grpc::load_reporter::GetCpuStatsImpl();
   uint64_t busy = p.first;
   uint64_t total = p.second;
-  ASSERT_LE(busy, total);
+  ASSERT_LE(busy, total) << "Busy time " << busy
+                         << " is larger than total time " << total;
 }
 
 TEST(GetCpuStatsTest, Ascending) {
   const size_t kRuns = 100;
   auto prev = grpc::load_reporter::GetCpuStatsImpl();
   for (size_t i = 0; i < kRuns; ++i) {
+#ifdef GPR_WINDOWS
+    // Windows counters can be jittery or have low resolution in a tight loop.
+    gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+                                 gpr_time_from_millis(1, GPR_TIMESPAN)));
+#endif
     auto cur = grpc::load_reporter::GetCpuStatsImpl();
-    ASSERT_LE(prev.first, cur.first);
-    ASSERT_LE(prev.second, cur.second);
+    ASSERT_LE(prev.first, cur.first)
+        << "Busy time decreased at run " << i << ": " << prev.first << " -> "
+        << cur.first;
+    ASSERT_LE(prev.second, cur.second)
+        << "Total time decreased at run " << i << ": " << prev.second << " -> "
+        << cur.second;
     prev = cur;
   }
 }


### PR DESCRIPTION
Windows' `GetSystemTimes` is a bit jittery and low-resolution when called in a tight loop, which causes processor counters to periodically report out-of-sync numbers. This makes the Ascending test flake out since metrics like idle can momentarily appear larger than total.
I've patched this with two fast fixes:
- In implementation: Added safety boundaries to floor metrics execution time at 0 if an out-of-sync read returns idle > total.
- In testing: Added a 1ms sleep (Windows only) to give processors room to sync metrics computation inside the tight loop and improved failure messages.
