### PR TITLE
Unregister CFStream callbacks during endpoint shutdown.

### DIFF
--- a/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
+++ b/src/core/lib/event_engine/cf_engine/cfstream_endpoint.cc
@@ -303,6 +303,12 @@ void CFStreamEndpointImpl::Shutdown() {
   read_event_.SetShutdown(shutdownStatus);
   write_event_.SetShutdown(shutdownStatus);
 
+  // Remove the callbacks, otherwise we have a leak due to the stream retaining
+  // a pointer to the client context (which is this object).
+  CFReadStreamSetClient(cf_read_stream_, kCFStreamEventNone, nullptr, nullptr);
+  CFWriteStreamSetClient(cf_write_stream_, kCFStreamEventNone, nullptr,
+                         nullptr);
+
   CFReadStreamSetDispatchQueue(cf_read_stream_, nullptr);
   CFWriteStreamSetDispatchQueue(cf_write_stream_, nullptr);
 


### PR DESCRIPTION
This change adds calls to CFReadStreamSetClient and CFWriteStreamSetClient with kCFStreamEventNone and null parameters in the Shutdown method. This prevents memory leaks.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

