### PR TITLE
[CI][Windows] Add exponential backoff to choco_install_with_retry.sh

### DIFF
--- a/tools/internal_ci/helper_scripts/choco_install_with_retry.sh
+++ b/tools/internal_ci/helper_scripts/choco_install_with_retry.sh
@@ -18,24 +18,37 @@
 
 # Ensure package to install is provided
 if [ -z "$1" ]; then
-    echo "Error: No package name provided to install with choco."
-    exit 1
+  echo "Error: No package name provided to install with choco."
+  exit 1
 fi
 
 PACKAGE=$1
 shift
-MAX_RETRIES=3
 
-echo "Installing $PACKAGE using 'choco'"
+MAX_RETRIES=4
+# Initial delay, will grow exponentially
+delay=5
+# Initial exit code.
+exit_code=1
 
-for ((i=1; i<=MAX_RETRIES; i++)); do
-    choco install "$PACKAGE" -y "$@" && exit 0
+PS4='+ $(date "+[%H:%M:%S %Z]")\011 '
+set -x
 
-    if [ $i -lt $MAX_RETRIES ]; then
-      echo "Attempt $i to install $PACKAGE failed. Retrying..."
-      sleep 3
-    fi
+echo "Installing '${PACKAGE} 'using 'choco'"
+
+for ((i = 1; i <= MAX_RETRIES; i++)); do
+  choco install "$PACKAGE" -y "$@"
+  exit_code=$?
+  (( exit_code == 0 )) && exit 0
+
+  if ((i < MAX_RETRIES)); then
+    echo "Attempt $i to install '${PACKAGE}' failed. Retrying in ${delay} seconds..."
+    sleep "${delay}"
+
+    # Exponential backoff.
+    delay=$(( delay * 5 ))
+  fi
 done
 
-echo "All attempts to install $PACKAGE failed. Exiting..."
-exit 1
+echo "All attempts to install '${PACKAGE}' failed. Exiting..."
+exit "${exit_code}"


### PR DESCRIPTION
Looks like retrying choco install with a fixed delay is not enough transient network issues or server-side throttling.

This change implements an exponential backoff strategy:
5 sec -> 25 sec -> 125 sec

Total: 155 seconds = 2 minutes and 35 seconds.

Other minor improvements: 
- Reformatted with `shfmt -i 2 -s`.
- Added PS4 timestamps and verbose logging.