### PR TITLE
[CI] Fix prod:grpc/core/master/windows/grpc_basictests_c test

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -23,13 +23,35 @@ set PATH=C:\tools\msys64\usr\bin;C:\Python310;C:\Program Files\CMake\bin;%PATH%
 @rem Print image ID of the windows kokoro image being used.
 cat C:\image_id.txt
 
-@rem install python 3.10 if not already present
-if not exist C:\Python310\python.exe (
-  bash "tools/internal_ci/helper_scripts/choco_install_with_retry.sh" python310 --no-progress || goto :error
+@rem install python 3.10 if not already present in either location
+set "PYTHON_DIR="
+if exist "C:\Program Files\Python310\python.exe" (
+  set "PYTHON_DIR=C:\Program Files\Python310"
+) else if exist "C:\Python310\python.exe" (
+  set "PYTHON_DIR=C:\Python310"
 )
 
+if "%PYTHON_DIR%"=="" (
+  bash "tools/internal_ci/helper_scripts/choco_install_with_retry.sh" python310 --no-progress || goto :error
+
+  @rem After install, check where it went
+  if exist "C:\Program Files\Python310\python.exe" (
+    set "PYTHON_DIR=C:\Program Files\Python310"
+  ) else if exist "C:\Python310\python.exe" (
+    set "PYTHON_DIR=C:\Python310"
+  ) else (
+    echo "Python 3.10 not found after installation."
+    goto :error
+  )
+)
+
+@rem Add to path to ensure it's preferred
+set "PATH=%PYTHON_DIR%;%PATH%"
+
 @rem create "python3" link that normally doesn't exist
-mklink C:\Python310\python3.exe C:\Python310\python.exe
+if not exist "%PYTHON_DIR%\python3.exe" (
+  mklink "%PYTHON_DIR%\python3.exe" "%PYTHON_DIR%\python.exe"
+)
 
 python --version
 python3 --version


### PR DESCRIPTION
# Description

Fix job - `prod:grpc/core/master/windows/grpc_basictests_c`

Failure logs shows Python 3.10 is installed at a different location and `mlink` was done at a different point

```
Installing 64-bit python310...
python310 has been installed.
Added C:\ProgramData\chocolatey\bin\python3.10.exe shim pointed to 'c:\python310\python.exe'.
WARNING: Provided python InstallDir was ignored by the python installer
WARNING: Its probable that you had pre-existing python installation
WARNING: Python installed to: 'C:\Program Files\Python310'
WARNING: Installation folder is not the default. Not changing permissions. Please ensure your installation is secure.
  python310 can be automatically uninstalled.
 The install of python310 was successful.
  Software installed as 'exe', install location is likely default.
```

# Testing

https://source.cloud.google.com/results/invocations/8ceee59c-608e-4485-94ae-f20081f9d532

