### PR TITLE
[Core] Set default ECDHE groups for BoringSSL and OpenSSL < 3.0

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1201,7 +1201,16 @@ static tsi_result populate_ssl_context(
     return TSI_FAILED_PRECONDITION;
 #endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
   } else {
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    // Default to standard ECDHE groups when none are explicitly configured.
+    // Using SSL_CTX_set1_groups_list ensures the supported_groups extension
+    // in ClientHello includes all curves, not just the tmp_ecdh single curve.
+    if (!SSL_CTX_set1_groups_list(context, "P-256:P-384:P-521")) {
+      LOG(ERROR) << "Could not set default key exchange groups.";
+      return TSI_INTERNAL_ERROR;
+    }
+    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L
     EC_KEY* ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
     if (!SSL_CTX_set_tmp_ecdh(context, ecdh)) {
       LOG(ERROR) << "Could not set ephemeral ECDH key.";


### PR DESCRIPTION
## Summary

Follow-up to #41807 and the key exchange group API added in `e83cfa8655`.

PR #41807 correctly removed the hardcoded P-256 for OpenSSL 3.0+ to support post-quantum key exchange (ML-KEM). However, the `else` branch for `OPENSSL_VERSION_NUMBER < 0x30000000L` — which includes BoringSSL (version `0x1010107f`) — still only configures P-256 via `SSL_CTX_set_tmp_ecdh`.

In BoringSSL, `SSL_CTX_set_tmp_ecdh` sets the ephemeral ECDH key for TLS 1.2 but does **not** populate the `supported_groups` TLS extension used for TLS 1.3 negotiation. When no explicit `key_exchange_groups` are configured (the default for C-core, PHP, Ruby, C++ clients), the ClientHello advertises only P-256 in `supported_groups`.

Servers that prefer or require other curves (e.g. P-521) send `handshake_failure` since no mutually supported group exists.

This fix uses `SSL_CTX_set1_groups_list` (the same function used by the opt-in key exchange group API) to set a standard default of **P-256, P-384, P-521** when no explicit groups are configured. This matches what browsers, Go's `crypto/tls`, and `grpcurl` offer by default.

The old `SSL_CTX_set_tmp_ecdh` path is preserved as a fallback for OpenSSL < 1.1.1.

## Test Plan

- [ ] Existing `SslTransportSecurityTest` tests pass (including `TestKeyExchangeGroupSuccess` and `TestKeyExchangeGroupMismatch`)
- [ ] Verified: handshake against a server requiring P-521 succeeds with this patch and fails without it