### PR TITLE
[Python] Fix GIL deadlocks: Release GIL during grpc_channel_destroy/grpc_shutdown in Channel close

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -62,7 +62,8 @@ cdef void _raise_call_error(c_call_error, metadata) except *:
   raise ValueError(_call_error(c_call_error, metadata))
 
 
-cdef _destroy_c_completion_queue(grpc_completion_queue *c_completion_queue):
+cdef void _destroy_c_completion_queue(
+    grpc_completion_queue *c_completion_queue) noexcept nogil:
   grpc_completion_queue_shutdown(c_completion_queue)
   grpc_completion_queue_destroy(c_completion_queue)
 
@@ -445,6 +446,9 @@ cdef _close(Channel channel, grpc_status_code code, object details,
     drain_calls):
   cdef _ChannelState state = channel._state
   cdef _CallState call_state
+  cdef grpc_completion_queue* c_call_cq
+  cdef grpc_completion_queue* c_conn_cq
+  cdef grpc_channel* c_channel
   encoded_details = _encode(details)
   with state.condition:
     if state.open:
@@ -471,11 +475,22 @@ cdef _close(Channel channel, grpc_status_code code, object details,
         while state.connectivity_due:
           state.condition.wait()
 
-      _destroy_c_completion_queue(state.c_call_completion_queue)
-      _destroy_c_completion_queue(state.c_connectivity_completion_queue)
-      grpc_channel_destroy(state.c_channel)
+      # grpc_channel_destroy can synchronously run ~PosixEventEngine ->
+      # Quiesce when this channel_stack holds the last
+      # shared_ptr<EventEngine> (channel_stack.cc:221), and grpc_shutdown can
+      # do similar global teardown. Both must release the GIL: an EventEngine
+      # worker may be inside cygrpc._destroy's `with gil:`
+      # (credentials.pyx.pxi) running Python __del__ code, and Quiesce will
+      # wait for that worker to exit.
+      c_call_cq = state.c_call_completion_queue
+      c_conn_cq = state.c_connectivity_completion_queue
+      c_channel = state.c_channel
       state.c_channel = NULL
-      grpc_shutdown()
+      with nogil:
+        _destroy_c_completion_queue(c_call_cq)
+        _destroy_c_completion_queue(c_conn_cq)
+        grpc_channel_destroy(c_channel)
+        grpc_shutdown()
       state.condition.notify_all()
     else:
       # Another call to close already completed in the past or is currently


### PR DESCRIPTION
## LLM disclosure

Disclosure: I have used LLMs to debug the issue and make the fix. I have verified the conclusions via inspecting gdb outputs manually. I have tried hard to make a reproducer. It's kind of hard to reproduce, as it only happens at scale. I had a reproducer that hijacked some internals to force a use of a separate `EventEngine` to force `Quiesce`, and wasn't able to repro this without it. I decided against pushing the reproducer as the code gets messy, you end up exposing testing details inside of channel.

## LLM Summary + details

`cygrpc._close` (`channel.pyx.pxi`) calls `grpc_completion_queue_shutdown/destroy`, `grpc_channel_destroy`, and `grpc_shutdown` without releasing the GIL. `grpc_channel_destroy` can synchronously run `~PosixEventEngine → Quiesce → BlockUntilThreadCount` when the `channel_stack` being destroyed holds the last `shared_ptr<EventEngine>` (`channel_stack.cc:221`). If an EventEngine worker is concurrently inside `cygrpc._destroy`'s `with gil:` (the `grpc_metadata_credentials_plugin.destroy` callback, `credentials.pyx.pxi`) running Python `__del__` code that momentarily releases and reacquires the GIL, the result is an AB-BA deadlock between the GIL and Quiesce's `CondVar` that freezes the entire Python process.

All four C functions are already declared `nogil` in `grpc.pxi`; this change just wraps the call sites in `with nogil:`.

## Observed in production

We hit this three times in production (grpcio 1.80.0, Python 3.13) with `google-cloud-pubsub`. The pattern was: per-operation, create a `PublisherClient` and a `SubscriberClient`, publish once, close both. The Subscriber was never used, and several such operations overlapped across threads. Each freeze required a hard restart.

## Stack traces (from a live deadlocked process, fully symbolized via gdb + a debug build of the same wheel)

### Thread A — Python thread inside `SubscriberClient.close()` (holds GIL)

```
syscall(FUTEX_WAIT_BITSET)
  absl::synchronization_internal::FutexWaiter::Wait
    absl::CondVar::WaitWithDeadline
      grpc_event_engine::experimental::LivingThreadCount::BlockUntilThreadCount(0, "shutting down", ...)   thread_count.cc
        grpc_event_engine::experimental::WorkStealingThreadPool::WorkStealingThreadPoolImpl::Quiesce       work_stealing_thread_pool.cc
          grpc_event_engine::experimental::PosixEventEngine::~PosixEventEngine
            std::_Sp_counted_base<...>::_M_release          (last shared_ptr<EventEngine>)
              grpc_core::ManualConstructor<std::shared_ptr<EventEngine>>::Destroy
                grpc_channel_stack_destroy                  channel_stack.cc:221
                  ChannelStackBuilderImpl::Build()::<lambda>::operator()
                    exec_ctx_run
                      grpc_core::ExecCtx::Flush
                        grpc_core::ExecCtx::~ExecCtx
                          grpc_channel_destroy              channel.cc            ← GIL still held (no `with nogil:`)
                            cygrpc._close                   channel.pyx.pxi:_close
                              grpc._channel.Channel._close
                                grpc._interceptor._Channel.close
                                  google.pubsub_v1.services.subscriber.transports.grpc.SubscriberGrpcTransport.close
                                    google.cloud.pubsub_v1.SubscriberClient.close
```

`gdb` inspection of the channel: `target=pubsub.googleapis.com:443`, two filters (`client_idle` + `client-channel`), `resolver_=nullptr`, `lb_policy_=nullptr`, `saved_service_config_=nullptr` — never connected. Thread-pool state at deadlock: `reserve_threads_=16`, `living_count_=1` (15 already exited after `Quiesce` set `shutdown_=true`), global queue empty.

### Thread B — `event_engine` worker (in `take_gil`)

```
take_gil                                                    Python/ceval_gil.c:353
  PyEval_RestoreThread          (Py_END_ALLOW_THREADS)
    sock_close                                              Modules/socketmodule.c:3408
      socket._real_close                                    socket.py:499
        socket.close                                        socket.py:505
          http.client.HTTPConnection.close                  http/client.py:1042
            urllib3.connection.HTTPConnection.close         urllib3/connection.py:377
              urllib3.connectionpool._close_pool_connections urllib3/connectionpool.py:1176
                weakref finalize callback                   weakref.py:590
                  urllib3.poolmanager.PoolManager.clear     urllib3/poolmanager.py:288
                    requests.adapters.HTTPAdapter.close     requests/adapters.py:519
                      requests.sessions.Session.close       requests/sessions.py:797
                        google.auth.transport.requests.Request.__del__    google/auth/transport/requests.py:150
                          (Py_DECREF refcount→0)
                            with gil:                       cygrpc._destroy, credentials.pyx.pxi
                              grpc_metadata_credentials_plugin.destroy
                                ~grpc_plugin_credentials
                                  ~grpc_composite_channel_credentials
                                    ~grpc_core::OldSubchannel
                                      grpc_core::ExecCtx::Flush
                                        grpc_core::WorkSerializer::WorkSerializerImpl::Run
                                          grpc_event_engine::experimental::WorkStealingThreadPool::ThreadState::Step
```

This worker is tearing down the (used) Publisher's subchannel. `cygrpc._destroy` does `with gil: cpython.Py_DECREF(<object>state)`; that drops `google.auth.transport.grpc.AuthMetadataPlugin`'s last ref, cascading to `Request.__del__ → requests.Session.close → urllib3 → socket.close()`. `sock_close` does `Py_BEGIN_ALLOW_THREADS; close(fd); Py_END_ALLOW_THREADS` — the `Py_END_ALLOW_THREADS` is the `take_gil` above.

### The cycle

Thread A holds the GIL and is parked in `Quiesce` waiting for every EventEngine worker to exit. Thread B is the last such worker; it cannot exit because it's mid-`__del__` waiting in `take_gil` for thread A to release the GIL. Every other Python thread also blocks on `take_gil`.

## Timeline

```
t0   Thread X closes the (used) PublisherClient.
        cygrpc._close → grpc_channel_destroy returns quickly; the connected
        subchannel's teardown is queued onto the EventEngine.

t1   EventEngine worker B picks that up:
        ~OldSubchannel → ~grpc_composite_channel_credentials
          → ~grpc_plugin_credentials
            → cygrpc._destroy:  with gil:  Py_DECREF(auth_plugin)
              → google.auth.transport.requests.Request.__del__
                → requests.Session.close → urllib3 → socket.close()
                  → Py_BEGIN_ALLOW_THREADS              ── B releases the GIL ──┐
                                                                                │
t2   Thread A (closing the never-used SubscriberClient) grabs the GIL: ◀────────┘
        cygrpc._close → grpc_channel_destroy            ── GIL held, no nogil ──
          LegacyChannel::Orphaned()
            ClientChannelFilter::StartTransportOp:
              GRPC_CHANNEL_STACK_REF      (1→2)
              work_serializer_->Run(...)  → event_engine_->Run(this)
          (returns; A continues toward ~LegacyChannel)

t2+ε A second idle EventEngine worker C picks up the WorkSerializer task:
        StartTransportOpLocked            (no resolver/LB/subchannel ⇒ no-op)
        GRPC_CHANNEL_STACK_UNREF          (2→1)          ── finishes in ~1 µs

t2+δ Thread A reaches ~LegacyChannel → ~channel_stack_:
        GRPC_CHANNEL_STACK_UNREF          (1→0)          ── A's UNREF is LAST
        destroy closure scheduled to A's ExecCtx

     (still inside grpc_channel_destroy, GIL still held)
        ~ExecCtx::Flush → grpc_channel_stack_destroy
          channel_stack.cc:221  stack->event_engine.Destroy()
            ~shared_ptr<EventEngine>      (last ref)
              ~PosixEventEngine
                WorkStealingThreadPoolImpl::Quiesce:
                  SetShutdown(true);  work_signal_.SignalAll()
                  BlockUntilThreadCount(0, "shutting down")   ◀─── A parks here

t3   Workers C (and the other 14) wake, see shutdown, no work → exit.
     living_count_: 16 → 1.   Only B remains.

t4   B's close() syscall returns:
        Py_END_ALLOW_THREADS → take_gil                  ◀─── B parks here
        (A holds the GIL; A is parked in Quiesce waiting for B)

     ╔═══════════════════════════════════════════════════════════════╗
     ║  AB-BA:   A holds GIL, waits Quiesce CondVar (needs B to exit) ║
     ║           B in take_gil, waits GIL (held by A)                 ║
     ║  Every other Python thread blocks in take_gil → process frozen ║
     ╚═══════════════════════════════════════════════════════════════╝
```

After the fix, A releases the GIL at `t2` before entering `grpc_channel_destroy`. At `t4` B reacquires the GIL, finishes `__del__`, returns to its worker loop, sees `shutdown_`, exits; `living_count_` reaches 0; A's `BlockUntilThreadCount` returns; A reacquires the GIL and `Channel.close()` returns.

## Why the never-connected channel matters

`LegacyChannel::Orphaned()` → `start_transport_op(disconnect)` → `ClientChannelFilter::StartTransportOp` does `GRPC_CHANNEL_STACK_REF` (1→2) and posts to its `WorkSerializer` (`work_serializer.cc:180`, which always dispatches via `event_engine_->Run(this)`). For a never-connected channel `StartTransportOpLocked` is a near-no-op (no resolver, no LB, no subchannels), so an idle EventEngine worker finishes it in microseconds and `STACK_UNREF`s (2→1) **before** the close thread reaches `~LegacyChannel → ~channel_stack_ → STACK_UNREF`. The close thread's UNREF is therefore the last (1→0), so the destroy closure runs in *its* `ExecCtx`, and `grpc_channel_stack_destroy → channel_stack.cc:221` runs `~shared_ptr<EventEngine>` on the close thread with the GIL held. For a normally connected channel the EventEngine worker's UNREF is last and the engine destructor runs there (no GIL), which is harmless.

## Why there is no regression test

Reproducing through the public Python API requires winning the microsecond `STACK_UNREF` race above **and** having no other `shared_ptr<EventEngine>` live at that instant. We could not trigger it locally in ~6 500 iterations across several stress harnesses. A deterministic test needs a `cygrpc.Channel` whose `c_channel` is a `GRPC_CLIENT_LAME_CHANNEL` (no `client_channel` filter ⇒ synchronous destroy) bound to an isolated `EventEngine`; we built that and verified that **without** this fix `Channel.close()` deadlocks and is killed by a `faulthandler` watchdog, and **with** this fix it returns. That scaffolding requires either compiling a helper into `cygrpc.so` or extending `bazel/cython_library.bzl` for cross-package `cimport`, so we left it out of this PR. Happy to add it in a follow-up if maintainers prefer; the diff and a captured failing/passing run are linked in the issue.

The fix itself is defensively obvious: all four functions are already declared `nogil` in `grpc.pxi`, so wrapping the call sites in `with nogil:` has no downside.
