### PR TITLE
update grpc_cli to use v1:reflection instead of v1alpha:reflection

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -56,7 +56,7 @@ grpc_cc_library(
         "//:gpr",
         "//:grpc++",
         "//:grpc++_config_proto",
-        "//src/proto/grpc/reflection/v1alpha:reflection_proto",
+        "//src/proto/grpc/reflection/v1:reflection_proto",
     ],
 )
 
@@ -183,7 +183,7 @@ grpc_cc_library(
         "//:grpc_slice",
         "//src/core:grpc_check",
         "//src/core:load_file",
-        "//src/proto/grpc/reflection/v1alpha:reflection_proto",
+        "//src/proto/grpc/reflection/v1:reflection_proto",
     ],
 )
 
@@ -409,7 +409,7 @@ grpc_cc_binary(
         ":grpc_cli_utils",
         ":test_config",
         "//:grpc++",
-        "//src/proto/grpc/reflection/v1alpha:reflection_proto",
+        "//src/proto/grpc/reflection/v1:reflection_proto",
     ],
 )
 

--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -23,11 +23,11 @@
 #include "src/core/util/crash.h"
 #include "absl/log/log.h"
 
-using grpc::reflection::v1alpha::ErrorResponse;
-using grpc::reflection::v1alpha::ListServiceResponse;
-using grpc::reflection::v1alpha::ServerReflection;
-using grpc::reflection::v1alpha::ServerReflectionRequest;
-using grpc::reflection::v1alpha::ServerReflectionResponse;
+using grpc::reflection::v1::ErrorResponse;
+using grpc::reflection::v1::ListServiceResponse;
+using grpc::reflection::v1::ServerReflection;
+using grpc::reflection::v1::ServerReflectionRequest;
+using grpc::reflection::v1::ServerReflectionResponse;
 
 namespace grpc {
 
@@ -282,7 +282,7 @@ ProtoReflectionDescriptorDatabase::ParseFileDescriptorProtoResponse(
 }
 
 void ProtoReflectionDescriptorDatabase::AddFileFromResponse(
-    const grpc::reflection::v1alpha::FileDescriptorResponse& response) {
+    const grpc::reflection::v1::FileDescriptorResponse& response) {
   for (int i = 0; i < response.file_descriptor_proto_size(); ++i) {
     const protobuf::FileDescriptorProto file_proto =
         ParseFileDescriptorProtoResponse(response.file_descriptor_proto(i));

--- a/test/cpp/util/proto_reflection_descriptor_database.h
+++ b/test/cpp/util/proto_reflection_descriptor_database.h
@@ -24,7 +24,7 @@
 #include <mutex>
 #include <vector>
 
-#include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
+#include "src/proto/grpc/reflection/v1/reflection.grpc.pb.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 
@@ -36,7 +36,7 @@ namespace grpc {
 class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
  public:
   explicit ProtoReflectionDescriptorDatabase(
-      std::unique_ptr<reflection::v1alpha::ServerReflection::Stub> stub);
+      std::unique_ptr<reflection::v1::ServerReflection::Stub> stub);
 
   explicit ProtoReflectionDescriptorDatabase(
       const std::shared_ptr<grpc::ChannelInterface>& channel);
@@ -79,25 +79,25 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
 
  private:
   typedef ClientReaderWriter<
-      grpc::reflection::v1alpha::ServerReflectionRequest,
-      grpc::reflection::v1alpha::ServerReflectionResponse>
+      grpc::reflection::v1::ServerReflectionRequest,
+      grpc::reflection::v1::ServerReflectionResponse>
       ClientStream;
 
   protobuf::FileDescriptorProto ParseFileDescriptorProtoResponse(
       const std::string& byte_fd_proto);
 
   void AddFileFromResponse(
-      const grpc::reflection::v1alpha::FileDescriptorResponse& response);
+      const grpc::reflection::v1::FileDescriptorResponse& response);
 
   std::shared_ptr<ClientStream> GetStream();
 
   bool DoOneRequest(
-      const grpc::reflection::v1alpha::ServerReflectionRequest& request,
-      grpc::reflection::v1alpha::ServerReflectionResponse& response);
+      const grpc::reflection::v1::ServerReflectionRequest& request,
+      grpc::reflection::v1::ServerReflectionResponse& response);
 
   std::shared_ptr<ClientStream> stream_;
   grpc::ClientContext ctx_;
-  std::unique_ptr<grpc::reflection::v1alpha::ServerReflection::Stub> stub_;
+  std::unique_ptr<grpc::reflection::v1::ServerReflection::Stub> stub_;
   absl::flat_hash_set<std::string> known_files_;
   absl::flat_hash_set<string> missing_symbols_;
   absl::flat_hash_map<string, absl::flat_hash_set<int>> missing_extensions_;


### PR DESCRIPTION
Updating the grpc_cli tool to use v1::reflection_proto instead of v1alph::reflection_proto

v1::reflection hasn't seen an update for the past 5 year. v1alpha 9 years. I'd argue that most of grpc servers use v1 reflection for the past couple years. For example Spring grpc default reflection uses v1.

If it helps, I used to have c++ readability ;) 

