### PR TITLE
[ObjC] Add receiveNextMessage to GRPCUnaryProtoCall

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -126,6 +126,26 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)cancel;
 
+/**
+ * Tell gRPC to receive another message.
+ *
+ * This method should only be used when flow control is enabled. If flow control is enabled, gRPC
+ * will only receive additional messages after the user indicates so by using either
+ * receiveNextMessage: or receiveNextMessages: methods. If flow control is not enabled, messages
+ * will be automatically received after the previous one is delivered.
+ */
+- (void)receiveNextMessage;
+
+/**
+ * Tell gRPC to receive another N message.
+ *
+ * This method should only be used when flow control is enabled. If flow control is enabled, the
+ * messages received from the server are buffered in gRPC until the user want to receive the next
+ * message. If flow control is not enabled, messages will be automatically received after the
+ * previous one is delivered.
+ */
+- (void)receiveNextMessages:(NSUInteger)numberOfMessages;
+
 @end
 
 /** A client-streaming RPC call with Protobuf. */

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -109,6 +109,14 @@
   [_call cancel];
 }
 
+- (void)receiveNextMessage {
+  [_call receiveNextMessage];
+}
+
+- (void)receiveNextMessages:(NSUInteger)numberOfMessages {
+  [_call receiveNextMessages:numberOfMessages];
+}
+
 @end
 
 @interface GRPCStreamingProtoCall () <GRPCResponseHandler>


### PR DESCRIPTION
Internal request b/503384941

GRPCUnaryProtoCall represent Unary and Server streaming RPC hence needed this method for later case.