### PR TITLE
thread_manager: fix wrong mutex in GetMaxActiveThreadsSoFar

### DIFF
--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -91,7 +91,7 @@ bool ThreadManager::IsShutdown() {
 }
 
 int ThreadManager::GetMaxActiveThreadsSoFar() {
-  grpc_core::MutexLock list_lock(&list_mu_);
+  grpc_core::MutexLock lock(&mu_);
   return max_active_threads_sofar_;
 }
 

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -25,6 +25,7 @@
 #include "src/core/lib/resource_quota/thread_quota.h"
 #include "src/core/util/sync.h"
 #include "src/core/util/thd.h"
+#include "absl/base/thread_annotations.h"
 
 namespace grpc {
 
@@ -143,7 +144,7 @@ class ThreadManager {
   // max_active_threads_sofar_
   grpc_core::Mutex mu_;
 
-  bool shutdown_;
+  bool shutdown_ ABSL_GUARDED_BY(mu_);
   grpc_core::CondVar shutdown_cv_;
 
   // The resource user object to use when requesting quota to create threads
@@ -155,7 +156,7 @@ class ThreadManager {
   grpc_core::ThreadQuotaPtr thread_quota_;
 
   // Number of threads doing polling
-  int num_pollers_;
+  int num_pollers_ ABSL_GUARDED_BY(mu_);
 
   // The minimum and maximum number of threads that should be doing polling
   int min_pollers_;
@@ -163,15 +164,15 @@ class ThreadManager {
 
   // The total number of threads currently active (includes threads includes the
   // threads that are currently polling i.e num_pollers_)
-  int num_threads_;
+  int num_threads_ ABSL_GUARDED_BY(mu_);
 
   // See GetMaxActiveThreadsSoFar()'s description.
   // To be more specific, this variable tracks the max value num_threads_ was
   // ever set so far
-  int max_active_threads_sofar_;
+  int max_active_threads_sofar_ ABSL_GUARDED_BY(mu_);
 
   grpc_core::Mutex list_mu_;
-  std::list<WorkerThread*> completed_threads_;
+  std::list<WorkerThread*> completed_threads_ ABSL_GUARDED_BY(list_mu_);
 };
 
 }  // namespace grpc

--- a/test/cpp/thread_manager/thread_manager_test.cc
+++ b/test/cpp/thread_manager/thread_manager_test.cc
@@ -177,6 +177,16 @@ TEST_P(ThreadManagerTest, TestThreadQuota) {
   }
 }
 
+TEST_P(ThreadManagerTest, TestMaxActiveThreadsSoFar) {
+  for (auto& tm : thread_manager_) {
+    int max_active = tm->GetMaxActiveThreadsSoFar();
+    EXPECT_GE(max_active, GetParam().min_pollers);
+    if (GetParam().thread_limit > 0) {
+      EXPECT_LE(max_active, GetParam().thread_limit);
+    }
+  }
+}
+
 }  // namespace
 }  // namespace grpc
 


### PR DESCRIPTION
## Problem
GetMaxActiveThreadsSoFar() was acquiring list_mu_ instead of mu_,
causing a potential data race. max_active_threads_sofar_ is written
under mu_ in both MainWorkLoop() and Initialize(), so reads must also
use mu_. list_mu_ guards completed_threads_ and has no relationship
to max_active_threads_sofar_.

## Fix
Replace list_mu_ with mu_ in GetMaxActiveThreadsSoFar().

## Testing
Added TestMaxActiveThreadsSoFar to verify that max_active_threads_sofar_
is at least min_pollers after shutdown, and does not exceed thread_limit
when one is set. The data race itself is confirmed by code inspection —
detecting it at runtime would require concurrent calls to
GetMaxActiveThreadsSoFar() during active polling under TSan.