### PR TITLE
[Python] Hide internal symbols from Python's `cygrpc` shared object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Dropbox, Inc.
 Google Inc.
+Signeen Inc.
 Skyscanner Ltd.
 WeWork Companies Inc.

--- a/PYTHON-MANIFEST.in
+++ b/PYTHON-MANIFEST.in
@@ -13,6 +13,7 @@ graft third_party/upb
 graft third_party/utf8_range
 graft third_party/xxhash
 graft third_party/zlib
+include src/python/grpcio/cygrpc_exports.lds
 include src/python/grpcio/_parallel_compile_patch.py
 include src/python/grpcio/_spawn_patch.py
 include src/python/grpcio/commands.py

--- a/setup.py
+++ b/setup.py
@@ -292,11 +292,17 @@ if EXTRA_ENV_LINK_ARGS is None:
             EXTRA_ENV_LINK_ARGS += " -latomic"
     if "linux" in sys.platform:
         EXTRA_ENV_LINK_ARGS += " -static-libgcc"
+        _version_script = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "src", "python", "grpcio", "cygrpc_exports.lds",
+        )
+        EXTRA_ENV_LINK_ARGS += " -Wl,--version-script=" + _version_script
 
 # Explicitly link Core Foundation framework for MacOS to ensure no symbol is
 # missing when compiled using package managers like Conda.
 if "darwin" in sys.platform:
     EXTRA_ENV_LINK_ARGS += " -framework CoreFoundation"
+    EXTRA_ENV_LINK_ARGS += " -Wl,-exported_symbol,_PyInit_cygrpc"
 
 EXTRA_COMPILE_ARGS = shlex.split(EXTRA_ENV_COMPILE_ARGS)
 EXTRA_LINK_ARGS = shlex.split(EXTRA_ENV_LINK_ARGS)

--- a/setup.py
+++ b/setup.py
@@ -299,7 +299,7 @@ if EXTRA_ENV_LINK_ARGS is None:
             "grpcio",
             "cygrpc_exports.lds",
         )
-        EXTRA_ENV_LINK_ARGS += " -Wl,--version-script=" + _version_script
+        EXTRA_ENV_LINK_ARGS += f' -Wl,--version-script="{_version_script}"'
 
 # Explicitly link Core Foundation framework for MacOS to ensure no symbol is
 # missing when compiled using package managers like Conda.

--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,10 @@ if EXTRA_ENV_LINK_ARGS is None:
         EXTRA_ENV_LINK_ARGS += " -static-libgcc"
         _version_script = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "src", "python", "grpcio", "cygrpc_exports.lds",
+            "src",
+            "python",
+            "grpcio",
+            "cygrpc_exports.lds",
         )
         EXTRA_ENV_LINK_ARGS += " -Wl,--version-script=" + _version_script
 

--- a/src/python/grpcio/cygrpc_exports.lds
+++ b/src/python/grpcio/cygrpc_exports.lds
@@ -1,0 +1,4 @@
+{
+    global: PyInit_cygrpc;
+    local: *;
+};


### PR DESCRIPTION
The `cygrpc` extension module statically links gRPC core, BoringSSL, c-ares, zlib, and abseil. Although the C/C++ sources are compiled with -fvisibility=hidden, the pre-built static libraries were not, so their symbols leak into the final .so as dynamic exports.

On Linux (1.80.0 manylinux wheel), `cygrpc.so` exports 431 symbols including c-ares internals. This causes problems when grpcio is loaded alongside other native extensions that bundle their own copies of the same libraries — symbol interposition can lead to crashes, silent corruption, or version mismatches.

Add a linker version script (Linux) and `-exported_symbol` (macOS) that export only `PyInit_cygrpc` and hide everything else.

Fixes #42434 