### PR TITLE
[EventEngine] Fix signedness mismatch in debugging check

### DIFF
--- a/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_endpoint.cc
@@ -1134,7 +1134,7 @@ bool PosixEndpointImpl::TcpFlush(absl::Status& status) {
     }
 
     GRPC_CHECK_EQ(outgoing_byte_idx_, 0u);
-    GRPC_CHECK_LE((*send_result), sending_length);
+    GRPC_CHECK_LE((static_cast<size_t>(*send_result)), sending_length);
     bytes_counter_ += *send_result;
     trailing = sending_length - static_cast<size_t>(*send_result);
     while (trailing > 0) {


### PR DESCRIPTION
Fix a bug in #41924 that introduced a comparison between signed and unsigned integers, which is rejected with strict warnings. The goal is to have the Bazel RBE Build Tests job pass.
