### PR TITLE
Fix TcharToChar appending stray null byte

### DIFF
--- a/src/core/util/tchar.cc
+++ b/src/core/util/tchar.cc
@@ -31,11 +31,11 @@ TcharString CharToTchar(std::string input) {
 }
 
 std::string TcharToChar(TcharString input) {
-  int needed =
-      WideCharToMultiByte(CP_UTF8, 0, input.c_str(), -1, NULL, 0, NULL, NULL);
+  int needed = WideCharToMultiByte(CP_UTF8, 0, input.c_str(), input.size(),
+                                   NULL, 0, NULL, NULL);
   if (needed <= 0) return std::string();
   std::string ret(needed, '\0');
-  WideCharToMultiByte(CP_UTF8, 0, input.c_str(), -1,
+  WideCharToMultiByte(CP_UTF8, 0, input.c_str(), input.size(),
                       const_cast<LPSTR>(ret.data()), needed, NULL, NULL);
   return ret;
 }


### PR DESCRIPTION
## Summary

Diagnosis and proposed fix by @zhizhi-dev in #41955 — this PR just lands it.

`TcharToChar` calls `WideCharToMultiByte` with `cchWideChar = -1`, which
treats the input as null-terminated and **counts the terminator** in the
returned byte length. The resulting `std::string` therefore has `size()`
one larger than the real content, with a trailing `'\0'` inside its
bounds.

This breaks exact-string comparisons against values read from environment
variables on Windows. For example, `set GRPC_VERBOSITY=INFO` produces:

    Unknown log verbosity: INFO
    Unknown tracer: timer_check

because the returned string is `"INFO\0"` (size 5), not `"INFO"` (size 4).

The fix is to pass `input.size()` instead of `-1`, which excludes the
terminator (`std::wstring::size()` does not include it).

Fixes #41955

## Test plan

- [ ] Build on Windows with `clang-cl`
- [ ] `set GRPC_VERBOSITY=INFO` no longer triggers "Unknown log verbosity"
- [ ] `set GRPC_TRACE=timer_check` no longer triggers "Unknown tracer"