### PR TITLE
Fix intermittent segfault in PHP plugin credentials

### DIFF
--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -28,11 +28,118 @@
 
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+#include <grpc/support/sync.h>
 
 #include "call.h"
 
 zend_class_entry *grpc_ce_call_credentials;
 PHP_GRPC_DECLARE_OBJECT_HANDLER(call_credentials_ce_handlers)
+
+static gpr_mu grpc_php_call_credentials_registry_mu;
+static plugin_state *grpc_php_call_credentials_registry_head = NULL;
+static int grpc_php_call_credentials_registry_initialized = 0;
+
+void grpc_php_call_credentials_module_init(void) {
+  if (!grpc_php_call_credentials_registry_initialized) {
+    gpr_mu_init(&grpc_php_call_credentials_registry_mu);
+    grpc_php_call_credentials_registry_head = NULL;
+    grpc_php_call_credentials_registry_initialized = 1;
+  }
+}
+
+void grpc_php_call_credentials_module_shutdown(void) {
+  if (grpc_php_call_credentials_registry_initialized) {
+    gpr_mu_destroy(&grpc_php_call_credentials_registry_mu);
+    grpc_php_call_credentials_registry_head = NULL;
+    grpc_php_call_credentials_registry_initialized = 0;
+  }
+}
+
+static void plugin_state_register(plugin_state *state) {
+  gpr_mu_lock(&grpc_php_call_credentials_registry_mu);
+  state->prev = NULL;
+  state->next = grpc_php_call_credentials_registry_head;
+  if (grpc_php_call_credentials_registry_head != NULL) {
+    grpc_php_call_credentials_registry_head->prev = state;
+  }
+  grpc_php_call_credentials_registry_head = state;
+  gpr_mu_unlock(&grpc_php_call_credentials_registry_mu);
+}
+
+static void plugin_state_unregister(plugin_state *state) {
+  gpr_mu_lock(&grpc_php_call_credentials_registry_mu);
+  if (state->prev != NULL) {
+    state->prev->next = state->next;
+  } else if (grpc_php_call_credentials_registry_head == state) {
+    grpc_php_call_credentials_registry_head = state->next;
+  }
+  if (state->next != NULL) {
+    state->next->prev = state->prev;
+  }
+  state->prev = NULL;
+  state->next = NULL;
+  gpr_mu_unlock(&grpc_php_call_credentials_registry_mu);
+}
+
+static int plugin_state_detach_locked(plugin_state *state,
+                                      zend_fcall_info **out_fci,
+                                      zend_fcall_info_cache **out_fci_cache,
+                                      zval *out_function_name,
+                                      zend_bool *out_function_name_addref) {
+  *out_fci = state->fci;
+  *out_fci_cache = state->fci_cache;
+  *out_function_name_addref = state->function_name_added_ref;
+  if (state->function_name_added_ref && state->fci != NULL) {
+    *out_function_name = state->fci->function_name;
+  }
+  state->fci = NULL;
+  state->fci_cache = NULL;
+  state->function_name_added_ref = 0;
+  return *out_fci != NULL || *out_fci_cache != NULL;
+}
+
+static void plugin_state_release_detached(zend_fcall_info *fci,
+                                          zend_fcall_info_cache *fci_cache,
+                                          zval *function_name,
+                                          zend_bool function_name_addref) {
+  if (function_name_addref) {
+    zval_ptr_dtor(function_name);
+  }
+  if (fci != NULL) free(fci);
+  if (fci_cache != NULL) free(fci_cache);
+}
+
+void grpc_php_call_credentials_request_shutdown(void) {
+  if (!grpc_php_call_credentials_registry_initialized) {
+    return;
+  }
+
+  while (1) {
+    zend_fcall_info *fci = NULL;
+    zend_fcall_info_cache *fci_cache = NULL;
+    zval function_name;
+    zend_bool addref = 0;
+    int found = 0;
+
+    gpr_mu_lock(&grpc_php_call_credentials_registry_mu);
+    for (plugin_state *s = grpc_php_call_credentials_registry_head; s != NULL;
+         s = s->next) {
+      gpr_mu_lock(&s->mu);
+      if (!s->invalidated) {
+        plugin_state_detach_locked(s, &fci, &fci_cache, &function_name, &addref);
+        s->invalidated = 1;
+        gpr_mu_unlock(&s->mu);
+        found = 1;
+        break;
+      }
+      gpr_mu_unlock(&s->mu);
+    }
+    gpr_mu_unlock(&grpc_php_call_credentials_registry_mu);
+
+    if (!found) break;
+    plugin_state_release_detached(fci, fci_cache, &function_name, addref);
+  }
+}
 
 /* Frees and destroys an instance of wrapped_grpc_call_credentials */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call_credentials)
@@ -121,10 +228,16 @@ PHP_METHOD(CallCredentials, createFromPlugin) {
   plugin_state *state;
   state = (plugin_state *)malloc(sizeof(plugin_state));
   memset(state, 0, sizeof(plugin_state));
+  gpr_mu_init(&state->mu);
 
-  /* save the user provided PHP callback function */
+  /* save the user provided PHP callback function. Addref the callable so it
+   * stays alive while we reference it; the matching dtor runs in
+   * plugin_destroy_state or in the PHP_RSHUTDOWN sweep, whichever comes first. */
   state->fci = fci;
   state->fci_cache = fci_cache;
+  Z_TRY_ADDREF(fci->function_name);
+  state->function_name_added_ref = 1;
+  plugin_state_register(state);
 
   grpc_metadata_credentials_plugin plugin;
   plugin.get_metadata = plugin_get_metadata;
@@ -139,7 +252,7 @@ PHP_METHOD(CallCredentials, createFromPlugin) {
   RETURN_DESTROY_ZVAL(creds_object);
 }
 
-/* Callback function for plugin creds API */
+/* Callback function for plugin creds API*/
 int plugin_get_metadata(
     void *ptr, grpc_auth_metadata_context context,
     grpc_credentials_plugin_metadata_cb cb, void *user_data,
@@ -149,6 +262,20 @@ int plugin_get_metadata(
   TSRMLS_FETCH();
 
   plugin_state *state = (plugin_state *)ptr;
+
+  *num_creds_md = 0;
+  *status = GRPC_STATUS_OK;
+  *error_details = NULL;
+
+  gpr_mu_lock(&state->mu);
+  if (state->invalidated || state->fci == NULL || state->fci_cache == NULL) {
+    *status = GRPC_STATUS_UNAVAILABLE;
+    *error_details = gpr_strdup(
+        "PHP plugin credentials callback was invoked after its owning PHP "
+        "request had ended");
+    gpr_mu_unlock(&state->mu);
+    return true;
+  }
 
   /* prepare to call the user callback function with info from the
    * grpc_auth_metadata_context */
@@ -167,10 +294,6 @@ int plugin_get_metadata(
 
   /* call the user callback function */
   PHP_GRPC_CALL_FUNCTION(state->fci, state->fci_cache);
-
-  *num_creds_md = 0;
-  *status = GRPC_STATUS_OK;
-  *error_details = NULL;
 
   bool should_return = false;
   grpc_metadata_array metadata;
@@ -192,6 +315,7 @@ int plugin_get_metadata(
     PHP_GRPC_FREE_STD_ZVAL(retval);
   }
   if (should_return) {
+    gpr_mu_unlock(&state->mu);
     return true;
   }
 
@@ -212,15 +336,30 @@ int plugin_get_metadata(
   }
 
   grpc_metadata_array_destroy(&metadata);
+  gpr_mu_unlock(&state->mu);
   return true;  // Synchronous return.
 }
 
-/* Cleanup function for plugin creds API */
+/* Cleanup function for plugin creds API*/
 void plugin_destroy_state(void *ptr) {
   plugin_state *state = (plugin_state *)ptr;
-  free(state->fci);
-  free(state->fci_cache);
+  plugin_state_unregister(state);
+
+  zend_fcall_info *fci = NULL;
+  zend_fcall_info_cache *fci_cache = NULL;
+  zval function_name;
+  zend_bool addref = 0;
+
+  gpr_mu_lock(&state->mu);
+  if (!state->invalidated) {
+    plugin_state_detach_locked(state, &fci, &fci_cache, &function_name, &addref);
+    state->invalidated = 1;
+  }
+  gpr_mu_unlock(&state->mu);
+  gpr_mu_destroy(&state->mu);
   free(state);
+
+  plugin_state_release_detached(fci, fci_cache, &function_name, addref);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_createComposite, 0, 0, 2)

--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -85,25 +85,30 @@ static int plugin_state_detach_locked(plugin_state *state,
                                       zend_fcall_info **out_fci,
                                       zend_fcall_info_cache **out_fci_cache,
                                       zval *out_function_name,
-                                      zend_bool *out_function_name_addref) {
+                                      zend_bool *out_callable_refs_added) {
   *out_fci = state->fci;
   *out_fci_cache = state->fci_cache;
-  *out_function_name_addref = state->function_name_added_ref;
-  if (state->function_name_added_ref && state->fci != NULL) {
+  if (state->callable_refs_added && state->fci != NULL) {
     *out_function_name = state->fci->function_name;
+    *out_callable_refs_added = 1;
+  } else {
+    *out_callable_refs_added = 0;
   }
   state->fci = NULL;
   state->fci_cache = NULL;
-  state->function_name_added_ref = 0;
+  state->callable_refs_added = 0;
   return *out_fci != NULL || *out_fci_cache != NULL;
 }
 
 static void plugin_state_release_detached(zend_fcall_info *fci,
                                           zend_fcall_info_cache *fci_cache,
                                           zval *function_name,
-                                          zend_bool function_name_addref) {
-  if (function_name_addref) {
+                                          zend_bool callable_refs_added) {
+  if (callable_refs_added) {
     zval_ptr_dtor(function_name);
+    if (fci != NULL && fci->object != NULL) {
+      OBJ_RELEASE(fci->object);
+    }
   }
   if (fci != NULL) free(fci);
   if (fci_cache != NULL) free(fci_cache);
@@ -118,6 +123,7 @@ void grpc_php_call_credentials_request_shutdown(void) {
     zend_fcall_info *fci = NULL;
     zend_fcall_info_cache *fci_cache = NULL;
     zval function_name;
+    ZVAL_UNDEF(&function_name);
     zend_bool addref = 0;
     int found = 0;
 
@@ -230,13 +236,26 @@ PHP_METHOD(CallCredentials, createFromPlugin) {
   memset(state, 0, sizeof(plugin_state));
   gpr_mu_init(&state->mu);
 
-  /* save the user provided PHP callback function. Addref the callable so it
-   * stays alive while we reference it; the matching dtor runs in
-   * plugin_destroy_state or in the PHP_RSHUTDOWN sweep, whichever comes first. */
+  /* Save the user-provided PHP callback. Addref every piece of the callable
+   * we will dereference later, so the user dropping their references doesn't
+   * free them out from under us:
+   *   - fci->function_name: the callable zval (closure / string name / array)
+   *   - fci->object:        the bound instance for object-method callables
+   *                         like [$obj, 'method']. Without this addref the
+   *                         instance can be GC'd while the plugin state is
+   *                         still alive, leading to a method dispatch on a
+   *                         freed zend_object.
+   * The two refs are atomic with respect to each other and are released as a
+   * unit in plugin_state_release_detached. The matching release runs in
+   * plugin_destroy_state or in the PHP_RSHUTDOWN sweep, whichever comes
+   * first. */
   state->fci = fci;
   state->fci_cache = fci_cache;
   Z_TRY_ADDREF(fci->function_name);
-  state->function_name_added_ref = 1;
+  if (fci->object != NULL) {
+    GC_ADDREF(fci->object);
+  }
+  state->callable_refs_added = 1;
   plugin_state_register(state);
 
   grpc_metadata_credentials_plugin plugin;
@@ -348,6 +367,7 @@ void plugin_destroy_state(void *ptr) {
   zend_fcall_info *fci = NULL;
   zend_fcall_info_cache *fci_cache = NULL;
   zval function_name;
+  ZVAL_UNDEF(&function_name);
   zend_bool addref = 0;
 
   gpr_mu_lock(&state->mu);

--- a/src/php/ext/grpc/call_credentials.h
+++ b/src/php/ext/grpc/call_credentials.h
@@ -46,7 +46,7 @@ typedef struct plugin_state {
   zend_fcall_info_cache *fci_cache;
   gpr_mu mu;
   zend_bool invalidated;
-  zend_bool function_name_added_ref;
+  zend_bool callable_refs_added;
   struct plugin_state *next;
   struct plugin_state *prev;
 } plugin_state;

--- a/src/php/ext/grpc/call_credentials.h
+++ b/src/php/ext/grpc/call_credentials.h
@@ -23,6 +23,7 @@
 
 #include <grpc/credentials.h>
 #include <grpc/grpc_security.h>
+#include <grpc/support/sync.h>
 
 /* Class entry for the CallCredentials PHP class */
 extern zend_class_entry *grpc_ce_call_credentials;
@@ -39,10 +40,15 @@ static inline wrapped_grpc_call_credentials
       (char*)(obj) - XtOffsetOf(wrapped_grpc_call_credentials, std));
 }
 
-/* Struct to hold callback function for plugin creds API */
+/* Struct to hold callback function for plugin creds API*/
 typedef struct plugin_state {
   zend_fcall_info *fci;
   zend_fcall_info_cache *fci_cache;
+  gpr_mu mu;
+  zend_bool invalidated;
+  zend_bool function_name_added_ref;
+  struct plugin_state *next;
+  struct plugin_state *prev;
 } plugin_state;
 
 /* Callback function for plugin creds API */
@@ -58,5 +64,8 @@ void plugin_destroy_state(void *ptr);
 
 /* Initializes the CallCredentials PHP class */
 void grpc_init_call_credentials(TSRMLS_D);
+void grpc_php_call_credentials_module_init(void);
+void grpc_php_call_credentials_module_shutdown(void);
+void grpc_php_call_credentials_request_shutdown(void);
 
 #endif /* NET_GRPC_PHP_GRPC_CALL_CREDENTIALS_H_ */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -64,7 +64,7 @@ zend_module_entry grpc_module_entry = {
   PHP_MINIT(grpc),
   PHP_MSHUTDOWN(grpc),
   PHP_RINIT(grpc),
-  NULL,
+  PHP_RSHUTDOWN(grpc),
   PHP_MINFO(grpc),
   PHP_GRPC_VERSION,
   PHP_MODULE_GLOBALS(grpc),
@@ -520,6 +520,7 @@ PHP_MINIT_FUNCTION(grpc) {
   grpc_init_timeval(TSRMLS_C);
   grpc_init_channel_credentials(TSRMLS_C);
   grpc_init_call_credentials(TSRMLS_C);
+  grpc_php_call_credentials_module_init();
   grpc_init_server_credentials(TSRMLS_C);
   return SUCCESS;
 }
@@ -541,6 +542,12 @@ PHP_MSHUTDOWN_FUNCTION(grpc) {
     grpc_shutdown();
     GRPC_G(initialized) = 0;
   }
+  grpc_php_call_credentials_module_shutdown();
+  return SUCCESS;
+}
+
+PHP_RSHUTDOWN_FUNCTION(grpc) {
+  grpc_php_call_credentials_request_shutdown();
   return SUCCESS;
 }
 /* }}} */

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -67,6 +67,8 @@ PHP_MSHUTDOWN_FUNCTION(grpc);
 PHP_MINFO_FUNCTION(grpc);
 /* Code that runs at request start */
 PHP_RINIT_FUNCTION(grpc);
+/* Code that runs at request shutdown */
+PHP_RSHUTDOWN_FUNCTION(grpc);
 
 /*
   Declare any global variables you may need between the BEGIN

--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -187,4 +187,64 @@ class CallCredentials2Test extends \PHPUnit\Framework\TestCase
         $this->assertTrue($event->send_close);
         $this->assertTrue($event->status->code == Grpc\STATUS_UNAVAILABLE);
     }
+
+    public function testCreateFromPluginWithDroppedBoundInstance()
+    {
+        $deadline = Grpc\Timeval::infFuture();
+        $status_text = 'xyz';
+        $call = new Grpc\Call($this->channel,
+                              '/abc/phony_method',
+                              $deadline,
+                              $this->host_override);
+
+        $callback_holder = new CallCredentials2TestCallbackHolder();
+        $call_credentials = Grpc\CallCredentials::createFromPlugin(
+            array($callback_holder, 'callbackFunc'));
+        unset($callback_holder);
+        gc_collect_cycles();
+
+        $call->setCredentials($call_credentials);
+
+        $event = $call->startBatch([
+            Grpc\OP_SEND_INITIAL_METADATA => [],
+            Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
+        ]);
+
+        $this->assertTrue($event->send_metadata);
+        $this->assertTrue($event->send_close);
+
+        $event = $this->server->requestCall();
+
+        $this->assertTrue(is_array($event->metadata));
+        $metadata = $event->metadata;
+        $this->assertTrue(array_key_exists('k1', $metadata));
+        $this->assertSame($metadata['k1'], ['v1']);
+
+        $server_call = $event->call;
+        $server_call->startBatch([
+            Grpc\OP_SEND_INITIAL_METADATA => [],
+            Grpc\OP_SEND_STATUS_FROM_SERVER => [
+                'metadata' => [],
+                'code' => Grpc\STATUS_INVALID_ARGUMENT,
+                'details' => $status_text,
+            ],
+            Grpc\OP_RECV_CLOSE_ON_SERVER => true,
+        ]);
+
+        $call->startBatch([
+            Grpc\OP_RECV_INITIAL_METADATA => true,
+            Grpc\OP_RECV_STATUS_ON_CLIENT => true,
+        ]);
+
+        unset($call);
+        unset($server_call);
+    }
+}
+
+class CallCredentials2TestCallbackHolder
+{
+    public function callbackFunc($context)
+    {
+        return ['k1' => ['v1']];
+    }
 }


### PR DESCRIPTION
Long-lived gRPC channels can keep a grpc_call_credentials alive past the PHP request that registered its plugin callback, so the next metadata fetch ends up calling into a closure whose Zend memory has already been freed (issue #42044). This patch addrefs the callable in createFromPlugin, keeps a process-global list of every live plugin_state, and adds a PHP_RSHUTDOWN sweep that drops the PHP refs before request memory goes away. The actual zval_ptr_dtor and free run with all locks released so a destructor cascade cannot re-enter the registry mutex via plugin_destroy_state. Built the alpine docker image and ran the existing PHP unit tests, all 161 pass and the post-shutdown abort that the lock-ordering bug triggered is gone.