### PR TITLE
[Ruby] Fix Ruby interceptors not running in FIFO order

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -169,7 +169,7 @@ module GRPC
     def intercept!(type, args = {})
       return yield if @interceptors.none?
 
-      i = @interceptors.pop
+      i = @interceptors.shift
       return yield unless i
 
       i.send(type, **args) do

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -203,6 +203,20 @@ describe 'Server Interceptors' do
         expect(stub.an_rpc(request)).to be_a(EchoMsg)
       end
     end
+
+    it 'should be invoked in FIFO order', server: true do
+      expect(interceptor).to receive(:request_response).ordered
+        .once.and_call_original
+      expect(interceptor2).to receive(:request_response).ordered
+        .once.and_call_original
+      expect(interceptor3).to receive(:request_response).ordered
+        .once.and_call_original
+
+      run_services_on_server(@server, services: [service]) do
+        stub = build_insecure_stub(EchoStub)
+        expect(stub.an_rpc(request)).to be_a(EchoMsg)
+      end
+    end
   end
 
   context 'when an interceptor is not added' do


### PR DESCRIPTION
Issue #42296 reports that Ruby interceptors run in LIFO order despite the docstring and the rest of gRPC promising FIFO. The bug is a single line in InterceptionContext#intercept!, which uses Array#pop instead of Array#shift, so a chain registered as [A, B, C] runs as C then B then A instead of A then B then C. This change flips it to shift, bringing Ruby in line with Go, Java, Python, and Node, and adds a regression test using rspec ordered so the order claim is actually checked. The interceptor API is still flagged EXPERIMENTAL in three places, so this is the right window for the behavior fix, but it should land with a release note since anyone who has been working around the bug will see their order reverse.