### PR TITLE
security: canonicalize :path before RBAC matching (sibling of CVE-2026-33186)

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -5300,6 +5300,7 @@ grpc_cc_library(
         "//:grpc_base",
         "//:parse_address",
         "//:sockaddr_utils",
+        "//:uri",
     ],
 )
 

--- a/src/core/lib/security/authorization/matchers.cc
+++ b/src/core/lib/security/authorization/matchers.cc
@@ -22,12 +22,83 @@
 
 #include "src/core/lib/address_utils/parse_address.h"
 #include "src/core/lib/address_utils/sockaddr_utils.h"
+#include "src/core/util/uri.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 
 namespace grpc_core {
+
+namespace {
+
+// Canonicalize a request :path value before comparing it against an
+// authorization policy rule.
+//
+// Background. The HTTP/2 :path pseudo-header MUST take the "path-absolute"
+// form (RFC 3986 §3.3) for http/https URIs (RFC 9113 §8.3.1). xDS RBAC
+// rules are validated at config-ingest time (xds_route_config_parser.cc)
+// against the same canonical shape. At request time the gRPC C++ matcher
+// previously compared raw byte sequences, which let a client defeat a deny
+// rule by sending any of the following non-canonical variants:
+//
+//   * "package.Service/Method"      (missing leading slash)
+//   * "//package.Service/Method"    (consecutive slashes)
+//   * "/x/../package.Service/Method" (dot-segment traversal)
+//   * "/%70ackage.Service/Method"   (percent-encoded prefix character)
+//
+// The grpc-Go fix for the same defect (CVE-2026-33186, fixed in v1.79.3)
+// rejects non-canonical :path at the HPACK pseudo-header layer. Here we
+// apply the equivalent normalization at the RBAC matcher so the matcher
+// sees a canonical path regardless of the client's framing.
+//
+// Returns false when the input cannot be reduced to a path-absolute form
+// (empty after decode, or dot-segment traversal escapes the root).
+bool CanonicalizePathForAuthorization(absl::string_view raw,
+                                      std::string* out) {
+  if (raw.empty()) {
+    return false;
+  }
+  std::string decoded = URI::PercentDecode(raw);
+  if (decoded.empty()) {
+    return false;
+  }
+  if (decoded.front() != '/') {
+    decoded.insert(decoded.begin(), '/');
+  }
+  // Walk segments, applying RFC 3986 §5.2.4 dot-segment removal and
+  // collapsing consecutive slashes in one pass.
+  std::vector<absl::string_view> segments;
+  size_t i = 1;  // skip the leading slash
+  while (i <= decoded.size()) {
+    size_t j = decoded.find('/', i);
+    if (j == std::string::npos) j = decoded.size();
+    absl::string_view seg(decoded.data() + i, j - i);
+    if (seg.empty() || seg == ".") {
+      // empty segment (collapse //) or current-directory marker — skip
+    } else if (seg == "..") {
+      if (segments.empty()) {
+        // Traversal above root is not representable as a path-absolute.
+        return false;
+      }
+      segments.pop_back();
+    } else {
+      segments.push_back(seg);
+    }
+    i = j + 1;
+  }
+  std::string result;
+  result.reserve(decoded.size());
+  for (absl::string_view seg : segments) {
+    result.push_back('/');
+    result.append(seg.data(), seg.size());
+  }
+  if (result.empty()) result.push_back('/');
+  *out = std::move(result);
+  return true;
+}
+
+}  // namespace
 
 std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
     Rbac::Permission permission) {
@@ -224,10 +295,14 @@ bool ReqServerNameAuthorizationMatcher::Matches(const EvaluateArgs&) const {
 
 bool PathAuthorizationMatcher::Matches(const EvaluateArgs& args) const {
   absl::string_view path = args.GetPath();
-  if (!path.empty()) {
-    return matcher_.Match(path);
+  if (path.empty()) {
+    return false;
   }
-  return false;
+  std::string canonical;
+  if (!CanonicalizePathForAuthorization(path, &canonical)) {
+    return false;
+  }
+  return matcher_.Match(canonical);
 }
 
 bool PolicyAuthorizationMatcher::Matches(const EvaluateArgs& args) const {

--- a/test/core/security/authorization_matchers_test.cc
+++ b/test/core/security/authorization_matchers_test.cc
@@ -202,22 +202,22 @@ TEST_F(AuthorizationMatchersTest,
 }
 
 TEST_F(AuthorizationMatchersTest, PathAuthorizationMatcherSuccessfulMatch) {
-  args_.AddPairToMetadata(":path", "expected/path");
+  args_.AddPairToMetadata(":path", "/expected/path");
   EvaluateArgs args = args_.MakeEvaluateArgs();
   PathAuthorizationMatcher matcher(
       StringMatcher::Create(StringMatcher::Type::kExact,
-                            /*matcher=*/"expected/path",
+                            /*matcher=*/"/expected/path",
                             /*case_sensitive=*/false)
           .value());
   EXPECT_TRUE(matcher.Matches(args));
 }
 
 TEST_F(AuthorizationMatchersTest, PathAuthorizationMatcherFailedMatch) {
-  args_.AddPairToMetadata(":path", "different/path");
+  args_.AddPairToMetadata(":path", "/different/path");
   EvaluateArgs args = args_.MakeEvaluateArgs();
   PathAuthorizationMatcher matcher(
       StringMatcher::Create(StringMatcher::Type::kExact,
-                            /*matcher=*/"expected/path",
+                            /*matcher=*/"/expected/path",
                             /*case_sensitive=*/false)
           .value());
   EXPECT_FALSE(matcher.Matches(args));
@@ -228,7 +228,77 @@ TEST_F(AuthorizationMatchersTest,
   EvaluateArgs args = args_.MakeEvaluateArgs();
   PathAuthorizationMatcher matcher(
       StringMatcher::Create(StringMatcher::Type::kExact,
-                            /*matcher=*/"expected/path",
+                            /*matcher=*/"/expected/path",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_FALSE(matcher.Matches(args));
+}
+
+// CVE-2026-33186 sibling: a deny rule on "/admin.Service/Method" must match
+// the canonicalized form of every non-canonical :path that would route to
+// the same handler. The four bypass shapes exercised below were demonstrated
+// by the C++ instance of CVE-2026-33186 against this matcher.
+
+TEST_F(AuthorizationMatchersTest,
+       PathAuthorizationMatcherCanonicalizesMissingLeadingSlash) {
+  args_.AddPairToMetadata(":path", "admin.Service/Method");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  PathAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"/admin.Service/Method",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest,
+       PathAuthorizationMatcherCollapsesConsecutiveSlashes) {
+  args_.AddPairToMetadata(":path", "//admin.Service/Method");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  PathAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"/admin.Service/Method",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest,
+       PathAuthorizationMatcherResolvesDotSegmentTraversal) {
+  args_.AddPairToMetadata(":path", "/public.Service/../admin.Service/Method");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  PathAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"/admin.Service/Method",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest,
+       PathAuthorizationMatcherDecodesPercentEncodedPrefix) {
+  // "%61" is the percent-encoded ASCII 'a'. Without decoding, the rule prefix
+  // "/admin.Service/" does not match "/%61dmin.Service/Method".
+  args_.AddPairToMetadata(":path", "/%61dmin.Service/Method");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  PathAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kExact,
+                            /*matcher=*/"/admin.Service/Method",
+                            /*case_sensitive=*/false)
+          .value());
+  EXPECT_TRUE(matcher.Matches(args));
+}
+
+TEST_F(AuthorizationMatchersTest,
+       PathAuthorizationMatcherRejectsTraversalAboveRoot) {
+  // A :path that resolves above the root cannot be represented as a
+  // path-absolute. The matcher must return false rather than passing the raw
+  // bytes through.
+  args_.AddPairToMetadata(":path", "/../etc/passwd");
+  EvaluateArgs args = args_.MakeEvaluateArgs();
+  PathAuthorizationMatcher matcher(
+      StringMatcher::Create(StringMatcher::Type::kSafeRegex,
+                            /*matcher=*/".*",
                             /*case_sensitive=*/false)
           .value());
   EXPECT_FALSE(matcher.Matches(args));


### PR DESCRIPTION
## Summary

`PathAuthorizationMatcher` in `src/core/lib/security/authorization/matchers.cc` compared the raw `:path` byte sequence against the configured rule. A client could defeat a path-keyed deny rule by sending a non-canonical `:path` that routes to the same handler but does not match the rule's canonical string:

* `package.Service/Method` (no leading slash)
* `//package.Service/Method` (consecutive slashes)
* `/x/../package.Service/Method` (dot-segment traversal)
* `/%70ackage.Service/Method` (percent-encoded prefix character)

This is the C++ instance of the defect class disclosed and fixed in grpc-Go as **CVE-2026-33186** (fixed in `google.golang.org/grpc` v1.79.3). The grpc-Go advisory rejects non-canonical `:path` at the HPACK pseudo-header layer before any user interceptor runs.

## Specification context

RFC 9113 §8.3.1 (HTTP/2 Request Pseudo-Header Fields):

> *"This pseudo-header field MUST NOT be empty for 'http' or 'https' URIs; 'http' or 'https' URIs that do not contain a path component MUST include a value of '/'."*

Combined with RFC 3986 §3.3, the `:path` for `http`/`https` schemes must take the `path-absolute` form. xDS RBAC rules are validated against the same canonical shape at config-ingest time (`xds_route_config_parser.cc`), but the request path was passed through unchanged at match time.

## Fix

Apply the canonicalization at the matcher input:

1. Percent-decode via the existing `URI::PercentDecode` utility.
2. Prepend a leading slash if missing.
3. Walk segments, collapsing empty (`//`) and current-directory (`.`) segments and resolving dot-segment traversal (`..`).
4. Return `false` if the path resolves above the root (no path-absolute form exists).
5. Match the canonical string against the rule.

The rule pattern is already canonical because xDS validation requires it. The deny rule `/admin.Service/*` therefore matches every variant above after canonicalization.

## Test coverage

`test/core/security/authorization_matchers_test.cc` gains five tests:

* `PathAuthorizationMatcherCanonicalizesMissingLeadingSlash`
* `PathAuthorizationMatcherCollapsesConsecutiveSlashes`
* `PathAuthorizationMatcherResolvesDotSegmentTraversal`
* `PathAuthorizationMatcherDecodesPercentEncodedPrefix`
* `PathAuthorizationMatcherRejectsTraversalAboveRoot`

The three pre-existing `PathAuthorizationMatcher*` tests are updated to use canonical `/expected/path` instead of the non-canonical `expected/path` fixtures they relied on.

## Build dependencies

`grpc_rbac_engine` in `src/core/BUILD` gains a `//:uri` dep for `URI::PercentDecode`.

## Disclosure

Reported to Google OSS VRP — issue tracker **512208837**. Triager classified the finding as **Intended Behavior** (out of monetary tier) and invited a public PR. This PR is that follow-up.

A sibling-pattern witness (Docker reproduction of the four bypass shapes against a live gRPC C++ server with `StaticDataAuthorizationPolicyProvider`) is available on request.

## Why bundle four shapes

Each shape is a distinct byte-level mismatch but they all stem from the same root cause (no request-time path normalization). Patching only the missing-leading-slash case would leave the other three bypasses open. The canonicalization step closes all four at the same callsite.
