### PR TITLE
[Core] Add adopter to make Core test code build with both protobuf 33 and 34

### DIFF
--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -61,7 +61,8 @@ ProtoReflectionDescriptorDatabase::~ProtoReflectionDescriptorDatabase() {
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileByNameImpl(
-    absl::string_view filename, protobuf::FileDescriptorProto* output) {
+    ProtoReflectionDescriptorDatabase::StringArg filename,
+    protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileByName(filename, output)) {
     return true;
   }
@@ -104,7 +105,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileByNameImpl(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbolImpl(
-    absl::string_view symbol_name, protobuf::FileDescriptorProto* output) {
+    ProtoReflectionDescriptorDatabase::StringArg symbol_name,
+    protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingSymbol(symbol_name, output)) {
     return true;
   }
@@ -147,8 +149,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbolImpl(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileContainingExtensionImpl(
-    absl::string_view containing_type, int field_number,
-    protobuf::FileDescriptorProto* output) {
+    ProtoReflectionDescriptorDatabase::StringArg containing_type,
+    int field_number, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingExtension(containing_type, field_number,
                                              output)) {
     return true;
@@ -205,7 +207,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtensionImpl(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbersImpl(
-    absl::string_view extendee_type, std::vector<int>* output) {
+    ProtoReflectionDescriptorDatabase::StringArg extendee_type,
+    std::vector<int>* output) {
   if (cached_extension_numbers_.find(extendee_type) !=
       cached_extension_numbers_.end()) {
     *output = cached_extension_numbers_[extendee_type];

--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -60,8 +60,8 @@ ProtoReflectionDescriptorDatabase::~ProtoReflectionDescriptorDatabase() {
   }
 }
 
-bool ProtoReflectionDescriptorDatabase::FindFileByName(
-    const string& filename, protobuf::FileDescriptorProto* output) {
+bool ProtoReflectionDescriptorDatabase::FindFileByNameImpl(
+    absl::string_view filename, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileByName(filename, output)) {
     return true;
   }
@@ -103,8 +103,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileByName(
   return cached_db_.FindFileByName(filename, output);
 }
 
-bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
-    const string& symbol_name, protobuf::FileDescriptorProto* output) {
+bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbolImpl(
+    absl::string_view symbol_name, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingSymbol(symbol_name, output)) {
     return true;
   }
@@ -146,8 +146,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
   return cached_db_.FindFileContainingSymbol(symbol_name, output);
 }
 
-bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
-    const string& containing_type, int field_number,
+bool ProtoReflectionDescriptorDatabase::FindFileContainingExtensionImpl(
+    absl::string_view containing_type, int field_number,
     protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingExtension(containing_type, field_number,
                                              output)) {
@@ -204,8 +204,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
                                                 output);
 }
 
-bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbers(
-    const string& extendee_type, std::vector<int>* output) {
+bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbersImpl(
+    absl::string_view extendee_type, std::vector<int>* output) {
   if (cached_extension_numbers_.find(extendee_type) !=
       cached_extension_numbers_.end()) {
     *output = cached_extension_numbers_[extendee_type];

--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -60,7 +60,7 @@ ProtoReflectionDescriptorDatabase::~ProtoReflectionDescriptorDatabase() {
   }
 }
 
-bool ProtoReflectionDescriptorDatabase::FindFileByNameImpl(
+bool ProtoReflectionDescriptorDatabase::FindFileByName(
     ProtoReflectionDescriptorDatabase::StringArg filename,
     protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileByName(filename, output)) {
@@ -104,7 +104,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileByNameImpl(
   return cached_db_.FindFileByName(filename, output);
 }
 
-bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbolImpl(
+bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
     ProtoReflectionDescriptorDatabase::StringArg symbol_name,
     protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingSymbol(symbol_name, output)) {
@@ -148,7 +148,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbolImpl(
   return cached_db_.FindFileContainingSymbol(symbol_name, output);
 }
 
-bool ProtoReflectionDescriptorDatabase::FindFileContainingExtensionImpl(
+bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
     ProtoReflectionDescriptorDatabase::StringArg containing_type,
     int field_number, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingExtension(containing_type, field_number,
@@ -206,7 +206,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtensionImpl(
                                                 output);
 }
 
-bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbersImpl(
+bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbers(
     ProtoReflectionDescriptorDatabase::StringArg extendee_type,
     std::vector<int>* output) {
   if (cached_extension_numbers_.find(extendee_type) !=

--- a/test/cpp/util/proto_reflection_descriptor_database.cc
+++ b/test/cpp/util/proto_reflection_descriptor_database.cc
@@ -31,6 +31,10 @@ using grpc::reflection::v1alpha::ServerReflectionResponse;
 
 namespace grpc {
 
+namespace {
+using StringArg = proto_reflection_detail::StringArg;
+}
+
 ProtoReflectionDescriptorDatabase::ProtoReflectionDescriptorDatabase(
     std::unique_ptr<ServerReflection::Stub> stub)
     : stub_(std::move(stub)) {}
@@ -61,8 +65,7 @@ ProtoReflectionDescriptorDatabase::~ProtoReflectionDescriptorDatabase() {
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileByName(
-    ProtoReflectionDescriptorDatabase::StringArg filename,
-    protobuf::FileDescriptorProto* output) {
+    StringArg filename, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileByName(filename, output)) {
     return true;
   }
@@ -105,8 +108,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileByName(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
-    ProtoReflectionDescriptorDatabase::StringArg symbol_name,
-    protobuf::FileDescriptorProto* output) {
+    StringArg symbol_name, protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingSymbol(symbol_name, output)) {
     return true;
   }
@@ -149,8 +151,8 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingSymbol(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
-    ProtoReflectionDescriptorDatabase::StringArg containing_type,
-    int field_number, protobuf::FileDescriptorProto* output) {
+    StringArg containing_type, int field_number,
+    protobuf::FileDescriptorProto* output) {
   if (cached_db_.FindFileContainingExtension(containing_type, field_number,
                                              output)) {
     return true;
@@ -207,8 +209,7 @@ bool ProtoReflectionDescriptorDatabase::FindFileContainingExtension(
 }
 
 bool ProtoReflectionDescriptorDatabase::FindAllExtensionNumbers(
-    ProtoReflectionDescriptorDatabase::StringArg extendee_type,
-    std::vector<int>* output) {
+    StringArg extendee_type, std::vector<int>* output) {
   if (cached_extension_numbers_.find(extendee_type) !=
       cached_extension_numbers_.end()) {
     *output = cached_extension_numbers_[extendee_type];

--- a/test/cpp/util/proto_reflection_descriptor_database.h
+++ b/test/cpp/util/proto_reflection_descriptor_database.h
@@ -79,6 +79,9 @@ class ProtoReflectionDescriptorDatabase final
     : public proto_reflection_detail::ProtobufDestriptorDatabase<
           ProtoReflectionDescriptorDatabase> {
  public:
+  using Base = proto_reflection_detail::ProtobufDestriptorDatabase<
+      ProtoReflectionDescriptorDatabase>;
+  using StringArg = Base::StringArg;
   explicit ProtoReflectionDescriptorDatabase(
       std::unique_ptr<reflection::v1alpha::ServerReflection::Stub> stub);
 
@@ -91,20 +94,20 @@ class ProtoReflectionDescriptorDatabase final
   //
   // Find a file by file name.  Fills in *output and returns true if found.
   // Otherwise, returns false, leaving the contents of *output undefined.
-  bool FindFileByNameImpl(absl::string_view filename,
+  bool FindFileByNameImpl(StringArg filename,
                           protobuf::FileDescriptorProto* output);
 
   // Find the file that declares the given fully-qualified symbol name.
   // If found, fills in *output and returns true, otherwise returns false
   // and leaves *output undefined.
-  bool FindFileContainingSymbolImpl(absl::string_view symbol_name,
+  bool FindFileContainingSymbolImpl(StringArg symbol_name,
                                     protobuf::FileDescriptorProto* output);
 
   // Find the file which defines an extension extending the given message type
   // with the given field number.  If found, fills in *output and returns true,
   // otherwise returns false and leaves *output undefined.  containing_type
   // must be a fully-qualified type name.
-  bool FindFileContainingExtensionImpl(absl::string_view containing_type,
+  bool FindFileContainingExtensionImpl(StringArg containing_type,
                                        int field_number,
                                        protobuf::FileDescriptorProto* output);
 
@@ -115,7 +118,7 @@ class ProtoReflectionDescriptorDatabase final
   // FindFileContainingExtension will return true on all of the found
   // numbers. Returns true if the search was successful, otherwise
   // returns false and leaves output unchanged.
-  bool FindAllExtensionNumbersImpl(absl::string_view extendee_type,
+  bool FindAllExtensionNumbersImpl(StringArg extendee_type,
                                    std::vector<int>* output);
 
   // Provide a list of full names of registered services

--- a/test/cpp/util/proto_reflection_descriptor_database.h
+++ b/test/cpp/util/proto_reflection_descriptor_database.h
@@ -39,36 +39,12 @@ namespace proto_reflection_detail {
 // This adaptor class allow us a transition period for testing and fixing
 // bugs that manifests on protobuf 34 and ensure the code is still buildable
 // on older versions.
-template <typename Impl>
-class ProtobufDestriptorDatabase : public protobuf::DescriptorDatabase {
- public:
-  static inline constexpr bool kIsProtobuf34OrLater = std::is_invocable_v<
-      decltype(&protobuf::DescriptorDatabase::FindFileByName),
-      protobuf::DescriptorDatabase*, absl::string_view,
-      protobuf::FileDescriptorProto*>;
-  using StringArg = std::conditional_t<kIsProtobuf34OrLater, absl::string_view,
-                                       const std::string&>;
-  bool FindFileByName(StringArg filename,
-                      protobuf::FileDescriptorProto* output) override {
-    return static_cast<Impl*>(this)->FindFileByNameImpl(filename, output);
-  }
-  bool FindFileContainingSymbol(
-      StringArg symbol_name, protobuf::FileDescriptorProto* output) override {
-    return static_cast<Impl*>(this)->FindFileContainingSymbolImpl(symbol_name,
-                                                                  output);
-  }
-  bool FindFileContainingExtension(
-      StringArg containing_type, int field_number,
-      protobuf::FileDescriptorProto* output) override {
-    return static_cast<Impl*>(this)->FindFileContainingExtensionImpl(
-        containing_type, field_number, output);
-  }
-  bool FindAllExtensionNumbers(StringArg extendee_type,
-                               std::vector<int>* output) override {
-    return static_cast<Impl*>(this)->FindAllExtensionNumbersImpl(extendee_type,
-                                                                 output);
-  }
-};
+static inline constexpr bool kIsProtobuf34OrLater =
+    std::is_invocable_v<decltype(&protobuf::DescriptorDatabase::FindFileByName),
+                        protobuf::DescriptorDatabase*, absl::string_view,
+                        protobuf::FileDescriptorProto*>;
+using StringArg = std::conditional_t<kIsProtobuf34OrLater, absl::string_view,
+                                     const std::string&>;
 
 }  // namespace proto_reflection_detail
 
@@ -76,12 +52,9 @@ class ProtobufDestriptorDatabase : public protobuf::DescriptorDatabase {
 // provides the methods defined by DescriptorDatabase interfaces. It can be used
 // to feed a DescriptorPool instance.
 class ProtoReflectionDescriptorDatabase final
-    : public proto_reflection_detail::ProtobufDestriptorDatabase<
-          ProtoReflectionDescriptorDatabase> {
+    : public protobuf::DescriptorDatabase {
  public:
-  using Base = proto_reflection_detail::ProtobufDestriptorDatabase<
-      ProtoReflectionDescriptorDatabase>;
-  using StringArg = Base::StringArg;
+  using StringArg = proto_reflection_detail::StringArg;
   explicit ProtoReflectionDescriptorDatabase(
       std::unique_ptr<reflection::v1alpha::ServerReflection::Stub> stub);
 
@@ -94,22 +67,22 @@ class ProtoReflectionDescriptorDatabase final
   //
   // Find a file by file name.  Fills in *output and returns true if found.
   // Otherwise, returns false, leaving the contents of *output undefined.
-  bool FindFileByNameImpl(StringArg filename,
-                          protobuf::FileDescriptorProto* output);
+  bool FindFileByName(StringArg filename,
+                      protobuf::FileDescriptorProto* output) override;
 
   // Find the file that declares the given fully-qualified symbol name.
   // If found, fills in *output and returns true, otherwise returns false
   // and leaves *output undefined.
-  bool FindFileContainingSymbolImpl(StringArg symbol_name,
-                                    protobuf::FileDescriptorProto* output);
+  bool FindFileContainingSymbol(StringArg symbol_name,
+                                protobuf::FileDescriptorProto* output) override;
 
   // Find the file which defines an extension extending the given message type
   // with the given field number.  If found, fills in *output and returns true,
   // otherwise returns false and leaves *output undefined.  containing_type
   // must be a fully-qualified type name.
-  bool FindFileContainingExtensionImpl(StringArg containing_type,
-                                       int field_number,
-                                       protobuf::FileDescriptorProto* output);
+  bool FindFileContainingExtension(
+      StringArg containing_type, int field_number,
+      protobuf::FileDescriptorProto* output) override;
 
   // Finds the tag numbers used by all known extensions of
   // extendee_type, and appends them to output in an undefined
@@ -118,8 +91,8 @@ class ProtoReflectionDescriptorDatabase final
   // FindFileContainingExtension will return true on all of the found
   // numbers. Returns true if the search was successful, otherwise
   // returns false and leaves output unchanged.
-  bool FindAllExtensionNumbersImpl(StringArg extendee_type,
-                                   std::vector<int>* output);
+  bool FindAllExtensionNumbers(StringArg extendee_type,
+                               std::vector<int>* output) override;
 
   // Provide a list of full names of registered services
   bool GetServices(std::vector<std::string>* output);

--- a/test/cpp/util/proto_reflection_descriptor_database.h
+++ b/test/cpp/util/proto_reflection_descriptor_database.h
@@ -22,6 +22,7 @@
 #include <grpcpp/impl/codegen/config_protobuf.h>
 
 #include <mutex>
+#include <type_traits>
 #include <vector>
 
 #include "src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h"
@@ -30,10 +31,53 @@
 
 namespace grpc {
 
+namespace proto_reflection_detail {
+
+// TODO(weizheyuan): Delete this intermediate adaptor once we drop support for
+// protobuf < 34.
+//
+// This adaptor class allow us a transition period for testing and fixing
+// bugs that manifests on protobuf 34 and ensure the code is still buildable
+// on older versions.
+template <typename Impl>
+class ProtobufDestriptorDatabase : public protobuf::DescriptorDatabase {
+ public:
+  static inline constexpr bool kIsProtobuf34OrLater = std::is_invocable_v<
+      decltype(&protobuf::DescriptorDatabase::FindFileByName),
+      protobuf::DescriptorDatabase*, absl::string_view,
+      protobuf::FileDescriptorProto*>;
+  using StringArg = std::conditional_t<kIsProtobuf34OrLater, absl::string_view,
+                                       const std::string&>;
+  bool FindFileByName(StringArg filename,
+                      protobuf::FileDescriptorProto* output) override {
+    return static_cast<Impl*>(this)->FindFileByNameImpl(filename, output);
+  }
+  bool FindFileContainingSymbol(
+      StringArg symbol_name, protobuf::FileDescriptorProto* output) override {
+    return static_cast<Impl*>(this)->FindFileContainingSymbolImpl(symbol_name,
+                                                                  output);
+  }
+  bool FindFileContainingExtension(
+      StringArg containing_type, int field_number,
+      protobuf::FileDescriptorProto* output) override {
+    return static_cast<Impl*>(this)->FindFileContainingExtensionImpl(
+        containing_type, field_number, output);
+  }
+  bool FindAllExtensionNumbers(StringArg extendee_type,
+                               std::vector<int>* output) override {
+    return static_cast<Impl*>(this)->FindAllExtensionNumbersImpl(extendee_type,
+                                                                 output);
+  }
+};
+
+}  // namespace proto_reflection_detail
+
 // ProtoReflectionDescriptorDatabase takes a stub of ServerReflection and
 // provides the methods defined by DescriptorDatabase interfaces. It can be used
 // to feed a DescriptorPool instance.
-class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
+class ProtoReflectionDescriptorDatabase final
+    : public proto_reflection_detail::ProtobufDestriptorDatabase<
+          ProtoReflectionDescriptorDatabase> {
  public:
   explicit ProtoReflectionDescriptorDatabase(
       std::unique_ptr<reflection::v1alpha::ServerReflection::Stub> stub);
@@ -47,22 +91,22 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   //
   // Find a file by file name.  Fills in *output and returns true if found.
   // Otherwise, returns false, leaving the contents of *output undefined.
-  bool FindFileByName(const string& filename,
-                      protobuf::FileDescriptorProto* output) override;
+  bool FindFileByNameImpl(absl::string_view filename,
+                          protobuf::FileDescriptorProto* output);
 
   // Find the file that declares the given fully-qualified symbol name.
   // If found, fills in *output and returns true, otherwise returns false
   // and leaves *output undefined.
-  bool FindFileContainingSymbol(const string& symbol_name,
-                                protobuf::FileDescriptorProto* output) override;
+  bool FindFileContainingSymbolImpl(absl::string_view symbol_name,
+                                    protobuf::FileDescriptorProto* output);
 
   // Find the file which defines an extension extending the given message type
   // with the given field number.  If found, fills in *output and returns true,
   // otherwise returns false and leaves *output undefined.  containing_type
   // must be a fully-qualified type name.
-  bool FindFileContainingExtension(
-      const string& containing_type, int field_number,
-      protobuf::FileDescriptorProto* output) override;
+  bool FindFileContainingExtensionImpl(absl::string_view containing_type,
+                                       int field_number,
+                                       protobuf::FileDescriptorProto* output);
 
   // Finds the tag numbers used by all known extensions of
   // extendee_type, and appends them to output in an undefined
@@ -71,8 +115,8 @@ class ProtoReflectionDescriptorDatabase : public protobuf::DescriptorDatabase {
   // FindFileContainingExtension will return true on all of the found
   // numbers. Returns true if the search was successful, otherwise
   // returns false and leaves output unchanged.
-  bool FindAllExtensionNumbers(const string& extendee_type,
-                               std::vector<int>* output) override;
+  bool FindAllExtensionNumbersImpl(absl::string_view extendee_type,
+                                   std::vector<int>* output);
 
   // Provide a list of full names of registered services
   bool GetServices(std::vector<std::string>* output);

--- a/tools/bazelify_tests/test/bazel_build_out_of_tree_with_protobuf_34_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_out_of_tree_with_protobuf_34_linux.sh
@@ -36,4 +36,5 @@ $GIT_ROOT/tools/bazel \
     "@grpc//:grpcpp_channelz" \
     "@grpc//:grpcpp_csds" \
     "@grpc//:grpcpp_orca_service" \
-    "@grpc//examples/protos/..."
+    "@grpc//examples/protos/..." \
+    "@grpc//test/cpp/util:grpc++_proto_reflection_desc_db" # for protobuf 33/34 compatibility

--- a/tools/bazelify_tests/test/bazel_build_out_of_tree_with_protobuf_34_linux.sh
+++ b/tools/bazelify_tests/test/bazel_build_out_of_tree_with_protobuf_34_linux.sh
@@ -36,5 +36,7 @@ $GIT_ROOT/tools/bazel \
     "@grpc//:grpcpp_channelz" \
     "@grpc//:grpcpp_csds" \
     "@grpc//:grpcpp_orca_service" \
-    "@grpc//examples/protos/..." \
-    "@grpc//test/cpp/util:grpc++_proto_reflection_desc_db" # for protobuf 33/34 compatibility
+    "@grpc//examples/protos/..."
+
+# Protobuf 33/34 compatibility.
+$GIT_ROOT/tools/bazel build "@grpc//test/cpp/util:grpc++_proto_reflection_desc_db"


### PR DESCRIPTION
Due to some known issues (https://github.com/grpc/grpc/issues/42192) we can't easily upgrade everything to use protobuf 34 in one monolithic PR.  Protobuf 34 also break some of our test code by changing `protobuf::DescriptorDatabase` to use absl::string_view instead of const std::string.

This PR adds some template code to make tests buildable with protobuf34, so we can test a selected set of targets on both 33/34 until we can finish the migration.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

