### PR TITLE
[Python] Fix Serialization error for None response

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -607,12 +607,16 @@ def _call_behavior(
             else:
                 response_or_iterator = behavior(argument, context)
 
-            # If server handlers don't return a response or iterator, treat
-            # as an error and raise an exception.
-            if response_or_iterator is None:
-                raise Exception(
+            # If server handlers set the context for error but don't return a
+            # response or iterator, treat as an error and raise an exception.
+            if (
+                response_or_iterator is None
+                and context.code() is not None
+                # and context.code() is not grpc.StatusCode.OK
+            ):
+                raise Exception( # noqa: TRY002, TRY301
                     context.code(), context.details()
-                )  # noqa: TRY002, TRY301
+                )
 
             return response_or_iterator, True
         except Exception as exception:  # pylint: disable=broad-except

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -612,9 +612,9 @@ def _call_behavior(
             if (
                 response_or_iterator is None
                 and context.code() is not None
-                # and context.code() is not grpc.StatusCode.OK
+                and context.code() is not grpc.StatusCode.OK
             ):
-                raise Exception( # noqa: TRY002, TRY301
+                raise Exception(  # noqa: TRY002, TRY301
                     context.code(), context.details()
                 )
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -606,6 +606,12 @@ def _call_behavior(
                 )
             else:
                 response_or_iterator = behavior(argument, context)
+
+            # If server handlers don't return a response or iterator, treat
+            # as an error and raise an exception.
+            if response_or_iterator is None:
+                raise Exception(context.code(), context.details())
+
             return response_or_iterator, True
         except Exception as exception:  # pylint: disable=broad-except
             with state.condition:

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -610,7 +610,9 @@ def _call_behavior(
             # If server handlers don't return a response or iterator, treat
             # as an error and raise an exception.
             if response_or_iterator is None:
-                raise Exception(context.code(), context.details())
+                raise Exception(
+                    context.code(), context.details()
+                )  # noqa: TRY002, TRY301
 
             return response_or_iterator, True
         except Exception as exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/42340

In the case of Server handlers setting the context with error code and details, but not aborting the RPC or raising an exception, the None response received from the handlers were being treated as a successful response and getting serialized, leading to the serialization error mentioned in #42340 

This PR, considers such None responses also as an error and raises an exception to correctly handle it.

As per #42340, Error seen on server side:
```
2026-05-08 19:28:18,835: ERROR    Exception serializing message!
Traceback (most recent call last):
  File "/xds_interop_server.runfiles/com_github_grpc_grpc/src/python/grpcio/grpc/_common.py", line 87, in _transform
    return transformer(message)
           ^^^^^^^^^^^^^^^^^^^^
  File "/xds_interop_server.runfiles/com_google_protobuf/python/google/protobuf/internal/python_message.py", line 1140, in SerializeToString
    if not self.IsInitialized():
           ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'IsInitialized'
```

With these changes, no more Serialization error on Server side. Instead it shows the same wrong socket error as seen on Client side:
```
2026-05-12 17:25:10,879: INFO     Test server listening on port 8080
2026-05-12 17:25:10,879: INFO     Maintenance server listening on port 8080
2026-05-12 17:26:20,921: ERROR    Exception calling application: (<StatusCode.NOT_FOUND: (5, 'not found')>, b'Failed to get the socket, please ensure your socket_id==10 is valid')
Traceback (most recent call last):
  File "/usr/home/user/.cache/bazel/_bazel_user/a79e574dae92a28db81879e89900fb50/execroot/_main/bazel-out/k8-dbg/bin/src/python/grpcio_tests/tests_py3_only/interop/xds_interop_server.runfiles/_main/src/python/grpcio/grpc/_server.py", line 613, in _call_behavior
    raise Exception(context.code(), context.details())
Exception: (<StatusCode.NOT_FOUND: (5, 'not found')>, b'Failed to get the socket, please ensure your socket_id==10 is valid')
```
