### PR TITLE
[PHP] Fix various credential issues

### DIFF
--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -170,18 +170,24 @@ PHP_METHOD(ChannelCredentials, createSsl) {
     return;
   }
 
-  php_grpc_int hashkey_len = root_certs_length + private_key_length + cert_chain_length;
+  php_grpc_int hashkey_len = root_certs_length + private_key_length + cert_chain_length + 2;
   char *hashkey = emalloc(hashkey_len + 1);
-  hashkey[0] = '\0';
+  size_t offset = 0;
   if (root_certs_length > 0) {
-    strcat(hashkey, pem_root_certs);
+    memcpy(hashkey + offset, pem_root_certs, root_certs_length);
+    offset += root_certs_length;
   }
+  hashkey[offset++] = '\0';
   if (private_key_length > 0) {
-    strcat(hashkey, pem_key_cert_pair.private_key);
+    memcpy(hashkey + offset, pem_key_cert_pair.private_key, private_key_length);
+    offset += private_key_length;
   }
+  hashkey[offset++] = '\0';
   if (cert_chain_length > 0) {
-    strcat(hashkey, pem_key_cert_pair.cert_chain);
+    memcpy(hashkey + offset, pem_key_cert_pair.cert_chain, cert_chain_length);
+    offset += cert_chain_length;
   }
+  hashkey[offset] = '\0';
 
   char *hashstr = malloc(41);
   generate_sha1_str(hashstr, hashkey, hashkey_len);

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -234,7 +234,9 @@ PHP_METHOD(ChannelCredentials, createComposite) {
   if (cred1->hashstr != NULL) {
     php_grpc_int cred1_len = strlen(cred1->hashstr);
     cred1_hashstr = malloc(cred1_len+1);
-    strcpy(cred1_hashstr, cred1->hashstr);
+    if (cred1_hashstr != NULL) {
+      strcpy(cred1_hashstr, cred1->hashstr);
+    }
   }
   zval *creds_object =
     grpc_php_wrap_channel_credentials(creds, cred1_hashstr, true TSRMLS_CC);

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -170,13 +170,17 @@ PHP_METHOD(ChannelCredentials, createSsl) {
     return;
   }
 
-  php_grpc_int hashkey_len = root_certs_length + cert_chain_length;
+  php_grpc_int hashkey_len = root_certs_length + private_key_length + cert_chain_length;
   char *hashkey = emalloc(hashkey_len + 1);
+  hashkey[0] = '\0';
   if (root_certs_length > 0) {
-    strcpy(hashkey, pem_root_certs);
+    strcat(hashkey, pem_root_certs);
+  }
+  if (private_key_length > 0) {
+    strcat(hashkey, pem_key_cert_pair.private_key);
   }
   if (cert_chain_length > 0) {
-    strcpy(hashkey, pem_key_cert_pair.cert_chain);
+    strcat(hashkey, pem_key_cert_pair.cert_chain);
   }
 
   char *hashstr = malloc(41);
@@ -220,9 +224,12 @@ PHP_METHOD(ChannelCredentials, createComposite) {
                                               NULL);
   // wrapped_grpc_channel_credentials object should keeps it's own
   // allocation. Otherwise it conflicts free hashstr with call.c.
-  php_grpc_int cred1_len = strlen(cred1->hashstr);
-  char *cred1_hashstr = malloc(cred1_len+1);
-  strcpy(cred1_hashstr, cred1->hashstr);
+  char *cred1_hashstr = NULL;
+  if (cred1->hashstr != NULL) {
+    php_grpc_int cred1_len = strlen(cred1->hashstr);
+    cred1_hashstr = malloc(cred1_len+1);
+    strcpy(cred1_hashstr, cred1->hashstr);
+  }
   zval *creds_object =
     grpc_php_wrap_channel_credentials(creds, cred1_hashstr, true TSRMLS_CC);
   RETURN_DESTROY_ZVAL(creds_object);
@@ -331,4 +338,11 @@ void grpc_init_channel_credentials(TSRMLS_D) {
   grpc_ce_channel_credentials = zend_register_internal_class(&ce TSRMLS_CC);
   PHP_GRPC_INIT_HANDLER(wrapped_grpc_channel_credentials,
                         channel_credentials_ce_handlers);
+}
+
+void grpc_shutdown_channel_credentials(TSRMLS_D) {
+  if (default_pem_root_certs) {
+    gpr_free(default_pem_root_certs);
+    default_pem_root_certs = NULL;
+  }
 }

--- a/src/php/ext/grpc/channel_credentials.h
+++ b/src/php/ext/grpc/channel_credentials.h
@@ -44,4 +44,7 @@ static inline wrapped_grpc_channel_credentials
 /* Initializes the ChannelCredentials PHP class */
 void grpc_init_channel_credentials(TSRMLS_D);
 
+/* Shuts down the ChannelCredentials PHP class */
+void grpc_shutdown_channel_credentials(TSRMLS_D);
+
 #endif /* NET_GRPC_PHP_GRPC_CHANNEL_CREDENTIALS_H_ */

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -538,6 +538,7 @@ PHP_MSHUTDOWN_FUNCTION(grpc) {
     zend_hash_destroy(&grpc_target_upper_bound_map);
     grpc_shutdown_timeval(TSRMLS_C);
     grpc_php_shutdown_completion_queue(TSRMLS_C);
+    grpc_shutdown_channel_credentials(TSRMLS_C);
     grpc_shutdown();
     GRPC_G(initialized) = 0;
   }

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -40,6 +40,47 @@ class ChannelCredentialsTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($channel_credentials);
     }
 
+    public function testCreateSslHashingIsolation()
+    {
+        $cred1 = Grpc\ChannelCredentials::createSsl('ca1', 'key1', 'cert1');
+        $channel1 = new Grpc\Channel('localhost:1', ['credentials' => $cred1]);
+        if (!method_exists($channel1, 'getChannelInfo')) {
+            $this->markTestSkipped('GRPC_PHP_DEBUG not enabled');
+        }
+        $info1 = $channel1->getChannelInfo();
+
+        // Change CA
+        $cred2 = Grpc\ChannelCredentials::createSsl('ca2', 'key1', 'cert1');
+        $channel2 = new Grpc\Channel('localhost:1', ['credentials' => $cred2]);
+        $info2 = $channel2->getChannelInfo();
+
+        // Change Key
+        $cred3 = Grpc\ChannelCredentials::createSsl('ca1', 'key2', 'cert1');
+        $channel3 = new Grpc\Channel('localhost:1', ['credentials' => $cred3]);
+        $info3 = $channel3->getChannelInfo();
+
+        // Change Cert
+        $cred4 = Grpc\ChannelCredentials::createSsl('ca1', 'key1', 'cert2');
+        $channel4 = new Grpc\Channel('localhost:1', ['credentials' => $cred4]);
+        $info4 = $channel4->getChannelInfo();
+
+        // All Same
+        $cred5 = Grpc\ChannelCredentials::createSsl('ca1', 'key1', 'cert1');
+        $channel5 = new Grpc\Channel('localhost:1', ['credentials' => $cred5]);
+        $info5 = $channel5->getChannelInfo();
+
+        $this->assertNotEquals($info1['key'], $info2['key']);
+        $this->assertNotEquals($info1['key'], $info3['key']);
+        $this->assertNotEquals($info1['key'], $info4['key']);
+        $this->assertEquals($info1['key'], $info5['key']);
+
+        $channel1->close();
+        $channel2->close();
+        $channel3->close();
+        $channel4->close();
+        $channel5->close();
+    }
+
     public function testCreateInsecure()
     {
         $channel_credentials = Grpc\ChannelCredentials::createInsecure();
@@ -60,6 +101,14 @@ class ChannelCredentialsTest extends \PHPUnit\Framework\TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $channel_credentials = Grpc\ChannelCredentials::createSsl([]);
+    }
+
+    public function testCreateCompositeWithDefault()
+    {
+        $cred1 = Grpc\ChannelCredentials::createDefault();
+        $cred2 = Grpc\CallCredentials::createFromPlugin(function($context) { return []; });
+        $channel_credentials = Grpc\ChannelCredentials::createComposite($cred1, $cred2);
+        $this->assertNotNull($channel_credentials);
     }
 
     public function testInvalidCreateComposite()


### PR DESCRIPTION
1. **Fix `createComposite` crash (Stability)**:
       - Added a `NULL` check for `cred1->hashstr` to prevent fatal `strlen(NULL)` segmentation faults when composing `createDefault()` credentials.

    2. **Fix `createSsl` hash generation (Security / Caching Isolation)**:
       - Replaced inefficient and binary-unsafe `strcat` calls with performant `memcpy` and explicit `\0` separators.
       - Included `private_key` in the hash calculation to ensure credentials with distinct private keys do not incorrectly share cached connections.

    3. **Fix `default_pem_root_certs` memory leak (Resource Cleanup)**:
       - Added `grpc_shutdown_channel_credentials()` hook invoked during `PHP_MSHUTDOWN_FUNCTION` to cleanly free allocated default root certificate buffers upon module unload.

