### PR TITLE
Fix a strict aliasing violation

### DIFF
--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -2270,10 +2270,10 @@ struct ChannelFilterWithFlagsMethods {
                                       grpc_channel_stack_filter_instance_number,
                                       args->config, args->blackboard));
     if (!status.ok()) {
-      new (elem->channel_data) F*(nullptr);
+      new (elem->channel_data) ChannelFilter*(nullptr);
       return absl_status_to_grpc_error(status.status());
     }
-    new (elem->channel_data) F*(status->release());
+    new (elem->channel_data) ChannelFilter*(status->release());
     return absl::OkStatus();
   }
 


### PR DESCRIPTION
The function ChannelFilterWithFlagsMethods::InitChannelElem creates a pointer in memory of type F* (the specific type of the filter) that is later accessed as if it were of type ChannelFilter* in the ChannelFilterFromElem function. This is technically a strict aliasing violation because the types of the pointer objects are different. Fix it by using the correct type for the pointer in InitChannelElem.

