### PR TITLE
[CI] Fix Asan thread_stress_test error by reducing thread count

### DIFF
--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -133,6 +133,9 @@ class CommonStressTestSyncServer : public BaseClass {
  public:
   void SetUp() override {
     ServerBuilder builder;
+    ResourceQuota quota;
+    quota.SetMaxThreads(500);
+    builder.SetResourceQuota(quota);
     this->SetUpStart(&builder, &service_);
     this->SetUpEnd(&builder);
   }


### PR DESCRIPTION
Reducing thread count of sync server for thread stress test to avoid exhausion of fd on RBE machines

