### PR TITLE
[Python] Update Contributing.md for Python bazel tests

### DIFF
--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -63,7 +63,10 @@ Ready to dive in?  We'll walk you through the entire process of making your firs
        bazel test --cache_test_results=no "//src/python/..." 
        ```
      * Consider adding flag - `--incompatible_default_to_explicit_init_py` flag to the above bazel commands,
-       in case failures are seen.
+       in case failures are seen. Final command would then be:
+       ```bash
+       bazel test --cache_test_results=no "//src/python/..." --incompatible_default_to_explicit_init_py 
+       ```
    * **Using Provided Scripts (Alternative):**
      * Install Python Modules:
        ```bash

--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -62,6 +62,8 @@ Ready to dive in?  We'll walk you through the entire process of making your firs
        ```bash
        bazel test --cache_test_results=no "//src/python/..." 
        ```
+     * Consider adding flag - `--incompatible_default_to_explicit_init_py` flag to the above bazel commands,
+       in case failures are seen.
    * **Using Provided Scripts (Alternative):**
      * Install Python Modules:
        ```bash

--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Ready to dive in?  We'll walk you through the entire process of making your firs
      * Consider adding flag - `--incompatible_default_to_explicit_init_py` flag to the above bazel commands,
        in case failures are seen. Final command would then be:
        ```bash
-       bazel test --cache_test_results=no "//src/python/..." --incompatible_default_to_explicit_init_py 
+       bazel test --cache_test_results=no "//src/python/..." --incompatible_default_to_explicit_init_py
        ```
    * **Using Provided Scripts (Alternative):**
      * Install Python Modules:

--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -67,6 +67,11 @@ Ready to dive in?  We'll walk you through the entire process of making your firs
        ```bash
        bazel test --cache_test_results=no "//src/python/..." --incompatible_default_to_explicit_init_py
        ```
+       Example failures:
+      ```
+       No module named 'src.python',
+       No module named 'src.proto'
+       ```
    * **Using Provided Scripts (Alternative):**
      * Install Python Modules:
        ```bash

--- a/src/python/CONTRIBUTING.md
+++ b/src/python/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Ready to dive in?  We'll walk you through the entire process of making your firs
        bazel test --cache_test_results=no "//src/python/..." --incompatible_default_to_explicit_init_py
        ```
        Example failures:
-      ```
+       ```
        No module named 'src.python',
        No module named 'src.proto'
        ```


### PR DESCRIPTION
# Description

Update `src/python/CONTRIBUTING.md` for Python bazel tests failure. 

Mention the flag needed to successfully run the tests - `--incompatible_default_to_explicit_init_py`