### PR TITLE
[Python] Part 3 - Sync stack Typehints grpc/_auth.py and grpc/_common.py with Pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ where = ["src/python/grpcio"]
 
 [tool.pyright]
 include = [
-    "src/python/grpcio/grpc/aio/_metadata.py",
+    "src/python/grpcio/grpc/_auth.py",
+    "src/python/grpcio/grpc/_common.py",
     "src/python/grpcio/grpc/aio/_base_server.py"
 ]
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -613,6 +613,9 @@ class AuthMetadataContext(abc.ABC):
       method_name: A string of the fully qualified method name being called.
     """
 
+    service_url: str
+    method_name: str
+
 
 class AuthMetadataPluginCallback(abc.ABC):
     """Callback object received by a metadata plugin."""

--- a/src/python/grpcio/grpc/_auth.py
+++ b/src/python/grpcio/grpc/_auth.py
@@ -52,9 +52,7 @@ class GoogleCallCredentials(grpc.AuthMetadataPlugin):
         try:
             if self._is_jwt:
                 access_token = self._credentials.get_access_token(
-                    additional_claims={
-                        "aud": context.service_url
-                    }
+                    additional_claims={"aud": context.service_url}
                 ).access_token
             else:
                 access_token = self._credentials.get_access_token().access_token

--- a/src/python/grpcio/grpc/_auth.py
+++ b/src/python/grpcio/grpc/_auth.py
@@ -23,7 +23,7 @@ def _sign_request(
     callback: grpc.AuthMetadataPluginCallback,
     token: Optional[str],
     error: Optional[Exception],
-):
+) -> None:
     metadata = (("authorization", "Bearer {}".format(token)),)
     callback(metadata, error)
 
@@ -48,12 +48,12 @@ class GoogleCallCredentials(grpc.AuthMetadataPlugin):
         self,
         context: grpc.AuthMetadataContext,
         callback: grpc.AuthMetadataPluginCallback,
-    ):
+    ) -> None:
         try:
             if self._is_jwt:
                 access_token = self._credentials.get_access_token(
                     additional_claims={
-                        "aud": context.service_url  # pytype: disable=attribute-error
+                        "aud": context.service_url  # pytype: disable=attribute-error # pyright: ignore[reportAttributeAccessIssue]
                     }
                 ).access_token
             else:

--- a/src/python/grpcio/grpc/_auth.py
+++ b/src/python/grpcio/grpc/_auth.py
@@ -53,7 +53,7 @@ class GoogleCallCredentials(grpc.AuthMetadataPlugin):
             if self._is_jwt:
                 access_token = self._credentials.get_access_token(
                     additional_claims={
-                        "aud": context.service_url  # pytype: disable=attribute-error # pyright: ignore[reportAttributeAccessIssue]
+                        "aud": context.service_url
                     }
                 ).access_token
             else:

--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -110,7 +110,7 @@ def _wait_once(
     wait_fn: Callable[..., bool],
     timeout: float,
     spin_cb: Optional[Callable[[], None]],
-):
+) -> None:
     wait_fn(timeout=timeout)
     if spin_cb is not None:
         spin_cb()

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyi
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyi
@@ -1,0 +1,39 @@
+# Copyright 2026 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ConnectivityState:
+    idle: int
+    connecting: int
+    ready: int
+    transient_failure: int
+    shutdown: int
+
+class StatusCode:
+    ok: int
+    cancelled: int
+    unknown: int
+    invalid_argument: int
+    deadline_exceeded: int
+    not_found: int
+    already_exists: int
+    permission_denied: int
+    unauthenticated: int
+    resource_exhausted: int
+    failed_precondition: int
+    aborted: int
+    out_of_range: int
+    unimplemented: int
+    internal: int
+    unavailable: int
+    data_loss: int

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyi
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyi
@@ -1,4 +1,4 @@
-# Copyright 2026 The gRPC Authors
+# Copyright 2026 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,28 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class ConnectivityState:
-    idle: int
-    connecting: int
-    ready: int
-    transient_failure: int
-    shutdown: int
+from typing import Any
 
-class StatusCode:
-    ok: int
-    cancelled: int
-    unknown: int
-    invalid_argument: int
-    deadline_exceeded: int
-    not_found: int
-    already_exists: int
-    permission_denied: int
-    unauthenticated: int
-    resource_exhausted: int
-    failed_precondition: int
-    aborted: int
-    out_of_range: int
-    unimplemented: int
-    internal: int
-    unavailable: int
-    data_loss: int
+def __getattr__(name: str) -> Any: ...


### PR DESCRIPTION
# Description

Add pyright checks for `src/python/grpcio/grpc/_auth.py` and `src/python/grpcio/grpc/_common.py` and verify type hints.

Fix the following errors - 

```
+ [01:52:23 UTC]	 exec pyright
/usr/local/google/home/asheshvidyut/grpc/src/python/grpcio/grpc/_auth.py
 /grpc/_auth.py:56:40 - error: Cannot access attribute "service_url" for class "AuthMetadataContext"
    Attribute "service_url" is unknown (reportAttributeAccessIssue)
/usr/local/google/home/asheshvidyut/grpc/src/python/grpcio/grpc/_common.py
 /grpc/_common.py:21:26 - error: "cygrpc" is unknown import symbol (reportAttributeAccessIssue)
2 errors, 0 warnings, 0 informations
```

# Previous 
* https://github.com/grpc/grpc/pull/42445

# Next
* https://github.com/grpc/grpc/pull/42452
