### PR TITLE
[Python] Part 5 - Sync Stack Typehints to _interceptor.py and validate with Pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ where = ["src/python/grpcio"]
 
 [tool.pyright]
 include = [
+    "src/python/grpcio/grpc/_interceptor.py",
     "src/python/grpcio/grpc/aio/_metadata.py",
     "src/python/grpcio/grpc/aio/_base_server.py"
 ]

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 """gRPC's Python API."""
 
+from __future__ import annotations
+
 import abc
 import contextlib
 import enum
 import logging
 import sys
+import typing
 
 from grpc import _compression
+from grpc._typing import MetadataType as _MetadataType
 from grpc._cython import cygrpc as _cygrpc
 from grpc._runtime_protos import protos
 from grpc._runtime_protos import protos_and_services
@@ -431,6 +435,13 @@ class ClientCallDetails(abc.ABC):
       compression: An element of grpc.Compression, e.g.
         grpc.Compression.Gzip.
     """
+
+    method: str
+    timeout: typing.Optional[float]
+    metadata: typing.Optional[_MetadataType]
+    credentials: typing.Optional[CallCredentials]
+    wait_for_ready: typing.Optional[bool]
+    compression: typing.Optional[Compression]
 
 
 class UnaryUnaryClientInterceptor(abc.ABC):

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -21,13 +21,16 @@ import enum
 import logging
 import sys
 import typing
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from grpc._typing import MetadataType as _MetadataType
 
 from grpc import _compression
 from grpc._cython import cygrpc as _cygrpc
 from grpc._runtime_protos import protos
 from grpc._runtime_protos import protos_and_services
 from grpc._runtime_protos import services
-from grpc._typing import MetadataType as _MetadataType
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -23,14 +23,14 @@ import sys
 import typing
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from grpc._typing import MetadataType as _MetadataType
-
 from grpc import _compression
 from grpc._cython import cygrpc as _cygrpc
 from grpc._runtime_protos import protos
 from grpc._runtime_protos import protos_and_services
 from grpc._runtime_protos import services
+
+if TYPE_CHECKING:
+    from grpc._typing import MetadataType as _MetadataType
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -23,11 +23,11 @@ import sys
 import typing
 
 from grpc import _compression
-from grpc._typing import MetadataType as _MetadataType
 from grpc._cython import cygrpc as _cygrpc
 from grpc._runtime_protos import protos
 from grpc._runtime_protos import protos_and_services
 from grpc._runtime_protos import services
+from grpc._typing import MetadataType as _MetadataType
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -28,9 +28,8 @@ from typing import (
     Union,
 )
 
-from typing_extensions import Self
-
 import grpc
+from typing_extensions import Self
 
 from ._typing import DeserializingFunction
 from ._typing import DoneCallbackType

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -248,10 +248,14 @@ class _UnaryOutcome(grpc.Call, grpc.Future):
     def result(self, ignored_timeout: Optional[float] = None) -> Any:
         return self._response
 
-    def exception(self, ignored_timeout: Optional[float] = None) -> Optional[Exception]:
+    def exception(
+        self, ignored_timeout: Optional[float] = None
+    ) -> Optional[Exception]:
         return None
 
-    def traceback(self, ignored_timeout: Optional[float] = None) -> Optional[types.TracebackType]:
+    def traceback(
+        self, ignored_timeout: Optional[float] = None
+    ) -> Optional[types.TracebackType]:
         return None
 
     def add_done_callback(self, fn: DoneCallbackType) -> None:
@@ -684,10 +688,16 @@ class _Channel(grpc.Channel):
         self._channel = channel
         self._interceptor = interceptor
 
-    def subscribe(self, callback: Callable[[grpc.ChannelConnectivity], None], try_to_connect: bool = False) -> None:
+    def subscribe(
+        self,
+        callback: Callable[[grpc.ChannelConnectivity], None],
+        try_to_connect: bool = False,
+    ) -> None:
         self._channel.subscribe(callback, try_to_connect=try_to_connect)
 
-    def unsubscribe(self, callback: Callable[[grpc.ChannelConnectivity], None]) -> None:
+    def unsubscribe(
+        self, callback: Callable[[grpc.ChannelConnectivity], None]
+    ) -> None:
         self._channel.unsubscribe(callback)
 
     # pylint: disable=arguments-differ
@@ -776,7 +786,12 @@ class _Channel(grpc.Channel):
     def __enter__(self) -> _Channel:
         return self
 
-    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[types.TracebackType]) -> bool:
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[types.TracebackType],
+    ) -> bool:
         self._close()
         return False
 

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -136,7 +136,9 @@ class _FailureOutcome(
     _exception: Exception
     _traceback: Optional[types.TracebackType]
 
-    def __init__(self, exception: Exception, traceback: Optional[types.TracebackType]):
+    def __init__(
+        self, exception: Exception, traceback: Optional[types.TracebackType]
+    ):
         super(_FailureOutcome, self).__init__()
         self._exception = exception
         self._traceback = traceback
@@ -680,9 +682,7 @@ class _Channel(grpc.Channel):
         self._channel = channel
         self._interceptor = interceptor
 
-    def subscribe(
-        self, callback: Callable, try_to_connect: bool = False
-    ):
+    def subscribe(self, callback: Callable, try_to_connect: bool = False):
         self._channel.subscribe(callback, try_to_connect=try_to_connect)
 
     def unsubscribe(self, callback: Callable):

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -17,8 +17,21 @@ from __future__ import annotations
 
 import collections
 import sys
-import types
-from typing import Any, Callable, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    import types
 
 import grpc
 
@@ -783,7 +796,7 @@ class _Channel(grpc.Channel):
     def _close(self) -> None:
         self._channel.close()
 
-    def __enter__(self) -> _Channel:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -30,9 +30,6 @@ from typing import (
 
 from typing_extensions import Self
 
-if TYPE_CHECKING:
-    import types
-
 import grpc
 
 from ._typing import DeserializingFunction
@@ -40,6 +37,9 @@ from ._typing import DoneCallbackType
 from ._typing import MetadataType
 from ._typing import RequestIterableType
 from ._typing import SerializingFunction
+
+if TYPE_CHECKING:
+    import types
 
 
 class _ServicePipeline:

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -78,7 +78,12 @@ def _unwrap_client_call_details(
     call_details: grpc.ClientCallDetails,
     default_details: grpc.ClientCallDetails,
 ) -> Tuple[
-    str, float, MetadataType, grpc.CallCredentials, bool, grpc.Compression
+    str,
+    Optional[float],
+    Optional[MetadataType],
+    Optional[grpc.CallCredentials],
+    Optional[bool],
+    Optional[grpc.Compression],
 ]:
     try:
         method = call_details.method  # pytype: disable=attribute-error
@@ -129,9 +134,9 @@ class _FailureOutcome(
     grpc.RpcError, grpc.Future, grpc.Call
 ):  # pylint: disable=too-many-ancestors
     _exception: Exception
-    _traceback: types.TracebackType
+    _traceback: Optional[types.TracebackType]
 
-    def __init__(self, exception: Exception, traceback: types.TracebackType):
+    def __init__(self, exception: Exception, traceback: Optional[types.TracebackType]):
         super(_FailureOutcome, self).__init__()
         self._exception = exception
         self._traceback = traceback
@@ -676,7 +681,7 @@ class _Channel(grpc.Channel):
         self._interceptor = interceptor
 
     def subscribe(
-        self, callback: Callable, try_to_connect: Optional[bool] = False
+        self, callback: Callable, try_to_connect: bool = False
     ):
         self._channel.subscribe(callback, try_to_connect=try_to_connect)
 
@@ -689,7 +694,7 @@ class _Channel(grpc.Channel):
         method: str,
         request_serializer: Optional[SerializingFunction] = None,
         response_deserializer: Optional[DeserializingFunction] = None,
-        _registered_method: Optional[bool] = False,
+        _registered_method: bool = False,
     ) -> grpc.UnaryUnaryMultiCallable:
         # pytype: disable=wrong-arg-count
         thunk = lambda m: self._channel.unary_unary(
@@ -709,7 +714,7 @@ class _Channel(grpc.Channel):
         method: str,
         request_serializer: Optional[SerializingFunction] = None,
         response_deserializer: Optional[DeserializingFunction] = None,
-        _registered_method: Optional[bool] = False,
+        _registered_method: bool = False,
     ) -> grpc.UnaryStreamMultiCallable:
         # pytype: disable=wrong-arg-count
         thunk = lambda m: self._channel.unary_stream(
@@ -729,7 +734,7 @@ class _Channel(grpc.Channel):
         method: str,
         request_serializer: Optional[SerializingFunction] = None,
         response_deserializer: Optional[DeserializingFunction] = None,
-        _registered_method: Optional[bool] = False,
+        _registered_method: bool = False,
     ) -> grpc.StreamUnaryMultiCallable:
         # pytype: disable=wrong-arg-count
         thunk = lambda m: self._channel.stream_unary(
@@ -749,7 +754,7 @@ class _Channel(grpc.Channel):
         method: str,
         request_serializer: Optional[SerializingFunction] = None,
         response_deserializer: Optional[DeserializingFunction] = None,
-        _registered_method: Optional[bool] = False,
+        _registered_method: bool = False,
     ) -> grpc.StreamStreamMultiCallable:
         # pytype: disable=wrong-arg-count
         thunk = lambda m: self._channel.stream_stream(

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 """Implementation of gRPC Python interceptors."""
 
+from __future__ import annotations
+
 import collections
 import sys
 import types
-from typing import Any, Callable, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Optional, Sequence, Tuple, Type, Union
 
 import grpc
 
@@ -173,7 +175,7 @@ class _FailureOutcome(
     def done(self) -> bool:
         return True
 
-    def result(self, ignored_timeout: Optional[float] = None):
+    def result(self, ignored_timeout: Optional[float] = None) -> Any:
         raise self._exception
 
     def exception(
@@ -186,19 +188,19 @@ class _FailureOutcome(
     ) -> Optional[types.TracebackType]:
         return self._traceback
 
-    def add_callback(self, unused_callback) -> bool:
+    def add_callback(self, unused_callback: Callable[[], None]) -> bool:
         return False
 
     def add_done_callback(self, fn: DoneCallbackType) -> None:
         fn(self)
 
-    def __iter__(self):
+    def __iter__(self) -> _FailureOutcome:
         return self
 
-    def __next__(self):
+    def __next__(self) -> Any:
         raise self._exception
 
-    def next(self):
+    def next(self) -> Any:
         return self.__next__()
 
 
@@ -231,7 +233,7 @@ class _UnaryOutcome(grpc.Call, grpc.Future):
     def cancel(self) -> bool:
         return self._call.cancel()
 
-    def add_callback(self, callback) -> bool:
+    def add_callback(self, callback: Callable[[], None]) -> bool:
         return self._call.add_callback(callback)
 
     def cancelled(self) -> bool:
@@ -243,13 +245,13 @@ class _UnaryOutcome(grpc.Call, grpc.Future):
     def done(self) -> bool:
         return True
 
-    def result(self, ignored_timeout: Optional[float] = None):
+    def result(self, ignored_timeout: Optional[float] = None) -> Any:
         return self._response
 
-    def exception(self, ignored_timeout: Optional[float] = None):
+    def exception(self, ignored_timeout: Optional[float] = None) -> Optional[Exception]:
         return None
 
-    def traceback(self, ignored_timeout: Optional[float] = None):
+    def traceback(self, ignored_timeout: Optional[float] = None) -> Optional[types.TracebackType]:
         return None
 
     def add_done_callback(self, fn: DoneCallbackType) -> None:
@@ -422,7 +424,7 @@ class _UnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
         credentials: Optional[grpc.CallCredentials] = None,
         wait_for_ready: Optional[bool] = None,
         compression: Optional[grpc.Compression] = None,
-    ):
+    ) -> Any:
         client_call_details = _ClientCallDetails(
             self._method,
             timeout,
@@ -624,7 +626,7 @@ class _StreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
         credentials: Optional[grpc.CallCredentials] = None,
         wait_for_ready: Optional[bool] = None,
         compression: Optional[grpc.Compression] = None,
-    ):
+    ) -> Any:
         client_call_details = _ClientCallDetails(
             self._method,
             timeout,
@@ -682,10 +684,10 @@ class _Channel(grpc.Channel):
         self._channel = channel
         self._interceptor = interceptor
 
-    def subscribe(self, callback: Callable, try_to_connect: bool = False):
+    def subscribe(self, callback: Callable[[grpc.ChannelConnectivity], None], try_to_connect: bool = False) -> None:
         self._channel.subscribe(callback, try_to_connect=try_to_connect)
 
-    def unsubscribe(self, callback: Callable):
+    def unsubscribe(self, callback: Callable[[grpc.ChannelConnectivity], None]) -> None:
         self._channel.unsubscribe(callback)
 
     # pylint: disable=arguments-differ
@@ -768,17 +770,17 @@ class _Channel(grpc.Channel):
             return _StreamStreamMultiCallable(thunk, method, self._interceptor)
         return thunk(method)
 
-    def _close(self):
+    def _close(self) -> None:
         self._channel.close()
 
-    def __enter__(self):
+    def __enter__(self) -> _Channel:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[types.TracebackType]) -> bool:
         self._close()
         return False
 
-    def close(self):
+    def close(self) -> None:
         self._channel.close()
 
 

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -28,7 +28,7 @@ from ._typing import SerializingFunction
 
 
 class _ServicePipeline:
-    interceptors: Tuple[grpc.ServerInterceptor]
+    interceptors: Tuple[grpc.ServerInterceptor, ...]
 
     def __init__(self, interceptors: Sequence[grpc.ServerInterceptor]):
         self.interceptors = tuple(interceptors)


### PR DESCRIPTION
# Description

Add Type Hints to `_interceptor.py` and validate with `Pyright`.

Fixes the following errors 

```
+ [07:22:49 UTC]	 exec pyright
  /grpc/_interceptor.py:34:29 - error: Cannot assign to attribute "interceptors" for class "_ServicePipeline*"
  /grpc/_interceptor.py:84:31 - error: Cannot access attribute "method" for class "ClientCallDetails"
  /grpc/_interceptor.py:86:34 - error: Cannot access attribute "method" for class "ClientCallDetails"
  /grpc/_interceptor.py:89:32 - error: Cannot access attribute "timeout" for class "ClientCallDetails"
  /grpc/_interceptor.py:91:35 - error: Cannot access attribute "timeout" for class "ClientCallDetails"
  /grpc/_interceptor.py:94:33 - error: Cannot access attribute "metadata" for class "ClientCallDetails"
  /grpc/_interceptor.py:96:36 - error: Cannot access attribute "metadata" for class "ClientCallDetails"
  /grpc/_interceptor.py:100:26 - error: Cannot access attribute "credentials" for class "ClientCallDetails"
  /grpc/_interceptor.py:104:29 - error: Cannot access attribute "credentials" for class "ClientCallDetails"
  /grpc/_interceptor.py:109:26 - error: Cannot access attribute "wait_for_ready" for class "ClientCallDetails"
  /grpc/_interceptor.py:113:29 - error: Cannot access attribute "wait_for_ready" for class "ClientCallDetails"
  /grpc/_interceptor.py:118:26 - error: Cannot access attribute "compression" for class "ClientCallDetails"
  /grpc/_interceptor.py:122:29 - error: Cannot access attribute "compression" for class "ClientCallDetails"
  /grpc/_interceptor.py:326:51 - error: Argument of type "TracebackType | None" cannot be assigned to parameter "traceback" of type "TracebackType" in function "__init__"
  /grpc/_interceptor.py:392:47 - error: Argument of type "TracebackType | None" cannot be assigned to parameter "traceback" of type "TracebackType" in function "__init__"
  /grpc/_interceptor.py:451:47 - error: Argument of type "TracebackType | None" cannot be assigned to parameter "traceback" of type "TracebackType" in function "__init__"
  /grpc/_interceptor.py:528:51 - error: Argument of type "TracebackType | None" cannot be assigned to parameter "traceback" of type "TracebackType" in function "__init__"
  /grpc/_interceptor.py:594:47 - error: Argument of type "TracebackType | None" cannot be assigned to parameter "traceback" of type "TracebackType" in function "__init__"
  /grpc/_interceptor.py:653:47 - error: Argument of type "TracebackType | None" cannot be assigned to parameter "traceback" of type "TracebackType" in function "__init__"
  /grpc/_interceptor.py:681:58 - error: Argument of type "bool | None" cannot be assigned to parameter "try_to_connect" of type "bool" in function "subscribe"
  /grpc/_interceptor.py:699:13 - error: Argument of type "bool | None" cannot be assigned to parameter "_registered_method" of type "bool" in function "unary_unary"
  /grpc/_interceptor.py:719:13 - error: Argument of type "bool | None" cannot be assigned to parameter "_registered_method" of type "bool" in function "unary_stream"
  /grpc/_interceptor.py:739:13 - error: Argument of type "bool | None" cannot be assigned to parameter "_registered_method" of type "bool" in function "stream_unary"
  /grpc/_interceptor.py:759:13 - error: Argument of type "bool | None" cannot be assigned to parameter "_registered_method" of type "bool" in function "stream_stream"
24 errors, 0 warnings, 0 informations
```

# Previous
* https://github.com/grpc/grpc/pull/42452

# Next
* https://github.com/grpc/grpc/pull/42455
