### PR TITLE
[ObjC] Updated BoringSSL template to support cpp17

### DIFF
--- a/BoringSSL-Package.swift
+++ b/BoringSSL-Package.swift
@@ -319,7 +319,7 @@ let package = Package(
         .headerSearchPath("include/"),
       ]
     ),
-    .executableTarget(
+    .testTarget(
       name: "build-test",
       dependencies: [
         "openssl_grpc",

--- a/BoringSSL-Package.swift
+++ b/BoringSSL-Package.swift
@@ -319,7 +319,7 @@ let package = Package(
         .headerSearchPath("include/"),
       ]
     ),
-    .testTarget(
+    .executableTarget(
       name: "build-test",
       dependencies: [
         "openssl_grpc",
@@ -327,5 +327,5 @@ let package = Package(
       path: testPath
     ),
   ],
-  cxxLanguageStandard: .cxx14
+  cxxLanguageStandard: .cxx17
 )

--- a/templates/BoringSSL-Package.swift.template
+++ b/templates/BoringSSL-Package.swift.template
@@ -52,7 +52,7 @@
             .headerSearchPath("include/"),
           ]
         ),
-        .testTarget(
+        .executableTarget(
           name: "build-test",
           dependencies: [
             "openssl_grpc",
@@ -60,5 +60,5 @@
           path: testPath
         ),
       ],
-      cxxLanguageStandard: .cxx14
+      cxxLanguageStandard: .cxx17
     )

--- a/templates/BoringSSL-Package.swift.template
+++ b/templates/BoringSSL-Package.swift.template
@@ -52,7 +52,7 @@
             .headerSearchPath("include/"),
           ]
         ),
-        .executableTarget(
+        .testTarget(
           name: "build-test",
           dependencies: [
             "openssl_grpc",


### PR DESCRIPTION


This PR uses the gRPC build system to generate the swift package file from the same boringssl version in third_party.
Will use the output to update the boringSSL-SwiftPM repo after this PR is merged.

Tested with

cp BoringSSL-Package.swift Package.swift
swift build
swift run build-test

