### PR TITLE
[xDS] fork XdsServerConfigFetcher and ServerConfigSelectorFilter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3012,6 +3012,7 @@ add_library(grpc
   src/core/server/server_config_selector_filter.cc
   src/core/server/xds_channel_stack_modifier.cc
   src/core/server/xds_server_config_fetcher.cc
+  src/core/server/xds_server_config_fetcher_legacy.cc
   src/core/service_config/service_config_channel_arg_filter.cc
   src/core/service_config/service_config_impl.cc
   src/core/service_config/service_config_parser.cc

--- a/Makefile
+++ b/Makefile
@@ -1449,6 +1449,7 @@ LIBGRPC_SRC = \
     src/core/server/server_config_selector_filter.cc \
     src/core/server/xds_channel_stack_modifier.cc \
     src/core/server/xds_server_config_fetcher.cc \
+    src/core/server/xds_server_config_fetcher_legacy.cc \
     src/core/service_config/service_config_channel_arg_filter.cc \
     src/core/service_config/service_config_impl.cc \
     src/core/service_config/service_config_parser.cc \

--- a/Package.swift
+++ b/Package.swift
@@ -1934,6 +1934,7 @@ let package = Package(
         "src/core/server/xds_channel_stack_modifier.cc",
         "src/core/server/xds_channel_stack_modifier.h",
         "src/core/server/xds_server_config_fetcher.cc",
+        "src/core/server/xds_server_config_fetcher_legacy.cc",
         "src/core/service_config/service_config.h",
         "src/core/service_config/service_config_call_data.h",
         "src/core/service_config/service_config_channel_arg_filter.cc",

--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -77,6 +77,7 @@ EXPERIMENT_ENABLES = {
     "unconstrained_max_quota_buffer_size": "unconstrained_max_quota_buffer_size",
     "use_call_event_engine_in_completion_queue": "use_call_event_engine_in_completion_queue",
     "wildcard_ip_expansion_restriction": "wildcard_ip_expansion_restriction",
+    "xds_server_filter_chain_per_route": "xds_server_filter_chain_per_route",
 }
 
 EXPERIMENT_POLLERS = [
@@ -210,6 +211,12 @@ EXPERIMENTS = {
             ],
             "secure_endpoint_test": [
                 "pipelined_read_secure_endpoint",
+            ],
+            "xds_end2end_test": [
+                "xds_server_filter_chain_per_route",
+            ],
+            "xds_test": [
+                "xds_server_filter_chain_per_route",
             ],
         },
         "on": {

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -2160,6 +2160,7 @@ libs:
   - src/core/server/server_config_selector_filter.cc
   - src/core/server/xds_channel_stack_modifier.cc
   - src/core/server/xds_server_config_fetcher.cc
+  - src/core/server/xds_server_config_fetcher_legacy.cc
   - src/core/service_config/service_config_channel_arg_filter.cc
   - src/core/service_config/service_config_impl.cc
   - src/core/service_config/service_config_parser.cc

--- a/config.m4
+++ b/config.m4
@@ -823,6 +823,7 @@ if test "$PHP_GRPC" != "no"; then
     src/core/server/server_config_selector_filter.cc \
     src/core/server/xds_channel_stack_modifier.cc \
     src/core/server/xds_server_config_fetcher.cc \
+    src/core/server/xds_server_config_fetcher_legacy.cc \
     src/core/service_config/service_config_channel_arg_filter.cc \
     src/core/service_config/service_config_impl.cc \
     src/core/service_config/service_config_parser.cc \

--- a/config.w32
+++ b/config.w32
@@ -788,6 +788,7 @@ if (PHP_GRPC != "no") {
     "src\\core\\server\\server_config_selector_filter.cc " +
     "src\\core\\server\\xds_channel_stack_modifier.cc " +
     "src\\core\\server\\xds_server_config_fetcher.cc " +
+    "src\\core\\server\\xds_server_config_fetcher_legacy.cc " +
     "src\\core\\service_config\\service_config_channel_arg_filter.cc " +
     "src\\core\\service_config\\service_config_impl.cc " +
     "src\\core\\service_config\\service_config_parser.cc " +

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -2053,6 +2053,7 @@ Pod::Spec.new do |s|
                       'src/core/server/xds_channel_stack_modifier.cc',
                       'src/core/server/xds_channel_stack_modifier.h',
                       'src/core/server/xds_server_config_fetcher.cc',
+                      'src/core/server/xds_server_config_fetcher_legacy.cc',
                       'src/core/service_config/service_config.h',
                       'src/core/service_config/service_config_call_data.h',
                       'src/core/service_config/service_config_channel_arg_filter.cc',

--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -1937,6 +1937,7 @@ Gem::Specification.new do |s|
   s.files += %w( src/core/server/xds_channel_stack_modifier.cc )
   s.files += %w( src/core/server/xds_channel_stack_modifier.h )
   s.files += %w( src/core/server/xds_server_config_fetcher.cc )
+  s.files += %w( src/core/server/xds_server_config_fetcher_legacy.cc )
   s.files += %w( src/core/service_config/service_config.h )
   s.files += %w( src/core/service_config/service_config_call_data.h )
   s.files += %w( src/core/service_config/service_config_channel_arg_filter.cc )

--- a/package.xml
+++ b/package.xml
@@ -1918,6 +1918,7 @@
     <file baseinstalldir="/" name="src/core/server/xds_channel_stack_modifier.cc" role="src" />
     <file baseinstalldir="/" name="src/core/server/xds_channel_stack_modifier.h" role="src" />
     <file baseinstalldir="/" name="src/core/server/xds_server_config_fetcher.cc" role="src" />
+    <file baseinstalldir="/" name="src/core/server/xds_server_config_fetcher_legacy.cc" role="src" />
     <file baseinstalldir="/" name="src/core/service_config/service_config.h" role="src" />
     <file baseinstalldir="/" name="src/core/service_config/service_config_call_data.h" role="src" />
     <file baseinstalldir="/" name="src/core/service_config/service_config_channel_arg_filter.cc" role="src" />

--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -6766,6 +6766,7 @@ grpc_cc_library(
     name = "grpc_xds_server_config_fetcher",
     srcs = [
         "server/xds_server_config_fetcher.cc",
+        "server/xds_server_config_fetcher_legacy.cc",
     ],
     external_deps = [
         "absl/base:core_headers",

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -259,6 +259,10 @@ const char* const description_wildcard_ip_expansion_restriction =
     "If set, adds optional restriction on when to expand wildcard IPs.";
 const char* const additional_constraints_wildcard_ip_expansion_restriction =
     "{}";
+const char* const description_xds_server_filter_chain_per_route =
+    "xDS servers use a separate filter chain for each route.";
+const char* const additional_constraints_xds_server_filter_chain_per_route =
+    "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -445,6 +449,10 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"wildcard_ip_expansion_restriction",
      description_wildcard_ip_expansion_restriction,
      additional_constraints_wildcard_ip_expansion_restriction, nullptr, 0,
+     false, true},
+    {"xds_server_filter_chain_per_route",
+     description_xds_server_filter_chain_per_route,
+     additional_constraints_xds_server_filter_chain_per_route, nullptr, 0,
      false, true},
 };
 
@@ -688,6 +696,10 @@ const char* const description_wildcard_ip_expansion_restriction =
     "If set, adds optional restriction on when to expand wildcard IPs.";
 const char* const additional_constraints_wildcard_ip_expansion_restriction =
     "{}";
+const char* const description_xds_server_filter_chain_per_route =
+    "xDS servers use a separate filter chain for each route.";
+const char* const additional_constraints_xds_server_filter_chain_per_route =
+    "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -874,6 +886,10 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"wildcard_ip_expansion_restriction",
      description_wildcard_ip_expansion_restriction,
      additional_constraints_wildcard_ip_expansion_restriction, nullptr, 0,
+     false, true},
+    {"xds_server_filter_chain_per_route",
+     description_xds_server_filter_chain_per_route,
+     additional_constraints_xds_server_filter_chain_per_route, nullptr, 0,
      false, true},
 };
 
@@ -1117,6 +1133,10 @@ const char* const description_wildcard_ip_expansion_restriction =
     "If set, adds optional restriction on when to expand wildcard IPs.";
 const char* const additional_constraints_wildcard_ip_expansion_restriction =
     "{}";
+const char* const description_xds_server_filter_chain_per_route =
+    "xDS servers use a separate filter chain for each route.";
+const char* const additional_constraints_xds_server_filter_chain_per_route =
+    "{}";
 }  // namespace
 
 namespace grpc_core {
@@ -1303,6 +1323,10 @@ const ExperimentMetadata g_experiment_metadata[] = {
     {"wildcard_ip_expansion_restriction",
      description_wildcard_ip_expansion_restriction,
      additional_constraints_wildcard_ip_expansion_restriction, nullptr, 0,
+     false, true},
+    {"xds_server_filter_chain_per_route",
+     description_xds_server_filter_chain_per_route,
+     additional_constraints_xds_server_filter_chain_per_route, nullptr, 0,
      false, true},
 };
 

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -143,6 +143,7 @@ inline bool IsTsiFrameProtectorWithoutLocksEnabled() { return false; }
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 inline bool IsUseCallEventEngineInCompletionQueueEnabled() { return false; }
 inline bool IsWildcardIpExpansionRestrictionEnabled() { return false; }
+inline bool IsXdsServerFilterChainPerRouteEnabled() { return false; }
 
 #elif defined(GPR_WINDOWS)
 inline bool IsBufferListDeletionPrepEnabled() { return false; }
@@ -231,6 +232,7 @@ inline bool IsTsiFrameProtectorWithoutLocksEnabled() { return false; }
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 inline bool IsUseCallEventEngineInCompletionQueueEnabled() { return false; }
 inline bool IsWildcardIpExpansionRestrictionEnabled() { return false; }
+inline bool IsXdsServerFilterChainPerRouteEnabled() { return false; }
 
 #else
 inline bool IsBufferListDeletionPrepEnabled() { return false; }
@@ -319,6 +321,7 @@ inline bool IsTsiFrameProtectorWithoutLocksEnabled() { return false; }
 inline bool IsUnconstrainedMaxQuotaBufferSizeEnabled() { return false; }
 inline bool IsUseCallEventEngineInCompletionQueueEnabled() { return false; }
 inline bool IsWildcardIpExpansionRestrictionEnabled() { return false; }
+inline bool IsXdsServerFilterChainPerRouteEnabled() { return false; }
 #endif
 
 #else
@@ -383,6 +386,7 @@ enum ExperimentIds {
   kExperimentIdUnconstrainedMaxQuotaBufferSize,
   kExperimentIdUseCallEventEngineInCompletionQueue,
   kExperimentIdWildcardIpExpansionRestriction,
+  kExperimentIdXdsServerFilterChainPerRoute,
   kNumExperiments
 };
 #define GRPC_EXPERIMENT_IS_INCLUDED_BUFFER_LIST_DELETION_PREP
@@ -627,6 +631,10 @@ inline bool IsUseCallEventEngineInCompletionQueueEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_WILDCARD_IP_EXPANSION_RESTRICTION
 inline bool IsWildcardIpExpansionRestrictionEnabled() {
   return IsExperimentEnabled<kExperimentIdWildcardIpExpansionRestriction>();
+}
+#define GRPC_EXPERIMENT_IS_INCLUDED_XDS_SERVER_FILTER_CHAIN_PER_ROUTE
+inline bool IsXdsServerFilterChainPerRouteEnabled() {
+  return IsExperimentEnabled<kExperimentIdXdsServerFilterChainPerRoute>();
 }
 
 extern const ExperimentMetadata g_experiment_metadata[kNumExperiments];

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -427,3 +427,8 @@
   expiry: 2026/07/01
   owner: alishananda@google.com
   test_tags: ["core_end2end_test"]
+- name: xds_server_filter_chain_per_route
+  description: xDS servers use a separate filter chain for each route.
+  expiry: 2026/09/01
+  owner: roth@google.com
+  test_tags: ["xds_end2end_test", "xds_test"]

--- a/src/core/server/server_config_selector_filter.cc
+++ b/src/core/server/server_config_selector_filter.cc
@@ -46,6 +46,127 @@ namespace grpc_core {
 
 namespace {
 
+class LegacyServerConfigSelectorFilter final
+    : public ImplementChannelFilter<LegacyServerConfigSelectorFilter>,
+      public InternallyRefCounted<LegacyServerConfigSelectorFilter> {
+ public:
+  explicit LegacyServerConfigSelectorFilter(
+      RefCountedPtr<ServerConfigSelectorProvider>
+          server_config_selector_provider);
+
+  static absl::string_view TypeName() {
+    return "server_config_selector_filter";
+  }
+
+  LegacyServerConfigSelectorFilter(const LegacyServerConfigSelectorFilter&) = delete;
+  LegacyServerConfigSelectorFilter& operator=(const LegacyServerConfigSelectorFilter&) =
+      delete;
+
+  static absl::StatusOr<OrphanablePtr<LegacyServerConfigSelectorFilter>> Create(
+      const ChannelArgs& args, ChannelFilter::Args);
+
+  void Orphan() override;
+
+  class Call {
+   public:
+    absl::Status OnClientInitialMetadata(ClientMetadata& md,
+                                         LegacyServerConfigSelectorFilter* filter);
+    static inline const NoInterceptor OnServerInitialMetadata;
+    static inline const NoInterceptor OnServerTrailingMetadata;
+    static inline const NoInterceptor OnClientToServerMessage;
+    static inline const NoInterceptor OnClientToServerHalfClose;
+    static inline const NoInterceptor OnServerToClientMessage;
+    static inline const NoInterceptor OnFinalize;
+  };
+
+  absl::StatusOr<RefCountedPtr<ServerConfigSelector>> config_selector() {
+    MutexLock lock(&mu_);
+    return config_selector_.value();
+  }
+
+ private:
+  class ServerConfigSelectorWatcher
+      : public ServerConfigSelectorProvider::ServerConfigSelectorWatcher {
+   public:
+    explicit ServerConfigSelectorWatcher(
+        RefCountedPtr<LegacyServerConfigSelectorFilter> filter)
+        : filter_(filter) {}
+    void OnServerConfigSelectorUpdate(
+        absl::StatusOr<RefCountedPtr<ServerConfigSelector>> update) override {
+      MutexLock lock(&filter_->mu_);
+      filter_->config_selector_ = std::move(update);
+    }
+
+   private:
+    RefCountedPtr<LegacyServerConfigSelectorFilter> filter_;
+  };
+
+  RefCountedPtr<ServerConfigSelectorProvider> server_config_selector_provider_;
+  Mutex mu_;
+  std::optional<absl::StatusOr<RefCountedPtr<ServerConfigSelector>>>
+      config_selector_ ABSL_GUARDED_BY(mu_);
+};
+
+absl::StatusOr<OrphanablePtr<LegacyServerConfigSelectorFilter>>
+LegacyServerConfigSelectorFilter::Create(const ChannelArgs& args,
+                                   ChannelFilter::Args) {
+  ServerConfigSelectorProvider* server_config_selector_provider =
+      args.GetObject<ServerConfigSelectorProvider>();
+  if (server_config_selector_provider == nullptr) {
+    return absl::UnknownError("No ServerConfigSelectorProvider object found");
+  }
+  return MakeOrphanable<LegacyServerConfigSelectorFilter>(
+      server_config_selector_provider->Ref());
+}
+
+LegacyServerConfigSelectorFilter::LegacyServerConfigSelectorFilter(
+    RefCountedPtr<ServerConfigSelectorProvider> server_config_selector_provider)
+    : server_config_selector_provider_(
+          std::move(server_config_selector_provider)) {
+  GRPC_CHECK(server_config_selector_provider_ != nullptr);
+  auto server_config_selector_watcher =
+      std::make_unique<ServerConfigSelectorWatcher>(Ref());
+  auto config_selector = server_config_selector_provider_->Watch(
+      std::move(server_config_selector_watcher));
+  MutexLock lock(&mu_);
+  // It's possible for the watcher to have already updated config_selector_
+  if (!config_selector_.has_value()) {
+    config_selector_ = std::move(config_selector);
+  }
+}
+
+void LegacyServerConfigSelectorFilter::Orphan() {
+  if (server_config_selector_provider_ != nullptr) {
+    server_config_selector_provider_->CancelWatch();
+  }
+  Unref();
+}
+
+absl::Status LegacyServerConfigSelectorFilter::Call::OnClientInitialMetadata(
+    ClientMetadata& md, LegacyServerConfigSelectorFilter* filter) {
+  GRPC_LATENT_SEE_SCOPE(
+      "LegacyServerConfigSelectorFilter::Call::OnClientInitialMetadata");
+  auto sel = filter->config_selector();
+  if (!sel.ok()) return sel.status();
+  auto call_config = sel.value()->GetCallConfig(&md);
+  if (!call_config.ok()) {
+    return absl::UnavailableError(StatusToString(call_config.status()));
+  }
+  auto* service_config_call_data =
+      GetContext<Arena>()->New<ServiceConfigCallData>(GetContext<Arena>());
+  service_config_call_data->SetServiceConfig(
+      std::move(call_config->service_config), call_config->method_configs);
+  return absl::OkStatus();
+}
+
+}  // namespace
+
+const grpc_channel_filter kLegacyServerConfigSelectorFilter =
+    MakePromiseBasedFilter<LegacyServerConfigSelectorFilter,
+                           FilterEndpoint::kServer>();
+
+namespace {
+
 class ServerConfigSelectorFilter final
     : public ImplementChannelFilter<ServerConfigSelectorFilter>,
       public InternallyRefCounted<ServerConfigSelectorFilter> {

--- a/src/core/server/server_config_selector_filter.cc
+++ b/src/core/server/server_config_selector_filter.cc
@@ -58,9 +58,10 @@ class LegacyServerConfigSelectorFilter final
     return "server_config_selector_filter";
   }
 
-  LegacyServerConfigSelectorFilter(const LegacyServerConfigSelectorFilter&) = delete;
-  LegacyServerConfigSelectorFilter& operator=(const LegacyServerConfigSelectorFilter&) =
+  LegacyServerConfigSelectorFilter(const LegacyServerConfigSelectorFilter&) =
       delete;
+  LegacyServerConfigSelectorFilter& operator=(
+      const LegacyServerConfigSelectorFilter&) = delete;
 
   static absl::StatusOr<OrphanablePtr<LegacyServerConfigSelectorFilter>> Create(
       const ChannelArgs& args, ChannelFilter::Args);
@@ -69,8 +70,8 @@ class LegacyServerConfigSelectorFilter final
 
   class Call {
    public:
-    absl::Status OnClientInitialMetadata(ClientMetadata& md,
-                                         LegacyServerConfigSelectorFilter* filter);
+    absl::Status OnClientInitialMetadata(
+        ClientMetadata& md, LegacyServerConfigSelectorFilter* filter);
     static inline const NoInterceptor OnServerInitialMetadata;
     static inline const NoInterceptor OnServerTrailingMetadata;
     static inline const NoInterceptor OnClientToServerMessage;
@@ -109,7 +110,7 @@ class LegacyServerConfigSelectorFilter final
 
 absl::StatusOr<OrphanablePtr<LegacyServerConfigSelectorFilter>>
 LegacyServerConfigSelectorFilter::Create(const ChannelArgs& args,
-                                   ChannelFilter::Args) {
+                                         ChannelFilter::Args) {
   ServerConfigSelectorProvider* server_config_selector_provider =
       args.GetObject<ServerConfigSelectorProvider>();
   if (server_config_selector_provider == nullptr) {

--- a/src/core/server/server_config_selector_filter.h
+++ b/src/core/server/server_config_selector_filter.h
@@ -26,6 +26,7 @@
 
 namespace grpc_core {
 
+extern const grpc_channel_filter kLegacyServerConfigSelectorFilter;
 extern const grpc_channel_filter kServerConfigSelectorFilter;
 
 }  // namespace grpc_core

--- a/src/core/server/xds_server_config_fetcher.cc
+++ b/src/core/server/xds_server_config_fetcher.cc
@@ -1306,7 +1306,7 @@ grpc_server_config_fetcher* grpc_server_config_fetcher_xds_create_legacy(
 
 grpc_server_config_fetcher* grpc_server_config_fetcher_xds_create(
     grpc_server_xds_status_notifier notifier, const grpc_channel_args* args) {
-  if (grpc_core::IsXdsServerFilterChainPerRouteEnabled()) {
+  if (!grpc_core::IsXdsServerFilterChainPerRouteEnabled()) {
     return grpc_server_config_fetcher_xds_create_legacy(notifier, args);
   }
   grpc_core::ExecCtx exec_ctx;

--- a/src/core/server/xds_server_config_fetcher_legacy.cc
+++ b/src/core/server/xds_server_config_fetcher_legacy.cc
@@ -1058,7 +1058,7 @@ absl::StatusOr<ChannelArgs> XdsServerConfigFetcher::ListenerWatcher::
     }
   }
   // Add config selector filter.
-  filters.push_back(&kServerConfigSelectorFilter);
+  filters.push_back(&kLegacyServerConfigSelectorFilter);
   channel_stack_modifier =
       MakeRefCounted<XdsChannelStackModifier>(std::move(filters));
   Match(
@@ -1302,13 +1302,7 @@ void XdsServerConfigFetcher::ListenerWatcher::FilterChainMatchManager::
 }  // namespace grpc_core
 
 grpc_server_config_fetcher* grpc_server_config_fetcher_xds_create_legacy(
-    grpc_server_xds_status_notifier notifier, const grpc_channel_args* args);
-
-grpc_server_config_fetcher* grpc_server_config_fetcher_xds_create(
     grpc_server_xds_status_notifier notifier, const grpc_channel_args* args) {
-  if (grpc_core::IsXdsServerFilterChainPerRouteEnabled()) {
-    return grpc_server_config_fetcher_xds_create_legacy(notifier, args);
-  }
   grpc_core::ExecCtx exec_ctx;
   grpc_core::ChannelArgs channel_args = grpc_core::CoreConfiguration::Get()
                                             .channel_args_preconditioning()

--- a/src/python/grpcio/grpc_core_dependencies.py
+++ b/src/python/grpcio/grpc_core_dependencies.py
@@ -798,6 +798,7 @@ CORE_SOURCE_FILES = [
     'src/core/server/server_config_selector_filter.cc',
     'src/core/server/xds_channel_stack_modifier.cc',
     'src/core/server/xds_server_config_fetcher.cc',
+    'src/core/server/xds_server_config_fetcher_legacy.cc',
     'src/core/service_config/service_config_channel_arg_filter.cc',
     'src/core/service_config/service_config_impl.cc',
     'src/core/service_config/service_config_parser.cc',

--- a/tools/doxygen/Doxyfile.c++.internal
+++ b/tools/doxygen/Doxyfile.c++.internal
@@ -2907,6 +2907,7 @@ src/core/server/server_interface.h \
 src/core/server/xds_channel_stack_modifier.cc \
 src/core/server/xds_channel_stack_modifier.h \
 src/core/server/xds_server_config_fetcher.cc \
+src/core/server/xds_server_config_fetcher_legacy.cc \
 src/core/service_config/service_config.h \
 src/core/service_config/service_config_call_data.h \
 src/core/service_config/service_config_channel_arg_filter.cc \

--- a/tools/doxygen/Doxyfile.core.internal
+++ b/tools/doxygen/Doxyfile.core.internal
@@ -2768,6 +2768,7 @@ src/core/server/server_interface.h \
 src/core/server/xds_channel_stack_modifier.cc \
 src/core/server/xds_channel_stack_modifier.h \
 src/core/server/xds_server_config_fetcher.cc \
+src/core/server/xds_server_config_fetcher_legacy.cc \
 src/core/service_config/GEMINI.md \
 src/core/service_config/service_config.h \
 src/core/service_config/service_config_call_data.h \


### PR DESCRIPTION
This paves the way to implement per-route filter chains on the server side.  I have added a `xds_server_filter_chain_per_route` experiment that controls whether we use the new impl or the old one.  The per-route filter chain functionality will be added in the new impl, and I will not start enabling the experiment until it's done.

I have copied xds_server_config_fetcher.cc to xds_server_config_fetcher_legacy.cc.  The only code that is exposed outside of that file is the `grpc_server_config_fetcher_xds_create()` function, which I've renamed to `grpc_server_config_fetcher_xds_create_legacy()`.  I then changed the `grpc_server_config_fetcher_xds_create()` function in xds_server_config_fetcher.cc to delegate to `grpc_server_config_fetcher_xds_create_legacy()` when the experiment is not enabled.

For the server config selector filter, I have duplicated the code, renaming one copy to `LegacyServerConfigSelectorFilter`.  The legacy `XdsServerConfigFetcher` impl (in xds_server_config_fetcher_legacy.cc) uses `LegacyServerConfigSelectorFilter`, whereas the new `XdsServerConfigFetcher` impl (in xds_server_config_fetcher.cc) uses `ServerConfigSelectorFilter`.

Currently, both old and new implementations are the same.