### PR TITLE
[Python][aio] Fix issue #42393: 100% CPU when Python run with -O flag

### DIFF
--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -477,7 +477,8 @@ class Channel(_base_channel.Channel):
         # calls and makes them return True. Thus, watch_connectivity_state should only return
         # True under normal operation; returning False indicates an implementation issue.
         #
-        # We do not use an assert statement here because asserts can be optimized out under python -O.
+        # We do not use an assert statement here because asserts
+        # can be optimized out under python -O.
         # See https://github.com/grpc/grpc/issues/42393 for context.
         resolved = await self._channel.watch_connectivity_state(
             last_observed_state.value[0], None

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -483,7 +483,9 @@ class Channel(_base_channel.Channel):
             last_observed_state.value[0], None
         )
         if not resolved:
-            error_msg = "gRPC channel connectivity state watch failed unexpectedly."
+            error_msg = (
+                "gRPC channel connectivity state watch failed unexpectedly."
+            )
             raise RuntimeError(error_msg)
 
     async def channel_ready(self) -> None:

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -473,6 +473,13 @@ class Channel(_base_channel.Channel):
         # statement because assert statements are optimized out under python -O,
         # which would skip awaiting watch_connectivity_state and cause a 100% CPU loop.
         # See https://github.com/grpc/grpc/issues/42393 for context.
+        #
+        # We assert resolved because watch_connectivity_state returns True when
+        # it observes a state change and False when it times out. A channel close
+        # triggers a transition to SHUTDOWN, which resolves all pending watch
+        # calls and makes them return True. Thus, watch_connectivity_state should
+        # only return True under normal operation; returning False indicates an
+        # implementation issue.
         resolved = await self._channel.watch_connectivity_state(
             last_observed_state.value[0], None
         )

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -469,22 +469,22 @@ class Channel(_base_channel.Channel):
         self,
         last_observed_state: grpc.ChannelConnectivity,
     ) -> None:
-        # The await expression must not be placed directly inside the assert
-        # statement because assert statements are optimized out under python -O,
-        # which would skip awaiting watch_connectivity_state and cause a 100% CPU loop.
-        # See https://github.com/grpc/grpc/issues/42393 for context.
+        # We raise a RuntimeError if watch_connectivity_state returns False.
         #
-        # We assert resolved because watch_connectivity_state returns True when
-        # it observes a state change and False when it times out. A channel close
-        # triggers a transition to SHUTDOWN, which resolves all pending watch
-        # calls and makes them return True. Thus, watch_connectivity_state should
-        # only return True under normal operation; returning False indicates an
-        # implementation issue.
+        # The watch_connectivity_state method returns True when it observes a state change
+        # and False when it times out (which shouldn't happen since no timeout is specified).
+        # A channel close triggers a transition to SHUTDOWN, which resolves all pending watch
+        # calls and makes them return True. Thus, watch_connectivity_state should only return
+        # True under normal operation; returning False indicates an implementation issue.
+        #
+        # We do not use an assert statement here because asserts can be optimized out under python -O.
+        # See https://github.com/grpc/grpc/issues/42393 for context.
         resolved = await self._channel.watch_connectivity_state(
             last_observed_state.value[0], None
         )
         if not resolved:
-            raise RuntimeError("Connectivity state watch failed")
+            error_msg = "Connectivity state watch failed"
+            raise RuntimeError(error_msg)
 
     async def channel_ready(self) -> None:
         state = self.get_state(try_to_connect=True)

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -483,7 +483,7 @@ class Channel(_base_channel.Channel):
             last_observed_state.value[0], None
         )
         if not resolved:
-            error_msg = "Connectivity state watch failed"
+            error_msg = "gRPC channel connectivity state watch failed unexpectedly."
             raise RuntimeError(error_msg)
 
     async def channel_ready(self) -> None:

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -483,7 +483,8 @@ class Channel(_base_channel.Channel):
         resolved = await self._channel.watch_connectivity_state(
             last_observed_state.value[0], None
         )
-        assert resolved
+        if not resolved:
+            raise RuntimeError("Connectivity state watch failed")
 
     async def channel_ready(self) -> None:
         state = self.get_state(try_to_connect=True)

--- a/src/python/grpcio/grpc/aio/_channel.py
+++ b/src/python/grpcio/grpc/aio/_channel.py
@@ -469,9 +469,14 @@ class Channel(_base_channel.Channel):
         self,
         last_observed_state: grpc.ChannelConnectivity,
     ) -> None:
-        assert await self._channel.watch_connectivity_state(
+        # The await expression must not be placed directly inside the assert
+        # statement because assert statements are optimized out under python -O,
+        # which would skip awaiting watch_connectivity_state and cause a 100% CPU loop.
+        # See https://github.com/grpc/grpc/issues/42393 for context.
+        resolved = await self._channel.watch_connectivity_state(
             last_observed_state.value[0], None
         )
+        assert resolved
 
     async def channel_ready(self) -> None:
         state = self.get_state(try_to_connect=True)


### PR DESCRIPTION
# Description 

Fixes issue - https://github.com/grpc/grpc/issues/42393

`-O` flag removes the `assert` statement - hence this line was getting removed, which caused the CPU spikes and infinite busy loop.

# Testing

* Manually built `grpc` from source, from this branch
* Used the repro code 
```py
import asyncio
import grpc

async def main():
    channel = grpc.aio.insecure_channel("localhost:1234")
    await channel.channel_ready()

if __name__ == "__main__":
    asyncio.run(main())

# python -O main.py
``` 
* Checked `htop` for CPU usage.