### PR TITLE
[BUILD][bzlmod] Include http2_status.h in public header to fix layering_check failures

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.h
@@ -28,6 +28,7 @@
 
 #include "src/core/channelz/channelz.h"
 #include "src/core/ext/transport/chttp2/transport/flow_control.h"
+#include "src/core/ext/transport/chttp2/transport/http2_status.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/buffer_list.h"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/42310

### Root Cause
The target `http2_status` was defined in `src/core/BUILD` (package `//src/core`), meaning its exported header path was mapped relative to `/src/core/` in Clang's module map (i.e., `ext/transport/chttp2/transport/http2_status.h`).

However, chttp2 source files (such as writing.cc) include this header using its absolute workspace path:

```c++
#include "src/core/ext/transport/chttp2/transport/http2_status.h"
```

When consumed under Bzlmod, the compiler's Clang module map generated for the external target failed to associate this #include statement with the `//src/core:http2_status` module due to this path mismatch. This triggered strict module layering violations:

```bash
error: module grpc+//:grpc_transport_chttp2 does not depend on a module exporting 'src/core/ext/transport/chttp2/transport/http2_status.h'
```

### Solution

Included http2_status.h inside the public chttp2_transport.h header of grpc_transport_chttp2. This exports the module transitively as part of grpc_transport_chttp2's public interface, resolving the compiler's layering check path mismatch.