### PR TITLE
[Ruby]Fix: Added stdbool.h to fix rake compile issues for ruby 3.2+

### DIFF
--- a/src/ruby/ext/grpc/rb_byte_buffer.c
+++ b/src/ruby/ext/grpc/rb_byte_buffer.c
@@ -23,6 +23,7 @@
 #include <grpc/byte_buffer_reader.h>
 #include <grpc/grpc.h>
 #include <grpc/slice.h>
+#include <stdbool.h>
 
 #include "rb_grpc.h"
 #include "rb_grpc_imports.generated.h"

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -23,6 +23,7 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/compression_types.h>
 #include <grpc/support/alloc.h>
+#include <stdbool.h>
 
 #include "rb_byte_buffer.h"
 #include "rb_call_credentials.h"

--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -26,6 +26,7 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <ruby/thread.h>
+#include <stdbool.h>
 
 #include "rb_call.h"
 #include "rb_event_thread.h"

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -27,6 +27,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <ruby/thread.h>
+#include <stdbool.h>
 
 #include "rb_byte_buffer.h"
 #include "rb_call.h"

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -23,6 +23,7 @@
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
+#include <stdbool.h>
 
 #include "rb_grpc.h"
 #include "rb_grpc_imports.generated.h"

--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -24,6 +24,7 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "rb_call_credentials.h"

--- a/src/ruby/ext/grpc/rb_completion_queue.c
+++ b/src/ruby/ext/grpc/rb_completion_queue.c
@@ -24,6 +24,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <ruby/thread.h>
+#include <stdbool.h>
 
 #include "rb_grpc.h"
 #include "rb_grpc_imports.generated.h"

--- a/src/ruby/ext/grpc/rb_compression_options.c
+++ b/src/ruby/ext/grpc/rb_compression_options.c
@@ -26,6 +26,7 @@
 #include <grpc/impl/grpc_types.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "rb_byte_buffer.h"

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -25,6 +25,7 @@
 #include <grpc/grpc_security.h>
 #include <grpc/support/atm.h>
 #include <grpc/support/log.h>
+#include <stdbool.h>
 
 #include "rb_byte_buffer.h"
 #include "rb_call.h"

--- a/src/ruby/ext/grpc/rb_server_credentials.c
+++ b/src/ruby/ext/grpc/rb_server_credentials.c
@@ -23,6 +23,7 @@
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
+#include <stdbool.h>
 
 #include "rb_grpc.h"
 #include "rb_grpc_imports.generated.h"

--- a/src/ruby/ext/grpc/rb_xds_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_xds_channel_credentials.c
@@ -24,6 +24,7 @@
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include "rb_call_credentials.h"

--- a/src/ruby/ext/grpc/rb_xds_server_credentials.c
+++ b/src/ruby/ext/grpc/rb_xds_server_credentials.c
@@ -23,6 +23,7 @@
 #include <grpc/credentials.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
+#include <stdbool.h>
 
 #include "rb_grpc.h"
 #include "rb_grpc_imports.generated.h"


### PR DESCRIPTION
Newer Ruby versions (Ruby 3.2+) have streamlined their public headers (`ruby.h`), removing transitive inclusions of standard headers like `<stdbool.h>`. This caused compilation failures (`unknown type name ‘bool’`) during `rake compile` because the gRPC extension files rely on `bool`, `true`, and `false`.

This PR fixes the build for Ruby 3.2+ while remaining fully backward-compatible with older Ruby versions by explicitly including `<stdbool.h>`  in the problematic files.

