### PR TITLE
[Python] Update `tools/distrib/install_all_python_modules.sh` with `--no-build-isolation` flag

### DIFF
--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -31,8 +31,8 @@ function maybe_run_command () {
   fi
 }
 
-# python3 -m pip install --upgrade "cython==3.1.1";
-# python3 -m pip install .;
+python3 -m pip install --upgrade "cython==3.1.1";
+python3 -m pip install .;
 
 # Build and install grpcio_tools
 pushd tools/distrib/python/grpcio_tools;

--- a/tools/distrib/install_all_python_modules.sh
+++ b/tools/distrib/install_all_python_modules.sh
@@ -23,14 +23,16 @@ cd "$BASEDIR";
 
 # unit-tests setup starts from here
 function maybe_run_command () {
+  local dir="$1"
+  local cmd="$2"
   # TODO(ssreenithi): find pyproject.toml/nox equivalent
-  if python3 setup.py --help-commands | grep "$1" &>/dev/null; then
-    python3 setup.py "$1";
+  if python3 "${dir}/setup.py" --help-commands | grep "${cmd}" &>/dev/null; then
+    python3 "${dir}/setup.py" "${cmd}";
   fi
 }
 
-python3 -m pip install --upgrade "cython==3.1.1";
-python3 -m pip install .;
+# python3 -m pip install --upgrade "cython==3.1.1";
+# python3 -m pip install .;
 
 # Build and install grpcio_tools
 pushd tools/distrib/python/grpcio_tools;
@@ -50,13 +52,13 @@ pushd py_xds_protos;
 popd;
 
 # Build and install individual gRPC packages
-pushd src/python;
-  for PACKAGE in ${PACKAGES}; do
-    pushd "${PACKAGE}";
-      python3 setup.py clean;
-      maybe_run_command preprocess
-      maybe_run_command build_package_protos
-      python3 -m pip install .;
-    popd;
-  done
-popd;
+for PACKAGE in ${PACKAGES}; do
+  PACKAGE_PATH="src/python/${PACKAGE}"
+
+  maybe_run_command "${PACKAGE_PATH}" preprocess
+  maybe_run_command "${PACKAGE_PATH}" build_package_protos
+
+  pushd "${PACKAGE_PATH}"
+    python3 -m pip install --no-build-isolation .
+  popd
+done

--- a/tools/distrib/python_tooling_tests.sh
+++ b/tools/distrib/python_tooling_tests.sh
@@ -25,3 +25,5 @@ TEST_MODULE="tests.unit.test_all_modules_installed"
 pushd src/python/grpcio_tests;
   python3 -m unittest "$TEST_MODULE"
 popd;
+
+chmod -R 755 src/

--- a/tools/distrib/python_tooling_tests.sh
+++ b/tools/distrib/python_tooling_tests.sh
@@ -18,12 +18,10 @@ set -ex
 BASEDIR=$(dirname "$0")/../..
 cd "$BASEDIR";
 
-# the test module 
-TEST_MODULE="tests.unit.test_all_modules_installed" 
+# the test module
+TEST_MODULE="tests.unit.test_all_modules_installed"
 
 # Run the specific test module
 pushd src/python/grpcio_tests;
-  python3 -m unittest "$TEST_MODULE" 
+  python3 -m unittest "$TEST_MODULE"
 popd;
-
-chmod -R 755 src/


### PR DESCRIPTION
Update `tools/distrib/install_all_python_modules.sh` with `--no-build-isolation` flag after pyproject.toml migration.

Fixes #42371 

