### PR TITLE
Fix unchecked malloc() return value in GrpcMemoryAllocatorImpl::MakeSlice

### DIFF
--- a/src/core/lib/resource_quota/memory_quota.cc
+++ b/src/core/lib/resource_quota/memory_quota.cc
@@ -406,6 +406,11 @@ void GrpcMemoryAllocatorImpl::Replenish() {
 grpc_slice GrpcMemoryAllocatorImpl::MakeSlice(MemoryRequest request) {
   auto size = Reserve(request.Increase(sizeof(SliceRefCount)));
   void* p = malloc(size);
+  if (GPR_UNLIKELY(p == nullptr)) {
+    Crash(absl::StrFormat(
+        "GrpcMemoryAllocatorImpl::MakeSlice: malloc(%zu) returned nullptr",
+        size));
+  }
   new (p) SliceRefCount(shared_from_this(), size);
   grpc_slice slice;
   slice.refcount = static_cast<SliceRefCount*>(p);


### PR DESCRIPTION
## Summary

Fixes an unchecked `malloc()` return value in `GrpcMemoryAllocatorImpl::MakeSlice()`.

## Problem

```cpp
auto size = Reserve(request.Increase(sizeof(SliceRefCount)));
void* p = malloc(size);
new (p) SliceRefCount(shared_from_this(), size);  // UB/SEGFAULT if p == nullptr
```

When the process is under memory pressure or when using custom allocators that return `nullptr` on allocation failure, placement `new` on a null pointer is undefined behavior and causes an immediate segfault. This crash bypasses gRPCs normal error propagation, making it unrecoverable.

## Fix

Add an explicit crash with a diagnostic message before dereferencing the pointer, consistent with how other allocation failures are handled in gRPC:

```cpp
void* p = malloc(size);
if (GPR_UNLIKELY(p == nullptr)) {
  Crash(absl::StrFormat(
      "GrpcMemoryAllocatorImpl::MakeSlice: malloc(%zu) returned nullptr", size));
}
```

This turns a silent undefined behavior crash into a clear, debuggable abort with context.

## Notes

> ⚠️ CLA signature required — signing at https://easycla.lfx.linuxfoundation.org before this PR can be merged.

Fixes #42148.
