### PR TITLE
[CI] Portability split

### DIFF
--- a/tools/internal_ci/linux/grpc_portability.cfg
+++ b/tools/internal_ci/linux/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux -e openssl --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f portability linux --exclude openssl --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_portability.cfg
+++ b/tools/internal_ci/linux/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux --exclude openssl --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f portability linux --exclude openssl --inner_jobs 32 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_portability_openssl.cfg
+++ b/tools/internal_ci/linux/grpc_portability_openssl.cfg
@@ -1,4 +1,4 @@
-# Copyright 2017 gRPC authors.
+# Copyright 2026 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux -e openssl --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f portability linux openssl --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/linux/grpc_portability_openssl.cfg
+++ b/tools/internal_ci/linux/grpc_portability_openssl.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux openssl --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f portability linux openssl --inner_jobs 32 -j 1 --bq_result_table aggregate_results"
 }

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -486,6 +486,7 @@ if __name__ == "__main__":
         help="Filter targets to run by label with AND semantics.",
     )
     argp.add_argument(
+        "-e",
         "--exclude",
         choices=_allowed_labels(),
         nargs="+",

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -473,7 +473,7 @@ if __name__ == "__main__":
     argp.add_argument(
         "-j",
         "--jobs",
-        default=multiprocessing.cpu_count() / _DEFAULT_INNER_JOBS,
+        default=None,
         type=int,
         help="Number of concurrent run_tests.py instances.",
     )

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -569,6 +569,11 @@ if __name__ == "__main__":
     )
     args = argp.parse_args()
 
+    if args.jobs is None:
+        args.jobs = int(multiprocessing.cpu_count() / args.inner_jobs)
+        if args.jobs < 1:
+            args.jobs = 1
+
     extra_args = []
     if args.build_only:
         extra_args.append("--build_only")


### PR DESCRIPTION
Splitting portability in 2 parts 
One for open ssl portability checks and rest. This help in terating and debugging quickly.
Also fixed the logic for parallelisation to use all cores

Passing run for rest : 
http://sponge2.corp.google.com/947c9b84-89a2-4b10-8ddc-da7c6cf1046c




