### PR TITLE
[CI][Fix] cmake: fix 'str' object has no attribute 'removeprefix'

### DIFF
--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -32,12 +32,19 @@
   grpcxx_libs = ['grpc++', 'grpc++_unsecure']
   protoc_libs = ['benchmark_helpers', 'grpc++_reflection', 'grpcpp_channelz']
 
+
+  def _remove_prefix(string, prefix):
+    # TODO(sergiitk): delete and use str.removeprefix once CI VMs off of py 3.8
+    if string.startswith(prefix):
+      return string[len(prefix):]
+    return string
+
   def third_party_proto_import_path(path):
     """Removes third_party prefix to match ProtoBuf's relative import path."""
     for lib in external_proto_libraries:
       if path.startswith(lib.proto_prefix):
-        path = path[len(lib.proto_prefix):]
-        path = path.removeprefix(lib.strip_path_prefix)
+        path = _remove_prefix(path, lib.proto_prefix)
+        path = _remove_prefix(path, lib.strip_path_prefix)
         break
     return path
 
@@ -514,10 +521,9 @@
   % for download_url in external_proto_library.urls:
   if (NOT EXISTS <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/${external_proto_library.destination} AND gRPC_DOWNLOAD_ARCHIVES)
     # Download the archive via HTTP, validate the checksum, and extract to ${external_proto_library.destination}.
-    ## TODO(sergiitk): revert removeprefix removal
     download_archive(
       <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/${external_proto_library.destination}
-      https://storage.googleapis.com/grpc-bazel-mirror/${download_url[8:] if download_url.startswith("https://") else download_url}
+      https://storage.googleapis.com/grpc-bazel-mirror/${_remove_prefix(download_url, "https://")}
       ${download_url}
       ${external_proto_library.hash}
       ${external_proto_library.strip_prefix}

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -514,9 +514,10 @@
   % for download_url in external_proto_library.urls:
   if (NOT EXISTS <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/${external_proto_library.destination} AND gRPC_DOWNLOAD_ARCHIVES)
     # Download the archive via HTTP, validate the checksum, and extract to ${external_proto_library.destination}.
+    # TODO(sergiitk): revert removeprefix removal
     download_archive(
       <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/${external_proto_library.destination}
-      https://storage.googleapis.com/grpc-bazel-mirror/${download_url.removeprefix("https://")}
+      https://storage.googleapis.com/grpc-bazel-mirror/${download_url[8:] if download_url.startswith("https://") else download_url}
       ${download_url}
       ${external_proto_library.hash}
       ${external_proto_library.strip_prefix}

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -514,7 +514,7 @@
   % for download_url in external_proto_library.urls:
   if (NOT EXISTS <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/${external_proto_library.destination} AND gRPC_DOWNLOAD_ARCHIVES)
     # Download the archive via HTTP, validate the checksum, and extract to ${external_proto_library.destination}.
-    # TODO(sergiitk): revert removeprefix removal
+    ## TODO(sergiitk): revert removeprefix removal
     download_archive(
       <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/${external_proto_library.destination}
       https://storage.googleapis.com/grpc-bazel-mirror/${download_url[8:] if download_url.startswith("https://") else download_url}


### PR DESCRIPTION
The `str.removeprefix` method was introduced in Python 3.9. Some CI environments still use older versions of Python, causing template rendering to fail. Replacing it with a slice-based approach for compatibility.

We should revert this once we upgrade `grpc-ubuntu20-large` Kokoro base VM image.

The issue was introduced in #42172 - but it's a CI tech debt issue. Normally we should be assuming that we run a modern python.