### PR TITLE
[retry] track throttler in channel rather than using blackboard

### DIFF
--- a/src/core/BUILD
+++ b/src/core/BUILD
@@ -4090,8 +4090,9 @@ grpc_cc_library(
     ],
     external_deps = ["absl/base:core_headers"],
     deps = [
-        "blackboard",
+        "grpc_service_config",
         "ref_counted",
+        "retry_service_config",
         "sync",
         "useful",
         "//:gpr",

--- a/src/core/call/status_util.cc
+++ b/src/core/call/status_util.cc
@@ -115,8 +115,6 @@ bool grpc_status_code_from_int(int status_int, grpc_status_code* status) {
 
 namespace grpc_core {
 
-namespace internal {
-
 std::string StatusCodeSet::ToString() const {
   std::vector<absl::string_view> codes;
   for (size_t i = 0; i < GPR_ARRAY_SIZE(g_status_string_entries); ++i) {
@@ -126,8 +124,6 @@ std::string StatusCodeSet::ToString() const {
   }
   return absl::StrCat("{", absl::StrJoin(codes, ","), "}");
 }
-
-}  // namespace internal
 
 absl::Status MaybeRewriteIllegalStatusCode(absl::Status status,
                                            absl::string_view source) {

--- a/src/core/call/status_util.h
+++ b/src/core/call/status_util.h
@@ -41,7 +41,6 @@ const char* grpc_status_code_to_string(grpc_status_code status);
 bool grpc_status_code_from_int(int status_int, grpc_status_code* status);
 
 namespace grpc_core {
-namespace internal {
 
 /// A set of grpc_status_code values.
 class StatusCodeSet {
@@ -66,8 +65,6 @@ class StatusCodeSet {
  private:
   int status_code_mask_ = 0;  // A bitfield of status codes in the set.
 };
-
-}  // namespace internal
 
 // Optionally rewrites a status as per
 // https://github.com/grpc/proposal/blob/master/A54-restrict-control-plane-status-codes.md.

--- a/src/core/client_channel/client_channel.cc
+++ b/src/core/client_channel/client_channel.cc
@@ -1392,15 +1392,14 @@ void ClientChannel::UpdateServiceConfigInDataPlaneLocked(
   }
   // Modify channel args.
   ChannelArgs new_args = args.SetObject(this).SetObject(saved_service_config_);
-  // Construct filter stack.
-  auto new_blackboard = MakeRefCounted<Blackboard>();
   const bool enable_retries =
       !channel_args_.WantMinimalStack() &&
       channel_args_.GetBool(GRPC_ARG_ENABLE_RETRIES).value_or(true);
   if (enable_retries) {
-    RetryInterceptor::UpdateBlackboard(*saved_service_config_,
-                                       blackboard_.get(), new_blackboard.get());
+    retry_throttler_updater_.Update(*saved_service_config_, new_args);
   }
+  // Construct filter stack.
+  auto new_blackboard = MakeRefCounted<Blackboard>();
   std::function<void(ServerMetadata&)> on_server_trailing_metadata;
   if (idle_timeout_ != Duration::Zero()) {
     on_server_trailing_metadata = [this](ServerMetadata&) {

--- a/src/core/client_channel/client_channel.h
+++ b/src/core/client_channel/client_channel.h
@@ -22,6 +22,7 @@
 #include "src/core/call/metadata.h"
 #include "src/core/client_channel/client_channel_factory.h"
 #include "src/core/client_channel/config_selector.h"
+#include "src/core/client_channel/retry_throttle.h"
 #include "src/core/client_channel/subchannel.h"
 #include "src/core/ext/filters/channel_idle/idle_filter_state.h"
 #include "src/core/filter/blackboard.h"
@@ -212,6 +213,8 @@ class ClientChannel : public Channel {
   RefCountedPtr<ServiceConfig> saved_service_config_
       ABSL_GUARDED_BY(*work_serializer_);
   RefCountedPtr<ConfigSelector> saved_config_selector_
+      ABSL_GUARDED_BY(*work_serializer_);
+  RetryThrottlerChannelArgsUpdater retry_throttler_updater_
       ABSL_GUARDED_BY(*work_serializer_);
   RefCountedPtr<const Blackboard> blackboard_
       ABSL_GUARDED_BY(*work_serializer_);

--- a/src/core/client_channel/client_channel_filter.cc
+++ b/src/core/client_channel/client_channel_filter.cc
@@ -1475,12 +1475,11 @@ void ClientChannelFilter::UpdateServiceConfigInDataPlaneLocked(
   bool enable_retries =
       !new_args.WantMinimalStack() &&
       new_args.GetBool(GRPC_ARG_ENABLE_RETRIES).value_or(true);
+  if (enable_retries) {
+    retry_throttler_updater_.Update(*service_config, new_args);
+  }
   // Construct dynamic filter stack.
   auto new_blackboard = MakeRefCounted<Blackboard>();
-  if (enable_retries) {
-    RetryFilter::UpdateBlackboard(*service_config, blackboard_.get(),
-                                  new_blackboard.get());
-  }
   LegacyFilterChainBuilder filter_chain_builder(enable_retries, new_args,
                                                 new_blackboard.get());
   config_selector->BuildFilterChains(filter_chain_builder, blackboard_.get(),

--- a/src/core/client_channel/client_channel_filter.h
+++ b/src/core/client_channel/client_channel_filter.h
@@ -36,6 +36,7 @@
 #include "src/core/client_channel/client_channel_factory.h"
 #include "src/core/client_channel/config_selector.h"
 #include "src/core/client_channel/dynamic_filters.h"
+#include "src/core/client_channel/retry_throttle.h"
 #include "src/core/client_channel/subchannel.h"
 #include "src/core/client_channel/subchannel_pool_interface.h"
 #include "src/core/filter/blackboard.h"
@@ -299,6 +300,8 @@ class ClientChannelFilter final {
   RefCountedPtr<ServiceConfig> saved_service_config_
       ABSL_GUARDED_BY(*work_serializer_);
   RefCountedPtr<ConfigSelector> saved_config_selector_
+      ABSL_GUARDED_BY(*work_serializer_);
+  RetryThrottlerChannelArgsUpdater retry_throttler_updater_
       ABSL_GUARDED_BY(*work_serializer_);
   RefCountedPtr<const Blackboard> blackboard_
       ABSL_GUARDED_BY(*work_serializer_);

--- a/src/core/client_channel/client_channel_plugin.cc
+++ b/src/core/client_channel/client_channel_plugin.cc
@@ -32,7 +32,7 @@ namespace grpc_core {
 
 void BuildClientChannelConfiguration(CoreConfiguration::Builder* builder) {
   internal::ClientChannelServiceConfigParser::Register(builder);
-  internal::RetryServiceConfigParser::Register(builder);
+  RetryServiceConfigParser::Register(builder);
   builder->channel_init()
       ->RegisterV2Filter<ClientChannelFilter>(GRPC_CLIENT_CHANNEL)
       .Terminal();

--- a/src/core/client_channel/retry_filter.cc
+++ b/src/core/client_channel/retry_filter.cc
@@ -81,9 +81,6 @@
 // TODO(roth): In subsequent PRs:
 // - implement hedging
 
-using grpc_core::internal::RetryGlobalConfig;
-using grpc_core::internal::RetryMethodConfig;
-using grpc_core::internal::RetryServiceConfigParser;
 using grpc_event_engine::experimental::EventEngine;
 
 namespace grpc_core {
@@ -92,33 +89,13 @@ namespace grpc_core {
 // RetryFilter
 //
 
-void RetryFilter::UpdateBlackboard(const ServiceConfig& service_config,
-                                   const Blackboard* old_blackboard,
-                                   Blackboard* new_blackboard) {
-  // Get retry throttling parameters from service config.
-  const auto* config = static_cast<const RetryGlobalConfig*>(
-      service_config.GetGlobalParsedConfig(
-          RetryServiceConfigParser::ParserIndex()));
-  if (config == nullptr) return;
-  // Get throttler.
-  RefCountedPtr<internal::RetryThrottler> throttler;
-  if (old_blackboard != nullptr) {
-    throttler = old_blackboard->Get<internal::RetryThrottler>("");
-  }
-  throttler = internal::RetryThrottler::Create(config->max_milli_tokens(),
-                                               config->milli_token_ratio(),
-                                               std::move(throttler));
-  new_blackboard->Set("", std::move(throttler));
-}
-
 RetryFilter::RetryFilter(const grpc_channel_element_args& args)
     : client_channel_(args.channel_args.GetObject<ClientChannelFilter>()),
       event_engine_(args.channel_args.GetObject<EventEngine>()),
       per_rpc_retry_buffer_size_(
           GetMaxPerRpcRetryBufferSize(args.channel_args)),
-      retry_throttler_(args.blackboard->Get<internal::RetryThrottler>("")),
-      service_config_parser_index_(
-          internal::RetryServiceConfigParser::ParserIndex()) {}
+      retry_throttler_(args.channel_args.GetObjectRef<RetryThrottler>()),
+      service_config_parser_index_(RetryServiceConfigParser::ParserIndex()) {}
 
 const RetryMethodConfig* RetryFilter::GetRetryPolicy(Arena* arena) {
   auto* svc_cfg_call_data = arena->GetContext<ServiceConfigCallData>();

--- a/src/core/client_channel/retry_filter.h
+++ b/src/core/client_channel/retry_filter.h
@@ -45,10 +45,6 @@ class RetryFilter final {
  public:
   static const grpc_channel_filter kFilterVtable;
 
-  static void UpdateBlackboard(const ServiceConfig& service_config,
-                               const Blackboard* old_blackboard,
-                               Blackboard* blackboard);
-
  private:
   // Old filter-stack style call implementation, in
   // retry_filter_legacy_call_data.{h,cc}
@@ -62,9 +58,9 @@ class RetryFilter final {
   // any even moderately compelling reason to do so.
   static double BackoffJitter() { return 0.2; }
 
-  const internal::RetryMethodConfig* GetRetryPolicy(Arena* arena);
+  const RetryMethodConfig* GetRetryPolicy(Arena* arena);
 
-  RefCountedPtr<internal::RetryThrottler> retry_throttler() const {
+  RefCountedPtr<RetryThrottler> retry_throttler() const {
     return retry_throttler_;
   }
 
@@ -108,7 +104,7 @@ class RetryFilter final {
   ClientChannelFilter* client_channel_;
   grpc_event_engine::experimental::EventEngine* const event_engine_;
   size_t per_rpc_retry_buffer_size_;
-  RefCountedPtr<internal::RetryThrottler> retry_throttler_;
+  RefCountedPtr<RetryThrottler> retry_throttler_;
   const size_t service_config_parser_index_;
 };
 

--- a/src/core/client_channel/retry_filter_legacy_call_data.h
+++ b/src/core/client_channel/retry_filter_legacy_call_data.h
@@ -369,8 +369,8 @@ class RetryFilter::LegacyCallData final {
 
   RetryFilter* chand_;
   grpc_polling_entity* pollent_;
-  RefCountedPtr<internal::RetryThrottler> retry_throttler_;
-  const internal::RetryMethodConfig* retry_policy_ = nullptr;
+  RefCountedPtr<RetryThrottler> retry_throttler_;
+  const RetryMethodConfig* retry_policy_ = nullptr;
   BackOff retry_backoff_;
 
   Timestamp deadline_;

--- a/src/core/client_channel/retry_interceptor.cc
+++ b/src/core/client_channel/retry_interceptor.cc
@@ -35,8 +35,8 @@ size_t GetMaxPerRpcRetryBufferSize(const ChannelArgs& args) {
 
 namespace retry_detail {
 
-RetryState::RetryState(const internal::RetryMethodConfig* retry_policy,
-                       RefCountedPtr<internal::RetryThrottler> retry_throttler)
+RetryState::RetryState(const RetryMethodConfig* retry_policy,
+                       RefCountedPtr<RetryThrottler> retry_throttler)
     : retry_policy_(retry_policy),
       retry_throttler_(std::move(retry_throttler)),
       retry_backoff_(
@@ -134,38 +134,10 @@ std::optional<Duration> RetryState::ShouldRetry(
 ////////////////////////////////////////////////////////////////////////////////
 // RetryInterceptor
 
-absl::StatusOr<RefCountedPtr<RetryInterceptor>> RetryInterceptor::Create(
-    const ChannelArgs& args, const FilterArgs& filter_args) {
-  auto retry_throttler = filter_args.GetState<internal::RetryThrottler>("");
-  return MakeRefCounted<RetryInterceptor>(args, std::move(retry_throttler));
-}
-
-void RetryInterceptor::UpdateBlackboard(const ServiceConfig& service_config,
-                                        const Blackboard* old_blackboard,
-                                        Blackboard* new_blackboard) {
-  const auto* config = static_cast<const internal::RetryGlobalConfig*>(
-      service_config.GetGlobalParsedConfig(
-          internal::RetryServiceConfigParser::ParserIndex()));
-  if (config == nullptr) return;
-  // Get existing throttle state.
-  RefCountedPtr<internal::RetryThrottler> throttler;
-  if (old_blackboard != nullptr) {
-    throttler = old_blackboard->Get<internal::RetryThrottler>("");
-  }
-  throttler = internal::RetryThrottler::Create(config->max_milli_tokens(),
-                                               config->milli_token_ratio(),
-                                               std::move(throttler));
-  CHECK_NE(new_blackboard, nullptr);
-  new_blackboard->Set("", std::move(throttler));
-}
-
-RetryInterceptor::RetryInterceptor(
-    const ChannelArgs& args,
-    RefCountedPtr<internal::RetryThrottler> retry_throttler)
+RetryInterceptor::RetryInterceptor(const ChannelArgs& args)
     : per_rpc_retry_buffer_size_(GetMaxPerRpcRetryBufferSize(args)),
-      service_config_parser_index_(
-          internal::RetryServiceConfigParser::ParserIndex()),
-      retry_throttler_(std::move(retry_throttler)) {}
+      service_config_parser_index_(RetryServiceConfigParser::ParserIndex()),
+      retry_throttler_(args.GetObjectRef<RetryThrottler>()) {}
 
 void RetryInterceptor::InterceptCall(
     UnstartedCallHandler unstarted_call_handler) {
@@ -177,10 +149,10 @@ void RetryInterceptor::InterceptCall(
   call->Start();
 }
 
-const internal::RetryMethodConfig* RetryInterceptor::GetRetryPolicy() {
+const RetryMethodConfig* RetryInterceptor::GetRetryPolicy() {
   auto* svc_cfg_call_data = MaybeGetContext<ServiceConfigCallData>();
   if (svc_cfg_call_data == nullptr) return nullptr;
-  return static_cast<const internal::RetryMethodConfig*>(
+  return static_cast<const RetryMethodConfig*>(
       svc_cfg_call_data->GetMethodParsedConfig(service_config_parser_index_));
 }
 

--- a/src/core/client_channel/retry_interceptor.h
+++ b/src/core/client_channel/retry_interceptor.h
@@ -29,8 +29,8 @@ namespace retry_detail {
 
 class RetryState {
  public:
-  RetryState(const internal::RetryMethodConfig* retry_policy,
-             RefCountedPtr<internal::RetryThrottler> retry_throttler);
+  RetryState(const RetryMethodConfig* retry_policy,
+             RefCountedPtr<RetryThrottler> retry_throttler);
 
   // if nullopt --> commit & don't retry
   // if duration --> retry after duration
@@ -50,8 +50,8 @@ class RetryState {
   }
 
  private:
-  const internal::RetryMethodConfig* const retry_policy_;
-  RefCountedPtr<internal::RetryThrottler> retry_throttler_;
+  const RetryMethodConfig* const retry_policy_;
+  RefCountedPtr<RetryThrottler> retry_throttler_;
   int num_attempts_completed_ = 0;
   BackOff retry_backoff_;
 };
@@ -60,17 +60,14 @@ class RetryState {
 
 class RetryInterceptor : public Interceptor {
  public:
-  RetryInterceptor(const ChannelArgs& args,
-                   RefCountedPtr<internal::RetryThrottler> retry_throttler);
-
   static absl::StatusOr<RefCountedPtr<RetryInterceptor>> Create(
-      const ChannelArgs& args, const FilterArgs& filter_args);
+      const ChannelArgs& args, const FilterArgs& /*filter_args*/) {
+    return MakeRefCounted<RetryInterceptor>(args);
+  }
+
+  RetryInterceptor(const ChannelArgs& args);
 
   void Orphaned() override {}
-
-  static void UpdateBlackboard(const ServiceConfig& service_config,
-                               const Blackboard* old_blackboard,
-                               Blackboard* new_blackboard);
 
  protected:
   void InterceptCall(UnstartedCallHandler unstarted_call_handler) override;
@@ -146,11 +143,11 @@ class RetryInterceptor : public Interceptor {
     bool committed_ = false;
   };
 
-  const internal::RetryMethodConfig* GetRetryPolicy();
+  const RetryMethodConfig* GetRetryPolicy();
 
   const size_t per_rpc_retry_buffer_size_;
   const size_t service_config_parser_index_;
-  const RefCountedPtr<internal::RetryThrottler> retry_throttler_;
+  const RefCountedPtr<RetryThrottler> retry_throttler_;
 };
 
 }  // namespace grpc_core

--- a/src/core/client_channel/retry_interceptor.h
+++ b/src/core/client_channel/retry_interceptor.h
@@ -65,7 +65,7 @@ class RetryInterceptor : public Interceptor {
     return MakeRefCounted<RetryInterceptor>(args);
   }
 
-  RetryInterceptor(const ChannelArgs& args);
+  explicit RetryInterceptor(const ChannelArgs& args);
 
   void Orphaned() override {}
 

--- a/src/core/client_channel/retry_service_config.cc
+++ b/src/core/client_channel/retry_service_config.cc
@@ -39,7 +39,6 @@
 #define MAX_MAX_RETRY_ATTEMPTS 5
 
 namespace grpc_core {
-namespace internal {
 
 //
 // RetryGlobalConfig
@@ -276,5 +275,4 @@ RetryServiceConfigParser::ParsePerMethodParams(const ChannelArgs& args,
   return std::move(method_params.retry_policy);
 }
 
-}  // namespace internal
 }  // namespace grpc_core

--- a/src/core/client_channel/retry_service_config.h
+++ b/src/core/client_channel/retry_service_config.h
@@ -36,7 +36,6 @@
 #include "absl/strings/string_view.h"
 
 namespace grpc_core {
-namespace internal {
 
 class RetryGlobalConfig final : public ServiceConfigParser::ParsedConfig {
  public:
@@ -110,7 +109,6 @@ class RetryServiceConfigParser final : public ServiceConfigParser::Parser {
   static absl::string_view parser_name() { return "retry"; }
 };
 
-}  // namespace internal
 }  // namespace grpc_core
 
 #endif  // GRPC_SRC_CORE_CLIENT_CHANNEL_RETRY_SERVICE_CONFIG_H

--- a/src/core/client_channel/retry_throttle.cc
+++ b/src/core/client_channel/retry_throttle.cc
@@ -22,10 +22,10 @@
 #include <cstdint>
 #include <limits>
 
+#include "src/core/client_channel/retry_service_config.h"
 #include "src/core/util/useful.h"
 
 namespace grpc_core {
-namespace internal {
 
 namespace {
 
@@ -69,11 +69,6 @@ RefCountedPtr<RetryThrottler> RetryThrottler::Create(
       max_milli_tokens, milli_token_ratio, initial_milli_tokens);
   if (previous != nullptr) previous->SetReplacement(throttle_data);
   return throttle_data;
-}
-
-UniqueTypeName RetryThrottler::Type() {
-  static UniqueTypeName::Factory factory("retry_throttle");
-  return factory.Create();
 }
 
 RetryThrottler::RetryThrottler(uintptr_t max_milli_tokens,
@@ -130,5 +125,22 @@ void RetryThrottler::RecordSuccess() {
                                  std::numeric_limits<intptr_t>::max())));
 }
 
-}  // namespace internal
+void RetryThrottlerChannelArgsUpdater::Update(
+    const ServiceConfig& service_config, ChannelArgs& args) {
+  // Get retry throttling parameters from service config.
+  const auto* config = static_cast<const RetryGlobalConfig*>(
+      service_config.GetGlobalParsedConfig(
+          RetryServiceConfigParser::ParserIndex()));
+  if (config == nullptr) {
+    throttler_.reset();  // No throttling config.
+    return;
+  }
+  // Create a new throttler that replaces the current throttler and add
+  // it to channel args.
+  throttler_ = RetryThrottler::Create(config->max_milli_tokens(),
+                                      config->milli_token_ratio(),
+                                      std::move(throttler_));
+  args = args.SetObject(throttler_);
+}
+
 }  // namespace grpc_core

--- a/src/core/client_channel/retry_throttle.h
+++ b/src/core/client_channel/retry_throttle.h
@@ -23,20 +23,18 @@
 
 #include <atomic>
 
-#include "src/core/filter/blackboard.h"
+#include "src/core/service_config/service_config.h"
+#include "src/core/util/ref_counted.h"
 #include "src/core/util/ref_counted_ptr.h"
 
 namespace grpc_core {
-namespace internal {
 
-/// Tracks retry throttling data for an individual server name.
-class RetryThrottler final : public Blackboard::Entry {
+/// Tracks retry throttling data for a channel.
+class RetryThrottler final : public RefCounted<RetryThrottler> {
  public:
   static RefCountedPtr<RetryThrottler> Create(
       uintptr_t max_milli_tokens, uintptr_t milli_token_ratio,
       RefCountedPtr<RetryThrottler> previous);
-
-  static UniqueTypeName Type();
 
   // Do not instantiate directly -- use Create() instead.
   RetryThrottler(uintptr_t max_milli_tokens, uintptr_t milli_token_ratio,
@@ -56,6 +54,14 @@ class RetryThrottler final : public Blackboard::Entry {
     return milli_tokens_.load(std::memory_order_relaxed);
   }
 
+  static absl::string_view ChannelArgName() {
+    return "grpc.internal.retry_throttler";
+  }
+  static int ChannelArgsCompare(const RetryThrottler* a,
+                                const RetryThrottler* b) {
+    return QsortCompare(a, b);
+  }
+
  private:
   void SetReplacement(RefCountedPtr<RetryThrottler> replacement);
 
@@ -70,7 +76,18 @@ class RetryThrottler final : public Blackboard::Entry {
   std::atomic<RetryThrottler*> replacement_{nullptr};
 };
 
-}  // namespace internal
+// Tracks retry throttler state across service config updates and
+// handles adding the current throttler to channel args.
+class RetryThrottlerChannelArgsUpdater final {
+ public:
+  // Applies the latest service config update and adds the current
+  // throttler to channel args if needed.
+  void Update(const ServiceConfig& service_config, ChannelArgs& args);
+
+ private:
+  RefCountedPtr<RetryThrottler> throttler_;
+};
+
 }  // namespace grpc_core
 
 #endif  // GRPC_SRC_CORE_CLIENT_CHANNEL_RETRY_THROTTLE_H

--- a/src/core/xds/grpc/xds_route_config.h
+++ b/src/core/xds/grpc/xds_route_config.h
@@ -59,7 +59,7 @@ struct XdsRouteConfigResource : public XdsResourceType::ResourceData {
                std::string /*LB policy config*/>;
 
   struct RetryPolicy {
-    internal::StatusCodeSet retry_on;
+    StatusCodeSet retry_on;
     uint32_t num_retries;
 
     struct RetryBackOff {

--- a/test/core/client_channel/retry_service_config_test.cc
+++ b/test/core/client_channel/retry_service_config_test.cc
@@ -57,7 +57,7 @@ TEST_F(RetryParserTest, ValidRetryThrottling) {
       "}";
   auto service_config = ServiceConfigImpl::Create(ChannelArgs(), test_json);
   ASSERT_TRUE(service_config.ok()) << service_config.status();
-  const auto* parsed_config = static_cast<internal::RetryGlobalConfig*>(
+  const auto* parsed_config = static_cast<RetryGlobalConfig*>(
       (*service_config)->GetGlobalParsedConfig(parser_index_));
   ASSERT_NE(parsed_config, nullptr);
   EXPECT_EQ(parsed_config->max_milli_tokens(), 2000);
@@ -135,8 +135,8 @@ TEST_F(RetryParserTest, ValidRetryPolicy) {
           ->GetMethodParsedConfigVector(
               grpc_slice_from_static_string("/TestServ/TestMethod"));
   ASSERT_NE(vector_ptr, nullptr);
-  const auto* parsed_config = static_cast<internal::RetryMethodConfig*>(
-      ((*vector_ptr)[parser_index_]).get());
+  const auto* parsed_config =
+      static_cast<RetryMethodConfig*>(((*vector_ptr)[parser_index_]).get());
   ASSERT_NE(parsed_config, nullptr);
   EXPECT_EQ(parsed_config->max_attempts(), 3);
   EXPECT_EQ(parsed_config->initial_backoff(), Duration::Seconds(1));
@@ -527,8 +527,8 @@ TEST_F(RetryParserTest, ValidRetryPolicyWithPerAttemptRecvTimeout) {
           ->GetMethodParsedConfigVector(
               grpc_slice_from_static_string("/TestServ/TestMethod"));
   ASSERT_NE(vector_ptr, nullptr);
-  const auto* parsed_config = static_cast<internal::RetryMethodConfig*>(
-      ((*vector_ptr)[parser_index_]).get());
+  const auto* parsed_config =
+      static_cast<RetryMethodConfig*>(((*vector_ptr)[parser_index_]).get());
   ASSERT_NE(parsed_config, nullptr);
   EXPECT_EQ(parsed_config->max_attempts(), 2);
   EXPECT_EQ(parsed_config->initial_backoff(), Duration::Seconds(1));
@@ -564,8 +564,8 @@ TEST_F(RetryParserTest,
           ->GetMethodParsedConfigVector(
               grpc_slice_from_static_string("/TestServ/TestMethod"));
   ASSERT_NE(vector_ptr, nullptr);
-  const auto* parsed_config = static_cast<internal::RetryMethodConfig*>(
-      ((*vector_ptr)[parser_index_]).get());
+  const auto* parsed_config =
+      static_cast<RetryMethodConfig*>(((*vector_ptr)[parser_index_]).get());
   ASSERT_NE(parsed_config, nullptr);
   EXPECT_EQ(parsed_config->max_attempts(), 2);
   EXPECT_EQ(parsed_config->initial_backoff(), Duration::Seconds(1));
@@ -602,8 +602,8 @@ TEST_F(RetryParserTest,
           ->GetMethodParsedConfigVector(
               grpc_slice_from_static_string("/TestServ/TestMethod"));
   ASSERT_NE(vector_ptr, nullptr);
-  const auto* parsed_config = static_cast<internal::RetryMethodConfig*>(
-      ((*vector_ptr)[parser_index_]).get());
+  const auto* parsed_config =
+      static_cast<RetryMethodConfig*>(((*vector_ptr)[parser_index_]).get());
   ASSERT_NE(parsed_config, nullptr);
   EXPECT_EQ(parsed_config->max_attempts(), 2);
   EXPECT_EQ(parsed_config->initial_backoff(), Duration::Seconds(1));

--- a/test/core/client_channel/retry_state_test.cc
+++ b/test/core/client_channel/retry_state_test.cc
@@ -179,25 +179,24 @@ auto AnySuccessfulMetadata() {
 auto SomeServerThrottleData() {
   return fuzztest::Map(
       [](uintptr_t max_milli_tokens, uintptr_t milli_token_ratio) {
-        return MakeRefCounted<internal::RetryThrottler>(
+        return MakeRefCounted<RetryThrottler>(
             max_milli_tokens, milli_token_ratio, max_milli_tokens);
       },
       Arbitrary<uintptr_t>(), Arbitrary<uintptr_t>());
 }
 
 auto AnyServerThrottleData() {
-  return OneOf(Just(RefCountedPtr<internal::RetryThrottler>()),
-               SomeServerThrottleData());
+  return OneOf(Just(RefCountedPtr<RetryThrottler>()), SomeServerThrottleData());
 }
 
 // Helper to get the debug tag passed to ShouldRetry correct
 std::string FuzzerDebugTag() { return "fuzzer"; }
 
 // Construct a policy from json text
-internal::RetryMethodConfig MakePolicy(absl::string_view json) {
+RetryMethodConfig MakePolicy(absl::string_view json) {
   auto json_obj = JsonParse(json);
   CHECK_OK(json_obj) << json;
-  auto obj = LoadFromJson<internal::RetryMethodConfig>(*json_obj);
+  auto obj = LoadFromJson<RetryMethodConfig>(*json_obj);
   CHECK_OK(obj) << json;
   return std::move(*obj);
 }
@@ -275,8 +274,8 @@ auto RetryMethodConfigWithRetryableStatusCodes(
       InRange(1e-12, 10.0));
 }
 
-void Printable(std::optional<internal::RetryMethodConfig> policy,
-               RefCountedPtr<internal::RetryThrottler> throttle_data) {
+void Printable(std::optional<RetryMethodConfig> policy,
+               RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(policy.has_value() ? &*policy : nullptr,
                          throttle_data);
   std::ignore = absl::StrCat(retry_state);
@@ -297,9 +296,9 @@ void NoPolicyNeverRetries(std::vector<ServerMetadataHandle> md,
 FUZZ_TEST(MyTestSuite, NoPolicyNeverRetries)
     .WithDomains(VectorOf(AnyServerMetadata()), Arbitrary<bool>());
 
-void SuccessfulRequestsNeverRetry(
-    internal::RetryMethodConfig policy, ServerMetadataHandle md, bool committed,
-    RefCountedPtr<internal::RetryThrottler> throttle_data) {
+void SuccessfulRequestsNeverRetry(RetryMethodConfig policy,
+                                  ServerMetadataHandle md, bool committed,
+                                  RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(&policy, throttle_data);
   EXPECT_EQ(retry_state.ShouldRetry(*md, committed, FuzzerDebugTag),
             std::nullopt);
@@ -308,9 +307,9 @@ FUZZ_TEST(MyTestSuite, SuccessfulRequestsNeverRetry)
     .WithDomains(AnyRetryMethodConfig(), AnySuccessfulMetadata(),
                  Arbitrary<bool>(), AnyServerThrottleData());
 
-void CommittedRequestsNeverRetry(
-    internal::RetryMethodConfig policy, ServerMetadataHandle md,
-    RefCountedPtr<internal::RetryThrottler> throttle_data) {
+void CommittedRequestsNeverRetry(RetryMethodConfig policy,
+                                 ServerMetadataHandle md,
+                                 RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(&policy, throttle_data);
   EXPECT_EQ(retry_state.ShouldRetry(*md, true, FuzzerDebugTag), std::nullopt);
 }
@@ -319,8 +318,8 @@ FUZZ_TEST(MyTestSuite, CommittedRequestsNeverRetry)
                  AnyServerThrottleData());
 
 void NonRetryableRequestsNeverRetry(
-    internal::RetryMethodConfig policy, ServerMetadataHandle md, bool committed,
-    RefCountedPtr<internal::RetryThrottler> throttle_data) {
+    RetryMethodConfig policy, ServerMetadataHandle md, bool committed,
+    RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(&policy, throttle_data);
   EXPECT_EQ(retry_state.ShouldRetry(*md, committed, FuzzerDebugTag),
             std::nullopt);
@@ -331,10 +330,10 @@ FUZZ_TEST(MyTestSuite, NonRetryableRequestsNeverRetry)
         ServerMetadataWithStatus(AnyStatusExcept(GRPC_STATUS_ABORTED)),
         Arbitrary<bool>(), AnyServerThrottleData());
 
-void NeverExceedMaxAttempts(
-    internal::RetryMethodConfig policy, std::vector<ServerMetadataHandle> md,
-    bool committed_at_end,
-    RefCountedPtr<internal::RetryThrottler> throttle_data) {
+void NeverExceedMaxAttempts(RetryMethodConfig policy,
+                            std::vector<ServerMetadataHandle> md,
+                            bool committed_at_end,
+                            RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(&policy, nullptr);
   int attempts_completed = 0;
   for (auto it = md.begin(); it != md.end(); ++it) {
@@ -351,9 +350,9 @@ FUZZ_TEST(MyTestSuite, NeverExceedMaxAttempts)
                  VectorOf(AnyServerMetadata()).WithMaxSize(7),
                  Arbitrary<bool>(), AnyServerThrottleData());
 
-void NeverRetryNegativePushback(
-    internal::RetryMethodConfig policy, ServerMetadataHandle md, bool committed,
-    RefCountedPtr<internal::RetryThrottler> throttle_data) {
+void NeverRetryNegativePushback(RetryMethodConfig policy,
+                                ServerMetadataHandle md, bool committed,
+                                RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(&policy, nullptr);
   EXPECT_EQ(retry_state.ShouldRetry(*md, committed, FuzzerDebugTag),
             std::nullopt);
@@ -363,9 +362,9 @@ FUZZ_TEST(MyTestSuite, NeverRetryNegativePushback)
                  ServerMetadataWithPushback(NegativeDuration()),
                  Arbitrary<bool>(), AnyServerThrottleData());
 
-void NeverExceedMaxBackoff(
-    internal::RetryMethodConfig policy, std::vector<ServerMetadataHandle> mds,
-    RefCountedPtr<internal::RetryThrottler> throttle_data) {
+void NeverExceedMaxBackoff(RetryMethodConfig policy,
+                           std::vector<ServerMetadataHandle> mds,
+                           RefCountedPtr<RetryThrottler> throttle_data) {
   RetryState retry_state(&policy, nullptr);
   for (const auto& md : mds) {
     auto delay = retry_state.ShouldRetry(*md, false, FuzzerDebugTag);

--- a/test/core/xds/xds_route_config_resource_type_test.cc
+++ b/test/core/xds/xds_route_config_resource_type_test.cc
@@ -752,7 +752,7 @@ TEST_P(RetryPolicyTest, Empty) {
   ASSERT_TRUE(action->retry_policy.has_value());
   const auto& retry_policy = *action->retry_policy;
   // Defaults.
-  auto expected_codes = internal::StatusCodeSet();
+  auto expected_codes = StatusCodeSet();
   EXPECT_EQ(retry_policy.retry_on, expected_codes)
       << "Actual: " << retry_policy.retry_on.ToString()
       << "\nExpected: " << expected_codes.ToString();
@@ -790,7 +790,7 @@ TEST_P(RetryPolicyTest, AllFields) {
   ASSERT_NE(action, nullptr);
   ASSERT_TRUE(action->retry_policy.has_value());
   const auto& retry_policy = *action->retry_policy;
-  auto expected_codes = internal::StatusCodeSet()
+  auto expected_codes = StatusCodeSet()
                             .Add(GRPC_STATUS_CANCELLED)
                             .Add(GRPC_STATUS_DEADLINE_EXCEEDED)
                             .Add(GRPC_STATUS_INTERNAL)
@@ -906,7 +906,7 @@ TEST_F(RetryPolicyOverrideTest, RoutePolicyOverridesVhostPolicy) {
       std::get_if<XdsRouteConfigResource::Route::RouteAction>(&route.action);
   ASSERT_NE(action, nullptr);
   ASSERT_TRUE(action->retry_policy.has_value());
-  auto expected_codes = internal::StatusCodeSet().Add(GRPC_STATUS_CANCELLED);
+  auto expected_codes = StatusCodeSet().Add(GRPC_STATUS_CANCELLED);
   EXPECT_EQ(action->retry_policy->retry_on, expected_codes)
       << "Actual: " << action->retry_policy->retry_on.ToString()
       << "\nExpected: " << expected_codes.ToString();


### PR DESCRIPTION
This paves the way for a subsequent PR that will move the blackboard out of the channel and make it an xDS-specific thing.  The retry throttler is the only non-xDS thing using the blackboard.

While I was at it, I moved some things out of the `internal` namespace that didn't need to be there.