### PR TITLE
Cherrypick - [RetryFilter::LegacyCallData]: avoid tripping abseil nullopt assertion

### DIFF
--- a/src/core/client_channel/retry_filter_legacy_call_data.cc
+++ b/src/core/client_channel/retry_filter_legacy_call_data.cc
@@ -966,7 +966,7 @@ void GetCallStatus(
       *is_lb_drop = true;
     }
   } else {
-    *status = *md_batch->get(GrpcStatusMetadata());
+    *status = md_batch->get(GrpcStatusMetadata()).value_or(GRPC_STATUS_UNKNOWN);
   }
   *server_pushback = md_batch->get(GrpcRetryPushbackMsMetadata());
   *stream_network_state = md_batch->get(GrpcStreamNetworkState());


### PR DESCRIPTION
This is triggered when dereferencing the `absl::optional<grpc_status_code>` when the map entry only contains an `absl::nullopt`.

Use `.value_or()` to avoid the problem, as done in the `SubchannelCall` code.

Resolves #34683.

Closes #42405

COPYBARA_INTEGRATE_REVIEW=https://github.com/grpc/grpc/pull/42405 from grrtrr:issue_34683 eaa887239f13b171cac5c6a876dd0f0682773b1f
PiperOrigin-RevId: 917487796