### PR TITLE
[xDS] fix use-after-free in global XdsClient map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1931,6 +1931,7 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx xds_audit_logger_registry_test)
   add_dependencies(buildtests_cxx xds_bootstrap_test)
   add_dependencies(buildtests_cxx xds_certificate_provider_test)
+  add_dependencies(buildtests_cxx xds_client_grpc_test)
   add_dependencies(buildtests_cxx xds_client_test)
   if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
     add_dependencies(buildtests_cxx xds_cluster_end2end_test)
@@ -39172,6 +39173,48 @@ target_link_libraries(xds_certificate_provider_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gtest
   absl::overload
+  grpc_test_util
+)
+
+
+endif()
+if(gRPC_BUILD_TESTS)
+
+add_executable(xds_client_grpc_test
+  test/core/xds/xds_client_grpc_test.cc
+)
+if(WIN32 AND MSVC)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(xds_client_grpc_test
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+    )
+  endif()
+endif()
+target_compile_features(xds_client_grpc_test PUBLIC cxx_std_17)
+target_include_directories(xds_client_grpc_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    third_party/googletest/googletest/include
+    third_party/googletest/googletest
+    third_party/googletest/googlemock/include
+    third_party/googletest/googlemock
+    ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(xds_client_grpc_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  gtest
   grpc_test_util
 )
 

--- a/build_autogenerated.yaml
+++ b/build_autogenerated.yaml
@@ -27611,6 +27611,16 @@ targets:
   - gtest
   - absl/functional:overload
   - grpc_test_util
+- name: xds_client_grpc_test
+  gtest: true
+  build: test
+  language: c++
+  headers: []
+  src:
+  - test/core/xds/xds_client_grpc_test.cc
+  deps:
+  - gtest
+  - grpc_test_util
 - name: xds_client_test
   gtest: true
   build: test

--- a/src/core/xds/grpc/xds_client_grpc.cc
+++ b/src/core/xds/grpc/xds_client_grpc.cc
@@ -191,6 +191,7 @@ const grpc_channel_args* g_channel_args ABSL_GUARDED_BY(*g_mu) = nullptr;
 // Key bytes live in clients so they outlive the entries in this map
 NoDestruct<std::map<absl::string_view, GrpcXdsClient*>> g_xds_client_map
     ABSL_GUARDED_BY(*g_mu);
+bool g_inhibit_map_removal ABSL_GUARDED_BY(*g_mu) = false;
 char* g_fallback_bootstrap_config ABSL_GUARDED_BY(*g_mu) = nullptr;
 NoDestruct<std::shared_ptr<GrpcXdsBootstrap>> g_parsed_bootstrap
     ABSL_GUARDED_BY(*g_mu);
@@ -296,6 +297,10 @@ absl::StatusOr<RefCountedPtr<GrpcXdsClient>> GrpcXdsClient::GetOrCreate(
     if (xds_client != nullptr) {
       return xds_client.TakeAsSubclass<GrpcXdsClient>();
     }
+    // Ref count was 0.  Remove the entry so that when we call emplace()
+    // below, we add a new entry, thus ensuring the lifetime of the map
+    // key is correct (since it points into the XdsClient instance).
+    g_xds_client_map->erase(it);
   }
   // The XdsClient doesn't exist, so we'll create it.
   std::shared_ptr<GrpcXdsBootstrap> bootstrap = std::move(bootstrap_override);
@@ -313,7 +318,9 @@ absl::StatusOr<RefCountedPtr<GrpcXdsClient>> GrpcXdsClient::GetOrCreate(
                                               certificate_provider_store),
       certificate_provider_store,
       GetStatsPluginGroupForKeyAndChannelArgs(key, args));
-  g_xds_client_map->insert_or_assign(xds_client->key(), xds_client.get());
+  auto [_, inserted] =
+      g_xds_client_map->emplace(xds_client->key(), xds_client.get());
+  GRPC_CHECK(inserted) << "Key: " << key;
   GRPC_TRACE_LOG(xds_client, INFO) << "[xds_client " << xds_client.get()
                                    << "] Created xDS client for key " << key;
   return xds_client;
@@ -368,6 +375,7 @@ void GrpcXdsClient::Orphaned() {
   XdsClient::Orphaned();
   lrs_client_.reset();
   MutexLock lock(g_mu);
+  if (g_inhibit_map_removal) return;
   auto it = g_xds_client_map->find(key_);
   if (it != g_xds_client_map->end() && it->second == this) {
     g_xds_client_map->erase(it);
@@ -450,6 +458,11 @@ namespace internal {
 void SetXdsChannelArgsForTest(grpc_channel_args* args) {
   MutexLock lock(g_mu);
   g_channel_args = args;
+}
+
+void SetInhibitXdsClientMapRemovalForTest(bool inhibit) {
+  MutexLock lock(g_mu);
+  g_inhibit_map_removal = inhibit;
 }
 
 void UnsetGlobalXdsClientsForTest() {

--- a/src/core/xds/grpc/xds_client_grpc.h
+++ b/src/core/xds/grpc/xds_client_grpc.h
@@ -112,6 +112,7 @@ class GrpcXdsClient final : public XdsClient {
 
 namespace internal {
 void SetXdsChannelArgsForTest(grpc_channel_args* args);
+void SetInhibitXdsClientMapRemovalForTest(bool inhibit);
 void UnsetGlobalXdsClientsForTest();
 // Sets bootstrap config to be used when no env var is set.
 // Does not take ownership of config.

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -379,6 +379,7 @@ grpc_cc_test(
     uses_event_engine = False,
     uses_polling = False,
     deps = [
+        "//:grpc_public_hdrs",
         "//src/core:grpc_xds_client",
         "//test/core/test_util:grpc_test_util",
     ],

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -370,6 +370,21 @@ grpc_fuzz_test(
 )
 
 grpc_cc_test(
+    name = "xds_client_grpc_test",
+    srcs = ["xds_client_grpc_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    tags = ["xds_test"],
+    uses_event_engine = False,
+    uses_polling = False,
+    deps = [
+        "//src/core:grpc_xds_client",
+        "//test/core/test_util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "xds_common_types_test",
     srcs = ["xds_common_types_test.cc"],
     external_deps = [

--- a/test/core/xds/xds_client_grpc_test.cc
+++ b/test/core/xds/xds_client_grpc_test.cc
@@ -1,0 +1,104 @@
+//
+// Copyright 2026 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/core/xds/grpc/xds_client_grpc.h"
+
+#include <grpc/grpc.h>
+
+#include <memory>
+
+#include "test/core/test_util/test_config.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace grpc_core {
+namespace testing {
+namespace {
+
+std::shared_ptr<GrpcXdsBootstrap> MakeBootstrap() {
+  auto bootstrap = GrpcXdsBootstrap::Create(
+      "{\"xds_servers\": ["
+      "{\"server_uri\": \"dns://example.com\", "
+      "\"channel_creds\": [{\"type\":\"insecure\"}]}"
+      "]}");
+  GRPC_CHECK(bootstrap.ok()) << bootstrap.status();
+  return std::move(*bootstrap);
+}
+
+TEST(GrpcXdsClient, GetOrCreate) {
+  constexpr absl::string_view kKey = "foo";
+  auto bootstrap = MakeBootstrap();
+  // Initial get will create the instance.
+  auto xds_client =
+      GrpcXdsClient::GetOrCreate(kKey, ChannelArgs(), "reason", bootstrap);
+  ASSERT_TRUE(xds_client.ok()) << xds_client.status();
+  // Getting again with the same parameters returns the same instance.
+  EXPECT_EQ(
+      GrpcXdsClient::GetOrCreate(kKey, ChannelArgs(), "reason", bootstrap),
+      xds_client);
+  // Unref the original instance.
+  auto weak_ref = (*xds_client)->WeakRef();
+  xds_client->reset();
+  // Getting again will create a new instance.
+  auto xds_client2 =
+      GrpcXdsClient::GetOrCreate(kKey, ChannelArgs(), "reason", bootstrap);
+  ASSERT_TRUE(xds_client2.ok()) << xds_client2.status();
+  EXPECT_NE(xds_client2->get(), weak_ref.get());
+}
+
+// This test covers a bug whereby we replaced the map entry for the
+// instance whose ref-count was zero but failed to replace the key,
+// which pointed into the original (now deleted) instance.
+TEST(GrpcXdsClient, GetOrCreateReplacesIfRefcountIsZero) {
+  constexpr absl::string_view kKey = "foo";
+  auto bootstrap = MakeBootstrap();
+  // Initial get will create the instance.
+  auto xds_client =
+      GrpcXdsClient::GetOrCreate(kKey, ChannelArgs(), "reason", bootstrap);
+  ASSERT_TRUE(xds_client.ok()) << xds_client.status();
+  // Unref it, but inhibit removing it from the map.
+  internal::SetInhibitXdsClientMapRemovalForTest(true);
+  auto weak_ref = (*xds_client)->WeakRef();
+  xds_client->reset();
+  internal::SetInhibitXdsClientMapRemovalForTest(false);
+  // Getting again with the same parameters will return a new instance,
+  // since the old one has a ref-count of zero.  The map key should no
+  // longer point into the original instance.
+  auto xds_client2 =
+      GrpcXdsClient::GetOrCreate(kKey, ChannelArgs(), "reason", bootstrap);
+  ASSERT_TRUE(xds_client2.ok()) << xds_client2.status();
+  // Now free the original instance.  If the map key was still pointing
+  // into the original instance, this would cause it to be invalid.
+  weak_ref.reset();
+  // Getting again with the same parameters should return the same
+  // instance again without crashing.
+  EXPECT_EQ(
+      GrpcXdsClient::GetOrCreate(kKey, ChannelArgs(), "reason", bootstrap),
+      xds_client2);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace grpc_core
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  grpc::testing::TestEnvironment env(&argc, argv);
+  grpc_init();
+  int result = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return result;
+}

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -11316,6 +11316,30 @@
     "flaky": false,
     "gtest": true,
     "language": "c++",
+    "name": "xds_client_grpc_test",
+    "platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "uses_polling": true
+  },
+  {
+    "args": [],
+    "benchmark": false,
+    "ci_platforms": [
+      "linux",
+      "mac",
+      "posix",
+      "windows"
+    ],
+    "cpu_cost": 1.0,
+    "exclude_configs": [],
+    "exclude_iomgrs": [],
+    "flaky": false,
+    "gtest": true,
+    "language": "c++",
     "name": "xds_client_test",
     "platforms": [
       "linux",


### PR DESCRIPTION
This fixes a bug introduced in #42080.  The key in the global map is an `absl::string_view` that points into a string owned by the `GrpcXdsClient` object itself.  However, using `insert_or_assign()` to update the map changes the value without modifying the key, leaving the key pointing into the original object.  Once the original object gets deallocated, this causes a use-after-free crash.

To fix this, I am explicitly removing the old entry when the ref-count is 0, so that when we add the new entry, there will not be any pre-existing map key present.

I've also added some tests to exercise this code, including one that catches this bug under ASAN.

b/508511003