### PR TITLE
[Ruby] Fix: Fixed qps worker nomethoderror and streaming shutdown deadlock

### DIFF
--- a/src/ruby/qps/client.rb
+++ b/src/ruby/qps/client.rb
@@ -116,6 +116,7 @@ class BenchmarkClient
   end
   def streaming_ping_ponger(req, stub, config, waiter)
     q = EnumeratorQueue.new(self)
+    Thread.current.thread_variable_set(:queue, q)
     resp = stub.streaming_call(q.each_item)
     start = Time.now
     q.push(req)
@@ -128,10 +129,12 @@ class BenchmarkClient
         q.push(req)
       else
         q.push(self) unless pushed_sentinal
-	# Continue polling on the responses to consume and release resources
+        # Continue polling on the responses to consume and release resources
         pushed_sentinal = true
       end
     end
+  ensure
+    Thread.current.thread_variable_set(:queue, nil)
   end
   def mark(reset)
     lat = Grpc::Testing::HistogramData.new(
@@ -151,8 +154,8 @@ class BenchmarkClient
   end
   def shutdown
     @done = true
-    @child_threads.each do |thread|
-      thread.join
-    end
+    @child_threads
+      .each { |t| t.thread_variable_get(:queue)&.push(self) }
+      .each(&:join)
   end
 end

--- a/src/ruby/qps/client.rb
+++ b/src/ruby/qps/client.rb
@@ -116,6 +116,7 @@ class BenchmarkClient
   end
   def streaming_ping_ponger(req, stub, config, waiter)
     q = EnumeratorQueue.new(self)
+    # Exposes the queue to the shutdown thread for termination
     Thread.current.thread_variable_set(:queue, q)
     return if @done
     resp = stub.streaming_call(q.each_item)
@@ -155,6 +156,7 @@ class BenchmarkClient
   end
   def shutdown
     @done = true
+    # Sends a stop signal to each streaming threads.
     @child_threads
       .each { |t| t.thread_variable_get(:queue)&.push(self) }
       .each(&:join)

--- a/src/ruby/qps/client.rb
+++ b/src/ruby/qps/client.rb
@@ -117,6 +117,7 @@ class BenchmarkClient
   def streaming_ping_ponger(req, stub, config, waiter)
     q = EnumeratorQueue.new(self)
     Thread.current.thread_variable_set(:queue, q)
+    return if @done
     resp = stub.streaming_call(q.each_item)
     start = Time.now
     q.push(req)

--- a/src/ruby/qps/worker.rb
+++ b/src/ruby/qps/worker.rb
@@ -25,7 +25,6 @@ require 'grpc'
 require 'optparse'
 require 'histogram'
 require 'etc'
-require 'facter'
 require 'client'
 require 'qps-common'
 require 'server'
@@ -33,7 +32,7 @@ require 'src/proto/grpc/testing/worker_service_services_pb'
 
 class WorkerServiceImpl < Grpc::Testing::WorkerService::Service
   def cpu_cores
-    Facter.value('processors')['count']
+    Etc.nprocessors
   end
   def run_server(reqs)
     q = EnumeratorQueue.new(self)


### PR DESCRIPTION
- NomethodError: Removed `facter` dependency and instead used native ruby `etc` extension to fetch cpu-count instead of upgrading the gem for 3.3 compatibility.

- Deadlock: Resolved the race condition between the shutdown signal and the streaming RPC loop by using Signal All -> Join All 

