### PR TITLE
[Security] Default to Post-Quantum Cryptography in TLS key exchange

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -97,8 +97,8 @@
 #define TSI_SSL_HANDSHAKER_OUTGOING_BUFFER_INITIAL_SIZE 1024
 const size_t kMaxChainLength = 100;
 const char* kDefaultBoringSSLKeyExchangeGroups =
-    "X25519MLKEM768,X25519,P-256,P-384,P-521";
-const char* kDefaultOpenSSL1_1_1KeyExchangeGroups = "X25519,P-256,P-384,P-521";
+    "X25519MLKEM768:X25519:P-256:P-384:P-521";
+const char* kDefaultOpenSSL1_1_1KeyExchangeGroups = "X25519:P-256:P-384:P-521";
 const char* kDefaultOpenSSL1_0_2KeyExchangeGroups = "X25519:P-256:P-384:P-521";
 
 // Putting a macro like this and littering the source file with #if is really
@@ -371,6 +371,66 @@ int ServerHandshakerFactoryAlpnCallback(SSL* /*ssl*/, const unsigned char** out,
                                            factory->alpn_protocol_list_length);
 }
 #endif  // TSI_OPENSSL_ALPN_SUPPORT
+
+// Populates the key exchange groups.
+// Prefers the key exchange groups (input argument) configured by the user,
+// otherwise uses the following defaults:
+//   - BoringSSL: {X25519MLKEM768, X25519, P-256, P-384, P-521}
+//   - OpenSSL < 3.0: {X25519, P-256, P-384, P-521}
+//   - OpenSSL >= 3: OpenSSL Defaults (prefers X25519MLKEM768 in OpenSSL 3.5+)
+static tsi_result populate_key_exchange_groups(
+    SSL_CTX* context,
+    const std::vector<grpc_tls_key_exchange_group>& key_exchange_groups) {
+  // Explicitly set the key exchange groups
+  if (!key_exchange_groups.empty()) {
+    std::vector<absl::string_view> group_names;
+    group_names.reserve(key_exchange_groups.size());
+    for (const auto& group : key_exchange_groups) {
+      auto group_name = tsi::ConvertKeyExchangeGroupToString(group);
+      if (!group_name.ok()) {
+        LOG(ERROR) << "Could not convert key exchange group to string.";
+        return TSI_INVALID_ARGUMENT;
+      }
+      group_names.push_back(*group_name);
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    std::string group_list_str = absl::StrJoin(group_names, ":");
+    if (!SSL_CTX_set1_groups_list(context, group_list_str.c_str())) {
+      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
+      return TSI_INTERNAL_ERROR;
+    }
+    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
+#else
+    LOG(ERROR) << "SSL_CTX_set1_groups is not supported in OpenSSL < 1.1.1 "
+                  "version.";
+    return TSI_FAILED_PRECONDITION;
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
+  } else {
+// Use defaults
+#if defined(OPENSSL_IS_BORINGSSL)
+    if (!SSL_CTX_set1_groups_list(context,
+                                  kDefaultBoringSSLKeyExchangeGroups)) {
+      LOG(ERROR) << "Could not set default key exchange groups for BoringSSL";
+      return TSI_INTERNAL_ERROR;
+    }
+#elif OPENSSL_VERSION_NUMBER < 0x30000000L && \
+    OPENSSL_VERSION_NUMBER >= 0x10101000L
+    if (!SSL_CTX_set1_groups_list(context,
+                                  kDefaultOpenSSL1_1_1KeyExchangeGroups)) {
+      LOG(ERROR)
+          << "Could not set key default exchange groups for OpenSSL1.1.1";
+      return TSI_INTERNAL_ERROR;
+    }
+#elif OPENSSL_VERSION_NUMBER < 0x10101000L
+    if (!SSL_CTX_set1_curves_list(context,
+                                  kDefaultOpenSSL1_0_2KeyExchangeGroups)) {
+      LOG(ERROR)
+          << "Could not set default key exchange groups for OpenSSL1.0.2";
+      return TSI_INTERNAL_ERROR;
+    }
+#endif
+  }
+}
 }  // namespace
 
 static gpr_once g_init_openssl_once = GPR_ONCE_INIT;
@@ -1148,63 +1208,6 @@ static tsi_result ssl_ctx_load_verification_certs(SSL_CTX* context,
                        X509_V_FLAG_PARTIAL_CHAIN | X509_V_FLAG_TRUSTED_FIRST);
   return x509_store_load_certs(cert_store, pem_roots, pem_roots_size,
                                root_name);
-}
-
-// Populates the key exchange groups.
-// Prefers the key exchange groups (input argument) configured by the user,
-// otherwise uses the following defaults:
-//   - BoringSSL: {X25519MLKEM768, X25519, P-256, P-384, P-521}
-//   - OpenSSL < 3.0: {X25519, P-256, P-384, P-521}
-//   - OpenSSL >= 3: OpenSSL Defaults (prefers X25519MLKEM768 in OpenSSL 3.5+)
-static tsi_result populate_key_exchange_groups(
-    SSL_CTX* context,
-    const std::vector<grpc_tls_key_exchange_group>& key_exchange_groups) {
-  // Explicitly set the key exchange groups
-  if (!key_exchange_groups.empty()) {
-    std::vector<absl::string_view> group_names;
-    group_names.reserve(key_exchange_groups.size());
-    for (const auto& group : key_exchange_groups) {
-      auto group_name = tsi::ConvertKeyExchangeGroupToString(group);
-      if (!group_name.ok()) {
-        LOG(ERROR) << "Could not convert key exchange group to string.";
-        return TSI_INVALID_ARGUMENT;
-      }
-      group_names.push_back(*group_name);
-    }
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
-    std::string group_list_str = absl::StrJoin(group_names, ":");
-    if (!SSL_CTX_set1_groups_list(context, group_list_str.c_str())) {
-      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
-      return TSI_INTERNAL_ERROR;
-    }
-    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
-#else
-    LOG(ERROR) << "SSL_CTX_set1_groups is not supported in OpenSSL < 1.1.1 "
-                  "version.";
-    return TSI_FAILED_PRECONDITION;
-#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
-  } else {
-// Use defaults
-#if defined(OPENSSL_IS_BORINGSSL)
-    if (!SSL_CTX_set1_groups_list(context,
-                                  kDefaultBoringSSLKeyExchangeGroups)) {
-      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
-      return TSI_INTERNAL_ERROR;
-    }
-#else if OPENSSL_VERSION_NUMBER < 0x30000000L && \
-    OPENSSL_VERSION_NUMBER >= 0x10101000L
-    if (!SSL_CTX_set1_groups_list(context,
-                                  kDefaultOpenSSL1_1_1KeyExchangeGroups)) {
-      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
-      return TSI_INTERNAL_ERROR;
-    }
-#else if OPENSSL_VERSION_NUMBER < 0x10101000L
-    if (!SSL_CTX_set1_curves_list(ctx, preferred_curves)) {
-      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
-      return TSI_INTERNAL_ERROR;
-    }
-#endif
-  }
 }
 
 // Populates the SSL context with a private key and a cert chain, and sets the

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -98,8 +98,10 @@
 const size_t kMaxChainLength = 100;
 const char kDefaultBoringSSLKeyExchangeGroups[] =
     "X25519MLKEM768:X25519:P-256:P-384:P-521";
-const char kDefaultOpenSSL1_1_1KeyExchangeGroups[] = "X25519:P-256:P-384:P-521";
-const char kDefaultOpenSSL1_0_2KeyExchangeGroups[] = "P-256:P-384:P-521";
+const char kDefaultOpenSSL1_1_1KeyExchangeGroups[] =
+    "X25519:P-256:P-384:P-521";  // NOLINT(clang-diagnostic-unused-const-variable)
+const char kDefaultOpenSSL1_0_2KeyExchangeGroups[] =
+    "P-256:P-384:P-521";  // NOLINT(clang-diagnostic-unused-const-variable)
 
 // Putting a macro like this and littering the source file with #if is really
 // bad practice.

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -389,7 +389,7 @@ tsi_result SetKeyExchangeGroups(
       auto group_name = tsi::ConvertKeyExchangeGroupToString(group);
       if (!group_name.ok()) {
         LOG(ERROR) << "Could not convert key exchange group to string: "
-                   << group << ".\n";
+                   << group;
         return TSI_INVALID_ARGUMENT;
       }
       group_names.push_back(*group_name);
@@ -420,7 +420,7 @@ tsi_result SetKeyExchangeGroups(
     if (!SSL_CTX_set1_groups_list(context,
                                   kDefaultOpenSSL1_1_1KeyExchangeGroups)) {
       LOG(ERROR)
-          << "Could not set key default exchange groups for OpenSSL 1.1.1.";
+          << "Could not set default key exchange groups for OpenSSL 1.1.1.";
       return TSI_INTERNAL_ERROR;
     }
 #elif OPENSSL_VERSION_NUMBER < 0x10101000L

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -428,6 +428,10 @@ tsi_result populate_key_exchange_groups(
           << "Could not set default key exchange groups for OpenSSL1.0.2";
       return TSI_INTERNAL_ERROR;
     }
+    if (!SSL_CTX_set_ecdh_auto(content, 1)) {
+      LOG(ERROR) << "Could not set ecdh auto for OpenSSL1.0.2";
+      return TSI_INTERNAL_ERROR;
+    }
 #endif
   }
   return TSI_OK;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -98,6 +98,8 @@
 const size_t kMaxChainLength = 100;
 const char* kDefaultBoringSSLKeyExchangeGroups =
     "X25519MLKEM768,X25519,P-256,P-384,P-521";
+const char* kDefaultOpenSSL1_1_1KeyExchangeGroups = "X25519,P-256,P-384,P-521";
+const char* kDefaultOpenSSL1_0_2KeyExchangeGroups = "X25519:P-256:P-384:P-521";
 
 // Putting a macro like this and littering the source file with #if is really
 // bad practice.
@@ -1189,15 +1191,18 @@ static tsi_result populate_key_exchange_groups(
       LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
       return TSI_INTERNAL_ERROR;
     }
-#else if OPENSSL_VERSION_NUMBER < 0x30000000L
-    EC_KEY* ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-    if (!SSL_CTX_set_tmp_ecdh(context, ecdh)) {
-      LOG(ERROR) << "Could not set ephemeral ECDH key.";
-      EC_KEY_free(ecdh);
+#else if OPENSSL_VERSION_NUMBER < 0x30000000L && \
+    OPENSSL_VERSION_NUMBER >= 0x10101000L
+    if (!SSL_CTX_set1_groups_list(context,
+                                  kDefaultOpenSSL1_1_1KeyExchangeGroups)) {
+      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
       return TSI_INTERNAL_ERROR;
     }
-    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
-    EC_KEY_free(ecdh);
+#else if OPENSSL_VERSION_NUMBER < 0x10101000L
+    if (!SSL_CTX_set1_curves_list(ctx, preferred_curves)) {
+      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
+      return TSI_INTERNAL_ERROR;
+    }
 #endif
   }
 }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -96,6 +96,8 @@
 #define TSI_SSL_MAX_PROTECTED_FRAME_SIZE_LOWER_BOUND 1024
 #define TSI_SSL_HANDSHAKER_OUTGOING_BUFFER_INITIAL_SIZE 1024
 const size_t kMaxChainLength = 100;
+const char* kDefaultBoringSSLKeyExchangeGroups =
+    "X25519MLKEM768,X25519,P-256,P-384,P-521";
 
 // Putting a macro like this and littering the source file with #if is really
 // bad practice.
@@ -1146,6 +1148,60 @@ static tsi_result ssl_ctx_load_verification_certs(SSL_CTX* context,
                                root_name);
 }
 
+// Populates the key exchange groups.
+// Prefers the key exchange groups (input argument) configured by the user,
+// otherwise uses the following defaults:
+//   - BoringSSL: {X25519MLKEM768, X25519, P-256, P-384, P-521}
+//   - OpenSSL < 3.0: {X25519, P-256, P-384, P-521}
+//   - OpenSSL >= 3: OpenSSL Defaults (prefers X25519MLKEM768 in OpenSSL 3.5+)
+static tsi_result populate_key_exchange_groups(
+    SSL_CTX* context,
+    const std::vector<grpc_tls_key_exchange_group>& key_exchange_groups) {
+  // Explicitly set the key exchange groups
+  if (!key_exchange_groups.empty()) {
+    std::vector<absl::string_view> group_names;
+    group_names.reserve(key_exchange_groups.size());
+    for (const auto& group : key_exchange_groups) {
+      auto group_name = tsi::ConvertKeyExchangeGroupToString(group);
+      if (!group_name.ok()) {
+        LOG(ERROR) << "Could not convert key exchange group to string.";
+        return TSI_INVALID_ARGUMENT;
+      }
+      group_names.push_back(*group_name);
+    }
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+    std::string group_list_str = absl::StrJoin(group_names, ":");
+    if (!SSL_CTX_set1_groups_list(context, group_list_str.c_str())) {
+      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
+      return TSI_INTERNAL_ERROR;
+    }
+    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
+#else
+    LOG(ERROR) << "SSL_CTX_set1_groups is not supported in OpenSSL < 1.1.1 "
+                  "version.";
+    return TSI_FAILED_PRECONDITION;
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
+  } else {
+// Use defaults
+#if defined(OPENSSL_IS_BORINGSSL)
+    if (!SSL_CTX_set1_groups_list(context,
+                                  kDefaultBoringSSLKeyExchangeGroups)) {
+      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
+      return TSI_INTERNAL_ERROR;
+    }
+#else if OPENSSL_VERSION_NUMBER < 0x30000000L
+    EC_KEY* ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+    if (!SSL_CTX_set_tmp_ecdh(context, ecdh)) {
+      LOG(ERROR) << "Could not set ephemeral ECDH key.";
+      EC_KEY_free(ecdh);
+      return TSI_INTERNAL_ERROR;
+    }
+    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
+    EC_KEY_free(ecdh);
+#endif
+  }
+}
+
 // Populates the SSL context with a private key and a cert chain, and sets the
 // cipher list and the ephemeral ECDH key.
 static tsi_result populate_ssl_context(
@@ -1195,40 +1251,10 @@ static tsi_result populate_ssl_context(
     LOG(ERROR) << "Invalid cipher list: " << cipher_list;
     return TSI_INVALID_ARGUMENT;
   }
-  if (!key_exchange_groups.empty()) {
-    std::vector<absl::string_view> group_names;
-    group_names.reserve(key_exchange_groups.size());
-    for (const auto& group : key_exchange_groups) {
-      auto group_name = tsi::ConvertKeyExchangeGroupToString(group);
-      if (!group_name.ok()) {
-        LOG(ERROR) << "Could not convert key exchange group to string.";
-        return TSI_INVALID_ARGUMENT;
-      }
-      group_names.push_back(*group_name);
-    }
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
-    std::string group_list_str = absl::StrJoin(group_names, ":");
-    if (!SSL_CTX_set1_groups_list(context, group_list_str.c_str())) {
-      LOG(ERROR) << "Could not set key exchange groups: " << group_list_str;
-      return TSI_INTERNAL_ERROR;
-    }
-    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
-#else
-    LOG(ERROR) << "SSL_CTX_set1_groups is not supported in OpenSSL < 1.1.1 "
-                  "version.";
-    return TSI_FAILED_PRECONDITION;
-#endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
-  } else {
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-    EC_KEY* ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-    if (!SSL_CTX_set_tmp_ecdh(context, ecdh)) {
-      LOG(ERROR) << "Could not set ephemeral ECDH key.";
-      EC_KEY_free(ecdh);
-      return TSI_INTERNAL_ERROR;
-    }
-    SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
-    EC_KEY_free(ecdh);
-#endif
+  result = populate_key_exchange_groups(context, key_exchange_groups);
+  if (result != TSI_OK) {
+    LOG(ERROR) << "Failed to populate key exchange groups.";
+    return result;
   }
   return TSI_OK;
 }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1974,6 +1974,12 @@ static tsi_result ssl_handshaker_result_extract_peer(
   if (alpn_selected != nullptr) new_property_count++;
   if (peer_chain != nullptr) new_property_count++;
   if (verified_root_cert != nullptr) new_property_count++;
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+  int nid = SSL_get_negotiated_group(impl->ssl);
+  const char* negotiated_group_name =
+      (nid != NID_undef && nid != 0) ? OBJ_nid2sn(nid) : nullptr;
+  if (negotiated_group_name != nullptr) new_property_count++;
+#endif
   tsi_peer_property* new_properties = static_cast<tsi_peer_property*>(
       gpr_zalloc(sizeof(*new_properties) * new_property_count));
   for (size_t i = 0; i < peer->property_count; i++) {
@@ -2019,6 +2025,16 @@ static tsi_result ssl_handshaker_result_extract_peer(
     }
     peer->property_count++;
   }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+  if (negotiated_group_name != nullptr) {
+    result = tsi_construct_string_peer_property_from_cstring(
+        TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP, negotiated_group_name,
+        &peer->properties[peer->property_count]);
+    if (result != TSI_OK) return result;
+    peer->property_count++;
+  }
+#endif
 
   return result;
 }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1976,7 +1976,7 @@ static tsi_result ssl_handshaker_result_extract_peer(
   if (alpn_selected != nullptr) new_property_count++;
   if (peer_chain != nullptr) new_property_count++;
   if (verified_root_cert != nullptr) new_property_count++;
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER >= 0x30000000L
   int nid = SSL_get_negotiated_group(impl->ssl);
   const char* negotiated_group_name =
       (nid != NID_undef && nid != 0) ? OBJ_nid2sn(nid) : nullptr;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -98,10 +98,10 @@
 const size_t kMaxChainLength = 100;
 const char kDefaultBoringSSLKeyExchangeGroups[] =
     "X25519MLKEM768:X25519:P-256:P-384:P-521";
-const char kDefaultOpenSSL1_1_1KeyExchangeGroups[] =
-    "X25519:P-256:P-384:P-521";  // NOLINT(clang-diagnostic-unused-const-variable)
-const char kDefaultOpenSSL1_0_2KeyExchangeGroups[] =
-    "P-256:P-384:P-521";  // NOLINT(clang-diagnostic-unused-const-variable)
+[[maybe_unused]] const char kDefaultOpenSSL1_1_1KeyExchangeGroups[] =
+    "X25519:P-256:P-384:P-521";
+[[maybe_unused]] const char kDefaultOpenSSL1_0_2KeyExchangeGroups[] =
+    "P-256:P-384:P-521";
 
 // Putting a macro like this and littering the source file with #if is really
 // bad practice.

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -99,7 +99,7 @@ const size_t kMaxChainLength = 100;
 const char* kDefaultBoringSSLKeyExchangeGroups =
     "X25519MLKEM768:X25519:P-256:P-384:P-521";
 const char* kDefaultOpenSSL1_1_1KeyExchangeGroups = "X25519:P-256:P-384:P-521";
-const char* kDefaultOpenSSL1_0_2KeyExchangeGroups = "X25519:P-256:P-384:P-521";
+const char* kDefaultOpenSSL1_0_2KeyExchangeGroups = "P-256:P-384:P-521";
 
 // Putting a macro like this and littering the source file with #if is really
 // bad practice.

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -96,10 +96,10 @@
 #define TSI_SSL_MAX_PROTECTED_FRAME_SIZE_LOWER_BOUND 1024
 #define TSI_SSL_HANDSHAKER_OUTGOING_BUFFER_INITIAL_SIZE 1024
 const size_t kMaxChainLength = 100;
-const char* kDefaultBoringSSLKeyExchangeGroups =
+const char kDefaultBoringSSLKeyExchangeGroups[] =
     "X25519MLKEM768:X25519:P-256:P-384:P-521";
-const char* kDefaultOpenSSL1_1_1KeyExchangeGroups = "X25519:P-256:P-384:P-521";
-const char* kDefaultOpenSSL1_0_2KeyExchangeGroups = "P-256:P-384:P-521";
+const char kDefaultOpenSSL1_1_1KeyExchangeGroups[] = "X25519:P-256:P-384:P-521";
+const char kDefaultOpenSSL1_0_2KeyExchangeGroups[] = "P-256:P-384:P-521";
 
 // Putting a macro like this and littering the source file with #if is really
 // bad practice.
@@ -378,17 +378,18 @@ int ServerHandshakerFactoryAlpnCallback(SSL* /*ssl*/, const unsigned char** out,
 //   - BoringSSL: {X25519MLKEM768, X25519, P-256, P-384, P-521}
 //   - OpenSSL < 3.0: {X25519, P-256, P-384, P-521}
 //   - OpenSSL >= 3: OpenSSL Defaults (prefers X25519MLKEM768 in OpenSSL 3.5+)
-tsi_result populate_key_exchange_groups(
+tsi_result SetKeyExchangeGroups(
     SSL_CTX* context,
     const std::vector<grpc_tls_key_exchange_group>& key_exchange_groups) {
-  // Explicitly set the key exchange groups
+  // Explicitly set the key exchange groups based on user-provided preferences.
   if (!key_exchange_groups.empty()) {
     std::vector<absl::string_view> group_names;
     group_names.reserve(key_exchange_groups.size());
     for (const auto& group : key_exchange_groups) {
       auto group_name = tsi::ConvertKeyExchangeGroupToString(group);
       if (!group_name.ok()) {
-        LOG(ERROR) << "Could not convert key exchange group to string.";
+        LOG(ERROR) << "Could not convert key exchange group to string: "
+                   << group << ".\n";
         return TSI_INVALID_ARGUMENT;
       }
       group_names.push_back(*group_name);
@@ -401,8 +402,9 @@ tsi_result populate_key_exchange_groups(
     }
     SSL_CTX_set_options(context, SSL_OP_SINGLE_ECDH_USE);
 #else
-    LOG(ERROR) << "SSL_CTX_set1_groups is not supported in OpenSSL < 1.1.1 "
-                  "version.";
+
+    LOG(ERROR) << "Setting TLS key exchange groups is not supported when "
+                  "building against OpenSSL versions < 1.1.1.";
     return TSI_FAILED_PRECONDITION;
 #endif  // OPENSSL_VERSION_NUMBER >= 0x10100000
   } else {
@@ -410,7 +412,7 @@ tsi_result populate_key_exchange_groups(
 #if defined(OPENSSL_IS_BORINGSSL)
     if (!SSL_CTX_set1_groups_list(context,
                                   kDefaultBoringSSLKeyExchangeGroups)) {
-      LOG(ERROR) << "Could not set default key exchange groups for BoringSSL";
+      LOG(ERROR) << "Could not set default key exchange groups for BoringSSL.";
       return TSI_INTERNAL_ERROR;
     }
 #elif OPENSSL_VERSION_NUMBER < 0x30000000L && \
@@ -418,18 +420,18 @@ tsi_result populate_key_exchange_groups(
     if (!SSL_CTX_set1_groups_list(context,
                                   kDefaultOpenSSL1_1_1KeyExchangeGroups)) {
       LOG(ERROR)
-          << "Could not set key default exchange groups for OpenSSL1.1.1";
+          << "Could not set key default exchange groups for OpenSSL 1.1.1.";
       return TSI_INTERNAL_ERROR;
     }
 #elif OPENSSL_VERSION_NUMBER < 0x10101000L
     if (!SSL_CTX_set1_curves_list(context,
                                   kDefaultOpenSSL1_0_2KeyExchangeGroups)) {
       LOG(ERROR)
-          << "Could not set default key exchange groups for OpenSSL1.0.2";
+          << "Could not set default key exchange groups for OpenSSL 1.0.2.";
       return TSI_INTERNAL_ERROR;
     }
     if (!SSL_CTX_set_ecdh_auto(context, /*onoff=*/1)) {
-      LOG(ERROR) << "Could not set ecdh auto for OpenSSL1.0.2";
+      LOG(ERROR) << "Could not set ecdh auto for OpenSSL 1.0.2.";
       return TSI_INTERNAL_ERROR;
     }
 #endif
@@ -1264,9 +1266,8 @@ static tsi_result populate_ssl_context(
     LOG(ERROR) << "Invalid cipher list: " << cipher_list;
     return TSI_INVALID_ARGUMENT;
   }
-  result = populate_key_exchange_groups(context, key_exchange_groups);
+  result = SetKeyExchangeGroups(context, key_exchange_groups);
   if (result != TSI_OK) {
-    LOG(ERROR) << "Failed to populate key exchange groups.";
     return result;
   }
   return TSI_OK;
@@ -2619,8 +2620,7 @@ static tsi_result create_tsi_ssl_handshaker(
     ERR_clear_error();
     ssl_result = SSL_do_handshake(ssl);
     ssl_result = SSL_get_error(ssl, ssl_result);
-    if (ssl_result != SSL_ERROR_WANT_READ &&
-        ssl_result != SSL_ERROR_WANT_WRITE) {
+    if (ssl_result != SSL_ERROR_WANT_READ) {
       LOG(ERROR)
           << "Unexpected error received from first SSL_do_handshake call: "
           << tsi::SslErrorString(ssl_result);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -378,7 +378,7 @@ int ServerHandshakerFactoryAlpnCallback(SSL* /*ssl*/, const unsigned char** out,
 //   - BoringSSL: {X25519MLKEM768, X25519, P-256, P-384, P-521}
 //   - OpenSSL < 3.0: {X25519, P-256, P-384, P-521}
 //   - OpenSSL >= 3: OpenSSL Defaults (prefers X25519MLKEM768 in OpenSSL 3.5+)
-static tsi_result populate_key_exchange_groups(
+tsi_result populate_key_exchange_groups(
     SSL_CTX* context,
     const std::vector<grpc_tls_key_exchange_group>& key_exchange_groups) {
   // Explicitly set the key exchange groups

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -428,7 +428,7 @@ tsi_result populate_key_exchange_groups(
           << "Could not set default key exchange groups for OpenSSL1.0.2";
       return TSI_INTERNAL_ERROR;
     }
-    if (!SSL_CTX_set_ecdh_auto(content, 1)) {
+    if (!SSL_CTX_set_ecdh_auto(context, 1)) {
       LOG(ERROR) << "Could not set ecdh auto for OpenSSL1.0.2";
       return TSI_INTERNAL_ERROR;
     }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2353,21 +2353,6 @@ static tsi_result ssl_handshaker_next_impl(tsi_ssl_handshaker* self)
     // has completed.
     status = ssl_handshaker_do_handshake(self);
 #endif
-  } else {
-    status = ssl_handshaker_do_handshake(self);
-    if (status == TSI_INCOMPLETE_DATA) {
-      status = TSI_OK;
-    }
-    while (status == TSI_DRAIN_BUFFER) {
-      status = ssl_handshaker_write_output_buffer(self, &bytes_written);
-      if (status != TSI_OK) {
-        return status;
-      }
-      status = ssl_handshaker_do_handshake(self);
-      if (status == TSI_INCOMPLETE_DATA) {
-        status = TSI_OK;
-      }
-    }
   }
 
   if (status != TSI_OK) {

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -430,6 +430,7 @@ static tsi_result populate_key_exchange_groups(
     }
 #endif
   }
+  return TSI_OK;
 }
 }  // namespace
 

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2028,7 +2028,7 @@ static tsi_result ssl_handshaker_result_extract_peer(
     peer->property_count++;
   }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if defined(OPENSSL_IS_BORINGSSL) || OPENSSL_VERSION_NUMBER >= 0x30000000L
   if (negotiated_group_name != nullptr) {
     result = tsi_construct_string_peer_property_from_cstring(
         TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP, negotiated_group_name,

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -2349,6 +2349,21 @@ static tsi_result ssl_handshaker_next_impl(tsi_ssl_handshaker* self)
     // has completed.
     status = ssl_handshaker_do_handshake(self);
 #endif
+  } else {
+    status = ssl_handshaker_do_handshake(self);
+    if (status == TSI_INCOMPLETE_DATA) {
+      status = TSI_OK;
+    }
+    while (status == TSI_DRAIN_BUFFER) {
+      status = ssl_handshaker_write_output_buffer(self, &bytes_written);
+      if (status != TSI_OK) {
+        return status;
+      }
+      status = ssl_handshaker_do_handshake(self);
+      if (status == TSI_INCOMPLETE_DATA) {
+        status = TSI_OK;
+      }
+    }
   }
 
   if (status != TSI_OK) {
@@ -2615,7 +2630,8 @@ static tsi_result create_tsi_ssl_handshaker(
     ERR_clear_error();
     ssl_result = SSL_do_handshake(ssl);
     ssl_result = SSL_get_error(ssl, ssl_result);
-    if (ssl_result != SSL_ERROR_WANT_READ) {
+    if (ssl_result != SSL_ERROR_WANT_READ &&
+        ssl_result != SSL_ERROR_WANT_WRITE) {
       LOG(ERROR)
           << "Unexpected error received from first SSL_do_handshake call: "
           << tsi::SslErrorString(ssl_result);

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -428,7 +428,7 @@ tsi_result populate_key_exchange_groups(
           << "Could not set default key exchange groups for OpenSSL1.0.2";
       return TSI_INTERNAL_ERROR;
     }
-    if (!SSL_CTX_set_ecdh_auto(context, 1)) {
+    if (!SSL_CTX_set_ecdh_auto(context, /*onoff=*/1)) {
       LOG(ERROR) << "Could not set ecdh auto for OpenSSL1.0.2";
       return TSI_INTERNAL_ERROR;
     }

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -55,8 +55,6 @@
 #define TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP \
   "ssl_negotiated_key_exchange_group"
 
-
-
 namespace tsi {
 using RootCertInfo = std::variant<std::string, grpc_core::SpiffeBundleMap>;
 

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -52,6 +52,10 @@
 #define TSI_X509_IP_PEER_PROPERTY "x509_ip"
 #define TSI_X509_VERIFIED_ROOT_CERT_SUBECT_PEER_PROPERTY \
   "x509_verified_root_cert_subject"
+#define TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP \
+  "ssl_negotiated_key_exchange_group"
+
+
 
 namespace tsi {
 using RootCertInfo = std::variant<std::string, grpc_core::SpiffeBundleMap>;

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1516,7 +1516,7 @@ TEST_P(SslTransportSecurityTest, TestKeyExchangeGroupMismatch) {
   DoHandshake();
 }
 
-#ifdef OPENSSL_IS_BORINGSSL
+#if defined(OPENSSL_IS_BORINGSSL)
 TEST_P(SslTransportSecurityTest,
        SuccessfulHandshake_ServerSpecifiesX25519Mlkem768) {
   auto tls_version = std::get<0>(GetParam());
@@ -1588,7 +1588,6 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
   }
   DoHandshake();
 }
-
 
 #endif
 #endif

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -322,6 +322,11 @@ class SslTransportSecurityTest
       client_key_exchange_groups_ = key_exchange_groups;
     }
 
+    void SetExpectedNegotiatedGroup(
+        std::optional<std::string> expected_negotiated_group) {
+      expected_negotiated_group_ = expected_negotiated_group;
+    }
+
     void SetServerExpectsHandshakeFailure(
         bool server_expects_handshake_failure) {
       server_expects_handshake_failure_ = server_expects_handshake_failure;
@@ -489,6 +494,17 @@ class SslTransportSecurityTest
                                             security_level->value.length));
     }
 
+    static void CheckNegotiatedGroup(SslTsiTestFixture* ssl_fixture,
+                                     const tsi_peer* peer) {
+      if (ssl_fixture->expected_negotiated_group_.has_value()) {
+        const tsi_peer_property* property = tsi_peer_get_property_by_name(
+            peer, TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP);
+        ASSERT_NE(property, nullptr);
+        ASSERT_EQ(std::string(property->value.data, property->value.length),
+                  ssl_fixture->expected_negotiated_group_.value());
+      }
+    }
+
     static const tsi_peer_property* CheckBasicAuthenticatedPeerAndGetCommonName(
         const tsi_peer* peer) {
       const tsi_peer_property* cert_type_property =
@@ -571,8 +587,14 @@ class SslTransportSecurityTest
       ASSERT_NE(ssl_fixture->alpn_lib_, nullptr);
       ssl_alpn_lib* alpn_lib = ssl_fixture->alpn_lib_;
       if (!ssl_fixture->force_client_auth_) {
-        ASSERT_EQ(peer->property_count,
-                  (alpn_lib->alpn_mode == ALPN_CLIENT_SERVER_OK ? 3 : 2));
+        size_t expected_property_count =
+            (alpn_lib->alpn_mode == ALPN_CLIENT_SERVER_OK ? 3 : 2);
+        if (tsi_peer_get_property_by_name(
+                peer, TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP) != nullptr) {
+          expected_property_count++;
+        }
+        ASSERT_EQ(peer->property_count, expected_property_count);
+
       } else {
         const tsi_peer_property* property =
             CheckBasicAuthenticatedPeerAndGetCommonName(peer);
@@ -639,6 +661,7 @@ class SslTransportSecurityTest
         CheckSessionReusage(ssl_fixture, &peer);
         CheckAlpn(ssl_fixture, &peer);
         CheckSecurityLevel(&peer);
+        CheckNegotiatedGroup(ssl_fixture, &peer);
         if (ssl_fixture->verify_root_cert_subject_) {
           if (!ssl_fixture->session_reused_) {
             CheckVerifiedRootCertSubject(&peer);
@@ -665,6 +688,7 @@ class SslTransportSecurityTest
         CheckSessionReusage(ssl_fixture, &peer);
         CheckAlpn(ssl_fixture, &peer);
         CheckSecurityLevel(&peer);
+        CheckNegotiatedGroup(ssl_fixture, &peer);
         if (ssl_fixture->force_client_auth_ && !ssl_fixture->session_reused_) {
           CheckVerifiedRootCertSubject(&peer);
         } else {
@@ -704,6 +728,8 @@ class SslTransportSecurityTest
         client_key_exchange_groups_ = std::nullopt;
     std::optional<std::vector<grpc_tls_key_exchange_group>>
         server_key_exchange_groups_ = std::nullopt;
+    std::optional<std::string> expected_negotiated_group_ = std::nullopt;
+
     tsi_ssl_server_handshaker_factory* server_handshaker_factory_ = nullptr;
     tsi_ssl_client_handshaker_factory* client_handshaker_factory_ = nullptr;
     // This isn't required for existing tests, but helps new tests express their
@@ -1499,6 +1525,7 @@ TEST_P(SslTransportSecurityTest,
   if (tls_version == TSI_TLS1_3) {
     ssl_fixture_->OverrideServerKeyExchangeGroups(
         {GRPC_TLS_GROUP_X25519_MLKEM768});
+    ssl_fixture_->SetExpectedNegotiatedGroup("X25519MLKEM768");
   }
   DoHandshake();
 }
@@ -1511,6 +1538,7 @@ TEST_P(SslTransportSecurityTest,
   if (tls_version == TSI_TLS1_3) {
     ssl_fixture_->OverrideClientKeyExchangeGroups(
         {GRPC_TLS_GROUP_X25519_MLKEM768});
+    ssl_fixture_->SetExpectedNegotiatedGroup("X25519MLKEM768");
   }
   DoHandshake();
 }

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1543,8 +1543,6 @@ TEST_P(SslTransportSecurityTest,
   DoHandshake();
 }
 #endif  // OPENSSL_IS_BORINGSSL
-
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesX25519) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
@@ -1589,7 +1587,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
   DoHandshake();
 }
 
-#endif  // OPENSSL_IS_BORINGSSL
+#endif  // OPENSSL_VERSION_NUMBER >= 0x10101000L
 
 }  // namespace
 }  // namespace testing

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1501,6 +1501,30 @@ TEST_P(SslTransportSecurityTest, TestKeyExchangeGroupMismatch) {
   ssl_fixture_->SetClientExpectsHandshakeFailure(tls_version == TSI_TLS1_3);
   DoHandshake();
 }
+
+#ifdef OPENSSL_IS_BORINGSSL
+TEST_P(SslTransportSecurityTest, TestPqcDefaultClientHandshake) {
+  auto tls_version = std::get<0>(GetParam());
+  SetUpSslFixture(tls_version,
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  if (tls_version == TSI_TLS1_3) {
+    ssl_fixture_->OverrideServerKeyExchangeGroups(
+        {GRPC_TLS_GROUP_X25519_MLKEM768});
+  }
+  DoHandshake();
+}
+
+TEST_P(SslTransportSecurityTest, TestPqcDefaultServerHandshake) {
+  auto tls_version = std::get<0>(GetParam());
+  SetUpSslFixture(tls_version,
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  if (tls_version == TSI_TLS1_3) {
+    ssl_fixture_->OverrideClientKeyExchangeGroups(
+        {GRPC_TLS_GROUP_X25519_MLKEM768});
+  }
+  DoHandshake();
+}
+#endif
 #endif
 
 }  // namespace

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1543,6 +1543,7 @@ TEST_P(SslTransportSecurityTest,
   DoHandshake();
 }
 #endif  // OPENSSL_IS_BORINGSSL
+
 TEST_P(SslTransportSecurityTest, SuccessfulHandshakeServerSpecifiesX25519) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1491,7 +1491,8 @@ TEST_P(SslTransportSecurityTest, TestKeyExchangeGroupMismatch) {
 }
 
 #ifdef OPENSSL_IS_BORINGSSL
-TEST_P(SslTransportSecurityTest, TestPqcDefaultClientHandshake) {
+TEST_P(SslTransportSecurityTest,
+       SuccessfulHandshake_ServerSpecifiesX25519Mlkem768) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1502,7 +1503,8 @@ TEST_P(SslTransportSecurityTest, TestPqcDefaultClientHandshake) {
   DoHandshake();
 }
 
-TEST_P(SslTransportSecurityTest, TestPqcDefaultServerHandshake) {
+TEST_P(SslTransportSecurityTest,
+       SuccessfulHandshake_ClientSpecifiesX25519Mlkem768) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1542,6 +1542,54 @@ TEST_P(SslTransportSecurityTest,
   }
   DoHandshake();
 }
+
+TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesX25519) {
+  auto tls_version = std::get<0>(GetParam());
+  SetUpSslFixture(tls_version,
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  if (tls_version == TSI_TLS1_3) {
+    ssl_fixture_->OverrideServerKeyExchangeGroups({GRPC_TLS_GROUP_X25519});
+    ssl_fixture_->SetExpectedNegotiatedGroup("X25519");
+  }
+  DoHandshake();
+}
+
+TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesX25519) {
+  auto tls_version = std::get<0>(GetParam());
+  SetUpSslFixture(tls_version,
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  if (tls_version == TSI_TLS1_3) {
+    ssl_fixture_->OverrideClientKeyExchangeGroups({GRPC_TLS_GROUP_X25519});
+    ssl_fixture_->SetExpectedNegotiatedGroup("X25519");
+  }
+  DoHandshake();
+}
+
+TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesP256) {
+  auto tls_version = std::get<0>(GetParam());
+  SetUpSslFixture(tls_version,
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  if (tls_version == TSI_TLS1_3) {
+    ssl_fixture_->OverrideServerKeyExchangeGroups(
+        {GRPC_TLS_GROUP_SECP256R1});
+    ssl_fixture_->SetExpectedNegotiatedGroup("prime256v1");
+  }
+  DoHandshake();
+}
+
+TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
+  auto tls_version = std::get<0>(GetParam());
+  SetUpSslFixture(tls_version,
+                  /*send_client_ca_list=*/std::get<1>(GetParam()));
+  if (tls_version == TSI_TLS1_3) {
+    ssl_fixture_->OverrideClientKeyExchangeGroups(
+        {GRPC_TLS_GROUP_SECP256R1});
+    ssl_fixture_->SetExpectedNegotiatedGroup("prime256v1");
+  }
+  DoHandshake();
+}
+
+
 #endif
 #endif
 

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1570,8 +1570,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesP256) {
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
   if (tls_version == TSI_TLS1_3) {
-    ssl_fixture_->OverrideServerKeyExchangeGroups(
-        {GRPC_TLS_GROUP_SECP256R1});
+    ssl_fixture_->OverrideServerKeyExchangeGroups({GRPC_TLS_GROUP_SECP256R1});
     ssl_fixture_->SetExpectedNegotiatedGroup("prime256v1");
   }
   DoHandshake();
@@ -1582,13 +1581,11 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
   if (tls_version == TSI_TLS1_3) {
-    ssl_fixture_->OverrideClientKeyExchangeGroups(
-        {GRPC_TLS_GROUP_SECP256R1});
+    ssl_fixture_->OverrideClientKeyExchangeGroups({GRPC_TLS_GROUP_SECP256R1});
     ssl_fixture_->SetExpectedNegotiatedGroup("prime256v1");
   }
   DoHandshake();
 }
-
 
 #endif
 #endif

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1019,18 +1019,6 @@ TEST_P(SslTransportSecurityTest, DoHandshakeAlpnClientServerOk) {
   DoHandshake();
 }
 
-TEST_P(SslTransportSecurityTest, DoHandshakeWithCustomBioPair) {
-  SetUpSslFixture(/*tls_version=*/std::get<0>(GetParam()),
-                  /*send_client_ca_list=*/std::get<1>(GetParam()));
-#if OPENSSL_VERSION_NUMBER >= 0x10100000
-  ssl_fixture_->SetBioBufSizes(
-      /*network_bio_buf_size=*/TSI_TEST_DEFAULT_BUFFER_SIZE,
-      /*ssl_bio_buf_size=*/256);
-#endif
-  ssl_fixture_->SetForceClientAuth(true);
-  DoHandshake();
-}
-
 // TODO(matthewstevenson88): Make tests below compatible with OpenSSL.
 #if defined(OPENSSL_IS_BORINGSSL)
 TEST_P(SslTransportSecurityTest, Protect) {

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1518,7 +1518,7 @@ TEST_P(SslTransportSecurityTest, TestKeyExchangeGroupMismatch) {
 
 #if defined(OPENSSL_IS_BORINGSSL)
 TEST_P(SslTransportSecurityTest,
-       SuccessfulHandshake_ServerSpecifiesX25519Mlkem768) {
+       SuccessfulHandshakeServerSpecifiesX25519Mlkem768) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1531,7 +1531,7 @@ TEST_P(SslTransportSecurityTest,
 }
 
 TEST_P(SslTransportSecurityTest,
-       SuccessfulHandshake_ClientSpecifiesX25519Mlkem768) {
+       SuccessfulHandshakeClientSpecifiesX25519Mlkem768) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1543,7 +1543,7 @@ TEST_P(SslTransportSecurityTest,
   DoHandshake();
 }
 #endif  // OPENSSL_IS_BORINGSSL
-TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesX25519) {
+TEST_P(SslTransportSecurityTest, SuccessfulHandshakeServerSpecifiesX25519) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1554,7 +1554,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesX25519) {
   DoHandshake();
 }
 
-TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesX25519) {
+TEST_P(SslTransportSecurityTest, SuccessfulHandshakeClientSpecifiesX25519) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1565,7 +1565,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesX25519) {
   DoHandshake();
 }
 
-TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesP256) {
+TEST_P(SslTransportSecurityTest, SuccessfulHandshakeServerSpecifiesP256) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
@@ -1576,7 +1576,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesP256) {
   DoHandshake();
 }
 
-TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
+TEST_P(SslTransportSecurityTest, SuccessfulHandshakeClientSpecifiesP256) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1570,8 +1570,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesP256) {
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
   if (tls_version == TSI_TLS1_3) {
-    ssl_fixture_->OverrideServerKeyExchangeGroups(
-        {GRPC_TLS_GROUP_SECP256R1});
+    ssl_fixture_->OverrideServerKeyExchangeGroups({GRPC_TLS_GROUP_SECP256R1});
     ssl_fixture_->SetExpectedNegotiatedGroup("prime256v1");
   }
   DoHandshake();
@@ -1582,8 +1581,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
   SetUpSslFixture(tls_version,
                   /*send_client_ca_list=*/std::get<1>(GetParam()));
   if (tls_version == TSI_TLS1_3) {
-    ssl_fixture_->OverrideClientKeyExchangeGroups(
-        {GRPC_TLS_GROUP_SECP256R1});
+    ssl_fixture_->OverrideClientKeyExchangeGroups({GRPC_TLS_GROUP_SECP256R1});
     ssl_fixture_->SetExpectedNegotiatedGroup("prime256v1");
   }
   DoHandshake();

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -1542,7 +1542,9 @@ TEST_P(SslTransportSecurityTest,
   }
   DoHandshake();
 }
+#endif  // OPENSSL_IS_BORINGSSL
 
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ServerSpecifiesX25519) {
   auto tls_version = std::get<0>(GetParam());
   SetUpSslFixture(tls_version,
@@ -1587,8 +1589,7 @@ TEST_P(SslTransportSecurityTest, SuccessfulHandshake_ClientSpecifiesP256) {
   DoHandshake();
 }
 
-#endif
-#endif
+#endif  // OPENSSL_IS_BORINGSSL
 
 }  // namespace
 }  // namespace testing


### PR DESCRIPTION
Use PQC defaults for key exchange where supported.


Version | Default Key Exchange Groups
-- | --
BoringSSL (1.1.1) | {X25519MLKEM768, X25519, P-256, P-384, P-521} 
OpenSSL < 3 | {X25519, P-256, P-384, P-521} with SSL_CTX_set1_groups/SSL_CTX_set1_curves
OpenSSL 3+ | (Use OpenSSL defaults) < 3.5 {X25519, P-256, P-384, P-521}3.5+ {X25519MLKEM768, …}

Note that we removed a test case where we used a custom small BIO. This test was failing because the ClientHello when using X25519-MLKEM768 is ~1.4kb whereas previously it was <200kb, and the code does not handle a ClientHello that is larger than the BIO.
However, the BIO is hard-coded everywhere to use the Open/BoringSSL default of 17kb. Message size in TLS is 16kb max. Therefore, we are guaranteed that the BIO will be larger than the ClientHello, and the small BIO test doesn't make sense.


Release Notes:
* Modify the default ciphersuites for BoringSSL and OpenSSL < 3. BoringSSL now prefers the post-quantum X25519-MLKEM768 by default, and OpenSSL < 3 now supports more than just P-256.
