### PR TITLE
Enable Unix Domain Socket on Windows

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/binder/binder_resolver.cc
@@ -18,7 +18,14 @@
 
 #ifdef GRPC_HAVE_UNIX_SOCKET
 
+#ifdef _WIN32
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+#else
 #include <sys/un.h>
+#endif
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>

--- a/src/core/ext/transport/binder/client/binder_connector.cc
+++ b/src/core/ext/transport/binder/client/binder_connector.cc
@@ -20,7 +20,14 @@
 #include "src/core/lib/iomgr/port.h"
 
 #ifdef GRPC_HAVE_UNIX_SOCKET
+#ifdef GPR_WINDOWS
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+#else
 #include <sys/un.h>
+#endif  // GPR_WINDOWS
 #endif
 
 #include <functional>

--- a/src/core/lib/address_utils/parse_address.cc
+++ b/src/core/lib/address_utils/parse_address.cc
@@ -23,7 +23,14 @@
 #include <stdio.h>
 #include <string.h>
 #ifdef GRPC_HAVE_UNIX_SOCKET
+#ifdef _WIN32
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+#else
 #include <sys/un.h>
+#endif
 #endif
 #ifdef GRPC_POSIX_SOCKET
 #include <errno.h>

--- a/src/core/lib/address_utils/sockaddr_utils.cc
+++ b/src/core/lib/address_utils/sockaddr_utils.cc
@@ -38,7 +38,14 @@
 #include "src/core/lib/iomgr/socket_utils.h"
 
 #ifdef GRPC_HAVE_UNIX_SOCKET
+#ifdef _WIN32
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+#else
 #include <sys/un.h>
+#endif
 #endif
 
 #ifdef GRPC_HAVE_UNIX_SOCKET

--- a/src/core/lib/iomgr/port.h
+++ b/src/core/lib/iomgr/port.h
@@ -24,6 +24,9 @@
  * apply to custom sockets too */
 #ifdef GPR_WINDOWS
 #define GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY 1
+#ifndef __MINGW32__
+#define GRPC_HAVE_UNIX_SOCKET 1
+#endif  // __MINGW32__
 #endif
 #if defined(GRPC_USE_EVENT_ENGINE)
 // Do Nothing

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -138,6 +138,8 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   grpc_winsocket_callback_info* info;
   grpc_error_handle error = GRPC_ERROR_NONE;
   async_connect* ac = NULL;
+  int addr_family;
+  int protocol;
 
   *endpoint = NULL;
 
@@ -146,14 +148,25 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
     addr = &addr6_v4mapped;
   }
 
-  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+  // extract family
+  addr_family =
+      (grpc_sockaddr_get_family(addr) == AF_UNIX) ? AF_UNIX : AF_INET6;
+  protocol = addr_family == AF_UNIX ? 0 : IPPROTO_TCP;
+
+  sock = WSASocket(addr_family, SOCK_STREAM, protocol, NULL, 0,
                    grpc_get_default_wsa_socket_flags());
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;
   }
 
-  error = grpc_tcp_prepare_socket(sock);
+  if (addr_family == AF_UNIX) {
+    // tcp settings for af_unix are skipped.
+    error = grpc_tcp_set_non_block(sock);
+  } else {
+    error = grpc_tcp_prepare_socket(sock);
+  }
+
   if (error != GRPC_ERROR_NONE) {
     goto failure;
   }
@@ -170,7 +183,15 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
     goto failure;
   }
 
-  grpc_sockaddr_make_wildcard6(0, &local_address);
+  if (addr_family == AF_UNIX) {
+    // For ConnectEx() to work for AF_UNIX, the sock needs to be bound to
+    // the local address of an unnamed socket.
+    local_address = {};
+    ((grpc_sockaddr*)local_address.addr)->sa_family = AF_UNIX;
+    local_address.len = sizeof(grpc_sockaddr);
+  } else {
+    grpc_sockaddr_make_wildcard6(0, &local_address);
+  }
 
   status =
       bind(sock, (grpc_sockaddr*)&local_address.addr, (int)local_address.len);

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -22,6 +22,12 @@
 
 #ifdef GRPC_WINSOCK_SOCKET
 
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+
+
 #include <inttypes.h>
 #include <io.h>
 
@@ -52,13 +58,21 @@
 /* one listening port */
 typedef struct grpc_tcp_listener grpc_tcp_listener;
 struct grpc_tcp_listener {
-  /* This seemingly magic number comes from AcceptEx's documentation. each
+  /* Buffer to hold the local and remote address.
+     This seemingly magic number comes from AcceptEx's documentation. each
      address buffer needs to have at least 16 more bytes at their end. */
+#ifdef GRPC_HAVE_UNIX_SOCKET
+  /* unix addr is larger than ip addr. */
+  uint8_t addresses[(sizeof(sockaddr_un) + 16) * 2] = {};
+#else
   uint8_t addresses[(sizeof(grpc_sockaddr_in6) + 16) * 2];
+#endif  // GRPC_HAVE_UNIX_SOCKET
   /* This will hold the socket for the next accept. */
   SOCKET new_socket;
   /* The listener winsocket. */
   grpc_winsocket* socket;
+  /* address of listener */
+  grpc_resolved_address resolved_addr;
   /* The actual TCP port number. */
   int port;
   unsigned port_index;
@@ -98,6 +112,33 @@ struct grpc_tcp_server {
   grpc_channel_args* channel_args;
 };
 
+void unlink_if_unix_domain_socket(const grpc_resolved_address* resolved_addr) {
+  #ifdef GRPC_HAVE_UNIX_SOCKET
+    const grpc_sockaddr* addr =
+        reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
+    if (addr->sa_family != AF_UNIX) {
+      return;
+    }
+    struct sockaddr_un* un =
+        reinterpret_cast<struct sockaddr_un*>(const_cast<sockaddr*>(addr));
+    // There is nothing to unlink for an abstract unix socket.
+    if (un->sun_path[0] == '\0' && un->sun_path[1] != '\0') {
+      return;
+    }
+    // For windows we need to remove the file instead of unlink.
+    DWORD attr = ::GetFileAttributesA(un->sun_path);
+    if (attr == INVALID_FILE_ATTRIBUTES) {
+      return;
+    }
+    if (attr & FILE_ATTRIBUTE_DIRECTORY || attr & FILE_ATTRIBUTE_READONLY) {
+      return;
+    }
+    ::DeleteFileA(un->sun_path);
+  #else
+    (void)resolved_addr;
+  #endif
+  }
+
 /* Public function. Allocates the proper data structures to hold a
    grpc_tcp_server. */
 static grpc_error_handle tcp_server_create(grpc_closure* shutdown_complete,
@@ -130,6 +171,7 @@ static void destroy_server(void* arg, grpc_error_handle error) {
     s->head = sp->next;
     sp->next = NULL;
     grpc_winsocket_destroy(sp->socket);
+    unlink_if_unix_domain_socket(&sp->resolved_addr);
     gpr_free(sp);
   }
   grpc_channel_args_destroy(s->channel_args);
@@ -196,10 +238,15 @@ static grpc_error_handle prepare_socket(SOCKET sock,
   grpc_error_handle error = GRPC_ERROR_NONE;
   int sockname_temp_len;
 
-  error = grpc_tcp_prepare_socket(sock);
+  if (grpc_sockaddr_get_family(addr) == AF_UNIX) {
+    error = grpc_tcp_set_non_block(sock);
+  } else {
+    error = grpc_tcp_prepare_socket(sock);
+  }
   if (error != GRPC_ERROR_NONE) {
     goto failure;
   }
+  unlink_if_unix_domain_socket(addr);
 
   if (bind(sock, (const grpc_sockaddr*)addr->addr, (int)addr->len) ==
       SOCKET_ERROR) {
@@ -249,7 +296,7 @@ static void decrement_active_ports_and_notify_locked(grpc_tcp_listener* sp) {
 static grpc_error_handle start_accept_locked(grpc_tcp_listener* port) {
   SOCKET sock = INVALID_SOCKET;
   BOOL success;
-  DWORD addrlen = sizeof(grpc_sockaddr_in6) + 16;
+  const DWORD addrlen = sizeof(port->addresses) / 2;
   DWORD bytes_received = 0;
   grpc_error_handle error = GRPC_ERROR_NONE;
 
@@ -257,14 +304,21 @@ static grpc_error_handle start_accept_locked(grpc_tcp_listener* port) {
     return GRPC_ERROR_NONE;
   }
 
-  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+  const int addr_family =
+  grpc_sockaddr_get_family(&port->resolved_addr) == AF_UNIX ? AF_UNIX
+                                                            : AF_INET6;
+  const int protocol = addr_family == AF_UNIX ? 0 : IPPROTO_TCP;
+  sock = WSASocket(addr_family, SOCK_STREAM, protocol, NULL, 0,
                    grpc_get_default_wsa_socket_flags());
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;
   }
-
-  error = grpc_tcp_prepare_socket(sock);
+  if (addr_family == AF_UNIX) {
+    error = grpc_tcp_set_non_block(sock);
+  } else {
+    error = grpc_tcp_prepare_socket(sock);
+  }
   if (error != GRPC_ERROR_NONE) goto failure;
 
   /* Start the "accept" asynchronously. */
@@ -347,7 +401,12 @@ static void on_accept(void* arg, grpc_error_handle error) {
       peer_name.len = (size_t)peer_name_len;
       std::string peer_name_string;
       if (!err) {
-        peer_name_string = grpc_sockaddr_to_uri(&peer_name);
+        auto addr_uri = grpc_sockaddr_to_uri(&peer_name);
+        if (!addr_uri.empty()) {
+          peer_name_string = addr_uri;
+        } else {
+          gpr_log(GPR_ERROR, "invalid peer name");
+        }
       } else {
         char* utf8_message = gpr_format_message(WSAGetLastError());
         gpr_log(GPR_ERROR, "getpeername error: %s", utf8_message);
@@ -432,6 +491,7 @@ static grpc_error_handle add_socket_to_server(grpc_tcp_server* s, SOCKET sock,
   sp->outstanding_calls = 0;
   sp->AcceptEx = AcceptEx;
   sp->new_socket = INVALID_SOCKET;
+  sp->resolved_addr = *addr;
   sp->port = port;
   sp->port_index = port_index;
   GRPC_CLOSURE_INIT(&sp->on_accept, on_accept, sp, grpc_schedule_on_exec_ctx);

--- a/src/core/lib/iomgr/unix_sockets_posix.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix.cc
@@ -24,7 +24,14 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef _WIN32
+// clang-format off
+#include <ws2def.h>
+#include <afunix.h>
+// clang-format on
+#else
 #include <sys/un.h>
+#endif
 
 #include "absl/strings/str_cat.h"
 
@@ -38,7 +45,9 @@
 #include "src/core/lib/transport/error_utils.h"
 
 void grpc_create_socketpair_if_unix(int sv[2]) {
-  GPR_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
+#ifndef GPR_WINDOWS
+  GRPC_CHECK_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+#endif
 }
 
 absl::StatusOr<std::vector<grpc_resolved_address>>
@@ -87,10 +96,12 @@ void grpc_unlink_if_unix_domain_socket(
     return;
   }
 
+#ifndef GPR_WINDOWS
   struct stat st;
   if (stat(un->sun_path, &st) == 0 && (st.st_mode & S_IFMT) == S_IFSOCK) {
     unlink(un->sun_path);
   }
+#endif
 }
 
 #endif


### PR DESCRIPTION
Enable Unix Domain Socket for Windows MSVC for the usage in C# Grpc.Core.

On the basis of performance measurements of C# Windows client with Unix Domain Sockets (basically, for TCP is the same), 
I observed ~15% better throughput for HealthCheck requests and ~45% less CPU usage, in case of Grpc.Core compared to Grpc.Net.Client.

---

C#, Windows, UDS

