### PR TITLE
[EventEngine] Add opt-in ares_getaddrinfo() path for hostname resolution

### DIFF
--- a/src/core/config/config_vars.cc
+++ b/src/core/config/config_vars.cc
@@ -52,6 +52,13 @@ ABSL_FLAG(absl::optional<std::string>, grpc_dns_resolver, {},
           "Declares which DNS resolver to use. The default is ares if gRPC is "
           "built with c-ares support. Otherwise, the value of this environment "
           "variable is ignored.");
+ABSL_FLAG(absl::optional<bool>, grpc_dns_ares_query_use_getaddrinfo, {},
+          "EXPERIMENTAL. If true, the c-ares based DNS resolver issues a "
+          "single combined A and AAAA query via ares_getaddrinfo() with "
+          "AF_UNSPEC instead of two separate ares_gethostbyname() queries. "
+          "This returns as soon as one address family is satisfied, avoiding "
+          "long delays when a resolver silently drops AAAA queries. See "
+          "https://github.com/grpc/grpc/issues/35638.");
 ABSL_FLAG(std::vector<std::string>, grpc_trace, {},
           "A comma separated list of tracers that provide additional insight "
           "into how gRPC C core is processing requests via debug logs.");
@@ -123,6 +130,10 @@ ConfigVars::ConfigVars(const Overrides& overrides)
           LoadConfig(FLAGS_grpc_experimental_memory_pressure_threshold,
                      "GRPC_EXPERIMENTAL_MEMORY_PRESSURE_THRESHOLD",
                      overrides.experimental_memory_pressure_threshold, 0.99)),
+      dns_ares_query_use_getaddrinfo_(
+          LoadConfig(FLAGS_grpc_dns_ares_query_use_getaddrinfo,
+                     "GRPC_DNS_ARES_QUERY_USE_GETADDRINFO",
+                     overrides.dns_ares_query_use_getaddrinfo, false)),
       enable_fork_support_(LoadConfig(
           FLAGS_grpc_enable_fork_support, "GRPC_ENABLE_FORK_SUPPORT",
           overrides.enable_fork_support, GRPC_ENABLE_FORK_SUPPORT_DEFAULT)),
@@ -180,7 +191,8 @@ std::string ConfigVars::ToString() const {
       "experiments: ", "\"", absl::CEscape(Experiments()), "\"",
       ", client_channel_backup_poll_interval_ms: ",
       ClientChannelBackupPollIntervalMs(), ", dns_resolver: ", "\"",
-      absl::CEscape(DnsResolver()), "\"", ", trace: ", "\"",
+      absl::CEscape(DnsResolver()), "\"", ", dns_ares_query_use_getaddrinfo: ",
+      DnsAresQueryUseGetaddrinfo() ? "true" : "false", ", trace: ", "\"",
       absl::CEscape(Trace()), "\"", ", verbosity: ", "\"",
       absl::CEscape(Verbosity()), "\"",
       ", enable_fork_support: ", EnableForkSupport() ? "true" : "false",

--- a/src/core/config/config_vars.h
+++ b/src/core/config/config_vars.h
@@ -39,6 +39,7 @@ class GPR_DLL ConfigVars {
     absl::optional<int32_t> chaotic_good_metrics_update_interval_ms;
     absl::optional<double> experimental_target_memory_pressure;
     absl::optional<double> experimental_memory_pressure_threshold;
+    absl::optional<bool> dns_ares_query_use_getaddrinfo;
     absl::optional<bool> enable_fork_support;
     absl::optional<bool> abort_on_leaks;
     absl::optional<bool> use_system_roots_over_language_callback;
@@ -82,6 +83,14 @@ class GPR_DLL ConfigVars {
   // with c-ares support. Otherwise, the value of this environment variable is
   // ignored.
   absl::string_view DnsResolver() const { return dns_resolver_; }
+  // EXPERIMENTAL. If true, the c-ares based DNS resolver issues a single
+  // combined A and AAAA query via ares_getaddrinfo() with AF_UNSPEC instead of
+  // two separate ares_gethostbyname() queries. This returns as soon as one
+  // address family is satisfied, avoiding long delays when a resolver silently
+  // drops AAAA queries. See https://github.com/grpc/grpc/issues/35638.
+  bool DnsAresQueryUseGetaddrinfo() const {
+    return dns_ares_query_use_getaddrinfo_;
+  }
   // A comma separated list of tracers that provide additional insight into how
   // gRPC C core is processing requests via debug logs.
   absl::string_view Trace() const { return trace_; }
@@ -148,6 +157,7 @@ class GPR_DLL ConfigVars {
   int32_t chaotic_good_metrics_update_interval_ms_;
   double experimental_target_memory_pressure_;
   double experimental_memory_pressure_threshold_;
+  bool dns_ares_query_use_getaddrinfo_;
   bool enable_fork_support_;
   bool abort_on_leaks_;
   bool use_system_roots_over_language_callback_;

--- a/src/core/config/config_vars.yaml
+++ b/src/core/config/config_vars.yaml
@@ -54,6 +54,16 @@
     with c-ares support. Otherwise, the value of this environment variable is
     ignored.
   fuzz: true
+- name: dns_ares_query_use_getaddrinfo
+  type: bool
+  default: false
+  description:
+    EXPERIMENTAL. If true, the c-ares based DNS resolver issues a single
+    combined A and AAAA query via ares_getaddrinfo() with AF_UNSPEC instead of
+    two separate ares_gethostbyname() queries. This returns as soon as one
+    address family is satisfied, avoiding long delays when a resolver silently
+    drops AAAA queries. See https://github.com/grpc/grpc/issues/35638.
+  fuzz: true
 - name: trace
   type: comma_separated_string
   default:

--- a/src/core/lib/event_engine/ares_resolver.cc
+++ b/src/core/lib/event_engine/ares_resolver.cc
@@ -368,7 +368,22 @@ void AresResolver::LookupHostname(
   callback_map_.emplace(++id_, std::move(callback));
   auto* resolver_arg = new HostnameQueryArg(this, id_, name, port);
   GRPC_CHECK_NE(channel_, nullptr);
-  if (AresIsIpv6LoopbackAvailable()) {
+  if (grpc_core::ConfigVars::Get().DnsAresQueryUseGetaddrinfo()) {
+    // Issue a single combined A + AAAA query. Unlike the two separate
+    // ares_gethostbyname() calls below, ares_getaddrinfo() with AF_UNSPEC
+    // returns as soon as one address family is satisfied and stops retrying the
+    // other, so a silently-dropped AAAA response no longer blocks resolution
+    // until the query timeout. See
+    // https://github.com/grpc/grpc/issues/35638.
+    //
+    // OnAddrinfoDoneLocked() owns the HostnameQueryArg and finalizes on this
+    // single callback, so unlike the ares_gethostbyname() paths below it does
+    // not use the pending_requests counter.
+    ares_addrinfo_hints hints = {};
+    hints.ai_family = AF_UNSPEC;
+    ares_getaddrinfo(channel_, std::string(host).c_str(), /*service=*/nullptr,
+                     &hints, &AresResolver::OnAddrinfoDoneLocked, resolver_arg);
+  } else if (AresIsIpv6LoopbackAvailable()) {
     // Note that using AF_UNSPEC for both IPv6 and IPv4 queries does not work in
     // all cases, e.g. for localhost:<> it only gets back the IPv6 result (i.e.
     // ::1).
@@ -715,32 +730,147 @@ void AresResolver::OnHostbynameDoneLocked(void* arg, int status,
       }
     }
   }
+  // Both the A and AAAA queries must complete before we report the (merged)
+  // result to the caller.
   if (hostname_qa->pending_requests == 0) {
-    auto nh =
-        ares_resolver->callback_map_.extract(hostname_qa->callback_map_id);
-    if (nh.empty()) {
-      delete hostname_qa;
-      return;
-    }
-    GRPC_CHECK(std::holds_alternative<
-               EventEngine::DNSResolver::LookupHostnameCallback>(nh.mapped()));
-    auto callback = std::get<EventEngine::DNSResolver::LookupHostnameCallback>(
-        std::move(nh.mapped()));
-    if (!hostname_qa->result.empty() || hostname_qa->error_status.ok()) {
-      ares_resolver->event_engine_->Run(
-          [callback = std::move(callback),
-           result = SortAddresses(hostname_qa->result)]() mutable {
-            callback(std::move(result));
-          });
-    } else {
-      ares_resolver->event_engine_->Run(
-          [callback = std::move(callback),
-           result = std::move(hostname_qa->error_status)]() mutable {
-            callback(std::move(result));
-          });
-    }
+    ares_resolver->FinishHostnameLookupLocked(
+        hostname_qa->callback_map_id, std::move(hostname_qa->result),
+        std::move(hostname_qa->error_status));
     delete hostname_qa;
   }
+}
+
+void AresResolver::FinishHostnameLookupLocked(
+    int callback_map_id, std::vector<EventEngine::ResolvedAddress> addresses,
+    absl::Status error_status) {
+  // Recover the pending LookupHostname callback by id. If it is gone the
+  // request was cancelled/shut down, so there is nothing to report.
+  auto nh = callback_map_.extract(callback_map_id);
+  if (nh.empty()) {
+    return;
+  }
+  GRPC_CHECK(
+      std::holds_alternative<EventEngine::DNSResolver::LookupHostnameCallback>(
+          nh.mapped()));
+  auto callback = std::get<EventEngine::DNSResolver::LookupHostnameCallback>(
+      std::move(nh.mapped()));
+  // Dispatch via event_engine_->Run() rather than calling inline: the callback
+  // is user code and mutex_ is held here, so running it inline could deadlock
+  // or re-enter the resolver.
+  if (!addresses.empty() || error_status.ok()) {
+    // Success (or a legitimately empty result). SortAddresses() applies RFC
+    // 6724 destination-address ordering (e.g. IPv6 loopback ahead of IPv4).
+    event_engine_->Run([callback = std::move(callback),
+                        result = SortAddresses(addresses)]() mutable {
+      callback(std::move(result));
+    });
+  } else {
+    // No addresses and an error was recorded: report the failure status.
+    event_engine_->Run([callback = std::move(callback),
+                        status = std::move(error_status)]() mutable {
+      callback(std::move(status));
+    });
+  }
+}
+
+// Completion callback for ares_getaddrinfo(). This is the ares_getaddrinfo()
+// analogue of OnHostbynameDoneLocked() above and is adapted from it; the result
+// parsing and completion logic mirror that function, differing only where the
+// ares_getaddrinfo() API requires it (see the per-block comments below). It is
+// only reached when the experimental GRPC_DNS_ARES_QUERY_USE_GETADDRINFO flag is
+// enabled; otherwise LookupHostname() uses the OnHostbynameDoneLocked() path.
+// Unlike OnHostbynameDoneLocked(), which c-ares calls once per address family
+// (A and AAAA) for a hostname, ares_getaddrinfo() makes a single combined query
+// and so this callback fires exactly once with all results in `addrinfo`.
+void AresResolver::OnAddrinfoDoneLocked(void* arg, int status, int /*timeouts*/,
+                                        struct ares_addrinfo* addrinfo) {
+  // `arg` is the HostnameQueryArg allocated in LookupHostname(). Adopt it into
+  // a unique_ptr so it is freed however we exit this function (success, error,
+  // or an already-cancelled request below).
+  std::unique_ptr<HostnameQueryArg> hostname_qa(
+      static_cast<HostnameQueryArg*>(arg));
+  auto* ares_resolver = hostname_qa->ares_resolver;
+  if (status != ARES_SUCCESS) {
+    // DNS lookup failed (e.g. NXDOMAIN, timeout, cancellation). Record the
+    // failure as an absl::Status; it is reported to the caller below.
+    std::string error_msg =
+        absl::StrFormat("address lookup failed for %s: %s",
+                        hostname_qa->query_name, ares_strerror(status));
+    GRPC_TRACE_LOG(cares_resolver, INFO)
+        << "(EventEngine c-ares resolver) resolver:" << ares_resolver
+        << " OnAddrinfoDoneLocked: " << error_msg;
+    hostname_qa->error_status = AresStatusToAbslStatus(status, error_msg);
+  } else {
+    GRPC_TRACE_LOG(cares_resolver, INFO)
+        << "(EventEngine c-ares resolver) resolver:" << ares_resolver
+        << " OnAddrinfoDoneLocked name=" << hostname_qa->query_name
+        << " ARES_SUCCESS";
+    // ares_getaddrinfo() returns its results as a singly-linked list of nodes
+    // (addrinfo->nodes), with both A and AAAA records intermixed. Walk the list
+    // and convert each node into an EventEngine::ResolvedAddress.
+    for (const ares_addrinfo_node* node = addrinfo != nullptr ? addrinfo->nodes
+                                                              : nullptr;
+         node != nullptr; node = node->ai_next) {
+      // Defensive cap against a malicious/huge DNS response OOMing the process.
+      if (hostname_qa->result.size() == kMaxRecordSize) {
+        LOG(ERROR) << "A/AAAA response exceeds maximum record size of 65536";
+        break;
+      }
+      switch (node->ai_family) {
+        case AF_INET6: {
+          // node->ai_addr points at a sockaddr_in6 for AF_INET6. Copy it out,
+          // then stamp in the port: DNS only yields an IP address, so the port
+          // comes from the host:port the caller originally asked to resolve.
+          size_t addr_len = sizeof(struct sockaddr_in6);
+          struct sockaddr_in6 addr;
+          memset(&addr, 0, addr_len);
+          memcpy(&addr, node->ai_addr, addr_len);
+          addr.sin6_port = htons(hostname_qa->port);
+          hostname_qa->result.emplace_back(
+              reinterpret_cast<const sockaddr*>(&addr), addr_len);
+          char output[INET6_ADDRSTRLEN];
+          ares_inet_ntop(AF_INET6, &addr.sin6_addr, output, INET6_ADDRSTRLEN);
+          GRPC_TRACE_LOG(cares_resolver, INFO)
+              << "(EventEngine c-ares resolver) resolver:" << ares_resolver
+              << " c-ares resolver gets a AF_INET6 result: \n  addr: " << output
+              << "\n  port: " << hostname_qa->port
+              << "\n  sin6_scope_id: " << addr.sin6_scope_id;
+          break;
+        }
+        case AF_INET: {
+          // Same as the AF_INET6 case above, but for an IPv4 sockaddr_in.
+          size_t addr_len = sizeof(struct sockaddr_in);
+          struct sockaddr_in addr;
+          memset(&addr, 0, addr_len);
+          memcpy(&addr, node->ai_addr, addr_len);
+          addr.sin_port = htons(hostname_qa->port);
+          hostname_qa->result.emplace_back(
+              reinterpret_cast<const sockaddr*>(&addr), addr_len);
+          char output[INET_ADDRSTRLEN];
+          ares_inet_ntop(AF_INET, &addr.sin_addr, output, INET_ADDRSTRLEN);
+          GRPC_TRACE_LOG(cares_resolver, INFO)
+              << "(EventEngine c-ares resolver) resolver:" << ares_resolver
+              << " c-ares resolver gets a AF_INET result: \n  addr: " << output
+              << "\n  port: " << hostname_qa->port;
+          break;
+        }
+        default:
+          // Ignore address families other than A/AAAA.
+          break;
+      }
+    }
+  }
+  // The ares_addrinfo list is heap-allocated by c-ares and owned by us (this
+  // differs from ares_gethostbyname(), whose hostent is owned by c-ares). Free
+  // it now that we have copied everything we need out of it.
+  if (addrinfo != nullptr) {
+    ares_freeaddrinfo(addrinfo);
+  }
+  // Report the (single, combined) result via the shared completion path. The
+  // unique_ptr above frees hostname_qa on return.
+  ares_resolver->FinishHostnameLookupLocked(
+      hostname_qa->callback_map_id, std::move(hostname_qa->result),
+      std::move(hostname_qa->error_status));
 }
 
 void AresResolver::OnSRVQueryDoneLocked(void* arg, int status, int /*timeouts*/,

--- a/src/core/lib/event_engine/ares_resolver.h
+++ b/src/core/lib/event_engine/ares_resolver.h
@@ -29,6 +29,7 @@
 
 #include <list>
 #include <memory>
+#include <vector>
 
 #include "src/core/lib/event_engine/grpc_polled_fd.h"
 #include "src/core/lib/event_engine/ref_counted_dns_resolver_interface.h"
@@ -134,6 +135,16 @@ class AresResolver : public RefCountedDNSResolverInterface {
   static void OnHostbynameDoneLocked(void* arg, int status, int /*timeouts*/,
                                      struct hostent* hostent)
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  static void OnAddrinfoDoneLocked(void* arg, int status, int /*timeouts*/,
+                                   struct ares_addrinfo* addrinfo)
+      ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  // Shared completion path for hostname lookups: looks up the pending
+  // LookupHostname callback by id and, if it is still registered, dispatches
+  // either the sorted addresses or the error status onto the EventEngine. Used
+  // by both OnHostbynameDoneLocked() and OnAddrinfoDoneLocked().
+  void FinishHostnameLookupLocked(
+      int callback_map_id, std::vector<EventEngine::ResolvedAddress> addresses,
+      absl::Status error_status) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
   static void OnSRVQueryDoneLocked(void* arg, int status, int /*timeouts*/,
                                    unsigned char* abuf,
                                    int alen) ABSL_NO_THREAD_SAFETY_ANALYSIS;

--- a/test/core/event_engine/test_suite/tests/dns_test.cc
+++ b/test/core/event_engine/test_suite/tests/dns_test.cc
@@ -435,6 +435,108 @@ TEST_F(EventEngineDNSTest, StressTestQueryARecordWithNameDeletion) {
   }
 }
 
+// Re-runs hostname resolution against the experimental ares_getaddrinfo() code
+// path (GRPC_DNS_ARES_QUERY_USE_GETADDRINFO=true). This issues a single
+// combined A + AAAA query instead of two separate ares_gethostbyname() queries,
+// which avoids long delays when a resolver silently drops AAAA responses. See
+// https://github.com/grpc/grpc/issues/35638.
+class EventEngineDNSGetAddrInfoTest : public EventEngineDNSTest {
+ protected:
+  static void SetUpTestSuite() {
+    grpc_core::ConfigVars::Overrides overrides;
+    overrides.dns_ares_query_use_getaddrinfo = true;
+    grpc_core::ConfigVars::SetOverrides(overrides);
+    EventEngineDNSTest::SetUpTestSuite();
+  }
+
+  static void TearDownTestSuite() {
+    EventEngineDNSTest::TearDownTestSuite();
+    grpc_core::ConfigVars::Reset();
+  }
+};
+
+// An ipv4-only target has no AAAA records, exercising the "only one address
+// family is returned" path that motivated the ares_getaddrinfo() switch.
+TEST_F(EventEngineDNSGetAddrInfoTest, QueryARecord) {
+  SKIP_TEST_FOR_NATIVE_DNS_RESOLVER();
+  auto dns_resolver = CreateDefaultDNSResolver();
+  dns_resolver->LookupHostname(
+      [this](auto result) {
+        ASSERT_TRUE(result.ok());
+        EXPECT_THAT(*result, UnorderedPointwise(
+                                 ResolvedAddressEq(),
+                                 {*URIToResolvedAddress("ipv4:1.2.3.4:443"),
+                                  *URIToResolvedAddress("ipv4:1.2.3.5:443"),
+                                  *URIToResolvedAddress("ipv4:1.2.3.6:443")}));
+        dns_resolver_signal_.Notify();
+      },
+      "ipv4-only-multi-target.dns-test.event-engine.",
+      /*default_port=*/"443");
+  dns_resolver_signal_.WaitForNotification();
+}
+
+TEST_F(EventEngineDNSGetAddrInfoTest, QueryAAAARecord) {
+  SKIP_TEST_FOR_NATIVE_DNS_RESOLVER();
+  auto dns_resolver = CreateDefaultDNSResolver();
+  dns_resolver->LookupHostname(
+      [this](auto result) {
+        ASSERT_TRUE(result.ok());
+        EXPECT_THAT(
+            *result,
+            UnorderedPointwise(
+                ResolvedAddressEq(),
+                {*URIToResolvedAddress("ipv6:[2607:f8b0:400a:801::1002]:443"),
+                 *URIToResolvedAddress("ipv6:[2607:f8b0:400a:801::1003]:443"),
+                 *URIToResolvedAddress(
+                     "ipv6:[2607:f8b0:400a:801::1004]:443")}));
+        dns_resolver_signal_.Notify();
+      },
+      "ipv6-only-multi-target.dns-test.event-engine.:443",
+      /*default_port=*/"");
+  dns_resolver_signal_.WaitForNotification();
+}
+
+// Both address families are present; verifies the combined query merges them.
+TEST_F(EventEngineDNSGetAddrInfoTest, QueryDualStackRecord) {
+  SKIP_TEST_FOR_NATIVE_DNS_RESOLVER();
+  auto dns_resolver = CreateDefaultDNSResolver();
+  dns_resolver->LookupHostname(
+      [this](auto result) {
+        ASSERT_TRUE(result.ok());
+        EXPECT_THAT(*result, UnorderedPointwise(
+                                 ResolvedAddressEq(),
+                                 {*URIToResolvedAddress("ipv4:1.2.3.4:443"),
+                                  *URIToResolvedAddress(
+                                      "ipv6:[2607:f8b0:400a:801::1002]:443")}));
+        dns_resolver_signal_.Notify();
+      },
+      "ipv4-and-ipv6-target.dns-test.event-engine.:443",
+      /*default_port=*/"");
+  dns_resolver_signal_.WaitForNotification();
+}
+
+// localhost is the case that motivated splitting LookupHostname() into two
+// separate ares_gethostbyname() queries: a single AF_UNSPEC gethostbyname()
+// only returns the IPv6 result (::1) for localhost (see the comment in
+// AresResolver::LookupHostname). ares_getaddrinfo() with AF_UNSPEC returns
+// both families, so verify that we get 127.0.0.1 and ::1 back.
+TEST_F(EventEngineDNSGetAddrInfoTest, QueryLocalhost) {
+  SKIP_TEST_FOR_NATIVE_DNS_RESOLVER();
+  auto dns_resolver = CreateDefaultDNSResolver();
+  dns_resolver->LookupHostname(
+      [this](auto result) {
+        ASSERT_TRUE(result.ok());
+        EXPECT_THAT(*result, UnorderedPointwise(
+                                 ResolvedAddressEq(),
+                                 {*URIToResolvedAddress("ipv4:127.0.0.1:443"),
+                                  *URIToResolvedAddress("ipv6:[::1]:443")}));
+        dns_resolver_signal_.Notify();
+      },
+      "localhost:443",
+      /*default_port=*/"");
+  dns_resolver_signal_.WaitForNotification();
+}
+
 #endif  // GRPC_IOS_EVENT_ENGINE_CLIENT
 
 #define EXPECT_SUCCESS()           \

--- a/test/core/event_engine/test_suite/tests/dns_test_record_groups.yaml
+++ b/test/core/event_engine/test_suite/tests/dns_test_record_groups.yaml
@@ -9,6 +9,9 @@ resolver_component_tests:
     - {TTL: '2100', data: '2607:f8b0:400a:801::1002', type: AAAA}
     - {TTL: '2100', data: '2607:f8b0:400a:801::1003', type: AAAA}
     - {TTL: '2100', data: '2607:f8b0:400a:801::1004', type: AAAA}
+    ipv4-and-ipv6-target:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    - {TTL: '2100', data: '2607:f8b0:400a:801::1002', type: AAAA}
     ipv6-loopback-preferred-target:
     - {TTL: '2100', data: '2002::1111', type: AAAA}
     - {TTL: '2100', data: '::1', type: AAAA}

--- a/test/core/test_util/fuzz_config_vars.cc
+++ b/test/core/test_util/fuzz_config_vars.cc
@@ -34,6 +34,10 @@ ConfigVars::Overrides OverridesFromFuzzConfigVars(
     overrides.experimental_memory_pressure_threshold =
         vars.experimental_memory_pressure_threshold();
   }
+  if (vars.has_dns_ares_query_use_getaddrinfo()) {
+    overrides.dns_ares_query_use_getaddrinfo =
+        vars.dns_ares_query_use_getaddrinfo();
+  }
   if (vars.has_enable_fork_support()) {
     overrides.enable_fork_support = vars.enable_fork_support();
   }

--- a/test/core/test_util/fuzz_config_vars.proto
+++ b/test/core/test_util/fuzz_config_vars.proto
@@ -24,6 +24,7 @@ message FuzzConfigVars {
   optional int32 channelz_max_orphaned_nodes = 475973073;
   optional double experimental_target_memory_pressure = 172375146;
   optional double experimental_memory_pressure_threshold = 402942472;
+  optional bool dns_ares_query_use_getaddrinfo = 79630330;
   optional bool enable_fork_support = 61008869;
   optional bool channelz_call_tracer = 346908333;
   optional string dns_resolver = 76817901;


### PR DESCRIPTION
Skydio uses gRPC extensively for inter-service communication. We recently hit an interesting but painful edge case with the default gRPC DNS resolver where DNS resolution would randomly take a long time (~8s) and cause gRPC calls to time out spuriously. This is a pretty disastrous failure mode.

## What this PR does

Adds an opt-in config var, **`GRPC_DNS_ARES_QUERY_USE_GETADDRINFO`** (default `false`). When enabled, `AresResolver::LookupHostname` issues a single combined query via **`ares_getaddrinfo(AF_UNSPEC)`** instead of two separate `ares_gethostbyname()` calls.

`ares_getaddrinfo()` requests A and AAAA together and returns as soon as one address family is satisfied, and it stops *retrying* the unsatisfied family rather than serially grinding through the search list. As a result, a healthy A record is no longer held hostage by a slow/broken AAAA lookup, which eliminates the multi-second stall.

## Why it's safe

- **Strictly opt-in.** The flag defaults to `false`, so the existing two-query `ares_gethostbyname()` path remains the default and is unchanged. There is **no behavior change** for any existing user unless they explicitly set the flag.
- **Reuses the existing result handling.** The new `OnAddrinfoDoneLocked()` callback reuses `HostnameQueryArg`, the same `sockaddr` construction, the `kMaxRecordSize` guard, and `SortAddresses()` (RFC 6724), and frees the result with `ares_freeaddrinfo()`. Result shape and ordering match the legacy path.
- **Narrow scope.** Only `LookupHostname` is affected; SRV and TXT resolution are untouched.

## Testing

Adds `EventEngineDNSGetAddrInfoTest`, which re-runs hostname resolution with the flag enabled against the fake DNS server:

- `QueryARecord` — IPv4-only target (no AAAA records), exercising the "only one address family is returned" path that motivated the change.
- `QueryAAAARecord` — IPv6-only target.
- `QueryDualStackRecord` — target with both A and AAAA, verifying the combined query merges both families.

## Notes for reviewers

This is intentionally the smallest, lowest-risk version of the fix: opt-in, default-off, no change to the default code path. I'd appreciate guidance on whether you'd prefer this remain a config var or whether a follow-up should explore making it the default (or the return-first-result-then-the-rest approach discussed in #35638).

Refs #35638