### PR TITLE
[CI] push_testing_images: add missing grpc_artifact_python_manylinux2014_aarch64

### DIFF
--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -85,6 +85,7 @@ EXCLUDE_DIRS=(
 ARM_DOCKERFILE_DIRS=(
   tools/dockerfile/distribtest/python_alpine_aarch64
   tools/dockerfile/distribtest/python_python310_bullseye_aarch64
+  tools/dockerfile/grpc_artifact_python_manylinux2014_aarch64
   tools/dockerfile/grpc_artifact_python_musllinux_1_2_aarch64
   tools/dockerfile/test/bazel_arm64
   tools/dockerfile/test/csharp_debian11_arm64


### PR DESCRIPTION
Update push_testing_images.sh: add `grpc_artifact_python_manylinux2014_aarch64` to `ARM_DOCKERFILE_DIRS` so that it's correctly identified as an ARM64 image.

Effectively this changes what job builds `us-docker.pkg.dev/grpc-testing/testing-images-public/grpc_artifact_python_manylinux2014_aarch64`:

- Moved from `grpc/core/master/linux/grpc_docker_build` (x64) to `grpc/core/master/linux/arm64/grpc_docker_build` (arm64) Kokoro job
- It's expected to speed up `grpc/core/master/linux/grpc_docker_build` since `grpc_artifact_python_manylinux2014_aarch64` no longer need to be cross-compiled.
