### PR TITLE
[Python] Handle custom Interceptor exceptions in InterceptedCall APIs 

### DIFF
--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -329,9 +329,9 @@ class InterceptedCall:
 
         call_completed = False
 
-        if (
-            interceptors_task.cancelled()
-            or interceptors_task.exception() is not None
+        if interceptors_task.cancelled() or (
+            interceptors_task.done()
+            and interceptors_task.exception() is not None
         ):
             call_completed = True
         else:

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -329,12 +329,15 @@ class InterceptedCall:
 
         call_completed = False
 
-        try:
+        if (
+            interceptors_task.cancelled()
+            or interceptors_task.exception() is not None
+        ):
+            call_completed = True
+        else:
             call = interceptors_task.result()
             if call.done():
                 call_completed = True
-        except (AioRpcError, asyncio.CancelledError):
-            call_completed = True
 
         if call_completed:
             for callback in self._pending_add_done_callbacks:
@@ -398,11 +401,14 @@ class InterceptedCall:
             self._pending_add_done_callbacks.append(callback)
             return
 
-        try:
-            call = self._interceptors_task.result()
-        except (AioRpcError, asyncio.CancelledError):
+        if (
+            self._interceptors_task.cancelled()
+            or self._interceptors_task.exception() is not None
+        ):
             callback(self)
             return
+
+        call = self._interceptors_task.result()
 
         if call.done():
             callback(self)

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -357,42 +357,49 @@ class InterceptedCall:
         callback(self)
 
     def cancel(self) -> bool:
+        if self._interceptors_task.cancelled():
+            return False
+
         if not self._interceptors_task.done():
             # There is no yet the intercepted call available,
             # Trying to cancel it by using the generic Asyncio
             # cancellation method.
             return self._interceptors_task.cancel()
 
-        try:
-            call = self._interceptors_task.result()
-        except AioRpcError:
+        if self._interceptors_task.exception() is not None:
             return False
-        except asyncio.CancelledError:
-            return False
+
+        call = self._interceptors_task.result()
 
         return call.cancel()
 
     def cancelled(self) -> bool:
+        if self._interceptors_task.cancelled():
+            return True
         if not self._interceptors_task.done():
             return False
 
-        try:
-            call = self._interceptors_task.result()
-        except AioRpcError as err:
-            return err.code() == grpc.StatusCode.CANCELLED
-        except asyncio.CancelledError:
-            return True
+        exc = self._interceptors_task.exception()
+        if exc is not None:
+            if isinstance(exc, asyncio.CancelledError):
+                return True
+            if isinstance(exc, AioRpcError):
+                return exc.code() == grpc.StatusCode.CANCELLED
+            return False
+
+        call = self._interceptors_task.result()
 
         return call.cancelled()
 
     def done(self) -> bool:
+        if self._interceptors_task.cancelled():
+            return True
         if not self._interceptors_task.done():
             return False
-
-        try:
-            call = self._interceptors_task.result()
-        except (AioRpcError, asyncio.CancelledError):
+        if self._interceptors_task.exception() is not None:
             return True
+
+        call = self._interceptors_task.result()
 
         return call.done()
 

--- a/src/python/grpcio/grpc/aio/_interceptor.py
+++ b/src/python/grpcio/grpc/aio/_interceptor.py
@@ -381,8 +381,6 @@ class InterceptedCall:
 
         exc = self._interceptors_task.exception()
         if exc is not None:
-            if isinstance(exc, asyncio.CancelledError):
-                return True
             if isinstance(exc, AioRpcError):
                 return exc.code() == grpc.StatusCode.CANCELLED
             return False

--- a/src/python/grpcio_tests/tests_aio/unit/client_unary_stream_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_unary_stream_interceptor_test.py
@@ -479,6 +479,97 @@ class TestUnaryStreamClientInterceptor(AioTestBase):
 
         await channel.close()
 
+    async def test_exception_raised_by_interceptor_done_callbacks_not_finished(
+        self,
+    ):
+        class InterceptorException(Exception):
+            pass
+
+        class Interceptor(aio.UnaryStreamClientInterceptor):
+            async def intercept_unary_stream(
+                self, continuation, client_call_details, request
+            ):
+                raise InterceptorException
+
+        channel = aio.insecure_channel(
+            UNREACHABLE_TARGET, interceptors=[Interceptor()]
+        )
+        request = messages_pb2.StreamingOutputCallRequest()
+        stub = test_pb2_grpc.TestServiceStub(channel)
+        call = stub.StreamingOutputCall(request)
+
+        validation = inject_callbacks(call)
+
+        with self.assertRaises(InterceptorException):
+            async for _ in call:
+                pass
+
+        await validation
+
+        await channel.close()
+
+    async def test_exception_raised_by_interceptor_done_callbacks_finished(
+        self,
+    ):
+        class InterceptorException(Exception):
+            pass
+
+        class Interceptor(aio.UnaryStreamClientInterceptor):
+            async def intercept_unary_stream(
+                self, continuation, client_call_details, request_iterator
+            ):
+                raise InterceptorException
+
+        channel = aio.insecure_channel(
+            UNREACHABLE_TARGET, interceptors=[Interceptor()]
+        )
+        stub = test_pb2_grpc.TestServiceStub(channel)
+
+        request = messages_pb2.StreamingOutputCallRequest()
+        call = stub.StreamingOutputCall(request)
+
+        with self.assertRaises(InterceptorException):
+            async for _ in call:
+                pass
+
+        validation = inject_callbacks(call)
+
+        await validation
+
+        await channel.close()
+
+    async def test_exception_raised_by_interceptor_state(self):
+        class InterceptorException(Exception):
+            pass
+
+        class Interceptor(aio.UnaryStreamClientInterceptor):
+            async def intercept_unary_stream(
+                self, continuation, client_call_details, request
+            ):
+                raise InterceptorException
+
+        channel = aio.insecure_channel(
+            UNREACHABLE_TARGET, interceptors=[Interceptor()]
+        )
+        request = messages_pb2.StreamingOutputCallRequest()
+        stub = test_pb2_grpc.TestServiceStub(channel)
+        call = stub.StreamingOutputCall(request)
+
+        # Before exception (task scheduled but not run)
+        self.assertFalse(call.done())
+        self.assertFalse(call.cancelled())
+
+        with self.assertRaises(InterceptorException):
+            async for _ in call:
+                pass
+
+        # After exception
+        self.assertTrue(call.done())
+        self.assertFalse(call.cancelled())
+        self.assertFalse(call.cancel())
+
+        await channel.close()
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/src/python/grpcio_tests/tests_aio/unit/client_unary_stream_interceptor_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/client_unary_stream_interceptor_test.py
@@ -456,79 +456,52 @@ class TestUnaryStreamClientInterceptor(AioTestBase):
         self.assertEqual(await call.code(), grpc.StatusCode.CANCELLED)
         await channel.close()
 
-    async def test_exception_raised_by_interceptor(self):
-        class InterceptorException(Exception):
-            pass
 
-        class Interceptor(aio.UnaryStreamClientInterceptor):
-            async def intercept_unary_stream(
-                self, continuation, client_call_details, request
-            ):
-                raise InterceptorException
+class _InterceptorException(Exception):
+    pass
 
-        channel = aio.insecure_channel(
-            UNREACHABLE_TARGET, interceptors=[Interceptor()]
+
+class _UnaryStreamExceptionRaisingInterceptor(aio.UnaryStreamClientInterceptor):
+    async def intercept_unary_stream(
+        self, continuation, client_call_details, request
+    ):
+        raise _InterceptorException()
+
+
+class TestUnaryStreamClientInterceptorCustomException(AioTestBase):
+
+    async def setUp(self):
+        self._channel = aio.insecure_channel(
+            UNREACHABLE_TARGET,
+            interceptors=[_UnaryStreamExceptionRaisingInterceptor()],
         )
-        request = messages_pb2.StreamingOutputCallRequest()
-        stub = test_pb2_grpc.TestServiceStub(channel)
-        call = stub.StreamingOutputCall(request)
+        self._stub = test_pb2_grpc.TestServiceStub(self._channel)
+        self._request = messages_pb2.StreamingOutputCallRequest()
 
-        with self.assertRaises(InterceptorException):
-            async for response in call:
+    async def tearDown(self):
+        await self._channel.close()
+
+    async def test_exception_raised_correctly(self):
+        call = self._stub.StreamingOutputCall(self._request)
+
+        with self.assertRaises(_InterceptorException):
+            async for _ in call:
                 pass
 
-        await channel.close()
-
-    async def test_exception_raised_by_interceptor_done_callbacks_not_finished(
-        self,
-    ):
-        class InterceptorException(Exception):
-            pass
-
-        class Interceptor(aio.UnaryStreamClientInterceptor):
-            async def intercept_unary_stream(
-                self, continuation, client_call_details, request
-            ):
-                raise InterceptorException
-
-        channel = aio.insecure_channel(
-            UNREACHABLE_TARGET, interceptors=[Interceptor()]
-        )
-        request = messages_pb2.StreamingOutputCallRequest()
-        stub = test_pb2_grpc.TestServiceStub(channel)
-        call = stub.StreamingOutputCall(request)
-
+    async def test_done_callbacks_triggered_when_registered_early(self):
+        call = self._stub.StreamingOutputCall(self._request)
         validation = inject_callbacks(call)
 
-        with self.assertRaises(InterceptorException):
+        with self.assertRaises(_InterceptorException):
             async for _ in call:
                 pass
 
         await validation
 
-        await channel.close()
+    async def test_done_callbacks_triggered_when_registered_late(self):
+        call = self._stub.StreamingOutputCall(self._request)
 
-    async def test_exception_raised_by_interceptor_done_callbacks_finished(
-        self,
-    ):
-        class InterceptorException(Exception):
-            pass
-
-        class Interceptor(aio.UnaryStreamClientInterceptor):
-            async def intercept_unary_stream(
-                self, continuation, client_call_details, request_iterator
-            ):
-                raise InterceptorException
-
-        channel = aio.insecure_channel(
-            UNREACHABLE_TARGET, interceptors=[Interceptor()]
-        )
-        stub = test_pb2_grpc.TestServiceStub(channel)
-
-        request = messages_pb2.StreamingOutputCallRequest()
-        call = stub.StreamingOutputCall(request)
-
-        with self.assertRaises(InterceptorException):
+        with self.assertRaises(_InterceptorException):
             async for _ in call:
                 pass
 
@@ -536,30 +509,14 @@ class TestUnaryStreamClientInterceptor(AioTestBase):
 
         await validation
 
-        await channel.close()
-
-    async def test_exception_raised_by_interceptor_state(self):
-        class InterceptorException(Exception):
-            pass
-
-        class Interceptor(aio.UnaryStreamClientInterceptor):
-            async def intercept_unary_stream(
-                self, continuation, client_call_details, request
-            ):
-                raise InterceptorException
-
-        channel = aio.insecure_channel(
-            UNREACHABLE_TARGET, interceptors=[Interceptor()]
-        )
-        request = messages_pb2.StreamingOutputCallRequest()
-        stub = test_pb2_grpc.TestServiceStub(channel)
-        call = stub.StreamingOutputCall(request)
+    async def test_call_states_on_interceptor_exception(self):
+        call = self._stub.StreamingOutputCall(self._request)
 
         # Before exception (task scheduled but not run)
         self.assertFalse(call.done())
         self.assertFalse(call.cancelled())
 
-        with self.assertRaises(InterceptorException):
+        with self.assertRaises(_InterceptorException):
             async for _ in call:
                 pass
 
@@ -567,8 +524,6 @@ class TestUnaryStreamClientInterceptor(AioTestBase):
         self.assertTrue(call.done())
         self.assertFalse(call.cancelled())
         self.assertFalse(call.cancel())
-
-        await channel.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/40964

The `done`, `cancel`, `cancelled` and `add_done_callback` APIs of aio._interceptor.InterceptedCall do not catch custom interceptor exceptions, leading to undesired behaviour such as `call.done()` failing and done_callbacks being left unexecuted. This PR fixes this by checking for `_interceptor_task.exception()` along with `_interceptor_task.result()`.

New tests have also been added to check these changes.