### PR TITLE
[Python] Mark grpcio-observability as Linux only

### DIFF
--- a/src/python/grpcio_observability/pyproject.toml
+++ b/src/python/grpcio_observability/pyproject.toml
@@ -28,6 +28,7 @@ readme = {file = "README.rst", content-type = "text/x-rst"}
 authors = [{name = "The gRPC Authors", email = "grpc-io@googlegroups.com"}]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]

--- a/src/python/grpcio_observability/setup.py
+++ b/src/python/grpcio_observability/setup.py
@@ -311,6 +311,7 @@ def extension_modules():
 if __name__ == "__main__":
     setuptools.setup(
         ext_modules=extension_modules(),
+        platforms=["Linux"],
         python_requires=f">={python_version.MIN_PYTHON_VERSION}",
         install_requires=[
             "grpcio=={version}".format(version=grpc_version.VERSION),


### PR DESCRIPTION
Change was **not** created by the release automation script, because it
doesn't handle a +2 version bump. See go/grpc-release

The package README says it is only compatible with linux. This adds that to the egg / pypi metadata.
