### PR TITLE
Initialize openssl with no atexit handler

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4644,7 +4644,6 @@ grpc_cc_library(
         "tsi_ssl_session_cache",
         "//src/core:channel_args",
         "//src/core:default_event_engine",
-        "//src/core:env",
         "//src/core:error",
         "//src/core:grpc_check",
         "//src/core:grpc_crl_provider",

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -520,7 +520,7 @@ static void verified_root_cert_free(void* /*parent*/, void* ptr,
 
 static void init_openssl(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
-  OPENSSL_init_ssl(0, nullptr);
+  OPENSSL_init_ssl(OPENSSL_INIT_NO_ATEXIT, nullptr);
   // Ensure OPENSSL global clean up happens after gRPC shutdown completes.
   // OPENSSL registers an exit handler to clean up global objects, which
   // otherwise may happen before gRPC removes all references to OPENSSL. Below

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -68,7 +68,6 @@
 #include "src/core/tsi/ssl_types.h"
 #include "src/core/tsi/transport_security.h"
 #include "src/core/tsi/transport_security_interface.h"
-#include "src/core/util/env.h"
 #include "src/core/util/grpc_check.h"
 #include "src/core/util/match.h"
 #include "src/core/util/ref_counted.h"
@@ -79,15 +78,9 @@
 #include "absl/functional/bind_front.h"
 #include "absl/log/log.h"
 #include "absl/strings/match.h"
-#include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
-
-// Name of the environment variable controlling OpenSSL cleanup timeout.
-// This variable allows users to specify the timeout (in seconds) for OpenSSL
-// resource cleanup during gRPC shutdown. If not set, a default timeout is used.
-#define GRPC_ARG_OPENSSL_CLEANUP_TIMEOUT_ENV "grpc.openssl_cleanup_timeout"
 
 // --- Constants. ---
 
@@ -521,31 +514,6 @@ static void verified_root_cert_free(void* /*parent*/, void* ptr,
 static void init_openssl(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
   OPENSSL_init_ssl(OPENSSL_INIT_NO_ATEXIT, nullptr);
-  // Ensure OPENSSL global clean up happens after gRPC shutdown completes.
-  // OPENSSL registers an exit handler to clean up global objects, which
-  // otherwise may happen before gRPC removes all references to OPENSSL. Below
-  // exit handler is guaranteed to run after OPENSSL's.
-  std::atexit([]() {
-    // Retrieve the OpenSSL cleanup timeout from the environment variable.
-    // This allows users to override the default cleanup timeout for OpenSSL
-    // resource deallocation during gRPC shutdown.
-    std::optional<std::string> env =
-        grpc_core::GetEnv(GRPC_ARG_OPENSSL_CLEANUP_TIMEOUT_ENV);
-    int timeout_sec = 2;
-    if (env.has_value()) {
-      int parsed_timeout_sec = 0;
-      if (absl::SimpleAtoi(*env, &parsed_timeout_sec)) {
-        timeout_sec = parsed_timeout_sec;
-      } else {
-        GRPC_TRACE_LOG(tsi, ERROR)
-            << "Invalid value [" << (*env) << "] for "
-            << GRPC_ARG_OPENSSL_CLEANUP_TIMEOUT_ENV
-            << " environment variable. Using default value of 2 seconds.";
-      }
-    }
-
-    grpc_wait_for_shutdown_with_timeout(absl::Seconds(timeout_sec));
-  });
 #else
   SSL_library_init();
   SSL_load_error_strings();


### PR DESCRIPTION
Since grpc shutdown does not guarantee that all eventengine threads have shut down, openssl cleanup can cause double frees if threads with openssl memory allocations shut down at the same time as openssl cleanup. Using NO_ATEXIT ensures that only thread shutdown will cleanup openssl and prevents the race condition.