### PR TITLE
[Python] Server destroy on stop to avoid memory leak

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -218,7 +218,8 @@ cdef class Server:
   def destroy(self):
     if self.c_server != NULL:
       if not self.is_started:
-        pass
+        if self.registered_completion_queues:
+          self._c_shutdown(self.registered_completion_queues[0], None)
       elif self.is_shutdown:
         pass
       elif not self.is_shutting_down:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -219,7 +219,8 @@ cdef class Server:
     if self.c_server != NULL:
       if not self.is_started:
         if self.registered_completion_queues:
-          self._c_shutdown(self.registered_completion_queues[0], None)
+          for queue in self.registered_completion_queue:
+            self._c_shutdown(queue, None)
       elif self.is_shutdown:
         pass
       elif not self.is_shutting_down:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -219,7 +219,7 @@ cdef class Server:
     if self.c_server != NULL:
       if not self.is_started:
         if self.registered_completion_queues:
-          for queue in self.registered_completion_queue:
+          for queue in self.registered_completion_queues:
             self._c_shutdown(queue, None)
       elif self.is_shutdown:
         pass

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -1336,6 +1336,7 @@ def _begin_shutdown_once(state: _ServerState) -> None:
 def _stop(state: _ServerState, grace: Optional[float]) -> threading.Event:
     with state.lock:
         if state.stage is _ServerStage.STOPPED:
+            state.server.destroy()
             shutdown_event = threading.Event()
             shutdown_event.set()
             return shutdown_event
@@ -1492,6 +1493,8 @@ class _Server(grpc.Server):
             # We can not grab a lock in __del__(), so set a flag to signal the
             # serving daemon thread (if it exists) to initiate shutdown.
             self._state.server_deallocated = True
+            if self._state.stage is _ServerStage.STOPPED:
+                self._state.server.destroy()
 
 
 def create_server(


### PR DESCRIPTION
# Description

Server destroy on stop to avoid memory leak.

Fixes - https://github.com/grpc/grpc/issues/31509

Before - 
<img width="1450" height="650" alt="before" src="https://github.com/user-attachments/assets/917d41d4-d998-4eab-b6d7-6418b8c179da" />

After -
<img width="1361" height="318" alt="after" src="https://github.com/user-attachments/assets/fddd8957-b40e-439c-8e86-7f92c1cde876" />


`check.py`

```py
import grpc
from concurrent import futures
tp = futures.ThreadPoolExecutor(max_workers=32)
while True:
    service=grpc.server(tp)
    service.stop(0)
```
