### PR TITLE
Limit bzlmod PR check workflow permissions

### DIFF
--- a/.github/workflows/pr-check-bzlmod-deps.yaml
+++ b/.github/workflows/pr-check-bzlmod-deps.yaml
@@ -10,6 +10,9 @@ on:
       - 'third_party/**'
       - 'tools/run_tests/sanity/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit `contents: read` permissions block to the bzlmod dependency PR check workflow
- keep the existing checkout and GitHub API read behavior for the dependency comparison script

## Security rationale
The workflow runs on `pull_request` and only needs repository read access plus the default token for read-only GitHub API requests. Without an explicit `permissions:` block, the job inherits repository defaults. Setting `contents: read` keeps the job least-privilege and removes unnecessary token authority from this PR-triggered workflow.

## Validation
- `git diff --check`
- `/tmp/actionlint-bin/actionlint .github/workflows/pr-check-bzlmod-deps.yaml`
- `uvx zizmor --min-severity medium --min-confidence medium --format json .github/workflows/pr-check-bzlmod-deps.yaml`

Note: zizmor still reports pre-existing unpinned action references for `actions/checkout@v6` and `actions/setup-python@v6`; the `excessive-permissions` finding for this workflow is removed by this patch.