### PR TITLE
[Ruby] Copied nativedebug package to pkg/ruby-native-debug-symbols for publish script to access

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -262,7 +262,9 @@ end
 
 desc 'Publish native debug rubygems to GCS'
 task 'publish:native_debug', [:gem_dir] do |_t, args|
+  require 'digest'
   require 'rubygems/package'
+  require 'open3'
 
   gem_dir = File.expand_path(args[:gem_dir] || 'build/ruby/nativedebug')
   force_upload = ENV['FORCE'].to_s.downcase == 'true'
@@ -281,13 +283,13 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
   end
 
   Dir.chdir(gem_dir) do
-    gems_by_version.each_key do |base_version|
+    gems_by_version.each do |base_version, version_gem_files|
       gcs_version_path = "#{gcs_base}/v#{base_version}"
 
       # Check only for existence of gems
-      gems_exist = system("gsutil ls #{gcs_version_path}/*.gem > /dev/null 2>&1")
+      _stdout, _stderr, status = Open3.capture3("gsutil ls #{gcs_version_path}/*.gem")
 
-      if gems_exist && !force_upload
+      if status.success? && !force_upload
         puts "Skipping v#{base_version}.Gems already exist in #{gcs_version_path}. Use 'FORCE=true' to overwrite"
         next
       end
@@ -301,11 +303,17 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
 
       begin
         # Generate checksums only for the gems belonging to this version
-        
-        fail 'Checksum generation failed' unless system("sha256sum *#{base_version}*.gem > checksums.txt")
+        File.open('checksums.txt', 'w') do |f|
+          version_gem_files.each do |gem_path|
+            gem_name = File.basename(gem_path)
+            checksum = Digest::SHA256.file(gem_name).hexdigest
+            f.puts "#{checksum}  #{gem_name}"
+          end
+        end
+        files_to_upload = version_gem_files.map { |f| File.basename(f) } + ['checksums.txt']
 
         # Upload all gems and the checksums file
-        upload_cmd = "gsutil -m cp *#{base_version}*.gem checksums.txt #{gcs_version_path}/"
+        upload_cmd = "gsutil -m cp #{files_to_upload.join(' ')} #{gcs_version_path}/"
         fail 'Upload failed' unless system(upload_cmd)
       ensure
         FileUtils.rm_f('checksums.txt')

--- a/Rakefile
+++ b/Rakefile
@@ -260,6 +260,28 @@ task 'gem:native', [:plat, :build_type] do |t, args|
   end
 end
 
+desc 'Publish native debug rubygems to GCS'
+task 'publish:native_debug', [:gem_dir] do |_t, args|
+  gem_dir = File.expand_path(args[:gem_dir] || 'tmp/nativedebug')
+  gcs_root = 'gs://packages.grpc.io/'
+  gcs_path = "#{gcs_root}grpc-ruby-native-debug-symbols"
+
+  fail "Directory '#{gem_dir}' not found" unless Dir.exist?(gem_dir)
+
+  gems = Dir["#{gem_dir}/*native-debug*.gem"]
+  fail "No native-debug gems found in '#{gem_dir}'" if gems.empty?
+
+  Dir.chdir(gem_dir) do
+    `sha256sum *native-debug*.gem > checksums.txt`
+    fail 'Checksum generation failed' unless $?.success?
+    `gsutil -m cp *native-debug*.gem checksums.txt #{gcs_path}`
+    fail 'Upload failed' unless $?.success?
+    `gsutil -m acl ch -u AllUsers:R #{gcs_path}* 2>/dev/null`
+  end
+
+  puts "Successfully published to: #{gcs_path}"
+end
+
 # Define dependencies between the suites.
 task 'suite:wrapper' => [:compile, :rubocop]
 task 'suite:idiomatic' => 'suite:wrapper'

--- a/Rakefile
+++ b/Rakefile
@@ -265,15 +265,26 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
   require 'digest'
   require 'rubygems/package'
   require 'open3'
+  require 'shellwords'
+
+  #Helper to log and execute commands
+  def run_cmd(*cmd_parts)
+    puts "Executing: #{Shellwords.join(cmd_parts)}"
+    success = system(*cmd_parts)
+    fail "Command failed: #{Shellwords.join(cmd_parts)}" unless success
+  end
 
   gem_dir = File.expand_path(args[:gem_dir] || 'build/ruby/nativedebug')
-  force_upload = ENV['FORCE'].to_s.downcase == 'true'
+  force_upload = ENV['REUPLOAD'].to_s.downcase == 'true'
   gcs_base = 'gs://packages.grpc.io/grpc-ruby-native-debug-symbols'
 
   fail "Directory '#{gem_dir}' not found" unless Dir.exist?(gem_dir)
 
   gem_files = Dir["#{gem_dir}/*native-debug*.gem"]
   fail "No native-debug gems found in '#{gem_dir}'" if gem_files.empty?
+
+  puts 'Checking gsutil availability and bucket access.'
+  run_cmd('gsutil', 'ls', '-b', gcs_base)
 
   gems_by_version = gem_files.group_by do |path|
     full_version = Gem::Package.new(path).spec.version.to_s
@@ -284,22 +295,23 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
 
   Dir.chdir(gem_dir) do
     gems_by_version.each do |base_version, version_gem_files|
+      puts "Processing base version #{base_version}."
+
       gcs_version_path = "#{gcs_base}/v#{base_version}"
 
       # Check only for existence of gems
-      _stdout, _stderr, status = Open3.capture3("gsutil ls #{gcs_version_path}/*.gem")
+      stdout, _stderr, status = Open3.capture3('gsutil', 'ls', "#{gcs_version_path}/*.gem")
+      has_gems = status.success? && !stdout.strip.empty?
 
-      if status.success? && !force_upload
-        puts "Skipping v#{base_version}.Gems already exist in #{gcs_version_path}. Use 'FORCE=true' to overwrite"
+      if has_gems && !force_upload
+        puts "Skipping v#{base_version}.Gems already exist in #{gcs_version_path}. Use 'REUPLOAD=true' to overwrite"
         next
       end
 
-      if force_upload
+      if force_upload && has_gems
         puts "Force upload enabled. Clearing existing files in #{gcs_version_path}."
-        system("gsutil -m rm #{gcs_version_path}/* > /dev/null 2>&1")
+        run_cmd('gsutil', '-m', 'rm', "#{gcs_version_path}/*.gem")
       end
-
-      puts "Processing base version #{base_version}."
 
       begin
         # Generate checksums only for the gems belonging to this version
@@ -310,11 +322,13 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
             f.puts "#{checksum}  #{gem_name}"
           end
         end
-        files_to_upload = version_gem_files.map { |f| File.basename(f) } + ['checksums.txt']
+        
+        puts 'Verifying checksums.'
+        run_cmd('sha256sum', '-c', 'checksums.txt')
 
         # Upload all gems and the checksums file
-        upload_cmd = "gsutil -m cp #{files_to_upload.join(' ')} #{gcs_version_path}/"
-        fail 'Upload failed' unless system(upload_cmd)
+        files_to_upload = version_gem_files.map { |f| File.basename(f) } + ['checksums.txt']
+        run_cmd('gsutil', '-m', 'cp', *files_to_upload, "#{gcs_version_path}/")
       ensure
         FileUtils.rm_f('checksums.txt')
       end

--- a/Rakefile
+++ b/Rakefile
@@ -253,8 +253,9 @@ task 'gem:native', [:plat, :build_type] do |t, args|
   unix_platforms.each do |plat|
     unless unix_platforms_without_debug_symbols.include?(plat)
       `bash src/ruby/nativedebug/build_package.sh #{plat}`
-      # Native debug gems uploaded to GCS, skip pkg/ to avoid RubyGems upload
-      # `cp src/ruby/nativedebug/pkg/*.gem pkg/`
+      # Native debug gems uploaded to GCS, are copied to ruby-native-debug-symbols for grpc_publish_packages to recognize
+      `mkdir -p pkg/ruby-native-debug-symbols`
+      `cp src/ruby/nativedebug/pkg/*.gem pkg/ruby-native-debug-symbols/`
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -254,32 +254,66 @@ task 'gem:native', [:plat, :build_type] do |t, args|
     unless unix_platforms_without_debug_symbols.include?(plat)
       `bash src/ruby/nativedebug/build_package.sh #{plat}`
       # Native debug gems uploaded to GCS, are copied to ruby-native-debug-symbols for grpc_publish_packages to recognize
-      `mkdir -p pkg/ruby-native-debug-symbols`
-      `cp src/ruby/nativedebug/pkg/*.gem pkg/ruby-native-debug-symbols/`
+      FileUtils.mkdir_p(target = 'pkg/ruby-native-debug-symbols')
+      FileUtils.cp(Dir.glob('src/ruby/nativedebug/pkg/*.gem'), target)
     end
   end
 end
 
 desc 'Publish native debug rubygems to GCS'
 task 'publish:native_debug', [:gem_dir] do |_t, args|
-  gem_dir = File.expand_path(args[:gem_dir] || 'tmp/nativedebug')
-  gcs_root = 'gs://packages.grpc.io/'
-  gcs_path = "#{gcs_root}grpc-ruby-native-debug-symbols"
+  require 'rubygems/package'
+
+  gem_dir = File.expand_path(args[:gem_dir] || 'build/ruby/nativedebug')
+  force_upload = ENV['FORCE'].to_s.downcase == 'true'
+  gcs_base = 'gs://packages.grpc.io/grpc-ruby-native-debug-symbols'
 
   fail "Directory '#{gem_dir}' not found" unless Dir.exist?(gem_dir)
 
-  gems = Dir["#{gem_dir}/*native-debug*.gem"]
-  fail "No native-debug gems found in '#{gem_dir}'" if gems.empty?
+  gem_files = Dir["#{gem_dir}/*native-debug*.gem"]
+  fail "No native-debug gems found in '#{gem_dir}'" if gem_files.empty?
 
-  Dir.chdir(gem_dir) do
-    `sha256sum *native-debug*.gem > checksums.txt`
-    fail 'Checksum generation failed' unless $?.success?
-    `gsutil -m cp *native-debug*.gem checksums.txt #{gcs_path}`
-    fail 'Upload failed' unless $?.success?
-    `gsutil -m acl ch -u AllUsers:R #{gcs_path}* 2>/dev/null`
+  gems_by_version = gem_files.group_by do |path|
+    full_version = Gem::Package.new(path).spec.version.to_s
+    full_version.match(/^(\d+\.\d+\.\d+)/)[1]
+  rescue StandardError => e
+    fail "Error: Cannot extract metadata from #{File.basename(path)}. Is it a valid gem? (#{e.message})"
   end
 
-  puts "Successfully published to: #{gcs_path}"
+  Dir.chdir(gem_dir) do
+    gems_by_version.each_key do |base_version|
+      gcs_version_path = "#{gcs_base}/v#{base_version}"
+
+      # Check only for existence of gems
+      gems_exist = system("gsutil ls #{gcs_version_path}/*.gem > /dev/null 2>&1")
+
+      if gems_exist && !force_upload
+        puts "Skipping v#{base_version}.Gems already exist in #{gcs_version_path}. Use 'FORCE=true' to overwrite"
+        next
+      end
+
+      if force_upload
+        puts "Force upload enabled. Clearing existing files in #{gcs_version_path}."
+        system("gsutil -m rm #{gcs_version_path}/* > /dev/null 2>&1")
+      end
+
+      puts "Processing base version #{base_version}."
+
+      begin
+        # Generate checksums only for the gems belonging to this version
+        
+        fail 'Checksum generation failed' unless system("sha256sum *#{base_version}*.gem > checksums.txt")
+
+        # Upload all gems and the checksums file
+        upload_cmd = "gsutil -m cp *#{base_version}*.gem checksums.txt #{gcs_version_path}/"
+        fail 'Upload failed' unless system(upload_cmd)
+      ensure
+        FileUtils.rm_f('checksums.txt')
+      end
+
+      puts "Successfully published version #{base_version}."
+    end
+  end
 end
 
 # Define dependencies between the suites.

--- a/Rakefile
+++ b/Rakefile
@@ -268,7 +268,7 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
   require 'open3'
   require 'shellwords'
 
-  # Helper to log and execute commands. Usage: run_cmd.call('gsutil', 'ls', '-b', gcs_base)
+  # Helper to log and execute commands. Usage: run_cmd.call('gcloud', 'storage', 'ls', gcs_base)
   run_cmd = lambda do |*cmd_parts|
     puts "Executing: #{Shellwords.join(cmd_parts)}"
     success = system(*cmd_parts)

--- a/Rakefile
+++ b/Rakefile
@@ -277,15 +277,16 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
 
   gem_dir = File.expand_path(args[:gem_dir] || 'build/ruby/nativedebug')
   force_upload = ENV['REUPLOAD'].to_s.downcase == 'true'
-  gcs_base = 'gs://packages.grpc.io/grpc-ruby-native-debug-symbols'
+  gcs_bucket = 'gs://packages.grpc.io'
+  gcs_base = "#{gcs_bucket}/grpc-ruby-native-debug-symbols"
 
   fail "Directory '#{gem_dir}' not found" unless Dir.exist?(gem_dir)
 
   gem_files = Dir["#{gem_dir}/*native-debug*.gem"]
   fail "No native-debug gems found in '#{gem_dir}'" if gem_files.empty?
 
-  puts 'Checking gsutil availability and bucket access.'
-  run_cmd.call('gsutil', 'ls', '-b', gcs_base)
+  puts 'Checking google cloud storage availability and bucket access.'
+  run_cmd.call('gcloud', 'storage', 'buckets', 'describe', gcs_bucket)
 
   gems_by_version = gem_files.group_by do |path|
     full_version = Gem::Package.new(path).spec.version.to_s
@@ -303,7 +304,7 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
       gcs_version_path = "#{gcs_base}/v#{base_version}"
 
       # Check only for existence of gems
-      stdout, _stderr, status = Open3.capture3('gsutil', 'ls', "#{gcs_version_path}/*.gem")
+      stdout, _stderr, status = Open3.capture3('gcloud', 'storage', 'ls', "#{gcs_version_path}/*.gem")
       has_gems = status.success? && !stdout.strip.empty?
 
       if has_gems && !force_upload
@@ -313,7 +314,7 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
 
       if force_upload && has_gems
         puts "Force upload enabled. Clearing existing files in #{gcs_version_path}."
-        run_cmd.call('gsutil', '-m', 'rm', "#{gcs_version_path}/*.gem", "#{gcs_version_path}/checksums.txt")
+        run_cmd.call('gcloud', 'storage', 'rm', "#{gcs_version_path}/*.gem", "#{gcs_version_path}/checksums.txt")
       end
 
       begin
@@ -331,7 +332,7 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
 
         # Upload all gems and the checksums file
         files_to_upload = version_gem_files.map { |f| File.basename(f) } + ['checksums.txt']
-        run_cmd.call('gsutil', '-m', 'cp', *files_to_upload, "#{gcs_version_path}/")
+        run_cmd.call('gcloud', 'storage', 'cp', *files_to_upload, "#{gcs_version_path}/")
       ensure
         FileUtils.rm_f('checksums.txt')
       end

--- a/Rakefile
+++ b/Rakefile
@@ -254,7 +254,8 @@ task 'gem:native', [:plat, :build_type] do |t, args|
     unless unix_platforms_without_debug_symbols.include?(plat)
       `bash src/ruby/nativedebug/build_package.sh #{plat}`
       # Native debug gems uploaded to GCS, are copied to ruby-native-debug-symbols for grpc_publish_packages to recognize
-      FileUtils.mkdir_p(target = 'pkg/ruby-native-debug-symbols')
+      target = 'pkg/ruby-native-debug-symbols'
+      FileUtils.mkdir_p(target)
       FileUtils.cp(Dir.glob('src/ruby/nativedebug/pkg/*.gem'), target)
     end
   end
@@ -267,8 +268,8 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
   require 'open3'
   require 'shellwords'
 
-  #Helper to log and execute commands
-  def run_cmd(*cmd_parts)
+  # Helper to log and execute commands. Usage: run_cmd.call('gsutil', 'ls', '-b', gcs_base)
+  run_cmd = lambda do |*cmd_parts|
     puts "Executing: #{Shellwords.join(cmd_parts)}"
     success = system(*cmd_parts)
     fail "Command failed: #{Shellwords.join(cmd_parts)}" unless success
@@ -284,11 +285,13 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
   fail "No native-debug gems found in '#{gem_dir}'" if gem_files.empty?
 
   puts 'Checking gsutil availability and bucket access.'
-  run_cmd('gsutil', 'ls', '-b', gcs_base)
+  run_cmd.call('gsutil', 'ls', '-b', gcs_base)
 
   gems_by_version = gem_files.group_by do |path|
     full_version = Gem::Package.new(path).spec.version.to_s
-    full_version.match(/^(\d+\.\d+\.\d+)/)[1]
+    match = full_version.match(/^(\d+\.\d+\.\d+)/)
+    fail "Unexpected version format: #{full_version}" unless match
+    match[1]
   rescue StandardError => e
     fail "Error: Cannot extract metadata from #{File.basename(path)}. Is it a valid gem? (#{e.message})"
   end
@@ -304,13 +307,13 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
       has_gems = status.success? && !stdout.strip.empty?
 
       if has_gems && !force_upload
-        puts "Skipping v#{base_version}.Gems already exist in #{gcs_version_path}. Use 'REUPLOAD=true' to overwrite"
+        puts "Skipping v#{base_version}. Gems already exist in #{gcs_version_path}. Use 'REUPLOAD=true' to overwrite"
         next
       end
 
       if force_upload && has_gems
         puts "Force upload enabled. Clearing existing files in #{gcs_version_path}."
-        run_cmd('gsutil', '-m', 'rm', "#{gcs_version_path}/*.gem")
+        run_cmd.call('gsutil', '-m', 'rm', "#{gcs_version_path}/*.gem", "#{gcs_version_path}/checksums.txt")
       end
 
       begin
@@ -322,13 +325,13 @@ task 'publish:native_debug', [:gem_dir] do |_t, args|
             f.puts "#{checksum}  #{gem_name}"
           end
         end
-        
+
         puts 'Verifying checksums.'
-        run_cmd('sha256sum', '-c', 'checksums.txt')
+        run_cmd.call('sha256sum', '-c', 'checksums.txt')
 
         # Upload all gems and the checksums file
         files_to_upload = version_gem_files.map { |f| File.basename(f) } + ['checksums.txt']
-        run_cmd('gsutil', '-m', 'cp', *files_to_upload, "#{gcs_version_path}/")
+        run_cmd.call('gsutil', '-m', 'cp', *files_to_upload, "#{gcs_version_path}/")
       ensure
         FileUtils.rm_f('checksums.txt')
       end

--- a/src/ruby/nativedebug/README.md
+++ b/src/ruby/nativedebug/README.md
@@ -19,10 +19,10 @@ for example, a lot of information will initially be missing.
 
 ## Download Location
 
-**Version 1.79.0+**: Download from GCS (exceeds RubyGems 500MB limit)
+**Version 1.79.0 and above**: Download from GCS (exceeds RubyGems 500MB limit)
 
 ```bash
-VERSION=1.79.1  # your grpc version
+VERSION=1.79.0  # your grpc version
 PLATFORM=x86_64-linux  # or x86-linux
 
 # Download gem

--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -174,8 +174,10 @@ if [[ -d "$INPUT_NATIVE_DEBUG_DIR" ]]; then
       exit 1
     fi
 
-    gsutil -m cp -n "$local_stage"/* "$GCS_NATIVE_DEBUG/v$GRPC_VERSION/"
-    echo "Uploaded Ruby native debug gems to $GCS_NATIVE_DEBUG/v$GRPC_VERSION/"
+    if ! gsutil -m cp -n "$local_stage"/* "$GCS_NATIVE_DEBUG/v$GRPC_VERSION/"; then
+      echo "Error: Failed to upload native debug rubygems to $GCS_NATIVE_DEBUG/v$GRPC_VERSION/"
+      exit 1
+    fi
 
     rm -rf "$local_stage"
   else

--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -34,8 +34,6 @@ GCS_ROOT=gs://packages.grpc.io/
 GCS_ARCHIVE_PREFIX=archive/
 GCS_ARCHIVE_ROOT=$GCS_ROOT$GCS_ARCHIVE_PREFIX
 GCS_INDEX=$GCS_ROOT$INDEX_FILENAME
-GCS_NATIVE_DEBUG=${GCS_ROOT}grpc-ruby-native-debug-symbols
-INPUT_NATIVE_DEBUG_DIR=${INPUT_ARTIFACTS}/ruby-native-debug-symbols
 
 LOCAL_STAGING_TEMPDIR=$(mktemp -d)
 LOCAL_BUILD_ROOT=$LOCAL_STAGING_TEMPDIR/$BUILD_RELPATH
@@ -155,35 +153,6 @@ EOF
 </build>
 EOF
 }> "$LOCAL_BUILD_INDEX"
-
-if [[ -d "$INPUT_NATIVE_DEBUG_DIR" ]]; then
-  debug_gems=("$INPUT_NATIVE_DEBUG_DIR"/grpc-native-debug-*.gem)
-
-  if [[ ${#debug_gems[@]} -gt 0 ]]; then
-    echo "Found ${#debug_gems[@]} Ruby native debug gems to upload."
-    local_stage="$(mktemp -d)"
-    cp "${debug_gems[@]}" "$local_stage/"
-
-    (
-      cd "$local_stage"
-      sha256sum ./*.gem > checksums.txt
-    )
-
-    if [[ ! -f "$local_stage/checksums.txt" ]]; then
-      echo "Error: checksums generation failed." >&2
-      exit 1
-    fi
-
-    if ! gsutil -m cp -n "$local_stage"/* "$GCS_NATIVE_DEBUG/v$GRPC_VERSION/"; then
-      echo "Error: Failed to upload native debug rubygems to $GCS_NATIVE_DEBUG/v$GRPC_VERSION/"
-      exit 1
-    fi
-
-    rm -rf "$local_stage"
-  else
-    echo "No Ruby native debug gems found to upload."
-  fi
-fi
 
 LOCAL_BUILD_INDEX_SIZE=$(stat -c%s "$LOCAL_BUILD_INDEX")
 LOCAL_BUILD_INDEX_SHA256=$(openssl sha256 -r "$LOCAL_BUILD_INDEX" | cut -d " " -f 1)


### PR DESCRIPTION
This PR fixes native debug gem upload issue that didn't happen after the following PR:
https://github.com/grpc/grpc/pull/41270

The PR missed copying native-debug gem to the corresponding directory after it was built. Current PR addresses it.

