### PR TITLE
ossfuzz: add service_config_fuzzer for JSON service config parser

### DIFF
--- a/test/core/service_config/service_config_fuzzer.cc
+++ b/test/core/service_config/service_config_fuzzer.cc
@@ -1,0 +1,39 @@
+// grpc_service_config_fuzzer.cc
+//
+// Fuzz target for gRPC service config parser.
+// gRPC clients accept a JSON service config string (from DNS TXT records,
+// or xDS management servers) that controls:
+//   - method configs (timeout, wait_for_ready, max_req/resp size, retry)
+//   - load balancing policy selection and parameters
+//   - health checking, message size limits
+//
+// None of these JSON parsers are currently covered by OSS-Fuzz.
+// The entry point is ServiceConfigImpl::Create() in
+// src/core/service_config/service_config_impl.cc.
+//
+// A bug in the JSON parser or method config deserialisation could allow
+// a malicious resolver (DNS rebinding, compromised xDS server) to cause
+// heap corruption or DoS in gRPC clients.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+
+#include "absl/strings/string_view.h"
+#include "src/core/service_config/service_config_impl.h"
+#include "src/core/util/ref_counted_ptr.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    std::string json_str(reinterpret_cast<const char *>(data), size);
+
+    // ParseJsonServiceConfig validates and parses the JSON service config
+    // exercising: JSON tokeniser, method config parser, LB policy parser,
+    // retry policy, timeout parsing, and the registered config parsers for
+    // each gRPC channel policy (round_robin, pick_first, weighted_round_robin,
+    // ring_hash, xds_cluster_impl, etc.)
+    grpc_core::ServiceConfigImpl::Create(
+        grpc_core::ChannelArgs(), json_str).IgnoreError();
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

gRPC clients accept a JSON **service config** string from DNS TXT records or xDS management servers, controlling method configs, load-balancing policy, retry policy, timeout, and message-size limits. The entry point `ServiceConfigImpl::Create()` in `src/core/service_config/service_config_impl.cc` has **no OSS-Fuzz coverage**.

## Affected code paths

- `src/core/service_config/service_config_impl.cc` – top-level JSON parsing
- `src/core/client_channel/client_channel_service_config.cc` – method config (timeout, wait_for_ready, retry)
- `src/core/client_channel/retry_service_config.cc` – retry policy deserialiser
- `src/core/transport/message_size_service_config.cc` – max_req/resp_size
- `src/core/ext/filters/rbac/rbac_service_config_parser.cc` – RBAC policy

## New harness: `test/core/service_config/service_config_fuzzer.cc`

Treats fuzz input as a JSON string and calls `ServiceConfigImpl::Create(ChannelArgs(), json_str)`, exercising all registered config parsers. A malicious resolver (DNS rebinding, compromised xDS server) feeding a crafted service config could trigger heap corruption or DoS.
