### PR TITLE
[authz] don't pass RBAC policy by value when constructing authorization engine

### DIFF
--- a/include/grpc/grpc_audit_logging.h
+++ b/include/grpc/grpc_audit_logging.h
@@ -78,11 +78,11 @@ class AuditLoggerFactory {
   virtual ~AuditLoggerFactory() = default;
   virtual absl::string_view name() const = 0;
 
-  virtual absl::StatusOr<std::unique_ptr<Config>> ParseAuditLoggerConfig(
+  virtual absl::StatusOr<std::shared_ptr<const Config>> ParseAuditLoggerConfig(
       const Json& json) = 0;
 
   virtual std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>) = 0;
+      std::shared_ptr<const Config> config) = 0;
 };
 
 // Registers an audit logger factory. This should only be called during

--- a/src/core/ext/filters/rbac/rbac_service_config_parser.cc
+++ b/src/core/ext/filters/rbac/rbac_service_config_parser.cc
@@ -205,7 +205,8 @@ struct RbacConfig {
       std::map<std::string, Policy> policies;
       // Defaults to kNone since its json field is optional.
       Rbac::AuditCondition audit_condition = Rbac::AuditCondition::kNone;
-      std::vector<std::unique_ptr<AuditLoggerFactory::Config>> logger_configs;
+      std::vector<std::shared_ptr<const AuditLoggerFactory::Config>>
+          logger_configs;
 
       Rules() {}
       Rules(const Rules&) = delete;

--- a/src/core/lib/security/authorization/audit_logging.cc
+++ b/src/core/lib/security/authorization/audit_logging.cc
@@ -62,7 +62,7 @@ bool AuditLoggerRegistry::FactoryExists(absl::string_view name) {
          registry->logger_factories_map_.end();
 }
 
-absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
 AuditLoggerRegistry::ParseConfig(absl::string_view name, const Json& json) {
   MutexLock lock(mu);
   auto it = registry->logger_factories_map_.find(name);
@@ -74,7 +74,7 @@ AuditLoggerRegistry::ParseConfig(absl::string_view name, const Json& json) {
 }
 
 std::unique_ptr<AuditLogger> AuditLoggerRegistry::CreateAuditLogger(
-    std::unique_ptr<AuditLoggerFactory::Config> config) {
+    std::shared_ptr<const AuditLoggerFactory::Config> config) {
   MutexLock lock(mu);
   auto it = registry->logger_factories_map_.find(config->name());
   GRPC_CHECK(it != registry->logger_factories_map_.end());

--- a/src/core/lib/security/authorization/audit_logging.h
+++ b/src/core/lib/security/authorization/audit_logging.h
@@ -36,17 +36,17 @@ namespace experimental {
 
 class AuditLoggerRegistry {
  public:
-  static void RegisterFactory(std::unique_ptr<AuditLoggerFactory>);
+  static void RegisterFactory(std::unique_ptr<AuditLoggerFactory> factory);
 
   static bool FactoryExists(absl::string_view name);
 
-  static absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+  static absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
   ParseConfig(absl::string_view name, const Json& json);
 
   // This assume the given config is parsed and validated already.
   // Therefore, it should always succeed in creating a logger.
   static std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>);
+      std::shared_ptr<const AuditLoggerFactory::Config> config);
 
   // Factories are registered during initialization. They should never be
   // unregistered since they will be looked up at any time till the program

--- a/src/core/lib/security/authorization/grpc_authorization_engine.cc
+++ b/src/core/lib/security/authorization/grpc_authorization_engine.cc
@@ -44,20 +44,18 @@ bool ShouldLog(const Decision& decision,
 
 }  // namespace
 
-GrpcAuthorizationEngine::GrpcAuthorizationEngine(Rbac policy)
-    : name_(std::move(policy.name)),
-      action_(policy.action),
-      audit_condition_(policy.audit_condition) {
-  for (auto& sub_policy : policy.policies) {
-    Policy policy;
-    policy.name = sub_policy.first;
-    policy.matcher = std::make_unique<PolicyAuthorizationMatcher>(
-        std::move(sub_policy.second));
-    policies_.push_back(std::move(policy));
+GrpcAuthorizationEngine::GrpcAuthorizationEngine(const Rbac& rbac)
+    : name_(rbac.name),
+      action_(rbac.action),
+      audit_condition_(rbac.audit_condition) {
+  for (auto& [name, policy] : rbac.policies) {
+    auto& engine_policy = policies_.emplace_back();
+    engine_policy.name = name;
+    engine_policy.matcher =
+        std::make_unique<PolicyAuthorizationMatcher>(policy);
   }
-  for (auto& logger_config : policy.logger_configs) {
-    auto logger =
-        AuditLoggerRegistry::CreateAuditLogger(std::move(logger_config));
+  for (const auto& logger_config : rbac.logger_configs) {
+    auto logger = AuditLoggerRegistry::CreateAuditLogger(logger_config);
     GRPC_CHECK(logger != nullptr);
     audit_loggers_.push_back(std::move(logger));
   }

--- a/src/core/lib/security/authorization/grpc_authorization_engine.h
+++ b/src/core/lib/security/authorization/grpc_authorization_engine.h
@@ -44,7 +44,7 @@ class GrpcAuthorizationEngine : public AuthorizationEngine {
   explicit GrpcAuthorizationEngine(Rbac::Action action)
       : action_(action), audit_condition_(Rbac::AuditCondition::kNone) {}
   // Builds GrpcAuthorizationEngine with allow/deny RBAC policy.
-  explicit GrpcAuthorizationEngine(const Rbac& policy);
+  explicit GrpcAuthorizationEngine(const Rbac& rbac);
 
   GrpcAuthorizationEngine(GrpcAuthorizationEngine&& other) noexcept;
   GrpcAuthorizationEngine& operator=(GrpcAuthorizationEngine&& other) noexcept;

--- a/src/core/lib/security/authorization/grpc_authorization_engine.h
+++ b/src/core/lib/security/authorization/grpc_authorization_engine.h
@@ -44,7 +44,7 @@ class GrpcAuthorizationEngine : public AuthorizationEngine {
   explicit GrpcAuthorizationEngine(Rbac::Action action)
       : action_(action), audit_condition_(Rbac::AuditCondition::kNone) {}
   // Builds GrpcAuthorizationEngine with allow/deny RBAC policy.
-  explicit GrpcAuthorizationEngine(Rbac policy);
+  explicit GrpcAuthorizationEngine(const Rbac& policy);
 
   GrpcAuthorizationEngine(GrpcAuthorizationEngine&& other) noexcept;
   GrpcAuthorizationEngine& operator=(GrpcAuthorizationEngine&& other) noexcept;

--- a/src/core/lib/security/authorization/matchers.cc
+++ b/src/core/lib/security/authorization/matchers.cc
@@ -30,13 +30,13 @@
 namespace grpc_core {
 
 std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
-    Rbac::Permission permission) {
+    const Rbac::Permission& permission) {
   switch (permission.type) {
     case Rbac::Permission::RuleType::kAnd: {
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
       matchers.reserve(permission.permissions.size());
       for (const auto& rule : permission.permissions) {
-        matchers.push_back(AuthorizationMatcher::Create(std::move(*rule)));
+        matchers.push_back(AuthorizationMatcher::Create(*rule));
       }
       return std::make_unique<AndAuthorizationMatcher>(std::move(matchers));
     }
@@ -44,43 +44,43 @@ std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
       matchers.reserve(permission.permissions.size());
       for (const auto& rule : permission.permissions) {
-        matchers.push_back(AuthorizationMatcher::Create(std::move(*rule)));
+        matchers.push_back(AuthorizationMatcher::Create(*rule));
       }
       return std::make_unique<OrAuthorizationMatcher>(std::move(matchers));
     }
     case Rbac::Permission::RuleType::kNot:
       return std::make_unique<NotAuthorizationMatcher>(
-          AuthorizationMatcher::Create(std::move(*permission.permissions[0])));
+          AuthorizationMatcher::Create(*permission.permissions[0]));
     case Rbac::Permission::RuleType::kAny:
       return std::make_unique<AlwaysAuthorizationMatcher>();
     case Rbac::Permission::RuleType::kHeader:
       return std::make_unique<HeaderAuthorizationMatcher>(
-          std::move(permission.header_matcher));
+          permission.header_matcher);
     case Rbac::Permission::RuleType::kPath:
       return std::make_unique<PathAuthorizationMatcher>(
-          std::move(permission.string_matcher));
+          permission.string_matcher);
     case Rbac::Permission::RuleType::kDestIp:
       return std::make_unique<IpAuthorizationMatcher>(
-          IpAuthorizationMatcher::Type::kDestIp, std::move(permission.ip));
+          IpAuthorizationMatcher::Type::kDestIp, permission.ip);
     case Rbac::Permission::RuleType::kDestPort:
       return std::make_unique<PortAuthorizationMatcher>(permission.port);
     case Rbac::Permission::RuleType::kMetadata:
       return std::make_unique<MetadataAuthorizationMatcher>(permission.invert);
     case Rbac::Permission::RuleType::kReqServerName:
       return std::make_unique<ReqServerNameAuthorizationMatcher>(
-          std::move(permission.string_matcher));
+          permission.string_matcher);
   }
   return nullptr;
 }
 
 std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
-    Rbac::Principal principal) {
+    const Rbac::Principal& principal) {
   switch (principal.type) {
     case Rbac::Principal::RuleType::kAnd: {
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
       matchers.reserve(principal.principals.size());
       for (const auto& id : principal.principals) {
-        matchers.push_back(AuthorizationMatcher::Create(std::move(*id)));
+        matchers.push_back(AuthorizationMatcher::Create(*id));
       }
       return std::make_unique<AndAuthorizationMatcher>(std::move(matchers));
     }
@@ -88,34 +88,33 @@ std::unique_ptr<AuthorizationMatcher> AuthorizationMatcher::Create(
       std::vector<std::unique_ptr<AuthorizationMatcher>> matchers;
       matchers.reserve(principal.principals.size());
       for (const auto& id : principal.principals) {
-        matchers.push_back(AuthorizationMatcher::Create(std::move(*id)));
+        matchers.push_back(AuthorizationMatcher::Create(*id));
       }
       return std::make_unique<OrAuthorizationMatcher>(std::move(matchers));
     }
     case Rbac::Principal::RuleType::kNot:
       return std::make_unique<NotAuthorizationMatcher>(
-          AuthorizationMatcher::Create(std::move(*principal.principals[0])));
+          AuthorizationMatcher::Create(*principal.principals[0]));
     case Rbac::Principal::RuleType::kAny:
       return std::make_unique<AlwaysAuthorizationMatcher>();
     case Rbac::Principal::RuleType::kPrincipalName:
       return std::make_unique<AuthenticatedAuthorizationMatcher>(
-          std::move(principal.string_matcher));
+          principal.string_matcher);
     case Rbac::Principal::RuleType::kSourceIp:
       return std::make_unique<IpAuthorizationMatcher>(
-          IpAuthorizationMatcher::Type::kSourceIp, std::move(principal.ip));
+          IpAuthorizationMatcher::Type::kSourceIp, principal.ip);
     case Rbac::Principal::RuleType::kDirectRemoteIp:
       return std::make_unique<IpAuthorizationMatcher>(
-          IpAuthorizationMatcher::Type::kDirectRemoteIp,
-          std::move(principal.ip));
+          IpAuthorizationMatcher::Type::kDirectRemoteIp, principal.ip);
     case Rbac::Principal::RuleType::kRemoteIp:
       return std::make_unique<IpAuthorizationMatcher>(
-          IpAuthorizationMatcher::Type::kRemoteIp, std::move(principal.ip));
+          IpAuthorizationMatcher::Type::kRemoteIp, principal.ip);
     case Rbac::Principal::RuleType::kHeader:
       return std::make_unique<HeaderAuthorizationMatcher>(
-          std::move(principal.header_matcher));
+          principal.header_matcher);
     case Rbac::Principal::RuleType::kPath:
       return std::make_unique<PathAuthorizationMatcher>(
-          std::move(principal.string_matcher.value()));
+          principal.string_matcher.value());
     case Rbac::Principal::RuleType::kMetadata:
       return std::make_unique<MetadataAuthorizationMatcher>(principal.invert);
   }
@@ -150,7 +149,8 @@ bool HeaderAuthorizationMatcher::Matches(const EvaluateArgs& args) const {
       args.GetHeaderValue(matcher_.name(), &concatenated_value));
 }
 
-IpAuthorizationMatcher::IpAuthorizationMatcher(Type type, Rbac::CidrRange range)
+IpAuthorizationMatcher::IpAuthorizationMatcher(Type type,
+                                               const Rbac::CidrRange& range)
     : type_(type), prefix_len_(range.prefix_len) {
   auto address =
       StringToSockaddr(range.address_prefix, 0);  // Port does not matter here.

--- a/src/core/lib/security/authorization/matchers.h
+++ b/src/core/lib/security/authorization/matchers.h
@@ -42,12 +42,12 @@ class AuthorizationMatcher {
   // Creates an instance of a matcher based off the rules defined in Permission
   // config.
   static std::unique_ptr<AuthorizationMatcher> Create(
-      Rbac::Permission permission);
+      const Rbac::Permission& permission);
 
   // Creates an instance of a matcher based off the rules defined in Principal
   // config.
   static std::unique_ptr<AuthorizationMatcher> Create(
-      Rbac::Principal principal);
+      const Rbac::Principal& principal);
 };
 
 class AlwaysAuthorizationMatcher : public AuthorizationMatcher {
@@ -113,8 +113,8 @@ class MetadataAuthorizationMatcher : public AuthorizationMatcher {
 // Perform a match against HTTP headers.
 class HeaderAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit HeaderAuthorizationMatcher(HeaderMatcher matcher)
-      : matcher_(std::move(matcher)) {}
+  explicit HeaderAuthorizationMatcher(const HeaderMatcher& matcher)
+      : matcher_(matcher) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
@@ -132,7 +132,7 @@ class IpAuthorizationMatcher : public AuthorizationMatcher {
     kRemoteIp,
   };
 
-  IpAuthorizationMatcher(Type type, Rbac::CidrRange range);
+  IpAuthorizationMatcher(Type type, const Rbac::CidrRange& range);
 
   bool Matches(const EvaluateArgs& args) const override;
 
@@ -158,8 +158,9 @@ class PortAuthorizationMatcher : public AuthorizationMatcher {
 // or DNS SAN in that order, otherwise uses subject field.
 class AuthenticatedAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit AuthenticatedAuthorizationMatcher(std::optional<StringMatcher> auth)
-      : matcher_(std::move(auth)) {}
+  explicit AuthenticatedAuthorizationMatcher(
+      const std::optional<StringMatcher>& auth)
+      : matcher_(auth) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
@@ -172,8 +173,8 @@ class AuthenticatedAuthorizationMatcher : public AuthorizationMatcher {
 class ReqServerNameAuthorizationMatcher : public AuthorizationMatcher {
  public:
   explicit ReqServerNameAuthorizationMatcher(
-      StringMatcher requested_server_name)
-      : matcher_(std::move(requested_server_name)) {}
+      const StringMatcher& requested_server_name)
+      : matcher_(requested_server_name) {}
 
   bool Matches(const EvaluateArgs&) const override;
 
@@ -184,8 +185,8 @@ class ReqServerNameAuthorizationMatcher : public AuthorizationMatcher {
 // Perform a match against the path header of HTTP request.
 class PathAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit PathAuthorizationMatcher(StringMatcher path)
-      : matcher_(std::move(path)) {}
+  explicit PathAuthorizationMatcher(const StringMatcher& path)
+      : matcher_(path) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 
@@ -198,11 +199,9 @@ class PathAuthorizationMatcher : public AuthorizationMatcher {
 // of its permissions and a match in one of its principals.
 class PolicyAuthorizationMatcher : public AuthorizationMatcher {
  public:
-  explicit PolicyAuthorizationMatcher(Rbac::Policy policy)
-      : permissions_(
-            AuthorizationMatcher::Create(std::move(policy.permissions))),
-        principals_(
-            AuthorizationMatcher::Create(std::move(policy.principals))) {}
+  explicit PolicyAuthorizationMatcher(const Rbac::Policy& policy)
+      : permissions_(AuthorizationMatcher::Create(policy.permissions)),
+        principals_(AuthorizationMatcher::Create(policy.principals)) {}
 
   bool Matches(const EvaluateArgs& args) const override;
 

--- a/src/core/lib/security/authorization/rbac_policy.h
+++ b/src/core/lib/security/authorization/rbac_policy.h
@@ -183,7 +183,7 @@ struct Rbac {
   std::map<std::string, Policy> policies;
 
   AuditCondition audit_condition;
-  std::vector<std::unique_ptr<experimental::AuditLoggerFactory::Config>>
+  std::vector<std::shared_ptr<const experimental::AuditLoggerFactory::Config>>
       logger_configs;
 };
 

--- a/src/core/lib/security/authorization/rbac_translator.cc
+++ b/src/core/lib/security/authorization/rbac_translator.cc
@@ -354,7 +354,7 @@ absl::StatusOr<Rbac> ParseAllowRulesArray(const Json& json,
               std::move(policies_or.value()));
 }
 
-absl::StatusOr<std::unique_ptr<experimental::AuditLoggerFactory::Config>>
+absl::StatusOr<std::shared_ptr<const experimental::AuditLoggerFactory::Config>>
 ParseAuditLogger(const Json& json, size_t pos) {
   if (json.type() != Json::Type::kObject) {
     return absl::InvalidArgumentError(
@@ -460,12 +460,11 @@ absl::Status ParseAuditLoggingOptions(const Json& json, RbacPolicies* rbacs) {
         }
         // Check the value since the unsupported logger config can also
         // return ok when marked as optional.
-        if (result.value() != nullptr) {
+        if (*result != nullptr) {
           // Only move the logger config over if audit condition is not NONE.
           if (rbacs->allow_policy.audit_condition !=
               Rbac::AuditCondition::kNone) {
-            rbacs->allow_policy.logger_configs.push_back(
-                std::move(result.value()));
+            rbacs->allow_policy.logger_configs.push_back(std::move(*result));
           }
           if (rbacs->deny_policy.has_value() &&
               rbacs->deny_policy->audit_condition !=
@@ -474,8 +473,7 @@ absl::Status ParseAuditLoggingOptions(const Json& json, RbacPolicies* rbacs) {
             // this time.
             auto result = ParseAuditLogger(loggers.at(i), i);
             GRPC_CHECK(result.ok());
-            rbacs->deny_policy->logger_configs.push_back(
-                std::move(result.value()));
+            rbacs->deny_policy->logger_configs.push_back(std::move(*result));
           }
         }
       }

--- a/src/core/lib/security/authorization/stdout_logger.cc
+++ b/src/core/lib/security/authorization/stdout_logger.cc
@@ -57,13 +57,13 @@ std::string StdoutAuditLoggerFactory::Config::ToString() const { return "{}"; }
 
 absl::string_view StdoutAuditLoggerFactory::name() const { return kName; }
 
-absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
 StdoutAuditLoggerFactory::ParseAuditLoggerConfig(const Json&) {
-  return std::make_unique<StdoutAuditLoggerFactory::Config>();
+  return std::make_shared<StdoutAuditLoggerFactory::Config>();
 }
 
 std::unique_ptr<AuditLogger> StdoutAuditLoggerFactory::CreateAuditLogger(
-    std::unique_ptr<AuditLoggerFactory::Config> config) {
+    std::shared_ptr<const AuditLoggerFactory::Config> config) {
   // Sanity check.
   GRPC_CHECK(config != nullptr);
   GRPC_CHECK_EQ(config->name(), name());

--- a/src/core/lib/security/authorization/stdout_logger.h
+++ b/src/core/lib/security/authorization/stdout_logger.h
@@ -28,30 +28,31 @@
 namespace grpc_core {
 namespace experimental {
 
-class StdoutAuditLogger : public AuditLogger {
+class StdoutAuditLogger final : public AuditLogger {
  public:
   StdoutAuditLogger() = default;
   absl::string_view name() const override { return "stdout_logger"; }
   void Log(const AuditContext&) override;
 };
 
-class StdoutAuditLoggerFactory : public AuditLoggerFactory {
+class StdoutAuditLoggerFactory final : public AuditLoggerFactory {
  public:
-  class Config : public AuditLoggerFactory::Config {
+  class Config final : public AuditLoggerFactory::Config {
    public:
     Config() = default;
     absl::string_view name() const override;
     std::string ToString() const override;
   };
+
   StdoutAuditLoggerFactory() = default;
 
   absl::string_view name() const override;
 
-  absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+  absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
   ParseAuditLoggerConfig(const Json& json) override;
 
   std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>) override;
+      std::shared_ptr<const AuditLoggerFactory::Config> config) override;
 };
 
 }  // namespace experimental

--- a/test/core/ext/filters/rbac/rbac_service_config_parser_test.cc
+++ b/test/core/ext/filters/rbac/rbac_service_config_parser_test.cc
@@ -69,7 +69,7 @@ class TestAuditLoggerFactory : public AuditLoggerFactory {
       std::map<absl::string_view, std::string>* configs)
       : configs_(configs) {}
   absl::string_view name() const override { return kLoggerName; }
-  absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+  absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
   ParseAuditLoggerConfig(const Json& json) override {
     // Invalidate configs with "bad" field in it.
     if (json.object().find("bad") != json.object().end()) {
@@ -78,7 +78,7 @@ class TestAuditLoggerFactory : public AuditLoggerFactory {
     return std::make_unique<Config>(json);
   }
   std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config> config) override {
+      std::shared_ptr<const AuditLoggerFactory::Config> config) override {
     // Only insert entry to the map when logger is created.
     configs_->emplace(name(), config->ToString());
     return std::make_unique<TestAuditLogger>();

--- a/test/core/security/grpc_audit_logging_test.cc
+++ b/test/core/security/grpc_audit_logging_test.cc
@@ -65,12 +65,12 @@ class TestAuditLoggerFactory : public AuditLoggerFactory {
 
   absl::string_view name() const override { return kName; }
   std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>) override {
+      std::shared_ptr<const AuditLoggerFactory::Config>) override {
     return std::make_unique<TestAuditLogger>();
   }
-  absl::StatusOr<std::unique_ptr<Config>> ParseAuditLoggerConfig(
+  absl::StatusOr<std::shared_ptr<const Config>> ParseAuditLoggerConfig(
       const Json&) override {
-    return std::make_unique<TestConfig>();
+    return std::make_shared<TestConfig>();
   }
 };
 

--- a/test/core/security/rbac_translator_test.cc
+++ b/test/core/security/rbac_translator_test.cc
@@ -82,16 +82,16 @@ class TestAuditLoggerFactory : public AuditLoggerFactory {
     std::string config_dump_;
   };
   absl::string_view name() const override { return kLoggerName; }
-  absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+  absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
   ParseAuditLoggerConfig(const Json& json) override {
     // Config with a field "bad" will be considered invalid.
     if (json.object().find("bad") != json.object().end()) {
       return absl::InvalidArgumentError("bad logger config.");
     }
-    return std::make_unique<TestAuditLoggerConfig>(JsonDump(json));
+    return std::make_shared<TestAuditLoggerConfig>(JsonDump(json));
   }
   std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>) override {
+      std::shared_ptr<const AuditLoggerFactory::Config>) override {
     // This test target should never need to create a logger.
     Crash("unreachable");
     return nullptr;

--- a/test/core/test_util/audit_logging_utils.cc
+++ b/test/core/test_util/audit_logging_utils.cc
@@ -60,13 +60,13 @@ absl::string_view TestAuditLoggerFactory::Config::name() const {
 
 absl::string_view TestAuditLoggerFactory::name() const { return kLoggerName; }
 
-absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
 TestAuditLoggerFactory::ParseAuditLoggerConfig(const Json&) {
   return std::make_unique<Config>();
 }
 
 std::unique_ptr<AuditLogger> TestAuditLoggerFactory::CreateAuditLogger(
-    std::unique_ptr<AuditLoggerFactory::Config>) {
+    std::shared_ptr<const AuditLoggerFactory::Config>) {
   return std::make_unique<TestAuditLogger>(audit_logs_);
 }
 

--- a/test/core/test_util/audit_logging_utils.h
+++ b/test/core/test_util/audit_logging_utils.h
@@ -54,10 +54,10 @@ class TestAuditLoggerFactory : public experimental::AuditLoggerFactory {
       : audit_logs_(audit_logs) {}
 
   absl::string_view name() const override;
-  absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+  absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
   ParseAuditLoggerConfig(const experimental::Json&) override;
   std::unique_ptr<experimental::AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>) override;
+      std::shared_ptr<const AuditLoggerFactory::Config>) override;
 
  private:
   std::vector<std::string>* audit_logs_;

--- a/test/core/xds/xds_audit_logger_registry_test.cc
+++ b/test/core/xds/xds_audit_logger_registry_test.cc
@@ -80,7 +80,7 @@ absl::StatusOr<std::string> ConvertAuditLoggerConfig(
 class TestAuditLoggerFactory : public AuditLoggerFactory {
  public:
   absl::string_view name() const override { return kName; }
-  absl::StatusOr<std::unique_ptr<AuditLoggerFactory::Config>>
+  absl::StatusOr<std::shared_ptr<const AuditLoggerFactory::Config>>
   ParseAuditLoggerConfig(const Json& json) override {
     if (json.object().find("bad") != json.object().end()) {
       return absl::InvalidArgumentError("invalid test_logger config");
@@ -88,7 +88,7 @@ class TestAuditLoggerFactory : public AuditLoggerFactory {
     return nullptr;
   }
   std::unique_ptr<AuditLogger> CreateAuditLogger(
-      std::unique_ptr<AuditLoggerFactory::Config>) override {
+      std::shared_ptr<const AuditLoggerFactory::Config>) override {
     Crash("unreachable");
     return nullptr;
   }


### PR DESCRIPTION
Change `GrpcAuthorizationEngine` to take a const reference to the RBAC policy and copy the fields it needs out of that policy, rather than taking it by value and moving fields out of it.  This paves the way for some changes that will pass in the RBAC policy from a shared config object that cannot be modified.

As part of this, change `AuditLoggerFactory` API to use shared_ptr instead of unique_ptr for audit logger configs.  This is a public API, but an experimental one, and it's unlikely that many people are using it.