### PR TITLE
[Python] Handle _InactiveRpcError pytorch exception wrapper edge case

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -380,6 +380,15 @@ class _InactiveRpcError(grpc.RpcError, grpc.Call, grpc.Future):
     _state: _RPCState
 
     def __init__(self, state: _RPCState):
+        if not isinstance(state, _RPCState):
+            # Handles exception wrapping edge-cases.
+            # See https://github.com/grpc/grpc/issues/38713 and
+            # https://github.com/pytorch/pytorch/issues/34130.
+            msg = "Inactive RPC Error: Invalid RPC state type."
+            if isinstance(state, str):
+                msg = f"{msg} Details: {state}"
+            state = _RPCState((), (), (), grpc.StatusCode.INTERNAL, state)
+
         with state.condition:
             self._state = _RPCState(
                 (),

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -387,7 +387,7 @@ class _InactiveRpcError(grpc.RpcError, grpc.Call, grpc.Future):
             msg = "Inactive RPC Error: Invalid RPC state type."
             if isinstance(state, str):
                 msg = f"{msg} Details: {state}"
-            state = _RPCState((), (), (), grpc.StatusCode.INTERNAL, state)
+            state = _RPCState((), (), (), grpc.StatusCode.INTERNAL, msg)
 
         with state.condition:
             self._state = _RPCState(


### PR DESCRIPTION
Handle an edge case where `_channel._InactiveRpcError` is wrapped by an application (or a third-party framework), and the wrapper incorrectly assumes it'll be possible to initialize and reraise it later with a string "message" argument.

Pytorch's exception wrapper results in `AttributeError: 'str' object has no attribute 'condition'`, see https://github.com/pytorch/pytorch/issues/34130.

Fixes #38713. Details in https://github.com/grpc/grpc/issues/38713#issuecomment-4679005990.