### PR TITLE
[Python] Add authority accessor to servicer context

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1136,6 +1136,15 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def experimental_authority(self) -> str:
+        """Accesses the host (:authority) sent by the client
+
+        Returns:
+          The :authority header of the RPC.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def peer(self):
         """Identifies the peer that invoked the RPC being serviced.
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pxd.pxi
@@ -38,6 +38,7 @@ cdef class RPCState(GrpcCallWrapper):
 
     cdef bytes method(self)
     cdef tuple invocation_metadata(self)
+    cdef bytes experimental_authority(self)
     cdef void raise_for_termination(self) except *
     cdef int get_write_flag(self)
     cdef Operation create_send_initial_metadata_op_if_not_sent(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/server.pyx.pxi
@@ -68,6 +68,9 @@ cdef class RPCState:
     cdef tuple invocation_metadata(self):
         return _metadata(&self.request_metadata)
 
+    cdef bytes experimental_authority(self):
+        return _slice_bytes(self.details.host)
+
     cdef void raise_for_termination(self) except *:
         """Raise exceptions if RPC is not running.
 
@@ -213,6 +216,9 @@ cdef class _ServicerContext:
     def invocation_metadata(self):
         return self._rpc_state.invocation_metadata()
 
+    def experimental_authority(self):
+        return self._rpc_state.experimental_authority().decode('utf-8')
+
     def set_code(self, object code):
         self._rpc_state.status_code = get_status_code(code)
         self._rpc_state.py_status_code = code
@@ -319,6 +325,9 @@ cdef class _SyncServicerContext:
 
     def invocation_metadata(self):
         return self._context.invocation_metadata()
+
+    def experimental_authority(self):
+        return self._context.experimental_authority()
 
     def set_code(self, object code):
         self._context.set_code(code)

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -400,6 +400,9 @@ class _Context(grpc.ServicerContext):
     def invocation_metadata(self) -> Optional[MetadataType]:
         return self._rpc_event.invocation_metadata
 
+    def experimental_authority(self) -> str:
+        return self._rpc_event.call_details.host.decode('utf-8')
+
     def peer(self) -> str:
         return _common.decode(self._rpc_event.call.peer())
 

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -236,6 +236,14 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         """
 
     @abc.abstractmethod
+    def experimental_authority(self) -> str:
+        """Accesses the host (:authority) sent by the client
+
+        Returns:
+          The :authority header of the RPC.
+        """
+
+    @abc.abstractmethod
     def set_code(self, code: grpc.StatusCode) -> None:
         """Sets the value to be used as status code upon RPC completion.
 

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -63,6 +63,7 @@
   "tests.unit._dynamic_stubs_test.DynamicStubTest",
   "tests.unit._empty_message_test.EmptyMessageTest",
   "tests.unit._error_message_encoding_test.ErrorMessageEncodingTest",
+  "tests.unit._experimental_authority_test.TestExperimentalAuthority",
   "tests.unit._exit_test.ExitTest",
   "tests.unit._grpc_shutdown_test.GrpcShutdownTest",
   "tests.unit._absl_log_test.AbslLogTest",

--- a/src/python/grpcio_tests/tests/unit/_experimental_authority_test.py
+++ b/src/python/grpcio_tests/tests/unit/_experimental_authority_test.py
@@ -1,0 +1,63 @@
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests exposure of the :authority header on synchronous servers."""
+
+import logging
+import unittest
+
+import grpc
+from concurrent import futures
+
+_REQUEST = b"\x01" * 100
+_TEST_UNARY_UNARY = "/test/TestUnaryUnary"
+
+def _test_unary_unary(
+        unused_request: bytes, servicer_context: grpc.ServicerContext
+):
+    return servicer_context.experimental_authority().encode('utf-8')
+
+_ROUTING_TABLE = {
+    _TEST_UNARY_UNARY: grpc.unary_unary_rpc_method_handler(_test_unary_unary),
+}
+
+class _GenericHandler(grpc.GenericRpcHandler):
+    def service(self, handler_call_details):
+        return _ROUTING_TABLE.get(handler_call_details.method)
+
+def _start_test_server(options=None):
+    server = grpc.server(futures.ThreadPoolExecutor())
+    port = server.add_insecure_port("[::]:0")
+    server.add_generic_rpc_handlers((_GenericHandler(),))
+    server.start()
+    return f"localhost:{port}", server
+
+class TestExperimentalAuthority(unittest.TestCase):
+    def setUp(self):
+        self._address, self._server = _start_test_server()
+        self._channel = grpc.insecure_channel(self._address)
+
+    def tearDown(self):
+        self._channel.close()
+        self._server.stop(None)
+
+    def test_experimental_authority(self):
+        multicallable = self._channel.unary_unary(_TEST_UNARY_UNARY)
+        response = multicallable(_REQUEST)
+        self.assertEqual(self._address, response.decode('utf-8'))
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    unittest.main(verbosity=2)
+

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -31,6 +31,7 @@
   "tests_aio.unit.context_peer_test.TestContextPeer",
   "tests_aio.unit.done_callback_test.TestClientSideDoneCallback",
   "tests_aio.unit.done_callback_test.TestServerSideDoneCallback",
+  "tests_aio.unit.experimental_authority_test.TestExperimentalAuthority",
   "tests_aio.unit.init_test.TestInit",
   "tests_aio.unit.metadata_test.TestMetadata",
   "tests_aio.unit.outside_init_test.TestOutsideInit",

--- a/src/python/grpcio_tests/tests_aio/unit/experimental_authority_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/experimental_authority_test.py
@@ -1,0 +1,65 @@
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests exposure of the :authority header on asynchronous servers."""
+
+import logging
+import unittest
+
+import grpc
+from grpc.experimental import aio
+
+from tests_aio.unit._test_base import AioTestBase
+
+_REQUEST = b"\x01" * 100
+_TEST_UNARY_UNARY = "/test/TestUnaryUnary"
+
+async def _test_unary_unary(
+        unused_request: bytes, servicer_context: aio.ServicerContext
+):
+    return servicer_context.experimental_authority().encode('utf-8')
+
+_ROUTING_TABLE = {
+    _TEST_UNARY_UNARY: grpc.unary_unary_rpc_method_handler(_test_unary_unary),
+}
+
+class _GenericHandler(grpc.GenericRpcHandler):
+    def service(self, handler_call_details):
+        return _ROUTING_TABLE.get(handler_call_details.method)
+
+async def _start_test_server(options=None):
+    server = aio.server(options=options)
+    port = server.add_insecure_port("[::]:0")
+    server.add_generic_rpc_handlers((_GenericHandler(),))
+    await server.start()
+    return f"localhost:{port}", server
+
+class TestExperimentalAuthority(AioTestBase):
+    async def setUp(self):
+        self._address, self._server = await _start_test_server()
+        self._channel = aio.insecure_channel(self._address)
+
+    async def tearDown(self):
+        await self._channel.close()
+        await self._server.stop(None)
+
+    async def test_experimental_authority(self):
+        multicallable = self._channel.unary_unary(_TEST_UNARY_UNARY)
+        response = await multicallable(_REQUEST)
+        self.assertEqual(self._address, response.decode('utf-8'))
+
+
+if __name__ == "__main__":
+    logging.basicConfig()
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
Fixes #38906

Description
This change exposes :authority on Python server-side ServicerContext, allowing service handlers to access the target hostname used by the client when making a RPC.
This is implemented for both sync and async server. The sync implementation reads `self._rpc_event.call_details.host`, where `call_details` is the Python wrapper around the underlying C struct. For async, implementation reads from `self.details.host` on RPCState, which holds the raw `grpc_call_details` C struct.

Other info:
- Named method `experimental_authority` since the C++ api mentioned from the ticket used it. I saw the decorator `@experimental_api` used in the codebase but not anywhere near where I placed my changes, so didn't include the decorator.
- The tests checks against the authority derived from channel target only, reason being there isn't a way for Python client-side users to set authority as mentioned in ticket 27520.

