### PR TITLE
Upgrade rules_swift 2.5.0 → 3.6.1 for Bazel 9 compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,12 +22,7 @@ module(
 # Regular dependencies
 # ====================
 
-# TODO(weizheyuan): Check if this version bump is still needed for BCR
-# releases after we drop bazel 7 supprot.
-#
-# Upgrade version of rules_swift to avoid an error in BCR CI of not
-# finding switfc.exe on Windows with bazel 7.
-bazel_dep(name = "rules_swift", version = "2.5.0")
+bazel_dep(name = "rules_swift", version = "3.6.1")
 
 # -- Abseil library.
 # Pinning version to be consistent with third_party/abseil-cpp

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,12 +78,6 @@ system_pip_parse(
     },
 )
 
-http_archive(
-    name = "build_bazel_rules_swift",
-    sha256 = "bf2861de6bf75115288468f340b0c4609cc99cc1ccc7668f0f71adfd853eedb3",
-    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.7.1/rules_swift.1.7.1.tar.gz",
-)
-
 load(
     "@build_bazel_apple_support//lib:repositories.bzl",
     "apple_support_dependencies",

--- a/templates/MODULE.bazel.inja
+++ b/templates/MODULE.bazel.inja
@@ -22,12 +22,7 @@ module(
 # Regular dependencies
 # ====================
 
-# TODO(weizheyuan): Check if this version bump is still needed for BCR
-# releases after we drop bazel 7 supprot.
-#
-# Upgrade version of rules_swift to avoid an error in BCR CI of not
-# finding switfc.exe on Windows with bazel 7.
-bazel_dep(name = "rules_swift", version = "2.5.0")
+bazel_dep(name = "rules_swift", version = "3.6.1")
 
 # -- Abseil library.
 # Pinning version to be consistent with third_party/abseil-cpp


### PR DESCRIPTION
rules_swift 2.5.0 declares `compatibility_level = 2`, which conflicts with Bazel 9's `bazel_tools` requiring rules_swift 3.x (`compatibility_level = 3`).

### Changes
- Bump `rules_swift` from 2.5.0 to 3.6.1 in `MODULE.bazel` and `templates/MODULE.bazel.inja`
- Remove the stale Bazel 7 workaround comment (the TODO and switfc.exe note are no longer relevant)
- Remove the stale `http_archive` for rules_swift 1.7.1 from `WORKSPACE` (now provided via Bzlmod)

rules_swift 3.6.1 is compatible with Bazel 7.x, 8.x, and 9.x LTS.