### PR TITLE
[xDS] restructure RouteConfig filter chain builder to support multiple VirtualHosts

### DIFF
--- a/src/core/resolver/xds/xds_resolver.cc
+++ b/src/core/resolver/xds/xds_resolver.cc
@@ -443,14 +443,15 @@ void XdsResolver::RouteConfigData::BuildFilterChains(
             XdsRouteConfigResource::Route::RouteAction::ClusterWeight>>(
             &route_action->action);
         weighted_clusters != nullptr) {
-      vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-          route_entry.route,
-          [&](size_t index,
-              absl::StatusOr<RefCountedPtr<const FilterChain>> filter_chain) {
-            GRPC_CHECK_LT(index, route_entry.weighted_cluster_state.size());
-            route_entry.weighted_cluster_state[index].filter_chain =
-                std::move(filter_chain);
-          });
+      auto weighted_cluster_builder =
+          vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(
+              route_entry.route);
+      for (size_t i = 0; i < weighted_clusters->size(); ++i) {
+        GRPC_CHECK_LT(i, route_entry.weighted_cluster_state.size());
+        route_entry.weighted_cluster_state[i].filter_chain =
+            weighted_cluster_builder.BuildFilterChainForClusterWeight(
+                (*weighted_clusters)[i]);
+      }
     }
     // If the route does not use WeightedClusters, then we generate a
     // filter chain for the route.

--- a/src/core/resolver/xds/xds_resolver.cc
+++ b/src/core/resolver/xds/xds_resolver.cc
@@ -423,12 +423,14 @@ void XdsResolver::RouteConfigData::BuildFilterChains(
     FilterChainBuilder& builder, Blackboard& blackboard) {
   const auto& hcm = std::get<XdsListenerResource::HttpConnectionManager>(
       xds_config.listener->listener);
-  XdsRouting::PerRouteFilterChainBuilder per_route_builder(
-      hcm.http_filters, http_filter_registry, *xds_config.virtual_host, builder,
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm.http_filters, http_filter_registry, builder,
       [](FilterChainBuilder& builder) {
         builder.AddFilter<ClusterSelectionFilter>(nullptr);
       },
       blackboard);
+  auto vhost_builder = route_config_builder.MakeVirtualHostFilterChainBuilder(
+      *xds_config.virtual_host);
   // Set the filter chain for each route.
   for (auto& route_entry : routes_) {
     const auto* route_action =
@@ -441,7 +443,7 @@ void XdsResolver::RouteConfigData::BuildFilterChains(
             XdsRouteConfigResource::Route::RouteAction::ClusterWeight>>(
             &route_action->action);
         weighted_clusters != nullptr) {
-      per_route_builder.BuildFilterChainForRouteWithWeightedClusters(
+      vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
           route_entry.route,
           [&](size_t index,
               absl::StatusOr<RefCountedPtr<const FilterChain>> filter_chain) {
@@ -454,7 +456,7 @@ void XdsResolver::RouteConfigData::BuildFilterChains(
     // filter chain for the route.
     else {
       route_entry.filter_chain =
-          per_route_builder.BuildFilterChainForRoute(route_entry.route);
+          vhost_builder.BuildFilterChainForRoute(route_entry.route);
     }
   }
 }

--- a/src/core/xds/grpc/xds_routing.cc
+++ b/src/core/xds/grpc/xds_routing.cc
@@ -190,16 +190,14 @@ std::optional<absl::string_view> XdsRouting::GetHeaderValue(
   return initial_metadata->GetStringValue(header_name, concatenated_value);
 }
 
-XdsRouting::PerRouteFilterChainBuilder::PerRouteFilterChainBuilder(
+XdsRouting::RouteConfigFilterChainBuilder::RouteConfigFilterChainBuilder(
     const std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>&
         hcm_filter_configs,
     const XdsHttpFilterRegistry& http_filter_registry,
-    const XdsRouteConfigResource::VirtualHost& vhost,
     FilterChainBuilder& builder,
     absl::AnyInvocable<void(FilterChainBuilder&)> add_last_filter,
     Blackboard& blackboard)
     : hcm_filter_configs_(hcm_filter_configs),
-      vhost_(vhost),
       builder_(builder),
       add_last_filter_(std::move(add_last_filter)),
       blackboard_(blackboard) {
@@ -214,6 +212,32 @@ XdsRouting::PerRouteFilterChainBuilder::PerRouteFilterChainBuilder(
     // Add filter to list.
     filter_impls_.push_back(filter_impl);
   }
+}
+
+absl::StatusOr<RefCountedPtr<const FilterChain>>
+XdsRouting::RouteConfigFilterChainBuilder::GetDefaultFilterChain() {
+  if (default_filter_chain_.ok() && *default_filter_chain_ == nullptr) {
+    GRPC_TRACE_LOG(xds_resolver, INFO) << "Building default filter chain:";
+    for (size_t i = 0; i < filter_impls_.size(); ++i) {
+      auto* filter_impl = filter_impls_[i];
+      const auto& filter_config = hcm_filter_configs_[i];
+      RefCountedPtr<const FilterConfig> config;
+      if (filter_config.filter_config != nullptr) {
+        config = filter_impl->MergeConfigs(filter_config.filter_config,
+                                           nullptr, nullptr, nullptr,
+                                           blackboard_);
+      }
+      GRPC_TRACE_LOG(xds_resolver, INFO)
+          << "  Adding filter=" << filter_config.name
+          << " config=" << (config == nullptr ? "<null>" : config->ToString());
+      filter_impl->AddFilter(builder_, std::move(config));
+    }
+    if (add_last_filter_ != nullptr) add_last_filter_(builder_);
+    default_filter_chain_ = builder_.Build();
+    GRPC_TRACE_LOG(xds_resolver, INFO)
+        << "Filter chain creation status: " << default_filter_chain_.status();
+  }
+  return default_filter_chain_;
 }
 
 namespace {
@@ -233,44 +257,51 @@ RefCountedPtr<const FilterConfig> GetOverrideConfig(
 }  // namespace
 
 absl::StatusOr<RefCountedPtr<const FilterChain>>
-XdsRouting::PerRouteFilterChainBuilder::GetDefaultFilterChain() {
-  if (default_filter_chain_.ok() && *default_filter_chain_ == nullptr) {
-    GRPC_TRACE_LOG(xds_resolver, INFO) << "Building default filter chain:";
-    for (size_t i = 0; i < filter_impls_.size(); ++i) {
-      auto* filter_impl = filter_impls_[i];
-      const auto& filter_config = hcm_filter_configs_[i];
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::GetVirtualHostFilterChain() {
+  if (vhost_filter_chain_.ok() && *vhost_filter_chain_ == nullptr) {
+    // If there are no per-vhost overrides, use the default filter chain.
+    if (vhost_.typed_per_filter_config.empty()) {
+      return route_config_builder_.GetDefaultFilterChain();
+    }
+    GRPC_TRACE_LOG(xds_resolver, INFO) << "Building virtual host filter chain:";
+    for (size_t i = 0; i < route_config_builder_.filter_impls_.size(); ++i) {
+      auto* filter_impl = route_config_builder_.filter_impls_[i];
+      const auto& filter_config = route_config_builder_.hcm_filter_configs_[i];
       RefCountedPtr<const FilterConfig> config;
       if (filter_config.filter_config != nullptr) {
         auto vhost_override_config = GetOverrideConfig(
             filter_impl, vhost_.typed_per_filter_config, filter_config.name);
         config = filter_impl->MergeConfigs(filter_config.filter_config,
                                            std::move(vhost_override_config),
-                                           nullptr, nullptr, blackboard_);
+                                           nullptr, nullptr,
+                                           route_config_builder_.blackboard_);
       }
       GRPC_TRACE_LOG(xds_resolver, INFO)
           << "  Adding filter=" << filter_config.name
           << " config=" << (config == nullptr ? "<null>" : config->ToString());
-      filter_impl->AddFilter(builder_, std::move(config));
+      filter_impl->AddFilter(route_config_builder_.builder_, std::move(config));
     }
-    if (add_last_filter_ != nullptr) add_last_filter_(builder_);
-    default_filter_chain_ = builder_.Build();
+    if (route_config_builder_.add_last_filter_ != nullptr) {
+      route_config_builder_.add_last_filter_(route_config_builder_.builder_);
+    }
+    vhost_filter_chain_ = route_config_builder_.builder_.Build();
     GRPC_TRACE_LOG(xds_resolver, INFO)
-        << "Filter chain creation status: " << default_filter_chain_.status();
+        << "Filter chain creation status: " << vhost_filter_chain_.status();
   }
-  return default_filter_chain_;
+  return vhost_filter_chain_;
 }
 
 absl::StatusOr<RefCountedPtr<const FilterChain>>
-XdsRouting::PerRouteFilterChainBuilder::BuildFilterChainForRoute(
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::BuildFilterChainForRoute(
     const XdsRouteConfigResource::Route& route) {
   GRPC_TRACE_LOG(xds_resolver, INFO)
       << "Building filter chain for route:" << route.ToString();
-  // If there are no per-route overrides, use the default filter chain.
-  if (route.typed_per_filter_config.empty()) return GetDefaultFilterChain();
+  // If there are no per-route overrides, use the vhost filter chain.
+  if (route.typed_per_filter_config.empty()) return GetVirtualHostFilterChain();
   // Otherwise, build a new filter chain for the route.
-  for (size_t i = 0; i < filter_impls_.size(); ++i) {
-    auto* filter_impl = filter_impls_[i];
-    const auto& filter_config = hcm_filter_configs_[i];
+  for (size_t i = 0; i < route_config_builder_.filter_impls_.size(); ++i) {
+    auto* filter_impl = route_config_builder_.filter_impls_[i];
+    const auto& filter_config = route_config_builder_.hcm_filter_configs_[i];
     RefCountedPtr<const FilterConfig> config;
     if (filter_config.filter_config != nullptr) {
       auto vhost_override_config = GetOverrideConfig(
@@ -279,22 +310,25 @@ XdsRouting::PerRouteFilterChainBuilder::BuildFilterChainForRoute(
           filter_impl, route.typed_per_filter_config, filter_config.name);
       config = filter_impl->MergeConfigs(
           filter_config.filter_config, std::move(vhost_override_config),
-          std::move(route_override_config), nullptr, blackboard_);
+          std::move(route_override_config), nullptr,
+          route_config_builder_.blackboard_);
     }
     GRPC_TRACE_LOG(xds_resolver, INFO)
         << "  Adding filter=" << filter_config.name
         << " config=" << (config == nullptr ? "<null>" : config->ToString());
-    filter_impl->AddFilter(builder_, std::move(config));
+    filter_impl->AddFilter(route_config_builder_.builder_, std::move(config));
   }
-  if (add_last_filter_ != nullptr) add_last_filter_(builder_);
+  if (route_config_builder_.add_last_filter_ != nullptr) {
+    route_config_builder_.add_last_filter_(route_config_builder_.builder_);
+  }
   absl::StatusOr<RefCountedPtr<const FilterChain>> route_filter_chain =
-      builder_.Build();
+      route_config_builder_.builder_.Build();
   GRPC_TRACE_LOG(xds_resolver, INFO)
       << "Filter chain creation status: " << route_filter_chain.status();
   return route_filter_chain;
 }
 
-void XdsRouting::PerRouteFilterChainBuilder::
+void XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::
     BuildFilterChainForRouteWithWeightedClusters(
         const XdsRouteConfigResource::Route& route,
         absl::FunctionRef<
@@ -321,9 +355,9 @@ void XdsRouting::PerRouteFilterChainBuilder::
       GRPC_TRACE_LOG(xds_resolver, INFO)
           << "Building filter chain for route:" << route.ToString()
           << " ClusterWeight:" << cluster_weight.ToString();
-      for (size_t i = 0; i < filter_impls_.size(); ++i) {
-        auto* filter_impl = filter_impls_[i];
-        const auto& filter_config = hcm_filter_configs_[i];
+      for (size_t i = 0; i < route_config_builder_.filter_impls_.size(); ++i) {
+        auto* filter_impl = route_config_builder_.filter_impls_[i];
+        const auto& filter_config = route_config_builder_.hcm_filter_configs_[i];
         RefCountedPtr<const FilterConfig> config;
         if (filter_config.filter_config != nullptr) {
           auto vhost_override_config = GetOverrideConfig(
@@ -336,15 +370,18 @@ void XdsRouting::PerRouteFilterChainBuilder::
           config = filter_impl->MergeConfigs(
               filter_config.filter_config, std::move(vhost_override_config),
               std::move(route_override_config),
-              std::move(cluster_weight_override_config), blackboard_);
+              std::move(cluster_weight_override_config),
+              route_config_builder_.blackboard_);
         }
         GRPC_TRACE_LOG(xds_resolver, INFO)
             << "  Adding filter=" << filter_config.name << " config="
             << (config == nullptr ? "<null>" : config->ToString());
-        filter_impl->AddFilter(builder_, std::move(config));
+        filter_impl->AddFilter(route_config_builder_.builder_, std::move(config));
       }
-      if (add_last_filter_ != nullptr) add_last_filter_(builder_);
-      auto filter_chain = builder_.Build();
+      if (route_config_builder_.add_last_filter_ != nullptr) {
+        route_config_builder_.add_last_filter_(route_config_builder_.builder_);
+      }
+      auto filter_chain = route_config_builder_.builder_.Build();
       GRPC_TRACE_LOG(xds_resolver, INFO)
           << "Filter chain creation status: " << filter_chain.status();
       set_filter_chain_for_cluster_weight(j, std::move(filter_chain));

--- a/src/core/xds/grpc/xds_routing.cc
+++ b/src/core/xds/grpc/xds_routing.cc
@@ -328,65 +328,58 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::BuildF
   return route_filter_chain;
 }
 
-void XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::
-    BuildFilterChainForRouteWithWeightedClusters(
-        const XdsRouteConfigResource::Route& route,
-        absl::FunctionRef<
-            void(size_t, absl::StatusOr<RefCountedPtr<const FilterChain>>)>
-            set_filter_chain_for_cluster_weight) {
-  // If any cluster weight does not have any filter config overrides,
-  // we'll reuse the route-level filter chain.  We construct it lazily
-  // and cache it so that we never construct it more than we need to.
-  absl::StatusOr<RefCountedPtr<const FilterChain>> route_filter_chain = nullptr;
-  const auto& route_action =
-      std::get<XdsRouteConfigResource::Route::RouteAction>(route.action);
-  const auto& cluster_weights = std::get<
-      std::vector<XdsRouteConfigResource::Route::RouteAction::ClusterWeight>>(
-      route_action.action);
-  for (size_t j = 0; j < cluster_weights.size(); ++j) {
-    const auto& cluster_weight = cluster_weights[j];
-    if (cluster_weight.typed_per_filter_config.empty()) {
-      // No per-ClusterWeight overrides, so use the route-level filter chain.
-      if (route_filter_chain.ok() && *route_filter_chain == nullptr) {
-        route_filter_chain = BuildFilterChainForRoute(route);
-      }
-      set_filter_chain_for_cluster_weight(j, route_filter_chain);
-    } else {
-      GRPC_TRACE_LOG(xds_resolver, INFO)
-          << "Building filter chain for route:" << route.ToString()
-          << " ClusterWeight:" << cluster_weight.ToString();
-      for (size_t i = 0; i < route_config_builder_.filter_impls_.size(); ++i) {
-        auto* filter_impl = route_config_builder_.filter_impls_[i];
-        const auto& filter_config = route_config_builder_.hcm_filter_configs_[i];
-        RefCountedPtr<const FilterConfig> config;
-        if (filter_config.filter_config != nullptr) {
-          auto vhost_override_config = GetOverrideConfig(
-              filter_impl, vhost_.typed_per_filter_config, filter_config.name);
-          auto route_override_config = GetOverrideConfig(
-              filter_impl, route.typed_per_filter_config, filter_config.name);
-          auto cluster_weight_override_config = GetOverrideConfig(
-              filter_impl, cluster_weight.typed_per_filter_config,
-              filter_config.name);
-          config = filter_impl->MergeConfigs(
-              filter_config.filter_config, std::move(vhost_override_config),
-              std::move(route_override_config),
-              std::move(cluster_weight_override_config),
-              route_config_builder_.blackboard_);
-        }
-        GRPC_TRACE_LOG(xds_resolver, INFO)
-            << "  Adding filter=" << filter_config.name << " config="
-            << (config == nullptr ? "<null>" : config->ToString());
-        filter_impl->AddFilter(route_config_builder_.builder_, std::move(config));
-      }
-      if (route_config_builder_.add_last_filter_ != nullptr) {
-        route_config_builder_.add_last_filter_(route_config_builder_.builder_);
-      }
-      auto filter_chain = route_config_builder_.builder_.Build();
-      GRPC_TRACE_LOG(xds_resolver, INFO)
-          << "Filter chain creation status: " << filter_chain.status();
-      set_filter_chain_for_cluster_weight(j, std::move(filter_chain));
-    }
+absl::StatusOr<RefCountedPtr<const FilterChain>>
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::WeightedClusterRouteFilterChainBuilder::GetRouteFilterChain() {
+  if (route_filter_chain_.ok() && *route_filter_chain_ == nullptr) {
+    route_filter_chain_ = vhost_builder_.BuildFilterChainForRoute(route_);
   }
+  return route_filter_chain_;
+}
+
+absl::StatusOr<RefCountedPtr<const FilterChain>>
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::WeightedClusterRouteFilterChainBuilder::BuildFilterChainForClusterWeight(
+    const XdsRouteConfigResource::Route::RouteAction::ClusterWeight&
+        cluster_weight) {
+  GRPC_TRACE_LOG(xds_resolver, INFO)
+      << "Building filter chain for route:" << route_.ToString()
+      << " ClusterWeight:" << cluster_weight.ToString();
+  // If there are no per-ClusterWeight overrides, use the route filter chain.
+  if (cluster_weight.typed_per_filter_config.empty()) {
+    return GetRouteFilterChain();
+  }
+  // Otherwise, build a new filter chain for the ClusterWeight.
+  auto& route_config_builder = vhost_builder_.route_config_builder_;
+  for (size_t i = 0; i < route_config_builder.filter_impls_.size(); ++i) {
+    auto* filter_impl = route_config_builder.filter_impls_[i];
+    const auto& filter_config = route_config_builder.hcm_filter_configs_[i];
+    RefCountedPtr<const FilterConfig> config;
+    if (filter_config.filter_config != nullptr) {
+      auto vhost_override_config = GetOverrideConfig(
+          filter_impl, vhost_builder_.vhost_.typed_per_filter_config,
+          filter_config.name);
+      auto route_override_config = GetOverrideConfig(
+          filter_impl, route_.typed_per_filter_config, filter_config.name);
+      auto cluster_weight_override_config = GetOverrideConfig(
+          filter_impl, cluster_weight.typed_per_filter_config,
+          filter_config.name);
+      config = filter_impl->MergeConfigs(
+          filter_config.filter_config, std::move(vhost_override_config),
+          std::move(route_override_config),
+          std::move(cluster_weight_override_config),
+          route_config_builder.blackboard_);
+    }
+    GRPC_TRACE_LOG(xds_resolver, INFO)
+        << "  Adding filter=" << filter_config.name << " config="
+        << (config == nullptr ? "<null>" : config->ToString());
+    filter_impl->AddFilter(route_config_builder.builder_, std::move(config));
+  }
+  if (route_config_builder.add_last_filter_ != nullptr) {
+    route_config_builder.add_last_filter_(route_config_builder.builder_);
+  }
+  auto filter_chain = route_config_builder.builder_.Build();
+  GRPC_TRACE_LOG(xds_resolver, INFO)
+      << "Filter chain creation status: " << filter_chain.status();
+  return filter_chain;
 }
 
 namespace {

--- a/src/core/xds/grpc/xds_routing.cc
+++ b/src/core/xds/grpc/xds_routing.cc
@@ -223,9 +223,8 @@ XdsRouting::RouteConfigFilterChainBuilder::GetDefaultFilterChain() {
       const auto& filter_config = hcm_filter_configs_[i];
       RefCountedPtr<const FilterConfig> config;
       if (filter_config.filter_config != nullptr) {
-        config = filter_impl->MergeConfigs(filter_config.filter_config,
-                                           nullptr, nullptr, nullptr,
-                                           blackboard_);
+        config = filter_impl->MergeConfigs(filter_config.filter_config, nullptr,
+                                           nullptr, nullptr, blackboard_);
       }
       GRPC_TRACE_LOG(xds_resolver, INFO)
           << "  Adding filter=" << filter_config.name
@@ -257,7 +256,8 @@ RefCountedPtr<const FilterConfig> GetOverrideConfig(
 }  // namespace
 
 absl::StatusOr<RefCountedPtr<const FilterChain>>
-XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::GetVirtualHostFilterChain() {
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::
+    GetVirtualHostFilterChain() {
   if (vhost_filter_chain_.ok() && *vhost_filter_chain_ == nullptr) {
     // If there are no per-vhost overrides, use the default filter chain.
     if (vhost_.typed_per_filter_config.empty()) {
@@ -271,10 +271,9 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::GetVir
       if (filter_config.filter_config != nullptr) {
         auto vhost_override_config = GetOverrideConfig(
             filter_impl, vhost_.typed_per_filter_config, filter_config.name);
-        config = filter_impl->MergeConfigs(filter_config.filter_config,
-                                           std::move(vhost_override_config),
-                                           nullptr, nullptr,
-                                           route_config_builder_.blackboard_);
+        config = filter_impl->MergeConfigs(
+            filter_config.filter_config, std::move(vhost_override_config),
+            nullptr, nullptr, route_config_builder_.blackboard_);
       }
       GRPC_TRACE_LOG(xds_resolver, INFO)
           << "  Adding filter=" << filter_config.name
@@ -292,8 +291,8 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::GetVir
 }
 
 absl::StatusOr<RefCountedPtr<const FilterChain>>
-XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::BuildFilterChainForRoute(
-    const XdsRouteConfigResource::Route& route) {
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::
+    BuildFilterChainForRoute(const XdsRouteConfigResource::Route& route) {
   GRPC_TRACE_LOG(xds_resolver, INFO)
       << "Building filter chain for route:" << route.ToString();
   // If there are no per-route overrides, use the vhost filter chain.
@@ -329,7 +328,8 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::BuildF
 }
 
 absl::StatusOr<RefCountedPtr<const FilterChain>>
-XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::WeightedClusterRouteFilterChainBuilder::GetRouteFilterChain() {
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::
+    WeightedClusterRouteFilterChainBuilder::GetRouteFilterChain() {
   if (route_filter_chain_.ok() && *route_filter_chain_ == nullptr) {
     route_filter_chain_ = vhost_builder_.BuildFilterChainForRoute(route_);
   }
@@ -337,9 +337,10 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::Weight
 }
 
 absl::StatusOr<RefCountedPtr<const FilterChain>>
-XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::WeightedClusterRouteFilterChainBuilder::BuildFilterChainForClusterWeight(
-    const XdsRouteConfigResource::Route::RouteAction::ClusterWeight&
-        cluster_weight) {
+XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::
+    WeightedClusterRouteFilterChainBuilder::BuildFilterChainForClusterWeight(
+        const XdsRouteConfigResource::Route::RouteAction::ClusterWeight&
+            cluster_weight) {
   GRPC_TRACE_LOG(xds_resolver, INFO)
       << "Building filter chain for route:" << route_.ToString()
       << " ClusterWeight:" << cluster_weight.ToString();
@@ -359,9 +360,9 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::Weight
           filter_config.name);
       auto route_override_config = GetOverrideConfig(
           filter_impl, route_.typed_per_filter_config, filter_config.name);
-      auto cluster_weight_override_config = GetOverrideConfig(
-          filter_impl, cluster_weight.typed_per_filter_config,
-          filter_config.name);
+      auto cluster_weight_override_config =
+          GetOverrideConfig(filter_impl, cluster_weight.typed_per_filter_config,
+                            filter_config.name);
       config = filter_impl->MergeConfigs(
           filter_config.filter_config, std::move(vhost_override_config),
           std::move(route_override_config),
@@ -369,8 +370,8 @@ XdsRouting::RouteConfigFilterChainBuilder::VirtualHostFilterChainBuilder::Weight
           route_config_builder.blackboard_);
     }
     GRPC_TRACE_LOG(xds_resolver, INFO)
-        << "  Adding filter=" << filter_config.name << " config="
-        << (config == nullptr ? "<null>" : config->ToString());
+        << "  Adding filter=" << filter_config.name
+        << " config=" << (config == nullptr ? "<null>" : config->ToString());
     filter_impl->AddFilter(route_config_builder.builder_, std::move(config));
   }
   if (route_config_builder.add_last_filter_ != nullptr) {

--- a/src/core/xds/grpc/xds_routing.h
+++ b/src/core/xds/grpc/xds_routing.h
@@ -93,6 +93,32 @@ class XdsRouting final {
     // Builds filter chains for each route within a VirtualHost.
     class VirtualHostFilterChainBuilder {
      public:
+      // Builds filter chains for each ClusterWeight within a route.
+      class WeightedClusterRouteFilterChainBuilder {
+       public:
+        WeightedClusterRouteFilterChainBuilder(
+            VirtualHostFilterChainBuilder& vhost_builder,
+            const XdsRouteConfigResource::Route& route)
+            : vhost_builder_(vhost_builder), route_(route) {}
+
+        // Builds a filter chain for a ClusterWeight.
+        absl::StatusOr<RefCountedPtr<const FilterChain>>
+        BuildFilterChainForClusterWeight(
+            const XdsRouteConfigResource::Route::RouteAction::ClusterWeight&
+                cluster_weight);
+
+       private:
+        absl::StatusOr<RefCountedPtr<const FilterChain>> GetRouteFilterChain();
+
+        VirtualHostFilterChainBuilder& vhost_builder_;
+        const XdsRouteConfigResource::Route& route_;
+
+        // Cached filter chain for the route, to be used for any ClusterWeight
+        // that does not have any filter config overrides.
+        absl::StatusOr<RefCountedPtr<const FilterChain>> route_filter_chain_ =
+            nullptr;
+      };
+
       VirtualHostFilterChainBuilder(
           RouteConfigFilterChainBuilder& route_config_builder,
           const XdsRouteConfigResource::VirtualHost& vhost)
@@ -103,14 +129,12 @@ class XdsRouting final {
       absl::StatusOr<RefCountedPtr<const FilterChain>> BuildFilterChainForRoute(
           const XdsRouteConfigResource::Route& route);
 
-      // Builds a filter chain for a route that uses WeightedClusters.
-      // The set_filter_chain_for_cluster_weight() function will be called
-      // once for each index in the WeightedClusters list.
-      void BuildFilterChainForRouteWithWeightedClusters(
-          const XdsRouteConfigResource::Route& route,
-          absl::FunctionRef<
-              void(size_t, absl::StatusOr<RefCountedPtr<const FilterChain>>)>
-              set_filter_chain_for_cluster_weight);
+      // Returns a filter chain builder for a given virtual host.
+      WeightedClusterRouteFilterChainBuilder
+      MakeWeightedClusterRouteFilterChainBuilder(
+          const XdsRouteConfigResource::Route& route) {
+        return WeightedClusterRouteFilterChainBuilder(*this, route);
+      }
 
      private:
       absl::StatusOr<RefCountedPtr<const FilterChain>>

--- a/src/core/xds/grpc/xds_routing.h
+++ b/src/core/xds/grpc/xds_routing.h
@@ -80,49 +80,74 @@ class XdsRouting final {
       grpc_metadata_batch* initial_metadata, absl::string_view header_name,
       std::string* concatenated_value);
 
-  // Logic for building a filter chain for a given route.  Caching is
-  // done to avoid unnecessary work while iterating over the list of
-  // routes in a given VirtualHost.
+  // Logic for building filter chains for each route within a
+  // RouteConfiguration.  Caching is done to avoid unnecessary work while
+  // iterating over the list of routes.
   //
   // TODO(roth): Currently, this class uses the xds_resolver tracer for
   // logging.  When we change the server side to use the new filter
   // config structure, add a new tracer and use that instead, so that it
   // can be used on both the client and server side.
-  class PerRouteFilterChainBuilder {
+  class RouteConfigFilterChainBuilder {
    public:
+    // Builds filter chains for each route within a VirtualHost.
+    class VirtualHostFilterChainBuilder {
+     public:
+      VirtualHostFilterChainBuilder(
+          RouteConfigFilterChainBuilder& route_config_builder,
+          const XdsRouteConfigResource::VirtualHost& vhost)
+          : route_config_builder_(route_config_builder), vhost_(vhost) {}
+
+      // Builds a filter chain for a route that has an individual cluster
+      // or a ClusterSpecifierPlugin.
+      absl::StatusOr<RefCountedPtr<const FilterChain>> BuildFilterChainForRoute(
+          const XdsRouteConfigResource::Route& route);
+
+      // Builds a filter chain for a route that uses WeightedClusters.
+      // The set_filter_chain_for_cluster_weight() function will be called
+      // once for each index in the WeightedClusters list.
+      void BuildFilterChainForRouteWithWeightedClusters(
+          const XdsRouteConfigResource::Route& route,
+          absl::FunctionRef<
+              void(size_t, absl::StatusOr<RefCountedPtr<const FilterChain>>)>
+              set_filter_chain_for_cluster_weight);
+
+     private:
+      absl::StatusOr<RefCountedPtr<const FilterChain>>
+      GetVirtualHostFilterChain();
+
+      RouteConfigFilterChainBuilder& route_config_builder_;
+      const XdsRouteConfigResource::VirtualHost& vhost_;
+
+      // Cached filter chain for the virtual host, to be used for any route
+      // that does not have any filter config overrides.
+      absl::StatusOr<RefCountedPtr<const FilterChain>> vhost_filter_chain_ =
+          nullptr;
+    };
+
     // The add_last_filter() callback is called on the builder after
     // adding all of the xDS HTTP filters and right before building the
     // filter chain.  May be null if not needed.
-    PerRouteFilterChainBuilder(
+    RouteConfigFilterChainBuilder(
         const std::vector<
             XdsListenerResource::HttpConnectionManager::HttpFilter>&
             hcm_filter_configs,
         const XdsHttpFilterRegistry& http_filter_registry,
-        const XdsRouteConfigResource::VirtualHost& vhost,
         FilterChainBuilder& builder,
         absl::AnyInvocable<void(FilterChainBuilder&)> add_last_filter,
         Blackboard& blackboard);
 
-    // Builds a filter chain for a route that has an individual cluster
-    // or a ClusterSpecifierPlugin.
-    absl::StatusOr<RefCountedPtr<const FilterChain>> BuildFilterChainForRoute(
-        const XdsRouteConfigResource::Route& route);
-
-    // Builds a filter chain for a route that uses WeightedClusters.
-    // The set_filter_chain_for_cluster_weight() function will be called
-    // once for each index in the WeightedClusters list.
-    void BuildFilterChainForRouteWithWeightedClusters(
-        const XdsRouteConfigResource::Route& route,
-        absl::FunctionRef<
-            void(size_t, absl::StatusOr<RefCountedPtr<const FilterChain>>)>
-            set_filter_chain_for_cluster_weight);
+    // Returns a filter chain builder for a given virtual host.
+    VirtualHostFilterChainBuilder MakeVirtualHostFilterChainBuilder(
+        const XdsRouteConfigResource::VirtualHost& vhost) {
+      return VirtualHostFilterChainBuilder(*this, vhost);
+    }
 
    private:
     absl::StatusOr<RefCountedPtr<const FilterChain>> GetDefaultFilterChain();
 
     const std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>&
         hcm_filter_configs_;
-    const XdsRouteConfigResource::VirtualHost& vhost_;
     FilterChainBuilder& builder_;
     absl::AnyInvocable<void(FilterChainBuilder&)> add_last_filter_;
     Blackboard& blackboard_;

--- a/src/core/xds/grpc/xds_routing.h
+++ b/src/core/xds/grpc/xds_routing.h
@@ -129,7 +129,8 @@ class XdsRouting final {
       absl::StatusOr<RefCountedPtr<const FilterChain>> BuildFilterChainForRoute(
           const XdsRouteConfigResource::Route& route);
 
-      // Returns a filter chain builder for a given virtual host.
+      // Returns a filter chain builder for a given route that uses
+      // WeightedClusters.
       WeightedClusterRouteFilterChainBuilder
       MakeWeightedClusterRouteFilterChainBuilder(
           const XdsRouteConfigResource::Route& route) {

--- a/test/core/xds/xds_routing_test.cc
+++ b/test/core/xds/xds_routing_test.cc
@@ -243,7 +243,7 @@ MATCHER_P(IsFilterChain, matcher, "") {
       result_listener);
 }
 
-class XdsPerRouteFilterChainBuilderTest : public ::testing::Test {
+class XdsRouteConfigFilterChainBuilderTest : public ::testing::Test {
  protected:
   void SetUp() override {
     registry_.RegisterFilter(std::make_unique<TestHttpFilter>());
@@ -333,29 +333,33 @@ class XdsPerRouteFilterChainBuilderTest : public ::testing::Test {
   RefCountedPtr<Blackboard> blackboard_;
 };
 
-TEST_F(XdsPerRouteFilterChainBuilderTest, BuildFilterChainForRouteNoOverrides) {
+TEST_F(XdsRouteConfigFilterChainBuilderTest, BuildFilterChainForRouteNoOverrides) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRoute();
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
-  auto filter_chain = chain_builder.BuildFilterChainForRoute(route);
+  auto filter_chain = vhost_builder.BuildFilterChainForRoute(route);
   EXPECT_THAT(filter_chain,
               IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
                   &TestFilter::kFilterVtable, "hcm/blackboard{hcm}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm"), "hcm");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteVirtualHostOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRoute();
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
-  auto filter_chain = chain_builder.BuildFilterChainForRoute(route);
+  auto filter_chain = vhost_builder.BuildFilterChainForRoute(route);
   EXPECT_THAT(
       filter_chain,
       IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
@@ -363,15 +367,17 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost"), "hcm+vhost");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteRouteOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRoute({{"filter1", MakeOverride("route")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
-  auto filter_chain = chain_builder.BuildFilterChainForRoute(route);
+  auto filter_chain = vhost_builder.BuildFilterChainForRoute(route);
   EXPECT_THAT(
       filter_chain,
       IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
@@ -379,15 +385,17 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
   EXPECT_EQ(GetBlackboardEntry("hcm+route"), "hcm+route");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteVirtualHostAndRouteOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRoute({{"filter1", MakeOverride("route")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
-  auto filter_chain = chain_builder.BuildFilterChainForRoute(route);
+  auto filter_chain = vhost_builder.BuildFilterChainForRoute(route);
   EXPECT_THAT(filter_chain,
               IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
                   &TestFilter::kFilterVtable,
@@ -395,17 +403,19 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+route"), "hcm+vhost+route");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteWithWeightedClustersNoOverrides) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route =
       MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(accumulator.filter_chains(),
               ::testing::ElementsAre(
@@ -414,17 +424,19 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
   EXPECT_EQ(GetBlackboardEntry("hcm"), "hcm");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteWithWeightedClustersVirtualHostOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route =
       MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(accumulator.filter_chains(),
               ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
@@ -433,18 +445,20 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost"), "hcm+vhost");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteWithWeightedClustersRouteOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route =
       MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)},
                                     {{"filter1", MakeOverride("route")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(accumulator.filter_chains(),
               ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
@@ -454,18 +468,20 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
 }
 
 TEST_F(
-    XdsPerRouteFilterChainBuilderTest,
+    XdsRouteConfigFilterChainBuilderTest,
     BuildFilterChainForRouteWithWeightedClustersVirtualHostAndRouteOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route =
       MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)},
                                     {{"filter1", MakeOverride("route")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(
       accumulator.filter_chains(),
@@ -475,17 +491,19 @@ TEST_F(
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+route"), "hcm+vhost+route");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest,
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
        BuildFilterChainForRouteWithWeightedClustersClusterWeightOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRouteWithWeightedClusters(
       {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(accumulator.filter_chains(),
               ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
@@ -495,17 +513,19 @@ TEST_F(XdsPerRouteFilterChainBuilderTest,
 }
 
 TEST_F(
-    XdsPerRouteFilterChainBuilderTest,
+    XdsRouteConfigFilterChainBuilderTest,
     BuildFilterChainForRouteWithWeightedClustersVirtualHostAndClusterWeightOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRouteWithWeightedClusters(
       {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(
       accumulator.filter_chains(),
@@ -516,18 +536,20 @@ TEST_F(
 }
 
 TEST_F(
-    XdsPerRouteFilterChainBuilderTest,
+    XdsRouteConfigFilterChainBuilderTest,
     BuildFilterChainForRouteWithWeightedClustersRouteAndClusterWeightOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRouteWithWeightedClusters(
       {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})},
       {{"filter1", MakeOverride("route")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(
       accumulator.filter_chains(),
@@ -538,18 +560,20 @@ TEST_F(
 }
 
 TEST_F(
-    XdsPerRouteFilterChainBuilderTest,
+    XdsRouteConfigFilterChainBuilderTest,
     BuildFilterChainForRouteWithWeightedClustersVirtualHostRouteAndClusterWeightOverride) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRouteWithWeightedClusters(
       {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})},
       {{"filter1", MakeOverride("route")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   EXPECT_THAT(accumulator.filter_chains(),
               ::testing::ElementsAre(
@@ -559,15 +583,17 @@ TEST_F(
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+route+cw"), "hcm+vhost+route+cw");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest, MultipleFilters) {
+TEST_F(XdsRouteConfigFilterChainBuilderTest, MultipleFilters) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm1"),
                      MakeHcmFilter("filter2", "hcm2")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost1")}});
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRoute({{"filter2", MakeOverride("route2")}});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
-  auto filter_chain = chain_builder.BuildFilterChainForRoute(route);
+  auto filter_chain = vhost_builder.BuildFilterChainForRoute(route);
   EXPECT_THAT(filter_chain,
               IsFilterChain(::testing::ElementsAre(
                   IsFilterAndConfig(&TestFilter::kFilterVtable,
@@ -578,16 +604,18 @@ TEST_F(XdsPerRouteFilterChainBuilderTest, MultipleFilters) {
   EXPECT_EQ(GetBlackboardEntry("hcm2+route2"), "hcm2+route2");
 }
 
-TEST_F(XdsPerRouteFilterChainBuilderTest, Caching) {
+TEST_F(XdsRouteConfigFilterChainBuilderTest, Caching) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
+  XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
+      hcm_filters, registry_, builder_, nullptr, *blackboard_);
   auto vhost = MakeVirtualHost();
+  auto vhost_builder =
+      route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
   auto route = MakeRouteWithWeightedClusters(
       {MakeClusterWeight("cluster0", 50), MakeClusterWeight("cluster1", 50)});
-  XdsRouting::PerRouteFilterChainBuilder chain_builder(
-      hcm_filters, registry_, vhost, builder_, nullptr, *blackboard_);
   WeightedClustersFilterChainAccumulator accumulator;
-  chain_builder.BuildFilterChainForRouteWithWeightedClusters(
+  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
       route, accumulator.GetCallback());
   ASSERT_EQ(accumulator.filter_chains().size(), 2);
   const auto& chain0 = accumulator.filter_chains()[0];

--- a/test/core/xds/xds_routing_test.cc
+++ b/test/core/xds/xds_routing_test.cc
@@ -301,7 +301,8 @@ class XdsRouteConfigFilterChainBuilderTest : public ::testing::Test {
   RefCountedPtr<Blackboard> blackboard_;
 };
 
-TEST_F(XdsRouteConfigFilterChainBuilderTest, BuildFilterChainForRouteNoOverrides) {
+TEST_F(XdsRouteConfigFilterChainBuilderTest,
+       BuildFilterChainForRouteNoOverrides) {
   std::vector<XdsListenerResource::HttpConnectionManager::HttpFilter>
       hcm_filters = {MakeHcmFilter("filter1", "hcm")};
   XdsRouting::RouteConfigFilterChainBuilder route_config_builder(
@@ -407,10 +408,10 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto cluster_weight = MakeClusterWeight("cluster1", 100);
   auto filter_chain =
       weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
-  EXPECT_THAT(filter_chain,
-              IsFilterChain(::testing::ElementsAre(
-                  IsFilterAndConfig(&TestFilter::kFilterVtable,
-                                    "hcm+vhost/blackboard{hcm+vhost}"))));
+  EXPECT_THAT(
+      filter_chain,
+      IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
+          &TestFilter::kFilterVtable, "hcm+vhost/blackboard{hcm+vhost}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost"), "hcm+vhost");
 }
 
@@ -429,10 +430,10 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto cluster_weight = MakeClusterWeight("cluster1", 100);
   auto filter_chain =
       weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
-  EXPECT_THAT(filter_chain,
-              IsFilterChain(::testing::ElementsAre(
-                  IsFilterAndConfig(&TestFilter::kFilterVtable,
-                                    "hcm+route/blackboard{hcm+route}"))));
+  EXPECT_THAT(
+      filter_chain,
+      IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
+          &TestFilter::kFilterVtable, "hcm+route/blackboard{hcm+route}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+route"), "hcm+route");
 }
 
@@ -452,11 +453,10 @@ TEST_F(
   auto cluster_weight = MakeClusterWeight("cluster1", 100);
   auto filter_chain =
       weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
-  EXPECT_THAT(
-      filter_chain,
-      IsFilterChain(::testing::ElementsAre(
-          IsFilterAndConfig(&TestFilter::kFilterVtable,
-                            "hcm+vhost+route/blackboard{hcm+vhost+route}"))));
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
+                  &TestFilter::kFilterVtable,
+                  "hcm+vhost+route/blackboard{hcm+vhost+route}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+route"), "hcm+vhost+route");
 }
 
@@ -477,9 +477,8 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto filter_chain =
       weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
   EXPECT_THAT(filter_chain,
-              IsFilterChain(::testing::ElementsAre(
-                  IsFilterAndConfig(&TestFilter::kFilterVtable,
-                                    "hcm+cw/blackboard{hcm+cw}"))));
+              IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
+                  &TestFilter::kFilterVtable, "hcm+cw/blackboard{hcm+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+cw"), "hcm+cw");
 }
 
@@ -500,11 +499,10 @@ TEST_F(
       MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}});
   auto filter_chain =
       weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
-  EXPECT_THAT(
-      filter_chain,
-      IsFilterChain(::testing::ElementsAre(
-          IsFilterAndConfig(&TestFilter::kFilterVtable,
-                            "hcm+vhost+cw/blackboard{hcm+vhost+cw}"))));
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(
+                  IsFilterAndConfig(&TestFilter::kFilterVtable,
+                                    "hcm+vhost+cw/blackboard{hcm+vhost+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+cw"), "hcm+vhost+cw");
 }
 
@@ -525,11 +523,10 @@ TEST_F(
       MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}});
   auto filter_chain =
       weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
-  EXPECT_THAT(
-      filter_chain,
-      IsFilterChain(::testing::ElementsAre(
-          IsFilterAndConfig(&TestFilter::kFilterVtable,
-                            "hcm+route+cw/blackboard{hcm+route+cw}"))));
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(
+                  IsFilterAndConfig(&TestFilter::kFilterVtable,
+                                    "hcm+route+cw/blackboard{hcm+route+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+route+cw"), "hcm+route+cw");
 }
 

--- a/test/core/xds/xds_routing_test.cc
+++ b/test/core/xds/xds_routing_test.cc
@@ -290,38 +290,6 @@ class XdsRouteConfigFilterChainBuilderTest : public ::testing::Test {
     return cluster_weight;
   }
 
-  XdsRouteConfigResource::Route MakeRouteWithWeightedClusters(
-      std::vector<XdsRouteConfigResource::Route::RouteAction::ClusterWeight>
-          cluster_weights,
-      XdsRouteConfigResource::TypedPerFilterConfig overrides = {}) {
-    XdsRouteConfigResource::Route route;
-    route.typed_per_filter_config = std::move(overrides);
-    XdsRouteConfigResource::Route::RouteAction route_action;
-    route_action.action = std::move(cluster_weights);
-    route.action = std::move(route_action);
-    return route;
-  }
-
-  class WeightedClustersFilterChainAccumulator {
-   public:
-    auto GetCallback() {
-      return [this](size_t index,
-                    absl::StatusOr<RefCountedPtr<const FilterChain>> result) {
-        if (filter_chains_.size() < index + 1) filter_chains_.resize(index + 1);
-        filter_chains_[index] = std::move(result);
-      };
-    }
-
-    const std::vector<absl::StatusOr<RefCountedPtr<const FilterChain>>>&
-    filter_chains() const {
-      return filter_chains_;
-    }
-
-   private:
-    std::vector<absl::StatusOr<RefCountedPtr<const FilterChain>>>
-        filter_chains_;
-  };
-
   absl::string_view GetBlackboardEntry(const std::string& key) {
     auto entry = blackboard_->Get<TestBlackboardEntry>(key);
     if (entry == nullptr) return "";
@@ -412,15 +380,15 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto vhost = MakeVirtualHost();
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route =
-      MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
-  EXPECT_THAT(accumulator.filter_chains(),
-              ::testing::ElementsAre(
-                  IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
-                      &TestFilter::kFilterVtable, "hcm/blackboard{hcm}")))));
+  auto route = MakeRoute();
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight = MakeClusterWeight("cluster1", 100);
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
+                  &TestFilter::kFilterVtable, "hcm/blackboard{hcm}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm"), "hcm");
 }
 
@@ -433,15 +401,16 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route =
-      MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
-  EXPECT_THAT(accumulator.filter_chains(),
-              ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
+  auto route = MakeRoute();
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight = MakeClusterWeight("cluster1", 100);
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(
                   IsFilterAndConfig(&TestFilter::kFilterVtable,
-                                    "hcm+vhost/blackboard{hcm+vhost}")))));
+                                    "hcm+vhost/blackboard{hcm+vhost}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost"), "hcm+vhost");
 }
 
@@ -454,16 +423,16 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto vhost = MakeVirtualHost();
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route =
-      MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)},
-                                    {{"filter1", MakeOverride("route")}});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
-  EXPECT_THAT(accumulator.filter_chains(),
-              ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
+  auto route = MakeRoute({{"filter1", MakeOverride("route")}});
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight = MakeClusterWeight("cluster1", 100);
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(
                   IsFilterAndConfig(&TestFilter::kFilterVtable,
-                                    "hcm+route/blackboard{hcm+route}")))));
+                                    "hcm+route/blackboard{hcm+route}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+route"), "hcm+route");
 }
 
@@ -477,17 +446,17 @@ TEST_F(
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route =
-      MakeRouteWithWeightedClusters({MakeClusterWeight("cluster1", 100)},
-                                    {{"filter1", MakeOverride("route")}});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
+  auto route = MakeRoute({{"filter1", MakeOverride("route")}});
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight = MakeClusterWeight("cluster1", 100);
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
   EXPECT_THAT(
-      accumulator.filter_chains(),
-      ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
+      filter_chain,
+      IsFilterChain(::testing::ElementsAre(
           IsFilterAndConfig(&TestFilter::kFilterVtable,
-                            "hcm+vhost+route/blackboard{hcm+vhost+route}")))));
+                            "hcm+vhost+route/blackboard{hcm+vhost+route}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+route"), "hcm+vhost+route");
 }
 
@@ -500,15 +469,17 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest,
   auto vhost = MakeVirtualHost();
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route = MakeRouteWithWeightedClusters(
-      {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
-  EXPECT_THAT(accumulator.filter_chains(),
-              ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
+  auto route = MakeRoute();
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight =
+      MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}});
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(
                   IsFilterAndConfig(&TestFilter::kFilterVtable,
-                                    "hcm+cw/blackboard{hcm+cw}")))));
+                                    "hcm+cw/blackboard{hcm+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+cw"), "hcm+cw");
 }
 
@@ -522,16 +493,18 @@ TEST_F(
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route = MakeRouteWithWeightedClusters(
-      {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
+  auto route = MakeRoute();
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight =
+      MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}});
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
   EXPECT_THAT(
-      accumulator.filter_chains(),
-      ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
+      filter_chain,
+      IsFilterChain(::testing::ElementsAre(
           IsFilterAndConfig(&TestFilter::kFilterVtable,
-                            "hcm+vhost+cw/blackboard{hcm+vhost+cw}")))));
+                            "hcm+vhost+cw/blackboard{hcm+vhost+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+cw"), "hcm+vhost+cw");
 }
 
@@ -545,17 +518,18 @@ TEST_F(
   auto vhost = MakeVirtualHost();
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route = MakeRouteWithWeightedClusters(
-      {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})},
-      {{"filter1", MakeOverride("route")}});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
+  auto route = MakeRoute({{"filter1", MakeOverride("route")}});
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight =
+      MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}});
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
   EXPECT_THAT(
-      accumulator.filter_chains(),
-      ::testing::ElementsAre(IsFilterChain(::testing::ElementsAre(
+      filter_chain,
+      IsFilterChain(::testing::ElementsAre(
           IsFilterAndConfig(&TestFilter::kFilterVtable,
-                            "hcm+route+cw/blackboard{hcm+route+cw}")))));
+                            "hcm+route+cw/blackboard{hcm+route+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+route+cw"), "hcm+route+cw");
 }
 
@@ -569,17 +543,17 @@ TEST_F(
   auto vhost = MakeVirtualHost({{"filter1", MakeOverride("vhost")}});
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route = MakeRouteWithWeightedClusters(
-      {MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}})},
-      {{"filter1", MakeOverride("route")}});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
-  EXPECT_THAT(accumulator.filter_chains(),
-              ::testing::ElementsAre(
-                  IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
-                      &TestFilter::kFilterVtable,
-                      "hcm+vhost+route+cw/blackboard{hcm+vhost+route+cw}")))));
+  auto route = MakeRoute({{"filter1", MakeOverride("route")}});
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight =
+      MakeClusterWeight("cluster1", 100, {{"filter1", MakeOverride("cw")}});
+  auto filter_chain =
+      weighted_cluster_builder.BuildFilterChainForClusterWeight(cluster_weight);
+  EXPECT_THAT(filter_chain,
+              IsFilterChain(::testing::ElementsAre(IsFilterAndConfig(
+                  &TestFilter::kFilterVtable,
+                  "hcm+vhost+route+cw/blackboard{hcm+vhost+route+cw}"))));
   EXPECT_EQ(GetBlackboardEntry("hcm+vhost+route+cw"), "hcm+vhost+route+cw");
 }
 
@@ -612,18 +586,16 @@ TEST_F(XdsRouteConfigFilterChainBuilderTest, Caching) {
   auto vhost = MakeVirtualHost();
   auto vhost_builder =
       route_config_builder.MakeVirtualHostFilterChainBuilder(vhost);
-  auto route = MakeRouteWithWeightedClusters(
-      {MakeClusterWeight("cluster0", 50), MakeClusterWeight("cluster1", 50)});
-  WeightedClustersFilterChainAccumulator accumulator;
-  vhost_builder.BuildFilterChainForRouteWithWeightedClusters(
-      route, accumulator.GetCallback());
-  ASSERT_EQ(accumulator.filter_chains().size(), 2);
-  const auto& chain0 = accumulator.filter_chains()[0];
-  const auto& chain1 = accumulator.filter_chains()[1];
-  ASSERT_TRUE(chain0.ok());
-  ASSERT_TRUE(chain1.ok());
-  EXPECT_NE(*chain0, nullptr);
-  EXPECT_EQ(*chain0, *chain1);
+  auto route = MakeRoute();
+  auto weighted_cluster_builder =
+      vhost_builder.MakeWeightedClusterRouteFilterChainBuilder(route);
+  auto cluster_weight0 = MakeClusterWeight("cluster0", 50);
+  auto chain0 = weighted_cluster_builder.BuildFilterChainForClusterWeight(
+      cluster_weight0);
+  auto cluster_weight1 = MakeClusterWeight("cluster1", 50);
+  auto chain1 = weighted_cluster_builder.BuildFilterChainForClusterWeight(
+      cluster_weight1);
+  EXPECT_EQ(chain0, chain1);
 }
 
 }  // namespace


### PR DESCRIPTION
Previously, this code assumed that the RouteConfig contained only one VirtualHost, because that's how things are on the client side.  However, on the server side, we support multiple VirtualHosts, so in preparation for using this code on the server side, I have redesigned it to support multiple VirtualHosts.

For consistency, I have also revamped the interface used for WeightedClusters, so that there is now a clear multi-level structure that works for both levels of nesting.