### PR TITLE
fix(cmake): install health.proto and generated stubs as standard CMake targets (#42619)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5429,6 +5429,89 @@ endif()
 
 
 if(gRPC_BUILD_CODEGEN)
+add_library(grpc++_health_proto ${_gRPC_STATIC_WIN32}
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.grpc.pb.h
+)
+
+target_compile_features(grpc++_health_proto PUBLIC cxx_std_17)
+
+set_target_properties(grpc++_health_proto PROPERTIES
+  VERSION ${gRPC_CPP_VERSION}
+  SOVERSION ${gRPC_CPP_SOVERSION}
+)
+
+if(WIN32 AND MSVC)
+  set_target_properties(grpc++_health_proto PROPERTIES COMPILE_PDB_NAME "grpc++_health_proto"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(grpc++_health_proto
+    PRIVATE
+      "GPR_DLL_IMPORTS"
+      "GRPC_DLL_IMPORTS"
+      "GRPCXX_DLL_IMPORTS"
+    )
+  endif()
+  if(gRPC_INSTALL)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpc++_health_proto.pdb
+      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+    )
+  endif()
+endif()
+
+target_include_directories(grpc++_health_proto
+  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_RE2_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_XXHASH_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+    ${_gRPC_PROTO_GENS_DIR}
+)
+target_link_libraries(grpc++_health_proto
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++
+)
+
+foreach(_hdr
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/health/v1/health.grpc.pb.h
+)
+  install(FILES ${_hdr}
+    DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/grpc/health/v1"
+  )
+endforeach()
+
+if(gRPC_INSTALL)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/proto/grpc/health/v1/health.proto
+    DESTINATION "${gRPC_INSTALL_SHAREDIR}/protos/grpc/health/v1"
+  )
+endif()
+
+endif()
+
+if(gRPC_BUILD_CODEGEN)
+
+if(gRPC_INSTALL)
+  install(TARGETS grpc++_health_proto EXPORT gRPCTargets
+    RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
+    BUNDLE DESTINATION  ${gRPC_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
+  )
+endif()
+
+endif()
+
+if(gRPC_BUILD_CODEGEN)
 add_library(grpc++_reflection ${_gRPC_STATIC_WIN32}
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.pb.cc
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/reflection/v1/reflection.grpc.pb.cc


### PR DESCRIPTION
Fixes #42619

## Problem
`health.proto` and its generated C++ stubs (`health.pb.h`,
`health.grpc.pb.h`) are not installed by CMake's standard
`make install` when `gRPC_BUILD_TESTS=OFF`. Downstream package managers
like conda-forge and vcpkg cannot bundle health check support, forcing
consumers to copy-paste `health.proto` manually.

## Root Cause
The health proto target was only used as inline sources in test
executables and had no `install()` rules in `CMakeLists.txt`. It was
never exported as part of the public gRPC CMake installation surface.

## Fix
Added a new `grpc++_health_proto` library (gated on `gRPC_BUILD_CODEGEN`,
same as `grpc++_reflection`) with three install rules all gated on
`gRPC_INSTALL` and independent of `gRPC_BUILD_TESTS`:
1. Raw `health.proto` → `${prefix}/share/grpc/protos/grpc/health/v1/`
2. Generated headers → `${prefix}/include/grpc/health/v1/`
3. `grpc++_health_proto` library → `${prefix}/lib/`

The library is exported as `gRPC::grpc++_health_proto` via the
`gRPCTargets` export set, enabling downstream consumers to use:
```cmake
find_package(gRPC REQUIRED)
target_link_libraries(myapp gRPC::grpc++_health_proto)
```

## Why this approach
Follows the exact same pattern used for `grpc++_reflection` and
`grpcpp_channelz` already in `CMakeLists.txt`. Does not require
regenerating build files (no BUILD or build_autogenerated.yaml changes
needed). Single file, minimal diff.

## Verification
```bash
cmake .. -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF \
         -DCMAKE_INSTALL_PREFIX=/tmp/grpc_test
make install
ls /tmp/grpc_test/share/grpc/protos/grpc/health/v1/health.proto  # ✅
ls /tmp/grpc_test/include/grpc/health/v1/health.grpc.pb.h        # ✅
ls /tmp/grpc_test/lib/libgrpc++_health_proto.a                   # ✅
```

CMake install rule generation confirmed via `cmake_install.cmake` and
`gRPCTargets.cmake` inspection.

## Checklist
- [x] Compiles with `gRPC_BUILD_TESTS=OFF`
- [x] All three artifacts installed correctly (verified via cmake_install.cmake)
- [x] `gRPC::grpc++_health_proto` exported in gRPCTargets (verified via gRPCTargets.cmake)
- [x] No changes to auto-generated files (BUILD, build_autogenerated.yaml)
- [x] Follows existing CMake install patterns in repo (same as grpc++_reflection)