### PR TITLE
[Python] Use local subchannel pool by default

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -53,6 +53,7 @@ import grpc.experimental
 _LOGGER = logging.getLogger(__name__)
 
 _USER_AGENT = "grpc-python/{}".format(_grpcio_metadata.__version__)
+_LOCAL_SUBCHANNEL_POOL_OPTION = ("grpc.use_local_subchannel_pool", 1)
 
 _EMPTY_FLAGS = 0
 
@@ -1994,10 +1995,20 @@ def _augment_options(
     base_options: Sequence[ChannelArgumentType],
     compression: Optional[grpc.Compression],
 ) -> Sequence[ChannelArgumentType]:
+    base_options = tuple(base_options)
     compression_option = _compression.create_channel_option(compression)
+    subchannel_pool_option = (
+        ()
+        if any(
+            option[0] == _LOCAL_SUBCHANNEL_POOL_OPTION[0]
+            for option in base_options
+        )
+        else (_LOCAL_SUBCHANNEL_POOL_OPTION,)
+    )
     return (
-        tuple(base_options)
+        base_options
         + compression_option
+        + subchannel_pool_option
         + (
             (
                 cygrpc.ChannelArgKey.primary_user_agent_string.decode(),

--- a/src/python/grpcio_tests/tests/unit/_channel_args_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_args_test.py
@@ -18,6 +18,7 @@ import logging
 import unittest
 
 import grpc
+from grpc import _channel
 
 
 class TestPointerWrapper:
@@ -43,6 +44,20 @@ INVALID_TEST_CHANNEL_ARGS = [
 class ChannelArgsTest(unittest.TestCase):
     def test_client(self):
         grpc.insecure_channel("localhost:8080", options=TEST_CHANNEL_ARGS)
+
+    def test_python_channels_default_to_local_subchannel_pool(self):
+        augmented_options = _channel._augment_options((), None)
+        self.assertIn(("grpc.use_local_subchannel_pool", 1), augmented_options)
+
+    def test_explicit_subchannel_pool_option_is_preserved(self):
+        augmented_options = _channel._augment_options(
+            (("grpc.use_local_subchannel_pool", 0),), None
+        )
+        self.assertEqual(
+            1,
+            augmented_options.count(("grpc.use_local_subchannel_pool", 0)),
+        )
+        self.assertNotIn(("grpc.use_local_subchannel_pool", 1), augmented_options)
 
     def test_server(self):
         grpc.server(


### PR DESCRIPTION
## Summary
Use a local subchannel pool by default for gRPC Python channels. This avoids retaining global subchannel-pool state for short-lived Python channels, which reduces RSS growth in workloads that repeatedly create a channel, perform one RPC, and close the channel.

## Related Issues/Tasks
- https://github.com/grpc/grpc/issues/38327
- Reproducer comment: https://github.com/grpc/grpc/issues/38327#issuecomment-2838757367

## Changes Made
- Add `grpc.use_local_subchannel_pool=1` to Python channel options when callers have not explicitly set the option.
- Preserve explicit caller overrides, including `grpc.use_local_subchannel_pool=0`.
- Add unit coverage for the Python default and override behavior.

## Confidence Level
Confidence Level: Claude

## Testing
- Built grpcio from source locally in `/home/discord/grpc-build-venv`.
- `PYTHONPATH=/home/discord/grpc-worktrees/fix-python-channel-memory-leak/src/python/grpcio_tests /home/discord/grpc-build-venv/bin/python -m unittest tests.unit._channel_args_test`
- `PYTHONPATH=/home/discord/grpc-worktrees/fix-python-channel-memory-leak/src/python/grpcio_tests /home/discord/grpc-build-venv/bin/python -m unittest tests_py3_only.unit._leak_test`
- `git diff --check`
- Manual client-only reproduction based on issue #38327 showed `grpc.use_local_subchannel_pool=1` substantially reduced post-warmup RSS growth in the repeated channel/create unary RPC close loop.
