### PR TITLE
[promise_based_filter] fix edge case in v3 to v2 interceptor bridge

### DIFF
--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1275,14 +1275,24 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
       InterActivityLatch<std::optional<ServerMetadataHandle>>
           server_initial_metadata;
       InterActivityPipe<MessageHandle, 1> server_to_client_messages;
+      InterActivityLatch<ServerMetadataHandle> server_trailing_metadata;
     };
     auto* pipe_owner = GetContext<Arena>()->ManagedNew<PipeOwner>();
+    initiator.SpawnInfallible(
+        "pull_server_trailing_metadata", [initiator, pipe_owner]() mutable {
+          return Map(
+              initiator.PullServerTrailingMetadata(),
+              [pipe_owner](ServerMetadataHandle metadata) {
+                pipe_owner->server_trailing_metadata.Set(std::move(metadata));
+                return Empty{};
+              });
+        });
     // Now return a promise that does all the things.
     return Race(
         // We need to start polling the initiator for server trailing
         // metadata immediately, since the v3 interceptor may generate a
         // failure before any of the other promises resolve.
-        initiator.PullServerTrailingMetadata(),
+        pipe_owner->server_trailing_metadata.Wait(),
         // This promise does the rest of the things, but it will always
         // return pending, because the promise can't actually finish
         // until the initiator returns trailing metadata above.

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1278,10 +1278,13 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
       InterActivityLatch<ServerMetadataHandle> server_trailing_metadata;
     };
     auto* pipe_owner = GetContext<Arena>()->ManagedNew<PipeOwner>();
-    // We need to start polling the initiator for server trailing
-    // metadata immediately, since the v3 interceptor may generate a
-    // failure before any of the other promises resolve.
     if (IsV2NonOwningWakerImplementationEnabled()) {
+      // We need to start polling the initiator for server trailing
+      // metadata immediately, since the v3 interceptor may generate a
+      // failure before any of the other promises resolve.
+      //
+      // Spawn a promise on the initiator's activity to pull server trailing
+      // metadata and pass it to the v2 activity via an inter-activity latch.
       initiator.SpawnInfallible(
           "pull_server_trailing_metadata",
           [initiator = initiator, pipe_owner]() mutable {
@@ -1293,184 +1296,196 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
                 });
           });
     }
-    // This promise does the rest of the things, but it will always
-    // return pending, because the promise can't actually finish
-    // until the initiator returns trailing metadata above.
-    auto rest_of_the_things_promise = TrySeq(
-        state->call_handler_latch.Wait(),
-        [initiator = initiator, pipe_owner, call_args = std::move(call_args),
-         next_promise_factory =
-             std::move(next_promise_factory)](CallHandler handler) mutable {
-          // Intercept all pipes from v2 API.
-          //
-          // For client-to-server messages, we do the following:
-          // 1. Push the message into the v3 initiator, which sends
-          //    it to the v3 interceptor.  Note that this needs to
-          //    be done inside of the v3 initiator's activity.
-          // 2. Pull the message from the v3 handler, where it will
-          //    arrive when the v3 interceptor is done with it.
-          //    Note that this needs to be done inside of the v3
-          //    handler's activity.  We then push the message into
-          //    an inter-activity pipe to return it to the v2 activity.
-          // 3. In the v2 activity, read the message from the
-          //    inter-activity pipe and send it on to the next
-          //    filter.
-          //
-          // Step 2: Spawn a promise to pull messages from the v3
-          // handler and push them into an inter-activity pipe to
-          // return them to the v2 activity.
-          handler.SpawnGuarded(
-              "pull_client_to_server_message", [handler, pipe_owner]() mutable {
-                return ForEach(
-                    MessagesFrom(handler), [pipe_owner](MessageHandle message) {
-                      return Map(
-                          pipe_owner->client_to_server_messages.sender.Push(
-                              std::move(message)),
-                          [](bool x) { return StatusFlag(x); });
-                    });
-              });
-          call_args.client_to_server_messages->InterceptAndMap(
-              [initiator, handler, pipe_owner](MessageHandle message) mutable {
-                // Step 1: Push the message onto the v3 initiator in
-                // its activity.
-                initiator.SpawnPushMessage(std::move(message));
-                // Step 3: Here in the v2 activity, read the message
-                // from the inter-activity pipe and return it.
-                return Map(
-                    pipe_owner->client_to_server_messages.receiver.Next(),
-                    [](InterActivityPipe<MessageHandle, 1>::NextResult message)
-                        -> std::optional<MessageHandle> {
-                      if (!message.has_value()) return std::nullopt;
-                      return std::move(*message);
-                    });
-              });
-          // For server initial metadata, we do a similar thing, but
-          // in the opposite direction, and using an inter-activity
-          // latch instead of a pipe:
-          // 1. Push the metadata into the v3 handler, which sends
-          //    it to the v3 interceptor.  Note that this needs to
-          //    be done inside of the v3 handler's activity.
-          // 2. Pull the metadata from the v3 initiator, where it will
-          //    arrive when the v3 interceptor is done with it.
-          //    Note that this needs to be done inside of the v3
-          //    initiator's activity.  We then use an inter-activity
-          //    latch to return the metadata to the v2 activity.
-          // 3. In the v2 activity, read the metadata from the
-          //    inter-activity latch and send it on to the previous
-          //    filter.
-          //
-          // Step 2: Spawn a promise to pull the metadata from the v3
-          // initiator and use an inter-activity latch to return it to
-          // the v2 activity.
-          initiator.SpawnGuarded(
-              "pull_server_initial_metadata",
-              [initiator, pipe_owner]() mutable {
-                return TrySeq(
-                    initiator.PullServerInitialMetadata(),
-                    [pipe_owner](std::optional<ServerMetadataHandle> metadata) {
-                      pipe_owner->server_initial_metadata.Set(
-                          std::move(metadata));
-                    });
-              });
-          call_args.server_initial_metadata->InterceptAndMap(
-              [initiator, handler,
-               pipe_owner](ServerMetadataHandle metadata) mutable {
-                // Step 1: Push the metadata onto the v3 handler in
-                // its activity.
-                handler.SpawnPushServerInitialMetadata(std::move(metadata));
-                // Step 3: Here in the v2 activity, read from the
-                // inter-activity latch and return the metadata.
-                return pipe_owner->server_initial_metadata.Wait();
-              });
-          // We handle server-to-client messages the same as
-          // client-to-server messages, except in the opposite
-          // direction:
-          // 1. Push the message into the v3 handler, which sends
-          //    it to the v3 interceptor.  Note that this needs to
-          //    be done inside of the v3 handler's activity.
-          // 2. Pull the message from the v3 initiator, where it will
-          //    arrive when the v3 interceptor is done with it.
-          //    Note that this needs to be done inside of the v3
-          //    initiator's activity.  We then push the message into
-          //    an inter-activity pipe to return it to the v2 activity.
-          // 3. In the v2 activity, read the message from the
-          //    inter-activity pipe and send it on to the next
-          //    filter.
-          //
-          // Step 2: Spawn a promise to pull messages from the v3
-          // initiator and push them into an inter-activity pipe to
-          // return them to the v2 activity.
-          initiator.SpawnGuarded(
-              "pull_server_to_client_message",
-              [initiator, pipe_owner]() mutable {
-                return ForEach(
-                    MessagesFrom(initiator),
-                    [pipe_owner](MessageHandle message) {
-                      return Map(
-                          pipe_owner->server_to_client_messages.sender.Push(
-                              std::move(message)),
-                          [](bool x) { return StatusFlag(x); });
-                    });
-              });
-          call_args.server_to_client_messages->InterceptAndMap(
-              [initiator, handler, pipe_owner](MessageHandle message) mutable {
-                // Step 1: Push the message onto the v3 handler in
-                // its activity.
-                handler.SpawnPushMessage(std::move(message));
-                // Step 3: Here in the v2 activity, read from the
-                // inter-activity pipe and return the messages.
-                return Map(
-                    pipe_owner->server_to_client_messages.receiver.Next(),
-                    [](InterActivityPipe<MessageHandle, 1>::NextResult message)
-                        -> std::optional<MessageHandle> {
-                      if (!message.has_value()) return std::nullopt;
-                      return std::move(*message);
-                    });
-              });
-          // In the v3 handler's activity, pull client initial metadata.
-          // Use an inter-activity latch to get it back to the v2
-          // activity.
-          handler.SpawnGuarded(
-              "pull_client_initial_metadata", [handler, pipe_owner]() mutable {
-                return TrySeq(handler.PullClientInitialMetadata(),
-                              [pipe_owner](ClientMetadataHandle metadata) {
-                                pipe_owner->client_initial_metadata.Set(
-                                    std::move(metadata));
-                              });
-              });
-          // A wrapper for next_promise_factory that does the following:
-          // - Pulls client initial metadata from the V3 handler via
-          //   the inter-activity latch and injects it into the next
-          //   V2 filter via CallArgs.
-          // - Polls the next promise to get server trailing metadata
-          //   from the next V2 filter and feeds it into the V3 handler.
-          // Note that this does not actually pull the trailing metadata
-          // from the V3 initiator; instead, we do that in a separate
-          // promise above.  That promise will always complete at the
-          // end of the call, so we always return pending here.
-          return Seq(pipe_owner->client_initial_metadata.Wait(),
-                     [next_promise_factory = std::move(next_promise_factory),
-                      call_args = std::move(call_args),
-                      handler](ClientMetadataHandle metadata) mutable {
-                       call_args.client_initial_metadata = std::move(metadata);
-                       return Seq(
-                           next_promise_factory(std::move(call_args)),
-                           [handler](ServerMetadataHandle metadata) mutable
-                               -> Poll<ServerMetadataHandle> {
-                             handler.SpawnPushServerTrailingMetadata(
-                                 std::move(metadata));
-                             // We always lose the race.
-                             return Pending{};
-                           });
-                     });
-        });
     // Now return a promise that does all the things.
-    if (!IsV2NonOwningWakerImplementationEnabled()) {
-      return Race(initiator.PullServerTrailingMetadata(),
-                  std::move(rest_of_the_things_promise));
-    }
-    return Race(pipe_owner->server_trailing_metadata.Wait(),
-                std::move(rest_of_the_things_promise));
+    return Race(
+        // Get server trailing metadata from the v3 promise via the
+        // inter-activity latch.
+        If(
+            IsV2NonOwningWakerImplementationEnabled(),
+            [pipe_owner]() {
+              return pipe_owner->server_trailing_metadata.Wait();
+            },
+            [initiator = initiator]() mutable {
+              return initiator.PullServerTrailingMetadata();
+            }),
+        // This promise does the rest of the things, but it will always
+        // return pending, because the promise can't actually finish
+        // until the initiator returns trailing metadata above.
+        TrySeq(
+            state->call_handler_latch.Wait(),
+            [initiator = initiator, pipe_owner,
+             call_args = std::move(call_args),
+             next_promise_factory =
+                 std::move(next_promise_factory)](CallHandler handler) mutable {
+              // Intercept all pipes from v2 API.
+              //
+              // For client-to-server messages, we do the following:
+              // 1. Push the message into the v3 initiator, which sends
+              //    it to the v3 interceptor.  Note that this needs to
+              //    be done inside of the v3 initiator's activity.
+              // 2. Pull the message from the v3 handler, where it will
+              //    arrive when the v3 interceptor is done with it.
+              //    Note that this needs to be done inside of the v3
+              //    handler's activity.  We then push the message into
+              //    an inter-activity pipe to return it to the v2 activity.
+              // 3. In the v2 activity, read the message from the
+              //    inter-activity pipe and send it on to the next
+              //    filter.
+              //
+              // Step 2: Spawn a promise to pull messages from the v3
+              // handler and push them into an inter-activity pipe to
+              // return them to the v2 activity.
+              handler.SpawnGuarded(
+                  "pull_client_to_server_message",
+                  [handler, pipe_owner]() mutable {
+                    return ForEach(
+                        MessagesFrom(handler),
+                        [pipe_owner](MessageHandle message) {
+                          return Map(
+                              pipe_owner->client_to_server_messages.sender.Push(
+                                  std::move(message)),
+                              [](bool x) { return StatusFlag(x); });
+                        });
+                  });
+              call_args.client_to_server_messages->InterceptAndMap(
+                  [initiator, handler,
+                   pipe_owner](MessageHandle message) mutable {
+                    // Step 1: Push the message onto the v3 initiator in
+                    // its activity.
+                    initiator.SpawnPushMessage(std::move(message));
+                    // Step 3: Here in the v2 activity, read the message
+                    // from the inter-activity pipe and return it.
+                    return Map(
+                        pipe_owner->client_to_server_messages.receiver.Next(),
+                        [](InterActivityPipe<MessageHandle, 1>::NextResult
+                               message) -> std::optional<MessageHandle> {
+                          if (!message.has_value()) return std::nullopt;
+                          return std::move(*message);
+                        });
+                  });
+              // For server initial metadata, we do a similar thing, but
+              // in the opposite direction, and using an inter-activity
+              // latch instead of a pipe:
+              // 1. Push the metadata into the v3 handler, which sends
+              //    it to the v3 interceptor.  Note that this needs to
+              //    be done inside of the v3 handler's activity.
+              // 2. Pull the metadata from the v3 initiator, where it will
+              //    arrive when the v3 interceptor is done with it.
+              //    Note that this needs to be done inside of the v3
+              //    initiator's activity.  We then use an inter-activity
+              //    latch to return the metadata to the v2 activity.
+              // 3. In the v2 activity, read the metadata from the
+              //    inter-activity latch and send it on to the previous
+              //    filter.
+              //
+              // Step 2: Spawn a promise to pull the metadata from the v3
+              // initiator and use an inter-activity latch to return it to
+              // the v2 activity.
+              initiator.SpawnGuarded(
+                  "pull_server_initial_metadata",
+                  [initiator, pipe_owner]() mutable {
+                    return TrySeq(
+                        initiator.PullServerInitialMetadata(),
+                        [pipe_owner](
+                            std::optional<ServerMetadataHandle> metadata) {
+                          pipe_owner->server_initial_metadata.Set(
+                              std::move(metadata));
+                        });
+                  });
+              call_args.server_initial_metadata->InterceptAndMap(
+                  [initiator, handler,
+                   pipe_owner](ServerMetadataHandle metadata) mutable {
+                    // Step 1: Push the metadata onto the v3 handler in
+                    // its activity.
+                    handler.SpawnPushServerInitialMetadata(std::move(metadata));
+                    // Step 3: Here in the v2 activity, read from the
+                    // inter-activity latch and return the metadata.
+                    return pipe_owner->server_initial_metadata.Wait();
+                  });
+              // We handle server-to-client messages the same as
+              // client-to-server messages, except in the opposite
+              // direction:
+              // 1. Push the message into the v3 handler, which sends
+              //    it to the v3 interceptor.  Note that this needs to
+              //    be done inside of the v3 handler's activity.
+              // 2. Pull the message from the v3 initiator, where it will
+              //    arrive when the v3 interceptor is done with it.
+              //    Note that this needs to be done inside of the v3
+              //    initiator's activity.  We then push the message into
+              //    an inter-activity pipe to return it to the v2 activity.
+              // 3. In the v2 activity, read the message from the
+              //    inter-activity pipe and send it on to the next
+              //    filter.
+              //
+              // Step 2: Spawn a promise to pull messages from the v3
+              // initiator and push them into an inter-activity pipe to
+              // return them to the v2 activity.
+              initiator.SpawnGuarded(
+                  "pull_server_to_client_message",
+                  [initiator, pipe_owner]() mutable {
+                    return ForEach(
+                        MessagesFrom(initiator),
+                        [pipe_owner](MessageHandle message) {
+                          return Map(
+                              pipe_owner->server_to_client_messages.sender.Push(
+                                  std::move(message)),
+                              [](bool x) { return StatusFlag(x); });
+                        });
+                  });
+              call_args.server_to_client_messages->InterceptAndMap(
+                  [initiator, handler,
+                   pipe_owner](MessageHandle message) mutable {
+                    // Step 1: Push the message onto the v3 handler in
+                    // its activity.
+                    handler.SpawnPushMessage(std::move(message));
+                    // Step 3: Here in the v2 activity, read from the
+                    // inter-activity pipe and return the messages.
+                    return Map(
+                        pipe_owner->server_to_client_messages.receiver.Next(),
+                        [](InterActivityPipe<MessageHandle, 1>::NextResult
+                               message) -> std::optional<MessageHandle> {
+                          if (!message.has_value()) return std::nullopt;
+                          return std::move(*message);
+                        });
+                  });
+              // In the v3 handler's activity, pull client initial metadata.
+              // Use an inter-activity latch to get it back to the v2
+              // activity.
+              handler.SpawnGuarded(
+                  "pull_client_initial_metadata",
+                  [handler, pipe_owner]() mutable {
+                    return TrySeq(handler.PullClientInitialMetadata(),
+                                  [pipe_owner](ClientMetadataHandle metadata) {
+                                    pipe_owner->client_initial_metadata.Set(
+                                        std::move(metadata));
+                                  });
+                  });
+              // A wrapper for next_promise_factory that does the following:
+              // - Pulls client initial metadata from the V3 handler via
+              //   the inter-activity latch and injects it into the next
+              //   V2 filter via CallArgs.
+              // - Polls the next promise to get server trailing metadata
+              //   from the next V2 filter and feeds it into the V3 handler.
+              // Note that this does not actually pull the trailing metadata
+              // from the V3 initiator; instead, we do that in a separate
+              // promise above.  That promise will always complete at the
+              // end of the call, so we always return pending here.
+              return Seq(
+                  pipe_owner->client_initial_metadata.Wait(),
+                  [next_promise_factory = std::move(next_promise_factory),
+                   call_args = std::move(call_args),
+                   handler](ClientMetadataHandle metadata) mutable {
+                    call_args.client_initial_metadata = std::move(metadata);
+                    return Seq(next_promise_factory(std::move(call_args)),
+                               [handler](ServerMetadataHandle metadata) mutable
+                                   -> Poll<ServerMetadataHandle> {
+                                 handler.SpawnPushServerTrailingMetadata(
+                                     std::move(metadata));
+                                 // We always lose the race.
+                                 return Pending{};
+                               });
+                  });
+            }));
   }
 
  protected:

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1278,200 +1278,199 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
       InterActivityLatch<ServerMetadataHandle> server_trailing_metadata;
     };
     auto* pipe_owner = GetContext<Arena>()->ManagedNew<PipeOwner>();
-    initiator.SpawnInfallible(
-        "pull_server_trailing_metadata",
-        [initiator = initiator, pipe_owner]() mutable {
-          return Map(
-              initiator.PullServerTrailingMetadata(),
-              [pipe_owner](ServerMetadataHandle metadata) {
-                pipe_owner->server_trailing_metadata.Set(std::move(metadata));
-                return Empty{};
+    // We need to start polling the initiator for server trailing
+    // metadata immediately, since the v3 interceptor may generate a
+    // failure before any of the other promises resolve.
+    if (IsV2NonOwningWakerImplementationEnabled()) {
+      initiator.SpawnInfallible(
+          "pull_server_trailing_metadata",
+          [initiator = initiator, pipe_owner]() mutable {
+            return Map(
+                initiator.PullServerTrailingMetadata(),
+                [pipe_owner](ServerMetadataHandle metadata) {
+                  pipe_owner->server_trailing_metadata.Set(std::move(metadata));
+                  return Empty{};
+                });
+          });
+    }
+    // This promise does the rest of the things, but it will always
+    // return pending, because the promise can't actually finish
+    // until the initiator returns trailing metadata above.
+    auto rest_of_the_things_promise = TrySeq(
+        state->call_handler_latch.Wait(),
+        [initiator = initiator, pipe_owner, call_args = std::move(call_args),
+         next_promise_factory =
+             std::move(next_promise_factory)](CallHandler handler) mutable {
+          // Intercept all pipes from v2 API.
+          //
+          // For client-to-server messages, we do the following:
+          // 1. Push the message into the v3 initiator, which sends
+          //    it to the v3 interceptor.  Note that this needs to
+          //    be done inside of the v3 initiator's activity.
+          // 2. Pull the message from the v3 handler, where it will
+          //    arrive when the v3 interceptor is done with it.
+          //    Note that this needs to be done inside of the v3
+          //    handler's activity.  We then push the message into
+          //    an inter-activity pipe to return it to the v2 activity.
+          // 3. In the v2 activity, read the message from the
+          //    inter-activity pipe and send it on to the next
+          //    filter.
+          //
+          // Step 2: Spawn a promise to pull messages from the v3
+          // handler and push them into an inter-activity pipe to
+          // return them to the v2 activity.
+          handler.SpawnGuarded(
+              "pull_client_to_server_message", [handler, pipe_owner]() mutable {
+                return ForEach(
+                    MessagesFrom(handler), [pipe_owner](MessageHandle message) {
+                      return Map(
+                          pipe_owner->client_to_server_messages.sender.Push(
+                              std::move(message)),
+                          [](bool x) { return StatusFlag(x); });
+                    });
               });
+          call_args.client_to_server_messages->InterceptAndMap(
+              [initiator, handler, pipe_owner](MessageHandle message) mutable {
+                // Step 1: Push the message onto the v3 initiator in
+                // its activity.
+                initiator.SpawnPushMessage(std::move(message));
+                // Step 3: Here in the v2 activity, read the message
+                // from the inter-activity pipe and return it.
+                return Map(
+                    pipe_owner->client_to_server_messages.receiver.Next(),
+                    [](InterActivityPipe<MessageHandle, 1>::NextResult message)
+                        -> std::optional<MessageHandle> {
+                      if (!message.has_value()) return std::nullopt;
+                      return std::move(*message);
+                    });
+              });
+          // For server initial metadata, we do a similar thing, but
+          // in the opposite direction, and using an inter-activity
+          // latch instead of a pipe:
+          // 1. Push the metadata into the v3 handler, which sends
+          //    it to the v3 interceptor.  Note that this needs to
+          //    be done inside of the v3 handler's activity.
+          // 2. Pull the metadata from the v3 initiator, where it will
+          //    arrive when the v3 interceptor is done with it.
+          //    Note that this needs to be done inside of the v3
+          //    initiator's activity.  We then use an inter-activity
+          //    latch to return the metadata to the v2 activity.
+          // 3. In the v2 activity, read the metadata from the
+          //    inter-activity latch and send it on to the previous
+          //    filter.
+          //
+          // Step 2: Spawn a promise to pull the metadata from the v3
+          // initiator and use an inter-activity latch to return it to
+          // the v2 activity.
+          initiator.SpawnGuarded(
+              "pull_server_initial_metadata",
+              [initiator, pipe_owner]() mutable {
+                return TrySeq(
+                    initiator.PullServerInitialMetadata(),
+                    [pipe_owner](std::optional<ServerMetadataHandle> metadata) {
+                      pipe_owner->server_initial_metadata.Set(
+                          std::move(metadata));
+                    });
+              });
+          call_args.server_initial_metadata->InterceptAndMap(
+              [initiator, handler,
+               pipe_owner](ServerMetadataHandle metadata) mutable {
+                // Step 1: Push the metadata onto the v3 handler in
+                // its activity.
+                handler.SpawnPushServerInitialMetadata(std::move(metadata));
+                // Step 3: Here in the v2 activity, read from the
+                // inter-activity latch and return the metadata.
+                return pipe_owner->server_initial_metadata.Wait();
+              });
+          // We handle server-to-client messages the same as
+          // client-to-server messages, except in the opposite
+          // direction:
+          // 1. Push the message into the v3 handler, which sends
+          //    it to the v3 interceptor.  Note that this needs to
+          //    be done inside of the v3 handler's activity.
+          // 2. Pull the message from the v3 initiator, where it will
+          //    arrive when the v3 interceptor is done with it.
+          //    Note that this needs to be done inside of the v3
+          //    initiator's activity.  We then push the message into
+          //    an inter-activity pipe to return it to the v2 activity.
+          // 3. In the v2 activity, read the message from the
+          //    inter-activity pipe and send it on to the next
+          //    filter.
+          //
+          // Step 2: Spawn a promise to pull messages from the v3
+          // initiator and push them into an inter-activity pipe to
+          // return them to the v2 activity.
+          initiator.SpawnGuarded(
+              "pull_server_to_client_message",
+              [initiator, pipe_owner]() mutable {
+                return ForEach(
+                    MessagesFrom(initiator),
+                    [pipe_owner](MessageHandle message) {
+                      return Map(
+                          pipe_owner->server_to_client_messages.sender.Push(
+                              std::move(message)),
+                          [](bool x) { return StatusFlag(x); });
+                    });
+              });
+          call_args.server_to_client_messages->InterceptAndMap(
+              [initiator, handler, pipe_owner](MessageHandle message) mutable {
+                // Step 1: Push the message onto the v3 handler in
+                // its activity.
+                handler.SpawnPushMessage(std::move(message));
+                // Step 3: Here in the v2 activity, read from the
+                // inter-activity pipe and return the messages.
+                return Map(
+                    pipe_owner->server_to_client_messages.receiver.Next(),
+                    [](InterActivityPipe<MessageHandle, 1>::NextResult message)
+                        -> std::optional<MessageHandle> {
+                      if (!message.has_value()) return std::nullopt;
+                      return std::move(*message);
+                    });
+              });
+          // In the v3 handler's activity, pull client initial metadata.
+          // Use an inter-activity latch to get it back to the v2
+          // activity.
+          handler.SpawnGuarded(
+              "pull_client_initial_metadata", [handler, pipe_owner]() mutable {
+                return TrySeq(handler.PullClientInitialMetadata(),
+                              [pipe_owner](ClientMetadataHandle metadata) {
+                                pipe_owner->client_initial_metadata.Set(
+                                    std::move(metadata));
+                              });
+              });
+          // A wrapper for next_promise_factory that does the following:
+          // - Pulls client initial metadata from the V3 handler via
+          //   the inter-activity latch and injects it into the next
+          //   V2 filter via CallArgs.
+          // - Polls the next promise to get server trailing metadata
+          //   from the next V2 filter and feeds it into the V3 handler.
+          // Note that this does not actually pull the trailing metadata
+          // from the V3 initiator; instead, we do that in a separate
+          // promise above.  That promise will always complete at the
+          // end of the call, so we always return pending here.
+          return Seq(pipe_owner->client_initial_metadata.Wait(),
+                     [next_promise_factory = std::move(next_promise_factory),
+                      call_args = std::move(call_args),
+                      handler](ClientMetadataHandle metadata) mutable {
+                       call_args.client_initial_metadata = std::move(metadata);
+                       return Seq(
+                           next_promise_factory(std::move(call_args)),
+                           [handler](ServerMetadataHandle metadata) mutable
+                               -> Poll<ServerMetadataHandle> {
+                             handler.SpawnPushServerTrailingMetadata(
+                                 std::move(metadata));
+                             // We always lose the race.
+                             return Pending{};
+                           });
+                     });
         });
     // Now return a promise that does all the things.
-    return Race(
-        // We need to start polling the initiator for server trailing
-        // metadata immediately, since the v3 interceptor may generate a
-        // failure before any of the other promises resolve.
-        pipe_owner->server_trailing_metadata.Wait(),
-        // This promise does the rest of the things, but it will always
-        // return pending, because the promise can't actually finish
-        // until the initiator returns trailing metadata above.
-        TrySeq(
-            state->call_handler_latch.Wait(),
-            [initiator = initiator, pipe_owner,
-             call_args = std::move(call_args),
-             next_promise_factory =
-                 std::move(next_promise_factory)](CallHandler handler) mutable {
-              // Intercept all pipes from v2 API.
-              //
-              // For client-to-server messages, we do the following:
-              // 1. Push the message into the v3 initiator, which sends
-              //    it to the v3 interceptor.  Note that this needs to
-              //    be done inside of the v3 initiator's activity.
-              // 2. Pull the message from the v3 handler, where it will
-              //    arrive when the v3 interceptor is done with it.
-              //    Note that this needs to be done inside of the v3
-              //    handler's activity.  We then push the message into
-              //    an inter-activity pipe to return it to the v2 activity.
-              // 3. In the v2 activity, read the message from the
-              //    inter-activity pipe and send it on to the next
-              //    filter.
-              //
-              // Step 2: Spawn a promise to pull messages from the v3
-              // handler and push them into an inter-activity pipe to
-              // return them to the v2 activity.
-              handler.SpawnGuarded(
-                  "pull_client_to_server_message",
-                  [handler, pipe_owner]() mutable {
-                    return ForEach(
-                        MessagesFrom(handler),
-                        [pipe_owner](MessageHandle message) {
-                          return Map(
-                              pipe_owner->client_to_server_messages.sender.Push(
-                                  std::move(message)),
-                              [](bool x) { return StatusFlag(x); });
-                        });
-                  });
-              call_args.client_to_server_messages->InterceptAndMap(
-                  [initiator, handler,
-                   pipe_owner](MessageHandle message) mutable {
-                    // Step 1: Push the message onto the v3 initiator in
-                    // its activity.
-                    initiator.SpawnPushMessage(std::move(message));
-                    // Step 3: Here in the v2 activity, read the message
-                    // from the inter-activity pipe and return it.
-                    return Map(
-                        pipe_owner->client_to_server_messages.receiver.Next(),
-                        [](InterActivityPipe<MessageHandle, 1>::NextResult
-                               message) -> std::optional<MessageHandle> {
-                          if (!message.has_value()) return std::nullopt;
-                          return std::move(*message);
-                        });
-                  });
-              // For server initial metadata, we do a similar thing, but
-              // in the opposite direction, and using an inter-activity
-              // latch instead of a pipe:
-              // 1. Push the metadata into the v3 handler, which sends
-              //    it to the v3 interceptor.  Note that this needs to
-              //    be done inside of the v3 handler's activity.
-              // 2. Pull the metadata from the v3 initiator, where it will
-              //    arrive when the v3 interceptor is done with it.
-              //    Note that this needs to be done inside of the v3
-              //    initiator's activity.  We then use an inter-activity
-              //    latch to return the metadata to the v2 activity.
-              // 3. In the v2 activity, read the metadata from the
-              //    inter-activity latch and send it on to the previous
-              //    filter.
-              //
-              // Step 2: Spawn a promise to pull the metadata from the v3
-              // initiator and use an inter-activity latch to return it to
-              // the v2 activity.
-              initiator.SpawnGuarded(
-                  "pull_server_initial_metadata",
-                  [initiator, pipe_owner]() mutable {
-                    return TrySeq(
-                        initiator.PullServerInitialMetadata(),
-                        [pipe_owner](
-                            std::optional<ServerMetadataHandle> metadata) {
-                          pipe_owner->server_initial_metadata.Set(
-                              std::move(metadata));
-                        });
-                  });
-              call_args.server_initial_metadata->InterceptAndMap(
-                  [initiator, handler,
-                   pipe_owner](ServerMetadataHandle metadata) mutable {
-                    // Step 1: Push the metadata onto the v3 handler in
-                    // its activity.
-                    handler.SpawnPushServerInitialMetadata(std::move(metadata));
-                    // Step 3: Here in the v2 activity, read from the
-                    // inter-activity latch and return the metadata.
-                    return pipe_owner->server_initial_metadata.Wait();
-                  });
-              // We handle server-to-client messages the same as
-              // client-to-server messages, except in the opposite
-              // direction:
-              // 1. Push the message into the v3 handler, which sends
-              //    it to the v3 interceptor.  Note that this needs to
-              //    be done inside of the v3 handler's activity.
-              // 2. Pull the message from the v3 initiator, where it will
-              //    arrive when the v3 interceptor is done with it.
-              //    Note that this needs to be done inside of the v3
-              //    initiator's activity.  We then push the message into
-              //    an inter-activity pipe to return it to the v2 activity.
-              // 3. In the v2 activity, read the message from the
-              //    inter-activity pipe and send it on to the next
-              //    filter.
-              //
-              // Step 2: Spawn a promise to pull messages from the v3
-              // initiator and push them into an inter-activity pipe to
-              // return them to the v2 activity.
-              initiator.SpawnGuarded(
-                  "pull_server_to_client_message",
-                  [initiator, pipe_owner]() mutable {
-                    return ForEach(
-                        MessagesFrom(initiator),
-                        [pipe_owner](MessageHandle message) {
-                          return Map(
-                              pipe_owner->server_to_client_messages.sender.Push(
-                                  std::move(message)),
-                              [](bool x) { return StatusFlag(x); });
-                        });
-                  });
-              call_args.server_to_client_messages->InterceptAndMap(
-                  [initiator, handler,
-                   pipe_owner](MessageHandle message) mutable {
-                    // Step 1: Push the message onto the v3 handler in
-                    // its activity.
-                    handler.SpawnPushMessage(std::move(message));
-                    // Step 3: Here in the v2 activity, read from the
-                    // inter-activity pipe and return the messages.
-                    return Map(
-                        pipe_owner->server_to_client_messages.receiver.Next(),
-                        [](InterActivityPipe<MessageHandle, 1>::NextResult
-                               message) -> std::optional<MessageHandle> {
-                          if (!message.has_value()) return std::nullopt;
-                          return std::move(*message);
-                        });
-                  });
-              // In the v3 handler's activity, pull client initial metadata.
-              // Use an inter-activity latch to get it back to the v2
-              // activity.
-              handler.SpawnGuarded(
-                  "pull_client_initial_metadata",
-                  [handler, pipe_owner]() mutable {
-                    return TrySeq(handler.PullClientInitialMetadata(),
-                                  [pipe_owner](ClientMetadataHandle metadata) {
-                                    pipe_owner->client_initial_metadata.Set(
-                                        std::move(metadata));
-                                  });
-                  });
-              // A wrapper for next_promise_factory that does the following:
-              // - Pulls client initial metadata from the V3 handler via
-              //   the inter-activity latch and injects it into the next
-              //   V2 filter via CallArgs.
-              // - Polls the next promise to get server trailing metadata
-              //   from the next V2 filter and feeds it into the V3 handler.
-              // Note that this does not actually pull the trailing metadata
-              // from the V3 initiator; instead, we do that in a separate
-              // promise above.  That promise will always complete at the
-              // end of the call, so we always return pending here.
-              return Seq(
-                  pipe_owner->client_initial_metadata.Wait(),
-                  [next_promise_factory = std::move(next_promise_factory),
-                   call_args = std::move(call_args),
-                   handler](ClientMetadataHandle metadata) mutable {
-                    call_args.client_initial_metadata = std::move(metadata);
-                    return Seq(next_promise_factory(std::move(call_args)),
-                               [handler](ServerMetadataHandle metadata) mutable
-                                   -> Poll<ServerMetadataHandle> {
-                                 handler.SpawnPushServerTrailingMetadata(
-                                     std::move(metadata));
-                                 // We always lose the race.
-                                 return Pending{};
-                               });
-                  });
-            }));
+    if (!IsV2NonOwningWakerImplementationEnabled()) {
+      return Race(initiator.PullServerTrailingMetadata(),
+                  std::move(rest_of_the_things_promise));
+    }
+    return Race(pipe_owner->server_trailing_metadata.Wait(),
+                std::move(rest_of_the_things_promise));
   }
 
  protected:

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1279,7 +1279,8 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
     };
     auto* pipe_owner = GetContext<Arena>()->ManagedNew<PipeOwner>();
     initiator.SpawnInfallible(
-        "pull_server_trailing_metadata", [initiator, pipe_owner]() mutable {
+        "pull_server_trailing_metadata",
+        [initiator = initiator, pipe_owner]() mutable {
           return Map(
               initiator.PullServerTrailingMetadata(),
               [pipe_owner](ServerMetadataHandle metadata) {


### PR DESCRIPTION
@rishesh007 sent me this fix a while back to address a problem running the RBAC filter via the v3-to-v2 interceptor bridge.  However, for some reason, this fix causes xds_composite_filter_end2end_test to crash (see [CI failures](https://btx.cloud.google.com/invocations/93b52c72-4e79-4047-a0a8-4eefe25d54fc/targets), [example log](https://btx.cloud.google.com/invocations/93b52c72-4e79-4047-a0a8-4eefe25d54fc/targets/%2F%2Ftest%2Fcpp%2Fend2end%2Fxds:xds_composite_filter_end2end_test@poller%3Depoll1;config=0a80cbee51aa0a27e4d074882ea437262000f4dfeacd1da0810eea0878cb53bd/log)) due to calling the unimplemented `WakeupAsync()` function, which is implemented only if the `v2_non_owning_waker_implementation` experiment is enabled.  Therefore, I am guarding this fix with the same experiment.