### PR TITLE
[Python] Keep Core initialized for Python runtime

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork.pyx.pxi
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import os
 import sys
 
@@ -38,6 +39,7 @@ if sys.platform == "win32":
     _GRPC_ENABLE_FORK_SUPPORT = False
 
 _fork_handler_failed = False
+_grpc_runtime_initialized = False
 
 # These cdef functions are always compiled, even on Windows, to satisfy the
 # declarations in fork.pxd.pxi. On Windows they are effectively unused
@@ -91,7 +93,16 @@ cdef void __postfork_child() noexcept nogil:
             os._exit(os.EX_USAGE)
 
 
+def _is_grpc_runtime_initialized():
+    return _grpc_runtime_initialized and grpc_is_initialized()
+
+
 def fork_handlers_and_grpc_init():
+    global _grpc_runtime_initialized
+    if not _grpc_runtime_initialized:
+        grpc_init()
+        atexit.register(grpc_shutdown)
+        _grpc_runtime_initialized = True
     grpc_init()
     if _GRPC_ENABLE_FORK_SUPPORT:
         with _fork_state.fork_handler_registered_lock:

--- a/src/python/grpcio_tests/tests/unit/_grpc_shutdown_test.py
+++ b/src/python/grpcio_tests/tests/unit/_grpc_shutdown_test.py
@@ -19,11 +19,17 @@ import time
 import unittest
 
 import grpc
+from grpc._cython import cygrpc
 
 _TIMEOUT_FOR_SEGFAULT = datetime.timedelta(seconds=10)
 
 
 class GrpcShutdownTest(unittest.TestCase):
+    def test_channel_close_keeps_python_runtime_initialized(self):
+        channel = grpc.insecure_channel("localhost:1")
+        channel.close()
+        self.assertTrue(cygrpc._is_grpc_runtime_initialized())
+
     def test_channel_close_with_connectivity_watcher(self):
         """Originated by https://github.com/grpc/grpc/issues/20299.
 


### PR DESCRIPTION
## Summary
Keep one gRPC Core initialization reference alive for the Python runtime after the first Python gRPC object is created. This prevents short-lived Python channels from driving Core through full init/shutdown cycles on every channel close, which reduces RSS growth in workloads that repeatedly create a channel, perform one RPC, and close it.

## Related Issues/Tasks
- https://github.com/grpc/grpc/issues/38327
- Reproducer comment: https://github.com/grpc/grpc/issues/38327#issuecomment-2838757367

## Changes Made
- Lazily take a Python-runtime Core init reference in `fork_handlers_and_grpc_init()` the first time Python creates a Core-backed object.
- Register the matching `grpc_shutdown()` with `atexit`, preserving balanced Core init/shutdown at process exit.
- Add regression coverage that closing a Python channel does not fully tear down Core while the Python runtime remains active.

## Confidence Level
Confidence Level: Claude

## Testing
- Built grpcio from source locally in `/home/discord/grpc-build-venv`.
- `PYTHONPATH=/home/discord/grpc-worktrees/fix-python-channel-memory-leak/src/python/grpcio_tests /home/discord/grpc-build-venv/bin/python -m unittest tests.unit._grpc_shutdown_test tests_py3_only.unit._leak_test`
- `PYTHONPATH=/home/discord/grpc-worktrees/fix-python-channel-memory-leak/src/python/grpcio_tests /home/discord/grpc-build-venv/bin/python -m unittest tests.unit._channel_args_test`
- Subprocess sanity check confirmed a channel can be created/closed and the process exits cleanly with the `atexit` shutdown.
- `git diff --check`
- Manual client-only reproduction based on issue #38327:
  - source-fixed short-lived channel loop: post-warmup RSS delta `0.027 MB` over 24k post-warmup iterations
  - grpcio 1.71.0 wheel under the same run: post-warmup RSS delta `0.437 MB`
  - source-fixed run kept Core alive with `threads=2` after closes, avoiding repeated Core init/shutdown churn.
