### PR TITLE
[Backport][v1.81.x][PSM interop] adds python kokoro config file for regional TD test

### DIFF
--- a/tools/internal_ci/linux/psm-regional_td-python.cfg
+++ b/tools/internal_ci/linux/psm-regional_td-python.cfg
@@ -15,7 +15,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
+build_file: "grpc/tools/internal_ci/linux/psm-interop-test-python.sh"
 timeout_mins: 30
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/psm-regional_td.cfg
+++ b/tools/internal_ci/linux/psm-regional_td.cfg
@@ -1,0 +1,30 @@
+# Copyright 2026 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/psm-interop-test-cpp.sh"
+timeout_mins: 30
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "regional_td"
+}


### PR DESCRIPTION
Backport of #42545 to v1.81.x.
---
Renaming tools/internal_ci/linux/psm-regional_td.cfg to make it consistent across languages and other psm test configs.