### PR TITLE
[Backport][v1.76.x][dns resolver] fix crash in legacy c-ares resolver

### DIFF
--- a/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -818,7 +818,7 @@ static void on_txt_done_locked(void* arg, int status, int /*timeouts*/,
   if (status != ARES_SUCCESS) goto fail;
   // Find service config in TXT record.
   for (result = reply; result != nullptr; result = result->next) {
-    if (result->record_start &&
+    if (result->record_start && result->length >= prefix_len &&
         memcmp(result->txt, g_service_config_attribute_prefix, prefix_len) ==
             0) {
       break;

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -537,6 +537,24 @@ current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
 
+test_runner_log('Run test with target: %s' % 'ipv4-svc_cfg_short_txt.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'ipv4-svc_cfg_short_txt.resolver-tests-version-4.grpctestingexp.',
+  '--do_ordered_address_comparison', 'False',
+  '--expected_addrs', '1.2.3.4:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_service_config_error', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'False',
+  '--enable_txt_queries', 'True',
+  '--inject_broken_nameserver_list', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port
+  ] + args.extra_args.split(','))
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
 test_runner_log('Run test with target: %s' % 'ipv4-svc_cfg_bad_client_language.resolver-tests-version-4.grpctestingexp.')
 current_test_subprocess = subprocess.Popen([
   args.test_bin_path,

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -397,8 +397,22 @@ resolver_component_tests:
     ipv4-svc_cfg_bad_json:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-svc_cfg_bad_json:
-    - {TTL: '2100', data: 'grpc_config=[{]',
-      type: TXT}
+    - {TTL: '2100', data: 'grpc_config=[{]', type: TXT}
+- expected_addrs:
+  - {address: '1.2.3.4:443', is_balancer: false}
+  do_ordered_address_comparison: false
+  expected_chosen_service_config: null
+  expected_service_config_error: null
+  expected_lb_policy: null
+  enable_srv_queries: false
+  enable_txt_queries: true
+  inject_broken_nameserver_list: false
+  record_to_resolve: ipv4-svc_cfg_short_txt
+  records:
+    ipv4-svc_cfg_short_txt:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-svc_cfg_short_txt:
+    - {TTL: '2100', data: 'grpc_', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
   do_ordered_address_comparison: false


### PR DESCRIPTION
Backport of #42027 to v1.76.x.
---
This code isn't actually used anywhere anymore, but fixing it just to be safe.