### PR TITLE
[Python] Unpin pip version in Python tests

### DIFF
--- a/test/distrib/python/test_packages.sh
+++ b/test/distrib/python/test_packages.sh
@@ -49,7 +49,7 @@ VIRTUAL_ENV=$(mktemp -d)
 # the version of the wheels we are testing.
 ${PYTHON_BIN:-python3} -m virtualenv "$VIRTUAL_ENV"
 PYTHON=$VIRTUAL_ENV/bin/python
-"$PYTHON" -m pip install --upgrade six pip==25.2 wheel setuptools
+"$PYTHON" -m pip install --upgrade six pip wheel setuptools
 
 function validate_wheel_hashes() {
   for file in "$@"; do

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -19,7 +19,7 @@ set PATH=C:\%1;C:\%1\scripts;%PATH%
 set PATH=C:\msys64\mingw%2\bin;C:\tools\msys64\mingw%2\bin;%PATH%
 :end_mingw64_installation
 
-python -m pip install --upgrade pip==25.2 six
+python -m pip install --upgrade pip six
 @rem Ping to a single version to make sure we're building the same artifacts
 python -m pip install setuptools==77.0.1 wheel==0.43.0
 python -m pip install --upgrade "cython==3.1.1"

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -28,7 +28,7 @@ export CCACHE_NOHASHDIR=true
 source tools/internal_ci/helper_scripts/prepare_ccache_symlinks_rc
 
 # Needed for building binary distribution wheels -- bdist_wheel
-"${PYTHON}" -m pip install --upgrade pip==25.2
+"${PYTHON}" -m pip install --upgrade pip
 # Ping to a single version to make sure we're building the same artifacts
 "${PYTHON}" -m pip install setuptools==77.0.1 wheel==0.43.0 build==1.3.0
 

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -146,7 +146,7 @@ pip_install() {
   $VENV_PYTHON -m pip install "$@"
 }
 
-pip_install --upgrade pip==25.2
+pip_install --upgrade pip
 pip_install --upgrade wheel
 pip_install --upgrade setuptools==77.0.1
 


### PR DESCRIPTION
`pip` was pinned to a lower version before we migrated to `pyproject.toml` build system. Now that we've migrated to it after #40833, we can revert the change from commit ce9f0496e7987a72874887a7331b1ab9aaee8988.

