### PR TITLE
[Python] Add abort_with_status to the aio ServicerContext ABC

### DIFF
--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -217,6 +217,25 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    async def abort_with_status(self, status: grpc.Status) -> NoReturn:
+        """Raises an exception to terminate the RPC with a non-OK status.
+
+        The status passed as argument will supersede any existing status code,
+        status message and trailing metadata.
+
+        This is an EXPERIMENTAL API.
+
+        Args:
+          status: A grpc.Status object. The status code in it must not be
+            StatusCode.OK.
+
+        Raises:
+          Exception: An exception is always raised to signal the abortion the
+            RPC to the gRPC runtime.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def set_trailing_metadata(self, trailing_metadata: MetadataType) -> None:
         """Sends the trailing metadata for the RPC.
 

--- a/src/python/grpcio/grpc/aio/_base_server.py
+++ b/src/python/grpcio/grpc/aio/_base_server.py
@@ -230,7 +230,7 @@ class ServicerContext(Generic[RequestType, ResponseType], abc.ABC):
             StatusCode.OK.
 
         Raises:
-          Exception: An exception is always raised to signal the abortion the
+          Exception: An exception is always raised to signal the abortion of the
             RPC to the gRPC runtime.
         """
         raise NotImplementedError()


### PR DESCRIPTION
Adds `abort_with_status` as an `@abc.abstractmethod` to the asynchronous `grpc.aio.ServicerContext` ABC (`src/python/grpcio/grpc/aio/_base_server.py`).

`abort_with_status` is already part of the public, documented API everywhere except the async ABC:

- The **synchronous** `grpc.ServicerContext` ABC declares it as an `@abc.abstractmethod`.
- The **concrete** async context that handlers receive, `grpc._cython.cygrpc._ServicerContext`, already implements it as a coroutine (it delegates to `abort`).

This PR just plugs the gap for the async ABC. This shouldn't change any behaviour, nor should it require any additional tests because `src/python/grpcio_tests/tests_aio/status/grpc_status_test.py` already exercises `abort_with_status` on a real async context.

Please let me know if there's any additional information required for the PR.