### PR TITLE
[Python] Pright typeCheckingMode - standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ include = [
     "src/python/grpcio/grpc/aio/_base_server.py"
 ]
 
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 exclude = [
     "**/third_party",
     "**/build",

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -587,6 +587,7 @@ class UnaryUnaryCall(
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
+        serialized_response: bytes = b""
         try:
             serialized_response = await self._cython_call.unary_unary(
                 serialized_request, self._metadata, self._context

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -587,7 +587,7 @@ class UnaryUnaryCall(
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
-        serialized_response: bytes = b""
+        serialized_response: Optional[bytes] = b""
         try:
             serialized_response = await self._cython_call.unary_unary(
                 serialized_request, self._metadata, self._context
@@ -596,7 +596,7 @@ class UnaryUnaryCall(
             if not self.cancelled():
                 self.cancel()
 
-        if self._cython_call.is_ok():
+        if self._cython_call.is_ok() and serialized_response is not None:
             return _common.deserialize(
                 serialized_response, self._response_deserializer
             )

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -147,7 +147,7 @@ class Metadata(Collection):  # noqa: PLW1641
     def set_all(self, key: MetadataKey, values: List[MetadataValue]) -> None:
         self._metadata[key] = values
 
-    def __contains__(self, key: MetadataKey) -> bool:
+    def __contains__(self, key: Any) -> bool:
         return key in self._metadata
 
     def __eq__(self, other: object) -> bool:

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -147,7 +147,7 @@ class Metadata(Collection):  # noqa: PLW1641
     def set_all(self, key: MetadataKey, values: List[MetadataValue]) -> None:
         self._metadata[key] = values
 
-    def __contains__(self, key: Any) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self._metadata
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
# Description

Change `typeCheckingMode` of Pyright to `standard`

Errors resolved - 

```
  grpc/aio/_call.py:600:17 - error: "serialized_response" is possibly unbound (reportPossiblyUnboundVariable)
grpc/aio/_metadata.py
  grpc/aio/_metadata.py:150:9 - error: Method "__contains__" overrides class "Container" in an incompatible manner
    Parameter 2 type mismatch: base parameter is type "Any", override parameter is type "MetadataKey"
```

# Testing

Ci