### PR TITLE
[Python] Pyright typeCheckingMode - standard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ include = [
     "src/python/grpcio/grpc/aio/_base_server.py"
 ]
 
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 exclude = [
     "**/third_party",
     "**/build",

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -584,7 +584,7 @@ class UnaryUnaryCall(
             self._request, self._request_serializer
         )
 
-        serialized_response: Optional[bytes] = b""
+        serialized_response: Optional[bytes] = None
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -587,6 +587,7 @@ class UnaryUnaryCall(
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
+        serialized_response: bytes = b""
         try:
             serialized_response = await self._cython_call.unary_unary(
                 serialized_request, self._metadata, self._context

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -584,10 +584,10 @@ class UnaryUnaryCall(
             self._request, self._request_serializer
         )
 
+        serialized_response: Optional[bytes] = b""
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
-        serialized_response: Optional[bytes] = b""
         try:
             serialized_response = await self._cython_call.unary_unary(
                 serialized_request, self._metadata, self._context

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -587,7 +587,7 @@ class UnaryUnaryCall(
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
-        serialized_response: bytes = b""
+        serialized_response: Optional[bytes] = b""
         try:
             serialized_response = await self._cython_call.unary_unary(
                 serialized_request, self._metadata, self._context
@@ -596,7 +596,7 @@ class UnaryUnaryCall(
             if not self.cancelled():
                 self.cancel()
 
-        if self._cython_call.is_ok():
+        if self._cython_call.is_ok() and serialized_response is not None:
             return _common.deserialize(
                 serialized_response, self._response_deserializer
             )

--- a/src/python/grpcio/grpc/aio/_call.py
+++ b/src/python/grpcio/grpc/aio/_call.py
@@ -584,7 +584,6 @@ class UnaryUnaryCall(
             self._request, self._request_serializer
         )
 
-        serialized_response: Optional[bytes] = None
         # NOTE(lidiz) asyncio.CancelledError is not a good transport for status,
         # because the asyncio.Task class do not cache the exception object.
         # https://github.com/python/cpython/blob/edad4d89e357c92f70c0324b937845d652b20afd/Lib/asyncio/tasks.py#L785
@@ -595,8 +594,9 @@ class UnaryUnaryCall(
         except asyncio.CancelledError:
             if not self.cancelled():
                 self.cancel()
+            return cygrpc.EOF
 
-        if self._cython_call.is_ok() and serialized_response is not None:
+        if self._cython_call.is_ok():
             return _common.deserialize(
                 serialized_response, self._response_deserializer
             )

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -150,8 +150,7 @@ class Metadata(Collection):  # noqa: PLW1641
     def __contains__(self, key: object) -> bool:
         if isinstance(key, MetadataKey):
             return key in self._metadata
-        err_msg = f"__contains__ on {self.__class__.__name__} expects MetadataKey type"
-        raise TypeError(err_msg)
+        return False
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -150,9 +150,8 @@ class Metadata(Collection):  # noqa: PLW1641
     def __contains__(self, key: object) -> bool:
         if isinstance(key, MetadataKey):
             return key in self._metadata
-        raise TypeError(
-            f"__contains__ on {self.__class__.__name__} expects MetadataKey type"
-        )
+        err_msg = f"__contains__ on {self.__class__.__name__} expects MetadataKey type"
+        raise TypeError(err_msg)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -148,7 +148,11 @@ class Metadata(Collection):  # noqa: PLW1641
         self._metadata[key] = values
 
     def __contains__(self, key: object) -> bool:
-        return key in self._metadata
+        if isinstance(key, MetadataKey):
+            return key in self._metadata
+        raise TypeError(
+            f"__contains__ on {self.__class__.__name__} expects MetadataKey type"
+        )
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -148,9 +148,9 @@ class Metadata(Collection):  # noqa: PLW1641
         self._metadata[key] = values
 
     def __contains__(self, key: object) -> bool:
-        if isinstance(key, MetadataKey):
-            return key in self._metadata
-        return False
+        if not isinstance(key, MetadataKey):
+            return False
+        return key in self._metadata
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -147,7 +147,7 @@ class Metadata(Collection):  # noqa: PLW1641
     def set_all(self, key: MetadataKey, values: List[MetadataValue]) -> None:
         self._metadata[key] = values
 
-    def __contains__(self, key: MetadataKey) -> bool:
+    def __contains__(self, key: Any) -> bool:
         return key in self._metadata
 
     def __eq__(self, other: object) -> bool:

--- a/src/python/grpcio/grpc/aio/_metadata.py
+++ b/src/python/grpcio/grpc/aio/_metadata.py
@@ -147,7 +147,7 @@ class Metadata(Collection):  # noqa: PLW1641
     def set_all(self, key: MetadataKey, values: List[MetadataValue]) -> None:
         self._metadata[key] = values
 
-    def __contains__(self, key: Any) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self._metadata
 
     def __eq__(self, other: object) -> bool:


### PR DESCRIPTION
# Description

Change `typeCheckingMode` of Pyright to `standard`

Errors resolved - 

```
  grpc/aio/_call.py:600:17 - error: "serialized_response" is possibly unbound (reportPossiblyUnboundVariable)
grpc/aio/_metadata.py
  grpc/aio/_metadata.py:150:9 - error: Method "__contains__" overrides class "Container" in an incompatible manner
    Parameter 2 type mismatch: base parameter is type "Any", override parameter is type "MetadataKey"
```

# Testing

Ci