### PR TITLE
[CI] Fix macos/grpc_objc_bazel_test

### DIFF
--- a/src/objective-c/tests/BUILD
+++ b/src/objective-c/tests/BUILD
@@ -260,7 +260,6 @@ grpc_objc_testing_library(
     deps = [
         "//src/core:cf_event_engine",
         "//test/core/event_engine/cf:cf_engine_unit_test_lib",
-        "//test/core/event_engine/test_suite/tests:dns",
         "//test/core/event_engine/test_suite/tests:timer",
     ],
 )

--- a/src/objective-c/tests/EventEngineTests/CFEventEngineUnitTests.mm
+++ b/src/objective-c/tests/EventEngineTests/CFEventEngineUnitTests.mm
@@ -22,7 +22,6 @@
 
 #include "src/core/lib/event_engine/cf_engine/cf_engine.h"
 #include "test/core/event_engine/test_suite/event_engine_test_framework.h"
-#include "test/core/event_engine/test_suite/tests/dns_test.h"
 #include "test/core/event_engine/test_suite/tests/timer_test.h"
 #include "test/core/test_util/test_config.h"
 
@@ -48,7 +47,6 @@
   };
   SetEventEngineFactories(factory, nullptr);
   grpc_event_engine::experimental::InitTimerTests();
-  grpc_event_engine::experimental::InitDNSTests();
   // TODO(ctiller): EventEngine temporarily needs grpc to be initialized first
   // until we clear out the iomgr shutdown code.
   grpc_init();


### PR DESCRIPTION
Upgrading rules_python to 2.0.2 introduced strict target platform checks, which broke the iOS simulator EventEngine tests analysis because it transitively depended on mock DNS server Python targets that require the 'twisted' library.

Since CFEventEngine does not support custom DNS servers, the mock DNS tests are not runnable or applicable here anyway. Removing this dependency fixes the iOS CI analysis and build.



