### PR TITLE
Fix big-endian test failure in BufferListTest

### DIFF
--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -237,9 +237,11 @@ TEST(BufferListTest, TestLongPendingAckForSomeTracedBuffers) {
           ASSERT_EQ(ts->acked_time.time.tv_sec, 123);
           ASSERT_EQ(ts->acked_time.time.tv_nsec, 456);
           ASSERT_GT(ts->info.length, 0);
-          *(reinterpret_cast<int*>(arg)) = 1;
+          gpr_atm_rel_store(reinterpret_cast<gpr_atm*>(arg),
+                            static_cast<gpr_atm>(1));
         } else if (error == absl::DeadlineExceededError("Ack timed out")) {
-          *(reinterpret_cast<int*>(arg)) = 2;
+          gpr_atm_rel_store(reinterpret_cast<gpr_atm*>(arg),
+                            static_cast<gpr_atm>(2));
         } else {
           ASSERT_TRUE(false);
         }


### PR DESCRIPTION
The TestLongPendingAckForSomeTracedBuffers callback wrote through an int* cast of a gpr_atm* (intptr_t*) pointer. On big-endian platforms (e.g. s390x) this stores the value in the upper 32 bits of the 64-bit atomic, so reading it back yields 1<<32 (4294967296) instead of 1.

Use gpr_atm_rel_store() with the correct gpr_atm type, consistent with every other test in the same file.

Fixes #35350




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.
release notes: no
-->

