### PR TITLE
guard end of line in http request version parsing

### DIFF
--- a/src/core/util/http_client/parser.cc
+++ b/src/core/util/http_client/parser.cc
@@ -125,7 +125,13 @@ static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
   if (cur == end || *cur++ != '/') {
     return GRPC_ERROR_CREATE("Expected '/'");
   }
+  if (cur == end) {
+    return GRPC_ERROR_CREATE("End of line in HTTP version string");
+  }
   vers_major = static_cast<uint8_t>(*cur++ - '1' + 1);
+  if (cur == end) {
+    return GRPC_ERROR_CREATE("End of line in HTTP version string");
+  }
   ++cur;
   if (cur == end) {
     return GRPC_ERROR_CREATE("End of line in HTTP version string");

--- a/src/core/util/http_client/parser.cc
+++ b/src/core/util/http_client/parser.cc
@@ -129,10 +129,9 @@ static grpc_error_handle handle_request_line(grpc_http_parser* parser) {
     return GRPC_ERROR_CREATE("End of line in HTTP version string");
   }
   vers_major = static_cast<uint8_t>(*cur++ - '1' + 1);
-  if (cur == end) {
-    return GRPC_ERROR_CREATE("End of line in HTTP version string");
+  if (cur == end || *cur++ != '.') {
+    return GRPC_ERROR_CREATE("Expected '.'");
   }
-  ++cur;
   if (cur == end) {
     return GRPC_ERROR_CREATE("End of line in HTTP version string");
   }

--- a/test/core/util/http_client/parser_test.cc
+++ b/test/core/util/http_client/parser_test.cc
@@ -314,6 +314,12 @@ TEST(ParserTest, MainTest) {
     test_request_fails(split_modes[i], "GET / ____/1.0\r\n");
     test_request_fails(split_modes[i], "GET / HTTP/1.2\r\n");
     test_request_fails(split_modes[i], "GET / HTTP/1.0\n");
+    // Request line that ends right after "HTTP/" walked past the end of the
+    // line while reading the version digits. The single-LF form reads past the
+    // buffer before the fix; both forms must be rejected without an OOB read.
+    test_request_fails(split_modes[i], "GET / HTTP/\n");
+    test_request_fails(split_modes[i], "GET / HTTP/\r\n");
+    test_request_fails(split_modes[i], "GET / HTTP/1\n");
 
     char* tmp1 =
         static_cast<char*>(gpr_malloc(2 * GRPC_HTTP_PARSER_MAX_HEADER_LENGTH));


### PR DESCRIPTION
handle_request_line in the http client parser reads the HTTP version major and minor digits without first checking cur against end, unlike handle_response_line in the same file which guards every read. A request line that ends right after `HTTP/` with a bare LF terminator walks one to two bytes past the parsed line, which ASAN flags as a heap read overflow when the line sits in its own buffer. This adds the same end-of-line guards before the major read, before the separator skip, and before the minor read.