### PR TITLE
[DO NOT MERGE][CMake] Update minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 set(PACKAGE_NAME          "grpc")
 set(PACKAGE_VERSION       "1.83.0-dev")

--- a/examples/android/helloworld/app/CMakeLists.txt
+++ b/examples/android/helloworld/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 set(helloworld_PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(helloworld_GRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")

--- a/examples/cpp/auth/CMakeLists.txt
+++ b/examples/cpp/auth/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Cancellation C CXX)
 

--- a/examples/cpp/cancellation/CMakeLists.txt
+++ b/examples/cpp/cancellation/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Cancellation C CXX)
 

--- a/examples/cpp/cmake/common.cmake
+++ b/examples/cpp/cmake/common.cmake
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building route_guide.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/examples/cpp/compression/CMakeLists.txt
+++ b/examples/cpp/compression/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Compression C CXX)
 

--- a/examples/cpp/deadline/CMakeLists.txt
+++ b/examples/cpp/deadline/CMakeLists.txt
@@ -16,7 +16,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building this example.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Deadline C CXX)
 

--- a/examples/cpp/error_details/CMakeLists.txt
+++ b/examples/cpp/error_details/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(ErrorDetails C CXX)
 

--- a/examples/cpp/error_handling/CMakeLists.txt
+++ b/examples/cpp/error_handling/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(ErrorHandling C CXX)
 

--- a/examples/cpp/flow_control/CMakeLists.txt
+++ b/examples/cpp/flow_control/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building example.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/generic_api/CMakeLists.txt
+++ b/examples/cpp/generic_api/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(GenericAPI C CXX)
 

--- a/examples/cpp/health/CMakeLists.txt
+++ b/examples/cpp/health/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -20,7 +20,7 @@
 # including the "helloworld" project itself.
 # See https://blog.kitware.com/cmake-superbuilds-git-submodules/
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 # Project
 project(HelloWorld-SuperBuild C CXX)

--- a/examples/cpp/interceptors/CMakeLists.txt
+++ b/examples/cpp/interceptors/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building keyvaluestore.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(KeyValueStore C CXX)
 

--- a/examples/cpp/keepalive/CMakeLists.txt
+++ b/examples/cpp/keepalive/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/load_balancing/CMakeLists.txt
+++ b/examples/cpp/load_balancing/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(LoadBalancing C CXX)
 

--- a/examples/cpp/metadata/CMakeLists.txt
+++ b/examples/cpp/metadata/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Metadata C CXX)
 

--- a/examples/cpp/multiplex/CMakeLists.txt
+++ b/examples/cpp/multiplex/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Multiplex C CXX)
 

--- a/examples/cpp/otel/CMakeLists.txt
+++ b/examples/cpp/otel/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(grpc_opentelemetry_example C CXX)
 

--- a/examples/cpp/otel/codelab/CMakeLists.txt
+++ b/examples/cpp/otel/codelab/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(grpc_opentelemetry_example C CXX)
 

--- a/examples/cpp/otel/ostream/CMakeLists.txt
+++ b/examples/cpp/otel/ostream/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(grpc_opentelemetry_example C CXX)
 

--- a/examples/cpp/retry/CMakeLists.txt
+++ b/examples/cpp/retry/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building retry.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(Retry C CXX)
 

--- a/examples/cpp/route_guide/CMakeLists.txt
+++ b/examples/cpp/route_guide/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building route_guide.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(RouteGuide C CXX)
 

--- a/examples/cpp/wait_for_ready/CMakeLists.txt
+++ b/examples/cpp/wait_for_ready/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 project(HelloWorld C CXX)
 

--- a/src/android/test/interop/app/CMakeLists.txt
+++ b/src/android/test/interop/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 
 set(PROTOBUF_PROTOC_EXECUTABLE "/usr/local/bin/protoc" CACHE STRING "Protoc binary on host")
 set(gRPC_CPP_PLUGIN_EXECUTABLE "/usr/local/bin/grpc_cpp_plugin" CACHE STRING "gRPC CPP plugin binary on host")

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -131,7 +131,7 @@ also sets up an `add_subdirectory()` rule for you. This causes gRPC to be
 built as part of your project.
 
 ```cmake
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.22)
 project(my_project)
 
 include(FetchContent)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -282,7 +282,7 @@
         protobuf_gen_files.add(src)
   %>
 
-  cmake_minimum_required(VERSION 3.16)
+  cmake_minimum_required(VERSION 3.22)
 
   set(PACKAGE_NAME          "grpc")
   set(PACKAGE_VERSION       "${settings.cpp_version}")

--- a/test/distrib/cpp/run_distrib_test_cmake.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake.sh
@@ -19,7 +19,12 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # Install openssl (to use instead of boringssl)
-apt-get update && apt-get install -y libssl-dev
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y libssl-dev wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
 
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}

--- a/test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_aarch64_cross.sh
@@ -19,7 +19,12 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # Install openssl (to use instead of boringssl)
-apt-get update && apt-get install -y libssl-dev
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y libssl-dev wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
 
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}

--- a/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.sh
@@ -19,7 +19,12 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # Install openssl (to use instead of boringssl)
-apt-get update && apt-get install -y libssl-dev
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y libssl-dev wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
 
 # To increase the confidence that gRPC installation works without depending on
 # too many submodules unnecessarily, just wipe out contents of most submodules

--- a/test/distrib/cpp/run_distrib_test_cmake_as_submodule.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_submodule.sh
@@ -18,6 +18,13 @@ set -ex
 
 cd "$(dirname "$0")/../../.."
 
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
+
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}
 

--- a/test/distrib/cpp/run_distrib_test_cmake_fetchcontent.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_fetchcontent.sh
@@ -20,7 +20,12 @@ cd "$(dirname "$0")/../../.."
 grpc_dir=$(pwd)
 
 # Install openssl (to use instead of boringssl)
-apt-get update && apt-get install -y libssl-dev
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y libssl-dev wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
 
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}

--- a/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_module_install.sh
@@ -19,7 +19,12 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # Install openssl (to use instead of boringssl)
-apt-get update && apt-get install -y libssl-dev
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y libssl-dev wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
 
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}

--- a/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
@@ -19,7 +19,12 @@ set -ex
 cd "$(dirname "$0")/../../.."
 
 # Install openssl (to use instead of boringssl)
-apt-get update && apt-get install -y libssl-dev
+# Install a newer CMake version at runtime to satisfy BoringSSL's 3.22+ requirement
+# (The pinned Docker image might only have an older CMake version, e.g. 3.18 on Debian 11)
+apt-get update && apt-get install -y libssl-dev wget
+wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
+export PATH="/usr/local/bin:$PATH"
+cmake --version
 
 # Use externally provided env to determine build parallelism, otherwise use default.
 GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS=${GRPC_CPP_DISTRIBTEST_BUILD_COMPILER_JOBS:-4}

--- a/tools/buildgen/generate_projects.sh
+++ b/tools/buildgen/generate_projects.sh
@@ -55,7 +55,7 @@ fi
 # Create a clean virtual environment.
 if [[ ! -d "${VENV_DIR}" ]]; then
   # Attempt to install virtualenv.
-  if ! python3 -m pip freeze | grep virtualenv &>/dev/null; then
+  if ! python3 -c "import virtualenv" &>/dev/null; then
     echo "virtualenv Python module not installed. Attempting to install via pip." >/dev/stderr
     if INSTALL_OUTPUT=$(! python3 -m pip install virtualenv --upgrade &>/dev/stdout); then
       echo "$INSTALL_OUTPUT"

--- a/tools/dockerfile/distribtest/cpp_debian11_aarch64_cross_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/cpp_debian11_aarch64_cross_x64/Dockerfile
@@ -15,7 +15,9 @@
 FROM debian:11
 
 # gRPC C++ dependencies based on https://github.com/grpc/grpc/blob/master/BUILDING.md
-RUN apt-get update && apt-get install -y build-essential autoconf cmake libtool pkg-config && apt-get clean
+# Install cmake from kitware binary release to get a newer version (3.22+)
+RUN apt-get update && apt-get install -y build-essential autoconf libtool pkg-config wget && apt-get clean
+RUN wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
 
 # C++ distribtests are setup in a way that requires git
 RUN apt-get update && apt-get install -y git && apt-get clean

--- a/tools/dockerfile/distribtest/cpp_debian11_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/cpp_debian11_x64/Dockerfile
@@ -15,7 +15,9 @@
 FROM debian:11
 
 # gRPC C++ dependencies based on https://github.com/grpc/grpc/blob/master/BUILDING.md
-RUN apt-get update && apt-get install -y build-essential autoconf cmake libtool pkg-config && apt-get clean
+# Install cmake from kitware binary release to get a newer version (3.22+)
+RUN apt-get update && apt-get install -y build-essential autoconf libtool pkg-config wget && apt-get clean
+RUN wget -qO- https://github.com/Kitware/CMake/releases/download/v3.28.1/cmake-3.28.1-linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local
 
 # C++ distribtests are setup in a way that requires git
 RUN apt-get update && apt-get install -y git && apt-get clean


### PR DESCRIPTION
DO NOT MERGE

Testing upgrading the CMake version - this is needed to upgrade BoringSSL