### PR TITLE
[telemetry] add plumbing for locality label

### DIFF
--- a/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
+++ b/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
@@ -88,10 +88,6 @@ namespace {
 
 constexpr absl::string_view kWeightedRoundRobin = "weighted_round_robin";
 
-constexpr absl::string_view kMetricLabelLocality = "grpc.lb.locality";
-constexpr absl::string_view kMetricLabelBackendService =
-    "grpc.lb.backend_service";
-
 const auto kMetricRrFallback =
     GlobalInstrumentsRegistry::RegisterUInt64Counter(
         "grpc.lb.wrr.rr_fallback",

--- a/src/core/load_balancing/xds/cds.cc
+++ b/src/core/load_balancing/xds/cds.cc
@@ -346,7 +346,9 @@ class PriorityEndpointIterator final : public EndpointAddressesIterator {
                   .SetObject(hierarchical_path_attr)
                   .Set(GRPC_ARG_ADDRESS_WEIGHT, endpoint_weight)
                   .SetObject(locality_name->Ref())
-                  .Set(GRPC_ARG_XDS_LOCALITY_WEIGHT, locality.lb_weight);
+                  .Set(GRPC_ARG_XDS_LOCALITY_WEIGHT, locality.lb_weight)
+                  .Set(GRPC_ARG_LB_LOCALITY,
+                       locality_name->human_readable_string().as_string_view());
           if (!use_http_connect_) args = args.Remove(GRPC_ARG_XDS_HTTP_PROXY);
           callback(EndpointAddresses(endpoint.addresses(), args));
         }

--- a/src/core/resolver/endpoint_addresses.h
+++ b/src/core/resolver/endpoint_addresses.h
@@ -45,6 +45,9 @@
 // Backend service name associated with the addresses.
 #define GRPC_ARG_BACKEND_SERVICE "grpc.internal.backend_service"
 
+// Locality name associated with the addresses.
+#define GRPC_ARG_LB_LOCALITY "grpc.internal.lb_locality"
+
 namespace grpc_core {
 
 // A list of addresses for a given endpoint with an associated set of channel

--- a/src/core/telemetry/metrics.h
+++ b/src/core/telemetry/metrics.h
@@ -39,6 +39,9 @@
 namespace grpc_core {
 
 constexpr absl::string_view kMetricLabelTarget = "grpc.target";
+constexpr absl::string_view kMetricLabelBackendService =
+    "grpc.lb.backend_service";
+constexpr absl::string_view kMetricLabelLocality = "grpc.lb.locality";
 
 // A global registry of instruments(metrics). This API is designed to be used
 // to register instruments (Counter, Histogram, and Gauge) as part of program

--- a/src/cpp/ext/otel/otel_plugin.cc
+++ b/src/cpp/ext/otel/otel_plugin.cc
@@ -919,21 +919,16 @@ OpenTelemetryPluginImpl::~OpenTelemetryPluginImpl() {
   }
 }
 
-namespace {
-constexpr absl::string_view kLocality = "grpc.lb.locality";
-constexpr absl::string_view kBackendService = "grpc.lb.backend_service";
-}  // namespace
-
 absl::string_view OpenTelemetryPluginImpl::OptionalLabelKeyToString(
     grpc_core::ClientCallTracerInterface::CallAttemptTracer::OptionalLabelKey
         key) {
   switch (key) {
     case grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kLocality:
-      return kLocality;
+      return grpc_core::kMetricLabelLocality;
     case grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kBackendService:
-      return kBackendService;
+      return grpc_core::kMetricLabelBackendService;
     case grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kTelemetryLabel:
       return OpenTelemetryCustomLabelKey();
@@ -945,10 +940,10 @@ absl::string_view OpenTelemetryPluginImpl::OptionalLabelKeyToString(
 std::optional<
     grpc_core::ClientCallTracerInterface::CallAttemptTracer::OptionalLabelKey>
 OpenTelemetryPluginImpl::OptionalLabelStringToKey(absl::string_view key) {
-  if (key == kLocality) {
+  if (key == grpc_core::kMetricLabelLocality) {
     return grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kLocality;
-  } else if (key == kBackendService) {
+  } else if (key == grpc_core::kMetricLabelBackendService) {
     return grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kBackendService;
   } else if (key == OpenTelemetryCustomLabelKey()) {


### PR DESCRIPTION
Changes:
- Add new `GRPC_ARG_LB_LOCALITY` channel arg to propagate locality label to subchannel.
- Populate that channel arg in the cds LB policy.
- Avoid duplicate definitions of the backend_service and locality labels in WRR and the OTel plugin by moving them to a common place.

@ttarnogrodzki had already implemented this as part of #41073 ([A94](https://github.com/grpc/proposal/blob/master/A94-subchannel-otel-metrics.md)), but @gtcooke94 also needs this to unblock #42606 ([A118](https://github.com/grpc/proposal/blob/master/A118-tls-telemetry.md)), so I'm pulling this piece out into a separate PR to get it merged quickly.