### PR TITLE
Fix ruby cq panic hang

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -23,11 +23,8 @@
 #include <grpc/grpc.h>
 #include <grpc/impl/codegen/compression_types.h>
 #include <grpc/support/alloc.h>
-#include <stdbool.h>
 
 #include "rb_byte_buffer.h"
-/* TODO(nnepal): Include grpc/grpc_security.h for pure ruby call
- * credentials after rb_call_credentials gets removed */
 #include "rb_call_credentials.h"
 #include "rb_completion_queue.h"
 #include "rb_grpc.h"
@@ -84,6 +81,7 @@ static VALUE sym_cancelled;
 typedef struct grpc_rb_call {
   grpc_call* wrapped;
   grpc_completion_queue* queue;
+  int queue_leaked;
 } grpc_rb_call;
 
 static void destroy_call(grpc_rb_call* call) {
@@ -91,7 +89,9 @@ static void destroy_call(grpc_rb_call* call) {
   if (call->wrapped != NULL) {
     grpc_call_unref(call->wrapped);
     call->wrapped = NULL;
-    grpc_rb_completion_queue_destroy(call->queue);
+    if (!call->queue_leaked) {
+      grpc_rb_completion_queue_destroy(call->queue);
+    }
     call->queue = NULL;
   }
 }
@@ -808,6 +808,8 @@ struct call_run_batch_args {
   unsigned write_flag;
   VALUE ops_hash;
   run_batch_stack* st;
+  int batch_started;
+  int event_plucked;
 };
 
 static VALUE grpc_rb_call_run_batch_try(VALUE value_args) {
@@ -831,8 +833,10 @@ static VALUE grpc_rb_call_run_batch_try(VALUE value_args) {
              "grpc_call_start_batch failed with %s (code=%d)",
              grpc_call_error_detail_of(err), err);
   }
-  ev = rb_completion_queue_pluck(args->call->queue, tag,
-                                 gpr_inf_future(GPR_CLOCK_REALTIME), "call op");
+  args->batch_started = 1;
+  args->event_plucked = 0;
+  ev = rb_completion_queue_pluck_track(args->call->queue, tag,
+                                 gpr_inf_future(GPR_CLOCK_REALTIME), "call op", &args->event_plucked);
   if (!ev.success) {
     rb_raise(grpc_rb_eCallError, "call#run_batch failed somehow");
   }
@@ -844,6 +848,18 @@ static VALUE grpc_rb_call_run_batch_try(VALUE value_args) {
 static VALUE grpc_rb_call_run_batch_ensure(VALUE value_args) {
   grpc_rb_fork_unsafe_end();
   struct call_run_batch_args* args = (struct call_run_batch_args*)value_args;
+
+  if (args->batch_started && rb_errinfo() != Qnil) {
+    if (!args->event_plucked) {
+      if (args->call) {
+        if (args->call->wrapped) {
+          grpc_call_cancel(args->call->wrapped, NULL);
+        }
+        args->call->queue_leaked = 1;
+      }
+      return Qnil;
+    }
+  }
 
   if (args->st) {
     grpc_run_batch_stack_cleanup(args->st);
@@ -890,7 +906,9 @@ static VALUE grpc_rb_call_run_batch(VALUE self, VALUE ops_hash) {
       .call = call,
       .write_flag = rb_write_flag == Qnil ? 0 : NUM2UINT(rb_write_flag),
       .ops_hash = ops_hash,
-      .st = NULL};
+      .st = NULL,
+      .batch_started = 0,
+      .event_plucked = 0};
 
   return rb_ensure(grpc_rb_call_run_batch_try, (VALUE)&args,
                    grpc_rb_call_run_batch_ensure, (VALUE)&args);
@@ -1073,5 +1091,6 @@ VALUE grpc_rb_wrap_call(grpc_call* c, grpc_completion_queue* q) {
   wrapper = ALLOC(grpc_rb_call);
   wrapper->wrapped = c;
   wrapper->queue = q;
+  wrapper->queue_leaked = 0;
   return TypedData_Wrap_Struct(grpc_rb_cCall, &grpc_call_data_type, wrapper);
 }

--- a/src/ruby/ext/grpc/rb_completion_queue.c
+++ b/src/ruby/ext/grpc/rb_completion_queue.c
@@ -24,7 +24,6 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <ruby/thread.h>
-#include <stdbool.h>
 
 #include "rb_grpc.h"
 #include "rb_grpc_imports.generated.h"
@@ -36,6 +35,7 @@ typedef struct next_call_stack {
   gpr_timespec timeout;
   void* tag;
   volatile int interrupted;
+  int* plucked_flag;
 } next_call_stack;
 
 /* Calls grpc_completion_queue_pluck without holding the ruby GIL */
@@ -47,7 +47,12 @@ static void* grpc_rb_completion_queue_pluck_no_gil(void* param) {
     deadline = gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), increment);
     next_call->event = grpc_completion_queue_pluck(
         next_call->cq, next_call->tag, deadline, NULL);
-    if (next_call->event.type != GRPC_QUEUE_TIMEOUT) break;
+    if (next_call->event.type != GRPC_QUEUE_TIMEOUT) {
+      if (next_call->plucked_flag) {
+        *next_call->plucked_flag = 1;
+      }
+      break;
+    }
     if (gpr_time_cmp(deadline, next_call->timeout) > 0) break;
     if (next_call->interrupted) break;
   }
@@ -71,15 +76,16 @@ static void unblock_func(void* param) {
 
 /* Does the same thing as grpc_completion_queue_pluck, while properly releasing
    the GVL and handling interrupts */
-grpc_event rb_completion_queue_pluck(grpc_completion_queue* queue, void* tag,
+grpc_event rb_completion_queue_pluck_track(grpc_completion_queue* queue, void* tag,
                                      gpr_timespec deadline,
-                                     const char* reason) {
+                                     const char* reason, int* plucked_flag) {
   next_call_stack next_call;
   MEMZERO(&next_call, next_call_stack, 1);
   next_call.cq = queue;
   next_call.timeout = deadline;
   next_call.tag = tag;
   next_call.event.type = GRPC_QUEUE_TIMEOUT;
+  next_call.plucked_flag = plucked_flag;
   /* Loop until we finish a pluck without an interruption. See
    * https://github.com/grpc/grpc/issues/38210 for an example of why
    * this is necessary. */
@@ -93,4 +99,10 @@ grpc_event rb_completion_queue_pluck(grpc_completion_queue* queue, void* tag,
   } while (next_call.interrupted);
   grpc_absl_log_str(GPR_DEBUG, "CQ pluck loop done: ", reason);
   return next_call.event;
+}
+
+grpc_event rb_completion_queue_pluck(grpc_completion_queue* queue, void* tag,
+                                     gpr_timespec deadline,
+                                     const char* reason) {
+  return rb_completion_queue_pluck_track(queue, tag, deadline, reason, NULL);
 }

--- a/src/ruby/ext/grpc/rb_completion_queue.h
+++ b/src/ruby/ext/grpc/rb_completion_queue.h
@@ -33,4 +33,8 @@ void grpc_rb_completion_queue_destroy(grpc_completion_queue* cq);
 grpc_event rb_completion_queue_pluck(grpc_completion_queue* queue, void* tag,
                                      gpr_timespec deadline, const char* reason);
 
+grpc_event rb_completion_queue_pluck_track(grpc_completion_queue* queue, void* tag,
+                                     gpr_timespec deadline, const char* reason,
+                                     int* plucked_flag);
+
 #endif /* GRPC_RB_COMPLETION_QUEUE_H_ */


### PR DESCRIPTION
# [Ruby] Fix segmentation faults and hangs when a thread panics during a gRPC call (Fixes #42541)

## Description

Fixes #42541

This PR fixes a critical stability issue in the Ruby gRPC extension where interrupting a thread during an active gRPC network call (e.g. via `Timeout::Error` or `GRPC::Cancelled`) could lead to either a complete hang of the Ruby VM or a hard crash (Segmentation Fault) during Garbage Collection.

### The Problem

When a Ruby exception interrupts a thread running `grpc_completion_queue_pluck`, the thread abandons the operation and unwinds the stack via `longjmp`. 
Because the C++ core was never told to abort the network operation, the event was left stranded. When the Ruby Garbage Collector subsequently attempted to destroy the `grpc_completion_queue`, the C++ engine panicked (`Check failed`) because it strictly requires queues to be empty before destruction, triggering a Segmentation Fault.

Attempting to defensively `pluck` the event in the `ensure` block after issuing a `grpc_call_cancel()` caused a secondary bug: it hung the Ruby VM. `grpc_call_cancel` is asynchronous, and waiting for the background thread to abort the socket while holding the Ruby GVL froze the entire application.

### The Solution: The "Safe Leak" Architecture

We cannot safely block on a C++ thread after a Ruby panic without risking a hang, and we cannot destroy an active queue without triggering a segfault. Therefore, we adopt a "safe leak" architecture (similar to how the Python gRPC engine handles `KeyboardInterrupt`).

1. **Track Pluck State:** Modified `rb_completion_queue.c` to track whether the event was naturally plucked before the exception fired.
2. **Asynchronous Cancellation:** In the `ensure` block in `rb_call.c`, if the event is still pending, we issue `grpc_call_cancel()`.
3. **Abandon the Event:** We intentionally **do not wait** for the event. The Ruby thread is allowed to escape immediately, guaranteeing the VM will never hang.
4. **Leak the Queue:** We set a `queue_leaked` flag on the `grpc_rb_call`. When the Garbage Collector runs, it sees this flag and intentionally skips `grpc_completion_queue_destroy`. 

The C++ background thread eventually completes the aborted network request and drops the event into the leaked queue using the leaked memory tag. Because the queue is never destroyed, the `Check failed` assertion is never evaluated.

By sacrificing a tiny queue in memory (a few kilobytes) during a catastrophic thread panic, we elegantly and definitively prevent both the Ruby VM hang and the C++ engine segfault.

## Testing Done
- Validated using a reproduction script that launches a batch operation against a blackhole IP (`10.255.255.1:54321`) and forcefully interrupts the thread via `t.raise(GRPC::Cancelled)`. 
- Confirmed the Ruby process escapes the thread immediately, the GC completes seamlessly, and the process exits with `0` without any hangs or segfaults.
