### PR TITLE
[subchannel] skip connection scaling tests if event_engine_client experiment is disabled

### DIFF
--- a/test/core/end2end/tests/connection_scaling.cc
+++ b/test/core/end2end/tests/connection_scaling.cc
@@ -44,6 +44,10 @@ CORE_END2END_TEST(Http2FullstackSingleHopTests, SubchannelConnectionScaling) {
     GTEST_SKIP()
         << "this test requires the subchannel_connection_scaling experiment";
   }
+  if (!IsEventEngineClientEnabled()) {
+    GTEST_SKIP()
+        << "this test requires the event_engine_client experiment";
+  }
   testing::ScopedExperimentalEnvVar env(
       "GRPC_EXPERIMENTAL_MAX_CONCURRENT_STREAMS_CONNECTION_SCALING");
   InitServer(DefaultServerArgs().Set(GRPC_ARG_MAX_CONCURRENT_STREAMS, 3));
@@ -126,6 +130,10 @@ CORE_END2END_TEST(Http2FullstackSingleHopTests,
   if (!IsSubchannelConnectionScalingEnabled()) {
     GTEST_SKIP()
         << "this test requires the subchannel_connection_scaling experiment";
+  }
+  if (!IsEventEngineClientEnabled()) {
+    GTEST_SKIP()
+        << "this test requires the event_engine_client experiment";
   }
   testing::ScopedExperimentalEnvVar env(
       "GRPC_EXPERIMENTAL_MAX_CONCURRENT_STREAMS_CONNECTION_SCALING");

--- a/test/core/end2end/tests/connection_scaling.cc
+++ b/test/core/end2end/tests/connection_scaling.cc
@@ -45,8 +45,7 @@ CORE_END2END_TEST(Http2FullstackSingleHopTests, SubchannelConnectionScaling) {
         << "this test requires the subchannel_connection_scaling experiment";
   }
   if (!IsEventEngineClientEnabled()) {
-    GTEST_SKIP()
-        << "this test requires the event_engine_client experiment";
+    GTEST_SKIP() << "this test requires the event_engine_client experiment";
   }
   testing::ScopedExperimentalEnvVar env(
       "GRPC_EXPERIMENTAL_MAX_CONCURRENT_STREAMS_CONNECTION_SCALING");
@@ -132,8 +131,7 @@ CORE_END2END_TEST(Http2FullstackSingleHopTests,
         << "this test requires the subchannel_connection_scaling experiment";
   }
   if (!IsEventEngineClientEnabled()) {
-    GTEST_SKIP()
-        << "this test requires the event_engine_client experiment";
+    GTEST_SKIP() << "this test requires the event_engine_client experiment";
   }
   testing::ScopedExperimentalEnvVar env(
       "GRPC_EXPERIMENTAL_MAX_CONCURRENT_STREAMS_CONNECTION_SCALING");


### PR DESCRIPTION
These tests seem to be flaking only in the specific combination of an opt build with the poll polling engine with the event_engine_client experiment disabled.  The problem appears to be that when the subchannel creates a second connection, all reads on the second subchannel take 5 seconds to complete, which almost certainly means that we're not properly polling the fd and are instead falling back to the client channel backup poller.

There is very likely some sort of bug here, possibly related to pollset_set handling, but it's not worth trying to fix, given how close we are to eliminating iomgr.  So for now, just skip these tests if the event_engine_client experiment is not enabled.