### PR TITLE
[Ruby] Fix: Addressed Array of strings passed as metadata

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -401,7 +401,6 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
   long i;
   grpc_slice key_slice;
   grpc_slice value_slice;
-  char* tmp_str = NULL;
 
   if (TYPE(key) == T_SYMBOL) {
     key_slice = grpc_slice_from_static_string(rb_id2name(SYM2ID(key)));
@@ -415,9 +414,9 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
   }
 
   if (!grpc_header_key_is_legal(key_slice)) {
-    tmp_str = grpc_slice_to_c_string(key_slice);
+    grpc_slice_unref(key_slice);
     rb_raise(rb_eArgError,
-             "'%s' is an invalid header key, must match [a-z0-9-_.]+", tmp_str);
+             "'%"PRIsVALUE"' is an invalid header key, must match [a-z0-9-_.]+", key);
     return ST_STOP;
   }
 
@@ -433,14 +432,15 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
           RSTRING_PTR(rb_ary_entry(val, i)), RSTRING_LEN(rb_ary_entry(val, i)));
       if (!grpc_is_binary_header(key_slice) &&
           !grpc_header_nonbin_value_is_legal(value_slice)) {
-        // The value has invalid characters
-        tmp_str = grpc_slice_to_c_string(value_slice);
-        rb_raise(rb_eArgError, "Header value '%s' has invalid characters",
-                 tmp_str);
+        VALUE val_entry = rb_ary_entry(val, i);
+        grpc_slice_unref(value_slice);
+        grpc_slice_unref(key_slice);
+        rb_raise(rb_eArgError, "Header value '%"PRIsVALUE"' has invalid characters",
+                 val_entry);
         return ST_STOP;
       }
       GRPC_RUBY_ASSERT(md_ary->count < md_ary->capacity);
-      md_ary->metadata[md_ary->count].key = key_slice;
+      md_ary->metadata[md_ary->count].key = grpc_slice_ref(key_slice);
       md_ary->metadata[md_ary->count].value = value_slice;
       md_ary->count += 1;
     }
@@ -449,20 +449,23 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
         grpc_slice_from_copied_buffer(RSTRING_PTR(val), RSTRING_LEN(val));
     if (!grpc_is_binary_header(key_slice) &&
         !grpc_header_nonbin_value_is_legal(value_slice)) {
-      // The value has invalid characters
-      tmp_str = grpc_slice_to_c_string(value_slice);
-      rb_raise(rb_eArgError, "Header value '%s' has invalid characters",
-               tmp_str);
+      grpc_slice_unref(value_slice);
+      grpc_slice_unref(key_slice);
+      rb_raise(rb_eArgError, "Header value '%"PRIsVALUE"' has invalid characters",
+               val);
       return ST_STOP;
     }
     GRPC_RUBY_ASSERT(md_ary->count < md_ary->capacity);
-    md_ary->metadata[md_ary->count].key = key_slice;
+    md_ary->metadata[md_ary->count].key = grpc_slice_ref(key_slice);
     md_ary->metadata[md_ary->count].value = value_slice;
     md_ary->count += 1;
   } else {
+    grpc_slice_unref(key_slice);
     rb_raise(rb_eArgError, "Header values must be of type string or array");
     return ST_STOP;
   }
+  /* Release the local reference; each entry now owns its own ref. */
+  grpc_slice_unref(key_slice);
   return ST_CONTINUE;
 }
 

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -430,11 +430,16 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
     array_length = RARRAY_LEN(val);
     /* If the value is an array, add capacity for each value in the array */
     for (i = 0; i < array_length; i++) {
-      value_slice = grpc_slice_from_copied_buffer(
-          RSTRING_PTR(rb_ary_entry(val, i)), RSTRING_LEN(rb_ary_entry(val, i)));
+      VALUE val_entry = rb_ary_entry(val, i);
+      if (TYPE(val_entry) != T_STRING) {
+        grpc_slice_unref(key_slice);
+        rb_raise(rb_eTypeError, "Header values in array must be strings");
+        return ST_STOP;
+      }
+      value_slice = grpc_slice_from_copied_buffer(RSTRING_PTR(val_entry),
+                                                  RSTRING_LEN(val_entry));
       if (!grpc_is_binary_header(key_slice) &&
           !grpc_header_nonbin_value_is_legal(value_slice)) {
-        VALUE val_entry = rb_ary_entry(val, i);
         grpc_slice_unref(value_slice);
         grpc_slice_unref(key_slice);
         rb_raise(rb_eArgError,

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -416,7 +416,9 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
   if (!grpc_header_key_is_legal(key_slice)) {
     grpc_slice_unref(key_slice);
     rb_raise(rb_eArgError,
-             "'%"PRIsVALUE"' is an invalid header key, must match [a-z0-9-_.]+", key);
+             "'%" PRIsVALUE
+             "' is an invalid header key, must match [a-z0-9-_.]+",
+             key);
     return ST_STOP;
   }
 
@@ -435,7 +437,8 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
         VALUE val_entry = rb_ary_entry(val, i);
         grpc_slice_unref(value_slice);
         grpc_slice_unref(key_slice);
-        rb_raise(rb_eArgError, "Header value '%"PRIsVALUE"' has invalid characters",
+        rb_raise(rb_eArgError,
+                 "Header value '%" PRIsVALUE "' has invalid characters",
                  val_entry);
         return ST_STOP;
       }
@@ -451,8 +454,8 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
         !grpc_header_nonbin_value_is_legal(value_slice)) {
       grpc_slice_unref(value_slice);
       grpc_slice_unref(key_slice);
-      rb_raise(rb_eArgError, "Header value '%"PRIsVALUE"' has invalid characters",
-               val);
+      rb_raise(rb_eArgError,
+               "Header value '%" PRIsVALUE "' has invalid characters", val);
       return ST_STOP;
     }
     GRPC_RUBY_ASSERT(md_ary->count < md_ary->capacity);

--- a/src/ruby/spec/call_spec.rb
+++ b/src/ruby/spec/call_spec.rb
@@ -181,6 +181,20 @@ describe GRPC::Core::Call do
     end
   end
 
+  describe '#run_batch with array-valued metadata' do
+    it 'does not crash with long key and array value (DFVULN-864)' do
+      make_test_call do |call|
+        long_key = 'x-grpc-test-echo-initial' # 24 bytes (> 23)
+        metadata = { long_key => %w[value-a value-b value-c] }
+        ops = {
+          GRPC::Core::CallOps::SEND_INITIAL_METADATA => metadata,
+          GRPC::Core::CallOps::SEND_CLOSE_FROM_CLIENT => nil
+        }
+        expect { call.run_batch(ops) }.to raise_error(GRPC::Core::CallError)
+      end
+    end
+  end
+
   def make_test_call
     call = @ch.create_call(nil, nil, 'phony_method', nil, deadline)
     yield call

--- a/src/ruby/spec/call_spec.rb
+++ b/src/ruby/spec/call_spec.rb
@@ -182,7 +182,7 @@ describe GRPC::Core::Call do
   end
 
   describe '#run_batch with array-valued metadata' do
-    it 'does not crash with long key and array value (DFVULN-864)' do
+    it 'does not crash with long key and array value' do
       make_test_call do |call|
         long_key = 'x-grpc-test-echo-initial' # 24 bytes (> 23)
         metadata = { long_key => %w[value-a value-b value-c] }

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -206,11 +206,11 @@ describe 'Server Interceptors' do
 
     it 'should be invoked in FIFO order', server: true do
       expect(interceptor).to receive(:request_response).ordered
-        .once.and_call_original
+                                                       .once.and_call_original
       expect(interceptor2).to receive(:request_response).ordered
-        .once.and_call_original
+                                                        .once.and_call_original
       expect(interceptor3).to receive(:request_response).ordered
-        .once.and_call_original
+                                                        .once.and_call_original
 
       run_services_on_server(@server, services: [service]) do
         stub = build_insecure_stub(EchoStub)

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -206,11 +206,11 @@ describe 'Server Interceptors' do
 
     it 'should be invoked in FIFO order', server: true do
       expect(interceptor).to receive(:request_response).ordered
-                                                       .once.and_call_original
+        .once.and_call_original
       expect(interceptor2).to receive(:request_response).ordered
-                                                        .once.and_call_original
+        .once.and_call_original
       expect(interceptor3).to receive(:request_response).ordered
-                                                        .once.and_call_original
+        .once.and_call_original
 
       run_services_on_server(@server, services: [service]) do
         stub = build_insecure_stub(EchoStub)

--- a/src/ruby/spec/generic/server_interceptors_spec.rb
+++ b/src/ruby/spec/generic/server_interceptors_spec.rb
@@ -205,12 +205,9 @@ describe 'Server Interceptors' do
     end
 
     it 'should be invoked in FIFO order', server: true do
-      expect(interceptor).to receive(:request_response).ordered
-        .once.and_call_original
-      expect(interceptor2).to receive(:request_response).ordered
-        .once.and_call_original
-      expect(interceptor3).to receive(:request_response).ordered
-        .once.and_call_original
+      expect(interceptor).to receive(:request_response).ordered.once.and_call_original
+      expect(interceptor2).to receive(:request_response).ordered.once.and_call_original
+      expect(interceptor3).to receive(:request_response).ordered.once.and_call_original
 
       run_services_on_server(@server, services: [service]) do
         stub = build_insecure_stub(EchoStub)


### PR DESCRIPTION
Resolved heap use-after-free in ruby c extension sending headers of type array/longer than 23 bytes.

*   Ensured each metadata array entry holds its own reference to the key slice by calling `grpc_slice_ref` for each assignment.
*   Calls `grpc_slice_unref` on local slices immediately before any `rb_raise` to handle non-local jumps.
*   Switched to Ruby's built-in `%"PRIsVALUE"` specifier for including Ruby objects in `rb_raise` error messages. This lets Ruby handle the string conversion safely, preventing leaks from temporary C strings.

Also fixed the rubocop issue in `src/ruby/spec/generic/server_interceptors_spec.rb`  #42346 