### PR TITLE
[experiment] Remove the event_engine_poller_for_python experiment

### DIFF
--- a/bazel/experiments.bzl
+++ b/bazel/experiments.bzl
@@ -32,7 +32,6 @@ EXPERIMENT_ENABLES = {
     "event_engine_listener": "event_engine_listener",
     "event_engine_callback_cq": "event_engine_callback_cq,event_engine_client,event_engine_listener",
     "event_engine_for_all_other_endpoints": "event_engine_client,event_engine_dns,event_engine_dns_non_client_channel,event_engine_for_all_other_endpoints,event_engine_listener",
-    "event_engine_poller_for_python": "event_engine_poller_for_python",
     "fail_recv_metadata_on_deadline_exceeded": "fail_recv_metadata_on_deadline_exceeded",
     "free_large_allocator": "free_large_allocator",
     "fuse_filters": "fuse_filters",
@@ -93,7 +92,6 @@ EXPERIMENT_POLLERS = [
     "event_engine_fork",
     "event_engine_listener",
     "event_engine_for_all_other_endpoints",
-    "event_engine_poller_for_python",
     "pipelined_read_secure_endpoint",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -477,10 +477,6 @@ else:
         ("GRPC_ENABLE_FORK_SUPPORT", 1),
     )
 
-# Fix for multiprocessing support on Apple devices.
-# TODO(vigneshbabu): Remove this once the poll poller gets fork support.
-DEFINE_MACROS += (("GRPC_PYTHON_BUILD", 1),)
-
 # Fix for Cython build issue in aarch64.
 # It's required to define this macro before include <inttypes.h>.
 # <inttypes.h> was included in core/telemetry/call_tracer.h.

--- a/src/core/client_channel/backup_poller.cc
+++ b/src/core/client_channel/backup_poller.cc
@@ -65,11 +65,6 @@ void grpc_client_channel_global_init_backup_polling() {
   g_backup_polling_disabled = grpc_core::IsEventEngineClientEnabled() &&
                               grpc_core::IsEventEngineListenerEnabled() &&
                               grpc_core::IsEventEngineDnsEnabled();
-#ifdef GRPC_PYTHON_BUILD
-  if (!grpc_core::IsEventEnginePollerForPythonEnabled()) {
-    g_backup_polling_disabled = false;
-  }
-#endif
   if (g_backup_polling_disabled) {
     return;
   }
@@ -159,21 +154,11 @@ static void g_poller_init_locked() {
   }
 }
 
-static bool g_can_poll_in_background() {
-#ifndef GRPC_PYTHON_BUILD
-  return grpc_iomgr_run_in_background();
-#else
-  // No iomgr "event_engines" (not to be confused with the new EventEngine)
-  // are able to run in background.
-  return false;
-#endif
-}
-
 void grpc_client_channel_start_backup_polling(
     grpc_pollset_set* interested_parties) {
   if (g_backup_polling_disabled ||
       g_poll_interval == grpc_core::Duration::Zero() ||
-      g_can_poll_in_background()) {
+      grpc_iomgr_run_in_background()) {
     return;
   }
   gpr_mu_lock(&g_poller_mu);
@@ -193,7 +178,7 @@ void grpc_client_channel_stop_backup_polling(
     grpc_pollset_set* interested_parties) {
   if (g_backup_polling_disabled ||
       g_poll_interval == grpc_core::Duration::Zero() ||
-      g_can_poll_in_background()) {
+      grpc_iomgr_run_in_background()) {
     return;
   }
   grpc_pollset_set_del_pollset(interested_parties, g_poller->pollset);

--- a/src/core/ext/transport/chaotic_good/server/chaotic_good_server.cc
+++ b/src/core/ext/transport/chaotic_good/server/chaotic_good_server.cc
@@ -713,9 +713,7 @@ absl::StatusOr<int> AddChaoticGoodPort(Server* server, std::string addr,
   const std::string parsed_addr = URI::PercentDecode(addr);
   absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> results =
       std::vector<EventEngine::ResolvedAddress>();
-  if (IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (IsEventEngineDnsNonClientChannelEnabled()) {
     absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver =
         args.GetObjectRef<EventEngine>()->GetDNSResolver(
             EventEngine::DNSResolver::ResolverOptions());

--- a/src/core/ext/transport/chaotic_good_legacy/server/chaotic_good_server.cc
+++ b/src/core/ext/transport/chaotic_good_legacy/server/chaotic_good_server.cc
@@ -489,9 +489,7 @@ absl::StatusOr<int> AddLegacyChaoticGoodPort(Server* server, std::string addr,
   const std::string parsed_addr = URI::PercentDecode(addr);
   absl::StatusOr<std::vector<EventEngine::ResolvedAddress>> results =
       std::vector<EventEngine::ResolvedAddress>();
-  if (IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (IsEventEngineDnsNonClientChannelEnabled()) {
     absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver =
         args.GetObjectRef<EventEngine>()->GetDNSResolver(
             EventEngine::DNSResolver::ResolverOptions());

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -736,9 +736,7 @@ absl::StatusOr<int> Chttp2ServerAddPort(Server* server, const char* addr,
       resolved = grpc_resolve_vsock_address(parsed_addr_unprefixed);
       GRPC_RETURN_IF_ERROR(resolved.status());
     } else {
-      if (IsEventEngineDnsNonClientChannelEnabled() &&
-          !grpc_event_engine::experimental::
-              EventEngineExperimentDisabledForPython()) {
+      if (IsEventEngineDnsNonClientChannelEnabled()) {
         absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>> ee_resolver =
             args.GetObjectRef<EventEngine>()->GetDNSResolver(
                 EventEngine::DNSResolver::ResolverOptions());

--- a/src/core/lib/event_engine/posix_engine/posix_engine.cc
+++ b/src/core/lib/event_engine/posix_engine/posix_engine.cc
@@ -76,14 +76,6 @@ namespace grpc_event_engine::experimental {
 
 namespace {
 
-bool ShouldUsePosixPoller() {
-#if defined(GRPC_PYTHON_BUILD)
-  return grpc_core::IsEventEnginePollerForPythonEnabled();
-#else
-  return true;
-#endif
-}
-
 #if GRPC_ENABLE_FORK_SUPPORT && GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK
 
 // Thread pool can outlive EE but we need to ensure the ordering if both
@@ -434,10 +426,8 @@ PosixEventEngine::PosixEventEngine(const Options& options)
     : connection_shards_(options.connection_shards),
       executor_(MakeThreadPool(options.reserve_threads)),
       timer_manager_(std::make_shared<TimerManager>(executor_)) {
-  if (ShouldUsePosixPoller()) {
-    poller_ = grpc_event_engine::experimental::MakeDefaultPoller(executor_);
-    SchedulePoller();
-  }
+  poller_ = grpc_event_engine::experimental::MakeDefaultPoller(executor_);
+  SchedulePoller();
 }
 
 #endif  // GRPC_POSIX_SOCKET_TCP

--- a/src/core/lib/event_engine/shim.cc
+++ b/src/core/lib/event_engine/shim.cc
@@ -21,29 +21,15 @@
 
 namespace grpc_event_engine::experimental {
 
-bool UseEventEngineClient() {
-  return !EventEngineExperimentDisabledForPython() &&
-         grpc_core::IsEventEngineClientEnabled();
-}
+bool UseEventEngineClient() { return grpc_core::IsEventEngineClientEnabled(); }
 
 bool UseEventEngineListener() {
-  return !EventEngineExperimentDisabledForPython() &&
-         grpc_core::IsEventEngineListenerEnabled();
+  return grpc_core::IsEventEngineListenerEnabled();
 }
 
 bool UsePollsetAlternative() {
   return UseEventEngineClient() && UseEventEngineListener() &&
          grpc_core::IsPollsetAlternativeEnabled();
-}
-
-// Returns true if the poller is disabled by build configuration or experiment
-// flags.
-bool EventEngineExperimentDisabledForPython() {
-#ifdef GRPC_PYTHON_BUILD
-  return !grpc_core::IsEventEnginePollerForPythonEnabled();
-#else
-  return false;
-#endif
 }
 
 }  // namespace grpc_event_engine::experimental

--- a/src/core/lib/event_engine/shim.h
+++ b/src/core/lib/event_engine/shim.h
@@ -35,10 +35,6 @@ bool UseEventEngineListener();
 // may disable the poller in some builds.
 bool UsePollsetAlternative();
 
-// Returns true if the poller is disabled by build configuration or experiment
-// flags.
-bool EventEngineExperimentDisabledForPython();
-
 }  // namespace grpc_event_engine::experimental
 
 #endif  // GRPC_SRC_CORE_LIB_EVENT_ENGINE_SHIM_H

--- a/src/core/lib/experiments/experiments.cc
+++ b/src/core/lib/experiments/experiments.cc
@@ -89,9 +89,6 @@ const uint8_t required_experiments_event_engine_for_all_other_endpoints[] = {
     static_cast<uint8_t>(
         grpc_core::kExperimentIdEventEngineDnsNonClientChannel),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineListener)};
-const char* const description_event_engine_poller_for_python =
-    "Enable event engine poller in gRPC Python";
-const char* const additional_constraints_event_engine_poller_for_python = "{}";
 const char* const description_fail_recv_metadata_on_deadline_exceeded =
     "Fail recv initial metadata when the deadline is exceeded.";
 const char* const
@@ -332,10 +329,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_event_engine_for_all_other_endpoints,
      additional_constraints_event_engine_for_all_other_endpoints,
      required_experiments_event_engine_for_all_other_endpoints, 4, true, false},
-    {"event_engine_poller_for_python",
-     description_event_engine_poller_for_python,
-     additional_constraints_event_engine_poller_for_python, nullptr, 0, true,
-     true},
     {"fail_recv_metadata_on_deadline_exceeded",
      description_fail_recv_metadata_on_deadline_exceeded,
      additional_constraints_fail_recv_metadata_on_deadline_exceeded, nullptr, 0,
@@ -560,9 +553,6 @@ const uint8_t required_experiments_event_engine_for_all_other_endpoints[] = {
     static_cast<uint8_t>(
         grpc_core::kExperimentIdEventEngineDnsNonClientChannel),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineListener)};
-const char* const description_event_engine_poller_for_python =
-    "Enable event engine poller in gRPC Python";
-const char* const additional_constraints_event_engine_poller_for_python = "{}";
 const char* const description_fail_recv_metadata_on_deadline_exceeded =
     "Fail recv initial metadata when the deadline is exceeded.";
 const char* const
@@ -803,10 +793,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_event_engine_for_all_other_endpoints,
      additional_constraints_event_engine_for_all_other_endpoints,
      required_experiments_event_engine_for_all_other_endpoints, 4, true, false},
-    {"event_engine_poller_for_python",
-     description_event_engine_poller_for_python,
-     additional_constraints_event_engine_poller_for_python, nullptr, 0, true,
-     true},
     {"fail_recv_metadata_on_deadline_exceeded",
      description_fail_recv_metadata_on_deadline_exceeded,
      additional_constraints_fail_recv_metadata_on_deadline_exceeded, nullptr, 0,
@@ -1031,9 +1017,6 @@ const uint8_t required_experiments_event_engine_for_all_other_endpoints[] = {
     static_cast<uint8_t>(
         grpc_core::kExperimentIdEventEngineDnsNonClientChannel),
     static_cast<uint8_t>(grpc_core::kExperimentIdEventEngineListener)};
-const char* const description_event_engine_poller_for_python =
-    "Enable event engine poller in gRPC Python";
-const char* const additional_constraints_event_engine_poller_for_python = "{}";
 const char* const description_fail_recv_metadata_on_deadline_exceeded =
     "Fail recv initial metadata when the deadline is exceeded.";
 const char* const
@@ -1274,10 +1257,6 @@ const ExperimentMetadata g_experiment_metadata[] = {
      description_event_engine_for_all_other_endpoints,
      additional_constraints_event_engine_for_all_other_endpoints,
      required_experiments_event_engine_for_all_other_endpoints, 4, true, false},
-    {"event_engine_poller_for_python",
-     description_event_engine_poller_for_python,
-     additional_constraints_event_engine_poller_for_python, nullptr, 0, true,
-     true},
     {"fail_recv_metadata_on_deadline_exceeded",
      description_fail_recv_metadata_on_deadline_exceeded,
      additional_constraints_fail_recv_metadata_on_deadline_exceeded, nullptr, 0,

--- a/src/core/lib/experiments/experiments.h
+++ b/src/core/lib/experiments/experiments.h
@@ -89,8 +89,6 @@ inline bool IsEventEngineListenerEnabled() { return true; }
 inline bool IsEventEngineCallbackCqEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FOR_ALL_OTHER_ENDPOINTS
 inline bool IsEventEngineForAllOtherEndpointsEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_POLLER_FOR_PYTHON
-inline bool IsEventEnginePollerForPythonEnabled() { return true; }
 inline bool IsFailRecvMetadataOnDeadlineExceededEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsFuseFiltersEnabled() { return false; }
@@ -188,8 +186,6 @@ inline bool IsEventEngineListenerEnabled() { return true; }
 inline bool IsEventEngineCallbackCqEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FOR_ALL_OTHER_ENDPOINTS
 inline bool IsEventEngineForAllOtherEndpointsEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_POLLER_FOR_PYTHON
-inline bool IsEventEnginePollerForPythonEnabled() { return true; }
 inline bool IsFailRecvMetadataOnDeadlineExceededEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsFuseFiltersEnabled() { return false; }
@@ -287,8 +283,6 @@ inline bool IsEventEngineListenerEnabled() { return true; }
 inline bool IsEventEngineCallbackCqEnabled() { return true; }
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FOR_ALL_OTHER_ENDPOINTS
 inline bool IsEventEngineForAllOtherEndpointsEnabled() { return true; }
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_POLLER_FOR_PYTHON
-inline bool IsEventEnginePollerForPythonEnabled() { return true; }
 inline bool IsFailRecvMetadataOnDeadlineExceededEnabled() { return false; }
 inline bool IsFreeLargeAllocatorEnabled() { return false; }
 inline bool IsFuseFiltersEnabled() { return false; }
@@ -371,7 +365,6 @@ enum ExperimentIds {
   kExperimentIdEventEngineListener,
   kExperimentIdEventEngineCallbackCq,
   kExperimentIdEventEngineForAllOtherEndpoints,
-  kExperimentIdEventEnginePollerForPython,
   kExperimentIdFailRecvMetadataOnDeadlineExceeded,
   kExperimentIdFreeLargeAllocator,
   kExperimentIdFuseFilters,
@@ -486,10 +479,6 @@ inline bool IsEventEngineCallbackCqEnabled() {
 #define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_FOR_ALL_OTHER_ENDPOINTS
 inline bool IsEventEngineForAllOtherEndpointsEnabled() {
   return IsExperimentEnabled<kExperimentIdEventEngineForAllOtherEndpoints>();
-}
-#define GRPC_EXPERIMENT_IS_INCLUDED_EVENT_ENGINE_POLLER_FOR_PYTHON
-inline bool IsEventEnginePollerForPythonEnabled() {
-  return IsExperimentEnabled<kExperimentIdEventEnginePollerForPython>();
 }
 #define GRPC_EXPERIMENT_IS_INCLUDED_FAIL_RECV_METADATA_ON_DEADLINE_EXCEEDED
 inline bool IsFailRecvMetadataOnDeadlineExceededEnabled() {

--- a/src/core/lib/experiments/experiments.yaml
+++ b/src/core/lib/experiments/experiments.yaml
@@ -150,13 +150,6 @@
   uses_polling: true
   allow_in_fuzzing_config: false
   platforms: ["all"]
-- name: event_engine_poller_for_python
-  description: "Enable event engine poller in gRPC Python"
-  expiry: 2026/06/30
-  owner: mlumish@google.com
-  test_tags: []
-  uses_polling: true
-  platforms: ["all"]
 - name: fail_recv_metadata_on_deadline_exceeded
   description: Fail recv initial metadata when the deadline is exceeded.
   expiry: 2026/09/01
@@ -239,12 +232,12 @@
   owner: akshitpatel@google.com
   test_tags: [flow_control_test]
 - name: optimization_01
-  description: Optimization 
+  description: Optimization
   expiry: 2026/09/07
   owner: tjagtap@google.com
   test_tags: []
 - name: optimization_02
-  description: Optimization 
+  description: Optimization
   expiry: 2026/09/07
   owner: tjagtap@google.com
   test_tags: []
@@ -264,7 +257,7 @@
   owner: alishananda@google.com
   test_tags: []
 - name: optimization_06
-  description: Optimization 
+  description: Optimization
   expiry: 2027/01/30
   owner: tjagtap@google.com
   test_tags: []
@@ -276,7 +269,7 @@
 - name: ph2_client
   description:
     Use promises for the http2 client transport. We have kept client and
-    server transport experiments separate to help with smoother roll outs. 
+    server transport experiments separate to help with smoother roll outs.
     When this flag is enabled for the test suites, it would test PH2 Client with CHTTP2 Server.
   expiry: 2027/03/16
   owner: tjagtap@google.com

--- a/src/core/lib/experiments/rollouts.yaml
+++ b/src/core/lib/experiments/rollouts.yaml
@@ -66,8 +66,6 @@
   default: true
 - name: event_engine_listener
   default: true
-- name: event_engine_poller_for_python
-  default: true
 - name: fail_recv_metadata_on_deadline_exceeded
   default: false
 - name: free_large_allocator

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -334,9 +334,7 @@ static void fork_fd_list_remove_grpc_fd(grpc_fd* fd) {
 
 static grpc_fd* fd_create(int fd, const char* name, bool track_err) {
   grpc_fd* new_fd = nullptr;
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     grpc_fd* new_fd = static_cast<grpc_fd*>(gpr_malloc(sizeof(grpc_fd)));
     new_fd->fd = fd;
     return new_fd;
@@ -418,9 +416,7 @@ static void fd_shutdown(grpc_fd* fd, grpc_error_handle why) {
 
 static void fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
                       const char* reason) {
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     GRPC_CHECK_NE(release_fd, nullptr);
     GRPC_CHECK_EQ(on_done, nullptr);
     *release_fd = fd->fd;

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -379,9 +379,7 @@ static void unref_by(grpc_fd* fd, int n) {
 }
 
 static grpc_fd* fd_create(int fd, const char* name, bool track_err) {
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     GRPC_TRACE_LOG(event_engine, ERROR)
         << "Creating a wrapped EventEngine grpc_fd with fd:" << fd;
     grpc_fd* new_fd = static_cast<grpc_fd*>(gpr_malloc(sizeof(grpc_fd)));
@@ -480,9 +478,7 @@ static int fd_wrapped_fd(grpc_fd* fd) {
 
 static void fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
                       const char* reason) {
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     GRPC_CHECK_NE(release_fd, nullptr);
     GRPC_CHECK_EQ(on_done, nullptr);
     *release_fd = fd->fd;

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -1926,9 +1926,7 @@ static const grpc_endpoint_vtable vtable = {tcp_read,
 grpc_endpoint* grpc_tcp_create(
     grpc_fd* fd, const grpc_event_engine::experimental::EndpointConfig& config,
     absl::string_view peer_string) {
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     // Create an EventEngine endpoint when creating the transport.
     auto* engine =
         reinterpret_cast<grpc_event_engine::experimental::EventEngine*>(
@@ -1956,9 +1954,7 @@ grpc_endpoint* grpc_tcp_create(grpc_fd* em_fd,
   GRPC_CHECK(!grpc_event_engine::experimental::UsePollsetAlternative())
       << "This function must not be called when the pollset_alternative "
          "experiment is enabled. This is a bug.";
-  GRPC_CHECK(
-      !grpc_core::IsEventEngineForAllOtherEndpointsEnabled() ||
-      grpc_event_engine::experimental::EventEngineExperimentDisabledForPython())
+  GRPC_CHECK(!grpc_core::IsEventEngineForAllOtherEndpointsEnabled())
       << "The event_engine_for_all_other_endpoints experiment should prevent "
          "this method from being called. This is a bug.";
   grpc_tcp* tcp = new grpc_tcp(options);

--- a/src/core/resolver/dns/dns_resolver_plugin.cc
+++ b/src/core/resolver/dns/dns_resolver_plugin.cc
@@ -36,12 +36,7 @@ void RegisterDnsResolver(CoreConfiguration::Builder* builder) {
       std::make_unique<EventEngineClientChannelDNSResolverFactory>());
   return;
 #endif
-#ifdef GRPC_PYTHON_BUILD
-  bool use_ee = IsEventEnginePollerForPythonEnabled();
-#else   // GRPC_PYTHON_BUILD
-  bool use_ee = true;
-#endif  // GRPC_PYTHON_BUILD
-  if (use_ee && IsEventEngineDnsEnabled()) {
+  if (IsEventEngineDnsEnabled()) {
     VLOG(2) << "Using EventEngine dns resolver";
     builder->resolver_registry()->RegisterResolverFactory(
         std::make_unique<EventEngineClientChannelDNSResolverFactory>());

--- a/src/core/util/http_client/httpcli.cc
+++ b/src/core/util/http_client/httpcli.cc
@@ -176,10 +176,7 @@ HttpRequest::HttpRequest(
       pollent_(pollent),
       pollset_set_(grpc_pollset_set_create()),
       test_only_generate_response_(std::move(test_only_generate_response)),
-      use_event_engine_dns_resolver_(
-          IsEventEngineDnsNonClientChannelEnabled() &&
-          !grpc_event_engine::experimental::
-              EventEngineExperimentDisabledForPython()),
+      use_event_engine_dns_resolver_(IsEventEngineDnsNonClientChannelEnabled()),
       resolver_(!use_event_engine_dns_resolver_ ? GetDNSResolver() : nullptr),
       ee_resolver_(
           use_event_engine_dns_resolver_

--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -32,7 +32,6 @@ pyx_library(
         "cygrpc.pyx",
     ],
     data = [":copy_roots_pem"],
-    defines = ["GRPC_PYTHON_BUILD=1"],
     deps = [
         "//:grpc",
         "//src/python/grpcio/grpc/_cython/_cygrpc/private_key_signing:private_key_signer_py_wrapper",

--- a/src/python/grpcio_tests/tests/fork/methods.py
+++ b/src/python/grpcio_tests/tests/fork/methods.py
@@ -206,16 +206,17 @@ class _ChildProcess:
     def finish(self):
         terminated = self.wait(_CHILD_FINISH_TIMEOUT_S)
 
-        waitstatus = self._rc
-        exit_code = os.waitstatus_to_exitcode(waitstatus)
-        sys.stderr.write(f"Exit code: {exit_code} ({waitstatus=})\n")
-
         if not terminated:
             sys.stderr.write("Finishing child %d\n" % self._child_pid)
             debugger.print_backtraces(self._child_pid)
             raise RuntimeError(
                 "Child process %d did not terminate" % self._child_pid
             )
+
+        waitstatus = self._rc
+        exit_code = os.waitstatus_to_exitcode(waitstatus)
+        sys.stderr.write(f"Exit code: {exit_code} ({waitstatus=})\n")
+
         if self._rc != 0:
             raise ValueError(
                 f"Child process {self._child_pid} failed"

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -922,9 +922,7 @@ inline bool IsTestSampledInPr(const CoreTestConfiguration* config) {
     }                                                                          \
     SKIP_IF_DISABLED_IN_CONFIG(config, #suite, #name);                         \
     SKIP_IF_NOT_SAMPLED_IN_PR(config);                                         \
-    if (IsEventEngineDnsNonClientChannelEnabled() &&                           \
-        !grpc_event_engine::experimental::                                     \
-            EventEngineExperimentDisabledForPython()) {                        \
+    if (IsEventEngineDnsNonClientChannelEnabled()) {                           \
       GTEST_SKIP() << "event_engine_dns_non_client_channel experiment breaks " \
                       "fuzzing currently";                                     \
     }                                                                          \

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -592,9 +592,7 @@ static void on_read_request_done_locked(void* arg, grpc_error_handle error) {
   // Resolve address.
   grpc_resolved_address first_address;
   VLOG(2) << "proxy connecting to backend: " << conn->http_request.path;
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled()) {
     auto resolver = conn->proxy->combiner->event_engine->GetDNSResolver(
         grpc_event_engine::experimental::EventEngine::DNSResolver::
             ResolverOptions());

--- a/test/core/event_engine/event_engine_test_utils.cc
+++ b/test/core/event_engine/event_engine_test_utils.cc
@@ -254,9 +254,7 @@ bool IsSaneTimerEnvironment() {
   return grpc_core::IsEventEngineClientEnabled() &&
          grpc_core::IsEventEngineListenerEnabled() &&
          grpc_core::IsEventEngineDnsEnabled() &&
-         grpc_core::IsEventEngineDnsNonClientChannelEnabled() &&
-         !grpc_event_engine::experimental::
-             EventEngineExperimentDisabledForPython();
+         grpc_core::IsEventEngineDnsNonClientChannelEnabled();
 }
 
 }  // namespace experimental

--- a/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
+++ b/test/core/event_engine/fuzzing_event_engine/fuzzing_event_engine.cc
@@ -802,9 +802,7 @@ class FuzzerDNSResolver : public ExtendedType<EventEngine::DNSResolver,
 absl::StatusOr<std::unique_ptr<EventEngine::DNSResolver>>
 FuzzingEventEngine::GetDNSResolver(const DNSResolver::ResolverOptions&) {
 #if defined(GRPC_POSIX_SOCKET_TCP)
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled()) {
     return std::make_unique<FuzzerDNSResolver>(shared_from_this());
   }
   return std::make_unique<NativePosixDNSResolver>(shared_from_this());

--- a/test/core/iomgr/fd_posix_test.cc
+++ b/test/core/iomgr/fd_posix_test.cc
@@ -510,9 +510,7 @@ static void destroy_pollset(void* p, grpc_error_handle /*error*/) {
 }
 
 TEST(FdPosixTest, MainTest) {
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     GTEST_SKIP() << "The event_engine_for_all_other_endpoints experiment is "
                     "enabled, which replaces iomgr grpc_fds with minimal "
                     "implementations. The full iomgr API is not supported, so "

--- a/test/core/iomgr/resolve_address_posix_test.cc
+++ b/test/core/iomgr/resolve_address_posix_test.cc
@@ -177,9 +177,7 @@ static void test_named_and_numeric_scope_ids(void) {
 ABSL_FLAG(std::string, resolver, "", "Resolver type (ares or native)");
 
 TEST(ResolveAddressUsingAresResolverPosixTest, MainTest) {
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() ||
-      grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled()) {
     GTEST_SKIP()
         << "The event_engine_dns_non_client_channel experiment is "
            "enabled, so the legacy resolver is not used in this binary.";

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -161,9 +161,7 @@ class ResolveAddressTest : public ::testing::Test {
 
  protected:
   void SetUp() override {
-    if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-        !grpc_event_engine::experimental::
-            EventEngineExperimentDisabledForPython()) {
+    if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
       GTEST_SKIP()
           << "Skipping all legacy ResolveAddress tests. The "
              "event_engine_for_all_other_endpoints experiment is enabled, so "

--- a/test/core/iomgr/tcp_posix_test.cc
+++ b/test/core/iomgr/tcp_posix_test.cc
@@ -647,9 +647,7 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(&argc, argv);
   grpc_init();
-  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineForAllOtherEndpointsEnabled()) {
     LOG(INFO) << "This test is skipped since the "
                  "event_engine_for_all_other_endpoints experiment is enabled, "
                  "which replaces iomgr grpc_fds with minimal implementations. "

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -135,9 +135,7 @@ void test_bind_server_to_addr(const char* host, bool secure) {
 }
 
 static bool external_dns_works(const char* host) {
-  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled() ||
-      grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (grpc_core::IsEventEngineDnsNonClientChannelEnabled()) {
     auto resolver =
         grpc_event_engine::experimental::GetDefaultEventEngine()
             ->GetDNSResolver(grpc_event_engine::experimental::EventEngine::

--- a/test/core/test_util/resolve_localhost_ip46.cc
+++ b/test/core/test_util/resolve_localhost_ip46.cc
@@ -41,9 +41,7 @@ bool localhost_to_ipv6 = false;
 gpr_once g_resolve_localhost_ipv46 = GPR_ONCE_INIT;
 
 void InitResolveLocalhost() {
-  if (IsEventEngineDnsNonClientChannelEnabled() &&
-      !grpc_event_engine::experimental::
-          EventEngineExperimentDisabledForPython()) {
+  if (IsEventEngineDnsNonClientChannelEnabled()) {
     auto resolver =
         grpc_event_engine::experimental::GetDefaultEventEngine()
             ->GetDNSResolver(grpc_event_engine::experimental::EventEngine::

--- a/test/core/transport/chttp2/settings_timeout_test.cc
+++ b/test/core/transport/chttp2/settings_timeout_test.cc
@@ -134,9 +134,7 @@ class Client {
   void Connect() {
     ExecCtx exec_ctx;
     grpc_resolved_address addr;
-    if (IsEventEngineDnsNonClientChannelEnabled() &&
-        !grpc_event_engine::experimental::
-            EventEngineExperimentDisabledForPython()) {
+    if (IsEventEngineDnsNonClientChannelEnabled()) {
       auto resolver =
           grpc_event_engine::experimental::GetDefaultEventEngine()
               ->GetDNSResolver(grpc_event_engine::experimental::EventEngine::


### PR DESCRIPTION
We have had two releases of the Python library with this experiment enabled and with no relevant significant bugs reported, so we can now remove it. This is the first EventEngine experiment we need to remove because its purpose is to be an additional gate to enabling other EventEngine experiments.

I also removed the `GRPC_PYTHON_BUILD` flag, because its only purpose is to disable EventEngine code in Python.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

