### PR TITLE
[BCR] Remove build support for macOS intel cpu.

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,6 @@
 matrix:
   platform:
     - debian11
-    - macos
     - macos_arm64
     - ubuntu2204
     - ubuntu2404


### PR DESCRIPTION
Our kokoro tests use Apple Silicon only. We don't test with intel CPU and it gives undebuggable presubmit failures when we're releasing 1.82.0 https://github.com/bazelbuild/bazel-central-registry/pull/9332#issuecomment-4804767021