### PR TITLE
Enable Python fork support by default

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork.pyx.pxi
@@ -31,7 +31,7 @@ _TRUE_VALUES = ['yes',  'Yes',  'YES', 'true', 'True', 'TRUE', '1']
 # This flag is not supported on Windows.
 # This flag is also not supported for non-native IO manager.
 _GRPC_ENABLE_FORK_SUPPORT = (
-    os.environ.get('GRPC_ENABLE_FORK_SUPPORT', '0')
+    os.environ.get('GRPC_ENABLE_FORK_SUPPORT', '1')
         .lower() in _TRUE_VALUES)
 
 if sys.platform == "win32":


### PR DESCRIPTION
The Python fork behavior was fixed in #41784. This change enables that behavior. That improves consistency with the Core, which already has its fork support code enabled by default in the Python build.

<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

