### PR TITLE
Segfault issue fixed while building gRPC with lto flag

### DIFF
--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -187,6 +187,7 @@ php_config_m4:
   - src/php/ext/grpc/channel_credentials.c
   - src/php/ext/grpc/completion_queue.c
   - src/php/ext/grpc/php_grpc.c
+  - src/php/ext/grpc/php_grpc_pin_self.c
   - src/php/ext/grpc/server.c
   - src/php/ext/grpc/server_credentials.c
   - src/php/ext/grpc/timeval.c

--- a/config.m4
+++ b/config.m4
@@ -996,7 +996,6 @@ if test "$PHP_GRPC" != "no"; then
     src/php/ext/grpc/channel_credentials.c \
     src/php/ext/grpc/completion_queue.c \
     src/php/ext/grpc/php_grpc.c \
-    src/php/ext/grpc/php_grpc_pin_self.c \
     src/php/ext/grpc/server.c \
     src/php/ext/grpc/server_credentials.c \
     src/php/ext/grpc/timeval.c \

--- a/config.m4
+++ b/config.m4
@@ -996,6 +996,7 @@ if test "$PHP_GRPC" != "no"; then
     src/php/ext/grpc/channel_credentials.c \
     src/php/ext/grpc/completion_queue.c \
     src/php/ext/grpc/php_grpc.c \
+    src/php/ext/grpc/php_grpc_pin_self.c \
     src/php/ext/grpc/server.c \
     src/php/ext/grpc/server_credentials.c \
     src/php/ext/grpc/timeval.c \

--- a/config.w32
+++ b/config.w32
@@ -960,6 +960,7 @@ if (PHP_GRPC != "no") {
     "src\\php\\ext\\grpc\\channel_credentials.c " +
     "src\\php\\ext\\grpc\\completion_queue.c " +
     "src\\php\\ext\\grpc\\php_grpc.c " +
+    "src\\php\\ext\\grpc\\php_grpc_pin_self.c " +
     "src\\php\\ext\\grpc\\server.c " +
     "src\\php\\ext\\grpc\\server_credentials.c " +
     "src\\php\\ext\\grpc\\timeval.c " +

--- a/package.xml
+++ b/package.xml
@@ -2290,8 +2290,8 @@
     <file baseinstalldir="/" name="src/php/ext/grpc/completion_queue.h" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/php7_wrapper.h" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc.c" role="src" />
-    <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc_pin_self.c" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc.h" role="src" />
+    <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc_pin_self.c" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/server.c" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/server.h" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/server_credentials.c" role="src" />

--- a/package.xml
+++ b/package.xml
@@ -2290,6 +2290,7 @@
     <file baseinstalldir="/" name="src/php/ext/grpc/completion_queue.h" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/php7_wrapper.h" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc.c" role="src" />
+    <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc_pin_self.c" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/php_grpc.h" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/server.c" role="src" />
     <file baseinstalldir="/" name="src/php/ext/grpc/server.h" role="src" />

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -75,7 +75,7 @@ if test "$PHP_GRPC" != "no"; then
 
   PHP_NEW_EXTENSION(grpc, byte_buffer.c call.c call_credentials.c channel.c \
     channel_credentials.c completion_queue.c timeval.c server.c \
-    server_credentials.c php_grpc.c, $ext_shared, , -Wall -Werror -std=c11 -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1)
+    server_credentials.c php_grpc.c php_grpc_pin_self.c, $ext_shared, , -Wall -Werror -std=c11 -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1)
 fi
 
 if test "$PHP_COVERAGE" = "yes"; then

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -17,6 +17,7 @@
  */
 
 #include "php_grpc.h"
+extern void grpc_php_pin_self_with_nodelete(void);
 
 #include "call.h"
 #include "channel.h"
@@ -249,7 +250,7 @@ void apply_ini_settings(TSRMLS_D) {
 
 /* {{{ PHP_MINIT_FUNCTION
  */
-PHP_MINIT_FUNCTION(grpc) {
+PHP_MINIT_FUNCTION(grpc) { grpc_php_pin_self_with_nodelete();
   REGISTER_INI_ENTRIES();
 
   /* Register call error constants */

--- a/src/php/ext/grpc/php_grpc_pin_self.c
+++ b/src/php/ext/grpc/php_grpc_pin_self.c
@@ -1,0 +1,12 @@
+#include <dlfcn.h>
+
+static int grpc_php_nodelete_anchor = 0;
+
+void grpc_php_pin_self_with_nodelete(void) {
+  Dl_info info;
+  if (dladdr(&grpc_php_nodelete_anchor, &info) && info.dli_fname) {
+    void *h = dlopen(info.dli_fname,
+                     RTLD_LAZY | RTLD_NOLOAD | RTLD_NODELETE);
+    (void)h; /* discard; NODELETE flag is now set on the loaded lib */
+  }
+}

--- a/src/php/ext/grpc/php_grpc_pin_self.c
+++ b/src/php/ext/grpc/php_grpc_pin_self.c
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2026 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #include <dlfcn.h>
 
 static int grpc_php_nodelete_anchor = 0;


### PR DESCRIPTION
### Root cause of Failure:
**Race Condition with dlclose():** The PHP gRPC extension (ext-grpc) spawns asynchronous, detached background worker threads inside its C-Core engine (e.g., EventEngine pools, DNS resolvers, and completion queues). During the process shutdown, PHP calls `PHP_MSHUTDOWN_FUNCTION (grpc_shutdown())` followed immediately by `dlclose("grpc.so")`.

**Virtual Memory Unmapping:** dlclose() instructs the dynamic linker (ld.so) to unmap (munmap) the extension's code segment (.text) from virtual memory. If any gRPC background worker thread is still running or wakes up from a syscall after dlclose(), its Program Counter ($pc / RIP) points to unmapped memory, triggering an instruction-fetch segmentation fault (SIGSEGV).

**Impact of -flto=auto:** Link-Time Optimization performs whole-program optimization across translation units—inlining across file boundaries and reordering static destructors and synchronization hooks. This shifts internal teardown timing, causing background worker threads to remain active slightly longer after `grpc_shutdown()` returns, reproducing the crash on ~30–40% of the process exits.

### changes/Fix needed:
**Self-Pinning with RTLD_NODELETE:** The extension must prevent the dynamic linker from un-mapping its executable code segment during `dlclose()` while detached worker threads may still exist.

**Implementation Steps**: (1) Create a C helper routine (e.g., `src/php/ext/grpc/php_grpc_pin_self.c`) that uses `dladdr()` to locate the loaded binary address and re-opens the library handle with the `RTLD_NODELETE` flag:
c
`
#include <dlfcn.h>
static int grpc_php_nodelete_anchor = 0;
void grpc_php_pin_self_with_nodelete(void) {
  Dl_info info;
  if (dladdr(&grpc_php_nodelete_anchor, &info) && info.dli_fname) {
    void *h = dlopen(info.dli_fname, RTLD_LAZY | RTLD_NOLOAD | RTLD_NODELETE);
    (void)h;
  }
}
`

(2) Invoke `grpc_php_pin_self_with_nodelete()` as the first statement inside `PHP_MINIT_FUNCTION(grpc)` in `src/php/ext/grpc/php_grpc.c`.

(3) Add `src/php/ext/grpc/php_grpc_pin_self.c` to the source compilation list in `src/php/ext/grpc/config.m4` & `build_handwritten.yaml`.