### PR TITLE
Support new counters in fake stats plugin

### DIFF
--- a/test/core/telemetry/BUILD
+++ b/test/core/telemetry/BUILD
@@ -59,6 +59,7 @@ grpc_cc_test(
     uses_polling = False,
     deps = [
         "//src/core:channel_args_endpoint_config",
+        "//src/core:instrument",
         "//src/core:metrics",
         "//test/core/test_util:fake_stats_plugin",
         "//test/core/test_util:grpc_test_util",

--- a/test/core/telemetry/metrics_test.cc
+++ b/test/core/telemetry/metrics_test.cc
@@ -15,9 +15,11 @@
 #include "src/core/telemetry/metrics.h"
 
 #include <memory>
+#include <numeric>
 #include <thread>
 
 #include "src/core/lib/event_engine/channel_args_endpoint_config.h"
+#include "src/core/telemetry/instrument.h"
 #include "test/core/test_util/fake_stats_plugin.h"
 #include "test/core/test_util/test_config.h"
 #include "gmock/gmock.h"
@@ -681,6 +683,36 @@ TEST_F(MetricsTest, ParallelStatsPluginRegistrationAndLookup) {
   EXPECT_THAT(GlobalStatsPluginRegistry::GetStatsPluginsForChannel(
                   StatsPluginChannelScope("", "", endpoint_config_)),
               ::testing::Pointee(::testing::SizeIs(10000)));
+}
+
+class TestDomain final : public InstrumentDomain<TestDomain> {
+ public:
+  using Backend = LowContentionBackend;
+  static constexpr absl::string_view kName = "test_domain";
+  GRPC_EMPTY_INSTRUMENT_DOMAIN_LABELS();
+
+  static inline const auto kCounter =
+      RegisterCounter("test_counter", "A test counter.", "unit");
+  static inline const auto kHistogram =
+      RegisterHistogram<ExponentialHistogramShape>("test_histogram",
+                                                   "A test histogram.", "unit", 100, 5);
+};
+
+TEST_F(MetricsTest, InstrumentDomainHistogramAndCounterQuery) {
+  constexpr absl::string_view kTarget = "test.target";
+  auto plugin = MakeStatsPluginForTarget(kTarget);
+  auto storage = TestDomain::GetStorage(plugin->GetCollectionScope());
+  storage->Increment(TestDomain::kCounter, 42);
+  storage->Increment(TestDomain::kHistogram, 10);
+  storage->Increment(TestDomain::kHistogram, 10);
+  storage->Increment(TestDomain::kHistogram, 10000);
+  auto counter_val = plugin->GetUInt64MetricValueByName(TestDomain::kCounter.name());
+  EXPECT_THAT(counter_val, ::testing::Optional(42));
+  auto hist_val = plugin->GetHistogramValueByName(TestDomain::kHistogram.name());
+  ASSERT_TRUE(hist_val.has_value());
+  ASSERT_EQ(hist_val->size(), 5);
+  uint64_t total_count = std::accumulate(hist_val->begin(), hist_val->end(), uint64_t{});
+  EXPECT_EQ(total_count, 3);
 }
 
 using MetricsDeathTest = MetricsTest;

--- a/test/core/telemetry/metrics_test.cc
+++ b/test/core/telemetry/metrics_test.cc
@@ -694,8 +694,8 @@ class TestDomain final : public InstrumentDomain<TestDomain> {
   static inline const auto kCounter =
       RegisterCounter("test_counter", "A test counter.", "unit");
   static inline const auto kHistogram =
-      RegisterHistogram<ExponentialHistogramShape>("test_histogram",
-                                                   "A test histogram.", "unit", 100, 5);
+      RegisterHistogram<ExponentialHistogramShape>(
+          "test_histogram", "A test histogram.", "unit", 100, 5);
 };
 
 TEST_F(MetricsTest, InstrumentDomainHistogramAndCounterQuery) {
@@ -706,12 +706,15 @@ TEST_F(MetricsTest, InstrumentDomainHistogramAndCounterQuery) {
   storage->Increment(TestDomain::kHistogram, 10);
   storage->Increment(TestDomain::kHistogram, 10);
   storage->Increment(TestDomain::kHistogram, 10000);
-  auto counter_val = plugin->GetUInt64MetricValueByName(TestDomain::kCounter.name());
+  auto counter_val =
+      plugin->GetUInt64MetricValueByName(TestDomain::kCounter.name());
   EXPECT_THAT(counter_val, ::testing::Optional(42));
-  auto hist_val = plugin->GetHistogramValueByName(TestDomain::kHistogram.name());
+  auto hist_val =
+      plugin->GetHistogramValueByName(TestDomain::kHistogram.name());
   ASSERT_TRUE(hist_val.has_value());
   ASSERT_EQ(hist_val->size(), 5);
-  uint64_t total_count = std::accumulate(hist_val->begin(), hist_val->end(), uint64_t{});
+  uint64_t total_count =
+      std::accumulate(hist_val->begin(), hist_val->end(), uint64_t{});
   EXPECT_EQ(total_count, 3);
 }
 

--- a/test/core/test_util/BUILD
+++ b/test/core/test_util/BUILD
@@ -600,6 +600,7 @@ grpc_cc_library(
         "//:grpc_base",
         "//src/core:examine_stack",
         "//src/core:grpc_check",
+        "//src/core:instrument",
         "//src/core:metrics",
         "//src/core:ref_counted",
         "//src/core:tcp_tracer",

--- a/test/core/test_util/fake_stats_plugin.cc
+++ b/test/core/test_util/fake_stats_plugin.cc
@@ -201,4 +201,36 @@ GlobalInstrumentsRegistryTestPeer::FindMetricDescriptorByName(
   return nullptr;
 }
 
+template <typename T>
+std::optional<T> FakeStatsPlugin::GetMetricValueByNameImpl(
+    absl::string_view name, absl::Span<const absl::string_view> labels) {
+  const auto* desc = instrument_detail::InstrumentIndex::Get().Find(name);
+  if (desc == nullptr) return std::nullopt;
+  const auto& names = desc->domain->label_names();
+  std::vector<std::string> keys;
+  keys.reserve(names.size());
+  for (const auto& label : names) {
+    keys.emplace_back(label.label());
+  }
+  std::vector<std::string> values(labels.begin(), labels.end());
+  DomainMetricsSink<T> sink(name, keys, values);
+  MetricsQuery().OnlyMetrics({std::string(name)}).Run(GetCollectionScope(), sink);
+  return sink.captured_value();
+}
+
+std::optional<uint64_t> FakeStatsPlugin::GetUInt64MetricValueByName(
+    absl::string_view name, absl::Span<const absl::string_view> labels) {
+  return GetMetricValueByNameImpl<uint64_t>(name, labels);
+}
+
+std::optional<int64_t> FakeStatsPlugin::GetInt64MetricValueByName(
+    absl::string_view name, absl::Span<const absl::string_view> labels) {
+  return GetMetricValueByNameImpl<int64_t>(name, labels);
+}
+
+std::optional<std::vector<uint64_t>> FakeStatsPlugin::GetHistogramValueByName(
+    absl::string_view name, absl::Span<const absl::string_view> labels) {
+  return GetMetricValueByNameImpl<std::vector<uint64_t>>(name, labels);
+}
+
 }  // namespace grpc_core

--- a/test/core/test_util/fake_stats_plugin.cc
+++ b/test/core/test_util/fake_stats_plugin.cc
@@ -214,7 +214,9 @@ std::optional<T> FakeStatsPlugin::GetMetricValueByNameImpl(
   }
   std::vector<std::string> values(labels.begin(), labels.end());
   DomainMetricsSink<T> sink(name, keys, values);
-  MetricsQuery().OnlyMetrics({std::string(name)}).Run(GetCollectionScope(), sink);
+  MetricsQuery()
+      .OnlyMetrics({std::string(name)})
+      .Run(GetCollectionScope(), sink);
   return sink.captured_value();
 }
 

--- a/test/core/test_util/fake_stats_plugin.h
+++ b/test/core/test_util/fake_stats_plugin.h
@@ -487,8 +487,6 @@ class FakeStatsPlugin : public StatsPlugin {
   std::optional<std::vector<uint64_t>> GetHistogramValueByName(
       absl::string_view name, absl::Span<const absl::string_view> labels = {});
 
-
-
  private:
   template <typename T>
   std::optional<T> GetMetricValueByNameImpl(

--- a/test/core/test_util/fake_stats_plugin.h
+++ b/test/core/test_util/fake_stats_plugin.h
@@ -21,6 +21,7 @@
 
 #include "src/core/lib/channel/promise_based_filter.h"
 #include "src/core/telemetry/call_tracer.h"
+#include "src/core/telemetry/instrument.h"
 #include "src/core/telemetry/metrics.h"
 #include "src/core/telemetry/tcp_tracer.h"
 #include "src/core/util/ref_counted.h"
@@ -275,6 +276,13 @@ class FakeStatsPlugin : public StatsPlugin {
               Crash("unknown instrument type");
           }
         });
+    InstrumentLabelSet labels;
+    InstrumentMetadata::ForEachInstrument([&](const auto* desc) {
+      for (const auto& l : desc->domain->label_names()) {
+        labels.Set(l);
+      }
+    });
+    collection_scope_ = CreateCollectionScope({}, labels);
   }
 
   RefCountedPtr<CollectionScope> GetCollectionScope() const override {
@@ -472,7 +480,120 @@ class FakeStatsPlugin : public StatsPlugin {
     return iter->second.GetValue(label_values, optional_values);
   }
 
+  std::optional<uint64_t> GetUInt64MetricValueByName(
+      absl::string_view name, absl::Span<const absl::string_view> labels = {});
+  std::optional<int64_t> GetInt64MetricValueByName(
+      absl::string_view name, absl::Span<const absl::string_view> labels = {});
+  std::optional<std::vector<uint64_t>> GetHistogramValueByName(
+      absl::string_view name, absl::Span<const absl::string_view> labels = {});
+
+
+
  private:
+  template <typename T>
+  std::optional<T> GetMetricValueByNameImpl(
+      absl::string_view name, absl::Span<const absl::string_view> labels);
+
+  template <typename T>
+  class DomainMetricsSink final : public MetricsSink {
+   public:
+    explicit DomainMetricsSink(absl::string_view target_name,
+                               absl::Span<const std::string> label_keys,
+                               absl::Span<const std::string> label_values)
+        : target_name_(target_name),
+          target_label_keys_(label_keys.begin(), label_keys.end()),
+          target_label_values_(label_values.begin(), label_values.end()) {}
+
+    void Counter(InstrumentLabelList label_keys,
+                 absl::Span<const std::string> label_values,
+                 absl::string_view name, uint64_t value) override {
+      if constexpr (std::is_same_v<T, uint64_t>) {
+        RecordValue(label_keys, label_values, name, value);
+      }
+    }
+    void UpDownCounter(InstrumentLabelList label_keys,
+                       absl::Span<const std::string> label_values,
+                       absl::string_view name, uint64_t value) override {
+      if constexpr (std::is_same_v<T, uint64_t>) {
+        RecordValue(label_keys, label_values, name, value);
+      }
+    }
+    void Histogram(InstrumentLabelList label_keys,
+                   absl::Span<const std::string> label_values,
+                   absl::string_view name, HistogramBuckets /*bounds*/,
+                   absl::Span<const uint64_t> counts) override {
+      if constexpr (std::is_same_v<T, std::vector<uint64_t>>) {
+        RecordValue(label_keys, label_values, name,
+                    std::vector<uint64_t>(counts.begin(), counts.end()));
+      }
+    }
+    void DoubleGauge(InstrumentLabelList label_keys,
+                     absl::Span<const std::string> label_values,
+                     absl::string_view name, double value) override {
+      if constexpr (std::is_same_v<T, double>) {
+        RecordValue(label_keys, label_values, name, value);
+      }
+    }
+    void IntGauge(InstrumentLabelList label_keys,
+                  absl::Span<const std::string> label_values,
+                  absl::string_view name, int64_t value) override {
+      if constexpr (std::is_same_v<T, int64_t>) {
+        RecordValue(label_keys, label_values, name, value);
+      }
+    }
+    void UintGauge(InstrumentLabelList label_keys,
+                   absl::Span<const std::string> label_values,
+                   absl::string_view name, uint64_t value) override {
+      if constexpr (std::is_same_v<T, uint64_t>) {
+        RecordValue(label_keys, label_values, name, value);
+      }
+    }
+
+    std::optional<T> captured_value() const { return captured_value_; }
+
+   private:
+    void RecordValue(InstrumentLabelList label_keys,
+                     absl::Span<const std::string> label_values,
+                     absl::string_view name, T value) {
+      if (!Matches(label_keys, label_values, name)) return;
+      if (!captured_value_.has_value()) {
+        captured_value_ = std::move(value);
+      } else {
+        if constexpr (std::is_arithmetic_v<T>) {
+          *captured_value_ += value;
+        } else if constexpr (std::is_same_v<T, std::vector<uint64_t>>) {
+          if (captured_value_->size() < value.size()) {
+            captured_value_->resize(value.size(), 0);
+          }
+          for (size_t i = 0; i < value.size(); ++i) {
+            (*captured_value_)[i] += value[i];
+          }
+        }
+      }
+    }
+    bool Matches(InstrumentLabelList label_keys,
+                 absl::Span<const std::string> label_values,
+                 absl::string_view name) const {
+      if (name != target_name_) return false;
+      if (label_keys.size() != target_label_keys_.size() ||
+          label_values.size() != target_label_values_.size()) {
+        return false;
+      }
+      for (size_t i = 0; i < label_keys.size(); ++i) {
+        if (label_keys[i].label() != target_label_keys_[i] ||
+            label_values[i] != target_label_values_[i]) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    absl::string_view target_name_;
+    std::vector<std::string> target_label_keys_;
+    std::vector<std::string> target_label_values_;
+    std::optional<T> captured_value_;
+  };
+
   class Reporter : public CallbackMetricReporter {
    public:
     explicit Reporter(FakeStatsPlugin& plugin) : plugin_(plugin) {}
@@ -654,8 +775,7 @@ class FakeStatsPlugin : public StatsPlugin {
   absl::flat_hash_map<uint32_t, Gauge<double>> double_callback_gauges_
       ABSL_GUARDED_BY(&callback_mu_);
   std::set<RegisteredMetricCallback*> callbacks_ ABSL_GUARDED_BY(&callback_mu_);
-  RefCountedPtr<CollectionScope> collection_scope_ =
-      CreateCollectionScope({}, {});
+  RefCountedPtr<CollectionScope> collection_scope_;
 };
 
 class FakeStatsPluginBuilder {


### PR DESCRIPTION
Support counters for new non-per-call metrics API in fake stats plugin.

* These changes were already implemented in #41073. They are being pulled out here so they can be merged to unblock #42606.

The only further changes are:
* Add support for stubbed out metrics like histogram.
* Add tests.