### PR TITLE
Revert "[telemetry] add plumbing for locality label (#42803)"

### DIFF
--- a/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
+++ b/src/core/load_balancing/weighted_round_robin/weighted_round_robin.cc
@@ -88,6 +88,10 @@ namespace {
 
 constexpr absl::string_view kWeightedRoundRobin = "weighted_round_robin";
 
+constexpr absl::string_view kMetricLabelLocality = "grpc.lb.locality";
+constexpr absl::string_view kMetricLabelBackendService =
+    "grpc.lb.backend_service";
+
 const auto kMetricRrFallback =
     GlobalInstrumentsRegistry::RegisterUInt64Counter(
         "grpc.lb.wrr.rr_fallback",

--- a/src/core/load_balancing/xds/cds.cc
+++ b/src/core/load_balancing/xds/cds.cc
@@ -346,9 +346,7 @@ class PriorityEndpointIterator final : public EndpointAddressesIterator {
                   .SetObject(hierarchical_path_attr)
                   .Set(GRPC_ARG_ADDRESS_WEIGHT, endpoint_weight)
                   .SetObject(locality_name->Ref())
-                  .Set(GRPC_ARG_XDS_LOCALITY_WEIGHT, locality.lb_weight)
-                  .Set(GRPC_ARG_LB_LOCALITY,
-                       locality_name->human_readable_string().as_string_view());
+                  .Set(GRPC_ARG_XDS_LOCALITY_WEIGHT, locality.lb_weight);
           if (!use_http_connect_) args = args.Remove(GRPC_ARG_XDS_HTTP_PROXY);
           callback(EndpointAddresses(endpoint.addresses(), args));
         }

--- a/src/core/resolver/endpoint_addresses.h
+++ b/src/core/resolver/endpoint_addresses.h
@@ -45,9 +45,6 @@
 // Backend service name associated with the addresses.
 #define GRPC_ARG_BACKEND_SERVICE "grpc.internal.backend_service"
 
-// Locality name associated with the addresses.
-#define GRPC_ARG_LB_LOCALITY "grpc.internal.lb_locality"
-
 namespace grpc_core {
 
 // A list of addresses for a given endpoint with an associated set of channel

--- a/src/core/telemetry/metrics.h
+++ b/src/core/telemetry/metrics.h
@@ -39,9 +39,6 @@
 namespace grpc_core {
 
 constexpr absl::string_view kMetricLabelTarget = "grpc.target";
-constexpr absl::string_view kMetricLabelBackendService =
-    "grpc.lb.backend_service";
-constexpr absl::string_view kMetricLabelLocality = "grpc.lb.locality";
 
 // A global registry of instruments(metrics). This API is designed to be used
 // to register instruments (Counter, Histogram, and Gauge) as part of program

--- a/src/cpp/ext/otel/otel_plugin.cc
+++ b/src/cpp/ext/otel/otel_plugin.cc
@@ -919,16 +919,21 @@ OpenTelemetryPluginImpl::~OpenTelemetryPluginImpl() {
   }
 }
 
+namespace {
+constexpr absl::string_view kLocality = "grpc.lb.locality";
+constexpr absl::string_view kBackendService = "grpc.lb.backend_service";
+}  // namespace
+
 absl::string_view OpenTelemetryPluginImpl::OptionalLabelKeyToString(
     grpc_core::ClientCallTracerInterface::CallAttemptTracer::OptionalLabelKey
         key) {
   switch (key) {
     case grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kLocality:
-      return grpc_core::kMetricLabelLocality;
+      return kLocality;
     case grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kBackendService:
-      return grpc_core::kMetricLabelBackendService;
+      return kBackendService;
     case grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kTelemetryLabel:
       return OpenTelemetryCustomLabelKey();
@@ -940,10 +945,10 @@ absl::string_view OpenTelemetryPluginImpl::OptionalLabelKeyToString(
 std::optional<
     grpc_core::ClientCallTracerInterface::CallAttemptTracer::OptionalLabelKey>
 OpenTelemetryPluginImpl::OptionalLabelStringToKey(absl::string_view key) {
-  if (key == grpc_core::kMetricLabelLocality) {
+  if (key == kLocality) {
     return grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kLocality;
-  } else if (key == grpc_core::kMetricLabelBackendService) {
+  } else if (key == kBackendService) {
     return grpc_core::ClientCallTracerInterface::CallAttemptTracer::
         OptionalLabelKey::kBackendService;
   } else if (key == OpenTelemetryCustomLabelKey()) {


### PR DESCRIPTION
This reverts commit eb0a9adf1f316ed2d5d19864e4c103975adc3664 / PR #42803.

---

Identified as a source of increased flakiness of `XdsTest/OutlierDetectionTest.EjectionRetainedAcrossPriorities/V3`.

Repro:

```sh
bazel test --nocache_test_results \
    --config=opt \
    --notest_keep_going --flaky_test_attempts=1 \
    --runs_per_test=1000 \
    "//test/cpp/end2end/xds:xds_outlier_detection_end2end_test@poller=epoll1" \
    --test_filter='XdsTest/OutlierDetectionTest.EjectionRetainedAcrossPriorities/V3'
```

Verified the revert works:

```
INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 8.7.0 will be used instead of system-wide bazel installation.
INFO: Analyzed target //test/cpp/end2end/xds:xds_outlier_detection_end2end_test@poller=epoll1 (0 packages loaded, 12 targets configured).
INFO: Found 1 test target...
Target //test/cpp/end2end/xds:xds_outlier_detection_end2end_test@poller=epoll1 up-to-date:
  bazel-bin/test/cpp/end2end/xds/xds_outlier_detection_end2end_test@poller=epoll1
INFO: Elapsed time: 29.800s, Critical Path: 5.44s
INFO: 1001 processes: 11 action cache hit, 1 internal, 1000 linux-sandbox.
INFO: Build completed successfully, 1001 total actions
//test/cpp/end2end/xds:xds_outlier_detection_end2end_test@poller=epoll1  PASSED in 5.4s
  Stats over 1000 runs: max = 5.4s, min = 1.2s, avg = 1.8s, dev = 0.6s

Executed 1 out of 1 test: 1 test passes.
```

<details><summary>Bisect log (replayable)</summary>
<p>

```sh
# bad: [bec89c58b1e1202b2ebfb9263954d40cc664920d] Delete obsolete ChunkStreamAssociationTrace
# good: [6da86f12fdea143e2bda42b5cd87c87665ee77d0] Fix OpenSSL < 3.0 TSI negotiated key exchange group test assertions (#42771)
git bisect start 'master' '6da86f12fdea143e2bda42b5cd87c87665ee77d0'
# good: [e7b195633a98064ab374cb9b6da5c1a06b609301] [subchannel] enable connection scaling experiment (#42440)
git bisect good e7b195633a98064ab374cb9b6da5c1a06b609301
# bad: [955e5ea042078ab451f9c02bcc6670f5bd4f4573] [Experiment][CoreE2E] Enable E2E tests (#42810)
git bisect bad 955e5ea042078ab451f9c02bcc6670f5bd4f4573
# bad: [b6a490efd289a5b1de231c37bbc4cf2b806062fa] [Python][grpcio-tools] Fix build error when CXX contains spaces (#42742)
git bisect bad b6a490efd289a5b1de231c37bbc4cf2b806062fa
# good: [716e2cde626de9e7d6b772fa11d26692b5c97b05] [TLS] certificate selection offloading (#41937)
git bisect good 716e2cde626de9e7d6b772fa11d26692b5c97b05
# bad: [7d737d057698c0121274f753478fb1d4ac96fabc] [Python] Unpin pip version in Python tests (#42731)
git bisect bad 7d737d057698c0121274f753478fb1d4ac96fabc
# bad: [eb0a9adf1f316ed2d5d19864e4c103975adc3664] [telemetry] add plumbing for locality label (#42803)
git bisect bad eb0a9adf1f316ed2d5d19864e4c103975adc3664
# first 'bad' commit: [eb0a9adf1f316ed2d5d19864e4c103975adc3664] [telemetry] add plumbing for locality label (#42803)
```
</p>
</details> 
