### PR TITLE
[Python] Using venv instead of virtualenv in sanity

### DIFF
--- a/tools/distrib/black_code.sh
+++ b/tools/distrib/black_code.sh
@@ -31,7 +31,7 @@ DIRS=(
 )
 
 VIRTUALENV=".venv-ci-black"
-python3 -m virtualenv "${VIRTUALENV}"
+python3 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python -VV
 

--- a/tools/distrib/check_pytype.sh
+++ b/tools/distrib/check_pytype.sh
@@ -16,7 +16,7 @@
 set -eux
 
 VIRTUALENV=".venv-ci-pytype"
-python3.11 -m virtualenv "${VIRTUALENV}"
+python3.11 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python -VV
 

--- a/tools/distrib/isort_code.sh
+++ b/tools/distrib/isort_code.sh
@@ -34,7 +34,7 @@ DIRS=(
 )
 
 VIRTUALENV=".venv-ci-isort"
-python3 -m virtualenv "${VIRTUALENV}"
+python3 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python -VV
 

--- a/tools/distrib/pylint_code.sh
+++ b/tools/distrib/pylint_code.sh
@@ -35,7 +35,7 @@ TEST_DIRS=(
 )
 
 VIRTUALENV=".venv-ci-pylint"
-python3.11 -m virtualenv "${VIRTUALENV}"
+python3.11 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python -VV
 

--- a/tools/distrib/pyright_code.sh
+++ b/tools/distrib/pyright_code.sh
@@ -20,7 +20,7 @@ set -ex
 cd "$(dirname "$0")/../.."
 
 VIRTUALENV=".venv-pyright"
-python3 -m virtualenv "${VIRTUALENV}"
+python3 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python3 -VV
 

--- a/tools/distrib/ruff_code.sh
+++ b/tools/distrib/ruff_code.sh
@@ -36,7 +36,7 @@ DIRS=(
 )
 
 VIRTUALENV=".venv-ci-ruff"
-python3 -m virtualenv "${VIRTUALENV}"
+python3 -m venv "${VIRTUALENV}"
 source "${VIRTUALENV}/bin/activate"
 python -VV
 


### PR DESCRIPTION
# Description

Using `venv` instead of `virtualenv` in sanity checks.

# Testing

