### PR TITLE
[alts] fix unused_bytes size underflow in alts handshaker result

### DIFF
--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -741,7 +741,7 @@ void alts_tsi_handshaker_result_set_unused_bytes(tsi_handshaker_result* result,
                                                  size_t bytes_consumed) {
   GRPC_CHECK(recv_bytes != nullptr);
   GRPC_CHECK_NE(result, nullptr);
-  if (GRPC_SLICE_LENGTH(*recv_bytes) == bytes_consumed) {
+  if (GRPC_SLICE_LENGTH(*recv_bytes) <= bytes_consumed) {
     return;
   }
   alts_tsi_handshaker_result* sresult =

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -1271,6 +1271,58 @@ TEST(AltsTsiHandshakerTest, CheckHandshakerIntegrityOnlySecurityLevel) {
   notification_destroy(&tsi_to_caller_notification);
 }
 
+TEST(AltsTsiHandshakerTest, SetUnusedBytesConsumedExceedsRecvBytes) {
+  // A malformed or malicious handshaker service response may report consuming
+  // more bytes than were actually received. bytes_consumed larger than the
+  // recv_bytes length must not underflow the size_t computation of the
+  // unused-bytes size (which would lead to a huge allocation / OOB read).
+  upb::Arena arena;
+  grpc_gcp_HandshakerResp* resp = grpc_gcp_HandshakerResp_new(arena.ptr());
+  grpc_gcp_HandshakerResult* hresult =
+      grpc_gcp_HandshakerResp_mutable_result(resp, arena.ptr());
+  grpc_gcp_Identity* peer_identity =
+      grpc_gcp_HandshakerResult_mutable_peer_identity(hresult, arena.ptr());
+  grpc_gcp_Identity_set_service_account(
+      peer_identity,
+      upb_StringView_FromString(ALTS_TSI_HANDSHAKER_TEST_PEER_IDENTITY));
+  grpc_gcp_HandshakerResult_set_key_data(
+      hresult, upb_StringView_FromString(ALTS_TSI_HANDSHAKER_TEST_KEY_DATA));
+  ASSERT_TRUE(grpc_gcp_handshaker_resp_set_peer_rpc_versions(
+      resp, arena.ptr(), ALTS_TSI_HANDSHAKER_TEST_MAX_RPC_VERSION_MAJOR,
+      ALTS_TSI_HANDSHAKER_TEST_MAX_RPC_VERSION_MINOR,
+      ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MAJOR,
+      ALTS_TSI_HANDSHAKER_TEST_MIN_RPC_VERSION_MINOR));
+  grpc_gcp_Identity* local_identity =
+      grpc_gcp_HandshakerResult_mutable_local_identity(hresult, arena.ptr());
+  grpc_gcp_Identity_set_service_account(
+      local_identity,
+      upb_StringView_FromString(ALTS_TSI_HANDSHAKER_TEST_LOCAL_IDENTITY));
+  grpc_gcp_HandshakerResult_set_application_protocol(
+      hresult,
+      upb_StringView_FromString(ALTS_TSI_HANDSHAKER_TEST_APPLICATION_PROTOCOL));
+  grpc_gcp_HandshakerResult_set_record_protocol(
+      hresult,
+      upb_StringView_FromString(ALTS_TSI_HANDSHAKER_TEST_RECORD_PROTOCOL));
+  tsi_handshaker_result* result = nullptr;
+  ASSERT_EQ(
+      alts_tsi_handshaker_result_create(resp, /*is_client=*/true, &result),
+      TSI_OK);
+  ASSERT_NE(result, nullptr);
+  grpc_slice recv_bytes =
+      grpc_slice_from_static_string(ALTS_TSI_HANDSHAKER_TEST_RECV_BYTES);
+  // Report one more byte consumed than is available in recv_bytes.
+  alts_tsi_handshaker_result_set_unused_bytes(
+      result, &recv_bytes, GRPC_SLICE_LENGTH(recv_bytes) + 1);
+  const unsigned char* unused_bytes = nullptr;
+  size_t unused_bytes_size = 0;
+  ASSERT_EQ(tsi_handshaker_result_get_unused_bytes(result, &unused_bytes,
+                                                   &unused_bytes_size),
+            TSI_OK);
+  ASSERT_EQ(unused_bytes_size, 0u);
+  grpc_slice_unref(recv_bytes);
+  tsi_handshaker_result_destroy(result);
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(&argc, argv);
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
alts_tsi_handshaker_result_set_unused_bytes skips the copy only when the received slice length equals bytes_consumed, but bytes_consumed is a uint32 taken directly from the handshaker service response and can be larger than the slice. When it is, the size_t subtraction wraps to a near-SIZE_MAX value and the gpr_zalloc/memcpy that follow read far past recv_bytes. Bail out whenever bytes_consumed is at least the received length so the subtraction can't underflow.