### PR TITLE
[Core][Filters] Fix v3 leak when in-flight bridged call is forced-cancel

### DIFF
--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1297,217 +1297,218 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
           });
     }
     // Now return a promise that does all the things.
-    //
     // The returned promise is wrapped in OnCancel so that, if the v2 stack
     // destroys it before it completes (e.g. the forced-cancellation path in
     // ServerCallData::Completed, which resets promise_ to an empty
     // ArenaPromise), we actively propagate a cancellation into the v3 call
-    // pair. Without this, the v3 CallSpine's spawned helper promises (notably
-    // pull_server_trailing_metadata) stay parked forever, so the spine -- and
-    // the v3 interceptor -- leaks and never learns about the cancellation.
-    //
-    // We use SpawnCancel (not Cancel) because this callback runs at promise
-    // destruction time on the v2 activity, not the v3 spine's activity; the
-    // push must be scheduled onto the spine's own party. The push is then
-    // drained by the always-present pull_server_trailing_metadata promise on
-    // the initiator's activity, which fires CallOnDone with the real
-    // cancelled flag and cleanly notifies the v3 CallHandler/interceptor.
+    // pair.
     return OnCancel(
         Race(
-        // Get server trailing metadata from the v3 promise via the
-        // inter-activity latch.
-        If(
-            IsV2NonOwningWakerImplementationEnabled(),
-            [pipe_owner]() {
-              return pipe_owner->server_trailing_metadata.Wait();
-            },
-            [initiator = initiator]() mutable {
-              return initiator.PullServerTrailingMetadata();
-            }),
-        // This promise does the rest of the things, but it will always
-        // return pending, because the promise can't actually finish
-        // until the initiator returns trailing metadata above.
-        TrySeq(
-            state->call_handler_latch.Wait(),
-            [initiator = initiator, pipe_owner,
-             call_args = std::move(call_args),
-             next_promise_factory =
-                 std::move(next_promise_factory)](CallHandler handler) mutable {
-              // Intercept all pipes from v2 API.
-              //
-              // For client-to-server messages, we do the following:
-              // 1. Push the message into the v3 initiator, which sends
-              //    it to the v3 interceptor.  Note that this needs to
-              //    be done inside of the v3 initiator's activity.
-              // 2. Pull the message from the v3 handler, where it will
-              //    arrive when the v3 interceptor is done with it.
-              //    Note that this needs to be done inside of the v3
-              //    handler's activity.  We then push the message into
-              //    an inter-activity pipe to return it to the v2 activity.
-              // 3. In the v2 activity, read the message from the
-              //    inter-activity pipe and send it on to the next
-              //    filter.
-              //
-              // Step 2: Spawn a promise to pull messages from the v3
-              // handler and push them into an inter-activity pipe to
-              // return them to the v2 activity.
-              handler.SpawnGuarded(
-                  "pull_client_to_server_message",
-                  [handler, pipe_owner]() mutable {
-                    return ForEach(
-                        MessagesFrom(handler),
-                        [pipe_owner](MessageHandle message) {
-                          return Map(
-                              pipe_owner->client_to_server_messages.sender.Push(
-                                  std::move(message)),
-                              [](bool x) { return StatusFlag(x); });
-                        });
-                  });
-              call_args.client_to_server_messages->InterceptAndMap(
-                  [initiator, handler,
-                   pipe_owner](MessageHandle message) mutable {
-                    // Step 1: Push the message onto the v3 initiator in
-                    // its activity.
-                    initiator.SpawnPushMessage(std::move(message));
-                    // Step 3: Here in the v2 activity, read the message
-                    // from the inter-activity pipe and return it.
-                    return Map(
-                        pipe_owner->client_to_server_messages.receiver.Next(),
-                        [](InterActivityPipe<MessageHandle, 1>::NextResult
-                               message) -> std::optional<MessageHandle> {
-                          if (!message.has_value()) return std::nullopt;
-                          return std::move(*message);
-                        });
-                  });
-              // For server initial metadata, we do a similar thing, but
-              // in the opposite direction, and using an inter-activity
-              // latch instead of a pipe:
-              // 1. Push the metadata into the v3 handler, which sends
-              //    it to the v3 interceptor.  Note that this needs to
-              //    be done inside of the v3 handler's activity.
-              // 2. Pull the metadata from the v3 initiator, where it will
-              //    arrive when the v3 interceptor is done with it.
-              //    Note that this needs to be done inside of the v3
-              //    initiator's activity.  We then use an inter-activity
-              //    latch to return the metadata to the v2 activity.
-              // 3. In the v2 activity, read the metadata from the
-              //    inter-activity latch and send it on to the previous
-              //    filter.
-              //
-              // Step 2: Spawn a promise to pull the metadata from the v3
-              // initiator and use an inter-activity latch to return it to
-              // the v2 activity.
-              initiator.SpawnGuarded(
-                  "pull_server_initial_metadata",
-                  [initiator, pipe_owner]() mutable {
-                    return TrySeq(
-                        initiator.PullServerInitialMetadata(),
-                        [pipe_owner](
-                            std::optional<ServerMetadataHandle> metadata) {
-                          pipe_owner->server_initial_metadata.Set(
-                              std::move(metadata));
-                        });
-                  });
-              call_args.server_initial_metadata->InterceptAndMap(
-                  [initiator, handler,
-                   pipe_owner](ServerMetadataHandle metadata) mutable {
-                    // Step 1: Push the metadata onto the v3 handler in
-                    // its activity.
-                    handler.SpawnPushServerInitialMetadata(std::move(metadata));
-                    // Step 3: Here in the v2 activity, read from the
-                    // inter-activity latch and return the metadata.
-                    return pipe_owner->server_initial_metadata.Wait();
-                  });
-              // We handle server-to-client messages the same as
-              // client-to-server messages, except in the opposite
-              // direction:
-              // 1. Push the message into the v3 handler, which sends
-              //    it to the v3 interceptor.  Note that this needs to
-              //    be done inside of the v3 handler's activity.
-              // 2. Pull the message from the v3 initiator, where it will
-              //    arrive when the v3 interceptor is done with it.
-              //    Note that this needs to be done inside of the v3
-              //    initiator's activity.  We then push the message into
-              //    an inter-activity pipe to return it to the v2 activity.
-              // 3. In the v2 activity, read the message from the
-              //    inter-activity pipe and send it on to the next
-              //    filter.
-              //
-              // Step 2: Spawn a promise to pull messages from the v3
-              // initiator and push them into an inter-activity pipe to
-              // return them to the v2 activity.
-              initiator.SpawnGuarded(
-                  "pull_server_to_client_message",
-                  [initiator, pipe_owner]() mutable {
-                    return ForEach(
-                        MessagesFrom(initiator),
-                        [pipe_owner](MessageHandle message) {
-                          return Map(
-                              pipe_owner->server_to_client_messages.sender.Push(
-                                  std::move(message)),
-                              [](bool x) { return StatusFlag(x); });
-                        });
-                  });
-              call_args.server_to_client_messages->InterceptAndMap(
-                  [initiator, handler,
-                   pipe_owner](MessageHandle message) mutable {
-                    // Step 1: Push the message onto the v3 handler in
-                    // its activity.
-                    handler.SpawnPushMessage(std::move(message));
-                    // Step 3: Here in the v2 activity, read from the
-                    // inter-activity pipe and return the messages.
-                    return Map(
-                        pipe_owner->server_to_client_messages.receiver.Next(),
-                        [](InterActivityPipe<MessageHandle, 1>::NextResult
-                               message) -> std::optional<MessageHandle> {
-                          if (!message.has_value()) return std::nullopt;
-                          return std::move(*message);
-                        });
-                  });
-              // In the v3 handler's activity, pull client initial metadata.
-              // Use an inter-activity latch to get it back to the v2
-              // activity.
-              handler.SpawnGuarded(
-                  "pull_client_initial_metadata",
-                  [handler, pipe_owner]() mutable {
-                    return TrySeq(handler.PullClientInitialMetadata(),
-                                  [pipe_owner](ClientMetadataHandle metadata) {
-                                    pipe_owner->client_initial_metadata.Set(
-                                        std::move(metadata));
-                                  });
-                  });
-              // A wrapper for next_promise_factory that does the following:
-              // - Pulls client initial metadata from the V3 handler via
-              //   the inter-activity latch and injects it into the next
-              //   V2 filter via CallArgs.
-              // - Polls the next promise to get server trailing metadata
-              //   from the next V2 filter and feeds it into the V3 handler.
-              // Note that this does not actually pull the trailing metadata
-              // from the V3 initiator; instead, we do that in a separate
-              // promise above.  That promise will always complete at the
-              // end of the call, so we always return pending here.
-              return Seq(
-                  pipe_owner->client_initial_metadata.Wait(),
-                  [next_promise_factory = std::move(next_promise_factory),
-                   call_args = std::move(call_args),
-                   handler](ClientMetadataHandle metadata) mutable {
-                    call_args.client_initial_metadata = std::move(metadata);
-                    return Seq(next_promise_factory(std::move(call_args)),
-                               [handler](ServerMetadataHandle metadata) mutable
-                                   -> Poll<ServerMetadataHandle> {
-                                 handler.SpawnPushServerTrailingMetadata(
-                                     std::move(metadata));
-                                 // We always lose the race.
-                                 return Pending{};
-                               });
-                  });
-            })),
+            // Get server trailing metadata from the v3 promise via the
+            // inter-activity latch.
+            If(
+                IsV2NonOwningWakerImplementationEnabled(),
+                [pipe_owner]() {
+                  return pipe_owner->server_trailing_metadata.Wait();
+                },
+                [initiator = initiator]() mutable {
+                  return initiator.PullServerTrailingMetadata();
+                }),
+            // This promise does the rest of the things, but it will always
+            // return pending, because the promise can't actually finish
+            // until the initiator returns trailing metadata above.
+            TrySeq(
+                state->call_handler_latch.Wait(),
+                [initiator = initiator, pipe_owner,
+                 call_args = std::move(call_args),
+                 next_promise_factory = std::move(next_promise_factory)](
+                    CallHandler handler) mutable {
+                  // Intercept all pipes from v2 API.
+                  //
+                  // For client-to-server messages, we do the following:
+                  // 1. Push the message into the v3 initiator, which sends
+                  //    it to the v3 interceptor.  Note that this needs to
+                  //    be done inside of the v3 initiator's activity.
+                  // 2. Pull the message from the v3 handler, where it will
+                  //    arrive when the v3 interceptor is done with it.
+                  //    Note that this needs to be done inside of the v3
+                  //    handler's activity.  We then push the message into
+                  //    an inter-activity pipe to return it to the v2 activity.
+                  // 3. In the v2 activity, read the message from the
+                  //    inter-activity pipe and send it on to the next
+                  //    filter.
+                  //
+                  // Step 2: Spawn a promise to pull messages from the v3
+                  // handler and push them into an inter-activity pipe to
+                  // return them to the v2 activity.
+                  handler.SpawnGuarded(
+                      "pull_client_to_server_message",
+                      [handler, pipe_owner]() mutable {
+                        return ForEach(
+                            MessagesFrom(handler),
+                            [pipe_owner](MessageHandle message) {
+                              return Map(pipe_owner->client_to_server_messages
+                                             .sender.Push(std::move(message)),
+                                         [](bool x) { return StatusFlag(x); });
+                            });
+                      });
+                  call_args.client_to_server_messages->InterceptAndMap(
+                      [initiator, handler,
+                       pipe_owner](MessageHandle message) mutable {
+                        // Step 1: Push the message onto the v3 initiator in
+                        // its activity.
+                        initiator.SpawnPushMessage(std::move(message));
+                        // Step 3: Here in the v2 activity, read the message
+                        // from the inter-activity pipe and return it.
+                        return Map(
+                            pipe_owner->client_to_server_messages.receiver
+                                .Next(),
+                            [](InterActivityPipe<MessageHandle, 1>::NextResult
+                                   message) -> std::optional<MessageHandle> {
+                              if (!message.has_value()) return std::nullopt;
+                              return std::move(*message);
+                            });
+                      });
+                  // For server initial metadata, we do a similar thing, but
+                  // in the opposite direction, and using an inter-activity
+                  // latch instead of a pipe:
+                  // 1. Push the metadata into the v3 handler, which sends
+                  //    it to the v3 interceptor.  Note that this needs to
+                  //    be done inside of the v3 handler's activity.
+                  // 2. Pull the metadata from the v3 initiator, where it will
+                  //    arrive when the v3 interceptor is done with it.
+                  //    Note that this needs to be done inside of the v3
+                  //    initiator's activity.  We then use an inter-activity
+                  //    latch to return the metadata to the v2 activity.
+                  // 3. In the v2 activity, read the metadata from the
+                  //    inter-activity latch and send it on to the previous
+                  //    filter.
+                  //
+                  // Step 2: Spawn a promise to pull the metadata from the v3
+                  // initiator and use an inter-activity latch to return it to
+                  // the v2 activity.
+                  initiator.SpawnGuarded(
+                      "pull_server_initial_metadata",
+                      [initiator, pipe_owner]() mutable {
+                        return TrySeq(
+                            initiator.PullServerInitialMetadata(),
+                            [pipe_owner](
+                                std::optional<ServerMetadataHandle> metadata) {
+                              pipe_owner->server_initial_metadata.Set(
+                                  std::move(metadata));
+                            });
+                      });
+                  call_args.server_initial_metadata->InterceptAndMap(
+                      [initiator, handler,
+                       pipe_owner](ServerMetadataHandle metadata) mutable {
+                        // Step 1: Push the metadata onto the v3 handler in
+                        // its activity.
+                        handler.SpawnPushServerInitialMetadata(
+                            std::move(metadata));
+                        // Step 3: Here in the v2 activity, read from the
+                        // inter-activity latch and return the metadata.
+                        return pipe_owner->server_initial_metadata.Wait();
+                      });
+                  // We handle server-to-client messages the same as
+                  // client-to-server messages, except in the opposite
+                  // direction:
+                  // 1. Push the message into the v3 handler, which sends
+                  //    it to the v3 interceptor.  Note that this needs to
+                  //    be done inside of the v3 handler's activity.
+                  // 2. Pull the message from the v3 initiator, where it will
+                  //    arrive when the v3 interceptor is done with it.
+                  //    Note that this needs to be done inside of the v3
+                  //    initiator's activity.  We then push the message into
+                  //    an inter-activity pipe to return it to the v2 activity.
+                  // 3. In the v2 activity, read the message from the
+                  //    inter-activity pipe and send it on to the next
+                  //    filter.
+                  //
+                  // Step 2: Spawn a promise to pull messages from the v3
+                  // initiator and push them into an inter-activity pipe to
+                  // return them to the v2 activity.
+                  initiator.SpawnGuarded(
+                      "pull_server_to_client_message",
+                      [initiator, pipe_owner]() mutable {
+                        return ForEach(
+                            MessagesFrom(initiator),
+                            [pipe_owner](MessageHandle message) {
+                              return Map(pipe_owner->server_to_client_messages
+                                             .sender.Push(std::move(message)),
+                                         [](bool x) { return StatusFlag(x); });
+                            });
+                      });
+                  call_args.server_to_client_messages->InterceptAndMap(
+                      [initiator, handler,
+                       pipe_owner](MessageHandle message) mutable {
+                        // Step 1: Push the message onto the v3 handler in
+                        // its activity.
+                        handler.SpawnPushMessage(std::move(message));
+                        // Step 3: Here in the v2 activity, read from the
+                        // inter-activity pipe and return the messages.
+                        return Map(
+                            pipe_owner->server_to_client_messages.receiver
+                                .Next(),
+                            [](InterActivityPipe<MessageHandle, 1>::NextResult
+                                   message) -> std::optional<MessageHandle> {
+                              if (!message.has_value()) return std::nullopt;
+                              return std::move(*message);
+                            });
+                      });
+                  // In the v3 handler's activity, pull client initial metadata.
+                  // Use an inter-activity latch to get it back to the v2
+                  // activity.
+                  handler.SpawnGuarded(
+                      "pull_client_initial_metadata",
+                      [handler, pipe_owner]() mutable {
+                        return TrySeq(
+                            handler.PullClientInitialMetadata(),
+                            [pipe_owner](ClientMetadataHandle metadata) {
+                              pipe_owner->client_initial_metadata.Set(
+                                  std::move(metadata));
+                            });
+                      });
+                  // A wrapper for next_promise_factory that does the following:
+                  // - Pulls client initial metadata from the V3 handler via
+                  //   the inter-activity latch and injects it into the next
+                  //   V2 filter via CallArgs.
+                  // - Polls the next promise to get server trailing metadata
+                  //   from the next V2 filter and feeds it into the V3 handler.
+                  // Note that this does not actually pull the trailing metadata
+                  // from the V3 initiator; instead, we do that in a separate
+                  // promise above.  That promise will always complete at the
+                  // end of the call, so we always return pending here.
+                  return Seq(
+                      pipe_owner->client_initial_metadata.Wait(),
+                      [next_promise_factory = std::move(next_promise_factory),
+                       call_args = std::move(call_args),
+                       handler](ClientMetadataHandle metadata) mutable {
+                        call_args.client_initial_metadata = std::move(metadata);
+                        return Seq(
+                            next_promise_factory(std::move(call_args)),
+                            [handler](ServerMetadataHandle metadata) mutable
+                                -> Poll<ServerMetadataHandle> {
+                              handler.SpawnPushServerTrailingMetadata(
+                                  std::move(metadata));
+                              // We always lose the race.
+                              return Pending{};
+                            });
+                      });
+                })),
         [initiator = initiator]() mutable {
           // The v2 promise was destroyed before completing: propagate the
           // cancellation into the v3 call pair so its CallSpine is torn down
           // and the v3 interceptor is notified.
-          initiator.SpawnCancel(
-              absl::CancelledError("call cancelled by v2 filter stack"));
+          if (IsV2NonOwningWakerImplementationEnabled()) {
+            initiator.SpawnCancel(
+                absl::CancelledError("call cancelled by v2 filter stack"));
+          } else {
+            initiator.SpawnInfallible("v2-force-cancel", [initiator]() mutable {
+              initiator.Cancel();
+              return Map(initiator.PullServerTrailingMetadata(),
+                         [](ServerMetadataHandle) { return Empty{}; });
+            });
+          }
         });
   }
 

--- a/src/core/lib/channel/promise_based_filter.h
+++ b/src/core/lib/channel/promise_based_filter.h
@@ -1297,7 +1297,23 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
           });
     }
     // Now return a promise that does all the things.
-    return Race(
+    //
+    // The returned promise is wrapped in OnCancel so that, if the v2 stack
+    // destroys it before it completes (e.g. the forced-cancellation path in
+    // ServerCallData::Completed, which resets promise_ to an empty
+    // ArenaPromise), we actively propagate a cancellation into the v3 call
+    // pair. Without this, the v3 CallSpine's spawned helper promises (notably
+    // pull_server_trailing_metadata) stay parked forever, so the spine -- and
+    // the v3 interceptor -- leaks and never learns about the cancellation.
+    //
+    // We use SpawnCancel (not Cancel) because this callback runs at promise
+    // destruction time on the v2 activity, not the v3 spine's activity; the
+    // push must be scheduled onto the spine's own party. The push is then
+    // drained by the always-present pull_server_trailing_metadata promise on
+    // the initiator's activity, which fires CallOnDone with the real
+    // cancelled flag and cleanly notifies the v3 CallHandler/interceptor.
+    return OnCancel(
+        Race(
         // Get server trailing metadata from the v3 promise via the
         // inter-activity latch.
         If(
@@ -1485,7 +1501,14 @@ class V3InterceptorToV2Bridge : public ChannelFilter, public Interceptor {
                                  return Pending{};
                                });
                   });
-            }));
+            })),
+        [initiator = initiator]() mutable {
+          // The v2 promise was destroyed before completing: propagate the
+          // cancellation into the v3 call pair so its CallSpine is torn down
+          // and the v3 interceptor is notified.
+          initiator.SpawnCancel(
+              absl::CancelledError("call cancelled by v2 filter stack"));
+        });
   }
 
  protected:

--- a/test/core/channel/BUILD
+++ b/test/core/channel/BUILD
@@ -149,6 +149,9 @@ grpc_cc_test(
     srcs = ["v3_bridge_test.cc"],
     external_deps = [
         "absl/log:log",
+        "absl/log:check",
+        "absl/synchronization",
+        "absl/time",
         "gtest",
     ],
     deps = [

--- a/test/core/channel/v3_bridge_test.cc
+++ b/test/core/channel/v3_bridge_test.cc
@@ -32,6 +32,7 @@
 #include "gtest/gtest.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/synchronization/notification.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 
@@ -159,8 +160,8 @@ TEST_F(V3BridgeTest, EarlyFailureCleansUpArena) {
 // handler so the test can observe whether the v3 call pair is ever torn down.
 class HangingInterceptor : public V3InterceptorToV2Bridge<HangingInterceptor> {
  public:
-  HangingInterceptor(std::shared_ptr<std::atomic<bool>> done,
-                     std::shared_ptr<std::atomic<bool>> cancelled)
+  HangingInterceptor(std::shared_ptr<absl::Notification> done,
+                     std::shared_ptr<bool> cancelled)
       : done_(std::move(done)), cancelled_(std::move(cancelled)) {}
 
   void InterceptCall(UnstartedCallHandler unstarted_call_handler) override {
@@ -170,8 +171,8 @@ class HangingInterceptor : public V3InterceptorToV2Bridge<HangingInterceptor> {
     CallHandler handler = unstarted_call_handler.StartCall();
     const bool registered = handler.OnDone(
         [done = done_, cancelled = cancelled_](bool was_cancelled) {
-          cancelled->store(was_cancelled, std::memory_order_release);
-          done->store(true, std::memory_order_release);
+          *cancelled = was_cancelled;
+          done->Notify();
         });
     CHECK(registered);
     handler_.emplace(std::move(handler));
@@ -179,35 +180,20 @@ class HangingInterceptor : public V3InterceptorToV2Bridge<HangingInterceptor> {
   void Orphaned() override {}
 
  private:
-  std::shared_ptr<std::atomic<bool>> done_;
-  std::shared_ptr<std::atomic<bool>> cancelled_;
+  std::shared_ptr<absl::Notification> done_;
+  std::shared_ptr<bool> cancelled_;
   std::optional<CallHandler> handler_;
 };
 
-// Reproduces the leak described when the v2 promise is force-destroyed while
-// the v3 call is still in flight (mirrors ServerCallData::Completed doing
-// `promise_ = ArenaPromise<ServerMetadataHandle>()`).
-//
-// Expected clean behavior: destroying the promise must propagate a
-// cancellation into the v3 call pair, so the v3 handler's OnDone fires (with
-// cancelled=true) and the v3 CallSpine is torn down.
-//
-// With the current code this FAILS: OnDone never fires because nothing tells
-// the v3 pair about the cancellation, so the pull_server_trailing_metadata
-// promise stays parked and the CallSpine leaks.
+// When the v2 promise is force-destroyed while the v3 call is still
+// in flight (as ServerCallData::Completed does with `promise =
+// ArenaPromise<>`), the bridge must propagate a cancellation to v3 call pair so
+// that the v3 handler's OnDone fires (with cancelled = true) and the v3 spine
+// is torn down rather than leaked.
 TEST_F(V3BridgeTest, ForceDestroyPromiseCancelsV3Call) {
-  auto done = std::make_shared<std::atomic<bool>>(false);
-  auto cancelled = std::make_shared<std::atomic<bool>>(false);
-  auto factory = SimpleArenaAllocator();
-  auto arena = factory->MakeArena();
-  arena->SetContext<grpc_event_engine::experimental::EventEngine>(
-      grpc_event_engine::experimental::GetDefaultEventEngine().get());
-  // Keep the activity alive for the whole test (including arena teardown) so
-  // that any non-owning wakers parked in the bridge's inter-activity latches
-  // are dropped against a live (no-op) activity rather than a dangling one.
-  TestActivity activity;
-  activity.Run([&]() {
-    promise_detail::Context<Arena> arena_ctx(arena.get());
+  auto done = std::make_shared<absl::Notification>(false);
+  auto cancelled = std::make_shared<bool>(false);
+  RunInActivity([&]() {
     HangingInterceptor bridge(done, cancelled);
     auto next_promise_factory = [](CallArgs) {
       return ArenaPromise<ServerMetadataHandle>(
@@ -219,35 +205,26 @@ TEST_F(V3BridgeTest, ForceDestroyPromiseCancelsV3Call) {
                   nullptr,
                   nullptr,
                   nullptr};
-    {
-      auto promise =
-          bridge.MakeCallPromise(std::move(args), next_promise_factory);
-      // Poll a few times to let the bridge wire everything up. The call is in
-      // flight, so the promise stays pending.
-      for (int i = 0; i < 10; ++i) {
-        Poll<ServerMetadataHandle> result = promise();
-        EXPECT_TRUE(result.pending());
-      }
-      EXPECT_FALSE(done->load(std::memory_order_acquire));
-      // Force-destroy the promise, simulating the v2 forced-cancellation path
-      // in ServerCallData::Completed (promise_ = ArenaPromise<...>()).
-    }
+    auto promise =
+        bridge.MakeCallPromise(std::move(args), next_promise_factory);
+    // Poll promise once to let the bridge wire everything up. The call is in
+    // flight, so the promise stays pending.
+    Poll<ServerMetadataHandle> result = promise();
+    EXPECT_TRUE(result.pending());
+    EXPECT_FALSE(done->HasBeenNotified());
+    // Promise is forced destroyed similar to how it's done in
+    // ServerCallData::Completed
+    promise = ArenaPromise<ServerMetadataHandle>();
     // The v3 call pair must be cancelled as a result. The cancellation is
     // pushed onto the v3 CallSpine's party and drained on an event engine
     // thread, so wait for OnDone to fire.
-    const absl::Time deadline = absl::Now() + absl::Seconds(5);
-    while (!done->load(std::memory_order_acquire) && absl::Now() < deadline) {
-      absl::SleepFor(absl::Milliseconds(2));
-    }
-    EXPECT_TRUE(done->load(std::memory_order_acquire))
+    EXPECT_TRUE(done->WaitForNotificationWithTimeout(absl::Seconds(2)))
         << "v3 handler OnDone never fired -- the v3 CallSpine leaked because "
            "the forced promise destruction was not propagated as a "
            "cancellation.";
-    EXPECT_TRUE(cancelled->load(std::memory_order_acquire))
+    EXPECT_TRUE(*cancelled)
         << "v3 call was torn down but not observed as a cancellation.";
-    // Release the arena while still inside the activity scope. With the fix the
-    // v3 spine has already been torn down, so this reclaims the arena cleanly.
-    arena.reset();
+    arena_.reset();
   });
 }
 

--- a/test/core/channel/v3_bridge_test.cc
+++ b/test/core/channel/v3_bridge_test.cc
@@ -15,7 +15,9 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
+#include <atomic>
 #include <memory>
+#include <optional>
 
 #include "src/core/call/call_spine.h"
 #include "src/core/call/metadata.h"
@@ -28,7 +30,10 @@
 #include "test/core/promise/poll_matcher.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 
 namespace grpc_core {
 namespace {
@@ -146,6 +151,104 @@ TEST_F(V3BridgeTest, EarlyFailureCleansUpArena) {
   });
   // Verify that the arena can be destroyed.
   arena.reset();
+}
+
+// An interceptor that wires up a real v3 call (so the bridge spawns all of its
+// helper promises) but never produces server trailing metadata -- i.e. the
+// call stays in flight forever. It registers an OnDone callback on the v3
+// handler so the test can observe whether the v3 call pair is ever torn down.
+class HangingInterceptor : public V3InterceptorToV2Bridge<HangingInterceptor> {
+ public:
+  HangingInterceptor(std::shared_ptr<std::atomic<bool>> done,
+                     std::shared_ptr<std::atomic<bool>> cancelled)
+      : done_(std::move(done)), cancelled_(std::move(cancelled)) {}
+
+  void InterceptCall(UnstartedCallHandler unstarted_call_handler) override {
+    // Consume the call: start it and hold on to the handler so the v3 spine
+    // stays alive. We deliberately never push trailing metadata, leaving the
+    // call in flight.
+    CallHandler handler = unstarted_call_handler.StartCall();
+    const bool registered = handler.OnDone(
+        [done = done_, cancelled = cancelled_](bool was_cancelled) {
+          cancelled->store(was_cancelled, std::memory_order_release);
+          done->store(true, std::memory_order_release);
+        });
+    CHECK(registered);
+    handler_.emplace(std::move(handler));
+  }
+  void Orphaned() override {}
+
+ private:
+  std::shared_ptr<std::atomic<bool>> done_;
+  std::shared_ptr<std::atomic<bool>> cancelled_;
+  std::optional<CallHandler> handler_;
+};
+
+// Reproduces the leak described when the v2 promise is force-destroyed while
+// the v3 call is still in flight (mirrors ServerCallData::Completed doing
+// `promise_ = ArenaPromise<ServerMetadataHandle>()`).
+//
+// Expected clean behavior: destroying the promise must propagate a
+// cancellation into the v3 call pair, so the v3 handler's OnDone fires (with
+// cancelled=true) and the v3 CallSpine is torn down.
+//
+// With the current code this FAILS: OnDone never fires because nothing tells
+// the v3 pair about the cancellation, so the pull_server_trailing_metadata
+// promise stays parked and the CallSpine leaks.
+TEST_F(V3BridgeTest, ForceDestroyPromiseCancelsV3Call) {
+  auto done = std::make_shared<std::atomic<bool>>(false);
+  auto cancelled = std::make_shared<std::atomic<bool>>(false);
+  auto factory = SimpleArenaAllocator();
+  auto arena = factory->MakeArena();
+  arena->SetContext<grpc_event_engine::experimental::EventEngine>(
+      grpc_event_engine::experimental::GetDefaultEventEngine().get());
+  // Keep the activity alive for the whole test (including arena teardown) so
+  // that any non-owning wakers parked in the bridge's inter-activity latches
+  // are dropped against a live (no-op) activity rather than a dangling one.
+  TestActivity activity;
+  activity.Run([&]() {
+    promise_detail::Context<Arena> arena_ctx(arena.get());
+    HangingInterceptor bridge(done, cancelled);
+    auto next_promise_factory = [](CallArgs) {
+      return ArenaPromise<ServerMetadataHandle>(
+          []() -> Poll<ServerMetadataHandle> { return Pending{}; });
+    };
+    CallArgs args{Arena::MakePooledForOverwrite<ClientMetadata>(),
+                  ClientInitialMetadataOutstandingToken::Empty(),
+                  nullptr,
+                  nullptr,
+                  nullptr,
+                  nullptr};
+    {
+      auto promise =
+          bridge.MakeCallPromise(std::move(args), next_promise_factory);
+      // Poll a few times to let the bridge wire everything up. The call is in
+      // flight, so the promise stays pending.
+      for (int i = 0; i < 10; ++i) {
+        Poll<ServerMetadataHandle> result = promise();
+        EXPECT_TRUE(result.pending());
+      }
+      EXPECT_FALSE(done->load(std::memory_order_acquire));
+      // Force-destroy the promise, simulating the v2 forced-cancellation path
+      // in ServerCallData::Completed (promise_ = ArenaPromise<...>()).
+    }
+    // The v3 call pair must be cancelled as a result. The cancellation is
+    // pushed onto the v3 CallSpine's party and drained on an event engine
+    // thread, so wait for OnDone to fire.
+    const absl::Time deadline = absl::Now() + absl::Seconds(5);
+    while (!done->load(std::memory_order_acquire) && absl::Now() < deadline) {
+      absl::SleepFor(absl::Milliseconds(2));
+    }
+    EXPECT_TRUE(done->load(std::memory_order_acquire))
+        << "v3 handler OnDone never fired -- the v3 CallSpine leaked because "
+           "the forced promise destruction was not propagated as a "
+           "cancellation.";
+    EXPECT_TRUE(cancelled->load(std::memory_order_acquire))
+        << "v3 call was torn down but not observed as a cancellation.";
+    // Release the arena while still inside the activity scope. With the fix the
+    // v3 spine has already been torn down, so this reclaims the arena cleanly.
+    arena.reset();
+  });
 }
 
 }  // namespace

--- a/test/core/channel/v3_bridge_test.cc
+++ b/test/core/channel/v3_bridge_test.cc
@@ -15,7 +15,6 @@
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
-#include <atomic>
 #include <memory>
 #include <optional>
 


### PR DESCRIPTION
Wrapped the returned promise in OnCancel , so cancellation is propagated into v3 call pair.

Added a pointed Unit test for the issue to verify fix

