### PR TITLE
[xds] Replace XdsGrpcService with GrpcXdsServerTarget directly in common types

### DIFF
--- a/src/core/xds/grpc/xds_common_types.cc
+++ b/src/core/xds/grpc/xds_common_types.cc
@@ -23,7 +23,6 @@
 #include "src/core/lib/slice/slice.h"
 #include "src/core/util/match.h"
 #include "src/core/util/string.h"
-#include "src/core/util/time.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
@@ -119,43 +118,6 @@ std::string CommonTlsContext::ToString() const {
 bool CommonTlsContext::Empty() const {
   return tls_certificate_provider_instance.Empty() &&
          certificate_validation_context.Empty();
-}
-
-//
-// XdsGrpcService
-//
-
-std::string XdsGrpcService::ToString() const {
-  std::string result = "{";
-  bool is_first = true;
-  if (server_target != nullptr) {
-    StrAppend(result, "server_target=");
-    StrAppend(result, server_target->Key());
-    is_first = false;
-  }
-  if (timeout != Duration::Zero()) {
-    if (!is_first) StrAppend(result, ", ");
-    StrAppend(result, "timeout=");
-    StrAppend(result, timeout.ToString());
-    is_first = false;
-  }
-  if (!initial_metadata.empty()) {
-    if (!is_first) StrAppend(result, ", ");
-    StrAppend(result, "initial_metadata=[");
-    bool is_first_metadata = true;
-    for (const auto& metadata : initial_metadata) {
-      if (!is_first_metadata) StrAppend(result, ", ");
-      StrAppend(result, "{key=");
-      StrAppend(result, metadata.first);
-      StrAppend(result, ", value=");
-      StrAppend(result, metadata.second);
-      StrAppend(result, "}");
-      is_first_metadata = false;
-    }
-    StrAppend(result, "]");
-  }
-  StrAppend(result, "}");
-  return result;
 }
 
 //

--- a/src/core/xds/grpc/xds_common_types.h
+++ b/src/core/xds/grpc/xds_common_types.h
@@ -26,9 +26,7 @@
 #include "src/core/call/metadata_batch.h"
 #include "src/core/util/json/json.h"
 #include "src/core/util/matchers.h"
-#include "src/core/util/time.h"
 #include "src/core/util/validation_errors.h"
-#include "src/core/xds/grpc/xds_server_grpc.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 
@@ -89,22 +87,6 @@ struct XdsExtension {
   // Validation fields that need to stay in scope until we're done
   // processing the extension.
   std::vector<ValidationErrors::ScopedField> validation_fields;
-};
-
-struct XdsGrpcService {
-  std::unique_ptr<GrpcXdsServerTarget> server_target;
-  Duration timeout;
-  std::vector<std::pair<std::string, std::string>> initial_metadata;
-
-  bool operator==(const XdsGrpcService& other) const {
-    if (timeout != other.timeout) return false;
-    if (initial_metadata != other.initial_metadata) return false;
-    if (server_target == nullptr) return other.server_target == nullptr;
-    if (other.server_target == nullptr) return false;
-    return server_target->Equals(*other.server_target);
-  }
-
-  std::string ToString() const;
 };
 
 struct HeaderMutationRules {

--- a/src/core/xds/grpc/xds_common_types_parser.cc
+++ b/src/core/xds/grpc/xds_common_types_parser.cc
@@ -689,33 +689,38 @@ std::pair<std::string, std::string> ParseXdsHeader(
 // ParseXdsGrpcService()
 //
 
-XdsGrpcService ParseXdsGrpcService(
+GrpcXdsServerTarget ParseXdsGrpcService(
     const XdsResourceType::DecodeContext& context,
     const envoy_config_core_v3_GrpcService* grpc_service,
     ValidationErrors* errors) {
   if (grpc_service == nullptr) {
     errors->AddError("field not set");
-    return {};
+    return GrpcXdsServerTarget(/*server_uri=*/"",
+                               /*channel_creds_config=*/nullptr,
+                               /*call_creds_configs=*/{});
   }
-  XdsGrpcService xds_grpc_service;
   // timeout
-  if (auto* timeout = envoy_config_core_v3_GrpcService_timeout(grpc_service);
-      timeout != nullptr) {
+  Duration timeout = Duration::Zero();
+  if (auto* timeout_proto =
+          envoy_config_core_v3_GrpcService_timeout(grpc_service);
+      timeout_proto != nullptr) {
     ValidationErrors::ScopedField field(errors, ".timeout");
-    xds_grpc_service.timeout = ParseDuration(timeout, errors);
-    if (xds_grpc_service.timeout <= Duration::Zero()) {
+    timeout = ParseDuration(timeout_proto, errors);
+    if (timeout <= Duration::Zero()) {
       errors->AddError("duration must be positive");
     }
   }
   // initial_metadata
+  std::vector<std::pair<std::string, std::string>> initial_metadata;
   size_t initial_metadata_size;
-  auto* initial_metadata = envoy_config_core_v3_GrpcService_initial_metadata(
-      grpc_service, &initial_metadata_size);
+  auto* initial_metadata_proto =
+      envoy_config_core_v3_GrpcService_initial_metadata(grpc_service,
+                                                        &initial_metadata_size);
   for (size_t i = 0; i < initial_metadata_size; ++i) {
     ValidationErrors::ScopedField field(
         errors, absl::StrCat(".initial_metadata[", i, "]"));
-    xds_grpc_service.initial_metadata.push_back(
-        ParseXdsHeader(initial_metadata[i], errors));
+    initial_metadata.push_back(
+        ParseXdsHeader(initial_metadata_proto[i], errors));
   }
   // google_grpc
   ValidationErrors::ScopedField field(errors, ".google_grpc");
@@ -723,99 +728,97 @@ XdsGrpcService ParseXdsGrpcService(
       envoy_config_core_v3_GrpcService_google_grpc(grpc_service);
   if (google_grpc == nullptr) {
     errors->AddError("field not set");
-  } else {
-    // target_uri
-    std::string target_uri = UpbStringToStdString(
-        envoy_config_core_v3_GrpcService_GoogleGrpc_target_uri(google_grpc));
-    if (!CoreConfiguration::Get().resolver_registry().IsValidTarget(
-            target_uri)) {
-      ValidationErrors::ScopedField field(errors, ".target_uri");
-      errors->AddError("invalid target URI");
-    }
-    // credentials
-    RefCountedPtr<const ChannelCredsConfig> channel_creds_config;
-    std::vector<RefCountedPtr<const CallCredsConfig>> call_creds_configs;
-    if (DownCast<const GrpcXdsServer&>(context.server).TrustedXdsServer()) {
-      // Trusted xDS server.  Use credentials from the GoogleGrpc proto.
-      // First, look at channel creds.
-      {
-        ValidationErrors::ScopedField field(errors,
-                                            ".channel_credentials_plugin");
-        size_t size;
-        const auto* const* channel_creds_plugin =
-            envoy_config_core_v3_GrpcService_GoogleGrpc_channel_credentials_plugin(
-                google_grpc, &size);
-        if (size == 0) {
-          errors->AddError("field not set");
-        } else {
-          const auto& registry =
-              CoreConfiguration::Get().channel_creds_registry();
-          const auto& certificate_providers =
-              DownCast<const GrpcXdsBootstrap&>(context.client->bootstrap())
-                  .certificate_providers();
-          for (size_t i = 0; i < size; ++i) {
-            ValidationErrors::ScopedField field(errors,
-                                                absl::StrCat("[", i, "]"));
-            absl::string_view type = UpbStringToAbsl(
-                google_protobuf_Any_type_url(channel_creds_plugin[i]));
-            if (!StripTypePrefix(type, errors)) continue;
-            if (!registry.IsProtoSupported(type)) continue;
-            ValidationErrors::ScopedField field2(errors, ".value");
-            absl::string_view serialized_config = UpbStringToAbsl(
-                google_protobuf_Any_value(channel_creds_plugin[i]));
-            channel_creds_config = registry.ParseProto(
-                type, serialized_config, certificate_providers, errors);
-            break;
-          }
-          if (channel_creds_config == nullptr) {
-            errors->AddError("no supported channel credentials type found");
-          }
-        }
-      }
-      // Now look at call creds.
-      {
-        ValidationErrors::ScopedField field(errors, ".call_credentials_plugin");
-        size_t size;
-        const auto* const* call_creds_plugin =
-            envoy_config_core_v3_GrpcService_GoogleGrpc_call_credentials_plugin(
-                google_grpc, &size);
-        const auto& registry = CoreConfiguration::Get().call_creds_registry();
+    return GrpcXdsServerTarget(/*server_uri=*/"",
+                               /*channel_creds_config=*/nullptr,
+                               /*call_creds_configs=*/{});
+  }
+  // target_uri
+  std::string target_uri = UpbStringToStdString(
+      envoy_config_core_v3_GrpcService_GoogleGrpc_target_uri(google_grpc));
+  if (!CoreConfiguration::Get().resolver_registry().IsValidTarget(target_uri)) {
+    ValidationErrors::ScopedField field(errors, ".target_uri");
+    errors->AddError("invalid target URI");
+  }
+  // credentials
+  RefCountedPtr<const ChannelCredsConfig> channel_creds_config;
+  std::vector<RefCountedPtr<const CallCredsConfig>> call_creds_configs;
+  if (DownCast<const GrpcXdsServer&>(context.server).TrustedXdsServer()) {
+    // Trusted xDS server.  Use credentials from the GoogleGrpc proto.
+    // First, look at channel creds.
+    {
+      ValidationErrors::ScopedField field(errors,
+                                          ".channel_credentials_plugin");
+      size_t size;
+      const auto* const* channel_creds_plugin =
+          envoy_config_core_v3_GrpcService_GoogleGrpc_channel_credentials_plugin(
+              google_grpc, &size);
+      if (size == 0) {
+        errors->AddError("field not set");
+      } else {
+        const auto& registry =
+            CoreConfiguration::Get().channel_creds_registry();
+        const auto& certificate_providers =
+            DownCast<const GrpcXdsBootstrap&>(context.client->bootstrap())
+                .certificate_providers();
         for (size_t i = 0; i < size; ++i) {
           ValidationErrors::ScopedField field(errors,
                                               absl::StrCat("[", i, "]"));
           absl::string_view type = UpbStringToAbsl(
-              google_protobuf_Any_type_url(call_creds_plugin[i]));
+              google_protobuf_Any_type_url(channel_creds_plugin[i]));
           if (!StripTypePrefix(type, errors)) continue;
           if (!registry.IsProtoSupported(type)) continue;
           ValidationErrors::ScopedField field2(errors, ".value");
-          absl::string_view serialized_config =
-              UpbStringToAbsl(google_protobuf_Any_value(call_creds_plugin[i]));
-          call_creds_configs.push_back(
-              registry.ParseProto(type, serialized_config, errors));
+          absl::string_view serialized_config = UpbStringToAbsl(
+              google_protobuf_Any_value(channel_creds_plugin[i]));
+          channel_creds_config = registry.ParseProto(
+              type, serialized_config, certificate_providers, errors);
+          break;
+        }
+        if (channel_creds_config == nullptr) {
+          errors->AddError("no supported channel credentials type found");
         }
       }
-    } else {
-      // Not a trusted xDS server.  Do lookup in bootstrap.
-      const auto& bootstrap =
-          DownCast<const GrpcXdsBootstrap&>(context.client->bootstrap());
-      auto& allowed_grpc_services = bootstrap.allowed_grpc_services();
-      auto it = allowed_grpc_services.find(target_uri);
-      if (it == allowed_grpc_services.end()) {
-        ValidationErrors::ScopedField field(errors, ".target_uri");
-        errors->AddError(
-            "service not present in \"allowed_grpc_services\" "
-            "in bootstrap config");
-      } else {
-        channel_creds_config = it->second.channel_creds_config;
-        call_creds_configs = it->second.call_creds_configs;
+    }
+    // Now look at call creds.
+    {
+      ValidationErrors::ScopedField field(errors, ".call_credentials_plugin");
+      size_t size;
+      const auto* const* call_creds_plugin =
+          envoy_config_core_v3_GrpcService_GoogleGrpc_call_credentials_plugin(
+              google_grpc, &size);
+      const auto& registry = CoreConfiguration::Get().call_creds_registry();
+      for (size_t i = 0; i < size; ++i) {
+        ValidationErrors::ScopedField field(errors, absl::StrCat("[", i, "]"));
+        absl::string_view type =
+            UpbStringToAbsl(google_protobuf_Any_type_url(call_creds_plugin[i]));
+        if (!StripTypePrefix(type, errors)) continue;
+        if (!registry.IsProtoSupported(type)) continue;
+        ValidationErrors::ScopedField field2(errors, ".value");
+        absl::string_view serialized_config =
+            UpbStringToAbsl(google_protobuf_Any_value(call_creds_plugin[i]));
+        call_creds_configs.push_back(
+            registry.ParseProto(type, serialized_config, errors));
       }
     }
-    xds_grpc_service.server_target = std::make_unique<GrpcXdsServerTarget>(
-        target_uri, std::move(channel_creds_config),
-        std::move(call_creds_configs), xds_grpc_service.initial_metadata,
-        xds_grpc_service.timeout);
+  } else {
+    // Not a trusted xDS server.  Do lookup in bootstrap.
+    const auto& bootstrap =
+        DownCast<const GrpcXdsBootstrap&>(context.client->bootstrap());
+    auto& allowed_grpc_services = bootstrap.allowed_grpc_services();
+    auto it = allowed_grpc_services.find(target_uri);
+    if (it == allowed_grpc_services.end()) {
+      ValidationErrors::ScopedField field(errors, ".target_uri");
+      errors->AddError(
+          "service not present in \"allowed_grpc_services\" "
+          "in bootstrap config");
+    } else {
+      channel_creds_config = it->second.channel_creds_config;
+      call_creds_configs = it->second.call_creds_configs;
+    }
   }
-  return xds_grpc_service;
+  return GrpcXdsServerTarget(target_uri, std::move(channel_creds_config),
+                             std::move(call_creds_configs),
+                             std::move(initial_metadata), timeout);
 }
 
 //

--- a/src/core/xds/grpc/xds_common_types_parser.h
+++ b/src/core/xds/grpc/xds_common_types_parser.h
@@ -35,6 +35,7 @@
 #include "src/core/util/time.h"
 #include "src/core/util/validation_errors.h"
 #include "src/core/xds/grpc/xds_common_types.h"
+#include "src/core/xds/grpc/xds_server_grpc.h"
 #include "src/core/xds/xds_client/xds_resource_type.h"
 #include "xds/type/matcher/v3/string.upb.h"
 
@@ -91,7 +92,7 @@ std::optional<XdsExtension> ExtractXdsExtension(
     const XdsResourceType::DecodeContext& context,
     const google_protobuf_Any* any, ValidationErrors* errors);
 
-XdsGrpcService ParseXdsGrpcService(
+GrpcXdsServerTarget ParseXdsGrpcService(
     const XdsResourceType::DecodeContext& context,
     const envoy_config_core_v3_GrpcService* grpc_service,
     ValidationErrors* errors);

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -453,6 +453,7 @@ grpc_cc_test(
         "//src/core:upb_utils",
         "//src/core:validation_errors",
         "//src/core:xds_common_types",
+        "//src/core:xds_server_grpc",
         "//test/core/test_util:grpc_test_util",
         "//test/core/test_util:scoped_env_var",
         "//test/cpp/util:grpc_cli_utils",

--- a/test/core/xds/xds_common_types_test.cc
+++ b/test/core/xds/xds_common_types_test.cc
@@ -54,6 +54,7 @@
 #include "src/core/util/validation_errors.h"
 #include "src/core/xds/grpc/xds_bootstrap_grpc.h"
 #include "src/core/xds/grpc/xds_common_types_parser.h"
+#include "src/core/xds/grpc/xds_server_grpc.h"
 #include "src/core/xds/xds_client/xds_bootstrap.h"
 #include "src/core/xds/xds_client/xds_client.h"
 #include "src/core/xds/xds_client/xds_resource_type.h"
@@ -1014,7 +1015,7 @@ class ParseXdsGrpcServiceTest : public XdsCommonTypesTest {
   // For convenience, tests build protos using the protobuf API, and
   // we convert it to a upb object, which is then passed to
   // ParseXdsGrpcService() for testing.
-  absl::StatusOr<XdsGrpcService> Parse(const GrpcService& proto) {
+  absl::StatusOr<GrpcXdsServerTarget> Parse(const GrpcService& proto) {
     // Serialize the protobuf proto.
     std::string serialized_proto;
     if (!proto.SerializeToString(&serialized_proto)) {
@@ -1028,13 +1029,13 @@ class ParseXdsGrpcServiceTest : public XdsCommonTypesTest {
     }
     // Now parse the upb proto.
     ValidationErrors errors;
-    XdsGrpcService xds_grpc_service =
+    GrpcXdsServerTarget target =
         ParseXdsGrpcService(MakeDecodeContext(), upb_proto, &errors);
     if (!errors.ok()) {
       return errors.status(absl::StatusCode::kInvalidArgument,
                            "validation failed");
     }
-    return xds_grpc_service;
+    return target;
   }
 };
 
@@ -1064,13 +1065,10 @@ TEST_F(ParseXdsGrpcServiceTest,
   google_grpc->add_call_credentials_plugin()->PackFrom(call_creds);
   auto xds_grpc_service = Parse(grpc_service);
   ASSERT_TRUE(xds_grpc_service.ok()) << xds_grpc_service.status();
-  ASSERT_NE(xds_grpc_service->server_target, nullptr);
-  EXPECT_EQ(xds_grpc_service->server_target->server_uri(),
-            "dns:server.example.com");
-  ASSERT_NE(xds_grpc_service->server_target->channel_creds_config(), nullptr);
-  EXPECT_EQ(xds_grpc_service->server_target->channel_creds_config()->type(),
-            "insecure");
-  EXPECT_THAT(xds_grpc_service->server_target->call_creds_configs(),
+  EXPECT_EQ(xds_grpc_service->server_uri(), "dns:server.example.com");
+  ASSERT_NE(xds_grpc_service->channel_creds_config(), nullptr);
+  EXPECT_EQ(xds_grpc_service->channel_creds_config()->type(), "insecure");
+  EXPECT_THAT(xds_grpc_service->call_creds_configs(),
               ::testing::ElementsAre(EqCredsConfig(
                   "jwt_token_file", "", "{path=\"/path/to/file\"}")));
 }
@@ -1113,13 +1111,10 @@ TEST_F(ParseXdsGrpcServiceTest, TrustedXdsServerWithCredentials) {
   google_grpc->add_call_credentials_plugin()->PackFrom(call_creds);
   auto xds_grpc_service = Parse(grpc_service);
   ASSERT_TRUE(xds_grpc_service.ok()) << xds_grpc_service.status();
-  ASSERT_NE(xds_grpc_service->server_target, nullptr);
-  EXPECT_EQ(xds_grpc_service->server_target->server_uri(),
-            "dns:server.example.com");
-  ASSERT_NE(xds_grpc_service->server_target->channel_creds_config(), nullptr);
-  EXPECT_EQ(xds_grpc_service->server_target->channel_creds_config()->type(),
-            "google_default");
-  EXPECT_THAT(xds_grpc_service->server_target->call_creds_configs(),
+  EXPECT_EQ(xds_grpc_service->server_uri(), "dns:server.example.com");
+  ASSERT_NE(xds_grpc_service->channel_creds_config(), nullptr);
+  EXPECT_EQ(xds_grpc_service->channel_creds_config()->type(), "google_default");
+  EXPECT_THAT(xds_grpc_service->call_creds_configs(),
               ::testing::ElementsAre(
                   EqCredsConfig("",
                                 "envoy.extensions.grpc_service.call_credentials"
@@ -1130,8 +1125,8 @@ TEST_F(ParseXdsGrpcServiceTest, TrustedXdsServerWithCredentials) {
                                 ".access_token.v3.AccessTokenCredentials",
                                 "{token=\"bar\"}")));
   // Unset fields have default values.
-  EXPECT_EQ(xds_grpc_service->timeout, Duration::Zero());
-  EXPECT_THAT(xds_grpc_service->initial_metadata, ::testing::ElementsAre());
+  EXPECT_EQ(xds_grpc_service->timeout(), Duration::Zero());
+  EXPECT_THAT(xds_grpc_service->initial_metadata(), ::testing::ElementsAre());
 }
 
 TEST_F(ParseXdsGrpcServiceTest, TrustedXdsServerWithChannelCredsUnset) {
@@ -1172,7 +1167,7 @@ TEST_F(ParseXdsGrpcServiceTest, Timeout) {
           InsecureCredentials());
   auto xds_grpc_service = Parse(grpc_service);
   ASSERT_TRUE(xds_grpc_service.ok()) << xds_grpc_service.status();
-  EXPECT_EQ(xds_grpc_service->timeout, Duration::Seconds(5));
+  EXPECT_EQ(xds_grpc_service->timeout(), Duration::Seconds(5));
 }
 
 TEST_F(ParseXdsGrpcServiceTest, InvalidTimeout) {
@@ -1204,7 +1199,7 @@ TEST_F(ParseXdsGrpcServiceTest, HeaderValueForNonBinaryHeader) {
           GoogleDefaultCredentials());
   auto xds_grpc_service = Parse(grpc_service);
   ASSERT_TRUE(xds_grpc_service.ok()) << xds_grpc_service.status();
-  EXPECT_THAT(xds_grpc_service->initial_metadata,
+  EXPECT_THAT(xds_grpc_service->initial_metadata(),
               ::testing::ElementsAre(::testing::Pair("foo", "bar")));
 }
 


### PR DESCRIPTION
Removes the redundant `XdsGrpcService` wrapper struct and replaces it with `GrpcXdsServerTarget` directly across xDS common types and parsers.

