### PR TITLE
[Python] Remove 3.15 until Python 3.15 RC is released.

### DIFF
--- a/build_handwritten.yaml
+++ b/build_handwritten.yaml
@@ -22,7 +22,6 @@ settings:
   - '3.12'
   - '3.13'
   - '3.14'
-  - '3.15'
   version: 1.83.0-dev
 configs:
   asan:

--- a/py_xds_protos/python_version.py
+++ b/py_xds_protos/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/py_xds_protos/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio/python_version.py
+++ b/src/python/grpcio/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_admin/python_version.py
+++ b/src/python/grpcio_admin/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_admin/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_channelz/python_version.py
+++ b/src/python/grpcio_channelz/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_channelz/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_csds/python_version.py
+++ b/src/python/grpcio_csds/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_csds/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_csm_observability/python_version.py
+++ b/src/python/grpcio_csm_observability/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_csm_observability/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_health_checking/python_version.py
+++ b/src/python/grpcio_health_checking/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_health_checking/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_observability/python_version.py
+++ b/src/python/grpcio_observability/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_observability/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_reflection/python_version.py
+++ b/src/python/grpcio_reflection/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_reflection/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_status/python_version.py
+++ b/src/python/grpcio_status/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_status/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_testing/python_version.py
+++ b/src/python/grpcio_testing/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_testing/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/src/python/grpcio_tests/python_version.py
+++ b/src/python/grpcio_tests/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_tests/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/tools/distrib/python/grpcio_tools/grpc_tools/python_version.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpcio_tools/grpc_tools/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"

--- a/tools/distrib/python/grpcio_tools/python_version.py
+++ b/tools/distrib/python/grpcio_tools/python_version.py
@@ -14,7 +14,7 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/tools/distrib/python/grpcio_tools/python_version.py.template`!!!
 
-SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14","3.15"]
+SUPPORTED_PYTHON_VERSIONS = ["3.10","3.11","3.12","3.13","3.14"]
 
 MIN_PYTHON_VERSION = "3.10"
-MAX_PYTHON_VERSION = "3.15"
+MAX_PYTHON_VERSION = "3.14"


### PR DESCRIPTION
# Description

Remove `3.15` from `Programming Language Classifiers` until `Python 3.15 RC` is released.

# Testing

Ci