### PR TITLE
[Python] Add per-call retry metrics to OpenTelemetry plugin

### DIFF
--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
@@ -131,8 +131,3 @@ def retry_metrics() -> List[Metric]:
         CLIENT_CALL_TRANSPARENT_RETRIES,
         CLIENT_CALL_RETRY_DELAY,
     ]
-
-
-def optional_metrics() -> List[Metric]:
-    """Metrics which are not enabled by default and must be requested by name."""
-    return retry_metrics()

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
@@ -85,22 +85,28 @@ CLIENT_CALL_RETRIES = Metric(
     "grpc.client.call.retries",
     MetricsName.CLIENT_RETRIES_PER_CALL,
     "{retry}",
-    "Number of retries during the client call. If there were no retries, 0 is not reported.",
+    (
+        "EXPERIMENTAL: Number of retries during the client call. If there were"
+        " no retries, 0 is not reported."
+    ),
 )
 CLIENT_CALL_TRANSPARENT_RETRIES = Metric(
     "grpc.client.call.transparent_retries",
     MetricsName.CLIENT_TRANSPARENT_RETRIES_PER_CALL,
     "{transparent_retry}",
     (
-        "Number of transparent retries during the client call. If there were"
-        " no transparent retries, 0 is not reported."
+        "EXPERIMENTAL: Number of transparent retries during the client call."
+        " If there were no transparent retries, 0 is not reported."
     ),
 )
 CLIENT_CALL_RETRY_DELAY = Metric(
     "grpc.client.call.retry_delay",
     MetricsName.CLIENT_RETRY_DELAY_PER_CALL,
     "s",
-    "Total time of delay while there is no active attempt during the client call",
+    (
+        "EXPERIMENTAL: Total time of delay while there is no active attempt"
+        " during the client call"
+    ),
 )
 
 

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
@@ -125,3 +125,8 @@ def retry_metrics() -> List[Metric]:
         CLIENT_CALL_TRANSPARENT_RETRIES,
         CLIENT_CALL_RETRY_DELAY,
     ]
+
+
+def optional_metrics() -> List[Metric]:
+    """Metrics which are not enabled by default and must be requested by name."""
+    return retry_metrics()

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
@@ -91,7 +91,10 @@ CLIENT_CALL_TRANSPARENT_RETRIES = Metric(
     "grpc.client.call.transparent_retries",
     MetricsName.CLIENT_TRANSPARENT_RETRIES_PER_CALL,
     "{transparent_retry}",
-    "Number of transparent retries during the client call. If there were no transparent retries, 0 is not reported.",
+    (
+        "Number of transparent retries during the client call. If there were"
+        " no transparent retries, 0 is not reported."
+    ),
 )
 CLIENT_CALL_RETRY_DELAY = Metric(
     "grpc.client.call.retry_delay",

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
@@ -81,6 +81,24 @@ SERVER_RPC_RECEIVED_BYTES = Metric(
     "By",
     "Compressed message bytes received per server call",
 )
+CLIENT_CALL_RETRIES = Metric(
+    "grpc.client.call.retries",
+    MetricsName.CLIENT_RETRIES_PER_CALL,
+    "{retry}",
+    "Number of retries during the client call. If there were no retries, 0 is not reported.",
+)
+CLIENT_CALL_TRANSPARENT_RETRIES = Metric(
+    "grpc.client.call.transparent_retries",
+    MetricsName.CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+    "{transparent_retry}",
+    "Number of transparent retries during the client call. If there were no transparent retries, 0 is not reported.",
+)
+CLIENT_CALL_RETRY_DELAY = Metric(
+    "grpc.client.call.retry_delay",
+    MetricsName.CLIENT_RETRY_DELAY_PER_CALL,
+    "s",
+    "Total time of delay while there is no active attempt during the client call",
+)
 
 
 def base_metrics() -> List[Metric]:
@@ -95,4 +113,12 @@ def base_metrics() -> List[Metric]:
         SERVER_RPC_DURATION,
         SERVER_RPC_SEND_BYTES,
         SERVER_RPC_RECEIVED_BYTES,
+    ]
+
+
+def retry_metrics() -> List[Metric]:
+    return [
+        CLIENT_CALL_RETRIES,
+        CLIENT_CALL_TRANSPARENT_RETRIES,
+        CLIENT_CALL_RETRY_DELAY,
     ]

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_measures.py
@@ -81,6 +81,33 @@ SERVER_RPC_RECEIVED_BYTES = Metric(
     "By",
     "Compressed message bytes received per server call",
 )
+CLIENT_CALL_RETRIES = Metric(
+    "grpc.client.call.retries",
+    MetricsName.CLIENT_RETRIES_PER_CALL,
+    "{retry}",
+    (
+        "EXPERIMENTAL: Number of retries during the client call. If there were"
+        " no retries, 0 is not reported."
+    ),
+)
+CLIENT_CALL_TRANSPARENT_RETRIES = Metric(
+    "grpc.client.call.transparent_retries",
+    MetricsName.CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+    "{transparent_retry}",
+    (
+        "EXPERIMENTAL: Number of transparent retries during the client call."
+        " If there were no transparent retries, 0 is not reported."
+    ),
+)
+CLIENT_CALL_RETRY_DELAY = Metric(
+    "grpc.client.call.retry_delay",
+    MetricsName.CLIENT_RETRY_DELAY_PER_CALL,
+    "s",
+    (
+        "EXPERIMENTAL: Total time of delay while there is no active attempt"
+        " during the client call"
+    ),
+)
 
 
 def base_metrics() -> List[Metric]:
@@ -95,4 +122,12 @@ def base_metrics() -> List[Metric]:
         SERVER_RPC_DURATION,
         SERVER_RPC_SEND_BYTES,
         SERVER_RPC_RECEIVED_BYTES,
+    ]
+
+
+def retry_metrics() -> List[Metric]:
+    return [
+        CLIENT_CALL_RETRIES,
+        CLIENT_CALL_TRANSPARENT_RETRIES,
+        CLIENT_CALL_RETRY_DELAY,
     ]

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -45,6 +45,13 @@ GRPC_METHOD_LABEL = "grpc.method"
 GRPC_TARGET_LABEL = "grpc.target"
 GRPC_CLIENT_METRIC_PREFIX = "grpc.client"
 GRPC_OTHER_LABEL_VALUE = "other"
+_PER_CALL_RETRY_METRICS = frozenset(
+    (
+        MetricsName.CLIENT_RETRIES_PER_CALL,
+        MetricsName.CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+        MetricsName.CLIENT_RETRY_DELAY_PER_CALL,
+    )
+)
 _observability_lock: threading.RLock = threading.RLock()
 _OPEN_TELEMETRY_OBSERVABILITY: Optional["OpenTelemetryObservability"] = None
 
@@ -87,13 +94,28 @@ class _OpenTelemetryPlugin:
         if meter_provider:
             meter = meter_provider.get_meter("grpc-python", grpc.__version__)
             enabled_metrics = _open_telemetry_measures.base_metrics()
+            if self._plugin.retry_per_call_metrics_enabled:
+                enabled_metrics = (
+                    enabled_metrics + _open_telemetry_measures.retry_metrics()
+                )
             self._metric_to_recorder = self._register_metrics(
                 meter, enabled_metrics
             )
 
     def _should_record(self, stats_data: StatsData) -> bool:
         # Decide if this plugin should record the stats_data.
-        return stats_data.name in self._metric_to_recorder
+        if stats_data.name not in self._metric_to_recorder:
+            return False
+        if stats_data.name in _PER_CALL_RETRY_METRICS:
+            # Per gRFC A66, per-call retry metrics are not reported for calls
+            # that had no retries (or no retry delay).
+            value = (
+                stats_data.value_float
+                if stats_data.measure_double
+                else stats_data.value_int
+            )
+            return value > 0
+        return True
 
     def _record_stats_data(self, stats_data: StatsData) -> None:
         recorder = self._metric_to_recorder[stats_data.name]
@@ -269,6 +291,16 @@ class _OpenTelemetryPlugin:
                 _open_telemetry_measures.SERVER_RPC_DURATION,
                 _open_telemetry_measures.SERVER_RPC_SEND_BYTES,
                 _open_telemetry_measures.SERVER_RPC_RECEIVED_BYTES,
+            ):
+                recorder = meter.create_histogram(
+                    name=metric.name,
+                    unit=metric.unit,
+                    description=metric.description,
+                )
+            elif metric in (
+                _open_telemetry_measures.CLIENT_CALL_RETRIES,
+                _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES,
+                _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
             ):
                 recorder = meter.create_histogram(
                     name=metric.name,

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -298,6 +298,9 @@ class _OpenTelemetryPlugin:
                 _open_telemetry_measures.CLIENT_RPC_DURATION,
                 _open_telemetry_measures.CLIENT_ATTEMPT_SEND_BYTES,
                 _open_telemetry_measures.CLIENT_ATTEMPT_RECEIVED_BYTES,
+                _open_telemetry_measures.CLIENT_CALL_RETRIES,
+                _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES,
+                _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
             ):
                 recorder = meter.create_histogram(
                     name=metric.name,
@@ -314,10 +317,6 @@ class _OpenTelemetryPlugin:
                 _open_telemetry_measures.SERVER_RPC_DURATION,
                 _open_telemetry_measures.SERVER_RPC_SEND_BYTES,
                 _open_telemetry_measures.SERVER_RPC_RECEIVED_BYTES,
-            ) or metric in (
-                _open_telemetry_measures.CLIENT_CALL_RETRIES,
-                _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES,
-                _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
             ):
                 recorder = meter.create_histogram(
                     name=metric.name,

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -291,13 +291,7 @@ class _OpenTelemetryPlugin:
                 _open_telemetry_measures.SERVER_RPC_DURATION,
                 _open_telemetry_measures.SERVER_RPC_SEND_BYTES,
                 _open_telemetry_measures.SERVER_RPC_RECEIVED_BYTES,
-            ):
-                recorder = meter.create_histogram(
-                    name=metric.name,
-                    unit=metric.unit,
-                    description=metric.description,
-                )
-            elif metric in (
+            ) or metric in (
                 _open_telemetry_measures.CLIENT_CALL_RETRIES,
                 _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES,
                 _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -46,11 +46,7 @@ GRPC_TARGET_LABEL = "grpc.target"
 GRPC_CLIENT_METRIC_PREFIX = "grpc.client"
 GRPC_OTHER_LABEL_VALUE = "other"
 _PER_CALL_RETRY_METRICS = frozenset(
-    (
-        MetricsName.CLIENT_RETRIES_PER_CALL,
-        MetricsName.CLIENT_TRANSPARENT_RETRIES_PER_CALL,
-        MetricsName.CLIENT_RETRY_DELAY_PER_CALL,
-    )
+    metric.cyname for metric in _open_telemetry_measures.retry_metrics()
 )
 _observability_lock: threading.RLock = threading.RLock()
 _OPEN_TELEMETRY_OBSERVABILITY: Optional["OpenTelemetryObservability"] = None

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -95,9 +95,7 @@ class _OpenTelemetryPlugin:
             meter = meter_provider.get_meter("grpc-python", grpc.__version__)
             enabled_metrics = _open_telemetry_measures.base_metrics()
             if self._plugin.retry_per_call_metrics_enabled:
-                enabled_metrics = (
-                    enabled_metrics + _open_telemetry_measures.retry_metrics()
-                )
+                enabled_metrics.extend(_open_telemetry_measures.retry_metrics())
             self._metric_to_recorder = self._register_metrics(
                 meter, enabled_metrics
             )
@@ -107,7 +105,7 @@ class _OpenTelemetryPlugin:
         if stats_data.name not in self._metric_to_recorder:
             return False
         if stats_data.name in _PER_CALL_RETRY_METRICS:
-            # Per gRFC A66, per-call retry metrics are not reported for calls
+            # Per gRFC A96, per-call retry metrics are not reported for calls
             # that had no retries (or no retry delay).
             value = (
                 stats_data.value_float

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -72,6 +72,30 @@ GRPC_STATUS_CODE_TO_STRING = {
 }
 
 
+def _enabled_optional_metrics(
+    enabled_metric_names: Iterable[str],
+) -> List[_open_telemetry_measures.Metric]:
+    """Resolves metric names to the optional metrics they enable.
+
+    Metrics which are enabled by default are always recorded, so naming one of
+    them is a no-op. Unknown names are rejected to surface typos.
+    """
+    optional_metrics = {
+        metric.name: metric
+        for metric in _open_telemetry_measures.optional_metrics()
+    }
+    default_metric_names = {
+        metric.name for metric in _open_telemetry_measures.base_metrics()
+    }
+    enabled_metrics = []
+    for name in enabled_metric_names:
+        if name in optional_metrics:
+            enabled_metrics.append(optional_metrics[name])
+        elif name not in default_metric_names:
+            raise ValueError(f"Unknown metric name: {name}")
+    return enabled_metrics
+
+
 class _OpenTelemetryPlugin:
     _plugin: OpenTelemetryPlugin
     _metric_to_recorder: Dict[MetricsName, Union[Counter, Histogram]]
@@ -86,12 +110,17 @@ class _OpenTelemetryPlugin:
         self._enabled_client_plugin_options = None
         self._enabled_server_plugin_options = None
 
+        # Resolve names before checking meter_provider so that an invalid name
+        # is reported even when no metrics will be collected.
+        enabled_optional_metrics = _enabled_optional_metrics(
+            self._plugin.enabled_metrics
+        )
+
         meter_provider = self._plugin.meter_provider
         if meter_provider:
             meter = meter_provider.get_meter("grpc-python", grpc.__version__)
             enabled_metrics = _open_telemetry_measures.base_metrics()
-            if self._plugin.retry_per_call_metrics_enabled:
-                enabled_metrics.extend(_open_telemetry_measures.retry_metrics())
+            enabled_metrics.extend(enabled_optional_metrics)
             self._metric_to_recorder = self._register_metrics(
                 meter, enabled_metrics
             )

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -72,29 +72,29 @@ GRPC_STATUS_CODE_TO_STRING = {
 }
 
 
-def _enabled_optional_metrics(
-    enabled_metric_names: Iterable[str],
+def _resolve_additional_metrics(
+    additional_metric_names: Iterable[str],
 ) -> List[_open_telemetry_measures.Metric]:
-    """Resolves metric names to the optional metrics they enable.
+    """Resolves metric names to the additional metrics they enable.
 
     Metrics which are enabled by default are always recorded, so naming one of
     them is a no-op. Unknown names are rejected to surface typos.
     """
     optional_metrics = {
         metric.name: metric
-        for metric in _open_telemetry_measures.optional_metrics()
+        for metric in _open_telemetry_measures.retry_metrics()
     }
     default_metric_names = {
         metric.name for metric in _open_telemetry_measures.base_metrics()
     }
-    enabled_metrics = []
-    for name in enabled_metric_names:
+    additional_metrics = []
+    for name in additional_metric_names:
         if name in optional_metrics:
-            enabled_metrics.append(optional_metrics[name])
+            additional_metrics.append(optional_metrics[name])
         elif name not in default_metric_names:
             error_msg = f"Unknown metric name: {name}"
             raise ValueError(error_msg)
-    return enabled_metrics
+    return additional_metrics
 
 
 class _OpenTelemetryPlugin:
@@ -113,15 +113,15 @@ class _OpenTelemetryPlugin:
 
         # Resolve names before checking meter_provider so that an invalid name
         # is reported even when no metrics will be collected.
-        enabled_optional_metrics = _enabled_optional_metrics(
-            self._plugin.enabled_metrics
+        additional_metrics = _resolve_additional_metrics(
+            self._plugin.additional_metrics
         )
 
         meter_provider = self._plugin.meter_provider
         if meter_provider:
             meter = meter_provider.get_meter("grpc-python", grpc.__version__)
             enabled_metrics = _open_telemetry_measures.base_metrics()
-            enabled_metrics.extend(enabled_optional_metrics)
+            enabled_metrics.extend(additional_metrics)
             self._metric_to_recorder = self._register_metrics(
                 meter, enabled_metrics
             )

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -92,7 +92,8 @@ def _enabled_optional_metrics(
         if name in optional_metrics:
             enabled_metrics.append(optional_metrics[name])
         elif name not in default_metric_names:
-            raise ValueError(f"Unknown metric name: {name}")
+            error_msg = f"Unknown metric name: {name}"
+            raise ValueError(error_msg)
     return enabled_metrics
 
 

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -45,6 +45,9 @@ GRPC_METHOD_LABEL = "grpc.method"
 GRPC_TARGET_LABEL = "grpc.target"
 GRPC_CLIENT_METRIC_PREFIX = "grpc.client"
 GRPC_OTHER_LABEL_VALUE = "other"
+_PER_CALL_RETRY_METRICS = frozenset(
+    metric.cyname for metric in _open_telemetry_measures.retry_metrics()
+)
 _observability_lock: threading.RLock = threading.RLock()
 _OPEN_TELEMETRY_OBSERVABILITY: Optional["OpenTelemetryObservability"] = None
 
@@ -69,6 +72,31 @@ GRPC_STATUS_CODE_TO_STRING = {
 }
 
 
+def _resolve_additional_metrics(
+    additional_metric_names: Iterable[str],
+) -> List[_open_telemetry_measures.Metric]:
+    """Resolves metric names to the additional metrics they enable.
+
+    Metrics which are enabled by default are always recorded, so naming one of
+    them is a no-op. Unknown names are rejected to surface typos.
+    """
+    optional_metrics = {
+        metric.name: metric
+        for metric in _open_telemetry_measures.retry_metrics()
+    }
+    default_metric_names = {
+        metric.name for metric in _open_telemetry_measures.base_metrics()
+    }
+    additional_metrics = []
+    for name in additional_metric_names:
+        if name in optional_metrics:
+            additional_metrics.append(optional_metrics[name])
+        elif name not in default_metric_names:
+            error_msg = f"Unknown metric name: {name}"
+            raise ValueError(error_msg)
+    return additional_metrics
+
+
 class _OpenTelemetryPlugin:
     _plugin: OpenTelemetryPlugin
     _metric_to_recorder: Dict[MetricsName, Union[Counter, Histogram]]
@@ -83,17 +111,35 @@ class _OpenTelemetryPlugin:
         self._enabled_client_plugin_options = None
         self._enabled_server_plugin_options = None
 
+        # Resolve names before checking meter_provider so that an invalid name
+        # is reported even when no metrics will be collected.
+        additional_metrics = _resolve_additional_metrics(
+            self._plugin.additional_metrics
+        )
+
         meter_provider = self._plugin.meter_provider
         if meter_provider:
             meter = meter_provider.get_meter("grpc-python", grpc.__version__)
             enabled_metrics = _open_telemetry_measures.base_metrics()
+            enabled_metrics.extend(additional_metrics)
             self._metric_to_recorder = self._register_metrics(
                 meter, enabled_metrics
             )
 
     def _should_record(self, stats_data: StatsData) -> bool:
         # Decide if this plugin should record the stats_data.
-        return stats_data.name in self._metric_to_recorder
+        if stats_data.name not in self._metric_to_recorder:
+            return False
+        if stats_data.name in _PER_CALL_RETRY_METRICS:
+            # Per gRFC A96, per-call retry metrics are not reported for calls
+            # that had no retries (or no retry delay).
+            value = (
+                stats_data.value_float
+                if stats_data.measure_double
+                else stats_data.value_int
+            )
+            return value > 0
+        return True
 
     def _record_stats_data(self, stats_data: StatsData) -> None:
         recorder = self._metric_to_recorder[stats_data.name]
@@ -253,6 +299,9 @@ class _OpenTelemetryPlugin:
                 _open_telemetry_measures.CLIENT_RPC_DURATION,
                 _open_telemetry_measures.CLIENT_ATTEMPT_SEND_BYTES,
                 _open_telemetry_measures.CLIENT_ATTEMPT_RECEIVED_BYTES,
+                _open_telemetry_measures.CLIENT_CALL_RETRIES,
+                _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES,
+                _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
             ):
                 recorder = meter.create_histogram(
                     name=metric.name,

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -88,7 +88,8 @@ def _resolve_additional_metrics(
         metric.name for metric in _open_telemetry_measures.base_metrics()
     }
     additional_metrics = []
-    for name in additional_metric_names:
+    # Deduplicate while preserving order, so a repeated name is resolved once.
+    for name in dict.fromkeys(additional_metric_names):
         if name in optional_metrics:
             additional_metrics.append(optional_metrics[name])
         elif name not in default_metric_names:

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_observability.py
@@ -45,8 +45,14 @@ GRPC_METHOD_LABEL = "grpc.method"
 GRPC_TARGET_LABEL = "grpc.target"
 GRPC_CLIENT_METRIC_PREFIX = "grpc.client"
 GRPC_OTHER_LABEL_VALUE = "other"
-_PER_CALL_RETRY_METRICS = frozenset(
-    metric.cyname for metric in _open_telemetry_measures.retry_metrics()
+# Retry counters are not reported when no retry happened. The retry delay is
+# gated in Core instead, since a delay of 0 is meaningful when there was a
+# retry.
+_PER_CALL_RETRY_COUNTERS = frozenset(
+    (
+        _open_telemetry_measures.CLIENT_CALL_RETRIES.cyname,
+        _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES.cyname,
+    )
 )
 _observability_lock: threading.RLock = threading.RLock()
 _OPEN_TELEMETRY_OBSERVABILITY: Optional["OpenTelemetryObservability"] = None
@@ -131,9 +137,9 @@ class _OpenTelemetryPlugin:
         # Decide if this plugin should record the stats_data.
         if stats_data.name not in self._metric_to_recorder:
             return False
-        if stats_data.name in _PER_CALL_RETRY_METRICS:
-            # Per gRFC A96, per-call retry metrics are not reported for calls
-            # that had no retries (or no retry delay).
+        if stats_data.name in _PER_CALL_RETRY_COUNTERS:
+            # Per gRFC A96, the per-call retry counters are not reported for
+            # calls that had no retries.
             value = (
                 stats_data.value_float
                 if stats_data.measure_double

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
@@ -129,8 +129,9 @@ class OpenTelemetryPlugin:
         be replaced with "other".
           enable_retry_per_call_metrics: Once set to True, per-call retry metrics
         (grpc.client.call.retries, grpc.client.call.transparent_retries and
-        grpc.client.call.retry_delay) will be recorded, following the OpenTelemetry
-        metrics gRFC (A66). These metrics are experimental and thus disabled by default.
+        grpc.client.call.retry_delay) will be recorded, following gRFC A96
+        (OTel Metrics for Retries). These metrics are experimental and thus
+        disabled by default.
         """
         self.plugin_options = plugin_options or []
         self.meter_provider = meter_provider

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
@@ -94,7 +94,7 @@ class OpenTelemetryPlugin:
     meter_provider: Optional[MeterProvider]
     target_attribute_filter: Callable[[str], bool]
     generic_method_attribute_filter: Callable[[str], bool]
-    enabled_metrics: List[str]
+    additional_metrics: List[str]
     _plugins: List[_open_telemetry_observability._OpenTelemetryPlugin]
 
     def __init__(
@@ -104,7 +104,7 @@ class OpenTelemetryPlugin:
         meter_provider: Optional[MeterProvider] = None,
         target_attribute_filter: Optional[Callable[[str], bool]] = None,
         generic_method_attribute_filter: Optional[Callable[[str], bool]] = None,
-        enabled_metrics: Optional[Iterable[str]] = None,
+        additional_metrics: Optional[Iterable[str]] = None,
     ):
         """
         Args:
@@ -127,16 +127,16 @@ class OpenTelemetryPlugin:
         this function returns.
         Return True means the original method name will be used, False means method name will
         be replaced with "other".
-          enabled_metrics: Names of metrics which are not enabled by default and
-        should be recorded by this plugin, for example the per-call retry
-        metrics from gRFC A96 (grpc.client.call.retries,
+          additional_metrics: Names of metrics which are not enabled by default
+        and should additionally be recorded by this plugin, for example the
+        per-call retry metrics from gRFC A96 (grpc.client.call.retries,
         grpc.client.call.transparent_retries and grpc.client.call.retry_delay).
         Metrics which are enabled by default are always recorded, so naming one
         of them here has no effect. An unknown metric name raises ValueError.
         """
         self.plugin_options = plugin_options or []
         self.meter_provider = meter_provider
-        self.enabled_metrics = list(enabled_metrics or [])
+        self.additional_metrics = list(additional_metrics or [])
         self.target_attribute_filter = target_attribute_filter or (
             lambda _target: True
         )

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
@@ -94,7 +94,7 @@ class OpenTelemetryPlugin:
     meter_provider: Optional[MeterProvider]
     target_attribute_filter: Callable[[str], bool]
     generic_method_attribute_filter: Callable[[str], bool]
-    retry_per_call_metrics_enabled: bool
+    enabled_metrics: List[str]
     _plugins: List[_open_telemetry_observability._OpenTelemetryPlugin]
 
     def __init__(
@@ -104,7 +104,7 @@ class OpenTelemetryPlugin:
         meter_provider: Optional[MeterProvider] = None,
         target_attribute_filter: Optional[Callable[[str], bool]] = None,
         generic_method_attribute_filter: Optional[Callable[[str], bool]] = None,
-        enable_retry_per_call_metrics: bool = False,
+        enabled_metrics: Optional[Iterable[str]] = None,
     ):
         """
         Args:
@@ -127,15 +127,16 @@ class OpenTelemetryPlugin:
         this function returns.
         Return True means the original method name will be used, False means method name will
         be replaced with "other".
-          enable_retry_per_call_metrics: Once set to True, per-call retry metrics
-        (grpc.client.call.retries, grpc.client.call.transparent_retries and
-        grpc.client.call.retry_delay) will be recorded, following gRFC A96
-        (OTel Metrics for Retries). These metrics are experimental and thus
-        disabled by default.
+          enabled_metrics: Names of metrics which are not enabled by default and
+        should be recorded by this plugin, for example the per-call retry
+        metrics from gRFC A96 (grpc.client.call.retries,
+        grpc.client.call.transparent_retries and grpc.client.call.retry_delay).
+        Metrics which are enabled by default are always recorded, so naming one
+        of them here has no effect. An unknown metric name raises ValueError.
         """
         self.plugin_options = plugin_options or []
         self.meter_provider = meter_provider
-        self.retry_per_call_metrics_enabled = enable_retry_per_call_metrics
+        self.enabled_metrics = list(enabled_metrics or [])
         self.target_attribute_filter = target_attribute_filter or (
             lambda _target: True
         )

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
@@ -94,6 +94,7 @@ class OpenTelemetryPlugin:
     meter_provider: Optional[MeterProvider]
     target_attribute_filter: Callable[[str], bool]
     generic_method_attribute_filter: Callable[[str], bool]
+    retry_per_call_metrics_enabled: bool
     _plugins: List[_open_telemetry_observability._OpenTelemetryPlugin]
 
     def __init__(
@@ -103,6 +104,7 @@ class OpenTelemetryPlugin:
         meter_provider: Optional[MeterProvider] = None,
         target_attribute_filter: Optional[Callable[[str], bool]] = None,
         generic_method_attribute_filter: Optional[Callable[[str], bool]] = None,
+        enable_retry_per_call_metrics: bool = False,
     ):
         """
         Args:
@@ -125,9 +127,14 @@ class OpenTelemetryPlugin:
         this function returns.
         Return True means the original method name will be used, False means method name will
         be replaced with "other".
+          enable_retry_per_call_metrics: Once set to True, per-call retry metrics
+        (grpc.client.call.retries, grpc.client.call.transparent_retries and
+        grpc.client.call.retry_delay) will be recorded, following the OpenTelemetry
+        metrics gRFC (A66). These metrics are experimental and thus disabled by default.
         """
         self.plugin_options = plugin_options or []
         self.meter_provider = meter_provider
+        self.retry_per_call_metrics_enabled = enable_retry_per_call_metrics
         self.target_attribute_filter = target_attribute_filter or (
             lambda _target: True
         )

--- a/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
+++ b/src/python/grpcio_observability/grpc_observability/_open_telemetry_plugin.py
@@ -94,6 +94,7 @@ class OpenTelemetryPlugin:
     meter_provider: Optional[MeterProvider]
     target_attribute_filter: Callable[[str], bool]
     generic_method_attribute_filter: Callable[[str], bool]
+    additional_metrics: List[str]
     _plugins: List[_open_telemetry_observability._OpenTelemetryPlugin]
 
     def __init__(
@@ -103,6 +104,7 @@ class OpenTelemetryPlugin:
         meter_provider: Optional[MeterProvider] = None,
         target_attribute_filter: Optional[Callable[[str], bool]] = None,
         generic_method_attribute_filter: Optional[Callable[[str], bool]] = None,
+        additional_metrics: Optional[Iterable[str]] = None,
     ):
         """
         Args:
@@ -125,9 +127,16 @@ class OpenTelemetryPlugin:
         this function returns.
         Return True means the original method name will be used, False means method name will
         be replaced with "other".
+          additional_metrics: Names of metrics which are not enabled by default
+        and should additionally be recorded by this plugin, for example the
+        per-call retry metrics from gRFC A96 (grpc.client.call.retries,
+        grpc.client.call.transparent_retries and grpc.client.call.retry_delay).
+        Metrics which are enabled by default are always recorded, so naming one
+        of them here has no effect. An unknown metric name raises ValueError.
         """
         self.plugin_options = plugin_options or []
         self.meter_provider = meter_provider
+        self.additional_metrics = list(additional_metrics or [])
         self.target_attribute_filter = target_attribute_filter or (
             lambda _target: True
         )

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -90,6 +90,7 @@ void PythonOpenCensusCallTracer::RecordAnnotation(
 PythonOpenCensusCallTracer::~PythonOpenCensusCallTracer() {
   if (PythonCensusStatsEnabled()) {
     context_.Labels().emplace_back(kClientMethod, method_);
+    context_.Labels().emplace_back(kClientTarget, target_);
     RecordIntMetric(kRpcClientRetriesPerCallMeasureName, retries_ - 1,
                     context_.Labels(), identifier_, registered_method_,
                     /*include_exchange_labels=*/true);  // exclude first attempt

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -124,7 +124,10 @@ PythonOpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
   {
     grpc_core::MutexLock lock(&mu_);
     if (transparent_retries_ != 0 || retries_ != 0) {
-      if (PythonCensusStatsEnabled() && num_active_rpcs_ == 0) {
+      // Transparent retries are not counted towards retry delay, matching the
+      // C++ OpenTelemetry plugin.
+      if (PythonCensusStatsEnabled() && num_active_rpcs_ == 0 &&
+          !is_transparent_retry) {
         retry_delay_ += absl::Now() - time_at_last_attempt_end_;
       }
     }

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -90,6 +90,7 @@ void PythonOpenCensusCallTracer::RecordAnnotation(
 PythonOpenCensusCallTracer::~PythonOpenCensusCallTracer() {
   if (PythonCensusStatsEnabled()) {
     context_.Labels().emplace_back(kClientMethod, method_);
+    context_.Labels().emplace_back(kClientTarget, target_);
     RecordIntMetric(kRpcClientRetriesPerCallMeasureName, retries_ - 1,
                     context_.Labels(), identifier_, registered_method_,
                     /*include_exchange_labels=*/true);  // exclude first attempt
@@ -123,7 +124,10 @@ PythonOpenCensusCallTracer::StartNewAttempt(bool is_transparent_retry) {
   {
     grpc_core::MutexLock lock(&mu_);
     if (transparent_retries_ != 0 || retries_ != 0) {
-      if (PythonCensusStatsEnabled() && num_active_rpcs_ == 0) {
+      // Transparent retries are not counted towards retry delay, matching the
+      // C++ OpenTelemetry plugin.
+      if (PythonCensusStatsEnabled() && num_active_rpcs_ == 0 &&
+          !is_transparent_retry) {
         retry_delay_ += absl::Now() - time_at_last_attempt_end_;
       }
     }

--- a/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
+++ b/src/python/grpcio_observability/grpc_observability/client_call_tracer.cc
@@ -97,10 +97,15 @@ PythonOpenCensusCallTracer::~PythonOpenCensusCallTracer() {
     RecordIntMetric(kRpcClientTransparentRetriesPerCallMeasureName,
                     transparent_retries_, context_.Labels(), identifier_,
                     registered_method_, /*include_exchange_labels=*/true);
-    RecordDoubleMetric(kRpcClientRetryDelayPerCallMeasureName,
-                       ToDoubleSeconds(retry_delay_), context_.Labels(),
-                       identifier_, registered_method_,
-                       /*include_exchange_labels=*/true);
+    // Unlike the retry counters, a retry delay of 0 is meaningful: it means
+    // the call was retried without waiting, for example when attempts
+    // overlap. Report it whenever there was a retry.
+    if (retries_ > 1) {
+      RecordDoubleMetric(kRpcClientRetryDelayPerCallMeasureName,
+                         ToDoubleSeconds(retry_delay_), context_.Labels(),
+                         identifier_, registered_method_,
+                         /*include_exchange_labels=*/true);
+    }
   }
 
   if (tracing_enabled_) {

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -45,6 +45,7 @@ OTEL_EXPORT_INTERVAL_S = 0.5
 _RETRY_METRIC_NAMES = [
     metric.name for metric in _open_telemetry_measures.retry_metrics()
 ]
+_BASE_METRIC_COUNT = len(_open_telemetry_measures.base_metrics())
 
 
 class OTelMetricExporter(MetricExporter):
@@ -317,7 +318,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
 
         self.all_metrics = defaultdict(list)
         _test_server.unary_unary_call(port=self._port)
-        with self.assertRaisesRegex(AssertionError, "No metrics was exported"):
+        with self.assertRaisesRegex(AssertionError, "Expected at least"):
             self._validate_metrics_exist(self.all_metrics)
 
     def testNoRecordAfterExitUseGlobal(self):
@@ -337,7 +338,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
 
         self.all_metrics = defaultdict(list)
         _test_server.unary_unary_call(port=self._port)
-        with self.assertRaisesRegex(AssertionError, "No metrics was exported"):
+        with self.assertRaisesRegex(AssertionError, "Expected at least"):
             self._validate_metrics_exist(self.all_metrics)
 
     def testRecordUnaryStream(self):
@@ -512,16 +513,15 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             self._server = server
             _test_server.unary_unary_call_with_retries(port=port)
 
-        # Wait until the value is recorded (appended after the entry in
+        # Wait until the values are recorded (appended after the entries in
         # all_metrics), so that indexing metric_values below cannot race with
         # the exporter thread.
         self.assert_eventually(
-            lambda: bool(self._exporter.metric_values.get(retries_metric)),
-            message=lambda: f"metric {retries_metric} not found in exported metrics: {self._exporter.metric_values.keys()}!",
-        )
-        self.assert_eventually(
-            lambda: bool(self._exporter.metric_values.get(retry_delay_metric)),
-            message=lambda: f"metric {retry_delay_metric} not found in exported metrics: {self._exporter.metric_values.keys()}!",
+            lambda: all(
+                self._exporter.metric_values.get(metric)
+                for metric in (retries_metric, retry_delay_metric)
+            ),
+            message=lambda: f"retry metrics not found in exported metrics: {self._exporter.metric_values.keys()}!",
         )
         # The call had NUM_FAILED_ATTEMPTS retries (first attempt excluded)
         # and spent time in retry backoff.
@@ -556,7 +556,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             self._server = server
             _test_server.unary_unary_call(port=port)
 
-        self._validate_metrics_exist(self.all_metrics)
+        self._validate_metrics_exist(self.all_metrics, _BASE_METRIC_COUNT)
         self._validate_all_metrics_names(self.all_metrics.keys())
 
     def testRetryMetricsDisabledByDefault(self):
@@ -569,7 +569,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             self._server = server
             _test_server.unary_unary_call_with_retries(port=port)
 
-        self._validate_metrics_exist(self.all_metrics)
+        self._validate_metrics_exist(self.all_metrics, _BASE_METRIC_COUNT)
         self._validate_all_metrics_names(self.all_metrics.keys())
         for retry_metric in _open_telemetry_measures.retry_metrics():
             self.assertNotIn(retry_metric.name, self.all_metrics)
@@ -583,7 +583,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             self._server = server
             _test_server.unary_unary_call(port=port)
 
-        self._validate_metrics_exist(self.all_metrics)
+        self._validate_metrics_exist(self.all_metrics, _BASE_METRIC_COUNT)
         self._validate_all_metrics_names(self.all_metrics.keys())
         # The call had no retries, so zero values should not be reported.
         for retry_metric in _open_telemetry_measures.retry_metrics():
@@ -606,11 +606,18 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         else:
             self.fail(message() + " after " + str(timeout))
 
-    def _validate_metrics_exist(self, all_metrics: Dict[str, Any]) -> None:
-        # Sleep here to make sure we have at least one export from OTel MetricExporter.
+    def _validate_metrics_exist(
+        self, all_metrics: Dict[str, Any], expected_count: int = 2
+    ) -> None:
+        # Sleep here to make sure we have at least the expected number of
+        # metrics from OTel MetricExporter. Waiting for a specific count avoids
+        # racing with exports that are still in flight.
         self.assert_eventually(
-            lambda: len(all_metrics.keys()) > 1,
-            message=lambda: f"No metrics was exported",
+            lambda: len(all_metrics.keys()) >= expected_count,
+            message=lambda: (
+                f"Expected at least {expected_count} metrics, got "
+                f"{len(all_metrics.keys())}: {all_metrics.keys()}"
+            ),
         )
 
     def _validate_all_metrics_names(self, metric_names: Set[str]) -> None:

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -505,7 +505,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
 
         with grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider,
-            enabled_metrics=_RETRY_METRIC_NAMES,
+            additional_metrics=_RETRY_METRIC_NAMES,
         ):
             server, port = _test_server.start_flaky_server(
                 num_failed_attempts=NUM_FAILED_ATTEMPTS
@@ -543,14 +543,14 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             grpc_observability.OpenTelemetryPlugin(
                 meter_provider=self._provider,
-                enabled_metrics=["grpc.client.call.no_such_metric"],
+                additional_metrics=["grpc.client.call.no_such_metric"],
             )
 
     def testEnablingDefaultMetricIsNoOp(self):
         default_metric = _open_telemetry_measures.CLIENT_ATTEMPT_STARTED.name
         with grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider,
-            enabled_metrics=[default_metric],
+            additional_metrics=[default_metric],
         ):
             server, port = _test_server.start_server()
             self._server = server
@@ -577,7 +577,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
     def testRetryMetricsNotReportedForCallsWithoutRetries(self):
         with grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider,
-            enabled_metrics=_RETRY_METRIC_NAMES,
+            additional_metrics=_RETRY_METRIC_NAMES,
         ):
             server, port = _test_server.start_server()
             self._server = server

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -69,6 +69,9 @@ class OTelMetricExporter(MetricExporter):
             preferred_aggregation=preferred_aggregation,
         )
         self.all_metrics = all_metrics
+        # Maps metric name to a list of recorded data point values (the sum
+        # for histogram data points).
+        self.metric_values = defaultdict(list)
 
     def export(
         self,
@@ -93,6 +96,13 @@ class OTelMetricExporter(MetricExporter):
                         self.all_metrics[metric.name].append(
                             data_point.attributes
                         )
+                        self.metric_values[metric.name].append(
+                            getattr(
+                                data_point,
+                                "sum",
+                                getattr(data_point, "value", None),
+                            )
+                        )
 
 
 class _ClientUnaryUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
@@ -115,9 +125,9 @@ class _ServerInterceptor(grpc.ServerInterceptor):
 class OpenTelemetryObservabilityTest(unittest.TestCase):
     def setUp(self):
         self.all_metrics = defaultdict(list)
-        otel_exporter = OTelMetricExporter(self.all_metrics)
+        self._exporter = OTelMetricExporter(self.all_metrics)
         reader = PeriodicExportingMetricReader(
-            exporter=otel_exporter,
+            exporter=self._exporter,
             export_interval_millis=OTEL_EXPORT_INTERVAL_S * 1000,
         )
         self._provider = MeterProvider(metric_readers=[reader])
@@ -477,6 +487,81 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         # For server metrics, all method name should be replaced with 'other'.
         self.assertTrue(GRPC_OTHER_LABEL_VALUE in server_method_values)
         self.assertTrue(UNARY_METHOD_NAME not in server_method_values)
+
+    def testRecordRetryMetrics(self):
+        UNARY_METHOD_NAME = "test/UnaryUnary"
+        NUM_FAILED_ATTEMPTS = 2
+        retries_metric = _open_telemetry_measures.CLIENT_CALL_RETRIES.name
+        retry_delay_metric = (
+            _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY.name
+        )
+        transparent_retries_metric = (
+            _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES.name
+        )
+
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            enable_retry_per_call_metrics=True,
+        ):
+            server, port = _test_server.start_flaky_server(
+                num_failed_attempts=NUM_FAILED_ATTEMPTS
+            )
+            self._server = server
+            _test_server.unary_unary_call_with_retries(port=port)
+
+        self.assert_eventually(
+            lambda: retries_metric in self.all_metrics,
+            message=lambda: f"metric {retries_metric} not found in exported metrics: {self.all_metrics.keys()}!",
+        )
+        self.assert_eventually(
+            lambda: retry_delay_metric in self.all_metrics,
+            message=lambda: f"metric {retry_delay_metric} not found in exported metrics: {self.all_metrics.keys()}!",
+        )
+        # The call had NUM_FAILED_ATTEMPTS retries (first attempt excluded)
+        # and spent time in retry backoff.
+        self.assertEqual(
+            self._exporter.metric_values[retries_metric][0],
+            NUM_FAILED_ATTEMPTS,
+        )
+        self.assertGreater(
+            self._exporter.metric_values[retry_delay_metric][0], 0
+        )
+        # No transparent retry happened, so 0 should not be reported.
+        self.assertNotIn(transparent_retries_metric, self.all_metrics)
+        # Per-call retry metrics should have method and target labels.
+        labels = self.all_metrics[retries_metric][0]
+        self.assertEqual(labels.get(GRPC_METHOD_LABEL), UNARY_METHOD_NAME)
+        self.assertIn(GRPC_TARGET_LABEL, labels)
+
+    def testRetryMetricsDisabledByDefault(self):
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider
+        ):
+            server, port = _test_server.start_flaky_server(
+                num_failed_attempts=2
+            )
+            self._server = server
+            _test_server.unary_unary_call_with_retries(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics.keys())
+        for retry_metric in _open_telemetry_measures.retry_metrics():
+            self.assertNotIn(retry_metric.name, self.all_metrics)
+
+    def testRetryMetricsNotReportedForCallsWithoutRetries(self):
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            enable_retry_per_call_metrics=True,
+        ):
+            server, port = _test_server.start_server()
+            self._server = server
+            _test_server.unary_unary_call(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics.keys())
+        # The call had no retries, so zero values should not be reported.
+        for retry_metric in _open_telemetry_measures.retry_metrics():
+            self.assertNotIn(retry_metric.name, self.all_metrics)
 
     def assert_eventually(
         self,

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -42,6 +42,9 @@ logger = logging.getLogger(__name__)
 
 STREAM_LENGTH = 5
 OTEL_EXPORT_INTERVAL_S = 0.5
+_RETRY_METRIC_NAMES = [
+    metric.name for metric in _open_telemetry_measures.retry_metrics()
+]
 
 
 class OTelMetricExporter(MetricExporter):
@@ -501,7 +504,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
 
         with grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider,
-            enable_retry_per_call_metrics=True,
+            enabled_metrics=_RETRY_METRIC_NAMES,
         ):
             server, port = _test_server.start_flaky_server(
                 num_failed_attempts=NUM_FAILED_ATTEMPTS
@@ -536,6 +539,26 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         self.assertEqual(labels.get(GRPC_METHOD_LABEL), UNARY_METHOD_NAME)
         self.assertIn(GRPC_TARGET_LABEL, labels)
 
+    def testEnablingUnknownMetricRaises(self):
+        with self.assertRaises(ValueError):
+            grpc_observability.OpenTelemetryPlugin(
+                meter_provider=self._provider,
+                enabled_metrics=["grpc.client.call.no_such_metric"],
+            )
+
+    def testEnablingDefaultMetricIsNoOp(self):
+        default_metric = _open_telemetry_measures.CLIENT_ATTEMPT_STARTED.name
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            enabled_metrics=[default_metric],
+        ):
+            server, port = _test_server.start_server()
+            self._server = server
+            _test_server.unary_unary_call(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics.keys())
+
     def testRetryMetricsDisabledByDefault(self):
         with grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider
@@ -554,7 +577,7 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
     def testRetryMetricsNotReportedForCallsWithoutRetries(self):
         with grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider,
-            enable_retry_per_call_metrics=True,
+            enabled_metrics=_RETRY_METRIC_NAMES,
         ):
             server, port = _test_server.start_server()
             self._server = server

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -509,13 +509,16 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
             self._server = server
             _test_server.unary_unary_call_with_retries(port=port)
 
+        # Wait until the value is recorded (appended after the entry in
+        # all_metrics), so that indexing metric_values below cannot race with
+        # the exporter thread.
         self.assert_eventually(
-            lambda: retries_metric in self.all_metrics,
-            message=lambda: f"metric {retries_metric} not found in exported metrics: {self.all_metrics.keys()}!",
+            lambda: bool(self._exporter.metric_values.get(retries_metric)),
+            message=lambda: f"metric {retries_metric} not found in exported metrics: {self._exporter.metric_values.keys()}!",
         )
         self.assert_eventually(
-            lambda: retry_delay_metric in self.all_metrics,
-            message=lambda: f"metric {retry_delay_metric} not found in exported metrics: {self.all_metrics.keys()}!",
+            lambda: bool(self._exporter.metric_values.get(retry_delay_metric)),
+            message=lambda: f"metric {retry_delay_metric} not found in exported metrics: {self._exporter.metric_values.keys()}!",
         )
         # The call had NUM_FAILED_ATTEMPTS retries (first attempt excluded)
         # and spent time in retry backoff.

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -566,6 +566,20 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
                 additional_metrics=["grpc.client.call.no_such_metric"],
             )
 
+    def testDuplicateAdditionalMetricsAreDeduplicated(self):
+        retries_metric = _open_telemetry_measures.CLIENT_CALL_RETRIES
+        plugin = grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            additional_metrics=[retries_metric.name, retries_metric.name],
+        )
+        # pylint: disable=protected-access
+        metric_to_recorder = plugin._plugins[0]._metric_to_recorder
+        self.assertEqual(
+            len(metric_to_recorder),
+            len(_open_telemetry_measures.base_metrics()) + 1,
+        )
+        self.assertIn(retries_metric.cyname, metric_to_recorder)
+
     def testEnablingDefaultMetricIsNoOp(self):
         default_metric = _open_telemetry_measures.CLIENT_ATTEMPT_STARTED.name
         with grpc_observability.OpenTelemetryPlugin(

--- a/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests/observability/_open_telemetry_observability_test.py
@@ -45,6 +45,9 @@ logger = logging.getLogger(__name__)
 
 STREAM_LENGTH = 5
 OTEL_EXPORT_INTERVAL_S = 0.5
+_RETRY_METRIC_NAMES = [
+    metric.name for metric in _open_telemetry_measures.retry_metrics()
+]
 
 
 class OTelMetricExporter(MetricExporter):
@@ -72,6 +75,9 @@ class OTelMetricExporter(MetricExporter):
             preferred_aggregation=preferred_aggregation,
         )
         self.all_metrics = all_metrics
+        # Maps metric name to a list of recorded data point values (the sum
+        # for histogram data points).
+        self.metric_values = defaultdict(list)
 
     def export(
         self,
@@ -96,6 +102,13 @@ class OTelMetricExporter(MetricExporter):
                         self.all_metrics[metric.name].append(
                             data_point.attributes
                         )
+                        self.metric_values[metric.name].append(
+                            getattr(
+                                data_point,
+                                "sum",
+                                getattr(data_point, "value", None),
+                            )
+                        )
 
 
 class _ClientUnaryUnaryInterceptor(grpc.UnaryUnaryClientInterceptor):
@@ -118,9 +131,9 @@ class _ServerInterceptor(grpc.ServerInterceptor):
 class OpenTelemetryObservabilityTest(unittest.TestCase):
     def setUp(self):
         self.all_metrics = defaultdict(list)
-        otel_exporter = OTelMetricExporter(self.all_metrics)
+        self._exporter = OTelMetricExporter(self.all_metrics)
         reader = PeriodicExportingMetricReader(
-            exporter=otel_exporter,
+            exporter=self._exporter,
             export_interval_millis=OTEL_EXPORT_INTERVAL_S * 1000,
         )
         self._provider = MeterProvider(metric_readers=[reader])
@@ -498,6 +511,103 @@ class OpenTelemetryObservabilityTest(unittest.TestCase):
         # For server metrics, all method name should be replaced with 'other'.
         self.assertTrue(GRPC_OTHER_LABEL_VALUE in server_method_values)
         self.assertTrue(UNARY_METHOD_NAME not in server_method_values)
+
+    def testRecordRetryMetrics(self):
+        UNARY_METHOD_NAME = "test/UnaryUnary"
+        NUM_FAILED_ATTEMPTS = 2
+        retries_metric = _open_telemetry_measures.CLIENT_CALL_RETRIES.name
+        retry_delay_metric = (
+            _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY.name
+        )
+        transparent_retries_metric = (
+            _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES.name
+        )
+
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            additional_metrics=_RETRY_METRIC_NAMES,
+        ):
+            server, port = _test_server.start_flaky_server(
+                num_failed_attempts=NUM_FAILED_ATTEMPTS
+            )
+            self._server = server
+            _test_server.unary_unary_call_with_retries(port=port)
+
+        # Wait until the values are recorded (appended after the entries in
+        # all_metrics), so that indexing metric_values below cannot race with
+        # the exporter thread.
+        self.assert_eventually(
+            lambda: all(
+                self._exporter.metric_values.get(metric)
+                for metric in (retries_metric, retry_delay_metric)
+            ),
+            message=lambda: f"retry metrics not found in exported metrics: {self._exporter.metric_values.keys()}!",
+        )
+        # The call had NUM_FAILED_ATTEMPTS retries (first attempt excluded)
+        # and spent time in retry backoff.
+        self.assertEqual(
+            self._exporter.metric_values[retries_metric][0],
+            NUM_FAILED_ATTEMPTS,
+        )
+        self.assertGreater(
+            self._exporter.metric_values[retry_delay_metric][0], 0
+        )
+        # No transparent retry happened, so 0 should not be reported.
+        self.assertNotIn(transparent_retries_metric, self.all_metrics)
+        # Per-call retry metrics should have method and target labels.
+        labels = self.all_metrics[retries_metric][0]
+        self.assertEqual(labels.get(GRPC_METHOD_LABEL), UNARY_METHOD_NAME)
+        self.assertIn(GRPC_TARGET_LABEL, labels)
+
+    def testEnablingUnknownMetricRaises(self):
+        with self.assertRaises(ValueError):
+            grpc_observability.OpenTelemetryPlugin(
+                meter_provider=self._provider,
+                additional_metrics=["grpc.client.call.no_such_metric"],
+            )
+
+    def testEnablingDefaultMetricIsNoOp(self):
+        default_metric = _open_telemetry_measures.CLIENT_ATTEMPT_STARTED.name
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            additional_metrics=[default_metric],
+        ):
+            server, port = _test_server.start_server()
+            self._server = server
+            _test_server.unary_unary_call(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics.keys())
+
+    def testRetryMetricsDisabledByDefault(self):
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider
+        ):
+            server, port = _test_server.start_flaky_server(
+                num_failed_attempts=2
+            )
+            self._server = server
+            _test_server.unary_unary_call_with_retries(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics.keys())
+        for retry_metric in _open_telemetry_measures.retry_metrics():
+            self.assertNotIn(retry_metric.name, self.all_metrics)
+
+    def testRetryMetricsNotReportedForCallsWithoutRetries(self):
+        with grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            additional_metrics=_RETRY_METRIC_NAMES,
+        ):
+            server, port = _test_server.start_server()
+            self._server = server
+            _test_server.unary_unary_call(port=port)
+
+        self._validate_metrics_exist(self.all_metrics)
+        self._validate_all_metrics_names(self.all_metrics.keys())
+        # The call had no retries, so zero values should not be reported.
+        for retry_metric in _open_telemetry_measures.retry_metrics():
+            self.assertNotIn(retry_metric.name, self.all_metrics)
 
     def assert_eventually(
         self,

--- a/src/python/grpcio_tests/tests/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests/observability/_test_server.py
@@ -213,9 +213,7 @@ def unary_unary_call_with_retries(port, registered_method=True):
         ("grpc.service_config", _RETRY_SERVICE_CONFIG),
         ("grpc.enable_retries", 1),
     )
-    with grpc.insecure_channel(
-        f"localhost:{port}", options=options
-    ) as channel:
+    with grpc.insecure_channel(f"localhost:{port}", options=options) as channel:
         multi_callable = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
             _registered_method=registered_method,

--- a/src/python/grpcio_tests/tests/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests/observability/_test_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from concurrent import futures
+import json
 from typing import Tuple
 
 import grpc
@@ -29,6 +30,23 @@ _STREAM_STREAM = "StreamStream"
 STREAM_LENGTH = 5
 TRIGGER_RPC_METADATA = ("control", "trigger_rpc")
 TRIGGER_RPC_TO_NEW_SERVER_METADATA = ("to_new_server", "")
+
+_RETRY_SERVICE_CONFIG = json.dumps(
+    {
+        "methodConfig": [
+            {
+                "name": [{"service": _SERVICE_NAME}],
+                "retryPolicy": {
+                    "maxAttempts": 4,
+                    "initialBackoff": "0.1s",
+                    "maxBackoff": "1s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": ["UNAVAILABLE"],
+                },
+            }
+        ]
+    }
+)
 
 
 def handle_unary_unary(request, servicer_context):
@@ -115,6 +133,44 @@ REGISTERED_RPC_METHOD_HANDLERS = {
 }
 
 
+class _FlakyMethodHandler(grpc.RpcMethodHandler):
+    """Unary-unary handler that fails the first num_failed_attempts requests
+    with UNAVAILABLE (a retryable status) and succeeds afterwards."""
+
+    def __init__(self, num_failed_attempts):
+        self.request_streaming = False
+        self.response_streaming = False
+        self.request_deserializer = None
+        self.response_serializer = None
+        self.unary_stream = None
+        self.stream_unary = None
+        self.stream_stream = None
+        self._remaining_failures = num_failed_attempts
+
+        def _handle(request, servicer_context):
+            if self._remaining_failures > 0:
+                self._remaining_failures -= 1
+                servicer_context.abort(
+                    grpc.StatusCode.UNAVAILABLE, "flaky failure"
+                )
+            return _RESPONSE
+
+        self.unary_unary = _handle
+
+
+def start_flaky_server(num_failed_attempts: int) -> Tuple[grpc.Server, int]:
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    handlers = {_UNARY_UNARY: _FlakyMethodHandler(num_failed_attempts)}
+    generic_handler = grpc.method_handlers_generic_handler(
+        _SERVICE_NAME, handlers
+    )
+    server.add_generic_rpc_handlers((generic_handler,))
+    server.add_registered_method_handlers(_SERVICE_NAME, handlers)
+    port = server.add_insecure_port("[::]:0")
+    server.start()
+    return server, port
+
+
 def start_server(
     interceptors=None, register_method=True
 ) -> Tuple[grpc.Server, int]:
@@ -150,6 +206,21 @@ def unary_unary_call(port, metadata=None, registered_method=False):
             )
         else:
             unused_response, call = multi_callable.with_call(_REQUEST)
+
+
+def unary_unary_call_with_retries(port, registered_method=True):
+    options = (
+        ("grpc.service_config", _RETRY_SERVICE_CONFIG),
+        ("grpc.enable_retries", 1),
+    )
+    with grpc.insecure_channel(
+        f"localhost:{port}", options=options
+    ) as channel:
+        multi_callable = channel.unary_unary(
+            grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
+            _registered_method=registered_method,
+        )
+        unused_response, call = multi_callable.with_call(_REQUEST)
 
 
 def intercepted_unary_unary_call(port, interceptors, metadata=None):

--- a/src/python/grpcio_tests/tests/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests/observability/_test_server.py
@@ -133,47 +133,35 @@ REGISTERED_RPC_METHOD_HANDLERS = {
 }
 
 
-class _FlakyMethodHandler(grpc.RpcMethodHandler):
-    """Unary-unary handler that fails the first num_failed_attempts requests
-    with UNAVAILABLE (a retryable status) and succeeds afterwards."""
+def _make_flaky_handler(num_failed_attempts):
+    """Returns a unary-unary handler that fails the first num_failed_attempts
+    requests with UNAVAILABLE (a retryable status) and succeeds afterwards."""
+    remaining_failures = [num_failed_attempts]
 
-    def __init__(self, num_failed_attempts):
-        self.request_streaming = False
-        self.response_streaming = False
-        self.request_deserializer = None
-        self.response_serializer = None
-        self.unary_stream = None
-        self.stream_unary = None
-        self.stream_stream = None
-        self._remaining_failures = num_failed_attempts
+    def _handle(request, servicer_context):
+        if remaining_failures[0] > 0:
+            remaining_failures[0] -= 1
+            servicer_context.abort(grpc.StatusCode.UNAVAILABLE, "flaky failure")
+        return _RESPONSE
 
-        def _handle(request, servicer_context):
-            if self._remaining_failures > 0:
-                self._remaining_failures -= 1
-                servicer_context.abort(
-                    grpc.StatusCode.UNAVAILABLE, "flaky failure"
-                )
-            return _RESPONSE
-
-        self.unary_unary = _handle
+    return grpc.unary_unary_rpc_method_handler(_handle)
 
 
 def start_flaky_server(num_failed_attempts: int) -> Tuple[grpc.Server, int]:
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    handlers = {_UNARY_UNARY: _FlakyMethodHandler(num_failed_attempts)}
-    generic_handler = grpc.method_handlers_generic_handler(
-        _SERVICE_NAME, handlers
-    )
-    server.add_generic_rpc_handlers((generic_handler,))
-    server.add_registered_method_handlers(_SERVICE_NAME, handlers)
-    port = server.add_insecure_port("[::]:0")
-    server.start()
-    return server, port
+    handlers = {_UNARY_UNARY: _make_flaky_handler(num_failed_attempts)}
+    return start_server(handlers=handlers, registered_handlers=handlers)
 
 
 def start_server(
-    interceptors=None, register_method=True
+    interceptors=None,
+    register_method=True,
+    handlers=None,
+    registered_handlers=None,
 ) -> Tuple[grpc.Server, int]:
+    if handlers is None:
+        handlers = RPC_METHOD_HANDLERS
+    if registered_handlers is None:
+        registered_handlers = REGISTERED_RPC_METHOD_HANDLERS
     if interceptors:
         server = grpc.server(
             futures.ThreadPoolExecutor(max_workers=10),
@@ -182,20 +170,22 @@ def start_server(
     else:
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     generic_handler = grpc.method_handlers_generic_handler(
-        _SERVICE_NAME, RPC_METHOD_HANDLERS
+        _SERVICE_NAME, handlers
     )
     server.add_generic_rpc_handlers((generic_handler,))
     if register_method:
         server.add_registered_method_handlers(
-            _SERVICE_NAME, REGISTERED_RPC_METHOD_HANDLERS
+            _SERVICE_NAME, registered_handlers
         )
     port = server.add_insecure_port("[::]:0")
     server.start()
     return server, port
 
 
-def unary_unary_call(port, metadata=None, registered_method=False):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+def unary_unary_call(
+    port, metadata=None, registered_method=False, options=None
+):
+    with grpc.insecure_channel(f"localhost:{port}", options=options) as channel:
         multi_callable = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
             _registered_method=registered_method,
@@ -213,12 +203,7 @@ def unary_unary_call_with_retries(port, registered_method=True):
         ("grpc.service_config", _RETRY_SERVICE_CONFIG),
         ("grpc.enable_retries", 1),
     )
-    with grpc.insecure_channel(f"localhost:{port}", options=options) as channel:
-        multi_callable = channel.unary_unary(
-            grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
-            _registered_method=registered_method,
-        )
-        unused_response, call = multi_callable.with_call(_REQUEST)
+    unary_unary_call(port, registered_method=registered_method, options=options)
 
 
 def intercepted_unary_unary_call(port, interceptors, metadata=None):

--- a/src/python/grpcio_tests/tests/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests/observability/_test_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from concurrent import futures
+import json
 from typing import Tuple
 
 import grpc
@@ -29,6 +30,23 @@ _STREAM_STREAM = "StreamStream"
 STREAM_LENGTH = 5
 TRIGGER_RPC_METADATA = ("control", "trigger_rpc")
 TRIGGER_RPC_TO_NEW_SERVER_METADATA = ("to_new_server", "")
+
+_RETRY_SERVICE_CONFIG = json.dumps(
+    {
+        "methodConfig": [
+            {
+                "name": [{"service": _SERVICE_NAME}],
+                "retryPolicy": {
+                    "maxAttempts": 4,
+                    "initialBackoff": "0.1s",
+                    "maxBackoff": "1s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": ["UNAVAILABLE"],
+                },
+            }
+        ]
+    }
+)
 
 
 def handle_unary_unary(request, servicer_context):
@@ -115,9 +133,35 @@ REGISTERED_RPC_METHOD_HANDLERS = {
 }
 
 
+def _make_flaky_handler(num_failed_attempts):
+    """Returns a unary-unary handler that fails the first num_failed_attempts
+    requests with UNAVAILABLE (a retryable status) and succeeds afterwards."""
+    remaining_failures = [num_failed_attempts]
+
+    def _handle(request, servicer_context):
+        if remaining_failures[0] > 0:
+            remaining_failures[0] -= 1
+            servicer_context.abort(grpc.StatusCode.UNAVAILABLE, "flaky failure")
+        return _RESPONSE
+
+    return grpc.unary_unary_rpc_method_handler(_handle)
+
+
+def start_flaky_server(num_failed_attempts: int) -> Tuple[grpc.Server, int]:
+    handlers = {_UNARY_UNARY: _make_flaky_handler(num_failed_attempts)}
+    return start_server(handlers=handlers, registered_handlers=handlers)
+
+
 def start_server(
-    interceptors=None, register_method=True
+    interceptors=None,
+    register_method=True,
+    handlers=None,
+    registered_handlers=None,
 ) -> Tuple[grpc.Server, int]:
+    if handlers is None:
+        handlers = RPC_METHOD_HANDLERS
+    if registered_handlers is None:
+        registered_handlers = REGISTERED_RPC_METHOD_HANDLERS
     if interceptors:
         server = grpc.server(
             futures.ThreadPoolExecutor(max_workers=10),
@@ -126,20 +170,22 @@ def start_server(
     else:
         server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
     generic_handler = grpc.method_handlers_generic_handler(
-        _SERVICE_NAME, RPC_METHOD_HANDLERS
+        _SERVICE_NAME, handlers
     )
     server.add_generic_rpc_handlers((generic_handler,))
     if register_method:
         server.add_registered_method_handlers(
-            _SERVICE_NAME, REGISTERED_RPC_METHOD_HANDLERS
+            _SERVICE_NAME, registered_handlers
         )
     port = server.add_insecure_port("[::]:0")
     server.start()
     return server, port
 
 
-def unary_unary_call(port, metadata=None, registered_method=False):
-    with grpc.insecure_channel(f"localhost:{port}") as channel:
+def unary_unary_call(
+    port, metadata=None, registered_method=False, options=None
+):
+    with grpc.insecure_channel(f"localhost:{port}", options=options) as channel:
         multi_callable = channel.unary_unary(
             grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
             _registered_method=registered_method,
@@ -150,6 +196,14 @@ def unary_unary_call(port, metadata=None, registered_method=False):
             )
         else:
             unused_response, call = multi_callable.with_call(_REQUEST)
+
+
+def unary_unary_call_with_retries(port, registered_method=True):
+    options = (
+        ("grpc.service_config", _RETRY_SERVICE_CONFIG),
+        ("grpc.enable_retries", 1),
+    )
+    unary_unary_call(port, registered_method=registered_method, options=options)
 
 
 def intercepted_unary_unary_call(port, interceptors, metadata=None):

--- a/src/python/grpcio_tests/tests_aio/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/observability/_test_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import json
 from typing import Tuple
 
 import grpc
@@ -20,11 +21,30 @@ import grpc
 _REQUEST = b"\x00\x00\x00"
 _RESPONSE = b"\x00\x00\x00"
 
+_SERVICE_NAME = "test"
+_UNARY_UNARY_METHOD = "UnaryUnary"
 _UNARY_UNARY = "/test/UnaryUnary"
 _UNARY_STREAM = "/test/UnaryStream"
 _STREAM_UNARY = "/test/StreamUnary"
 _STREAM_STREAM = "/test/StreamStream"
 STREAM_LENGTH = 5
+
+_RETRY_SERVICE_CONFIG = json.dumps(
+    {
+        "methodConfig": [
+            {
+                "name": [{"service": _SERVICE_NAME}],
+                "retryPolicy": {
+                    "maxAttempts": 4,
+                    "initialBackoff": "0.1s",
+                    "maxBackoff": "1s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": ["UNAVAILABLE"],
+                },
+            }
+        ]
+    }
+)
 
 
 class _GenericHandler(grpc.GenericRpcHandler):
@@ -76,8 +96,49 @@ async def start_server() -> Tuple[grpc.aio.Server, int]:
     return server, port
 
 
+def _make_flaky_handler(num_failed_attempts):
+    """Returns a unary-unary handler that fails the first num_failed_attempts
+    requests with UNAVAILABLE (a retryable status) and succeeds afterwards."""
+    remaining_failures = [num_failed_attempts]
+
+    async def _handle(unused_request, servicer_context):
+        if remaining_failures[0] > 0:
+            remaining_failures[0] -= 1
+            await servicer_context.abort(
+                grpc.StatusCode.UNAVAILABLE, "flaky failure"
+            )
+        return _RESPONSE
+
+    return grpc.unary_unary_rpc_method_handler(_handle)
+
+
+async def start_flaky_server(
+    num_failed_attempts: int,
+) -> Tuple[grpc.aio.Server, int]:
+    server = grpc.aio.server()
+    port = server.add_insecure_port("[::]:0")
+    handlers = {_UNARY_UNARY_METHOD: _make_flaky_handler(num_failed_attempts)}
+    server.add_generic_rpc_handlers(
+        (grpc.method_handlers_generic_handler(_SERVICE_NAME, handlers),)
+    )
+    await server.start()
+    return server, port
+
+
 async def unary_unary_call(port):
     async with grpc.aio.insecure_channel(f"localhost:{port}") as channel:
+        multi_callable = channel.unary_unary(_UNARY_UNARY)
+        unused_response = await multi_callable(_REQUEST)
+
+
+async def unary_unary_call_with_retries(port):
+    options = (
+        ("grpc.service_config", _RETRY_SERVICE_CONFIG),
+        ("grpc.enable_retries", 1),
+    )
+    async with grpc.aio.insecure_channel(
+        f"localhost:{port}", options=options
+    ) as channel:
         multi_callable = channel.unary_unary(_UNARY_UNARY)
         unused_response = await multi_callable(_REQUEST)
 

--- a/src/python/grpcio_tests/tests_aio/observability/_test_server.py
+++ b/src/python/grpcio_tests/tests_aio/observability/_test_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import json
 from typing import Tuple
 
 import grpc
@@ -191,3 +192,66 @@ async def stream_stream_call_with_client_cancel(port, registered_method=False):
         await call.write(_REQUEST)
         await call.read()
         return call.cancel()
+
+
+_RETRY_SERVICE_CONFIG = json.dumps(
+    {
+        "methodConfig": [
+            {
+                "name": [{"service": _SERVICE_NAME}],
+                "retryPolicy": {
+                    "maxAttempts": 4,
+                    "initialBackoff": "0.1s",
+                    "maxBackoff": "1s",
+                    "backoffMultiplier": 2,
+                    "retryableStatusCodes": ["UNAVAILABLE"],
+                },
+            }
+        ]
+    }
+)
+
+
+def _make_flaky_handler(num_failed_attempts):
+    """Returns a unary-unary handler that fails the first num_failed_attempts
+    requests with UNAVAILABLE (a retryable status) and succeeds afterwards."""
+    remaining_failures = [num_failed_attempts]
+
+    async def _handle(unused_request, servicer_context):
+        if remaining_failures[0] > 0:
+            remaining_failures[0] -= 1
+            await servicer_context.abort(
+                grpc.StatusCode.UNAVAILABLE, "flaky failure"
+            )
+        return _RESPONSE
+
+    return grpc.unary_unary_rpc_method_handler(_handle)
+
+
+async def start_flaky_server(
+    num_failed_attempts: int,
+) -> Tuple[grpc.aio.Server, int]:
+    server = grpc.aio.server()
+    port = server.add_insecure_port("[::]:0")
+    handlers = {_UNARY_UNARY: _make_flaky_handler(num_failed_attempts)}
+    generic_handler = grpc.method_handlers_generic_handler(
+        _SERVICE_NAME, handlers
+    )
+    server.add_generic_rpc_handlers((generic_handler,))
+    await server.start()
+    return server, port
+
+
+async def unary_unary_call_with_retries(port, registered_method=False):
+    options = (
+        ("grpc.service_config", _RETRY_SERVICE_CONFIG),
+        ("grpc.enable_retries", 1),
+    )
+    async with grpc.aio.insecure_channel(
+        f"localhost:{port}", options=options
+    ) as channel:
+        multi_callable = channel.unary_unary(
+            grpc._common.fully_qualified_method(_SERVICE_NAME, _UNARY_UNARY),
+            _registered_method=registered_method,
+        )
+        unused_response = await multi_callable(_REQUEST)

--- a/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
@@ -194,7 +194,7 @@ class OpenTelemetryObservabilityRetryTest(AioTestBase):
         self._provider = otel_metrics.MeterProvider(metric_readers=(reader,))
         self._otel_plugin = grpc_observability.OpenTelemetryPlugin(
             meter_provider=self._provider,
-            enabled_metrics=_RETRY_METRIC_NAMES,
+            additional_metrics=_RETRY_METRIC_NAMES,
         )
         self._otel_plugin.register_global()
         self._server, self._port = await _test_server.start_flaky_server(

--- a/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
@@ -33,6 +33,10 @@ logger = logging.getLogger(__name__)
 
 STREAM_LENGTH = 5
 OTEL_EXPORT_INTERVAL_S = 0.5
+_RETRY_METRIC_NAMES = [
+    metric.name for metric in _open_telemetry_measures.retry_metrics()
+]
+_NUM_FAILED_ATTEMPTS = 2
 
 
 class OTelMetricExporter(otel_metrics_export.MetricExporter):
@@ -174,6 +178,56 @@ class OpenTelemetryObservabilityTest(AioTestBase):
                         f"in exported metrics: {metric_names}!"
                     ),
                 )
+
+
+class OpenTelemetryObservabilityRetryTest(AioTestBase):
+    """Validates that the per-call retry metrics are recorded for the AsyncIO
+    stack, which uses the same call tracer as the sync stack."""
+
+    async def setUp(self):
+        self.all_metrics = collections.defaultdict(list)
+        otel_exporter = OTelMetricExporter(self.all_metrics)
+        reader = otel_metrics_export.PeriodicExportingMetricReader(
+            exporter=otel_exporter,
+            export_interval_millis=OTEL_EXPORT_INTERVAL_S * 1000,
+        )
+        self._provider = otel_metrics.MeterProvider(metric_readers=(reader,))
+        self._otel_plugin = grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            enabled_metrics=_RETRY_METRIC_NAMES,
+        )
+        self._otel_plugin.register_global()
+        self._server, self._port = await _test_server.start_flaky_server(
+            num_failed_attempts=_NUM_FAILED_ATTEMPTS
+        )
+
+    async def tearDown(self):
+        await self._server.stop(0)
+        self._otel_plugin.deregister_global()
+        self._provider.shutdown(timeout_millis=1_000)
+
+    async def test_record_retry_metrics(self):
+        await _test_server.unary_unary_call_with_retries(port=self._port)
+
+        # Sleep here to make sure we have at least one export from
+        # OTel MetricExporter.
+        await asyncio.sleep(5)
+        for metric in (
+            _open_telemetry_measures.CLIENT_CALL_RETRIES,
+            _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
+        ):
+            self.assertTrue(
+                metric.name in self.all_metrics,
+                msg=(
+                    f"metric {metric.name} not found"
+                    f"in exported metrics: {self.all_metrics.keys()}!"
+                ),
+            )
+        # No transparent retry happened, so 0 should not be reported.
+        self.assertNotIn(
+            _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES.name,
+            self.all_metrics,
+        )
 
 
 if __name__ == "__main__":

--- a/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
@@ -14,10 +14,11 @@
 
 import asyncio
 import collections
+import datetime
 import logging
 import os
 import sys
-from typing import Any, List, Set
+from typing import Any, Callable, List, Optional, Set
 import unittest
 
 import grpc_observability
@@ -36,6 +37,7 @@ OTEL_EXPORT_INTERVAL_S = 0.5
 _RETRY_METRIC_NAMES = [
     metric.name for metric in _open_telemetry_measures.retry_metrics()
 ]
+_BASE_METRIC_COUNT = len(_open_telemetry_measures.base_metrics())
 _NUM_FAILED_ATTEMPTS = 2
 
 
@@ -94,11 +96,45 @@ class OTelMetricExporter(otel_metrics_export.MetricExporter):
                         )
 
 
+class _ObservabilityTestBase(AioTestBase):
+    async def assert_eventually(
+        self,
+        predicate: Callable[[], bool],
+        *,
+        timeout: Optional[datetime.timedelta] = None,
+        message: Optional[Callable[[], str]] = None,
+    ) -> None:
+        message = message or (lambda: "Proposition did not evaluate to true")
+        timeout = timeout or datetime.timedelta(seconds=5)
+        end = datetime.datetime.now() + timeout
+        while datetime.datetime.now() < end:
+            if predicate():
+                return
+            await asyncio.sleep(OTEL_EXPORT_INTERVAL_S)
+        self.fail(message())
+
+    async def _validate_metrics_exist(
+        self,
+        all_metrics: dict[str, Any],
+        expected_count: int = _BASE_METRIC_COUNT,
+    ) -> None:
+        # Wait until we have at least the expected number of metrics from the
+        # OTel MetricExporter instead of relying on a fixed sleep, so that we
+        # do not race with exports that are still in flight.
+        await self.assert_eventually(
+            lambda: len(all_metrics.keys()) >= expected_count,
+            message=lambda: (
+                f"Expected at least {expected_count} metrics, got "
+                f"{len(all_metrics.keys())}: {all_metrics.keys()}"
+            ),
+        )
+
+
 @unittest.skipIf(
     os.name == "nt" or "darwin" in sys.platform,
     "Observability is not supported in Windows and MacOS",
 )
-class OpenTelemetryObservabilityTest(AioTestBase):
+class OpenTelemetryObservabilityTest(_ObservabilityTestBase):
     async def setUp(self):
         self.all_metrics = collections.defaultdict(list)
         otel_exporter = OTelMetricExporter(self.all_metrics)
@@ -142,17 +178,6 @@ class OpenTelemetryObservabilityTest(AioTestBase):
         await self._validate_metrics_exist(self.all_metrics)
         self._validate_all_metrics_names(self.all_metrics.keys())
 
-    async def _validate_metrics_exist(
-        self, all_metrics: dict[str, Any]
-    ) -> None:
-        # Sleep here to make sure we have at least one export from
-        # OTel MetricExporter.
-        await asyncio.sleep(5)
-        self.assertTrue(
-            len(all_metrics.keys()) > 1,
-            msg="No metrics were exported after 5s",
-        )
-
     def _validate_all_metrics_names(self, metric_names: Set[str]) -> None:
         self._validate_server_metrics_names(metric_names)
         self._validate_client_metrics_names(metric_names)
@@ -180,7 +205,11 @@ class OpenTelemetryObservabilityTest(AioTestBase):
                 )
 
 
-class OpenTelemetryObservabilityRetryTest(AioTestBase):
+@unittest.skipIf(
+    os.name == "nt" or "darwin" in sys.platform,
+    "Observability is not supported in Windows and MacOS",
+)
+class OpenTelemetryObservabilityRetryTest(_ObservabilityTestBase):
     """Validates that the per-call retry metrics are recorded for the AsyncIO
     stack, which uses the same call tracer as the sync stack."""
 
@@ -209,9 +238,12 @@ class OpenTelemetryObservabilityRetryTest(AioTestBase):
     async def test_record_retry_metrics(self):
         await _test_server.unary_unary_call_with_retries(port=self._port)
 
-        # Sleep here to make sure we have at least one export from
-        # OTel MetricExporter.
-        await asyncio.sleep(5)
+        # Base metrics plus grpc.client.call.retries and
+        # grpc.client.call.retry_delay. Transparent retries stay at 0 and are
+        # therefore not reported.
+        await self._validate_metrics_exist(
+            self.all_metrics, expected_count=_BASE_METRIC_COUNT + 2
+        )
         for metric in (
             _open_telemetry_measures.CLIENT_CALL_RETRIES,
             _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,

--- a/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
@@ -41,6 +41,10 @@ logger = logging.getLogger(__name__)
 
 STREAM_LENGTH = 5
 OTEL_EXPORT_INTERVAL_S = 0.5
+_RETRY_METRIC_NAMES = [
+    metric.name for metric in _open_telemetry_measures.retry_metrics()
+]
+_NUM_FAILED_ATTEMPTS = 2
 
 
 class OTelMetricExporter(otel_metrics_export.MetricExporter):
@@ -505,6 +509,61 @@ class OpenTelemetryObservabilityRegisteredMethodsTest(
         self._validate_all_metrics_names(self.all_metrics.keys())
         self._validate_all_method_labels(
             self.all_metrics, "test/StreamStreamAlt"
+        )
+
+
+@unittest.skipIf(
+    os.name == "nt" or "darwin" in sys.platform,
+    "Observability is not supported in Windows and MacOS",
+)
+class OpenTelemetryObservabilityRetryTest(OpenTelemetryObservabilityBase):
+    """Validates that the per-call retry metrics are recorded for the AsyncIO
+    stack, which uses the same call tracer as the sync stack."""
+
+    async def setUp(self):
+        # Same setup as the base class, except that the plugin also records
+        # the per-call retry metrics, which are not enabled by default.
+        self.all_metrics = collections.defaultdict(list)
+        otel_exporter = OTelMetricExporter(self.all_metrics)
+        reader = otel_metrics_export.PeriodicExportingMetricReader(
+            exporter=otel_exporter,
+            export_interval_millis=OTEL_EXPORT_INTERVAL_S * 1000,
+        )
+        self._provider = otel_metrics.MeterProvider(metric_readers=(reader,))
+        self._otel_plugin = grpc_observability.OpenTelemetryPlugin(
+            meter_provider=self._provider,
+            additional_metrics=_RETRY_METRIC_NAMES,
+        )
+        self._otel_plugin.register_global()
+        self._server, self._port = await _test_server.start_flaky_server(
+            num_failed_attempts=_NUM_FAILED_ATTEMPTS
+        )
+
+    async def test_record_retry_metrics(self):
+        await _test_server.unary_unary_call_with_retries(port=self._port)
+
+        # Base metrics plus grpc.client.call.retries and
+        # grpc.client.call.retry_delay. Transparent retries stay at 0 and are
+        # therefore not reported.
+        await self._validate_metrics_exist(
+            self.all_metrics,
+            expected_count=len(_open_telemetry_measures.base_metrics()) + 2,
+        )
+        for metric in (
+            _open_telemetry_measures.CLIENT_CALL_RETRIES,
+            _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
+        ):
+            self.assertTrue(
+                metric.name in self.all_metrics,
+                msg=(
+                    f"metric {metric.name} not found"
+                    f"in exported metrics: {self.all_metrics.keys()}!"
+                ),
+            )
+        # No transparent retry happened, so 0 should not be reported.
+        self.assertNotIn(
+            _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES.name,
+            self.all_metrics,
         )
 
 

--- a/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
+++ b/src/python/grpcio_tests/tests_aio/observability/open_telemetry_observability_test.py
@@ -542,24 +542,24 @@ class OpenTelemetryObservabilityRetryTest(OpenTelemetryObservabilityBase):
     async def test_record_retry_metrics(self):
         await _test_server.unary_unary_call_with_retries(port=self._port)
 
-        # Base metrics plus grpc.client.call.retries and
-        # grpc.client.call.retry_delay. Transparent retries stay at 0 and are
-        # therefore not reported.
-        await self._validate_metrics_exist(
-            self.all_metrics,
-            expected_count=len(_open_telemetry_measures.base_metrics()) + 2,
-        )
-        for metric in (
+        # The per-call retry metrics are recorded when the client call tracer
+        # is destroyed, which happens after the attempt tracers have reported,
+        # so they can arrive in a later export batch than the base metrics.
+        retry_metrics = (
             _open_telemetry_measures.CLIENT_CALL_RETRIES,
             _open_telemetry_measures.CLIENT_CALL_RETRY_DELAY,
-        ):
-            self.assertTrue(
-                metric.name in self.all_metrics,
-                msg=(
-                    f"metric {metric.name} not found"
-                    f"in exported metrics: {self.all_metrics.keys()}!"
-                ),
-            )
+        )
+
+        await self.assert_eventually(
+            lambda: all(
+                metric.name in self.all_metrics for metric in retry_metrics
+            ),
+            timeout=datetime.timedelta(seconds=10),
+            message=lambda: (
+                "retry metrics not found in exported metrics: "
+                f"{self.all_metrics.keys()}!"
+            ),
+        )
         # No transparent retry happened, so 0 should not be reported.
         self.assertNotIn(
             _open_telemetry_measures.CLIENT_CALL_TRANSPARENT_RETRIES.name,

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -4,6 +4,8 @@
   "tests_aio.health_check.health_servicer_test.HealthServicerTest",
   "tests_aio.interop.local_interop_test.InsecureLocalInteropTest",
   "tests_aio.interop.local_interop_test.SecureLocalInteropTest",
+  "tests_aio.observability.open_telemetry_observability_test.OpenTelemetryObservabilityRetryTest",
+  "tests_aio.observability.open_telemetry_observability_test.OpenTelemetryObservabilityTest",
   "tests_aio.reflection.reflection_servicer_test.ReflectionServicerTest",
   "tests_aio.status.grpc_status_test.StatusTest",
   "tests_aio.unit._metadata_test.TestMetadataWithServer",

--- a/src/python/grpcio_tests/tests_aio/tests.json
+++ b/src/python/grpcio_tests/tests_aio/tests.json
@@ -6,6 +6,7 @@
   "tests_aio.interop.local_interop_test.SecureLocalInteropTest",
   "tests_aio.observability.open_telemetry_observability_test.OpenTelemetryObservabilityUnregisteredMethodsTest",
   "tests_aio.observability.open_telemetry_observability_test.OpenTelemetryObservabilityRegisteredMethodsTest",
+  "tests_aio.observability.open_telemetry_observability_test.OpenTelemetryObservabilityRetryTest",
   "tests_aio.reflection.reflection_servicer_test.ReflectionServicerTest",
   "tests_aio.status.grpc_status_test.StatusTest",
   "tests_aio.unit._metadata_test.TestMetadataWithServer",


### PR DESCRIPTION
This PR adds support for the per-call retry metrics defined in
[gRFC A66](https://github.com/grpc/proposal/blob/master/A66-otel-stats.md)
to the Python OpenTelemetry observability plugin:

- `grpc.client.call.retries`
- `grpc.client.call.transparent_retries`
- `grpc.client.call.retry_delay`
