### PR TITLE
[Security] Plumb SSL key exchange group to auth context.

### DIFF
--- a/include/grpc/credentials.h
+++ b/include/grpc/credentials.h
@@ -765,6 +765,8 @@ typedef struct grpc_tls_custom_verification_check_request {
      * This value will only be filled if the cryptographic peer certificate
      * verification was successful */
     const char* verified_root_cert_subject;
+    /* The negotiated key exchange group. */
+    const char* negotiated_key_exchange_group;
   } peer_info;
 } grpc_tls_custom_verification_check_request;
 

--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -44,6 +44,8 @@ extern "C" {
 // https://www.openssl.org/docs/man1.1.0/man3/SSL_get_peer_cert_chain.html.
 #define GRPC_X509_PEM_CERT_CHAIN_PROPERTY_NAME "x509_pem_cert_chain"
 #define GRPC_SSL_SESSION_REUSED_PROPERTY "ssl_session_reused"
+#define GRPC_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP_PROPERTY_NAME \
+  "ssl_negotiated_key_exchange_group"
 #define GRPC_TRANSPORT_SECURITY_LEVEL_PROPERTY_NAME "security_level"
 #define GRPC_PEER_DNS_PROPERTY_NAME "peer_dns"
 #define GRPC_PEER_SPIFFE_ID_PROPERTY_NAME "peer_spiffe_id"

--- a/include/grpcpp/security/tls_certificate_verifier.h
+++ b/include/grpcpp/security/tls_certificate_verifier.h
@@ -68,6 +68,7 @@ class TlsCustomVerificationCheckRequest {
   // ex: "CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU"
   // ex: "CN=GTS Root R1,O=Google Trust Services LLC,C=US"
   grpc::string_ref verified_root_cert_subject() const;
+  grpc::string_ref negotiated_key_exchange_group() const;
   std::vector<grpc::string_ref> uri_names() const;
   std::vector<grpc::string_ref> dns_names() const;
   std::vector<grpc::string_ref> email_names() const;

--- a/src/core/credentials/transport/tls/ssl_utils.cc
+++ b/src/core/credentials/transport/tls/ssl_utils.cc
@@ -303,6 +303,10 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
       grpc_auth_context_add_property(ctx.get(),
                                      GRPC_SSL_SESSION_REUSED_PROPERTY,
                                      prop->value.data, prop->value.length);
+    } else if (strcmp(prop->name, TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP) == 0) {
+      grpc_auth_context_add_property(
+          ctx.get(), GRPC_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP_PROPERTY_NAME,
+          prop->value.data, prop->value.length);
     } else if (strcmp(prop->name, TSI_SECURITY_LEVEL_PEER_PROPERTY) == 0) {
       grpc_auth_context_add_property(
           ctx.get(), GRPC_TRANSPORT_SECURITY_LEVEL_PROPERTY_NAME,

--- a/src/core/credentials/transport/tls/tls_security_connector.cc
+++ b/src/core/credentials/transport/tls/tls_security_connector.cc
@@ -75,6 +75,7 @@ void PendingVerifierRequestInit(
   bool has_peer_cert = false;
   bool has_peer_cert_full_chain = false;
   bool has_verified_root_cert_subject = false;
+  bool has_negotiated_key_exchange_group = false;
   std::vector<char*> uri_names;
   std::vector<char*> dns_names;
   std::vector<char*> email_names;
@@ -111,6 +112,10 @@ void PendingVerifierRequestInit(
       request->peer_info.verified_root_cert_subject =
           CopyCoreString(prop->value.data, prop->value.length);
       has_verified_root_cert_subject = true;
+    } else if (strcmp(prop->name, TSI_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP) == 0) {
+      request->peer_info.negotiated_key_exchange_group =
+          CopyCoreString(prop->value.data, prop->value.length);
+      has_negotiated_key_exchange_group = true;
     }
   }
   if (!has_common_name) {
@@ -124,6 +129,9 @@ void PendingVerifierRequestInit(
   }
   if (!has_verified_root_cert_subject) {
     request->peer_info.verified_root_cert_subject = nullptr;
+  }
+  if (!has_negotiated_key_exchange_group) {
+    request->peer_info.negotiated_key_exchange_group = nullptr;
   }
   request->peer_info.san_names.uri_names_size = uri_names.size();
   if (!uri_names.empty()) {
@@ -213,6 +221,10 @@ void PendingVerifierRequestDestroy(
   }
   if (request->peer_info.verified_root_cert_subject != nullptr) {
     gpr_free(const_cast<char*>(request->peer_info.verified_root_cert_subject));
+  }
+  if (request->peer_info.negotiated_key_exchange_group != nullptr) {
+    gpr_free(
+        const_cast<char*>(request->peer_info.negotiated_key_exchange_group));
   }
 }
 

--- a/src/cpp/common/tls_certificate_verifier.cc
+++ b/src/cpp/common/tls_certificate_verifier.cc
@@ -72,6 +72,13 @@ grpc::string_ref TlsCustomVerificationCheckRequest::verified_root_cert_subject()
              : "";
 }
 
+grpc::string_ref
+TlsCustomVerificationCheckRequest::negotiated_key_exchange_group() const {
+  return c_request_->peer_info.negotiated_key_exchange_group != nullptr
+             ? c_request_->peer_info.negotiated_key_exchange_group
+             : "";
+}
+
 std::vector<grpc::string_ref> TlsCustomVerificationCheckRequest::uri_names()
     const {
   std::vector<grpc::string_ref> uri_names;

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -125,6 +125,7 @@ class AuthContextTest(unittest.TestCase):
                 "security_level": [b"TSI_PRIVACY_AND_INTEGRITY"],
                 "transport_security_type": [b"ssl"],
                 "ssl_session_reused": [b"false"],
+                "ssl_negotiated_key_exchange_group": [b"X25519MLKEM768"],
             },
             auth_data[_AUTH_CTX],
         )

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -118,6 +118,21 @@ class AuthContextTest(unittest.TestCase):
         server.stop(None)
 
         auth_data = pickle.loads(response)
+        # The group here will depend on the underlying Open/BoringSSL version.
+        auth_ctx = auth_data[_AUTH_CTX]
+        self.assertIn("ssl_negotiated_key_exchange_group", auth_ctx)
+        key_exchange_group = auth_ctx.pop("ssl_negotiated_key_exchange_group")
+        self.assertEqual(len(key_exchange_group), 1)
+        self.assertIn(
+            key_exchange_group[0],
+            [
+                b"X25519MLKEM768",
+                b"X25519",
+                b"prime256v1",
+                b"P-256",
+                b"secp384r1",
+            ],
+        )
         self.assertIsNone(auth_data[_ID])
         self.assertIsNone(auth_data[_ID_KEY])
         self.assertDictEqual(
@@ -125,9 +140,8 @@ class AuthContextTest(unittest.TestCase):
                 "security_level": [b"TSI_PRIVACY_AND_INTEGRITY"],
                 "transport_security_type": [b"ssl"],
                 "ssl_session_reused": [b"false"],
-                "ssl_negotiated_key_exchange_group": [b"X25519MLKEM768"],
             },
-            auth_data[_AUTH_CTX],
+            auth_ctx,
         )
 
     def testSecureClientCert(self):

--- a/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
@@ -129,6 +129,7 @@ class TestAuthContext(AioTestBase):
                 "security_level": [b"TSI_PRIVACY_AND_INTEGRITY"],
                 "transport_security_type": [b"ssl"],
                 "ssl_session_reused": [b"false"],
+                "ssl_negotiated_key_exchange_group": [b"X25519MLKEM768"],
             },
             auth_data[_AUTH_CTX],
         )

--- a/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
+++ b/src/python/grpcio_tests/tests_aio/unit/auth_context_test.py
@@ -122,6 +122,21 @@ class TestAuthContext(AioTestBase):
         await server.stop(None)
 
         auth_data = pickle.loads(response)
+        # The group here will depend on the underlying Open/BoringSSL version.
+        auth_ctx = auth_data[_AUTH_CTX]
+        self.assertIn("ssl_negotiated_key_exchange_group", auth_ctx)
+        key_exchange_group = auth_ctx.pop("ssl_negotiated_key_exchange_group")
+        self.assertEqual(len(key_exchange_group), 1)
+        self.assertIn(
+            key_exchange_group[0],
+            [
+                b"X25519MLKEM768",
+                b"X25519",
+                b"prime256v1",
+                b"P-256",
+                b"secp384r1",
+            ],
+        )
         self.assertIsNone(auth_data[_ID])
         self.assertIsNone(auth_data[_ID_KEY])
         self.assertDictEqual(
@@ -129,9 +144,8 @@ class TestAuthContext(AioTestBase):
                 "security_level": [b"TSI_PRIVACY_AND_INTEGRITY"],
                 "transport_security_type": [b"ssl"],
                 "ssl_session_reused": [b"false"],
-                "ssl_negotiated_key_exchange_group": [b"X25519MLKEM768"],
             },
-            auth_data[_AUTH_CTX],
+            auth_ctx,
         )
 
     async def test_secure_client_cert(self):

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -1657,6 +1657,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
         "absl/log",
+        "absl/strings:string_view",
         "absl/synchronization",
     ],
     tags = ["tls_credentials_test"],

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -66,6 +66,34 @@ class NoOpCertificateVerifier : public ExternalCertificateVerifier {
   }
 };
 
+class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
+ public:
+  explicit KeyExchangeGroupCheckingVerifier(std::string expected_group)
+      : expected_group_(std::move(expected_group)) {}
+
+  ~KeyExchangeGroupCheckingVerifier() override = default;
+
+  bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
+              std::function<void(grpc::Status)>,
+              grpc::Status* sync_status) override {
+    if (request->negotiated_key_exchange_group() != expected_group_) {
+      *sync_status = grpc::Status(
+          grpc::StatusCode::UNAUTHENTICATED,
+          "Key exchange group mismatch: expected " + expected_group_ +
+              ", got " + std::string(request->negotiated_key_exchange_group()));
+    } else {
+      *sync_status = grpc::Status(grpc::StatusCode::OK, "");
+    }
+    return true;
+  }
+
+  void Cancel(grpc::experimental::TlsCustomVerificationCheckRequest*) override {
+  }
+
+ private:
+  std::string expected_group_;
+};
+
 class TlsCredentialsTest : public ::testing::Test {
  protected:
   void RunServer(absl::Notification* notification,
@@ -136,6 +164,25 @@ void DoRpc(const std::string& server_addr,
   EXPECT_EQ(response.message(), kMessage);
 }
 
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
+void DoRpcAndExpectFailure(const std::string& server_addr,
+                           const TlsChannelCredentialsOptions& tls_options,
+                           grpc::StatusCode expected_code) {
+  std::shared_ptr<Channel> channel =
+      grpc::CreateChannel(server_addr, TlsCredentials(tls_options));
+
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  grpc::testing::EchoRequest request;
+  grpc::testing::EchoResponse response;
+  request.set_message(kMessage);
+  ClientContext context;
+  context.set_deadline(grpc_timeout_seconds_to_deadline(/*time_s=*/10));
+  grpc::Status result = stub->Echo(&context, request, &response);
+  EXPECT_EQ(result.error_code(), expected_code)
+      << "Expected failure with code " << expected_code << ", but got code "
+      << result.error_code() << ", message: " << result.error_message();
+}
+
 // TODO(gregorycooke) - failing with OpenSSL1.0.2
 #if OPENSSL_VERSION_NUMBER >= 0x10100000
 // How do we test that skipping server certificate verification works as
@@ -172,7 +219,8 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupMlkem) {
   notification.WaitForNotification();
   TlsChannelCredentialsOptions tls_options;
   tls_options.set_certificate_verifier(
-      ExternalCertificateVerifier::Create<NoOpCertificateVerifier>());
+      ExternalCertificateVerifier::Create<KeyExchangeGroupCheckingVerifier>(
+          "X25519MLKEM768"));
   tls_options.set_check_call_host(false);
   tls_options.set_key_exchange_groups({GRPC_TLS_GROUP_X25519_MLKEM768});
   std::string root_cert = grpc_core::testing::GetFileContents(kCaCertPath);
@@ -195,7 +243,8 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupX25519) {
   notification.WaitForNotification();
   TlsChannelCredentialsOptions tls_options;
   tls_options.set_certificate_verifier(
-      ExternalCertificateVerifier::Create<NoOpCertificateVerifier>());
+      ExternalCertificateVerifier::Create<KeyExchangeGroupCheckingVerifier>(
+          "X25519"));
   tls_options.set_check_call_host(false);
   tls_options.set_key_exchange_groups({GRPC_TLS_GROUP_X25519});
   std::string root_cert = grpc_core::testing::GetFileContents(kCaCertPath);
@@ -218,7 +267,8 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupSECP256R1) {
   notification.WaitForNotification();
   TlsChannelCredentialsOptions tls_options;
   tls_options.set_certificate_verifier(
-      ExternalCertificateVerifier::Create<NoOpCertificateVerifier>());
+      ExternalCertificateVerifier::Create<KeyExchangeGroupCheckingVerifier>(
+          "prime256v1"));
   tls_options.set_check_call_host(false);
   tls_options.set_key_exchange_groups({GRPC_TLS_GROUP_SECP256R1});
   std::string root_cert = grpc_core::testing::GetFileContents(kCaCertPath);
@@ -228,6 +278,31 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupSECP256R1) {
   tls_options.set_root_certificate_provider(client_certificate_provider);
   tls_options.set_sni_override("foo.test.google.fr");
   DoRpc(server_addr_, tls_options);
+}
+
+TEST_F(TlsCredentialsTest, KeyExchangeGroupMismatchFailsWithTestVerifier) {
+  server_addr_ = absl::StrCat("localhost:",
+                              std::to_string(grpc_pick_unused_port_or_die()));
+  absl::Notification notification;
+  const std::vector<grpc_tls_key_exchange_group> key_exchange_groups = {
+      GRPC_TLS_GROUP_X25519};
+  server_thread_ = new std::thread(
+      [&]() { RunServer(&notification, &key_exchange_groups); });
+  notification.WaitForNotification();
+  TlsChannelCredentialsOptions tls_options;
+  tls_options.set_certificate_verifier(
+      ExternalCertificateVerifier::Create<KeyExchangeGroupCheckingVerifier>(
+          "prime256v1"));
+  tls_options.set_check_call_host(false);
+  tls_options.set_key_exchange_groups({GRPC_TLS_GROUP_X25519});
+  std::string root_cert = grpc_core::testing::GetFileContents(kCaCertPath);
+  auto client_certificate_provider =
+      std::make_shared<grpc::experimental::StaticDataCertificateProvider>(
+          root_cert);
+  tls_options.set_root_certificate_provider(client_certificate_provider);
+  tls_options.set_sni_override("foo.test.google.fr");
+  DoRpcAndExpectFailure(server_addr_, tls_options,
+                        grpc::StatusCode::UNAUTHENTICATED);
 }
 #endif  // OPENSSL_IS_BORINGSSL
 

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -37,6 +37,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "absl/log/log.h"
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/notification.h"
 
 namespace grpc {
@@ -68,8 +69,8 @@ class NoOpCertificateVerifier : public ExternalCertificateVerifier {
 
 class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
  public:
-  explicit KeyExchangeGroupCheckingVerifier(std::string expected_group)
-      : expected_group_(std::move(expected_group)) {}
+  explicit KeyExchangeGroupCheckingVerifier(absl::string_view expected_group)
+      : expected_group_(expected_group) {}
 
   ~KeyExchangeGroupCheckingVerifier() override = default;
 
@@ -79,11 +80,10 @@ class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
     grpc::string_ref negotiated_group =
         request->negotiated_key_exchange_group();
     if (negotiated_group != expected_group_) {
-      *sync_status = grpc::Status(
-          grpc::StatusCode::UNAUTHENTICATED,
-          "Key exchange group mismatch: expected " + expected_group_ +
-              ", got " +
-              std::string(negotiated_group.data(), negotiated_group.length()));
+      *sync_status = grpc::Status(grpc::StatusCode::UNAUTHENTICATED,
+                                  "Key exchange group mismatch: expected " +
+                                      expected_group_ + ", got " +
+                                      std::string(negotiated_group));
     } else {
       *sync_status = grpc::Status(grpc::StatusCode::OK, "");
     }
@@ -150,7 +150,8 @@ class TlsCredentialsTest : public ::testing::Test {
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
 void DoRpc(const std::string& server_addr,
-           const TlsChannelCredentialsOptions& tls_options) {
+           const TlsChannelCredentialsOptions& tls_options,
+           absl::string_view expected_key_exchange_group = "") {
   std::shared_ptr<Channel> channel =
       grpc::CreateChannel(server_addr, TlsCredentials(tls_options));
 
@@ -165,6 +166,15 @@ void DoRpc(const std::string& server_addr,
                            << result.error_message() << ", "
                            << result.error_details();
   EXPECT_EQ(response.message(), kMessage);
+  if (!expected_group.empty()) {
+    std::shared_ptr<const AuthContext> auth_context = context.auth_context();
+    ASSERT_NE(auth_context, nullptr);
+    std::vector<grpc::string_ref> properties = auth_context->FindPropertyValues(
+        GRPC_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP_PROPERTY_NAME);
+    ASSERT_EQ(properties.size(), 1u);
+    EXPECT_EQ(expected_group,
+              absl::string_view(properties[0].data(), properties[0].length()));
+  }
 }
 
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
@@ -239,7 +249,8 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupMlkem) {
           root_cert);
   tls_options.set_root_certificate_provider(client_certificate_provider);
   tls_options.set_sni_override("foo.test.google.fr");
-  DoRpc(server_addr_, tls_options);
+  DoRpc(server_addr_, tls_options,
+        /*expected_key_exchange_group=*/"X25519MLKEM768");
 }
 
 TEST_F(TlsCredentialsTest, KeyExchangeGroupX25519) {
@@ -263,7 +274,7 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupX25519) {
           root_cert);
   tls_options.set_root_certificate_provider(client_certificate_provider);
   tls_options.set_sni_override("foo.test.google.fr");
-  DoRpc(server_addr_, tls_options);
+  DoRpc(server_addr_, tls_options, /*expected_key_exchange_group=*/"X25519");
 }
 
 TEST_F(TlsCredentialsTest, KeyExchangeGroupSECP256R1) {
@@ -287,7 +298,8 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupSECP256R1) {
           root_cert);
   tls_options.set_root_certificate_provider(client_certificate_provider);
   tls_options.set_sni_override("foo.test.google.fr");
-  DoRpc(server_addr_, tls_options);
+  DoRpc(server_addr_, tls_options,
+        /*expected_key_exchange_group=*/"prime256v1");
 }
 
 TEST_F(TlsCredentialsTest, KeyExchangeGroupMismatchFailsWithTestVerifier) {

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -80,7 +80,9 @@ class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
       *sync_status = grpc::Status(
           grpc::StatusCode::UNAUTHENTICATED,
           "Key exchange group mismatch: expected " + expected_group_ +
-              ", got " + std::string(request->negotiated_key_exchange_group()));
+              ", got " +
+              std::string(request->negotiated_key_exchange_group().data(),
+                          request->negotiated_key_exchange_group().length()));
     } else {
       *sync_status = grpc::Status(grpc::StatusCode::OK, "");
     }
@@ -297,8 +299,9 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupMismatchFailsWithTestVerifier) {
   tls_options.set_key_exchange_groups({GRPC_TLS_GROUP_X25519});
   std::string root_cert = grpc_core::testing::GetFileContents(kCaCertPath);
   auto client_certificate_provider =
-      std::make_shared<grpc::experimental::StaticDataCertificateProvider>(
-          root_cert);
+      std::make_shared<grpc::experimental::InMemoryCertificateProvider>();
+  EXPECT_EQ(client_certificate_provider->UpdateRoot(root_cert),
+            absl::OkStatus());
   tls_options.set_root_certificate_provider(client_certificate_provider);
   tls_options.set_sni_override("foo.test.google.fr");
   DoRpcAndExpectFailure(server_addr_, tls_options,

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -76,14 +76,14 @@ class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
   bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
               std::function<void(grpc::Status)>,
               grpc::Status* sync_status) override {
-    grpc::string_ref negotiated_group = request->negotiated_key_exchange_group();
+    grpc::string_ref negotiated_group =
+        request->negotiated_key_exchange_group();
     if (negotiated_group != expected_group_) {
       *sync_status = grpc::Status(
           grpc::StatusCode::UNAUTHENTICATED,
           "Key exchange group mismatch: expected " + expected_group_ +
               ", got " +
-              std::string(negotiated_group.data(),
-                          negotiated_group.length()));
+              std::string(negotiated_group.data(), negotiated_group.length()));
     } else {
       *sync_status = grpc::Status(grpc::StatusCode::OK, "");
     }

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -80,10 +80,11 @@ class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
     grpc::string_ref negotiated_group =
         request->negotiated_key_exchange_group();
     if (negotiated_group != expected_group_) {
-      *sync_status = grpc::Status(grpc::StatusCode::UNAUTHENTICATED,
-                                  "Key exchange group mismatch: expected " +
-                                      expected_group_ + ", got " +
-                                      std::string(negotiated_group));
+      *sync_status = grpc::Status(
+          grpc::StatusCode::UNAUTHENTICATED,
+          "Key exchange group mismatch: expected " + expected_group_ +
+              ", got " +
+              std::string(negotiated_group.data(), negotiated_group.length()));
     } else {
       *sync_status = grpc::Status(grpc::StatusCode::OK, "");
     }
@@ -166,13 +167,13 @@ void DoRpc(const std::string& server_addr,
                            << result.error_message() << ", "
                            << result.error_details();
   EXPECT_EQ(response.message(), kMessage);
-  if (!expected_group.empty()) {
+  if (!expected_key_exchange_group.empty()) {
     std::shared_ptr<const AuthContext> auth_context = context.auth_context();
     ASSERT_NE(auth_context, nullptr);
     std::vector<grpc::string_ref> properties = auth_context->FindPropertyValues(
         GRPC_SSL_NEGOTIATED_KEY_EXCHANGE_GROUP_PROPERTY_NAME);
     ASSERT_EQ(properties.size(), 1u);
-    EXPECT_EQ(expected_group,
+    EXPECT_EQ(expected_key_exchange_group,
               absl::string_view(properties[0].data(), properties[0].length()));
   }
 }

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -169,7 +169,8 @@ void DoRpc(const std::string& server_addr,
 // NOLINTNEXTLINE(clang-diagnostic-unused-function)
 void DoRpcAndExpectFailure(const std::string& server_addr,
                            const TlsChannelCredentialsOptions& tls_options,
-                           grpc::StatusCode expected_code) {
+                           grpc::StatusCode expected_code,
+                           const std::string& expected_message_substr = "") {
   std::shared_ptr<Channel> channel =
       grpc::CreateChannel(server_addr, TlsCredentials(tls_options));
 
@@ -183,6 +184,12 @@ void DoRpcAndExpectFailure(const std::string& server_addr,
   EXPECT_EQ(result.error_code(), expected_code)
       << "Expected failure with code " << expected_code << ", but got code "
       << result.error_code() << ", message: " << result.error_message();
+  if (!expected_message_substr.empty()) {
+    EXPECT_NE(result.error_message().find(expected_message_substr),
+              std::string::npos)
+        << "Expected error message containing '" << expected_message_substr
+        << "', got: '" << result.error_message() << "'";
+  }
 }
 
 // TODO(gregorycooke) - failing with OpenSSL1.0.2
@@ -304,8 +311,9 @@ TEST_F(TlsCredentialsTest, KeyExchangeGroupMismatchFailsWithTestVerifier) {
             absl::OkStatus());
   tls_options.set_root_certificate_provider(client_certificate_provider);
   tls_options.set_sni_override("foo.test.google.fr");
-  DoRpcAndExpectFailure(server_addr_, tls_options,
-                        grpc::StatusCode::UNAUTHENTICATED);
+  DoRpcAndExpectFailure(
+      server_addr_, tls_options, grpc::StatusCode::UNAVAILABLE,
+      "Key exchange group mismatch: expected prime256v1, got X25519");
 }
 #endif  // OPENSSL_IS_BORINGSSL
 

--- a/test/cpp/end2end/tls_credentials_test.cc
+++ b/test/cpp/end2end/tls_credentials_test.cc
@@ -76,13 +76,14 @@ class KeyExchangeGroupCheckingVerifier : public ExternalCertificateVerifier {
   bool Verify(grpc::experimental::TlsCustomVerificationCheckRequest* request,
               std::function<void(grpc::Status)>,
               grpc::Status* sync_status) override {
-    if (request->negotiated_key_exchange_group() != expected_group_) {
+    grpc::string_ref negotiated_group = request->negotiated_key_exchange_group();
+    if (negotiated_group != expected_group_) {
       *sync_status = grpc::Status(
           grpc::StatusCode::UNAUTHENTICATED,
           "Key exchange group mismatch: expected " + expected_group_ +
               ", got " +
-              std::string(request->negotiated_key_exchange_group().data(),
-                          request->negotiated_key_exchange_group().length()));
+              std::string(negotiated_group.data(),
+                          negotiated_group.length()));
     } else {
       *sync_status = grpc::Status(grpc::StatusCode::OK, "");
     }

--- a/test/cpp/security/tls_certificate_verifier_test.cc
+++ b/test/cpp/security/tls_certificate_verifier_test.cc
@@ -210,7 +210,7 @@ TEST(TlsCertificateVerifierTest, VerifiedRootCertSubjectVerifierFailsMismatch) {
 }
 
 TEST(TlsCertificateVerifierTest, NegotiatedKeyExchangeGroupProperty) {
-  grpc_tls_custom_verification_check_request request;
+  grpc_tls_custom_verification_check_request request = {};
   constexpr char kExpectedGroup[] = "X25519";
   request.peer_info.negotiated_key_exchange_group = kExpectedGroup;
   TlsCustomVerificationCheckRequest cpp_request(&request);

--- a/test/cpp/security/tls_certificate_verifier_test.cc
+++ b/test/cpp/security/tls_certificate_verifier_test.cc
@@ -209,6 +209,16 @@ TEST(TlsCertificateVerifierTest, VerifiedRootCertSubjectVerifierFailsMismatch) {
             "VerifiedRootCertSubjectVerifier failed");
 }
 
+TEST(TlsCertificateVerifierTest, NegotiatedKeyExchangeGroupProperty) {
+  grpc_tls_custom_verification_check_request request;
+  constexpr char kExpectedGroup[] = "X25519";
+  request.peer_info.negotiated_key_exchange_group = kExpectedGroup;
+  TlsCustomVerificationCheckRequest cpp_request(&request);
+  EXPECT_EQ(cpp_request.negotiated_key_exchange_group(), kExpectedGroup);
+  request.peer_info.negotiated_key_exchange_group = nullptr;
+  EXPECT_EQ(cpp_request.negotiated_key_exchange_group(), "");
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace grpc


### PR DESCRIPTION
Plumb the negotiated key exchange group all the way to the custom verification check.
This allows users to check the negotiated key exchange group to ensure, for example, they are using post-quantum crypto.