### PR TITLE
fix: eliminate StackAddressEscape in GetChannelInfoField (channel_cc.cc)

### DIFF
--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -82,12 +82,11 @@ inline grpc_slice SliceFromArray(const char* arr, size_t len) {
 }
 
 std::string GetChannelInfoField(grpc_channel* channel,
-                                grpc_channel_info* channel_info,
-                                char*** channel_info_field) {
+                                char** grpc_channel_info::* field) {
   char* value = nullptr;
-  memset(channel_info, 0, sizeof(*channel_info));
-  *channel_info_field = &value;
-  grpc_channel_get_info(channel, channel_info);
+  grpc_channel_info channel_info = {};
+  channel_info.*field = &value;
+  grpc_channel_get_info(channel, &channel_info);
   if (value == nullptr) return "";
   std::string result = value;
   gpr_free(value);
@@ -97,15 +96,12 @@ std::string GetChannelInfoField(grpc_channel* channel,
 }  // namespace
 
 std::string Channel::GetLoadBalancingPolicyName() const {
-  grpc_channel_info channel_info;
-  return GetChannelInfoField(c_channel_, &channel_info,
-                             &channel_info.lb_policy_name);
+  return GetChannelInfoField(c_channel_, &grpc_channel_info::lb_policy_name);
 }
 
 std::string Channel::GetServiceConfigJSON() const {
-  grpc_channel_info channel_info;
-  return GetChannelInfoField(c_channel_, &channel_info,
-                             &channel_info.service_config_json);
+  return GetChannelInfoField(c_channel_,
+                             &grpc_channel_info::service_config_json);
 }
 
 namespace experimental {


### PR DESCRIPTION
## Summary

`GetChannelInfoField` in `src/cpp/client/channel_cc.cc` stored the address of its local `char* value` into a caller-owned `grpc_channel_info` (`*channel_info_field = &value;`). After the helper returned, the caller's struct still pointed at the dead stack slot, which Chromium's clang static analyzer reports as `clang-analyzer-core.StackAddressEscape` at lines 84 and 87.

This restructures the helper so no stack address outlives its frame: the `grpc_channel_info` local now lives inside the helper, and the field is selected via a pointer-to-member (`char** grpc_channel_info::* field`) instead of a raw `char***`. Both `value` and `channel_info` are created and destroyed in the same frame, so the escape pattern is gone with zero behavior change.

## Why this matters

The struct was never read after the helper returned, so behavior is correct today, but the escaping-address pattern is fragile and blocks Chromium's clean-analyzer goal (#31316). The two call sites (`Channel::GetLoadBalancingPolicyName`, `Channel::GetServiceConfigJSON`) become one-liners that pass `&grpc_channel_info::lb_policy_name` / `&grpc_channel_info::service_config_json`, which also removes the caller-side `grpc_channel_info` locals that previously fed the raw out-parameter.

## Testing

The change is confined to the anonymous-namespace helper and its two call sites; the observable output of both public methods is unchanged. `grpc_channel_get_info` is still invoked with a zero-initialized `grpc_channel_info` and the same field wired to `value`, so returned policy-name and service-config strings are identical.

Fixes #31316
