### PR TITLE
[xDS gRPC transport] handle call creds per-call instead of per-channel

### DIFF
--- a/src/core/xds/grpc/xds_transport_grpc.cc
+++ b/src/core/xds/grpc/xds_transport_grpc.cc
@@ -78,6 +78,7 @@ GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::GrpcStreamingCall(
     WeakRefCountedPtr<GrpcXdsTransportFactory> factory, Channel* channel,
     const char* method,
     std::unique_ptr<StreamingCall::EventHandler> event_handler,
+    grpc_call_credentials* call_creds,
     const std::vector<std::pair<std::string, std::string>>& initial_metadata,
     Duration timeout)
     : factory_(std::move(factory)), event_handler_(std::move(event_handler)) {
@@ -91,6 +92,8 @@ GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall::GrpcStreamingCall(
       /*authority=*/std::nullopt, deadline,
       /*registered_method=*/true, /*arena_init_function=*/std::nullopt);
   GRPC_CHECK_NE(call_, nullptr);
+  // Set call creds, if any.
+  if (call_creds != nullptr) grpc_call_set_credentials(call_, call_creds);
   // Init data associated with the call.
   grpc_metadata_array_init(&initial_metadata_recv_);
   grpc_metadata_array_init(&trailing_metadata_recv_);
@@ -301,22 +304,6 @@ RefCountedPtr<Channel> CreateXdsChannel(
   RefCountedPtr<grpc_channel_credentials> channel_creds =
       CoreConfiguration::Get().channel_creds_registry().CreateChannelCreds(
           server.channel_creds_config(), certificate_provider_store);
-  RefCountedPtr<grpc_call_credentials> call_creds;
-  for (const auto& call_creds_config : server.call_creds_configs()) {
-    RefCountedPtr<grpc_call_credentials> creds =
-        CoreConfiguration::Get().call_creds_registry().CreateCallCreds(
-            call_creds_config);
-    if (call_creds == nullptr) {
-      call_creds = std::move(creds);
-    } else {
-      call_creds = MakeRefCounted<grpc_composite_call_credentials>(
-          std::move(call_creds), std::move(creds));
-    }
-  }
-  if (call_creds != nullptr) {
-    channel_creds = MakeRefCounted<grpc_composite_channel_credentials>(
-        std::move(channel_creds), std::move(call_creds));
-  }
   return RefCountedPtr<Channel>(Channel::FromC(grpc_channel_create(
       server.server_uri().c_str(), channel_creds.get(), args.ToC().get())));
 }
@@ -330,12 +317,25 @@ std::string GetChannelKey(const GrpcXdsServerInterface& server) {
         ", channel_creds={type=", server.channel_creds_config()->type(),
         ", config=", server.channel_creds_config()->ToString(), "}");
   }
-  for (const auto& call_creds_config : server.call_creds_configs()) {
-    absl::StrAppend(&result, ", call_creds={type=", call_creds_config->type(),
-                    ", config=", call_creds_config->ToString(), "}");
-  }
   absl::StrAppend(&result, "}");
   return result;
+}
+
+RefCountedPtr<grpc_call_credentials> GetCallCredsForTransport(
+    const GrpcXdsServerInterface& server) {
+  RefCountedPtr<grpc_call_credentials> call_creds;
+  for (const auto& call_creds_config : server.call_creds_configs()) {
+    RefCountedPtr<grpc_call_credentials> creds =
+        CoreConfiguration::Get().call_creds_registry().CreateCallCreds(
+            call_creds_config);
+    if (call_creds == nullptr) {
+      call_creds = std::move(creds);
+    } else {
+      call_creds = MakeRefCounted<grpc_composite_call_credentials>(
+          std::move(call_creds), std::move(creds));
+    }
+  }
+  return call_creds;
 }
 
 }  // namespace
@@ -367,19 +367,19 @@ class GrpcXdsTransportFactory::SharedChannel final
 
 GrpcXdsTransportFactory::GrpcXdsTransport::GrpcXdsTransport(
     WeakRefCountedPtr<GrpcXdsTransportFactory> factory,
-    RefCountedPtr<SharedChannel> channel,
-    const XdsBootstrap::XdsServerTarget& server, absl::Status* status)
+    RefCountedPtr<SharedChannel> channel, const GrpcXdsServerInterface& server,
+    absl::Status* status)
     : XdsTransport(GRPC_TRACE_FLAG_ENABLED(xds_client_refcount)
                        ? "GrpcXdsTransport"
                        : nullptr),
       factory_(std::move(factory)),
       key_(server.Key()),
-      channel_(std::move(channel)) {
+      channel_(std::move(channel)),
+      call_creds_(GetCallCredsForTransport(server)),
+      initial_metadata_(server.initial_metadata()),
+      timeout_(server.timeout()) {
   GRPC_TRACE_LOG(xds_client, INFO)
       << "[GrpcXdsTransport " << this << "] created";
-  const auto& grpc_server = DownCast<const GrpcXdsServerInterface&>(server);
-  initial_metadata_ = grpc_server.initial_metadata();
-  timeout_ = grpc_server.timeout();
   if (channel_->channel()->IsLame()) {
     *status = absl::UnavailableError("xds client has a lame channel");
   }
@@ -443,7 +443,8 @@ GrpcXdsTransportFactory::GrpcXdsTransport::CreateStreamingCall(
     std::unique_ptr<StreamingCall::EventHandler> event_handler) {
   return MakeOrphanable<GrpcStreamingCall>(
       factory_.WeakRef(DEBUG_LOCATION, "StreamingCall"), channel_->channel(),
-      method, std::move(event_handler), initial_metadata_, timeout_);
+      method, std::move(event_handler), call_creds_.get(), initial_metadata_,
+      timeout_);
 }
 
 void GrpcXdsTransportFactory::GrpcXdsTransport::ResetBackoff() {
@@ -512,7 +513,7 @@ GrpcXdsTransportFactory::GetTransport(
     }
     transport = MakeRefCounted<GrpcXdsTransport>(
         WeakRefAsSubclass<GrpcXdsTransportFactory>(), std::move(channel),
-        server, status);
+        grpc_server, status);
     transports_.emplace(std::move(key), transport.get());
   }
   return transport;

--- a/src/core/xds/grpc/xds_transport_grpc.h
+++ b/src/core/xds/grpc/xds_transport_grpc.h
@@ -38,6 +38,7 @@
 #include "src/core/util/sync.h"
 #include "src/core/util/time.h"
 #include "src/core/xds/grpc/certificate_provider_store_interface.h"
+#include "src/core/xds/grpc/xds_server_grpc_interface.h"
 #include "src/core/xds/xds_client/xds_bootstrap.h"
 #include "src/core/xds/xds_client/xds_transport.h"
 #include "absl/container/flat_hash_map.h"
@@ -83,8 +84,7 @@ class GrpcXdsTransportFactory::GrpcXdsTransport final
 
   GrpcXdsTransport(WeakRefCountedPtr<GrpcXdsTransportFactory> factory,
                    RefCountedPtr<SharedChannel> channel,
-                   const XdsBootstrap::XdsServerTarget& server,
-                   absl::Status* status);
+                   const GrpcXdsServerInterface& server, absl::Status* status);
   ~GrpcXdsTransport() override;
 
   void Orphaned() override;
@@ -108,6 +108,7 @@ class GrpcXdsTransportFactory::GrpcXdsTransport final
   WeakRefCountedPtr<GrpcXdsTransportFactory> factory_;
   std::string key_;
   RefCountedPtr<SharedChannel> channel_;
+  RefCountedPtr<grpc_call_credentials> call_creds_;
   std::vector<std::pair<std::string, std::string>> initial_metadata_;
   Duration timeout_;
 
@@ -123,6 +124,7 @@ class GrpcXdsTransportFactory::GrpcXdsTransport::GrpcStreamingCall final
       WeakRefCountedPtr<GrpcXdsTransportFactory> factory, Channel* channel,
       const char* method,
       std::unique_ptr<StreamingCall::EventHandler> event_handler,
+      grpc_call_credentials* call_creds,
       const std::vector<std::pair<std::string, std::string>>& initial_metadata,
       Duration timeout);
   ~GrpcStreamingCall() override;

--- a/test/core/xds/BUILD
+++ b/test/core/xds/BUILD
@@ -317,8 +317,8 @@ grpc_cc_test(
         "absl/synchronization",
     ],
     tags = ["xds_test"],
-    uses_event_engine = True,
-    uses_polling = True,
+    uses_event_engine = False,
+    uses_polling = False,
     deps = [
         "//:config",
         "//:exec_ctx",

--- a/test/core/xds/xds_transport_grpc_test.cc
+++ b/test/core/xds/xds_transport_grpc_test.cc
@@ -37,19 +37,28 @@ namespace {
 class GrpcXdsTransportTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    auto json = JsonParse("{\"channel_creds\": [{\"type\": \"insecure\"}]}");
+    auto json = JsonParse(
+        "{\"channel_creds\": [{\"type\": \"insecure\"}], "
+        "\"call_creds\": [{\"type\": \"jwt_token_file\", "
+        "\"config\": {\"jwt_token_file\": \"/path/to/file\"}}]}");
     ASSERT_TRUE(json.ok()) << json.status().ToString();
     ValidationErrors errors;
     channel_creds_config_ =
         ParseXdsBootstrapChannelCreds(*json, JsonArgs(), &errors);
     ASSERT_TRUE(errors.ok());
     ASSERT_NE(channel_creds_config_, nullptr);
+    call_creds_configs_ =
+        ParseXdsBootstrapCallCreds(*json, JsonArgs(), &errors);
+    ASSERT_TRUE(errors.ok());
+    ASSERT_GT(call_creds_configs_.size(), 0);
     auto store = MakeRefCounted<CertificateProviderStore>(
         CertificateProviderStore::PluginDefinitionMap{});
     factory_ = MakeRefCounted<GrpcXdsTransportFactory>(ChannelArgs(),
                                                        std::move(store));
   }
+
   RefCountedPtr<const ChannelCredsConfig> channel_creds_config_;
+  std::vector<RefCountedPtr<const CallCredsConfig>> call_creds_configs_;
   RefCountedPtr<GrpcXdsTransportFactory> factory_;
 };
 
@@ -66,6 +75,29 @@ TEST_F(GrpcXdsTransportTest, IdenticalTargetsShareTransport) {
   auto transport2 = factory_->GetTransport(target, &status2);
   ASSERT_TRUE(status2.ok()) << status2.ToString();
   EXPECT_EQ(transport1, transport2);
+}
+
+TEST_F(GrpcXdsTransportTest, DifferingCallCredsSharesChannel) {
+  ExecCtx exec_ctx;
+  GrpcXdsServerTarget target1("localhost:1234", channel_creds_config_,
+                              /*call_creds_configs=*/{},
+                              /*initial_metadata=*/{}, Duration::Seconds(10));
+  GrpcXdsServerTarget target2("localhost:1234", channel_creds_config_,
+                              /*call_creds_configs=*/call_creds_configs_,
+                              /*initial_metadata=*/{}, Duration::Seconds(10));
+  EXPECT_NE(target1.Key(), target2.Key());
+  absl::Status status1;
+  auto transport1 = factory_->GetTransport(target1, &status1);
+  ASSERT_TRUE(status1.ok()) << status1.ToString();
+  absl::Status status2;
+  auto transport2 = factory_->GetTransport(target2, &status2);
+  ASSERT_TRUE(status2.ok()) << status2.ToString();
+  EXPECT_NE(transport1, transport2);
+  auto* grpc_transport1 =
+      DownCast<GrpcXdsTransportFactory::GrpcXdsTransport*>(transport1.get());
+  auto* grpc_transport2 =
+      DownCast<GrpcXdsTransportFactory::GrpcXdsTransport*>(transport2.get());
+  EXPECT_EQ(grpc_transport1->channel(), grpc_transport2->channel());
 }
 
 TEST_F(GrpcXdsTransportTest, DifferingMetadataSharesChannel) {


### PR DESCRIPTION
This way, we won't needlessly recreate the channel if the call creds change.