### PR TITLE
[jwt] validate json field types before use in verifier

### DIFF
--- a/src/core/credentials/call/jwt/jwt_verifier.cc
+++ b/src/core/credentials/call/jwt/jwt_verifier.cc
@@ -173,9 +173,8 @@ static jose_header* jose_header_from_json(Json json) {
   // Beware of this if we add HMAC support:
   // https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
   //
-  alg_value = it->second.string().c_str();
-  if (it->second.type() != Json::Type::kString ||
-      strncmp(alg_value, "RS", 2) != 0 ||
+  alg_value = validate_string_field(it->second, "alg");
+  if (alg_value == nullptr || strncmp(alg_value, "RS", 2) != 0 ||
       evp_md_from_alg(alg_value) == nullptr) {
     LOG(ERROR) << "Invalid alg field";
     goto error;
@@ -443,6 +442,9 @@ static Json json_from_http(const grpc_http_response* response) {
 }
 
 static const Json* find_property_by_name(const Json& json, const char* name) {
+  if (json.type() != Json::Type::kObject) {
+    return nullptr;
+  }
   auto it = json.object().find(name);
   if (it == json.object().end()) {
     return nullptr;
@@ -610,7 +612,9 @@ static EVP_PKEY* find_verification_key(const Json& json, const char* header_alg,
     // { <kid1>: <x5091>, <kid2>: <x5092>, ... }
     const Json* cur = find_property_by_name(json, header_kid);
     if (cur == nullptr) return nullptr;
-    return extract_pkey_from_x509(cur->string().c_str());
+    const char* x509_str = validate_string_field(*cur, "x509");
+    if (x509_str == nullptr) return nullptr;
+    return extract_pkey_from_x509(x509_str);
   }
   if (jwt_keys->type() != Json::Type::kArray) {
     LOG(ERROR) << "Unexpected value type of keys property in jwks key set.";

--- a/test/core/credentials/call/jwt/jwt_verifier_test.cc
+++ b/test/core/credentials/call/jwt/jwt_verifier_test.cc
@@ -604,6 +604,24 @@ TEST(JwtVerifierTest, JwtVerifierBadFormat) {
   grpc_core::HttpRequest::SetOverride(nullptr, nullptr, nullptr);
 }
 
+// The JOSE header of this token decodes to {"alg":{}}, i.e. the alg field is
+// present but is not a string. The verifier must reject it rather than reading
+// the non-string field.
+TEST(JwtVerifierTest, JwtVerifierNonStringAlgFormat) {
+  grpc_core::ExecCtx exec_ctx;
+  grpc_jwt_verifier* verifier = grpc_jwt_verifier_create(nullptr, 0);
+  grpc_core::HttpRequest::SetOverride(httpcli_get_should_not_be_called,
+                                      httpcli_post_should_not_be_called,
+                                      httpcli_put_should_not_be_called);
+  grpc_jwt_verifier_verify(verifier, nullptr,
+                           "eyJhbGciOnt9fQ.eyJpc3MiOiJ4In0.AAAA",
+                           expected_audience, on_verification_bad_format,
+                           const_cast<char*>(expected_user_data));
+  grpc_jwt_verifier_destroy(verifier);
+  grpc_core::ExecCtx::Get()->Flush();
+  grpc_core::HttpRequest::SetOverride(nullptr, nullptr, nullptr);
+}
+
 // find verification key: bad jks, cannot find key in jks
 // bad signature custom provided email
 // bad key


### PR DESCRIPTION
jose_header_from_json reads the alg field with Json::string() before confirming it is a string, and find_verification_key does the same for the kid-indexed key entry, so a token whose JOSE header carries a non-string alg such as {"alg":{}}, or a key-server entry that maps the requested kid to a non-string, aborts the process through std::bad_variant_access inside grpc_jwt_verifier_verify. find_property_by_name also calls Json::object() on the untrusted key and openid responses without first checking the value is an object. Route those reads through the existing validate_string_field helper and add the object guard so malformed input is reported as BAD_FORMAT.